### PR TITLE
Extract deployment docs from CLAUDE.md

### DIFF
--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -1,0 +1,187 @@
+# Docker Deployment
+
+AgentWire can run fully containerized with Docker Compose. The containerized stack provides:
+- **Portal** - Web UI, session orchestration, WebSocket server
+- **STT** - Speech-to-text service (faster-whisper)
+- **TTS** - RunPod serverless (external) or local Chatterbox container (optional)
+
+## Quick Start
+
+```bash
+# Build and start the stack
+docker-compose up --build
+
+# Or run in background
+docker-compose up -d --build
+
+# View logs
+docker-compose logs -f
+
+# Stop services
+docker-compose down
+```
+
+## Architecture
+
+The containerized portal is **orchestration-only** - it doesn't run tmux sessions internally. Instead, it manages sessions on remote machines via SSH, including the host machine.
+
+```
+┌─────────────────────────────────────────────────┐
+│  Host Machine (Your Mac/Linux)                  │
+│  ├── Browser → https://localhost:8765           │
+│  ├── tmux sessions (managed via SSH)            │
+│  └── ~/.agentwire/machines.json:                │
+│      {                                           │
+│        "id": "local",                            │
+│        "host": "host.docker.internal"  ← magic! │
+│      }                                           │
+└─────────────────────────────────────────────────┘
+          │
+          ├─ Portal Container (port 8765) - ORCHESTRATOR ONLY
+          │  ├── WebSocket server (voice UI)
+          │  ├── HTTP API (session management)
+          │  └── SSH client → manages sessions on ALL machines
+          │                    (including host via "local")
+          │
+          ├─ STT Container (internal port 8100)
+          │  ├── faster-whisper
+          │  └── FastAPI server
+          │
+          └─ TTS (RunPod Serverless)
+```
+
+**Key Design:** The portal container treats the host as a remote machine using Docker's `host.docker.internal` hostname. This keeps the portal stateless and makes all session management consistent (everything via SSH).
+
+**Session Listing:**
+- From host: Groups by actual hostname (e.g., "Jordans-Mini:")
+- From container: Groups by machine ID (e.g., "local:", "dotdev-pc:")
+
+## Environment Variables
+
+Configure via `.env` file or shell environment:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STT_ARCH` | `cpu` | STT architecture: `cpu` or `gpu` |
+| `WHISPER_MODEL` | `base` | Whisper model: `tiny`, `base`, `small`, `medium`, `large-v2`, `large-v3` |
+| `WHISPER_DEVICE` | `cpu` | Whisper device: `cpu` or `cuda` |
+| `WHISPER_LANGUAGE` | `en` | Language code or `auto` |
+| `TTS_BACKEND` | `runpod` | TTS backend: `runpod` or `chatterbox` (if local TTS container enabled) |
+
+## Volume Mounts
+
+The Portal container mounts:
+- `~/.agentwire` - Configuration, rooms.json, certificates
+- `~/.ssh` (read-only) - SSH keys for remote machine access
+- `~/projects` - Projects directory for worktrees
+
+## Configuration Override
+
+Docker Compose automatically configures the Portal to use the containerized STT service:
+
+```yaml
+environment:
+  - AGENTWIRE_STT__BACKEND=remote
+  - AGENTWIRE_STT__URL=http://stt:8100
+  - AGENTWIRE_TTS__BACKEND=${TTS_BACKEND:-runpod}
+```
+
+**Note:** If using local Chatterbox TTS, uncomment the `tts` service in `docker-compose.yml`.
+
+## Multi-Arch Builds
+
+Build and push images for multiple architectures:
+
+```bash
+# Build locally
+./scripts/build-local.sh
+
+# Build and push to Docker Hub (multi-arch)
+export DOCKER_USERNAME=yourname
+./scripts/build-containers.sh
+```
+
+Builds create:
+- **Portal** - `linux/amd64`, `linux/arm64`
+- **STT CPU** - `linux/amd64`, `linux/arm64`
+- **STT GPU** - `linux/amd64` only (NVIDIA CUDA)
+
+See `scripts/README.md` for detailed build documentation.
+
+## GPU Support (STT)
+
+For GPU-accelerated STT, use the GPU variant:
+
+```bash
+# Build GPU variant
+STT_ARCH=gpu ./scripts/build-local.sh
+
+# Run with GPU support (requires NVIDIA Docker runtime)
+docker-compose -f docker-compose.gpu.yml up
+```
+
+Requires:
+- NVIDIA GPU
+- NVIDIA Docker runtime installed
+- `docker-compose.gpu.yml` configured with GPU resources
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| STT container unhealthy | Check logs: `docker logs agentwire-stt` |
+| Portal can't reach STT | Verify network: `docker exec agentwire-portal curl http://stt:8100/health` |
+| Port 8765 already in use | Change port in `docker-compose.yml` or stop conflicting service |
+| Build fails with "gcc not found" | Fixed in Dockerfile.stt (includes build-essential) |
+| Volume mount permission errors | Ensure `~/.agentwire` exists and is accessible |
+
+**Health checks:**
+
+```bash
+# Portal health
+curl -k https://localhost:8765/health
+
+# STT health (from portal container)
+docker exec agentwire-portal curl http://stt:8100/health
+```
+
+**Restart services:**
+
+```bash
+# Restart all services
+docker-compose restart
+
+# Rebuild specific service
+docker-compose up -d --build portal
+
+# View logs
+docker-compose logs -f portal stt
+```
+
+## Future: Sandbox Sessions
+
+**Concept:** Dedicated worker containers for volatile/untrusted projects.
+
+```
+Portal Container (orchestrator)
+  └─> spawns ephemeral worker containers
+      ├── Isolated filesystem (no host access)
+      ├── GPU support (optional)
+      ├── Limited network access
+      └── Auto-destroyed after session ends
+```
+
+**Use cases:**
+- Running untrusted code from third parties
+- Testing volatile/experimental projects
+- CTF challenges and security research
+- Temporary development environments
+- Learning/educational contexts
+
+**Benefits:**
+- Complete isolation from host
+- No risk to personal data or projects
+- GPU acceleration for ML/AI workflows
+- Fresh environment every time
+
+This would be a future enhancement tracked as a mission in `docs/missions/`.

