### PR TITLE
feat: Network-aware CLI with tunnels and remote commands

### DIFF
--- a/agentwire/errors.py
+++ b/agentwire/errors.py
@@ -1,0 +1,224 @@
+"""
+AgentWire error classes with actionable messages.
+
+Follows the WHAT/WHY/HOW pattern:
+- WHAT: Clear description of what went wrong
+- WHY: Context to understand the cause
+- HOW: Actionable steps to fix the issue
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class NetworkError(Exception):
+    """
+    Network-related error with actionable context.
+
+    Example usage:
+        raise NetworkError(
+            what="Cannot reach TTS service on gpu-server",
+            why={
+                "service": "tts",
+                "machine": "gpu-server",
+                "url": "http://localhost:8100",
+                "status": "connection refused",
+            },
+            how=[
+                "Check if tunnel is running: agentwire tunnels status",
+                "Create missing tunnels: agentwire tunnels up",
+                "Verify TTS is running on remote: ssh gpu-server 'curl localhost:8100/health'",
+            ],
+        )
+    """
+
+    what: str
+    why: dict = field(default_factory=dict)
+    how: List[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return self.format_message()
+
+    def format_message(self) -> str:
+        """Format error with WHAT/WHY/HOW structure."""
+        lines = [f"ERROR: {self.what}"]
+
+        if self.why:
+            lines.append("")
+            lines.append("Context:")
+            for k, v in self.why.items():
+                lines.append(f"  {k}: {v}")
+
+        if self.how:
+            lines.append("")
+            lines.append("To fix:")
+            for i, step in enumerate(self.how, 1):
+                lines.append(f"  {i}. {step}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class TunnelError(NetworkError):
+    """Error related to SSH tunnel operations."""
+
+    pass
+
+
+@dataclass
+class ServiceError(NetworkError):
+    """Error related to service health/connectivity."""
+
+    pass
+
+
+@dataclass
+class MachineError(NetworkError):
+    """Error related to remote machine operations."""
+
+    pass
+
+
+# Common error factories for consistent messaging
+
+
+def tunnel_not_running(
+    service: str,
+    machine: str,
+    local_port: int,
+    remote_port: int,
+) -> TunnelError:
+    """Create error for missing tunnel."""
+    return TunnelError(
+        what=f"Tunnel to {machine} is not running",
+        why={
+            "service": service,
+            "machine": machine,
+            "local_port": local_port,
+            "remote_port": remote_port,
+        },
+        how=[
+            "Create the tunnel: agentwire tunnels up",
+            "Or manually: ssh -L {local_port}:localhost:{remote_port} -N -f {machine}".format(
+                local_port=local_port, remote_port=remote_port, machine=machine
+            ),
+        ],
+    )
+
+
+def tunnel_creation_failed(
+    machine: str,
+    local_port: int,
+    remote_port: int,
+    ssh_error: str,
+) -> TunnelError:
+    """Create error for failed tunnel creation."""
+    how = [
+        f"Verify SSH connectivity: ssh {machine} echo ok",
+        "Check SSH key is configured correctly",
+        f"Ensure port {remote_port} is not blocked by firewall",
+    ]
+
+    # Add specific hints based on error
+    if "permission denied" in ssh_error.lower():
+        how.insert(0, "Check SSH key permissions: chmod 600 ~/.ssh/id_*")
+    elif "connection refused" in ssh_error.lower():
+        how.insert(0, f"Ensure {machine} is reachable and SSH is running")
+    elif "host key" in ssh_error.lower():
+        how.insert(0, f"Accept host key: ssh-keyscan {machine} >> ~/.ssh/known_hosts")
+    elif "address already in use" in ssh_error.lower():
+        how.insert(0, f"Find process using port: lsof -i :{local_port}")
+        how.insert(1, "Kill stale tunnels: agentwire tunnels down")
+
+    return TunnelError(
+        what=f"Failed to create tunnel to {machine}",
+        why={
+            "machine": machine,
+            "local_port": local_port,
+            "remote_port": remote_port,
+            "ssh_error": ssh_error,
+        },
+        how=how,
+    )
+
+
+def service_unreachable(
+    service: str,
+    url: str,
+    error: Optional[str] = None,
+    is_remote: bool = False,
+    machine: Optional[str] = None,
+) -> ServiceError:
+    """Create error for unreachable service."""
+    how = []
+
+    if is_remote and machine:
+        how.extend(
+            [
+                "Check if tunnel is running: agentwire tunnels status",
+                "Create missing tunnels: agentwire tunnels up",
+                f"Verify service on remote: ssh {machine} 'curl {url}/health'",
+            ]
+        )
+    else:
+        how.extend(
+            [
+                f"Start the service: agentwire {service} start",
+                f"Check service logs: tmux attach -t agentwire-{service}",
+            ]
+        )
+
+    return ServiceError(
+        what=f"{service.capitalize()} service is not responding",
+        why={
+            "service": service,
+            "url": url,
+            "error": error or "connection refused",
+            "location": f"remote ({machine})" if is_remote else "local",
+        },
+        how=how,
+    )
+
+
+def machine_not_found(machine_id: str, available: List[str]) -> MachineError:
+    """Create error for unknown machine reference."""
+    available_str = ", ".join(available) if available else "(none registered)"
+
+    return MachineError(
+        what=f"Machine '{machine_id}' not found in configuration",
+        why={
+            "machine": machine_id,
+            "available_machines": available_str,
+            "config_file": "~/.agentwire/machines.json",
+        },
+        how=[
+            f"Add the machine: agentwire machine add {machine_id} --host <ip-or-hostname>",
+            "Or fix the machine ID in config.yaml services section",
+        ],
+    )
+
+
+def ssh_unreachable(
+    machine_id: str,
+    host: str,
+    user: Optional[str] = None,
+    error: Optional[str] = None,
+) -> MachineError:
+    """Create error for SSH connectivity failure."""
+    target = f"{user}@{host}" if user else host
+
+    return MachineError(
+        what=f"Cannot reach {machine_id} via SSH",
+        why={
+            "machine": machine_id,
+            "ssh_target": target,
+            "error": error or "connection timed out",
+        },
+        how=[
+            f"Test connectivity: ssh -o ConnectTimeout=5 {target} echo ok",
+            "Check if machine is powered on and network is reachable",
+            "Verify SSH key is configured: ssh-add -l",
+            f"Check ~/.ssh/config has correct settings for {host}",
+        ],
+    )

--- a/agentwire/init_orchestrator.py
+++ b/agentwire/init_orchestrator.py
@@ -1,0 +1,190 @@
+"""Spawn orchestrator session with init instructions for advanced setup."""
+
+import importlib.resources
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# ANSI colors (matching onboarding.py)
+BOLD = "\033[1m"
+GREEN = "\033[92m"
+YELLOW = "\033[93m"
+CYAN = "\033[96m"
+RED = "\033[91m"
+RESET = "\033[0m"
+
+
+def print_success(text: str) -> None:
+    """Print success message."""
+    print(f"{GREEN}✓{RESET} {text}")
+
+
+def print_warning(text: str) -> None:
+    """Print warning message."""
+    print(f"{YELLOW}!{RESET} {text}")
+
+
+def print_error(text: str) -> None:
+    """Print error message."""
+    print(f"{RED}✗{RESET} {text}")
+
+
+def prompt_choice(question: str, options: list[tuple[str, str]], default: int = 1) -> str:
+    """Prompt user to choose from options. Returns the option key."""
+    print(question)
+    print()
+    for i, (key, description) in enumerate(options, 1):
+        marker = f"{GREEN}→{RESET}" if i == default else " "
+        print(f"  {marker} {i}. {description}")
+    print()
+
+    while True:
+        choice = input(f"Choose [1-{len(options)}] (default: {default}): ").strip()
+        if not choice:
+            return options[default - 1][0]
+        try:
+            idx = int(choice)
+            if 1 <= idx <= len(options):
+                return options[idx - 1][0]
+        except ValueError:
+            pass
+        print_error(f"Please enter a number between 1 and {len(options)}")
+
+
+def tmux_session_exists(session_name: str) -> bool:
+    """Check if a tmux session exists."""
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def load_init_prompt() -> str:
+    """Load the init prompt template from package resources."""
+    try:
+        # Python 3.9+ way to read package resources
+        files = importlib.resources.files("agentwire")
+        prompt_path = files.joinpath("prompts", "init.md")
+        return prompt_path.read_text()
+    except Exception as e:
+        # Fallback: try reading from filesystem relative to this file
+        fallback_path = Path(__file__).parent / "prompts" / "init.md"
+        if fallback_path.exists():
+            return fallback_path.read_text()
+        print_error(f"Could not load init prompt: {e}")
+        return ""
+
+
+def send_to_session(session_name: str, text: str) -> bool:
+    """Send text to a tmux session using agentwire send."""
+    # Use agentwire send which handles the pause-before-enter properly
+    result = subprocess.run(
+        ["agentwire", "send", "-s", session_name, text],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def spawn_init_orchestrator() -> int:
+    """Spawn orchestrator session with init instructions.
+
+    Returns:
+        Exit code (0 for success)
+    """
+    session_name = "agentwire"
+
+    # Check if session already exists
+    if tmux_session_exists(session_name):
+        print(f"\n{YELLOW}Orchestrator session '{session_name}' already exists.{RESET}")
+
+        choice = prompt_choice(
+            "What would you like to do?",
+            [
+                ("attach", "Attach to existing session"),
+                ("restart", "Kill and restart with init prompt"),
+                ("cancel", "Cancel"),
+            ],
+            default=1,
+        )
+
+        if choice == "cancel":
+            print("\nSetup cancelled.")
+            return 0
+
+        if choice == "attach":
+            print(f"\nAttaching to session... (Ctrl+B D to detach)")
+            subprocess.run(["tmux", "attach-session", "-t", session_name])
+            return 0
+
+        if choice == "restart":
+            print(f"Killing existing session...")
+            subprocess.run(["tmux", "kill-session", "-t", session_name])
+
+    # Find project directory (where agentwire source lives)
+    # First check if we're in a development environment
+    project_root = Path(__file__).parent.parent
+    if not (project_root / "pyproject.toml").exists():
+        # Fallback to standard location
+        project_root = Path.home() / "projects" / "agentwire"
+
+    if not project_root.exists():
+        # Use home projects directory as fallback
+        project_root = Path.home() / "projects"
+
+    print(f"\n{BOLD}Starting orchestrator session...{RESET}")
+    print(f"Working directory: {project_root}")
+
+    # Create tmux session
+    result = subprocess.run([
+        "tmux", "new-session", "-d", "-s", session_name,
+        "-c", str(project_root),
+    ])
+
+    if result.returncode != 0:
+        print_error("Failed to create tmux session")
+        return 1
+
+    print_success("Created tmux session")
+
+    # Start Claude with --dangerously-skip-permissions
+    subprocess.run([
+        "tmux", "send-keys", "-t", session_name,
+        "claude --dangerously-skip-permissions", "Enter"
+    ])
+
+    print("Waiting for Claude to start...")
+
+    # Wait for Claude to be ready (check for prompt)
+    # Claude typically takes 2-4 seconds to initialize
+    time.sleep(3)
+
+    # Load and send the init prompt
+    init_prompt = load_init_prompt()
+
+    if not init_prompt:
+        print_warning("Could not load init prompt, starting empty session")
+    else:
+        print("Sending init instructions...")
+
+        # Use agentwire send which handles multiline prompts properly
+        if send_to_session(session_name, init_prompt):
+            print_success("Sent init instructions to Claude")
+        else:
+            print_warning("Could not send via agentwire, trying direct tmux...")
+            # Fallback: send a shorter intro if agentwire send fails
+            intro = "You are helping set up AgentWire. Start by greeting the user and asking about their setup (single machine or multiple machines). Use AskUserQuestion for choices."
+            subprocess.run([
+                "tmux", "send-keys", "-t", session_name,
+                intro, "Enter"
+            ])
+
+    print(f"\n{GREEN}✓{RESET} Orchestrator started with init instructions")
+    print(f"\n{BOLD}Attaching to session...{RESET} (Ctrl+B D to detach)")
+
+    # Attach user to the session
+    subprocess.run(["tmux", "attach-session", "-t", session_name])
+
+    return 0

--- a/agentwire/network.py
+++ b/agentwire/network.py
@@ -1,0 +1,202 @@
+"""
+Network context helper for AgentWire.
+
+Understands network topology and routing between machines and services.
+"""
+
+import json
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .config import Config, get_config
+
+
+@dataclass
+class TunnelSpec:
+    """Specification for an SSH tunnel."""
+
+    local_port: int
+    remote_machine: str
+    remote_port: int
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for this tunnel spec."""
+        return f"{self.local_port}-{self.remote_machine}-{self.remote_port}"
+
+
+class NetworkContext:
+    """Understands the network topology and how to reach services."""
+
+    def __init__(self, config: Config, machines: list[dict]):
+        """
+        Initialize with config and machines list.
+
+        Args:
+            config: Loaded Config object (with services section)
+            machines: List of machine dicts from machines.json
+        """
+        self.config = config
+        self.machines = {m["id"]: m for m in machines if "id" in m}
+        self.local_machine_id = self._detect_local_machine()
+
+    def _detect_local_machine(self) -> Optional[str]:
+        """
+        Detect which machine we're running on.
+
+        Matches current hostname against machine IDs and hosts.
+        Returns None if not a registered machine (standalone mode).
+        """
+        hostname = socket.gethostname().lower()
+
+        for machine_id, machine in self.machines.items():
+            # Check if hostname matches machine ID
+            if machine_id.lower() == hostname:
+                return machine_id
+
+            # Check if hostname matches host field
+            host = machine.get("host", "").lower()
+            if host == hostname or host.split(".")[0] == hostname:
+                return machine_id
+
+            # Check if hostname matches the short form of host
+            if hostname.split(".")[0] == host.split(".")[0] and host:
+                return machine_id
+
+        return None
+
+    def is_local(self, service: str) -> bool:
+        """
+        Is this service running on the current machine?
+
+        Args:
+            service: Service name ("portal" or "tts")
+
+        Returns:
+            True if service runs locally (machine is None or matches local machine)
+        """
+        service_config = getattr(self.config.services, service, None)
+        if service_config is None:
+            return True  # Unknown service defaults to local
+
+        machine = service_config.machine
+        if machine is None:
+            return True  # Explicitly local
+
+        return machine == self.local_machine_id
+
+    def get_service_url(self, service: str, use_tunnel: bool = True) -> str:
+        """
+        Get URL to reach service.
+
+        Args:
+            service: Service name ("portal" or "tts")
+            use_tunnel: If True and service is remote, assume tunnel exists on localhost
+
+        Returns:
+            URL like "http://localhost:8765" or "http://192.168.1.50:8765"
+        """
+        service_config = getattr(self.config.services, service, None)
+        if service_config is None:
+            # Fallback for unknown services
+            return "http://localhost:8765"
+
+        if self.is_local(service):
+            return f"http://localhost:{service_config.port}"
+
+        if use_tunnel:
+            # Assume tunnel brings remote port to localhost
+            return f"http://localhost:{service_config.port}"
+
+        # Direct connection to remote
+        machine = self.machines.get(service_config.machine)
+        if machine:
+            host = machine.get("host", service_config.machine)
+            return f"http://{host}:{service_config.port}"
+
+        return f"http://localhost:{service_config.port}"
+
+    def get_required_tunnels(self) -> list[TunnelSpec]:
+        """
+        What tunnels does THIS machine need?
+
+        Returns tunnels needed to reach services that run on other machines.
+        """
+        tunnels = []
+
+        for service_name in ["portal", "tts"]:
+            service_config = getattr(self.config.services, service_name, None)
+            if service_config is None:
+                continue
+
+            if not self.is_local(service_name) and service_config.machine:
+                tunnels.append(
+                    TunnelSpec(
+                        local_port=service_config.port,
+                        remote_machine=service_config.machine,
+                        remote_port=service_config.port,
+                    )
+                )
+
+        return tunnels
+
+    def get_ssh_target(self, service: str) -> Optional[str]:
+        """
+        If service is remote, return SSH target for commands.
+
+        Returns:
+            SSH target like "user@host" or None if service is local
+        """
+        service_config = getattr(self.config.services, service, None)
+        if service_config is None or self.is_local(service):
+            return None
+
+        machine = self.machines.get(service_config.machine)
+        if machine is None:
+            return None
+
+        host = machine.get("host", service_config.machine)
+        user = machine.get("user")
+
+        if user:
+            return f"{user}@{host}"
+        return host
+
+    def get_machine_for_service(self, service: str) -> Optional[str]:
+        """
+        Get the machine ID where a service runs.
+
+        Args:
+            service: Service name ("portal" or "tts")
+
+        Returns:
+            Machine ID or None if service runs locally
+        """
+        service_config = getattr(self.config.services, service, None)
+        if service_config is None:
+            return None
+        return service_config.machine
+
+    @classmethod
+    def from_config(cls) -> "NetworkContext":
+        """
+        Create NetworkContext from default config location.
+
+        Loads config and machines.json automatically.
+        """
+        config = get_config()
+
+        # Load machines
+        machines_file = Path.home() / ".agentwire" / "machines.json"
+        machines = []
+        if machines_file.exists():
+            try:
+                with open(machines_file) as f:
+                    data = json.load(f)
+                    machines = data.get("machines", [])
+            except (json.JSONDecodeError, IOError):
+                pass
+
+        return cls(config, machines)

