### PR TITLE
Extract CLI and Portal docs from CLAUDE.md

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1,0 +1,381 @@
+# AgentWire CLI Reference
+
+> Complete CLI command reference. For project overview, see [CLAUDE.md](../CLAUDE.md).
+
+All session commands support the `session@machine` format for remote operations and `--json` for machine-readable output.
+
+```bash
+# Initialize configuration
+agentwire init
+
+# Portal (web server)
+agentwire portal start     # Start in tmux (agentwire-portal)
+agentwire portal serve     # Run in foreground (for debugging)
+agentwire portal stop      # Stop the portal
+agentwire portal status    # Check if running
+
+# TTS Server
+agentwire tts start        # Start Chatterbox in tmux (agentwire-tts)
+agentwire tts serve        # Run in foreground (for debugging)
+agentwire tts stop         # Stop TTS server
+agentwire tts status       # Check TTS status
+
+# Voice (smart routing: browser if connected, local if not)
+agentwire say "Hello"              # Auto-detect room from env/tmux
+agentwire say "Hello" -v voice     # Specify voice
+agentwire say "Hello" -r room      # Specify room explicitly
+
+# Voice input (push-to-talk recording)
+agentwire listen                      # Toggle recording (start/stop)
+agentwire listen start                # Start recording
+agentwire listen stop -s <session>    # Stop and send to session
+agentwire listen cancel               # Cancel recording
+
+# Voice cloning
+agentwire voiceclone start        # Start recording voice sample
+agentwire voiceclone stop <name>  # Stop and upload as voice clone
+agentwire voiceclone cancel       # Cancel current recording
+agentwire voiceclone list         # List available voices
+agentwire voiceclone delete <name>  # Delete a voice clone
+
+# Session management
+agentwire list                              # List sessions from ALL machines
+agentwire list --local                      # List only local sessions
+agentwire new -s <name> [-p path] [-f]      # Create Claude Code session
+agentwire new -s <name> -t <template>       # Create session with template
+agentwire new -s <name> --no-bypass         # Normal mode (permission prompts)
+agentwire new -s <name> --restricted        # Restricted mode (voice-only)
+agentwire new -s <name> --worker            # Worker session (autonomous)
+agentwire new -s <name> --orchestrator      # Orchestrator session (voice-first)
+agentwire output -s <session> [-n lines]    # Read recent session output
+agentwire kill -s <session>                 # Clean shutdown (/exit then kill)
+agentwire send -s <session> "prompt"        # Send prompt + Enter
+agentwire send-keys -s <session> "text" Enter  # Send keys with pause between
+agentwire recreate -s <name>                # Destroy and recreate with fresh worktree
+agentwire fork -s <source> -t <target>      # Fork session (preserves conversation)
+
+# Machine management
+agentwire machine list                # List machines with status
+agentwire machine add <id> [options]  # Add a machine to portal
+agentwire machine remove <id>         # Remove with cleanup
+
+# Session templates
+agentwire template list               # List available templates
+agentwire template show <name>        # Show template details
+agentwire template create <name>      # Create new template interactively
+agentwire template delete <name>      # Delete a template
+agentwire template install-samples    # Install sample templates
+
+# Safety & Security (Damage Control)
+agentwire safety check "command"      # Test if command would be blocked
+agentwire safety status               # Show pattern counts and recent blocks
+agentwire safety logs --tail 20       # Query audit logs
+agentwire safety install              # Install damage control hooks
+
+# Skills (Claude Code integration)
+agentwire skills install              # Install Claude Code skills
+agentwire skills status               # Check installation status
+agentwire skills uninstall            # Remove skills
+
+# Network & Tunnels
+agentwire network status              # Show complete network health
+agentwire tunnels up                  # Create all required SSH tunnels
+agentwire tunnels down                # Tear down all tunnels
+agentwire tunnels status              # Show tunnel health
+agentwire tunnels check               # Verify tunnels with health checks
+agentwire doctor                      # Auto-diagnose and fix common issues
+agentwire doctor --yes                # Auto-fix without prompting
+agentwire doctor --dry-run            # Show what would be fixed
+
+# Development
+agentwire dev              # Start orchestrator session (agentwire)
+agentwire rebuild          # Clear uv cache and reinstall from source
+agentwire uninstall        # Clear uv cache and remove tool
+agentwire generate-certs   # Generate SSL certificates
+```
+
+## Session Name Formats
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| `name` | `api` | Local session in ~/projects/api |
+| `project/branch` | `api/feature` | Local worktree session |
+| `name@machine` | `ml@gpu-server` | Remote session |
+| `project/branch@machine` | `ml/train@gpu-server` | Remote worktree session |
+| `name-fork-N` | `api-fork-1` | Forked session (auto-generated by `fork` command) |
+
+## Command Examples
+
+### List Sessions
+
+```bash
+# List all sessions (local + all machines)
+agentwire list
+
+# Output:
+# LOCAL:
+#   api: 1 window (~/projects/api)
+#   auth/feature: 1 window (~/projects/auth-worktrees/feature)
+#
+# dotdev-pc:
+#   ml: 1 window (~/projects/ml)
+#   training: 1 window (~/projects/training)
+
+# JSON output
+agentwire list --json
+# {"local": [{"name": "api", "windows": 1, "path": "/Users/dotdev/projects/api"}], "machines": {"dotdev-pc": [...]}}
+```
+
+### Create Sessions
+
+```bash
+# Local session (standard project)
+agentwire new -s api
+
+# Local worktree session
+agentwire new -s api/feature
+
+# Remote session
+agentwire new -s ml@gpu-server
+
+# Remote worktree session
+agentwire new -s ml/experiment@gpu-server
+
+# With custom path
+agentwire new -s api -p ~/custom/path
+
+# With template
+agentwire new -s api -t code-review
+
+# Restricted mode (voice-only)
+agentwire new -s assistant --restricted
+
+# JSON output
+agentwire new -s api/feature --json
+# {"success": true, "session": "api/feature", "path": "/Users/dotdev/projects/api-worktrees/feature", "branch": "feature", "machine": null}
+
+agentwire new -s ml@gpu-server --json
+# {"success": true, "session": "ml@gpu-server", "path": "/home/user/projects/ml", "branch": null, "machine": "gpu-server"}
+```
+
+### Send Prompts
+
+```bash
+# Send to local session
+agentwire send -s api "run the tests"
+
+# Send to local worktree session
+agentwire send -s api/feature "check the build"
+
+# Send to remote session
+agentwire send -s ml@gpu-server "start training"
+
+# Send to remote worktree session
+agentwire send -s ml/experiment@gpu-server "analyze results"
+
+# JSON output
+agentwire send -s api "run tests" --json
+# {"success": true, "session": "api", "message": "Prompt sent"}
+```
+
+### Read Output
+
+```bash
+# Read from local session (last 50 lines by default)
+agentwire output -s api
+
+# Read more lines
+agentwire output -s api -n 100
+
+# Read from local worktree session
+agentwire output -s api/feature -n 30
+
+# Read from remote session
+agentwire output -s ml@gpu-server -n 100
+
+# Read from remote worktree session
+agentwire output -s ml/experiment@gpu-server
+
+# JSON output
+agentwire output -s api --json
+# {"success": true, "session": "api", "output": "...", "lines": 50}
+```
+
+### Kill Sessions
+
+```bash
+# Kill local session
+agentwire kill -s api
+
+# Kill local worktree session (also removes worktree)
+agentwire kill -s api/feature
+
+# Kill remote session
+agentwire kill -s ml@gpu-server
+
+# Kill remote worktree session (removes remote worktree)
+agentwire kill -s ml/experiment@gpu-server
+
+# JSON output
+agentwire kill -s api --json
+# {"success": true, "session": "api", "message": "Session killed"}
+```
+
+### Recreate Sessions (Fresh Worktree)
+
+```bash
+# Recreate local worktree session
+# 1. Kills session and removes worktree
+# 2. Pulls latest from main branch
+# 3. Creates fresh worktree
+# 4. Starts new Claude Code session
+agentwire recreate -s api/feature
+
+# Recreate remote worktree session
+agentwire recreate -s ml/experiment@gpu-server
+
+# JSON output
+agentwire recreate -s api/feature --json
+# {"success": true, "session": "api/feature", "path": "/Users/dotdev/projects/api-worktrees/feature", "branch": "feature", "recreated": true}
+```
+
+### Fork Sessions (Preserve Conversation)
+
+```bash
+# Fork local session (creates api-fork-1)
+agentwire fork -s api -t api-fork-1
+
+# Fork local worktree session (creates new worktree)
+agentwire fork -s api/feature -t api/experiment
+
+# Fork remote session
+agentwire fork -s ml@gpu-server -t ml-fork-1@gpu-server
+
+# Fork remote worktree session
+agentwire fork -s ml/train@gpu-server -t ml/test@gpu-server
+
+# JSON output
+agentwire fork -s api -t api-fork-1 --json
+# {"success": true, "source": "api", "target": "api-fork-1", "forked": true, "path": "/Users/dotdev/projects/api"}
+```
+
+## Worktree Session Patterns
+
+When worktrees are enabled (`projects.worktrees.enabled: true`), sessions with `/` in the name trigger worktree creation:
+
+```bash
+# Pattern: project/branch creates worktree at ~/projects/{project}-worktrees/{branch}/
+
+# Local worktree
+agentwire new -s api/feature
+# -> Creates: ~/projects/api-worktrees/feature/
+# -> Branch: feature
+# -> Session: api/feature
+
+# Remote worktree
+agentwire new -s ml/experiment@gpu-server
+# -> Creates: /home/user/projects/ml-worktrees/experiment/
+# -> Branch: experiment
+# -> Session: ml/experiment@gpu-server
+
+# Recreate pattern (fresh start)
+agentwire recreate -s api/feature
+# 1. Kill session + remove worktree
+# 2. Pull latest main
+# 3. Create fresh worktree from main
+# 4. Start new session
+
+# Fork pattern (preserve context)
+agentwire fork -s api/feature -t api/experiment
+# 1. Create new worktree (api/experiment)
+# 2. Fork Claude conversation context
+# 3. New session can continue from where original left off
+```
+
+## JSON Output Examples
+
+All commands support `--json` for machine-readable output. Examples:
+
+```bash
+# List sessions
+agentwire list --json
+{
+  "local": [
+    {"name": "api", "windows": 1, "path": "/Users/dotdev/projects/api"},
+    {"name": "api/feature", "windows": 1, "path": "/Users/dotdev/projects/api-worktrees/feature"}
+  ],
+  "machines": {
+    "dotdev-pc": [
+      {"name": "ml", "windows": 1, "path": "/home/user/projects/ml"}
+    ],
+    "gpu-server": [
+      {"name": "training", "windows": 1, "path": "/home/user/projects/training"}
+    ]
+  }
+}
+
+# Create session
+agentwire new -s api/feature --json
+{
+  "success": true,
+  "session": "api/feature",
+  "path": "/Users/dotdev/projects/api-worktrees/feature",
+  "branch": "feature",
+  "machine": null
+}
+
+# Create remote session
+agentwire new -s ml@gpu-server --json
+{
+  "success": true,
+  "session": "ml@gpu-server",
+  "path": "/home/user/projects/ml",
+  "branch": null,
+  "machine": "gpu-server"
+}
+
+# Send prompt
+agentwire send -s api "run tests" --json
+{
+  "success": true,
+  "session": "api",
+  "message": "Prompt sent"
+}
+
+# Read output
+agentwire output -s api --json
+{
+  "success": true,
+  "session": "api",
+  "output": "...",
+  "lines": 50
+}
+
+# Kill session
+agentwire kill -s api/feature --json
+{
+  "success": true,
+  "session": "api/feature",
+  "message": "Session killed, worktree removed"
+}
+
+# Recreate session
+agentwire recreate -s api/feature --json
+{
+  "success": true,
+  "session": "api/feature",
+  "path": "/Users/dotdev/projects/api-worktrees/feature",
+  "branch": "feature",
+  "recreated": true
+}
+
+# Fork session
+agentwire fork -s api -t api-fork-1 --json
+{
+  "success": true,
+  "source": "api",
+  "target": "api-fork-1",
+  "forked": true,
+  "path": "/Users/dotdev/projects/api"
+}
+```

