### PR TITLE
feat: implement session templates for pre-configured session setups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ agentwire say --room api "Done"  # Send TTS to room
 # Session management
 agentwire list                              # List sessions from ALL machines
 agentwire new -s <name> [-p path] [-f]      # Create Claude Code session
+agentwire new -s <name> -t <template>       # Create session with template
 agentwire new -s <name> --restricted        # Create restricted mode session
 agentwire output -s <session> [-n lines]    # Read recent session output
 agentwire kill -s <session>                 # Clean shutdown (/exit then kill)
@@ -113,6 +114,13 @@ agentwire fork -s <source> -t <target>      # Fork session (preserves conversati
 agentwire machine list                # List machines with status
 agentwire machine add <id> [options]  # Add a machine to portal
 agentwire machine remove <id>         # Remove with cleanup
+
+# Session templates
+agentwire template list               # List available templates
+agentwire template show <name>        # Show template details
+agentwire template create <name>      # Create new template interactively
+agentwire template delete <name>      # Delete a template
+agentwire template install-samples    # Install sample templates
 
 # Skills (Claude Code integration)
 agentwire skills install              # Install Claude Code skills
@@ -209,6 +217,7 @@ All config lives in `~/.agentwire/`:
 | `config.yaml` | Main configuration |
 | `machines.json` | Remote machine registry |
 | `rooms.json` | Per-session settings (voice, role, model) |
+| `templates/*.yaml` | Session templates (voice, initial prompt, settings) |
 | `roles/*.md` | Role context files for Claude sessions |
 | `cert.pem`, `key.pem` | SSL certificates |
 