--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -186,8 +186,12 @@ def backup_config() -> Optional[Path]:
     return None
 
 
-def run_onboarding() -> int:
-    """Run the interactive onboarding wizard."""
+def run_onboarding(skip_orchestrator: bool = False) -> int:
+    """Run the interactive onboarding wizard.
+
+    Args:
+        skip_orchestrator: If True, skip the final orchestrator setup prompt.
+    """
     print()
     print(f"{BOLD}Welcome to AgentWire Setup!{RESET}")
     print()
@@ -635,7 +639,7 @@ Stay focused on your project directory and commit frequently.
     # ─────────────────────────────────────────────────────────────
     # Summary
     # ─────────────────────────────────────────────────────────────
-    print_header("Setup Complete!")
+    print_header("Local Setup Complete!")
 
     print(f"{BOLD}Your configuration:{RESET}")
     print(f"  Projects:    {config['projects_dir']}")
@@ -648,6 +652,20 @@ Stay focused on your project directory and commit frequently.
     print(f"  STT:         {config['stt_backend']}")
     print(f"  Machines:    {len(config['machines'])} configured" if config['machines'] else "  Machines:    Local only")
 
+    # ─────────────────────────────────────────────────────────────
+    # Orchestrator Setup (Optional)
+    # ─────────────────────────────────────────────────────────────
+    if not skip_orchestrator:
+        print()
+        print_info("The next step is optional: Claude can help you with advanced setup")
+        print_info("(multi-machine networking, TTS configuration, testing services).")
+        print()
+
+        if prompt_yes_no("Ready to start orchestrator setup?"):
+            from .init_orchestrator import spawn_init_orchestrator
+            return spawn_init_orchestrator()
+
+    # User declined orchestrator setup (or skip_orchestrator=True) - show manual next steps
     print()
     print(f"{BOLD}Next steps:{RESET}")
     if config['tts_backend'] == 'chatterbox':
