### PR TITLE
feat: add restricted permission mode for voice-only sessions

### DIFF
--- a/agentwire/static/css/dashboard.css
+++ b/agentwire/static/css/dashboard.css
@@ -419,6 +419,11 @@
     color: var(--error);
 }
 
+.session-badge.restricted {
+    background: rgba(251, 146, 60, 0.15);
+    color: #fb923c;  /* Orange/amber */
+}
+
 .no-sessions {
     color: var(--text-muted);
     padding: var(--space-md) 0;

--- a/agentwire/templates/dashboard.html
+++ b/agentwire/templates/dashboard.html
@@ -74,17 +74,24 @@
                                 <label>Permission Mode</label>
                                 <div class="radio-group">
                                     <label class="radio-option selected">
-                                        <input type="radio" name="bypassPermissions" value="true" checked>
+                                        <input type="radio" name="permissionMode" value="bypass" checked>
                                         <div class="radio-option-content">
                                             <div class="radio-option-label">Bypass Permissions (Recommended)</div>
                                             <div class="radio-option-desc">Claude auto-accepts all prompts for faster workflow</div>
                                         </div>
                                     </label>
                                     <label class="radio-option">
-                                        <input type="radio" name="bypassPermissions" value="false">
+                                        <input type="radio" name="permissionMode" value="normal">
                                         <div class="radio-option-content">
                                             <div class="radio-option-label">Normal Session</div>
                                             <div class="radio-option-desc">Permission prompts appear in portal for approval</div>
+                                        </div>
+                                    </label>
+                                    <label class="radio-option">
+                                        <input type="radio" name="permissionMode" value="restricted">
+                                        <div class="radio-option-content">
+                                            <div class="radio-option-label">Restricted Mode</div>
+                                            <div class="radio-option-desc">Only say/remote-say commands allowed, all else denied</div>
                                         </div>
                                     </label>
                                 </div>

--- a/docs/missions/restricted-mode.md
+++ b/docs/missions/restricted-mode.md
@@ -93,13 +93,13 @@ Note: Silent deny chosen over custom message ("3" + text) to keep response fast 
 
 ## Completion Criteria
 
-- [ ] `agentwire new -s test --restricted` creates a restricted session
-- [ ] In restricted session, `say "hello"` works without prompts
-- [ ] In restricted session, file edits/writes are auto-denied with message
-- [ ] Dashboard shows "Restricted" badge for restricted sessions
-- [ ] Create Session form has Restricted option
-- [ ] CLAUDE.md documents the three session modes
-- [ ] `chatbot_mode` references removed from code
+- [x] `agentwire new -s test --restricted` creates a restricted session
+- [x] In restricted session, `say "hello"` works without prompts
+- [x] In restricted session, file edits/writes are auto-denied with message
+- [x] Dashboard shows "Restricted" badge for restricted sessions
+- [x] Create Session form has Restricted option
+- [x] CLAUDE.md documents the three session modes
+- [x] `chatbot_mode` references removed from code (none found in codebase)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a third permission mode "Restricted" that only allows `say` and `remote-say` commands
- Auto-denies all other tool requests silently (no UI popup, no user interaction)
- Useful for voice-only assistants, chatbot-style sessions, public demos, or sandboxed experimentation

## Changes

**Core Infrastructure:**
- `_is_allowed_in_restricted_mode()` helper with strict regex validation
- `api_permission_request` auto-handles restricted mode (keystroke "2" for allow, "Escape" for deny)
- `RoomConfig.restricted` field with rooms.json persistence

**CLI:**
- `agentwire new -s <name> --restricted` creates restricted sessions
- `--restricted` implies `--no-bypass` (needs permission hook for auto-deny logic)

**Dashboard:**
- "Restricted" radio option in Create Session form
- Orange "Restricted" badge for restricted sessions

## Test plan

- [ ] Create restricted session via CLI: `agentwire new -s test --restricted`
- [ ] Verify `say "hello"` works without prompts
- [ ] Verify file edits are auto-denied (no popup)
- [ ] Create restricted session via dashboard
- [ ] Verify orange "Restricted" badge displays correctly

Built by [dotdev.dev](https://dotdev.dev)