--- a/docs/PORTAL.md
+++ b/docs/PORTAL.md
@@ -1,0 +1,344 @@
+# AgentWire Portal Features
+
+> Web portal documentation. For project overview, see [CLAUDE.md](../CLAUDE.md). For CLI commands, see [CLI-REFERENCE.md](./CLI-REFERENCE.md).
+
+## Portal Modes
+
+The portal provides three distinct modes for interacting with Claude Code sessions. All modes can work simultaneously - you can switch between them without disconnecting.
+
+### Ambient Mode
+
+Voice-first, minimal UI focused on conversational interaction.
+
+**Features:**
+- Animated orb visualization showing session state
+- Push-to-talk voice input
+- TTS audio playback
+- AskUserQuestion popups
+- Permission modals (for normal/restricted sessions)
+
+**Use for:**
+- Hands-free interaction
+- Casual queries and conversation
+- Voice-driven workflows
+- Monitoring session activity at a glance
+
+**State indicators:**
+
+| State | Color | Meaning |
+|-------|-------|---------|
+| Ready | Green | Idle, waiting for input |
+| Listening | Yellow | Recording voice input |
+| Processing | Purple | Transcribing or agent working |
+| Generating | Blue | TTS generating voice |
+| Speaking | Green | Playing audio response |
+
+### Monitor Mode
+
+Read-only terminal output with text input for sending prompts.
+
+**Features:**
+- Live terminal output via `tmux capture-pane` polling
+- Text input area for sending prompts
+- AskUserQuestion popups
+- Permission modals with diff preview
+- Multiline input support (Enter to send, Shift+Enter for newline)
+
+**Use for:**
+- Observing Claude work in real-time
+- Sending text prompts without voice
+- Guided interaction with popups and modals
+- Reading session output without full terminal features
+
+**How it works:**
+- Polls `tmux capture-pane` every 500ms for output
+- Sends input via `tmux send-keys`
+- One-way display (read-only, not a real terminal)
+- Works even when Terminal mode is connected
+
+### Terminal Mode
+
+Full interactive terminal via xterm.js attached to tmux session.
+
+**Features:**
+- Real terminal emulation (xterm.js)
+- Connected via `tmux attach` over WebSocket
+- Full readline, vim, tab completion support
+- Bidirectional input/output
+- Hardware acceleration (WebGL when available)
+- Clickable URLs (via xterm-addon-web-links)
+- Auto-resize on browser window changes
+- Terminal size shown in status (e.g., "Connected (120x40)")
+
+**Use for:**
+- Real development work
+- Using vim, emacs, or other TUI editors
+- Interactive commands (Python REPL, database shells)
+- Full shell features (tab completion, command history)
+- When Monitor mode's read-only view isn't enough
+
+**Activation:**
+1. Click Terminal tab
+2. Click "Activate Interactive Terminal" button
+3. Terminal connects via WebSocket to tmux session
+4. Terminal stays connected even when switching to other modes
+
+**Keyboard shortcuts** (only active when Terminal tab visible):
+
+| Shortcut | Action |
+|----------|--------|
+| Cmd/Ctrl+K | Clear terminal (sends `clear` command) |
+| Cmd/Ctrl+D | Disconnect terminal |
+
+**Copy/paste:**
+- Cmd/Ctrl+C, Cmd/Ctrl+V work natively
+- Middle-click paste on Linux supported
+- No UI hints shown (relies on standard browser behavior)
+
+**Theme:**
+- Automatically matches portal theme (dark/light)
+- Updates when portal theme changes
+
+**Desktop-only:**
+- Terminal mode disabled on mobile/tablet devices
+- Shows message: "Terminal mode requires desktop browser"
+
+**Connection states:**
+
+| State | Indicator | Meaning |
+|-------|-----------|---------|
+| Connected | Green | Active connection to tmux session |
+| Connecting | Yellow | WebSocket establishing connection |
+| Disconnected | Red | Connection lost or not started |
+| Error | Amber | Connection failed, reconnect available |
+
+**Error handling:**
+- Shows user-friendly error messages
+- Provides "Reconnect" button on failure
+- Gracefully handles session termination
+- Cleans up WebSocket on disconnect
+
+### Simultaneous Operation
+
+**All three modes work together:**
+
+1. **Monitor + Terminal** - Monitor polling continues while Terminal is connected. Both see the same session output.
+2. **Voice + Terminal** - Can use voice input in Ambient mode while Terminal mode shows the terminal.
+3. **Local tmux + Portal** - Your local `tmux attach` works alongside both Monitor and Terminal modes. All attachments see the same session.
+
+**Input from any mode appears in all modes:**
+- Type in Monitor text input -> appears in Terminal
+- Type in Terminal -> appears in Monitor output
+- Voice prompt in Ambient -> appears in both Monitor and Terminal
+
+**Why this works:**
+- Monitor uses `tmux capture-pane` (read-only, doesn't interfere)
+- Terminal uses `tmux attach` (one of many possible attachments)
+- tmux allows multiple simultaneous attachments
+- All modes read from the same tmux session
+
+## Room UI Controls
+
+The room page header provides device and voice controls:
+
+| Control | Purpose |
+|---------|---------|
+| Mode tabs | Switch between Ambient, Monitor, and Terminal modes |
+| Mic selector | Choose audio input device (saved to localStorage) |
+| Speaker selector | Choose audio output device (Chrome/Edge only) |
+| Voice selector | TTS voice for this room (saved to rooms.json) |
+
+**Mode persistence:** Last selected mode is remembered per room in localStorage. Reloading the page restores your previous mode.
+
+**Activity detection:** The portal auto-detects session activity - if any output appears (even from manual commands), the orb switches to Processing state. Returns to Ready after 10s of inactivity.
+
+## Image Attachments
+
+Attach images to messages for debugging, sharing screenshots, or reference:
+
+| Method | Description |
+|--------|-------------|
+| Paste (Ctrl/Cmd+V) | Paste image from clipboard |
+| Attach button | Click to select image file |
+
+Images are uploaded to the configured `uploads.dir` and referenced in messages using Claude Code's `@/path/to/file` syntax. Configure in `config.yaml`:
+
+```yaml
+uploads:
+  dir: "~/.agentwire/uploads"  # Should be accessible from all machines
+  max_size_mb: 10
+  cleanup_days: 7              # Auto-delete old uploads
+```
+
+## Multiline Text Input
+
+The text input area supports multiline messages with auto-resize:
+
+| Action | Result |
+|--------|--------|
+| Type text | Textarea auto-expands as content grows |
+| **Enter** | Submits the message |
+| **Shift+Enter** | Adds a newline (for multi-paragraph messages) |
+| Clear text | Textarea collapses back to single line |
+
+The textarea starts as a single line and dynamically expands up to 10 lines before scrolling. This provides a natural typing experience for both quick single-line messages and longer multi-paragraph prompts.
+
+## Voice Output
+
+Claude (or users) can trigger TTS using the unified `agentwire say` command:
+
+```bash
+agentwire say "Hello world"          # Smart routing to browser or local
+agentwire say "Message" -v voice     # Specify voice
+agentwire say "Message" -r room      # Specify room
+```
+
+**How it works:**
+
+1. Command detects room from `--room`, `AGENTWIRE_ROOM` env var, or tmux session name
+2. Checks if portal has active browser connections for that room
+3. If connected -> Sends to portal (plays on browser/tablet)
+4. If not connected -> Generates locally and plays via system audio
+
+**Room detection priority:**
+1. `--room` argument (explicit)
+2. `AGENTWIRE_ROOM` env var (set automatically when session is created)
+3. Current tmux session name (if running in tmux)
+
+**For remote sessions:** `AGENTWIRE_ROOM` includes `@machine` suffix (e.g., `myproject@dotdev-pc`)
+
+TTS audio includes 300ms silence padding to prevent first-syllable cutoff.
+
+## AskUserQuestion Popup
+
+When Claude Code uses the AskUserQuestion tool, the portal displays a modal with clickable options:
+
+- Question text is spoken aloud via TTS when the popup appears
+- Click any option to submit the answer
+- "Type something" options show a text input with Send button
+- Supports multi-line questions
+
+## Actions Menu (Terminal Mode)
+
+In monitor mode, a menu button appears above the mic button. Hover over action buttons to see labels.
+
+**For regular project sessions:**
+
+| Action | Icon | Description |
+|--------|------|-------------|
+| New Room | + | Creates a sibling session in a new worktree, opens in new tab (parallel work) |
+| Fork Session | Fork | Forks the Claude Code conversation context into a new session (preserves history) |
+| Recreate Session | Refresh | Destroys current session/worktree, pulls latest, creates fresh worktree and Claude Code session |
+
+**Fork Session** uses Claude Code's `--resume <id> --fork-session` to create a new session that inherits the conversation context. Creates sessions named `project-fork-1`, `project-fork-2`, etc. Useful when you want to try different approaches without losing the current session's progress.
+
+**For system sessions** (`agentwire`, `agentwire-portal`, `agentwire-tts`):
+
+| Action | Icon | Description |
+|--------|------|-------------|
+| Restart Service | Refresh | Properly restarts the service (portal schedules delayed restart, TTS stops/starts, orchestrator restarts Claude) |
+
+## Create Session Form
+
+The dashboard's Create Session form supports machine selection, input validation, git detection, and worktree creation:
+
+| Field | Description |
+|-------|-------------|
+| Session Name | Project name (blocks `@ / \ : * ? " < > |` and spaces) |
+| Machine | Dropdown: Local or any configured remote machine |
+| Project Path | Auto-fills to `{projectsDir}/{sessionName}` (editable) |
+| Voice | TTS voice for the room |
+| Permission Mode | Bypass (recommended) or Normal (prompted) |
+
+**Git Repository Detection:**
+When the project path points to a git repo, additional options appear:
+- Current branch indicator (e.g., "on main")
+- **Create worktree** checkbox (checked by default)
+- **Branch Name** input with auto-suggested unique name (e.g., `jan-3-2026--1`)
+
+**Smart Defaults:**
+- Session name auto-fills path: typing `api` -> `~/projects/api`
+- Machine selection updates path placeholder to remote's `projects_dir`
+- Branch names auto-increment to avoid conflicts
+- Last selected machine is remembered in localStorage
+
+**Session Name Derivation:**
+
+| Machine | Worktree | CLI Session Name |
+|---------|----------|------------------|
+| local | no | `myapp` |
+| local | yes | `myapp/jan-3-2026--1` |
+| gpu-server | no | `myapp@gpu-server` |
+| gpu-server | yes | `myapp/jan-3-2026--1@gpu-server` |
+
+## Portal API
+
+### Core Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Health check |
+| `/api/sessions` | GET | List all tmux sessions |
+| `/api/sessions/{name}` | DELETE | Close/kill a session |
+| `/api/sessions/archive` | GET | List archived sessions |
+| `/api/create` | POST | Create new session (accepts machine, worktree, branch) |
+| `/api/check-path` | GET | Check if path exists and is git repo |
+| `/api/check-branches` | GET | Get existing branches matching prefix |
+
+### Room Management
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/room/{name}/config` | POST | Update room config (voice, etc.) |
+| `/api/room/{name}/recreate` | POST | Destroy and recreate session with fresh worktree |
+| `/api/room/{name}/spawn-sibling` | POST | Create parallel session in new worktree |
+| `/api/room/{name}/fork` | POST | Fork Claude Code session (preserves conversation) |
+| `/api/room/{name}/restart-service` | POST | Restart system service |
+| `/api/rooms/{name}/connections` | GET | Get connection count for room |
+
+### Voice & Input
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/say/{name}` | POST | Generate TTS and broadcast to room |
+| `/api/local-tts/{name}` | POST | Generate TTS for local playback |
+| `/api/answer/{name}` | POST | Submit answer to AskUserQuestion |
+| `/api/voices` | GET | List available TTS voices |
+| `/transcribe` | POST | Transcribe audio (multipart form) |
+| `/upload` | POST | Upload image (multipart form) |
+| `/send/{name}` | POST | Send text to session |
+
+### Machine Management
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/machines` | GET | List configured machines |
+| `/api/machines` | POST | Add a machine |
+| `/api/machines/{id}` | DELETE | Remove a machine |
+| `/api/machine/{id}/status` | GET | Get machine status |
+
+### Configuration & Templates
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/config` | GET | Get current config |
+| `/api/config` | POST | Save config |
+| `/api/config/reload` | POST | Reload config from disk |
+| `/api/templates` | GET | List templates |
+| `/api/templates` | POST | Create template |
+| `/api/templates/{name}` | GET | Get template details |
+| `/api/templates/{name}` | DELETE | Delete template |
+
+### Permission Handling
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/permission/{name}` | POST | Submit permission request (from hook) |
+| `/api/permission/{name}/respond` | POST | User responds to permission request |
+
+### WebSocket Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/ws/{name}` | Main room WebSocket (ambient/monitor modes) |
+| `/ws/terminal/{name}` | Terminal attach WebSocket (xterm.js) |


### PR DESCRIPTION
## Summary

Part of the CLAUDE.md slimdown effort. Extracts two major sections into standalone documentation files:

- **docs/CLI-REFERENCE.md** (381 lines) - Complete CLI command reference including session name formats, command examples, worktree patterns, and JSON output examples
- **docs/PORTAL.md** (344 lines) - Portal features documentation covering modes (Ambient, Monitor, Terminal), UI controls, image attachments, voice output, and API endpoints

Both files include cross-references back to CLAUDE.md for project overview.

## Test plan

- [ ] Verify docs/CLI-REFERENCE.md renders correctly on GitHub
- [ ] Verify docs/PORTAL.md renders correctly on GitHub
- [ ] Confirm cross-reference links work

Built by [dotdev.dev](https://dotdev.dev)