@@ -657,5 +675,8 @@ Stay focused on your project directory and commit frequently.
         print(f"  1. {CYAN}agentwire portal start{RESET}  # Start the web portal")
     print(f"  3. Open {CYAN}https://localhost:8765{RESET} in your browser")
     print()
+    if not skip_orchestrator:
+        print_info("Run 'agentwire dev' anytime to start the orchestrator session.")
+        print()
 
     return 0

--- a/agentwire/prompts/__init__.py
+++ b/agentwire/prompts/__init__.py
@@ -1,0 +1,1 @@
+# Prompt templates for AgentWire orchestrator sessions

--- a/agentwire/prompts/init.md
+++ b/agentwire/prompts/init.md
@@ -1,0 +1,155 @@
+# AgentWire Init Session
+
+You are helping a user set up AgentWire for the first time. The CLI wizard has already completed local setup (config directory, SSL certs, audio device, projects directory).
+
+Your job is to walk them through advanced setup.
+
+## Your Tasks
+
+1. **Understand their setup**
+   - Ask if they're using just this machine, or multiple machines
+   - Ask about TTS: local (if GPU), remote GPU machine, or skip voice
+
+2. **Configure services** (based on their answers)
+   - For single machine: ensure services.portal and services.tts are both null (local)
+   - For multi-machine: help them add machines and configure service locations
+
+3. **Add remote machines** (if multi-machine)
+   - For each machine: get hostname/IP, SSH user, projects directory
+   - Run `agentwire machine add` for each
+   - Test SSH connectivity
+
+4. **Configure TTS location**
+   - If TTS on remote GPU: update config.yaml services.tts.machine
+   - Verify TTS dependencies are installed on that machine
+
+5. **Test everything**
+   - Run `agentwire tunnels up` to create needed tunnels
+   - Run `agentwire network status` to verify all services
+   - Run `agentwire tts status` and `agentwire portal status`
+
+6. **Start services**
+   - Start TTS if remote
+   - Start portal
+   - Test voice with a quick `remote-say "Setup complete!"`
+
+## Guidelines
+
+- Use AskUserQuestion for choices (single vs multi, TTS location, etc.)
+- Run CLI commands to actually configure things, don't just tell the user to do it
+- If something fails, explain what went wrong and offer to retry or skip
+- Be encouraging - this is their first time!
+
+## Example Flow
+
+Start by greeting them:
+
+"Let's finish setting up AgentWire! The basic configuration is done. Now I'll help you set up the network topology - where services run and how machines connect."
+
+Then ask about their setup:
+
+[AskUserQuestion: "What kind of setup do you have?"
+  - "Just this machine (simple)"
+  - "Multiple machines (e.g., separate GPU for TTS)"
+  - "I'm not sure yet, help me decide"]
+
+### If "Just this machine" selected:
+
+Great! Single-machine setup is the simplest. All services will run locally.
+
+Run these commands to verify everything works:
+```bash
+agentwire portal start
+agentwire tts start
+```
+
+Then test voice:
+```bash
+remote-say "Hello! Your AgentWire setup is complete."
+```
+
+### If "Multiple machines" selected:
+
+"Great! Let's add your other machines. First, tell me about your TTS setup."
+
+[AskUserQuestion: "Where will TTS (voice synthesis) run?"
+  - "This machine has a GPU"
+  - "I have a separate GPU machine"
+  - "Skip voice features for now"]
+
+If they have a separate GPU machine:
+
+"What's the hostname or IP of your GPU machine?"
+[AskUserQuestion with text input]
+
+"What's your SSH username on that machine?"
+[AskUserQuestion with text input, default to current username]
+
+Then run:
+```bash
+agentwire machine add gpu-server --host <their-host> --user <their-user>
+```
+
+Test the connection:
+```bash
+ssh <user>@<host> "echo Connection successful"
+```
+
+### If "Help me decide" selected:
+
+Explain the trade-offs:
+
+"Here's how to think about it:
+
+**Single machine** is best when:
+- You have a GPU on this machine for TTS
+- You want the simplest possible setup
+- You're just getting started
+
+**Multiple machines** is best when:
+- You have a separate GPU server (TTS needs CUDA)
+- You want to run Claude sessions on remote machines
+- You're working with a team
+
+What sounds closer to your situation?"
+
+Then re-ask the setup type question.
+
+## Verification
+
+After configuration, verify everything:
+
+[AskUserQuestion: "I've configured your network. Ready to test everything?"
+  - "Yes, run tests"
+  - "Show me the config first"
+  - "Let me make changes first"]
+
+If "Yes, run tests":
+```bash
+agentwire network status
+```
+
+If tests pass:
+```bash
+remote-say "Congratulations! Your AgentWire network is fully configured and working."
+```
+
+## Success Message
+
+When everything is working:
+
+"Your AgentWire setup is complete!
+
+**What you can do now:**
+- Open https://localhost:8765 in your browser for the web portal
+- Create coding sessions with `agentwire new -s myproject`
+- Send voice commands from your phone/tablet
+- Use /sessions, /send, /output skills to orchestrate
+
+**Quick reference:**
+- `agentwire portal start/stop/status` - Manage web portal
+- `agentwire tts start/stop/status` - Manage TTS server
+- `agentwire list` - See all sessions
+- `agentwire network status` - Check network health
+
+Happy coding!"

