### PR TITLE
feat: persistent toast notifications + portal_notify() MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,13 +351,14 @@ The agentwire MCP server provides tools that wrap CLI functionality. Use these i
 | Open panel | `desktop_open_panel(panel_type="sessions")` |
 | Open artifact window (URL/file) | `desktop_open_artifact(url="...", title="...")` |
 | Write HTML + open as artifact | `desktop_write_artifact(filename="...", html_content="...", title="...")` |
+| Post toast notification | `portal_notify(text="...", session="...", priority="normal")` |
 | Close window | `desktop_close_window(window_id="...")` |
 | Focus window | `desktop_focus_window(window_id="...")` |
 | Tile window | `desktop_tile_window(window_id="...", zone="left")` |
 | Minimize all | `desktop_minimize_all()` |
 | Multi-window layout | `desktop_layout(windows=[{id: "...", zone: "left"}])` |
 
-**86 tools total.** When to use CLI vs MCP:
+**87 tools total.** When to use CLI vs MCP:
 - **MCP tools** — Agents in sessions (orchestrators, workers)
 - **CLI commands** — Humans, shell scripts, automation outside of agent sessions
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -74,6 +74,7 @@ class ProjectsConfig:
 
     dir: Path = field(default_factory=lambda: Path.home() / "projects")
     worktrees: WorktreesConfig = field(default_factory=WorktreesConfig)
+    extra: list = field(default_factory=list)
 
     def __post_init__(self):
         self.dir = _expand_path(self.dir) or Path.home() / "projects"
@@ -355,6 +356,7 @@ def _dict_to_config(data: dict) -> Config:
     projects = ProjectsConfig(
         dir=projects_data.get("dir", "~/projects"),
         worktrees=worktrees,
+        extra=projects_data.get("extra", []),
     )
 
     # TTS

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2457,6 +2457,29 @@ def desktop_layout(windows: list[dict]) -> str:
     return f"Failed to apply layout: {data.get('error', 'Unknown error')}"
 
 
+@mcp.tool()
+def portal_notify(text: str, session: str | None = None, priority: str = "normal") -> str:
+    """Post a toast notification to the portal desktop.
+
+    Creates a persistent visual notification in the bottom-right of the portal.
+    Clicking the toast opens the notifications session for interactive chat.
+
+    Args:
+        text: Notification message text.
+        session: Session name this notification relates to (shown as badge).
+        priority: 'normal' or 'high' (high gets accent border).
+
+    Returns:
+        Notification ID or error description.
+    """
+    body = {"text": text, "priority": priority}
+    if session:
+        body["session"] = session
+    data = _portal_request("POST", "/api/desktop/notification", body)
+    if data.get("success"):
+        return f"Notification posted (id: {data.get('id')})."
+    return f"Failed to post notification: {data.get('error', 'Unknown error')}"
+
 
 
 # =============================================================================

--- a/agentwire/projects.py
+++ b/agentwire/projects.py
@@ -197,6 +197,85 @@ done
     return projects
 
 