@@ -238,6 +247,86 @@ projects:
   worktrees:
     enabled: true
 ```
+
+---
+
+## Session Templates
+
+Session templates provide pre-configured settings for common use cases: initial prompts, voice, permission modes, and more.
+
+### Template CLI Commands
+
+```bash
+# List available templates
+agentwire template list
+
+# Show template details
+agentwire template show <name>
+
+# Create a new template (interactive)
+agentwire template create <name>
+
+# Install sample templates
+agentwire template install-samples
+
+# Delete a template
+agentwire template delete <name>
+```
+
+### Using Templates
+
+```bash
+# Create session with a template
+agentwire new -s my-project -t code-review
+
+# Template settings apply:
+# - Voice
+# - Permission mode (bypass/normal/restricted)
+# - Initial prompt (sent after Claude is ready)
+```
+
+### Template File Format
+
+Templates are YAML files in `~/.agentwire/templates/`:
+
+```yaml
+name: code-review
+description: Review code and find bugs
+voice: bashbunni
+initial_prompt: |
+  Review the codebase and provide:
+  1. Code quality issues
+  2. Potential bugs
+  3. Performance improvements
+
+  Start by exploring the project structure.
+bypass_permissions: true
+restricted: false
+```
+
+### Template Variables
+
+Use these in `initial_prompt` - they're expanded when the session starts:
+
+| Variable | Description |
+|----------|-------------|
+| `{{project_name}}` | Project name from session |
+| `{{branch}}` | Git branch (if worktree session) |
+| `{{machine}}` | Machine ID (if remote) |
+
+### Sample Templates
+
+Install sample templates with:
+
+```bash
+agentwire template install-samples
+```
+
+Included samples:
+- `code-review` - Review code, find bugs, suggest improvements
+- `feature-impl` - Implement features with planning
+- `bug-fix` - Systematic bug investigation and fixing
+- `voice-assistant` - Voice-only assistant (restricted mode)
 
 ---
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -145,6 +145,79 @@ class UploadsConfig:
 
 
 @dataclass
+class TemplatesConfig:
+    """Session templates configuration."""
+
+    dir: Path = field(
+        default_factory=lambda: Path.home() / ".agentwire" / "templates"
+    )
+
+    def __post_init__(self):
+        self.dir = _expand_path(self.dir) or self.dir
+
+
+@dataclass
+class Template:
+    """A session template with pre-configured settings.
+
+    Stored as YAML files in ~/.agentwire/templates/
+    """
+
+    name: str
+    description: str = ""
+    role: str | None = None  # Role file from ~/.agentwire/roles/
+    voice: str | None = None  # TTS voice
+    project: str | None = None  # Default project path
+    initial_prompt: str = ""  # Context sent to Claude on session start
+    bypass_permissions: bool = True  # Permission mode
+    restricted: bool = False  # Restricted mode
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for YAML serialization."""
+        d = {
+            "name": self.name,
+            "description": self.description,
+            "initial_prompt": self.initial_prompt,
+            "bypass_permissions": self.bypass_permissions,
+            "restricted": self.restricted,
+        }
+        if self.role:
+            d["role"] = self.role
+        if self.voice:
+            d["voice"] = self.voice
+        if self.project:
+            d["project"] = self.project
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Template":
+        """Create Template from dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            role=data.get("role"),
+            voice=data.get("voice"),
+            project=data.get("project"),
+            initial_prompt=data.get("initial_prompt", ""),
+            bypass_permissions=data.get("bypass_permissions", True),
+            restricted=data.get("restricted", False),
+        )
+
+    def expand_variables(self, variables: dict[str, str]) -> str:
+        """Expand template variables in the initial prompt.
+
+        Supported variables:
+        - {{project_name}} - Name of the project/session
+        - {{branch}} - Current git branch
+        - {{machine}} - Machine ID if remote
+        """
+        prompt = self.initial_prompt
+        for key, value in variables.items():
+            prompt = prompt.replace(f"{{{{{key}}}}}", value or "")
+        return prompt
+
+
+@dataclass
 class PortalConfig:
     """Portal connection settings (for remote machines)."""
 
@@ -183,6 +256,7 @@ class Config:
     uploads: UploadsConfig = field(default_factory=UploadsConfig)
     portal: PortalConfig = field(default_factory=PortalConfig)
     services: ServicesConfig = field(default_factory=ServicesConfig)
+    templates: TemplatesConfig = field(default_factory=TemplatesConfig)
 
 
 def _merge_dict(base: dict, override: dict) -> dict:
@@ -345,6 +419,12 @@ def _dict_to_config(data: dict) -> Config:
         tts=tts_service,
     )
 
+    # Templates
+    templates_data = data.get("templates", {})
+    templates = TemplatesConfig(
+        dir=templates_data.get("dir", "~/.agentwire/templates"),
+    )
+
     return Config(
         server=server,
         projects=projects,
@@ -356,6 +436,7 @@ def _dict_to_config(data: dict) -> Config:
         uploads=uploads,
         portal=portal,
         services=services,
+        templates=templates,
     )
 
 
@@ -410,3 +491,122 @@ def reload_config(config_path: Optional[Path] = None) -> Config:
     global _config
     _config = load_config(config_path)
     return _config
+
+
+# =============================================================================
+# Template Management Functions
+# =============================================================================
+
+
+def load_templates(templates_dir: Optional[Path] = None) -> list[Template]:
+    """Load all templates from the templates directory.
+
+    Args:
+        templates_dir: Path to templates directory. Defaults to config's templates.dir
+
+    Returns:
+        List of Template objects sorted by name.
+    """
+    if templates_dir is None:
+        templates_dir = get_config().templates.dir
+
+    templates_dir = Path(templates_dir).expanduser().resolve()
+
+    if not templates_dir.exists():
+        return []
+
+    templates = []
+    for file_path in templates_dir.glob("*.yaml"):
+        try:
+            with open(file_path) as f:
+                data = yaml.safe_load(f) or {}
+            # Ensure name matches filename if not specified
+            if not data.get("name"):
+                data["name"] = file_path.stem
+            templates.append(Template.from_dict(data))
+        except Exception:
+            # Skip invalid template files
+            continue
+
+    return sorted(templates, key=lambda t: t.name)
+
+
+def load_template(name: str, templates_dir: Optional[Path] = None) -> Optional[Template]:
+    """Load a specific template by name.
+
+    Args:
+        name: Template name (without .yaml extension)
+        templates_dir: Path to templates directory. Defaults to config's templates.dir
+
+    Returns:
+        Template object if found, None otherwise.
+    """
+    if templates_dir is None:
+        templates_dir = get_config().templates.dir
+
+    templates_dir = Path(templates_dir).expanduser().resolve()
+    template_file = templates_dir / f"{name}.yaml"
+
+    if not template_file.exists():
+        return None
+
+    try:
+        with open(template_file) as f:
+            data = yaml.safe_load(f) or {}
+        if not data.get("name"):
+            data["name"] = name
+        return Template.from_dict(data)
+    except Exception:
+        return None
+
+
+def save_template(template: Template, templates_dir: Optional[Path] = None) -> bool:
+    """Save a template to disk.
+
+    Args:
+        template: Template object to save
+        templates_dir: Path to templates directory. Defaults to config's templates.dir
+
+    Returns:
+        True if saved successfully, False otherwise.
+    """
+    if templates_dir is None:
+        templates_dir = get_config().templates.dir
+
+    templates_dir = Path(templates_dir).expanduser().resolve()
+    templates_dir.mkdir(parents=True, exist_ok=True)
+
+    template_file = templates_dir / f"{template.name}.yaml"
+
+    try:
+        with open(template_file, "w") as f:
+            yaml.safe_dump(template.to_dict(), f, default_flow_style=False, sort_keys=False)
+        return True
+    except Exception:
+        return False
+
+
+def delete_template(name: str, templates_dir: Optional[Path] = None) -> bool:
+    """Delete a template from disk.
+
+    Args:
+        name: Template name (without .yaml extension)
+        templates_dir: Path to templates directory. Defaults to config's templates.dir
+
+    Returns:
+        True if deleted successfully, False otherwise.
+    """
+    if templates_dir is None:
+        templates_dir = get_config().templates.dir
+
+    templates_dir = Path(templates_dir).expanduser().resolve()
+    template_file = templates_dir / f"{name}.yaml"
+
+    if not template_file.exists():
+        return False
+
+    try:
+        template_file.unlink()
+        return True
+    except Exception:
+        return False

--- a/agentwire/sample_templates/bug-fix.yaml
+++ b/agentwire/sample_templates/bug-fix.yaml
@@ -1,0 +1,15 @@
+name: bug-fix
+description: Investigate and fix bugs systematically
+initial_prompt: |
+  I'm debugging an issue in {{project_name}}.
+
+  Approach:
+  1. Understand the bug report/symptoms
+  2. Reproduce the issue (find relevant tests or create one)
+  3. Locate the root cause
+  4. Implement a fix
+  5. Verify the fix works
+
+  Tell me about the bug.
+bypass_permissions: true
+restricted: false

--- a/agentwire/sample_templates/code-review.yaml
+++ b/agentwire/sample_templates/code-review.yaml
@@ -1,0 +1,12 @@
+name: code-review
+description: Review code, suggest improvements, find bugs
+initial_prompt: |
+  Review the codebase and provide:
+  1. Code quality issues or anti-patterns
+  2. Potential bugs or edge cases
+  3. Performance improvements
+  4. Security concerns
+
+  Start by exploring the project structure and understanding the architecture.
+bypass_permissions: true
+restricted: false

--- a/agentwire/sample_templates/feature-impl.yaml
+++ b/agentwire/sample_templates/feature-impl.yaml
@@ -1,0 +1,13 @@
+name: feature-impl
+description: Implement a feature with planning and tests
+initial_prompt: |
+  I'm working on {{project_name}}{{branch}}.
+
+  Before implementing anything:
+  1. Read relevant docs and code
+  2. Understand existing patterns
+  3. Create a todo list to track progress
+
+  Ask me what feature to implement.
+bypass_permissions: true
+restricted: false

--- a/agentwire/sample_templates/voice-assistant.yaml
+++ b/agentwire/sample_templates/voice-assistant.yaml
@@ -1,0 +1,20 @@
+name: voice-assistant
+description: Voice-only assistant (no code execution)
+voice: bashbunni
+initial_prompt: |
+  You are a voice-only assistant. Use `say "..."` for all responses.
+
+  You can:
+  - Answer questions about programming
+  - Explain concepts
+  - Discuss architecture decisions
+  - Provide code suggestions (spoken, not written)
+
+  You cannot:
+  - Edit files
+  - Run commands
+  - Make any changes to the codebase
+
+  Start by introducing yourself.
+bypass_permissions: false
+restricted: true

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -155,6 +155,11 @@ class AgentWireServer:
         self.app.router.add_get("/api/config", self.api_get_config)
         self.app.router.add_post("/api/config", self.api_save_config)
         self.app.router.add_post("/api/config/reload", self.api_reload_config)
+        # Template management
+        self.app.router.add_get("/api/templates", self.api_list_templates)
+        self.app.router.add_get("/api/templates/{name}", self.api_get_template)
+        self.app.router.add_post("/api/templates", self.api_create_template)
+        self.app.router.add_delete("/api/templates/{name}", self.api_delete_template)
         # Permission request handling (from Claude Code hook)
         # Note: respond route must come first as aiohttp matches in order
         self.app.router.add_post("/api/permission/{name:.+}/respond", self.api_permission_respond)
@@ -749,6 +754,7 @@ class AgentWireServer:
             machine: Machine ID ('local' or remote machine ID)
             worktree: Whether to create a worktree session
             branch: Branch name for worktree sessions
+            template: Template name to apply (optional)
 
         Session naming:
             - worktree + branch: project/branch (or project/branch@machine)
@@ -765,6 +771,7 @@ class AgentWireServer:
             machine = data.get("machine", "local")
             worktree = data.get("worktree", False)
             branch = data.get("branch", "").strip()
+            template_name = data.get("template")
 
             if not name:
                 return web.json_response({"error": "Session name is required"})
@@ -788,6 +795,9 @@ class AgentWireServer:
             # Pass -p when provided (CLI uses it to locate repo for worktree creation)
             if custom_path:
                 args.extend(["-p", custom_path])
+            # Pass template if provided
+            if template_name:
+                args.extend(["-t", template_name])
             # Restricted mode implies --no-bypass (needs permission hook to work)
             if restricted:
                 args.append("--restricted")
@@ -801,15 +811,18 @@ class AgentWireServer:
                 error_msg = result.get("error", "Failed to create session")
                 return web.json_response({"error": error_msg})
 
-            # CLI updates rooms.json with bypass_permissions/restricted, but we need to add voice
+            # CLI updates rooms.json with bypass_permissions/restricted and template voice
+            # We may still need to set voice if user selected one explicitly (overrides template)
             session_name = result.get("session", cli_session)
             configs = self._load_room_configs()
             if session_name not in configs:
                 configs[session_name] = {}
-            configs[session_name]["voice"] = voice
+            # Only set voice if explicitly provided (not using template default)
+            if voice != self.config.tts.default_voice or not template_name:
+                configs[session_name]["voice"] = voice
             self._save_room_configs(configs)
 
-            return web.json_response({"success": True, "name": session_name})
+            return web.json_response({"success": True, "name": session_name, "template": template_name})
 
         except Exception as e:
             logger.error(f"Failed to create session: {e}")
@@ -1165,6 +1178,71 @@ projects:
             return web.json_response({"success": True})
         except Exception as e:
             return web.json_response({"error": str(e)})
+
+    async def api_list_templates(self, request: web.Request) -> web.Response:
+        """List available session templates."""
+        from .config import load_templates
+
+        templates = load_templates()
+        return web.json_response([t.to_dict() for t in templates])
+
+    async def api_get_template(self, request: web.Request) -> web.Response:
+        """Get details of a specific template."""
+        from .config import load_template
+
+        name = request.match_info["name"]
+        template = load_template(name)
+
+        if template is None:
+            return web.json_response({"error": f"Template '{name}' not found"}, status=404)
+
+        return web.json_response(template.to_dict())
+
+    async def api_create_template(self, request: web.Request) -> web.Response:
+        """Create or update a session template."""
+        from .config import Template, save_template, load_template
+
+        try:
+            data = await request.json()
+            name = data.get("name", "").strip()
+
+            if not name:
+                return web.json_response({"error": "Template name is required"})
+
+            # Check if it already exists and overwrite not specified
+            if load_template(name) and not data.get("overwrite", False):
+                return web.json_response({"error": f"Template '{name}' already exists. Set overwrite=true to replace."})
+
+            template = Template(
+                name=name,
+                description=data.get("description", ""),
+                role=data.get("role"),
+                voice=data.get("voice"),
+                project=data.get("project"),
+                initial_prompt=data.get("initial_prompt", ""),
+                bypass_permissions=data.get("bypass_permissions", True),
+                restricted=data.get("restricted", False),
+            )
+
+            if save_template(template):
+                return web.json_response({"success": True, "template": template.to_dict()})
+            else:
+                return web.json_response({"error": "Failed to save template"})
+
+        except Exception as e:
+            logger.error(f"Failed to create template: {e}")
+            return web.json_response({"error": str(e)})
+
+    async def api_delete_template(self, request: web.Request) -> web.Response:
+        """Delete a session template."""
+        from .config import delete_template
+
+        name = request.match_info["name"]
+
+        if delete_template(name):
+            return web.json_response({"success": True})
+        else:
+            return web.json_response({"error": f"Template '{name}' not found or failed to delete"}, status=404)
 
     async def handle_transcribe(self, request: web.Request) -> web.Response:
         """Transcribe audio to text."""

--- a/agentwire/static/css/dashboard.css
+++ b/agentwire/static/css/dashboard.css
@@ -722,3 +722,33 @@
     outline: none;
     border-color: var(--primary);
 }
+
+/* =============================================================================
+   Template Selector
+   ============================================================================= */
+
+.template-preview {
+    margin-top: var(--space-sm);
+    padding: var(--space-sm);
+    background: rgba(0, 221, 0, 0.05);
+    border: 1px solid rgba(0, 221, 0, 0.2);
+    border-radius: var(--radius-sm);
+}
+
+.template-description {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-bottom: var(--space-sm);
+}
+
+.template-prompt {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    white-space: pre-wrap;
+    max-height: 100px;
+    overflow-y: auto;
+    padding: var(--space-sm);
+    background: var(--bg-dark);
+    border-radius: var(--radius-sm);
+}

--- a/agentwire/templates/dashboard.html
+++ b/agentwire/templates/dashboard.html
@@ -63,6 +63,17 @@
                                 </div>
                             </div>
                             <div class="form-row">
+                                <label>Template (optional)</label>
+                                <select id="sessionTemplate">
+                                    <option value="">None - Start fresh</option>
+                                    <!-- Populated from /api/templates -->
+                                </select>
+                                <div id="templatePreview" class="template-preview" style="display: none;">
+                                    <div class="template-description" id="templateDescription"></div>
+                                    <div class="template-prompt" id="templatePrompt"></div>
+                                </div>
+                            </div>
+                            <div class="form-row">
                                 <label>Voice</label>
                                 <select id="sessionVoice">
                                     {% for voice in voices %}

--- a/docs/missions/session-templates.md
+++ b/docs/missions/session-templates.md
@@ -65,11 +65,11 @@ Templates stored in `~/.agentwire/templates/` as YAML or JSON files.
 
 ## Completion Criteria
 
-- [ ] Can create a template via CLI or portal
-- [ ] Can create session with template applied
-- [ ] Initial prompt sent automatically to new session
-- [ ] Templates visible in portal Create Session form
-- [ ] Variables expanded in initial prompt
+- [x] Can create a template via CLI or portal
+- [x] Can create session with template applied
+- [x] Initial prompt sent automatically to new session
+- [x] Templates visible in portal Create Session form
+- [x] Variables expanded in initial prompt
 
 ## Example Template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["agentwire"]
-artifacts = ["agentwire/skills/*.md"]
+artifacts = ["agentwire/skills/*.md", "agentwire/sample_templates/*.yaml"]
 exclude = [
     "agentwire/static/*.xcf",
     "agentwire/static/*-blue.*",


### PR DESCRIPTION
## Summary
- Adds session templates that pre-load Claude with project-specific context when sessions start
- Templates are YAML files stored in `~/.agentwire/templates/` with optional role, voice, and permission settings
- Includes CLI commands (`template list/show/create/delete/install-samples`), `--template` flag for `agentwire new`, and portal UI integration

## Test plan
- [ ] Run `agentwire template install-samples` and verify templates appear with `agentwire template list`
- [ ] Create a session with `agentwire new -s test --template feature-impl` and verify initial prompt is sent
- [ ] Use portal Create Session form, select a template, and verify initial prompt delivery
- [ ] Verify template variable expansion ({{project_name}}, {{branch}}) in prompts

Built by [dotdev.dev](https://dotdev.dev)