--- a/agentwire/tunnels.py
+++ b/agentwire/tunnels.py
@@ -1,0 +1,376 @@
+"""
+SSH tunnel management for AgentWire.
+
+Creates and monitors SSH tunnels to reach remote services.
+"""
+
+import json
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .network import NetworkContext, TunnelSpec
+
+
+@dataclass
+class TunnelStatus:
+    """Status of a tunnel."""
+
+    spec: TunnelSpec
+    status: str  # "up", "down", "error"
+    pid: Optional[int] = None
+    error: Optional[str] = None
+    latency_ms: Optional[int] = None
+
+
+class TunnelManager:
+    """Manages SSH tunnels for reaching remote services."""
+
+    def __init__(self, state_dir: Optional[Path] = None):
+        """
+        Initialize tunnel manager.
+
+        Args:
+            state_dir: Directory to store tunnel state (PIDs, etc.)
+                      Defaults to ~/.agentwire/tunnels/
+        """
+        self.state_dir = state_dir or (Path.home() / ".agentwire" / "tunnels")
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_state_file(self, spec: TunnelSpec) -> Path:
+        """Get path to state file for a tunnel."""
+        return self.state_dir / f"{spec.id}.json"
+
+    def _get_ssh_target(self, machine_id: str, ctx: Optional[NetworkContext] = None) -> Optional[str]:
+        """Get SSH target (user@host) for a machine."""
+        if ctx is None:
+            ctx = NetworkContext.from_config()
+
+        machine = ctx.machines.get(machine_id)
+        if machine is None:
+            return None
+
+        host = machine.get("host", machine_id)
+        user = machine.get("user")
+
+        if user:
+            return f"{user}@{host}"
+        return host
+
+    def check_tunnel(self, spec: TunnelSpec) -> TunnelStatus:
+        """
+        Check if a tunnel is running.
+
+        Checks:
+        1. State file exists with PID
+        2. Process is actually running
+        3. Local port is listening (optional)
+
+        Returns:
+            TunnelStatus with current state
+        """
+        state_file = self._get_state_file(spec)
+
+        if not state_file.exists():
+            return TunnelStatus(spec=spec, status="down")
+
+        try:
+            state = json.loads(state_file.read_text())
+            pid = state.get("pid")
+
+            if pid is None:
+                return TunnelStatus(spec=spec, status="down")
+
+            # Check if process is running
+            try:
+                os.kill(pid, 0)  # Signal 0 just checks if process exists
+            except (OSError, ProcessLookupError):
+                # Process not running, clean up state file
+                state_file.unlink(missing_ok=True)
+                return TunnelStatus(spec=spec, status="down")
+
+            # Process is running
+            return TunnelStatus(spec=spec, status="up", pid=pid)
+
+        except (json.JSONDecodeError, IOError) as e:
+            return TunnelStatus(spec=spec, status="error", error=str(e))
+
+    def create_tunnel(self, spec: TunnelSpec, ctx: Optional[NetworkContext] = None) -> TunnelStatus:
+        """
+        Create an SSH tunnel.
+
+        Uses: ssh -L local_port:localhost:remote_port -N -f user@host
+
+        Args:
+            spec: Tunnel specification
+            ctx: Optional NetworkContext (loaded if not provided)
+
+        Returns:
+            TunnelStatus with result
+        """
+        # Check if already running
+        existing = self.check_tunnel(spec)
+        if existing.status == "up":
+            return existing
+
+        # Get SSH target
+        ssh_target = self._get_ssh_target(spec.remote_machine, ctx)
+        if ssh_target is None:
+            return TunnelStatus(
+                spec=spec,
+                status="error",
+                error=f"Machine '{spec.remote_machine}' not found in machines.json",
+            )
+
+        # Build SSH command
+        # -L local_port:localhost:remote_port - Port forwarding
+        # -N - Don't execute remote command
+        # -f - Go to background
+        # -o ExitOnForwardFailure=yes - Exit if port forward fails
+        # -o ServerAliveInterval=60 - Keep connection alive
+        # -o ServerAliveCountMax=3 - Max missed keepalives
+        cmd = [
+            "ssh",
+            "-L", f"{spec.local_port}:localhost:{spec.remote_port}",
+            "-N",
+            "-f",
+            "-o", "ExitOnForwardFailure=yes",
+            "-o", "ServerAliveInterval=60",
+            "-o", "ServerAliveCountMax=3",
+            ssh_target,
+        ]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+            if result.returncode != 0:
+                return TunnelStatus(
+                    spec=spec,
+                    status="error",
+                    error=result.stderr.strip() or f"SSH exited with code {result.returncode}",
+                )
+
+            # Find the PID of the SSH process
+            # The -f flag backgrounds the process, so we need to find it
+            pid = self._find_tunnel_pid(spec)
+
+            if pid:
+                # Save state
+                state = {"pid": pid, "spec": {"local_port": spec.local_port, "remote_machine": spec.remote_machine, "remote_port": spec.remote_port}}
+                self._get_state_file(spec).write_text(json.dumps(state))
+
+                return TunnelStatus(spec=spec, status="up", pid=pid)
+            else:
+                return TunnelStatus(
+                    spec=spec,
+                    status="error",
+                    error="SSH started but could not find process",
+                )
+
+        except subprocess.TimeoutExpired:
+            return TunnelStatus(spec=spec, status="error", error="SSH connection timed out")
+        except Exception as e:
+            return TunnelStatus(spec=spec, status="error", error=str(e))
+
+    def _find_tunnel_pid(self, spec: TunnelSpec) -> Optional[int]:
+        """Find the PID of an SSH tunnel process."""
+        # Use pgrep to find SSH processes with our port forward
+        try:
+            # Look for: ssh -L <local_port>:localhost:<remote_port>
+            pattern = f"-L.*{spec.local_port}:localhost:{spec.remote_port}"
+            result = subprocess.run(
+                ["pgrep", "-f", pattern],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode == 0 and result.stdout.strip():
+                # Return first matching PID
+                pids = result.stdout.strip().split("\n")
+                return int(pids[0])
+
+        except Exception:
+            pass
+
+        return None
+
+    def destroy_tunnel(self, spec: TunnelSpec) -> TunnelStatus:
+        """
+        Destroy an SSH tunnel.
+
+        Args:
+            spec: Tunnel specification
+
+        Returns:
+            TunnelStatus (should be "down" if successful)
+        """
+        status = self.check_tunnel(spec)
+
+        if status.status == "down":
+            return status
+
+        if status.pid:
+            try:
+                os.kill(status.pid, signal.SIGTERM)
+                # Wait a bit for graceful shutdown
+                time.sleep(0.5)
+
+                # Check if still running
+                try:
+                    os.kill(status.pid, 0)
+                    # Still running, force kill
+                    os.kill(status.pid, signal.SIGKILL)
+                except (OSError, ProcessLookupError):
+                    pass  # Process is gone
+
+            except (OSError, ProcessLookupError):
+                pass  # Process already gone
+
+        # Clean up state file
+        self._get_state_file(spec).unlink(missing_ok=True)
+
+        return TunnelStatus(spec=spec, status="down")
+
+    def ensure_tunnels(self, ctx: Optional[NetworkContext] = None) -> list[TunnelStatus]:
+        """
+        Ensure all required tunnels are running.
+
+        Args:
+            ctx: Optional NetworkContext (loaded if not provided)
+
+        Returns:
+            List of TunnelStatus for all required tunnels
+        """
+        if ctx is None:
+            ctx = NetworkContext.from_config()
+
+        results = []
+
+        for spec in ctx.get_required_tunnels():
+            status = self.check_tunnel(spec)
+
+            if status.status != "up":
+                status = self.create_tunnel(spec, ctx)
+
+            results.append(status)
+
+        return results
+
+    def list_tunnels(self) -> list[TunnelStatus]:
+        """
+        List all known tunnels from state files.
+
+        Returns:
+            List of TunnelStatus for all tracked tunnels
+        """
+        results = []
+
+        for state_file in self.state_dir.glob("*.json"):
+            try:
+                state = json.loads(state_file.read_text())
+                spec_data = state.get("spec", {})
+
+                spec = TunnelSpec(
+                    local_port=spec_data.get("local_port", 0),
+                    remote_machine=spec_data.get("remote_machine", "unknown"),
+                    remote_port=spec_data.get("remote_port", 0),
+                )
+
+                status = self.check_tunnel(spec)
+                results.append(status)
+
+            except (json.JSONDecodeError, IOError):
+                continue
+
+        return results
+
+    def destroy_all_tunnels(self) -> int:
+        """
+        Destroy all managed tunnels.
+
+        Returns:
+            Number of tunnels destroyed
+        """
+        count = 0
+        for status in self.list_tunnels():
+            if status.status == "up":
+                self.destroy_tunnel(status.spec)
+                count += 1
+        return count
+
+
+def test_ssh_connectivity(host: str, user: Optional[str] = None, timeout: int = 5) -> Optional[int]:
+    """
+    Test SSH connectivity to a host.
+
+    Args:
+        host: Hostname or IP
+        user: Optional username
+        timeout: Connection timeout in seconds
+
+    Returns:
+        Latency in milliseconds, or None if unreachable
+    """
+    target = f"{user}@{host}" if user else host
+
+    start = time.time()
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o", "ConnectTimeout=" + str(timeout),
+                "-o", "StrictHostKeyChecking=accept-new",
+                "-o", "BatchMode=yes",
+                target,
+                "echo ok",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 2,
+        )
+
+        if result.returncode == 0:
+            elapsed = time.time() - start
+            return int(elapsed * 1000)
+
+    except (subprocess.TimeoutExpired, Exception):
+        pass
+
+    return None
+
+
+def test_service_health(url: str, timeout: int = 5) -> tuple[bool, Optional[str]]:
+    """
+    Test if a service is responding.
+
+    Args:
+        url: Full URL to health endpoint
+        timeout: Request timeout in seconds
+
+    Returns:
+        Tuple of (is_healthy, error_message)
+    """
+    import urllib.request
+    import urllib.error
+    import ssl
+
+    try:
+        # Create SSL context that accepts self-signed certs
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as response:
+            if response.status == 200:
+                return True, None
+            return False, f"HTTP {response.status}"
+
+    except urllib.error.URLError as e:
+        return False, str(e.reason)
+    except Exception as e:
+        return False, str(e)