+def _resolve_extra_projects(extra: list[dict], machine_filter: str | None = None) -> list[dict]:
+    """Resolve explicitly configured extra project paths.
+
+    Each entry in extra is a dict with 'path' and optional 'machine' (default: 'local').
+    Reads .agentwire.yml from each path for type/roles.
+
+    Args:
+        extra: List of extra project entries from config.
+        machine_filter: Only include projects matching this machine.
+
+    Returns:
+        List of project dicts: {name, path, type, roles, machine}
+    """
+    import base64
+
+    projects = []
+    for entry in extra:
+        path = entry.get("path", "")
+        if not path:
+            continue
+        entry_machine = entry.get("machine", "local")
+
+        # Filter by machine if requested
+        if machine_filter is not None:
+            if machine_filter != entry_machine:
+                continue
+
+        if entry_machine == "local":
+            # Local: read .agentwire.yml directly
+            p = Path(path).expanduser().resolve()
+            if not p.is_dir():
+                continue
+            config_file = p / ".agentwire.yml"
+            try:
+                cfg = yaml.safe_load(config_file.read_text()) or {} if config_file.exists() else {}
+            except Exception:
+                cfg = {}
+            projects.append({
+                "name": entry.get("name", p.name),
+                "path": str(p),
+                "type": cfg.get("type", "claude-bypass"),
+                "roles": cfg.get("roles", []),
+                "machine": "local",
+            })
+        else:
+            # Remote: read .agentwire.yml via SSH
+            m = _get_machine_config(entry_machine)
+            if not m:
+                continue
+            cmd = f'''
+if [ -d "{path}" ]; then
+  if [ -f "{path}/.agentwire.yml" ]; then
+    cat "{path}/.agentwire.yml" | base64 -w0 2>/dev/null || cat "{path}/.agentwire.yml" | base64
+  else
+    echo ""
+  fi
+fi
+'''
+            success, output = _run_ssh_command(m, cmd)
+            cfg = {}
+            if success and output.strip():
+                try:
+                    config_yaml = base64.b64decode(output.strip()).decode("utf-8")
+                    cfg = yaml.safe_load(config_yaml) or {}
+                except Exception:
+                    pass
+
+            name = entry.get("name", Path(path).name)
+            projects.append({
+                "name": name,
+                "path": path,
+                "type": cfg.get("type", "claude-bypass"),
+                "roles": cfg.get("roles", []),
+                "machine": entry_machine,
+            })
+
+    return projects
+
+
 def get_projects(machine: str | None = None) -> list[dict]:
     """Discover projects from machine's projects_dir.
 
@@ -228,6 +307,14 @@ def get_projects(machine: str | None = None) -> list[dict]:
         if m and m.get("projects_dir"):
             remote_projects = _discover_remote_projects(m)
             projects.extend(remote_projects)
+
+    # Extra projects from config (explicit paths outside projects_dir)
+    extra_projects = _resolve_extra_projects(config.projects.extra, machine)
+    # Deduplicate by (machine, path) — extras don't override discovered projects
+    seen = {(p["machine"], p["path"]) for p in projects}
+    for ep in extra_projects:
+        if (ep["machine"], ep["path"]) not in seen:
+            projects.append(ep)
 
     # Sort by machine then name
     projects.sort(key=lambda p: (p["machine"], p["name"]))

--- a/agentwire/roles/notifications.md
+++ b/agentwire/roles/notifications.md
@@ -1,0 +1,65 @@
+---
+name: notifications
+description: Portal notification agent — crafts and speaks idle session reminders
+---
+
+# Notifications Agent
+
+You are the portal's notification voice. The portal sends you periodic updates about idle sessions that have open browser windows, and you craft a brief, natural, spoken summary using `say()`.
+
+## What you receive
+
+The portal's idle nag loop sends you `[IDLE NAG]` messages listing sessions that are idle with open windows. Each entry includes:
+- **session name**: the tmux session (e.g., `slack-ch-sitematch-qr`, `piinpoint`)
+- **idle_minutes**: how long it's been idle
+- **nag_count**: how many times you've already nagged about this session (1 = first time)
+- **last_output_snippet**: the last few lines of session output (what it's waiting on)
+
+## How to respond
+
+1. Read the data and **triage** — decide which sessions actually need a nag
+2. If any sessions need attention, craft ONE short, natural spoken sentence and `say()` it
+3. If nothing needs a nag, stay silent — do NOT call `say()`
+4. Do NOT use any other tools — just `say()` or nothing
+
+## When to skip a nag
+
+Not every idle session needs a reminder. Use the last_output_snippet to judge:
+
+- **Session completed its task** — output shows a summary, "done", commit message, PR link, or the agent signed off. The user just hasn't given it new work yet. **Skip it.**
+- **User acknowledged** — output shows the user responded "thanks", "got it", "ok", or similar, and no new question is pending. **Skip it.**
+- **Waiting at a clean prompt** — the session is at a bare `>` or `$` prompt with no pending question. Nothing to nag about. **Skip it.**
+- **Agent asked a question or needs input** — output ends with a question, a choice to make, a confirmation prompt, or "waiting for". **Nag.**
+- **Agent hit an error and stopped** — output shows an error or failure the user should see. **Nag.**
+- **Ambiguous** — when in doubt after many nags (nag_count >= 5), lean toward skipping. If it was important, earlier nags already flagged it.
+
+## Tone and style
+
+- Conversational, not robotic. Like a helpful assistant giving a quick verbal status update.
+- Vary your phrasing. Never repeat the same structure twice in a row.
+- Group sessions naturally: "We've got a couple that have been sitting idle for a while — piinpoint and the sitematch QR channel — and jordan devbox just wrapped up too."
+- Scale personality with nag_count:
+  - **1-2**: Matter-of-fact. "Heads up, piinpoint and the sitematch channel are both waiting on you."
+  - **3-4**: Slightly more pointed. "Still waiting on you for piinpoint — it's been about 15 minutes now."
+  - **5+**: Get creative and playful. Light humor is encouraged. "At this point piinpoint is starting to wonder if you've gone for a walk."
+- If the last_output_snippet contains a question, mention what it's asking about.
+- Keep it to 1-3 sentences max. This is spoken aloud — brevity matters.
+- When you skip all sessions, say nothing. Silence is fine.
+
+## Examples
+
+**Nagging (sessions need attention):**
+
+"Hey, quick heads up — piinpoint has been idle for about 5 minutes and it's asking about the hosting approach."
+
+"We've got two that are really waiting on you — piinpoint's been idle 20 minutes and the devbox session about 10. Might want to check in."
+
+"So piinpoint is still parked waiting on your input about the hosting decision. Just saying."
+
+**Mixed (some need nags, some don't):**
+
+"Piinpoint needs your input on the deployment config. The sitematch channel finished up — that one's fine."
+
+**Skipping (nothing needs attention):**
+
+_(silence — no say() call)_

--- a/agentwire/roles/notifications.md
+++ b/agentwire/roles/notifications.md
@@ -1,11 +1,11 @@
 ---
 name: notifications
-description: Portal notification agent — crafts and speaks idle session reminders
+description: Portal notification agent — crafts and speaks idle session reminders with persistent toast notifications
 ---
 
 # Notifications Agent
 
-You are the portal's notification voice. The portal sends you periodic updates about idle sessions that have open browser windows, and you craft a brief, natural, spoken summary using `say()`.
+You are the portal's notification voice. The portal sends you periodic updates about idle sessions that have open browser windows, and you craft a brief, natural, spoken summary using `say()` and post persistent visual toasts using `portal_notify()`.
 
 ## What you receive
 
@@ -18,9 +18,11 @@ The portal's idle nag loop sends you `[IDLE NAG]` messages listing sessions that
 ## How to respond
 
 1. Read the data and **triage** — decide which sessions actually need a nag
-2. If any sessions need attention, craft ONE short, natural spoken sentence and `say()` it
-3. If nothing needs a nag, stay silent — do NOT call `say()`
-4. Do NOT use any other tools — just `say()` or nothing
+2. If any sessions need attention:
+   - Call `portal_notify(text, session=<session_name>)` for each session that needs a nag — this posts a persistent toast the user can see and click
+   - Call `say()` with ONE short spoken sentence summarizing what needs attention (audio companion to the toasts)
+3. If nothing needs a nag, stay silent — do NOT call `say()` or `portal_notify()`
+4. Only use `say()` and `portal_notify()` — no other tools
 
 ## When to skip a nag
 
@@ -33,33 +35,49 @@ Not every idle session needs a reminder. Use the last_output_snippet to judge:
 - **Agent hit an error and stopped** — output shows an error or failure the user should see. **Nag.**
 - **Ambiguous** — when in doubt after many nags (nag_count >= 5), lean toward skipping. If it was important, earlier nags already flagged it.
 
+## Toast vs. speech
+
+- `portal_notify()` — persistent, visual. The user sees it even if they weren't listening. One toast per session that needs attention.
+- `say()` — ephemeral, audio. One sentence summarizing all sessions. Draws immediate attention.
+
+Always post toasts first, then speak. The toast text should be specific (what the session is waiting on). The spoken text should be a brief overview.
+
+## Interactive chat
+
+When the user opens your session (by clicking a toast), they want to discuss the notifications. Help them:
+- **Snooze**: "Remind me about piinpoint in 30 minutes" — acknowledge and note it
+- **Acknowledge**: "I know about that one" / "Stop nagging about piinpoint" — acknowledge
+- **Schedule**: "I'll deal with piinpoint tomorrow" — acknowledge
+
+Be conversational. You're a helpful assistant managing their attention across sessions.
+
 ## Tone and style
 
 - Conversational, not robotic. Like a helpful assistant giving a quick verbal status update.
 - Vary your phrasing. Never repeat the same structure twice in a row.
-- Group sessions naturally: "We've got a couple that have been sitting idle for a while — piinpoint and the sitematch QR channel — and jordan devbox just wrapped up too."
+- Toast text: concise and specific. "Waiting for your input on the deployment config" not "Session is idle".
+- Group sessions naturally in the spoken message: "We've got a couple that need attention — piinpoint and the sitematch channel."
 - Scale personality with nag_count:
   - **1-2**: Matter-of-fact. "Heads up, piinpoint and the sitematch channel are both waiting on you."
   - **3-4**: Slightly more pointed. "Still waiting on you for piinpoint — it's been about 15 minutes now."
   - **5+**: Get creative and playful. Light humor is encouraged. "At this point piinpoint is starting to wonder if you've gone for a walk."
 - If the last_output_snippet contains a question, mention what it's asking about.
-- Keep it to 1-3 sentences max. This is spoken aloud — brevity matters.
+- Keep spoken text to 1-3 sentences max. This is spoken aloud — brevity matters.
 - When you skip all sessions, say nothing. Silence is fine.
 
 ## Examples
 
 **Nagging (sessions need attention):**
 
-"Hey, quick heads up — piinpoint has been idle for about 5 minutes and it's asking about the hosting approach."
+Toast: `portal_notify("Waiting for your input on the hosting approach", session="piinpoint")`
+Speech: `say("Hey, quick heads up — piinpoint has been idle for about 5 minutes and it's asking about the hosting approach.")`
 
-"We've got two that are really waiting on you — piinpoint's been idle 20 minutes and the devbox session about 10. Might want to check in."
+**Multiple sessions:**
 
-"So piinpoint is still parked waiting on your input about the hosting decision. Just saying."
-
-**Mixed (some need nags, some don't):**
-
-"Piinpoint needs your input on the deployment config. The sitematch channel finished up — that one's fine."
+Toast 1: `portal_notify("Asking about deployment config — idle 20 min", session="piinpoint")`
+Toast 2: `portal_notify("Hit an error in test suite — idle 10 min", session="jordan-devbox")`
+Speech: `say("Two sessions need you — piinpoint's been waiting 20 minutes on the deployment config, and the devbox hit a test error.")`
 
 **Skipping (nothing needs attention):**
 
-_(silence — no say() call)_
+_(silence — no say() or portal_notify() calls)_

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -136,6 +136,7 @@ class AgentWireServer:
         self.session_activity: dict[str, dict] = {}  # Global activity tracking for all sessions
         self.dashboard_clients: set = set()  # WebSocket clients for dashboard updates
         self.session_client_counts: dict[str, int] = {}  # Attached tmux client counts per session
+        self.active_notifications: dict[str, dict] = {}  # id -> notification for persistence across refresh
         self.machine_status_checker = CachedStatusChecker(ttl_seconds=30)  # Progressive loading for machines
         self.remote_sessions_checker = CachedStatusChecker(ttl_seconds=20)  # Progressive loading for remote sessions
         self.projects_checker = CachedStatusChecker(ttl_seconds=30)  # Progressive loading for projects
@@ -214,6 +215,10 @@ class AgentWireServer:
         self.app.router.add_post("/api/desktop/window/tile", self.api_desktop_tile)
         self.app.router.add_post("/api/desktop/window/minimize-all", self.api_desktop_minimize_all)
         self.app.router.add_post("/api/desktop/layout", self.api_desktop_layout)
+        # Desktop notifications
+        self.app.router.add_post("/api/desktop/notification", self.api_desktop_notification)
+        self.app.router.add_post("/api/desktop/notification/dismiss", self.api_desktop_notification_dismiss)
+        self.app.router.add_get("/api/desktop/notifications", self.api_desktop_notifications_list)
         # Scheduler monitoring endpoints
         self.app.router.add_get("/api/scheduler/live", self.api_scheduler_live)
         self.app.router.add_get("/api/scheduler/events", self.api_scheduler_events)
@@ -946,6 +951,56 @@ class AgentWireServer:
             "windows": windows,
         })
         return web.json_response({"success": True})
+
+    # =========================================================================
+    # Desktop Notifications API
+    # =========================================================================
+
+    async def api_desktop_notification(self, request):
+        """POST /api/desktop/notification — post a toast notification to the portal."""
+        data = await request.json()
+        text = data.get("text", "")
+        if not text:
+            return web.json_response({"success": False, "error": "text required"}, status=400)
+
+        import uuid
+        notification_id = data.get("id") or str(uuid.uuid4())[:8]
+        session = data.get("session")
+        priority = data.get("priority", "normal")
+
+        notification = {
+            "id": notification_id,
+            "text": text,
+            "session": session,
+            "priority": priority,
+            "timestamp": time.time(),
+        }
+
+        self.active_notifications[notification_id] = notification
+
+        await self.broadcast_dashboard("notification", notification)
+
+        return web.json_response({"success": True, "id": notification_id})
+
+    async def api_desktop_notification_dismiss(self, request):
+        """POST /api/desktop/notification/dismiss — dismiss a notification."""
+        data = await request.json()
+        notification_id = data.get("id")
+        if not notification_id:
+            return web.json_response({"success": False, "error": "id required"}, status=400)
+
+        self.active_notifications.pop(notification_id, None)
+
+        await self.broadcast_dashboard("notification_dismiss", {"id": notification_id})
+
+        return web.json_response({"success": True})
+
+    async def api_desktop_notifications_list(self, request):
+        """GET /api/desktop/notifications — list active notifications (for page load restore)."""
+        return web.json_response({
+            "success": True,
+            "notifications": list(self.active_notifications.values()),
+        })
 
     async def api_artifacts_upload(self, request):
         """POST /api/artifacts/upload — write HTML content to the artifacts directory."""

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1216,6 +1216,122 @@ class AgentWireServer:
                 logger.debug(f"[Monitor] Error in monitor loop: {e}")
                 await asyncio.sleep(2)  # Back off on errors
 
+    async def idle_nag_loop(self):
+        """Background task: periodically check for idle sessions with open browser windows.
+
+        Gathers idle session data and sends it to the agentwire-notifications session,
+        which crafts a natural TTS message and speaks it via say().
+        """
+        NAG_INTERVAL = 60  # seconds between scans (testing: 60, prod: 300)
+        NAG_IDLE_THRESHOLD = 120  # seconds idle before including in nag (2 min minimum)
+        NAG_SESSION = "agentwire-notifications"
+        SERVICE_PREFIX = "agentwire-"
+        nag_counts: dict[str, int] = {}  # session -> consecutive nag count
+
+        logger.info("[IdleNag] Starting idle nag loop (interval: %ds, threshold: %ds)",
+                     NAG_INTERVAL, NAG_IDLE_THRESHOLD)
+
+        # Let the monitor warm up first
+        await asyncio.sleep(10)
+
+        while True:
+            try:
+                if not self.dashboard_clients:
+                    nag_counts.clear()
+                    await asyncio.sleep(NAG_INTERVAL)
+                    continue
+
+                # Find sessions with open browser windows that are truly idle
+                idle_sessions = []
+                for name, info in self.session_activity.items():
+                    if name.startswith(SERVICE_PREFIX):
+                        continue
+                    if name == NAG_SESSION:
+                        continue
+                    if self.session_client_counts.get(name, 0) == 0:
+                        nag_counts.pop(name, None)
+                        continue
+                    last_ts = info.get("last_output_timestamp", 0.0)
+                    idle_secs = time.time() - last_ts if last_ts else float('inf')
+                    if idle_secs > NAG_IDLE_THRESHOLD:
+                        idle_sessions.append((name, idle_secs))
+                    else:
+                        nag_counts.pop(name, None)
+
+                if not idle_sessions:
+                    await asyncio.sleep(NAG_INTERVAL)
+                    continue
+
+                # Gather session metadata
+                sessions_info = await self._get_sessions_data()
+                sessions_by_name = {s.get("name", ""): s for s in sessions_info}
+
+                # Fetch fresh output for each idle session
+                session_data = []
+                for name, idle_secs in idle_sessions:
+                    nag_counts[name] = nag_counts.get(name, 0) + 1
+                    idle_min = int(idle_secs / 60)
+
+                    # Session metadata
+                    meta = sessions_by_name.get(name, {})
+
+                    # Get a fuller snapshot of the session output
+                    output_snippet = ""
+                    try:
+                        success, output_result = await self.run_agentwire_cmd(
+                            ["output", "-s", name, "-n", "30"]
+                        )
+                        if success:
+                            output_snippet = output_result.get("output", "")[-1000:]
+                    except Exception:
+                        output_snippet = self.session_activity.get(name, {}).get("last_output", "")[-500:]
+
+                    session_data.append({
+                        "session": name,
+                        "idle_minutes": idle_min,
+                        "nag_count": nag_counts[name],
+                        "type": meta.get("type", "unknown"),
+                        "roles": meta.get("roles", []),
+                        "project_path": meta.get("path", ""),
+                        "machine": meta.get("machine") or "local",
+                        "last_output_snippet": output_snippet,
+                    })
+
+                # Send to the notifications session
+                prompt = (
+                    f"[IDLE NAG] The following {len(session_data)} session(s) have open browser windows "
+                    f"but are idle. Review each one's output to decide if it actually needs a nag "
+                    f"(waiting on input, hit an error) or should be skipped (task complete, user "
+                    f"acknowledged, sitting at a clean prompt). Only say() if something needs attention.\n\n"
+                )
+                for sd in session_data:
+                    roles_str = ", ".join(sd["roles"]) if sd["roles"] else "none"
+                    prompt += (
+                        f"### {sd['session']}\n"
+                        f"- Idle: {sd['idle_minutes']}min | Nagged: {sd['nag_count']}x\n"
+                        f"- Type: {sd['type']} | Roles: {roles_str}\n"
+                        f"- Project: {sd['project_path']} | Machine: {sd['machine']}\n"
+                    )
+                    if sd['last_output_snippet']:
+                        prompt += f"- Last output:\n```\n{sd['last_output_snippet']}\n```\n"
+                    prompt += "\n"
+
+                logger.info("[IdleNag] Sending to %s: %d idle session(s)", NAG_SESSION, len(session_data))
+                success, _ = await self.run_agentwire_cmd([
+                    "send", "-s", NAG_SESSION, prompt
+                ])
+                if not success:
+                    logger.warning("[IdleNag] Failed to send to %s — is the session running?", NAG_SESSION)
+
+                await asyncio.sleep(NAG_INTERVAL)
+
+            except asyncio.CancelledError:
+                logger.info("[IdleNag] Idle nag loop stopped")
+                break
+            except Exception as e:
+                logger.debug("[IdleNag] Error: %s", e)
+                await asyncio.sleep(NAG_INTERVAL)
+
     async def handle_websocket(self, request: web.Request) -> web.WebSocketResponse:
         """Handle WebSocket connections for a session."""
         name = request.match_info["name"]
@@ -4280,6 +4396,9 @@ async def run_server(config: Config):
 
     # Start session monitor for all-sessions dashboard indicators
     monitor_task = asyncio.create_task(server.monitor_all_sessions())
+
+    # Start idle nag loop (TTS reminders for idle sessions with open windows)
+    idle_nag_task = asyncio.create_task(server.idle_nag_loop())
 
     # Sessions are now fetched dynamically from tmux + .agentwire.yml
     # No cache to rebuild or periodically refresh

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -3768,3 +3768,108 @@ body.sidebar-pinned .sidebar-tab {
     border-color: var(--orb-processing);
     color: #fff;
 }
+
+/* =========================================================================
+   Toast Notification Panel
+   ========================================================================= */
+
+.notification-panel {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    z-index: 1500;
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 8px;
+    max-height: calc(100vh - 32px);
+    overflow-y: auto;
+    pointer-events: none;
+    scrollbar-width: none;
+}
+
+.notification-panel::-webkit-scrollbar {
+    display: none;
+}
+
+.notification-toast {
+    pointer-events: auto;
+    width: 340px;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    opacity: 0;
+    transform: translateX(100%);
+    transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.notification-toast.visible {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.notification-toast.dismissing {
+    animation: toast-dismiss 200ms ease forwards;
+}
+
+@keyframes toast-dismiss {
+    to {
+        opacity: 0;
+        transform: translateX(100%);
+    }
+}
+
+.notification-toast.high {
+    border-color: var(--error);
+}
+
+.notification-toast-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+
+.notification-session-badge {
+    font-size: 11px;
+    color: var(--accent);
+    background: rgba(74, 222, 128, 0.1);
+    padding: 1px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 180px;
+}
+
+.notification-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-left: auto;
+}
+
+.notification-dismiss {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+}
+
+.notification-dismiss:hover {
+    color: var(--text);
+}
+
+.notification-toast-body {
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.4;
+    cursor: pointer;
+    word-wrap: break-word;
+}
+
+.notification-toast-body:hover {
+    color: #fff;
+}

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -336,6 +336,15 @@ class DesktopManager {
                 this.emit('agent_progress', msg);
                 break;
 
+            // Desktop notifications (from MCP agents via portal API)
+            case 'notification':
+                this.emit('notification', msg);
+                break;
+
+            case 'notification_dismiss':
+                this.emit('notification_dismiss', { id: msg.id });
+                break;
+
             default:
                 // Unknown message types are silently ignored
         }

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -20,6 +20,7 @@ import { projectsSection } from './sidebar/projects-section.js';
 import { schedulerSection } from './sidebar/scheduler-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { socialsSection } from './sidebar/socials-section.js';
+import { notificationsPanel } from './notifications-panel.js';
 
 // State - track open windows
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
@@ -180,6 +181,14 @@ async function init() {
                 tileManager._tileWindow(w.id, w.zone);
             }
         }
+    });
+
+    // Initialize notifications panel
+    notificationsPanel.init();
+
+    // Click on a toast -> open the notifications session as interactive terminal
+    document.addEventListener('open-notification-session', () => {
+        openSessionTerminal('agentwire-notifications', 'terminal');
     });
 
     // Set initial voice indicator state

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -1,0 +1,138 @@
+/**
+ * Notifications Panel — floating toast notifications anchored to bottom-right.
+ *
+ * Listens for 'notification' events from desktop-manager, renders toasts,
+ * supports dismiss and click-to-open-session.
+ */
+
+import { desktop } from './desktop-manager.js';
+
+const NOTIFICATIONS_SESSION = 'agentwire-notifications';
+const MAX_TOASTS = 8;
+
+class NotificationsPanel {
+    constructor() {
+        /** @type {Map<string, HTMLElement>} id -> toast element */
+        this.toasts = new Map();
+        this.container = null;
+    }
+
+    init() {
+        this.container = document.createElement('div');
+        this.container.className = 'notification-panel';
+        document.body.appendChild(this.container);
+
+        // Listen for notification events
+        desktop.on('notification', (data) => this._addToast(data));
+        desktop.on('notification_dismiss', ({ id }) => this._removeToast(id));
+
+        // Restore active notifications on page load
+        this._restore();
+    }
+
+    async _restore() {
+        try {
+            const resp = await fetch('/api/desktop/notifications');
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const notifications = data.notifications || [];
+            for (const n of notifications) {
+                this._addToast(n);
+            }
+        } catch {
+            // Portal not reachable, ignore
+        }
+    }
+
+    _addToast(notification) {
+        const { id, text, session, priority, timestamp } = notification;
+        if (!id || !text) return;
+
+        // Update existing toast if same id
+        if (this.toasts.has(id)) {
+            this._removeToast(id, false);
+        }
+
+        // Evict oldest if at capacity
+        if (this.toasts.size >= MAX_TOASTS) {
+            const oldest = this.toasts.keys().next().value;
+            this._removeToast(oldest, false);
+        }
+
+        const toast = document.createElement('div');
+        toast.className = `notification-toast${priority === 'high' ? ' high' : ''}`;
+        toast.dataset.id = id;
+
+        const timeStr = this._formatTime(timestamp);
+
+        toast.innerHTML = `
+            <div class="notification-toast-header">
+                ${session ? `<span class="notification-session-badge">${this._escapeHtml(session)}</span>` : ''}
+                <span class="notification-time">${timeStr}</span>
+                <button class="notification-dismiss" title="Dismiss">&times;</button>
+            </div>
+            <div class="notification-toast-body">${this._escapeHtml(text)}</div>
+        `;
+
+        // Click body -> open notifications session terminal
+        toast.querySelector('.notification-toast-body').addEventListener('click', () => {
+            // Import dynamically to avoid circular deps
+            const event = new CustomEvent('open-notification-session');
+            document.dispatchEvent(event);
+        });
+
+        // Dismiss button
+        toast.querySelector('.notification-dismiss').addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._dismissToast(id);
+        });
+
+        // Prepend (newest on top — CSS uses flex-direction: column-reverse)
+        this.container.appendChild(toast);
+
+        // Trigger slide-in animation
+        requestAnimationFrame(() => toast.classList.add('visible'));
+
+        this.toasts.set(id, toast);
+    }
+
+    _removeToast(id, animate = true) {
+        const toast = this.toasts.get(id);
+        if (!toast) return;
+
+        if (animate) {
+            toast.classList.add('dismissing');
+            toast.addEventListener('animationend', () => toast.remove(), { once: true });
+        } else {
+            toast.remove();
+        }
+        this.toasts.delete(id);
+    }
+
+    async _dismissToast(id) {
+        this._removeToast(id, true);
+        try {
+            await fetch('/api/desktop/notification/dismiss', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id }),
+            });
+        } catch {
+            // Best effort
+        }
+    }
+
+    _formatTime(timestamp) {
+        if (!timestamp) return '';
+        const d = new Date(timestamp * 1000);
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+    _escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+}
+
+export const notificationsPanel = new NotificationsPanel();


### PR DESCRIPTION
## Summary

- **Toast notification panel** — floating bottom-right UI in the portal that shows persistent notifications from the idle nag loop
- **`portal_notify()` MCP tool** — notifications session calls this to post visual toasts alongside `say()` for audio
- **Click-to-chat** — clicking a toast opens the `agentwire-notifications` session as an interactive terminal for snooze/acknowledge/schedule
- **Page refresh persistence** — server stores active notifications in memory, client restores them via `GET /api/desktop/notifications`

## Files changed

| File | Change |
|------|--------|
| `agentwire/server.py` | 3 notification API endpoints + server-side state dict |
| `agentwire/static/js/notifications-panel.js` | **New** — toast panel with slide-in/dismiss animations |
| `agentwire/static/js/desktop-manager.js` | `notification` + `notification_dismiss` WebSocket message handlers |
| `agentwire/static/js/desktop.js` | Import panel, init, wire click-to-open |
| `agentwire/static/css/desktop.css` | Toast panel styles (z-index 1500, column-reverse stacking) |
| `agentwire/mcp_server.py` | `portal_notify(text, session, priority)` MCP tool |
| `agentwire/roles/notifications.md` | Updated role: toast + audio, interactive chat guidance |
| `CLAUDE.md` | Document new tool, bump count to 87 |

## Test plan

- [ ] Restart portal, refresh browser
- [ ] Open session windows, let them go idle
- [ ] Verify toast appears in bottom-right after nag fires
- [ ] Verify clicking toast opens `agentwire-notifications` terminal
- [ ] Chat with notifications session: "stop nagging about X" — verify acknowledgement
- [ ] Verify toasts persist across page refresh
- [ ] Verify dismiss button removes toast from UI and server

🤖 Generated with [Claude Code](https://claude.com/claude-code)