--- a/docs/runpod-tts.md
+++ b/docs/runpod-tts.md
@@ -1,0 +1,201 @@
+# RunPod Serverless TTS
+
+AgentWire TTS can run on RunPod serverless infrastructure instead of a local GPU machine. This provides pay-per-use GPU access without maintaining dedicated hardware.
+
+## Why RunPod Serverless?
+
+| Benefit | Description |
+|---------|-------------|
+| **No GPU required** | Run TTS on cloud GPUs (RTX 3090, A100, etc.) |
+| **Pay per use** | Only charged when generating audio (~$0.0004/sec on RTX 3090) |
+| **Auto-scaling** | Scales to zero when idle, spins up on demand |
+| **Custom voices** | Bundle voices in Docker image OR upload dynamically via network volumes |
+| **Network volumes** | Persistent storage for voice clones without rebuilding Docker image |
+
+## Prerequisites
+
+- Docker Hub account for hosting the image
+- RunPod account with API key
+- Custom voice files in `~/.agentwire/voices/` (optional)
+
+## Setup Steps
+
+### 1. Build and Deploy Docker Image
+
+```bash
+# Set your Docker Hub username
+export DOCKER_USERNAME=yourname
+
+# Build and push image to Docker Hub
+./scripts/deploy-runpod.sh
+```
+
+This creates a Docker image with:
+- Chatterbox TurboTTS model
+- Your custom voice clones from `~/.agentwire/voices/`
+- CUDA 12.1 + cuDNN 8 for GPU acceleration
+
+### 2. Create RunPod Endpoint
+
+```bash
+# Set RunPod API key
+export RUNPOD_API_KEY=your_runpod_api_key_here
+
+# Create serverless endpoint
+./scripts/runpod-endpoint.py create
+```
+
+This creates a serverless endpoint and saves the endpoint ID to `~/.agentwire/runpod_endpoint.txt`.
+
+### 3. Configure AgentWire
+
+Edit `~/.agentwire/config.yaml`:
+
+```yaml
+tts:
+  backend: runpod  # Change from "chatterbox" to "runpod"
+  default_voice: bashbunni
+  runpod_endpoint_id: your_endpoint_id  # From runpod-endpoint.py create
+  runpod_api_key: your_runpod_api_key   # RunPod API key
+  runpod_timeout: 60  # Request timeout in seconds
+```
+
+**Security note:** API keys in config files are less secure than environment variables. For production, use:
+
+```bash
+export AGENTWIRE_TTS__RUNPOD_API_KEY=your_key
+# Config will be overridden by env var
+```
+
+### 4. Test Endpoint
+
+```bash
+# Test deployed endpoint
+./scripts/test-runpod-remote.sh
+```
+
+This sends a TTS request and saves the audio to `test_output.wav`.
+
+## RunPod Management Commands
+
+```bash
+# List all endpoints
+./scripts/runpod-endpoint.py list
+
+# Get endpoint details
+./scripts/runpod-endpoint.py get <endpoint_id>
+
+# Delete endpoint
+./scripts/runpod-endpoint.py delete <endpoint_id>
+```
+
+## Cost Estimation
+
+RunPod serverless pricing (as of 2024):
+
+| GPU | Price per second | TTS generation (~5s) |
+|-----|------------------|---------------------|
+| RTX 3090 | $0.00039/sec | ~$0.002 |
+| RTX 4090 | $0.00069/sec | ~$0.003 |
+| A100 SXM | $0.00139/sec | ~$0.007 |
+
+**Idle cost:** $0 (scales to zero when not in use)
+
+## Workflow Comparison
+
+| Aspect | Local GPU | RunPod Serverless |
+|--------|-----------|-------------------|
+| **Setup** | One-time GPU setup | Docker + endpoint creation |
+| **Cost** | GPU hardware + electricity | Pay per use |
+| **Latency** | ~1-2s | ~3-5s (includes cold start) |
+| **Maintenance** | Manual updates | Automatic via Docker rebuild |
+| **Scaling** | Fixed capacity | Auto-scales to demand |
+
+## Voice Management
+
+AgentWire supports two methods for managing voices on RunPod:
+
+### Option 1: Network Volume (Recommended)
+
+Upload voices dynamically without rebuilding the Docker image using RunPod's network volumes:
+
+**Setup:**
+1. Create a network volume in RunPod dashboard
+2. Attach it to your serverless endpoint (auto-mounts at `/runpod-volume/`)
+3. Upload voices via the API:
+
+```python
+import base64
+import requests
+from pathlib import Path
+
+# Read voice file
+voice_path = Path("~/.agentwire/voices/bashbunni.wav").expanduser()
+audio_bytes = voice_path.read_bytes()
+audio_b64 = base64.b64encode(audio_bytes).decode('utf-8')
+
+# Upload to network volume
+response = requests.post(
+    f"https://api.runpod.ai/v2/{endpoint_id}/runsync",
+    json={
+        "input": {
+            "action": "upload_voice",
+            "voice_name": "bashbunni",
+            "audio_base64": audio_b64
+        }
+    },
+    headers={"Authorization": f"Bearer {api_key}"},
+    timeout=300
+)
+```
+
+**Voice lookup hierarchy:**
+1. Bundled voices in `/voices/` (baked into Docker image)
+2. Network voices in `/runpod-volume/` (persistent, uploadable)
+
+See `upload_bashbunni.py` and `test_tiny_tina.py` for complete examples.
+
+### Option 2: Bundled Voices (Docker Image)
+
+Bundle voices into the Docker image (requires rebuild for updates):
+
+1. Add voices to `~/.agentwire/voices/`
+2. Rebuild and push Docker image:
+   ```bash
+   ./scripts/deploy-runpod.sh
+   ```
+3. Restart portal to reload config:
+   ```bash
+   agentwire portal stop
+   agentwire portal start
+   ```
+
+**When to use bundled vs network volumes:**
+- **Bundled**: Voices you'll always need (e.g., default voice)
+- **Network volume**: Dynamic voices, testing, user-uploaded voices
+
+## Troubleshooting
+
+**"Voice not found" errors:**
+- Voice clones must exist in `~/.agentwire/voices/` when building the Docker image
+- Rebuild and redeploy after adding new voices
+
+**Timeout errors:**
+- Increase `runpod_timeout` in config (default: 60 seconds)
+- Cold starts can take 10-20 seconds on first request
+
+**Endpoint creation fails:**
+- Verify RunPod API key is correct
+- Check Docker image was pushed to Docker Hub
+- Ensure image name matches: `$DOCKER_USERNAME/agentwire-tts:latest`
+
+## Local Testing (Optional)
+
+Test the Docker image locally before deploying:
+
+```bash
+# Requires local NVIDIA GPU with Docker
+./scripts/test-runpod-local.sh
+```
+
+This builds the image and tests the handler without deploying to RunPod.


### PR DESCRIPTION
## Summary
- Extract Docker container deployment docs to `docs/docker-deployment.md` (187 lines)
- Extract RunPod serverless TTS setup to `docs/runpod-tts.md` (201 lines)

Part of CLAUDE.md slimdown effort - moving deployment-specific reference docs to dedicated files.

## Test plan
- [x] Verify extracted content matches original CLAUDE.md sections
- [ ] Review docs render correctly on GitHub

Built by [dotdev.dev](https://dotdev.dev)