--- a/agentwire/validation.py
+++ b/agentwire/validation.py
@@ -1,0 +1,371 @@
+"""
+AgentWire configuration validation.
+
+Validates config and machines.json for consistency, providing actionable error messages.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from .config import Config, load_config
+
+
+@dataclass
+class ConfigWarning:
+    """Non-fatal config issue."""
+
+    message: str
+    context: dict = field(default_factory=dict)
+    suggestion: str = ""
+
+    def format_message(self) -> str:
+        """Format warning for display."""
+        lines = [f"WARNING: {self.message}"]
+        if self.context:
+            lines.append("")
+            lines.append("Context:")
+            for k, v in self.context.items():
+                lines.append(f"  {k}: {v}")
+        if self.suggestion:
+            lines.append("")
+            lines.append(f"Suggestion: {self.suggestion}")
+        return "\n".join(lines)
+
+
+@dataclass
+class ConfigError:
+    """Fatal config issue that must be fixed."""
+
+    message: str
+    context: dict = field(default_factory=dict)
+    fix_steps: List[str] = field(default_factory=list)
+
+    def format_message(self) -> str:
+        """Format error with WHAT/WHY/HOW."""
+        lines = [
+            f"ERROR: {self.message}",
+            "",
+            "Context:",
+        ]
+        for k, v in self.context.items():
+            lines.append(f"  {k}: {v}")
+        if self.fix_steps:
+            lines.append("")
+            lines.append("To fix:")
+            for i, step in enumerate(self.fix_steps, 1):
+                lines.append(f"  {i}. {step}")
+        return "\n".join(lines)
+
+
+def _load_machines(machines_file: Path) -> tuple[Optional[List[dict]], Optional[str]]:
+    """Load machines from JSON file.
+
+    Returns:
+        Tuple of (machines_list, error_message)
+    """
+    if not machines_file.exists():
+        return [], None  # Empty is valid, not an error
+
+    try:
+        with open(machines_file) as f:
+            data = json.load(f)
+            return data.get("machines", []), None
+    except json.JSONDecodeError as e:
+        return None, f"Invalid JSON: {e}"
+    except IOError as e:
+        return None, f"Cannot read file: {e}"
+
+
+def _validate_port(port: int, service_name: str, config_path: str) -> Optional[ConfigError]:
+    """Validate that a port is in valid range."""
+    if not isinstance(port, int) or port < 1 or port > 65535:
+        return ConfigError(
+            message=f"Invalid port {port}. Must be between 1 and 65535",
+            context={
+                "service": service_name,
+                "port": port,
+                "config_path": config_path,
+            },
+            fix_steps=[
+                f"Edit {config_path}",
+                f"Set {service_name} port to a valid value (1-65535)",
+            ],
+        )
+    return None
+
+
+def _validate_url(url: str, service_name: str, config_path: str) -> List[ConfigWarning]:
+    """Validate URL format and return warnings."""
+    warnings = []
+
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme:
+            warnings.append(ConfigWarning(
+                message=f"URL missing scheme in {service_name}",
+                context={"url": url, "service": service_name},
+                suggestion=f"Use full URL like 'http://{url}' or 'https://{url}'",
+            ))
+        if not parsed.netloc and not parsed.path:
+            warnings.append(ConfigWarning(
+                message=f"URL appears incomplete in {service_name}",
+                context={"url": url, "service": service_name},
+                suggestion="Use a complete URL like 'http://localhost:8100'",
+            ))
+    except Exception:
+        warnings.append(ConfigWarning(
+            message=f"Could not parse URL in {service_name}",
+            context={"url": url, "service": service_name},
+            suggestion="Check URL format",
+        ))
+
+    return warnings
+
+
+def _get_machine_ids(machines: List[dict]) -> set:
+    """Extract machine IDs from machines list."""
+    return {m.get("id") for m in machines if m.get("id")}
+
+
+def validate_config(
+    config: Config,
+    machines_file: Path,
+) -> tuple[List[ConfigWarning], List[ConfigError]]:
+    """
+    Validate config and return issues.
+
+    Checks:
+    - services.*.machine references exist in machines.json
+    - ports are valid (1-65535)
+    - Referenced files exist
+    - URL formats are valid
+
+    Args:
+        config: Loaded Config object
+        machines_file: Path to machines.json
+
+    Returns:
+        Tuple of (warnings, errors)
+    """
+    warnings: List[ConfigWarning] = []
+    errors: List[ConfigError] = []
+
+    config_path = "~/.agentwire/config.yaml"
+
+    # Load machines
+    machines, load_error = _load_machines(machines_file)
+    if load_error:
+        errors.append(ConfigError(
+            message=f"Cannot read machines.json: {load_error}",
+            context={
+                "file": str(machines_file),
+            },
+            fix_steps=[
+                "Run: agentwire init",
+                f"Or fix the file manually: {machines_file}",
+            ],
+        ))
+        # Can't validate machine references without valid machines.json
+        machines = []
+
+    machine_ids = _get_machine_ids(machines) if machines else set()
+
+    # Validate server port
+    port_error = _validate_port(config.server.port, "server", config_path)
+    if port_error:
+        errors.append(port_error)
+
+    # Validate TTS URL
+    warnings.extend(_validate_url(config.tts.url, "tts", config_path))
+
+    # Validate portal URL
+    warnings.extend(_validate_url(config.portal.url, "portal", config_path))
+
+    # Check if machines.json exists when expected
+    if not machines_file.exists():
+        warnings.append(ConfigWarning(
+            message="No machines.json found",
+            context={"expected_path": str(machines_file)},
+            suggestion="Run 'agentwire init' to create configuration files",
+        ))
+
+    # Validate SSL config
+    ssl = config.server.ssl
+    if ssl.cert and not ssl.cert.exists():
+        warnings.append(ConfigWarning(
+            message="SSL certificate file not found",
+            context={"path": str(ssl.cert)},
+            suggestion="Run 'agentwire generate-certs' to create SSL certificates",
+        ))
+    if ssl.key and not ssl.key.exists():
+        warnings.append(ConfigWarning(
+            message="SSL key file not found",
+            context={"path": str(ssl.key)},
+            suggestion="Run 'agentwire generate-certs' to create SSL certificates",
+        ))
+
+    # Validate uploads directory parent exists
+    uploads_parent = config.uploads.dir.parent
+    if not uploads_parent.exists():
+        warnings.append(ConfigWarning(
+            message="Uploads directory parent does not exist",
+            context={"path": str(config.uploads.dir)},
+            suggestion=f"Create the directory: mkdir -p {config.uploads.dir}",
+        ))
+
+    # Validate rooms.json exists
+    if not config.rooms.file.exists():
+        warnings.append(ConfigWarning(
+            message="No rooms.json found",
+            context={"expected_path": str(config.rooms.file)},
+            suggestion="Run 'agentwire init' to create configuration files",
+        ))
+
+    # Validate each machine in machines.json has required fields
+    if machines:
+        for machine in machines:
+            machine_id = machine.get("id")
+            if not machine_id:
+                errors.append(ConfigError(
+                    message="Machine entry missing 'id' field",
+                    context={
+                        "machine": str(machine),
+                        "file": str(machines_file),
+                    },
+                    fix_steps=[
+                        f"Edit {machines_file}",
+                        "Add 'id' field to the machine entry",
+                    ],
+                ))
+                continue
+
+            if not machine.get("host"):
+                errors.append(ConfigError(
+                    message=f"Machine '{machine_id}' missing 'host' field",
+                    context={
+                        "machine_id": machine_id,
+                        "file": str(machines_file),
+                    },
+                    fix_steps=[
+                        f"Edit {machines_file}",
+                        f"Add 'host' field for machine '{machine_id}'",
+                        "Example: \"host\": \"192.168.1.50\" or \"host\": \"my-server.local\"",
+                    ],
+                ))
+
+    return warnings, errors
+
+
+def validate_machine_reference(
+    machine_id: str,
+    service_name: str,
+    machines_file: Path,
+) -> Optional[ConfigError]:
+    """
+    Validate that a machine reference exists in machines.json.
+
+    Used for services that reference machines (e.g., TTS on remote machine).
+
+    Args:
+        machine_id: The machine ID being referenced
+        service_name: Name of the service referencing the machine
+        machines_file: Path to machines.json
+
+    Returns:
+        ConfigError if machine not found, None if valid
+    """
+    machines, load_error = _load_machines(machines_file)
+
+    if load_error:
+        return ConfigError(
+            message=f"Cannot validate machine reference: {load_error}",
+            context={
+                "machine": machine_id,
+                "service": service_name,
+                "file": str(machines_file),
+            },
+            fix_steps=[
+                "Run: agentwire init",
+                f"Or fix the file manually: {machines_file}",
+            ],
+        )
+
+    machine_ids = _get_machine_ids(machines) if machines else set()
+
+    if machine_id not in machine_ids:
+        # Build helpful error with available machines
+        available = ", ".join(sorted(machine_ids)) if machine_ids else "(none registered)"
+
+        return ConfigError(
+            message=f"Unknown machine '{machine_id}' in services.{service_name}.machine",
+            context={
+                "service": service_name,
+                "machine": machine_id,
+                "config_path": "~/.agentwire/config.yaml",
+                "available_machines": available,
+            },
+            fix_steps=[
+                f"Add the machine:    agentwire machine add {machine_id} --host <ip-or-hostname>",
+                f"Fix the config:     Edit ~/.agentwire/config.yaml services.{service_name}.machine",
+            ],
+        )
+
+    return None
+
+
+def cmd_config_validate(args=None) -> int:
+    """Run all config validation checks.
+
+    Args:
+        args: Optional argparse namespace (for CLI integration)
+
+    Returns:
+        0 if no errors, 1 if errors found
+    """
+    # Load config
+    try:
+        config = load_config()
+    except Exception as e:
+        print(f"ERROR: Failed to load config: {e}")
+        print("")
+        print("To fix:")
+        print("  1. Run: agentwire init")
+        print("  2. Or check ~/.agentwire/config.yaml for syntax errors")
+        return 1
+
+    # Run validation
+    warnings, errors = validate_config(config, config.machines.file)
+
+    # Print results
+    if not warnings and not errors:
+        print("Config validation passed. No issues found.")
+        print("")
+        print("Files checked:")
+        print(f"  - ~/.agentwire/config.yaml")
+        print(f"  - {config.machines.file}")
+        print(f"  - {config.rooms.file}")
+        return 0
+
+    # Print warnings first
+    if warnings:
+        print(f"Found {len(warnings)} warning(s):\n")
+        for i, warning in enumerate(warnings, 1):
+            print(f"[{i}] {warning.format_message()}")
+            print("")
+
+    # Print errors
+    if errors:
+        print(f"Found {len(errors)} error(s):\n")
+        for i, error in enumerate(errors, 1):
+            print(f"[{i}] {error.format_message()}")
+            print("")
+        print("To see registered machines: agentwire machine list")
+
+    # Summary
+    print("---")
+    print(f"Summary: {len(warnings)} warning(s), {len(errors)} error(s)")
+
+    return 1 if errors else 0

--- a/examples/config-distributed.yaml
+++ b/examples/config-distributed.yaml
@@ -1,5 +1,13 @@
 # AgentWire Distributed Configuration Example
 # For setups with components on different machines
+#
+# This example shows a multi-machine setup:
+#   - Portal runs on your laptop/desktop (orchestrator)
+#   - TTS runs on a GPU server (for Chatterbox voice synthesis)
+#   - STT runs locally (uses laptop's Neural Engine on macOS)
+#   - Sessions can run locally or on remote machines
+#
+# Required: machines.json must have "gpu-server" defined
 
 # === Server (runs on orchestrator machine) ===
 server:
@@ -8,8 +16,8 @@ server:
   ssl:
     cert: "~/.agentwire/cert.pem"
     key: "~/.agentwire/key.pem"
-  
-  # Public URL that clients use to connect
+
+  # Public URL that clients use to connect (for phones/tablets on LAN)
   public_url: "https://mac-mini.local:8765"
 
 # === Projects ===
@@ -19,18 +27,37 @@ projects:
     enabled: true
     suffix: "-worktrees"
 
-# === TTS (remote GPU server) ===
+# === Service Locations (Network Topology) ===
+# This is the key section for distributed setups.
+# AgentWire uses this to determine which tunnels to create.
+services:
+  # Portal runs locally (where you run `agentwire portal start`)
+  portal:
+    machine: null               # null = this machine
+    port: 8765
+    health_endpoint: "/health"
+
+  # TTS runs on GPU server (requires tunnel)
+  # When you run `agentwire tunnels up`, it creates:
+  #   ssh -L 8100:localhost:8100 -N -f developer@192.168.1.50
+  tts:
+    machine: "gpu-server"       # Must exist in machines.json
+    port: 8100
+    health_endpoint: "/health"
+
+# === TTS Backend Settings ===
 tts:
   backend: "chatterbox"
-  
-  # Point to remote TTS server
-  url: "http://gpu-server:8100"
-  
+
+  # This URL is used AFTER the tunnel is created
+  # Tunnel maps localhost:8100 -> gpu-server:8100
+  url: "http://localhost:8100"
+
   default_voice: "default"
   exaggeration: 0.5
   cfg_weight: 0.5
 
-# === STT (local on orchestrator) ===
+# === STT (local on orchestrator - uses Apple Neural Engine on macOS) ===
 stt:
   backend: "whisperkit"
   model_path: "~/models/whisperkit/large-v3"
@@ -40,9 +67,21 @@ stt:
 agent:
   command: "claude --dangerously-skip-permissions"
 
-# === Machines (define all remote hosts) ===
+# === Remote Machines Registry ===
 machines:
   file: "~/.agentwire/machines.json"
 
 rooms:
   file: "~/.agentwire/rooms.json"
+
+# === Usage ===
+# 1. Ensure machines.json has gpu-server defined
+# 2. Run: agentwire tunnels up    (creates SSH tunnels)
+# 3. Run: agentwire portal start  (starts web UI)
+# 4. On GPU server: agentwire tts start
+# 5. Access portal at https://localhost:8765
+#
+# Diagnostics:
+#   agentwire network status    # Check all services
+#   agentwire tunnels status    # Check tunnels
+#   agentwire doctor            # Auto-fix issues

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -8,7 +8,7 @@ server:
   ssl:
     cert: "~/.agentwire/cert.pem"
     key: "~/.agentwire/key.pem"
-  
+
   # Public URL for clients (when behind proxy or on different network)
   # public_url: "https://myserver.local:8765"
 
@@ -24,11 +24,11 @@ projects:
 tts:
   # Backend: chatterbox | elevenlabs | none
   backend: "chatterbox"
-  
+
   # TTS server URL - can be local or remote
   url: "http://localhost:8100"
   # Remote example: url: "http://gpu-server:8100"
-  
+
   # Default voice settings
   default_voice: "default"
   exaggeration: 0.5            # 0-1, voice expressiveness
@@ -41,10 +41,10 @@ stt:
   #   Linux: whispercpp, openai
   #   Any:   openai (requires API key)
   backend: "whisperkit"
-  
+
   # Local model path (for whisperkit/whispercpp)
   model_path: "~/models/whisperkit/large-v3"
-  
+
   # Language for transcription
   language: "en"
 
@@ -53,6 +53,24 @@ agent:
   # Command to start AI agent in new sessions
   # Placeholders: {name}, {path}, {model}
   command: "claude --dangerously-skip-permissions"
+
+# === Service Locations (Network Topology) ===
+# Define where each service runs. For single-machine setups,
+# leave machine as null (or omit entirely) - no tunnels needed.
+services:
+  # Portal (web UI, WebSocket server)
+  portal:
+    machine: null               # null = runs on this machine
+    port: 8765
+    health_endpoint: "/health"
+
+  # TTS server (Chatterbox voice synthesis)
+  tts:
+    machine: null               # null = runs locally
+    port: 8100
+    health_endpoint: "/health"
+    # For remote TTS on GPU server, use:
+    # machine: "gpu-server"     # Must exist in machines.json
 
 # === Remote Machines Registry ===
 machines:


### PR DESCRIPTION
## Summary
- Adds service location transparency so CLI commands work identically from any machine
- Implements SSH tunnel management with PID tracking for multi-machine topologies
- Makes portal and TTS commands remote-aware (can start/stop on any configured machine)
- Adds config validation with actionable WHAT/WHY/HOW error messages
- Adds network status and doctor commands for debugging connectivity issues

## Test plan
- [ ] Run `agentwire init` on a fresh machine to test guided onboarding
- [ ] Test `agentwire tunnels up/down/status` with multi-machine config
- [ ] Test `agentwire portal start` when portal.machine is set to a remote machine
- [ ] Test `agentwire network status` and `agentwire doctor` commands
- [ ] Verify config validation catches missing machines and invalid service references

Built by [dotdev.dev](https://dotdev.dev)