### PR TITLE
feat: pi-zai session types — Z.AI via pi coding agent

### DIFF
--- a/.claude/skills/agentwire-pi-zai/SKILL.md
+++ b/.claude/skills/agentwire-pi-zai/SKILL.md
@@ -31,6 +31,9 @@ agentwire new -s fast --type pi-zai --model glm-4.7-flash
 
 # Persist type to .agentwire.yml (opt-in)
 agentwire new -s project --type pi-zai --persist
+
+# Add custom env vars (repeatable, injected via tmux set-environment)
+agentwire new -s project --type pi-zai --env OPENAI_KEY=sk-... --env DEBUG=1
 ```
 
 ## Three Variants

--- a/.claude/skills/agentwire-pi-zai/SKILL.md
+++ b/.claude/skills/agentwire-pi-zai/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: agentwire-pi-zai
+description: Pi coding agent integration (Z.AI) — `pi-zai` / `pi-zai-restricted` / `pi-zai-readonly` session types, install (`npm install -g @mariozechner/pi-coding-agent`), config (`pi.binary`, `pi.default_model`, `zai.api_key`), tool translation (Claude CamelCase → pi lowercase), role injection via `--append-system-prompt`, limitations vs Claude Code (no MCP client, no `--disallowedTools`, no `--resume --fork-session`, no hook integration). Use when setting up pi-zai sessions, debugging pi tool execution, or explaining when to pick pi-zai vs claude-*.
+---
+
+# pi-zai — Z.AI via Pi Coding Agent
+
+Pi is a minimal terminal coding agent (MIT licensed, [github.com/badlogic/pi-mono](https://github.com/badlogic/pi-mono)) with native Z.AI provider support. Used for Z.AI work so Claude Code stays pure for Anthropic subscription.
+
+Replaces the claudeGLM env-var wrapper approach, which stopped working when Claude Code's OAuth auth began overriding inline `ANTHROPIC_*` env vars.
+
+## Install
+
+```bash
+# One-time
+npm install -g @mariozechner/pi-coding-agent
+
+# Verify
+agentwire doctor    # reports pi version
+pi --version
+```
+
+## Session Creation
+
+```bash
+# Full access (closest to claude-bypass)
+agentwire new -s project --type pi-zai -p ~/projects/project
+
+# Override model
+agentwire new -s fast --type pi-zai --model glm-4.7-flash
+
+# Persist type to .agentwire.yml (opt-in)
+agentwire new -s project --type pi-zai --persist
+```
+
+## Three Variants
+
+| Type | Tools | Use Case |
+|------|-------|----------|
+| `pi-zai` | read, bash, edit, write | Full access, closest to claude-bypass |
+| `pi-zai-restricted` | read, grep, find, bash | Worker panes — commands allowed, no edits |
+| `pi-zai-readonly` | read, grep, find | Audit / inspection — pure file inspection |
+
+Unlike Claude Code's permission modes, pi has no permission system to bypass — the variants translate directly to pi's `--tools` whitelist.
+
+## Config
+
+In `~/.agentwire/config.yaml`:
+
+```yaml
+zai:
+  api_key: "your-zai-api-key"      # or env ZAI_API_KEY
+  base_url: "https://api.z.ai/api/anthropic"
+  timeout_ms: 3000000
+
+pi:
+  default_model: "glm-5"   # glm-5 | glm-5.1 | glm-4.7 | glm-4.7-flash | ...
+  binary: "pi"             # override if not on PATH (e.g., nvm path)
+```
+
+## Session Type Separation
+
+| Use Case | Agent | Config |
+|----------|-------|--------|
+| Human-directed work | `claude` (Anthropic) | `type: claude-bypass` |
+| Cost-sensitive / Z.AI subscription | `pi-zai` (Z.AI native) | `type: pi-zai` |
+| Worker panes (Z.AI, no edits) | `pi-zai-restricted` | `type: pi-zai-restricted` |
+| Audit/inspection (Z.AI, read-only) | `pi-zai-readonly` | `type: pi-zai-readonly` |
+
+## Tool Translation
+
+Role tool names are translated Claude CamelCase → pi lowercase, and filtered to pi's supported set:
+
+| Claude | Pi |
+|--------|-----|
+| `Read` | `read` |
+| `Bash` | `bash` |
+| `Edit` | `edit` |
+| `Write` | `write` |
+| `Grep` | `grep` |
+| `Glob` / `LS` | `find` / `ls` |
+
+Unsupported Claude tools (`WebFetch`, `Task`, `TodoWrite`, MCP tools, etc.) are silently filtered. Role tools not in the pi-supported set drop out.
+
+## Role Injection
+
+Same mechanism as Claude Code — merged role instructions write to a temp file and are passed via `--append-system-prompt "$(<file)"`. Variants `pi-zai-restricted` and `pi-zai-readonly` skip role injection since those are curated contexts.
+
+## Limitations vs Claude Code
+
+- **No MCP client** — pi-zai sessions cannot call agentwire MCP tools. Use Claude Code for orchestrator sessions that need MCP.
+- **No `--disallowedTools`** — can only whitelist tools. Roles with a `disallowed` list have no effect on pi.
+- **No session forking** — `--resume --fork-session` isn't supported. Linear resume works via `--session <file> --continue`. For fork-like behavior, copy the JSONL file manually.
+- **No hook system integration** — idle-handler, damage-control, and user-prompt-submit hooks don't fire for pi sessions.
+- **Idle detection works** — pi runs under `node`, so existing tmux process detection correctly identifies idle (shell) vs busy (node) states.
+
+## Session Storage
+
+Pi persists every session to `~/.pi/agent/sessions/<cwd-encoded>/<timestamp>_<uuid>.jsonl`. CWD is encoded with `--` separators (e.g., `/Users/dotdev/projects/foo` → `--Users-dotdev-projects-foo--`).
+
+Each JSONL line records one event: model, user message, assistant message with tool calls, tool results. Sessions are recoverable after crashes — extract file writes from `toolCall` events to rebuild generated artifacts.
+
+## Known Gotchas
+
+- **GLM identity hallucination** — GLM models often claim to be Claude (Z.AI trained on Claude outputs). Don't rely on self-reports; verify via the JSONL event stream (`"provider":"zai"`, Z.AI-formatted response IDs).
+- **Pi pre-1.0** — v0.66.1 is the tested baseline. Breaking changes possible between minors.
+- **Binary location via nvm** — pi installs at `~/.nvm/versions/node/<ver>/bin/pi`. Set `pi.binary` if not on PATH.
+- **API key in command string** — `ZAI_API_KEY={key}` prefixes the command, so the key is visible in `ps auxwww` and shell history. Matches the pattern the removed claudeGLM wrapper used.
+
+## See Also
+
+- `docs/pi-zai.md` — full user guide, compatibility matrix, troubleshooting
+- `docs/missions/pi-harness-overview.md` — 5-phase integration roadmap
+- `agentwire-project-config` skill — `.agentwire.yml` session type field

--- a/.claude/skills/agentwire-pi-zai/SKILL.md
+++ b/.claude/skills/agentwire-pi-zai/SKILL.md
@@ -105,7 +105,7 @@ Each JSONL line records one event: model, user message, assistant message with t
 - **GLM identity hallucination** — GLM models often claim to be Claude (Z.AI trained on Claude outputs). Don't rely on self-reports; verify via the JSONL event stream (`"provider":"zai"`, Z.AI-formatted response IDs).
 - **Pi pre-1.0** — v0.66.1 is the tested baseline. Breaking changes possible between minors.
 - **Binary location via nvm** — pi installs at `~/.nvm/versions/node/<ver>/bin/pi`. Set `pi.binary` if not on PATH.
-- **API key in command string** — `ZAI_API_KEY={key}` prefixes the command, so the key is visible in `ps auxwww` and shell history. Matches the pattern the removed claudeGLM wrapper used.
+- **API key via tmux set-environment** — `ZAI_API_KEY` is injected onto the tmux session with `tmux set-environment -t <session>` at creation time, so it doesn't appear in `ps auxwww` or shell history. Worker panes inherit automatically. If you spawn pi manually outside an agentwire session, you'll need to export `ZAI_API_KEY` yourself.
 
 ## See Also
 

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -28,13 +28,15 @@ session:
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `type` | `claude-bypass`, `claude-auto`, `claude-prompted`, `claude-restricted` | Session permission level. **Use `claude-auto` for overnight/unattended work** — same capability as `claude-bypass` but with AI classifier blocking dangerous actions. Requires Team/Enterprise plan. |
+| `type` | `claude-bypass`, `claude-auto`, `claude-prompted`, `claude-restricted`, `pi-zai`, `pi-zai-restricted`, `pi-zai-readonly` | Session permission level. **Use `claude-auto` for overnight/unattended work** — same capability as `claude-bypass` but with AI classifier blocking dangerous actions. Requires Team/Enterprise plan. |
 | `roles` | List of role names | Roles to load (from bundled or `~/.agentwire/roles/`) |
 | `voice` | Voice name | TTS voice for this project |
 | `parent` | Session name | Parent session for hierarchical notifications |
 | `shell` | `/bin/sh`, `/bin/bash`, etc. | Default shell for task commands |
 | `tasks` | Task definitions | Scheduled workload configurations |
 | `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist |
+
+For Z.AI sessions (`pi-zai*`), see the `agentwire-pi-zai` skill.
 
 ## Task Schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The `agentwire-mcp-tools` skill has the full reference (87 tools covering sessio
 | `wiki/` | LLM-maintained knowledge base (Karpathy LLM Wiki pattern) |
 | `logs/` | Audit logs for damage-control |
 
-Per-project config lives in `.agentwire.yml` at the project root — see `agentwire-project-config` skill for fields and task schema.
+Per-project config lives in `.agentwire.yml` at the project root — see `agentwire-project-config` skill for fields and task schema. For Z.AI / pi-zai sessions, see the `agentwire-pi-zai` skill.
 
 ## Key Patterns
 
@@ -119,10 +119,13 @@ Reference detail lives in skills under `.claude/skills/` — invoke as needed:
 | `agentwire-project-config` | Editing `.agentwire.yml`, defining tasks, roles, idle notifications |
 | `agentwire-scheduler` | Scheduled task gates/schedule/priority + overnight queue |
 | `agentwire-desktop-ui` | Editing portal static files (sidebar, windows, artifacts) |
+| `agentwire-pi-zai` | Setting up Z.AI sessions via pi coding agent |
 
 ## Docs
 
 - CLI: `agentwire --help` or `agentwire <cmd> --help`
+- `docs/pi-zai.md` - Pi coding agent + Z.AI session types
+- `docs/missions/pi-harness-overview.md` - Pi integration roadmap across phases
 - `docs/channels.md` - Channel developer guide
 - `docs/PORTAL.md` - Portal modes and API reference
 - `docs/security/damage-control.md` - Safety hooks documentation

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2,7 +2,7 @@
 
 import argparse
 import base64
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import datetime
 import importlib.resources
 import json
@@ -81,6 +81,46 @@ class AgentCommand:
     """Result of building an agent command."""
     command: str  # The shell command to execute
     temp_file: str | None = None  # Temp file to clean up after agent starts
+    env: dict[str, str] = field(default_factory=dict)  # Secrets to inject via tmux set-environment (keeps keys out of `ps`)
+
+
+def inject_session_env(session: str, env: dict[str, str], remote_host: str | None = None) -> None:
+    """Set env vars on a tmux session so panes inherit them without exposing secrets.
+
+    Using `tmux set-environment -t <session>` keeps API keys out of the command
+    string (which would otherwise be visible in `ps auxwww` and shell history).
+    """
+    if not env:
+        return
+    for key, value in env.items():
+        if remote_host:
+            subprocess.run(
+                ["ssh", remote_host, "tmux", "set-environment", "-t",
+                 shlex.quote(session), shlex.quote(key), shlex.quote(value)],
+                check=False,
+            )
+        else:
+            subprocess.run(
+                ["tmux", "set-environment", "-t", session, key, value],
+                check=False,
+            )
+
+
+def build_session_env_shell_fragment(session: str, env: dict[str, str]) -> str:
+    """Build a shell fragment of `tmux set-environment` calls for chained remote commands.
+
+    Returns a trailing `&& ` string ready to splice into an ssh-executed compound
+    command. Empty string if no env.
+    """
+    if not env:
+        return ""
+    parts = []
+    for key, value in env.items():
+        parts.append(
+            f"tmux set-environment -t {shlex.quote(session)} "
+            f"{shlex.quote(key)} {shlex.quote(value)}"
+        )
+    return " && ".join(parts) + " && "
 
 
 def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None, model: str | None = None) -> AgentCommand:
@@ -107,13 +147,12 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
         zai = config.get("zai", {})
         pi_config = config.get("pi", {})
 
-        # Pi reads ZAI_API_KEY from env. Unlike Claude Code, pi has native
-        # Z.AI provider support (--provider zai), so we don't override URLs.
-        env_prefix = f"ZAI_API_KEY={shlex.quote(zai.get('api_key', ''))} "
+        # Pi reads ZAI_API_KEY from env. We inject it via `tmux set-environment`
+        # (see inject_session_env) so the key never appears in `ps auxwww`.
         pi_binary = pi_config.get("binary", "pi")
         default_model = pi_config.get("default_model", "glm-5")
 
-        parts = [env_prefix + pi_binary, "--provider", "zai"]
+        parts = [pi_binary, "--provider", "zai"]
         parts.extend(["--model", model or default_model])
 
         # Permission variants (pi has no permission system to bypass; variants
@@ -142,6 +181,7 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
         return AgentCommand(
             command=" ".join(parts),
             temp_file=temp_file,
+            env={"ZAI_API_KEY": zai.get("api_key", "")},
         )
 
     # === Claude Code ===
@@ -3489,12 +3529,15 @@ def cmd_new(args) -> int:
             except Exception as e:
                 print(f"Warning: Failed to write system prompt to remote: {e}", file=sys.stderr)
 
+        env_fragment = build_session_env_shell_fragment(session_name, agent.env)
+
         # Create session - Agent starts immediately if not bare
         if agent_cmd:
             create_cmd = (
                 f"tmux new-session -d -s {shlex.quote(session_name)} -c {shlex.quote(remote_path)} && "
                 f"tmux send-keys -t {shlex.quote(session_name)} 'cd {shlex.quote(remote_path)}' Enter && "
                 f"sleep 0.1 && "
+                f"{env_fragment}"
                 f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(agent_cmd)} Enter"
             )
         else:
@@ -3637,6 +3680,9 @@ def cmd_new(args) -> int:
     agent = build_agent_command(session_type, roles if roles else None, model=model_override)
 
     agent_cmd = agent.command
+
+    # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+    inject_session_env(session_name, agent.env)
 
     # Start agent command if not bare
     if agent_cmd:
@@ -4139,6 +4185,12 @@ def cmd_spawn(args) -> int:
     agent_cmd = agent.command
 
     try:
+        # Inject secrets onto the parent session before spawning the pane so the
+        # new pane inherits them from tmux (avoids putting keys in `ps`).
+        parent_session = session or pane_manager.get_current_session()
+        if parent_session:
+            inject_session_env(parent_session, agent.env)
+
         # Spawn pane first to get the pane index
         pane_index = pane_manager.spawn_worker_pane(
             session=session,
@@ -4516,11 +4568,13 @@ def cmd_recreate(args) -> int:
         # Build agent command using the standard function
         agent = build_agent_command(session_type_str)
         agent_cmd = agent.command
+        env_fragment = build_session_env_shell_fragment(session_name, agent.env)
 
         create_cmd = (
             f"tmux new-session -d -s {shlex.quote(session_name)} -c {shlex.quote(session_path)} && "
             f"tmux send-keys -t {shlex.quote(session_name)} 'cd {shlex.quote(session_path)}' Enter && "
             f"sleep 0.1 && "
+            f"{env_fragment}"
             f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(agent_cmd)} Enter"
         )
 
@@ -4632,6 +4686,9 @@ def cmd_recreate(args) -> int:
         check=True
     )
     time.sleep(0.1)
+
+    # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+    inject_session_env(session_name, agent.env)
 
     # Start the agent with appropriate command
     if agent_cmd:
@@ -4891,11 +4948,13 @@ def cmd_fork(args) -> int:
         agent = build_agent_command(session_type_str, roles)
 
         agent_cmd = agent.command
+        env_fragment = build_session_env_shell_fragment(target_session, agent.env)
 
         create_session_cmd = (
             f"tmux new-session -d -s {shlex.quote(target_session)} -c {shlex.quote(target_path)} && "
             f"tmux send-keys -t {shlex.quote(target_session)} 'cd {shlex.quote(target_path)}' Enter && "
             f"sleep 0.1 && "
+            f"{env_fragment}"
             f"tmux send-keys -t {shlex.quote(target_session)} {shlex.quote(agent_cmd)} Enter"
         )
 
@@ -5043,6 +5102,9 @@ def cmd_fork(args) -> int:
         # Build agent command
         agent = build_agent_command(session_type_str, roles)
 
+        # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+        inject_session_env(target_session, agent.env)
+
         agent_cmd = agent.command
         if agent_cmd:
             # Inject --resume <id> --fork-session right after the 'claude' binary
@@ -5156,6 +5218,10 @@ def cmd_fork(args) -> int:
     # Build agent command
     agent = build_agent_command(session_type_str, roles)
     agent_cmd = agent.command
+
+    # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+    inject_session_env(target_session, agent.env)
+
     if agent_cmd:
         subprocess.run(
             ["tmux", "send-keys", "-t", target_session, agent_cmd, "Enter"],
@@ -5752,6 +5818,9 @@ def cmd_dev(args) -> int:
     subprocess.run([
         "tmux", "new-session", "-d", "-s", session_name, "-c", str(project_dir),
     ])
+
+    # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+    inject_session_env(session_name, agent.env)
 
     # Start agent with agentwire config
     if agent_cmd:

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -87,9 +87,9 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
     """Build the agent command for a session.
 
     Args:
-        session_type: Session type (e.g., "claude-bypass", "claude-auto", "bare")
+        session_type: Session type (e.g., "claude-bypass", "claude-auto", "pi-zai", "bare")
         roles: Optional list of roles to apply
-        model: Optional model override (e.g., "haiku", "sonnet", "opus")
+        model: Optional model override (e.g., "haiku", "sonnet", "opus", "glm-5")
 
     Returns:
         AgentCommand with the command string and metadata
@@ -100,6 +100,49 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
 
     # Merge roles if provided
     merged = merge_roles(roles) if roles else None
+
+    # === Pi coding agent via Z.AI GLM ===
+    if session_type.startswith("pi-zai"):
+        config = load_config()
+        zai = config.get("zai", {})
+        pi_config = config.get("pi", {})
+
+        # Pi reads ZAI_API_KEY from env. Unlike Claude Code, pi has native
+        # Z.AI provider support (--provider zai), so we don't override URLs.
+        env_prefix = f"ZAI_API_KEY={shlex.quote(zai.get('api_key', ''))} "
+        pi_binary = pi_config.get("binary", "pi")
+        default_model = pi_config.get("default_model", "glm-5")
+
+        parts = [env_prefix + pi_binary, "--provider", "zai"]
+        parts.extend(["--model", model or default_model])
+
+        # Permission variants (pi has no permission system to bypass; variants
+        # translate to pi's --tools whitelist instead)
+        temp_file = None
+        if session_type == "pi-zai-restricted":
+            parts.extend(["--tools", "read,grep,find,bash"])
+        elif session_type == "pi-zai-readonly":
+            parts.extend(["--tools", "read,grep,find"])
+        elif merged and merged.tools:
+            # Translate Claude tool names to pi's lowercase tool names.
+            # Pi only supports: read, bash, edit, write, grep, find, ls
+            pi_valid = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+            pi_tools = [t.lower() for t in merged.tools if t.lower() in pi_valid]
+            if pi_tools:
+                parts.extend(["--tools", ",".join(pi_tools)])
+
+        # Role-based system prompt (skipped for restricted/readonly — those are curated contexts)
+        if merged and merged.instructions and session_type not in ("pi-zai-restricted", "pi-zai-readonly"):
+            f = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+            f.write(merged.instructions)
+            f.close()
+            temp_file = f.name
+            parts.append(f'--append-system-prompt "$(<{temp_file})"')
+
+        return AgentCommand(
+            command=" ".join(parts),
+            temp_file=temp_file,
+        )
 
     # === Claude Code ===
     if session_type.startswith("claude"):
@@ -6069,6 +6112,23 @@ def cmd_doctor(args) -> int:
         print("  [..] claude: not found (optional, use --bare sessions or other agents)")
         print("     Install: https://github.com/anthropics/claude-code")
 
+    # Check Pi coding agent (optional, for pi-zai session types)
+    pi_path = shutil.which("pi")
+    if pi_path:
+        try:
+            # Pi prints --version to stderr, so merge with stdout
+            result = subprocess.run(
+                [pi_path, "--version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            pi_version = (result.stdout + result.stderr).strip()
+            print(f"  [ok] pi: {pi_path} (v{pi_version})")
+        except Exception:
+            print(f"  [ok] pi: {pi_path}")
+    else:
+        print("  [..] pi: not found (optional, required for pi-zai session types)")
+        print("     Install: npm install -g @mariozechner/pi-coding-agent")
+
     # 3. Check AgentWire scripts
     print("\nChecking AgentWire scripts...")
 
@@ -9854,7 +9914,7 @@ def main() -> int:
     new_parser.add_argument("-p", "--path", help="Working directory (default: ~/projects/<name>)")
     new_parser.add_argument("-f", "--force", action="store_true", help="Replace existing session")
     # Session type
-    new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, standard, worker, voice)")
+    new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
     # Roles
     new_parser.add_argument("--roles", help="Comma-separated list of roles (preserves existing config, defaults to agentwire for new projects)")
     new_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
@@ -9889,7 +9949,7 @@ def main() -> int:
     spawn_parser.add_argument("-s", "--session", help="Target session (default: auto-detect)")
     spawn_parser.add_argument("--cwd", help="Working directory (default: current)")
     spawn_parser.add_argument("--branch", "-b", help="Create worktree on this branch for isolated commits")
-    spawn_parser.add_argument("--type", help="Session type (claude-bypass, claude-prompted, claude-restricted)")
+    spawn_parser.add_argument("--type", help="Session type (claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly)")
     spawn_parser.add_argument("--roles", default="worker", help="Comma-separated roles (default: worker)")
     spawn_parser.add_argument("--no-wait", action="store_true", help="Don't wait for worker to be ready (default: wait up to 30s)")
     spawn_parser.add_argument("--timeout", type=int, default=30, help="Seconds to wait for worker ready (default: 30)")
@@ -9927,7 +9987,7 @@ def main() -> int:
     recreate_parser = subparsers.add_parser("recreate", help="Destroy and recreate session with fresh worktree")
     recreate_parser.add_argument("-s", "--session", required=True, help="Session name (project/branch or project/branch@machine)")
     # Session type
-    recreate_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, standard, worker, voice)")
+    recreate_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
     recreate_parser.add_argument("--json", action="store_true", help="Output as JSON")
     recreate_parser.set_defaults(func=cmd_recreate)
 
@@ -9936,7 +9996,7 @@ def main() -> int:
     fork_parser.add_argument("-s", "--source", required=True, help="Source session (project or project/branch)")
     fork_parser.add_argument("-t", "--target", required=True, help="Target session (must include branch: project/new-branch)")
     # Session type
-    fork_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, standard, worker, voice)")
+    fork_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
     fork_parser.add_argument("--commit", metavar="REF", help="Fork from this commit/ref instead of HEAD (e.g. abc123, main~5)")
     fork_parser.add_argument("--json", action="store_true", help="Output as JSON")
     fork_parser.set_defaults(func=cmd_fork)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -106,6 +106,26 @@ def inject_session_env(session: str, env: dict[str, str], remote_host: str | Non
             )
 
 
+def parse_env_args(env_args: list[str] | None) -> dict[str, str]:
+    """Parse repeated `--env KEY=VAL` flags into a dict.
+
+    Raises SystemExit via argparse pattern if an entry lacks `=`.
+    """
+    if not env_args:
+        return {}
+    result: dict[str, str] = {}
+    for entry in env_args:
+        if "=" not in entry:
+            print(f"Error: --env expects KEY=VAL, got {entry!r}", file=sys.stderr)
+            sys.exit(2)
+        key, value = entry.split("=", 1)
+        if not key:
+            print(f"Error: --env KEY cannot be empty (got {entry!r})", file=sys.stderr)
+            sys.exit(2)
+        result[key] = value
+    return result
+
+
 def build_session_env_shell_fragment(session: str, env: dict[str, str]) -> str:
     """Build a shell fragment of `tmux set-environment` calls for chained remote commands.
 
@@ -3507,8 +3527,7 @@ def cmd_new(args) -> int:
 
         # Build agent command
         agent = build_agent_command(session_type, roles if roles else None)
-
-    
+        agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
         agent_cmd = agent.command
 
@@ -3678,6 +3697,7 @@ def cmd_new(args) -> int:
     # Build agent command
     model_override = getattr(args, 'model', None)
     agent = build_agent_command(session_type, roles if roles else None, model=model_override)
+    agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
     agent_cmd = agent.command
 
@@ -4181,6 +4201,7 @@ def cmd_spawn(args) -> int:
 
     # Build agent command
     agent = build_agent_command(session_type_str, roles if roles else None)
+    agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
     agent_cmd = agent.command
 
@@ -4567,6 +4588,7 @@ def cmd_recreate(args) -> int:
 
         # Build agent command using the standard function
         agent = build_agent_command(session_type_str)
+        agent.env.update(parse_env_args(getattr(args, 'env', None)))
         agent_cmd = agent.command
         env_fragment = build_session_env_shell_fragment(session_name, agent.env)
 
@@ -4671,6 +4693,7 @@ def cmd_recreate(args) -> int:
 
     # Build agent command
     agent = build_agent_command(session_type_str, roles)
+    agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
     agent_cmd = agent.command
 
@@ -4754,6 +4777,7 @@ def cmd_worktree(args) -> int:
             'force': False, 'bare': False, 'restricted': False, 'prompted': False,
             'type': getattr(args, 'type', None), 'roles': getattr(args, 'roles', None),
             'instructions': None, 'persist': False,
+            'env': getattr(args, 'env', None),
         })())
 
     # If worktree already exists, reattach
@@ -4946,6 +4970,7 @@ def cmd_fork(args) -> int:
 
         # Build agent command
         agent = build_agent_command(session_type_str, roles)
+        agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
         agent_cmd = agent.command
         env_fragment = build_session_env_shell_fragment(target_session, agent.env)
@@ -5101,6 +5126,7 @@ def cmd_fork(args) -> int:
 
         # Build agent command
         agent = build_agent_command(session_type_str, roles)
+        agent.env.update(parse_env_args(getattr(args, 'env', None)))
 
         # Inject secrets via tmux set-environment (keeps keys out of `ps`)
         inject_session_env(target_session, agent.env)
@@ -5217,6 +5243,7 @@ def cmd_fork(args) -> int:
 
     # Build agent command
     agent = build_agent_command(session_type_str, roles)
+    agent.env.update(parse_env_args(getattr(args, 'env', None)))
     agent_cmd = agent.command
 
     # Inject secrets via tmux set-environment (keeps keys out of `ps`)
@@ -9988,6 +10015,7 @@ def main() -> int:
     new_parser.add_argument("--roles", help="Comma-separated list of roles (preserves existing config, defaults to agentwire for new projects)")
     new_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
     new_parser.add_argument("--persist", action="store_true", help="Write --type/--roles to .agentwire.yml (default: session-level override only)")
+    new_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable, keeps secrets out of `ps`)")
     new_parser.add_argument("--json", action="store_true", help="Output as JSON")
     new_parser.set_defaults(func=cmd_new)
 
@@ -10022,6 +10050,7 @@ def main() -> int:
     spawn_parser.add_argument("--roles", default="worker", help="Comma-separated roles (default: worker)")
     spawn_parser.add_argument("--no-wait", action="store_true", help="Don't wait for worker to be ready (default: wait up to 30s)")
     spawn_parser.add_argument("--timeout", type=int, default=30, help="Seconds to wait for worker ready (default: 30)")
+    spawn_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var onto parent session (repeatable)")
     spawn_parser.add_argument("--json", action="store_true", help="Output as JSON")
     spawn_parser.set_defaults(func=cmd_spawn)
 
@@ -10057,6 +10086,7 @@ def main() -> int:
     recreate_parser.add_argument("-s", "--session", required=True, help="Session name (project/branch or project/branch@machine)")
     # Session type
     recreate_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
+    recreate_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
     recreate_parser.add_argument("--json", action="store_true", help="Output as JSON")
     recreate_parser.set_defaults(func=cmd_recreate)
 
@@ -10067,6 +10097,7 @@ def main() -> int:
     # Session type
     fork_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
     fork_parser.add_argument("--commit", metavar="REF", help="Fork from this commit/ref instead of HEAD (e.g. abc123, main~5)")
+    fork_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
     fork_parser.add_argument("--json", action="store_true", help="Output as JSON")
     fork_parser.set_defaults(func=cmd_fork)
 
@@ -10080,6 +10111,7 @@ def main() -> int:
     wt_parser.add_argument("--project", "-p", help="Path to git repo (default: from config or cwd)")
     wt_parser.add_argument("--type", help="Session type override")
     wt_parser.add_argument("--roles", help="Comma-separated role names")
+    wt_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
     wt_parser.add_argument("--json", action="store_true", help="Output as JSON")
     wt_parser.set_defaults(func=cmd_worktree)
 

--- a/agentwire/overnight.py
+++ b/agentwire/overnight.py
@@ -498,7 +498,7 @@ def dispatch_item(item: OvernightItem, config) -> bool:
 
     Returns True if dispatch succeeded.
     """
-    from .__main__ import build_agent_command, _wait_for_agent_ready
+    from .__main__ import build_agent_command, _wait_for_agent_ready, inject_session_env
 
     project = item.project_path
     session = item.session
@@ -537,6 +537,9 @@ def dispatch_item(item: OvernightItem, config) -> bool:
         subprocess.run(["tmux", "kill-session", "-t", session], capture_output=True)
         _log_event("dispatch_failed", item_id=item.id, error=item.error)
         return False
+
+    # Inject secrets via tmux set-environment (keeps keys out of `ps`)
+    inject_session_env(session, agent.env)
 
     # Inject --resume <id> --fork-session
     if item.resume_session_id:

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -13,12 +13,15 @@ import yaml
 
 
 class SessionType(str, Enum):
-    """Session type determines Claude execution mode."""
-    BARE = "bare"                    # No Claude, just tmux session
+    """Session type determines agent execution mode."""
+    BARE = "bare"                    # No agent, just tmux session
     CLAUDE_BYPASS = "claude-bypass"  # Claude with --dangerously-skip-permissions
     CLAUDE_AUTO = "claude-auto"      # Claude with auto mode (classifier safety net)
     CLAUDE_PROMPTED = "claude-prompted"  # Claude with permission hooks
     CLAUDE_RESTRICTED = "claude-restricted"  # Claude with only say allowed
+    PI_ZAI = "pi-zai"                      # Pi coding agent via Z.AI GLM (full tools)
+    PI_ZAI_RESTRICTED = "pi-zai-restricted"  # Pi via Z.AI, read+search+bash (no edits)
+    PI_ZAI_READONLY = "pi-zai-readonly"      # Pi via Z.AI, read-only inspection
     # Universal types (agent-agnostic, map to agent-specific types)
     STANDARD = "standard"  # Full automation -> claude-bypass
     WORKER = "worker"      # Worker pane -> claude-restricted
@@ -70,6 +73,7 @@ def normalize_session_type(session_type: str, agent_type: str) -> str:
     # If already agent-specific, return as-is
     agent_specific_types = [
         "claude-bypass", "claude-auto", "claude-prompted", "claude-restricted",
+        "pi-zai", "pi-zai-restricted", "pi-zai-readonly",
         "bare"
     ]
     if session_type in agent_specific_types:

--- a/docs/missions/pi-harness-overview.md
+++ b/docs/missions/pi-harness-overview.md
@@ -1,0 +1,91 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Pi Harness Integration — Overview
+
+Integrate [pi coding agent](https://github.com/badlogic/pi-mono) as the harness for all Z.AI work. Keeps Claude Code pure for Anthropic subscription and unlocks new capabilities (dual-mode REPL + programmable).
+
+**Context:** The previous claudeGLM wrapper (env var override into the `claude` binary) was removed from main on 2026-04-12 — Claude Code ignores inline `ANTHROPIC_*` env vars when OAuth auth is active, so the wrapper silently stopped working. Pi replaces that approach with a proper standalone binary that has native Z.AI provider support.
+
+**Decision made 2026-04-13** after hands-on evaluation. See `~/.agentwire/wiki/wiki/research/pi-coding-agent-zai-harness.md` for the full evaluation.
+
+## Why Pi
+
+| Benefit | Detail |
+|---------|--------|
+| Native Z.AI provider | `--provider zai` built-in — no env var hacks |
+| Minimal tool surface | 4 tools (read/write/edit/bash), smaller system prompt, more context |
+| Print mode (`-p`) | Non-interactive execution, exits when done — perfect for automation |
+| JSON event stream | `--mode json` emits JSONL for programmatic parsing |
+| RPC protocol | `--mode rpc` for bidirectional control (future) |
+| CLAUDE.md aware | Loads CLAUDE.md/AGENTS.md from cwd automatically |
+| `--append-system-prompt` | Identical flag to Claude Code — role injection works unchanged |
+| MIT licensed | No subscription tied to anyone's binary |
+| Thinking control | `--thinking off\|low\|medium\|high\|xhigh` per task |
+
+## The Architecture
+
+Pi unlocks a **dual-mode** model that Claude Code can't cleanly provide:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Claude Code (Anthropic subscription)                   │
+│  ├─ Human-directed interactive sessions                 │
+│  ├─ Orchestrator sessions (need MCP tools)              │
+│  └─ Overnight queue dispatch                            │
+├─────────────────────────────────────────────────────────┤
+│  Pi REPL Mode (Z.AI subscription)                       │
+│  ├─ Interactive coding, cost-sensitive                  │
+│  ├─ Worker panes that take multiple tasks               │
+│  └─ Live exploration / debugging                        │
+├─────────────────────────────────────────────────────────┤
+│  Pi Programmable Mode (Z.AI subscription)               │
+│  ├─ Workflow action nodes                               │
+│  ├─ Scheduler task nodes                                │
+│  └─ Chainable automation DAGs                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Mission Phases
+
+Each phase is its own mission doc. Execute sequentially — each validates the next.
+
+| # | Mission | Doc | Status |
+|---|---------|-----|--------|
+| 1 | Pi Session Type | `pi-session-type.md` | **complete (2026-04-13)** |
+| 2 | Pi Workflow Engine | `pi-workflow-engine.md` | planned |
+| 3 | Scheduler Workflows | `pi-scheduler-workflows.md` | planned |
+| 4 | Advanced Workflow Patterns | `pi-workflow-advanced.md` | planned |
+| 5 | Workflow Desktop UI | `pi-workflow-ui.md` | planned |
+
+**Completion target:** Phases 1–3 by 2026-05-15. Phase 4–5 as needed.
+
+## Dependencies Across Phases
+
+```
+Phase 1 (Session Type)
+  │
+  ├──► Phase 2 (Workflow Engine) ──► Phase 3 (Scheduler Workflows)
+                                         │
+                                         ├──► Phase 4 (Advanced Patterns)
+                                         └──► Phase 5 (Desktop UI)
+```
+
+Phase 1 validates pi works in our stack. Phase 2 builds the engine pi powers. Phases 3–5 extend the engine.
+
+## Key Non-Goals
+
+- **Not replacing Claude Code entirely** — Claude Code remains the primary harness for Anthropic-subscription work and anything requiring the agentwire MCP client
+- **Not adding MCP to pi** — pi intentionally doesn't ship MCP; workflow nodes can call agentwire CLI via bash when needed
+
+## Migration Plan (High Level)
+
+1. Phase 1 ships: `pi-zai` session type is the sole Z.AI path (claudeGLM already gone from main)
+2. Scheduler migrates tasks to `pi-zai` as Phase 3 workflow engine lands
+3. Phases 4–5 extend pi for advanced patterns and UI
+
+## Open Questions Across All Phases
+
+- Pi RPC protocol docs are sparse — does it stabilize before we depend on it?
+- How do we handle pi binary upgrades? npm global install, version pinning?
+- Should workflow nodes support non-pi engines (Claude Code fallback)?
+- What's the right event/state persistence store for long-running workflows?

--- a/docs/missions/pi-scheduler-workflows.md
+++ b/docs/missions/pi-scheduler-workflows.md
@@ -1,0 +1,196 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Phase 3 — Scheduler Workflows
+
+Integrate the pi workflow engine (Phase 2) with the existing scheduler so scheduled tasks can be workflows instead of single prompts. Migrate existing scheduler tasks one-by-one as workflows prove out.
+
+**Phase of:** `pi-harness-overview.md`
+**Status:** planned
+**Estimated effort:** 1 week
+**Depends on:** Phase 1, Phase 2
+**Blocks:** Phase 4 (advanced patterns use scheduler as a driver)
+
+## Goal
+
+Scheduled tasks in `~/.agentwire/scheduler.yaml` can reference a workflow instead of (or in addition to) a single prompt. When the scheduler fires the task, it runs the workflow and reports status.
+
+## Why This Matters
+
+Scheduler tasks today are single-prompt monoliths. Fragile prompts fail in opaque ways. With workflow-backed tasks:
+- Each step is independently testable
+- Failures point to a specific node, not "the task failed"
+- Retries happen at the node level, not re-running the whole task
+- Cost and duration are measurable per step
+- Common patterns (analyze → verify → report) become reusable
+
+## Scope
+
+### In Scope
+
+- New `workflow:` field in scheduler task schema
+- Scheduler dispatch path for workflow tasks (bypasses tmux session creation)
+- Workflow run results feed into existing notification/summary system
+- Morning report includes per-node workflow details
+- At least 3 existing scheduler tasks migrated to workflows
+- Gate preconditions (`git_commit`, `git_diff`, `command`) still work for workflow tasks
+- Failure handling: partial failures, node-level retry, workflow-level retry
+
+### Out of Scope (Later)
+
+- Running workflows across multiple machines (deferred)
+- Workflow versioning / migrations (deferred)
+- Automatic rollback on failure (Phase 4)
+- Workflow composition — workflows calling workflows (Phase 4)
+
+## Approach
+
+### 1. Extend Scheduler Task Schema
+
+```yaml
+# ~/.agentwire/scheduler.yaml
+tasks:
+  # Existing prompt-based task (still supported)
+  morning-briefing:
+    schedule: { every: day, at: "08:00" }
+    prompt: "Summarize my day..."
+    type: claude-bypass
+  
+  # New: workflow-backed task
+  nightly-doc-audit:
+    schedule: { every: day, at: "23:00" }
+    workflow: doc-drift-check
+    inputs:
+      paths: [docs/, agentwire/]
+    gate:
+      git_diff: [docs/, agentwire/]
+    retries: 2
+    notify: voice
+```
+
+### 2. Dispatch Path
+
+Current scheduler:
+1. Check gate preconditions
+2. Acquire lock
+3. Render prompt template
+4. Create tmux session
+5. Send prompt to session
+6. Monitor for idle
+7. Extract summary
+8. Release lock, notify
+
+New workflow path:
+1. Check gate preconditions (unchanged)
+2. Acquire lock (unchanged)
+3. Load workflow definition
+4. Render inputs (from task-level `inputs:` + gate outputs)
+5. Call `workflows.runner.run_workflow(name, inputs)` directly — no tmux needed
+6. Receive structured result (status, outputs, node events)
+7. Persist result as scheduler run record
+8. Release lock, notify with node-level detail
+
+Key insight: **workflow tasks don't need tmux sessions.** They run the pi binary in subprocesses, collect JSONL, produce results. Simpler, faster, cheaper.
+
+### 3. Task Result Mapping
+
+Scheduler expects exit codes (see CLAUDE.md: 0=complete, 1=failed, 2=incomplete, etc.). Map workflow status:
+
+| Workflow result | Scheduler exit code |
+|-----------------|--------------------|
+| All nodes succeed | 0 (complete) |
+| Any node fails with `on_error: fail` | 1 (failed) |
+| Gate precondition failed | 3 (skipped) |
+| Timeout exceeded | 5 (timeout) |
+| Invalid workflow definition | 4 (pre failure) |
+
+### 4. Morning Report Integration
+
+Scheduler report HTML needs new sections:
+- Workflow runs: duration, cost per node, files modified, failures
+- Per-node breakdown when a workflow fails
+- Cost rollup across workflow tasks
+
+### 5. Migration of Existing Tasks
+
+Existing tasks to evaluate for workflow migration:
+
+| Current Task | Workflow Candidate | Benefit |
+|--------------|-------------------|---------|
+| `code-quality` | `code-quality-sweep` workflow | Multi-file, can parallelize in Phase 4 |
+| `doc-drift` | `doc-drift-check` workflow | Already conceptually multi-step |
+| `performance-audit` | `performance-audit` workflow | Separate measure → compare → report phases |
+| `design-audit` | `design-audit` workflow | Currently fails because Chrome headless issue — workflow can branch around failure |
+| `console-cleanup` | `console-cleanup` workflow | Currently too aggressive — workflow adds verify step |
+| `wiki-ingest` | `wiki-ingest` workflow | Parallel per raw file, good Phase 4 candidate |
+
+**Migration rule:** Don't migrate all at once. Pick one, convert, run for a week, compare quality/cost, decide.
+
+### 6. Scheduler Workflow Commands
+
+```bash
+# Dry-run a scheduled workflow
+agentwire scheduler run <task> --dry-run   # Shows workflow execution plan
+
+# See why a workflow task failed
+agentwire scheduler history <task>  # Now includes workflow run IDs
+agentwire workflow show <run-id>    # Drill into node details
+```
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `agentwire/scheduler/tasks.py` | Extend TaskConfig dataclass with `workflow`, `inputs` fields |
+| `agentwire/scheduler/dispatcher.py` | New `dispatch_workflow_task()` path alongside existing `dispatch_session_task()` |
+| `agentwire/scheduler/schema.py` | Validate workflow reference exists when `workflow:` field set |
+| `agentwire/scheduler/report.py` | Render workflow task runs in morning report |
+| `agentwire/scheduler/cli.py` | Update `scheduler run` to handle workflow tasks |
+| `~/.agentwire/scheduler.yaml` | Migrated tasks (one at a time) |
+| `docs/scheduler.md` | Document workflow task schema |
+| `tests/scheduler/test_workflow_dispatch.py` | New integration tests |
+
+## Success Criteria
+
+- [ ] Scheduler `workflow:` field works end-to-end with a real task
+- [ ] Gates still gate workflow tasks (git_commit, git_diff, command)
+- [ ] Cooldown, retries, priority all apply to workflow tasks
+- [ ] Exit codes map correctly to scheduler status
+- [ ] Morning report shows workflow details per task
+- [ ] At least 3 existing tasks successfully migrated, producing results comparable in quality to the original prompt versions
+- [ ] No regression in non-workflow task behavior
+
+## Testing Plan
+
+### Unit Tests
+- TaskConfig accepts both `prompt:` and `workflow:` (but not both)
+- Schema validation: workflow reference must resolve to existing YAML
+- Exit code mapping for all workflow result types
+
+### Integration Tests
+- Schedule a workflow task, fire it, verify it runs and reports
+- Fire a workflow task with failing gate, verify it skips correctly
+- Fire a workflow task that hits a node failure with `retries: 2`, verify retry happens
+- Fire a workflow task with partial outputs, verify post-commands get the outputs
+
+### Manual QA
+- Pick one real scheduler task, convert to workflow, run for 7 days
+- Compare: success rate, cost, debuggability, duration
+- Document findings in the mission file before moving to next task
+
+## Open Questions
+
+- **Lock granularity:** Should workflow tasks use node-level locks or just task-level? Start with task-level (simpler), revisit if parallelism becomes common.
+- **Gate output → workflow input:** Gates today produce output (e.g., `git_diff` files). Should these feed workflow inputs automatically? Probably yes — expose `gate.git_diff.files` as workflow input.
+- **Scheduler UI:** Does the portal need a new view for workflow tasks? Defer to Phase 5.
+- **Long-running workflows:** What if a workflow takes 20 minutes? Does scheduler block the dispatch queue? Run workflows in background subprocess with their own lifecycle.
+
+## Rollout
+
+1. **Week 1:** Build dispatch path, test with single example workflow task
+2. **Week 2:** Migrate first real task (`doc-drift` is a good candidate — non-critical, already multi-step in spirit)
+3. **Week 3:** Migrate second task, compare metrics
+4. **Week 4:** Migrate third task, decide on acceleration
+
+## Notes
+
+This phase is where the scheduler fully switches from monolithic `pi-zai` task prompts to composable workflow DAGs. Individual-prompt scheduler tasks stay supported (migration is opt-in per task), but workflows become the preferred pattern for anything multi-step.

--- a/docs/missions/pi-session-type.md
+++ b/docs/missions/pi-session-type.md
@@ -1,0 +1,238 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Phase 1 — Pi Session Type
+
+Add `pi-zai*` session types to agentwire so users can spawn pi-based interactive sessions the same way they spawn Claude Code sessions today.
+
+**Phase of:** `pi-harness-overview.md`
+**Status:** complete (code shipped 2026-04-13)
+**Estimated effort:** 2–3 days (actual: 1 day)
+**Depends on:** none
+**Blocks:** Phase 2 (workflow engine validates pi invocation path)
+
+## Goal
+
+Provide a first-class mechanism for running Z.AI-backed interactive sessions (replacing the removed claudeGLM wrapper). A user should be able to run:
+
+```bash
+agentwire new -s myproject --type pi-zai -p ~/projects/myproject
+```
+
+...and get a pi session attached to their project, with CLAUDE.md loaded, roles applied, Z.AI models ready.
+
+## Scope
+
+### In Scope
+
+- New session types: `pi-zai`, `pi-zai-restricted`, `pi-zai-readonly`
+- `build_agent_command()` extended with pi-zai branch
+- Role injection via `--append-system-prompt` (same mechanism as Claude Code)
+- Tool restriction via `--tools` flag (translated role tool lists to pi's lowercase names)
+- Idle detection updated to recognize pi's `node` process when running
+- `.agentwire.yml` validation accepts new types
+- Config schema: `pi.default_model` in `config.yaml` (default `glm-5`)
+- Documentation: new `docs/pi-zai.md`, updates to `CLAUDE.md`
+
+### Out of Scope (Later Phases)
+
+- Workflow/programmatic mode (Phase 2)
+- Scheduler integration (Phase 3)
+- Session forking equivalent to `--resume --fork-session` (deferred — pi uses `--session <file> --continue`, needs its own fork helper)
+- MCP client for pi (not planned — pi intentionally doesn't ship MCP)
+- Claude Code removal / deprecation
+
+## Approach
+
+### 1. Extend `build_agent_command()` in `agentwire/__main__.py`
+
+Add a new branch to handle `pi-zai*` session types (inserted before the `claude` block):
+
+```python
+if session_type.startswith("pi-zai"):
+    config = load_config()
+    zai = config.get("zai", {})
+    pi_config = config.get("pi", {})
+    
+    env_prefix = f"ZAI_API_KEY={shlex.quote(zai.get('api_key', ''))} "
+    
+    parts = [env_prefix + "pi", "--provider", "zai"]
+    
+    # Model selection
+    default_model = pi_config.get("default_model", "glm-5")
+    parts.extend(["--model", model or default_model])
+    
+    # Permission variants (pi has no permission system, but tool restriction maps)
+    if session_type == "pi-zai-restricted":
+        parts.extend(["--tools", "read,grep,find,bash"])
+    elif session_type == "pi-zai-readonly":
+        parts.extend(["--tools", "read,grep,find"])
+    # "pi-zai" uses pi's default: read,bash,edit,write
+    
+    # Role-based flags
+    temp_file = None
+    if merged and session_type not in ("pi-zai-restricted", "pi-zai-readonly"):
+        if merged.tools:
+            # Translate Claude tool names to pi tool names (lowercase)
+            pi_tools = [t.lower() for t in merged.tools if t.lower() in 
+                        ("read", "bash", "edit", "write", "grep", "find", "ls")]
+            if pi_tools:
+                parts.extend(["--tools", ",".join(pi_tools)])
+        
+        # Note: pi has no --disallowedTools equivalent
+        # Merged disallowed_tools intentionally ignored with warning in log
+        
+        if merged.instructions:
+            f = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+            f.write(merged.instructions)
+            f.close()
+            temp_file = f.name
+            parts.append(f'--append-system-prompt "$(<{temp_file})"')
+    
+    return AgentCommand(
+        command=" ".join(parts),
+        temp_file=temp_file,
+    )
+```
+
+### 2. Update config schema
+
+Add to `agentwire/config.py`:
+
+```python
+DEFAULT_CONFIG = {
+    # ... existing ...
+    "pi": {
+        "default_model": "glm-5",
+        "binary": "pi",  # override if installed elsewhere
+    },
+}
+```
+
+Add to example `config.yaml` in docs.
+
+### 3. Update idle detection
+
+`agentwire/completion.py` — `_session_has_agent()` currently returns False when pane shows a bare shell. Pi shows as `node` when running, so:
+
+```python
+AGENT_PROCESSES = {"claude", "node", "python"}  # Add node for pi
+SHELL_PROCESSES = {"zsh", "bash", "sh", "fish", "tcsh", "csh"}
+
+def _session_has_agent(session: str) -> bool:
+    # ... existing tmux list-panes logic ...
+    # Now checks if any pane runs an agent process (not shell)
+```
+
+Need to verify this doesn't break existing Claude Code detection — Claude Code also runs under node on some setups.
+
+### 4. Update `.agentwire.yml` validation
+
+`agentwire/project_config.py` — add to SessionType enum/Literal:
+
+```python
+SessionType = Literal[
+    "claude-bypass", "claude-auto", "claude-prompted", "claude-restricted",
+    "pi-zai", "pi-zai-restricted", "pi-zai-readonly",
+    "bare",
+]
+```
+
+### 5. Documentation
+
+- New file: `docs/pi-zai.md` with setup, config, troubleshooting
+- Update `CLAUDE.md` in project root: add pi-zai to session types table
+- Update `README.md` if it mentions session types
+- Update `agentwire --help` output (argparse choices)
+
+### 6. Dev dependency: check pi is installed
+
+On `agentwire doctor`, check `which pi` and report version. If missing:
+```
+Pi coding agent not installed. Install with: npm install -g @mariozechner/pi-coding-agent
+```
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `agentwire/__main__.py` | Add `pi-zai*` branch to `build_agent_command()` (lines ~85-199) |
+| `agentwire/__main__.py` | Update argparse `--type` choices to include pi-zai variants |
+| `agentwire/config.py` | Add `pi` section to DEFAULT_CONFIG |
+| `agentwire/project_config.py` | Extend SessionType Literal |
+| `agentwire/completion.py` | Update idle detection for node/pi |
+| `agentwire/agents/tmux.py` | Review `_format_agent_command()` for pi-specific flags (resume path) |
+| `agentwire/doctor.py` | Add pi installation check |
+| `docs/pi-zai.md` | New file: setup, examples, config, gotchas |
+| `CLAUDE.md` | Add pi-zai to session types docs |
+| `tests/test_build_agent_command.py` | New tests for pi-zai branch |
+| `tests/test_project_config.py` | Update enum validation tests |
+
+## Success Criteria
+
+- [x] `agentwire new -s test --type pi-zai -p /tmp/test-project` creates a session with pi running
+- [x] `.agentwire.yml` with `type: pi-zai` loads correctly, pi inherits roles/instructions
+- [x] Sending prompt via `agentwire send -s test "..."` works (interactive)
+- [x] Idle detection works (node while running, shell when exited — pre-existing logic handles this)
+- [x] Role injection works: spawn with role, pi correctly identifies itself as a worker pane
+- [x] `agentwire doctor` reports pi version when installed, clear error when missing
+- [x] All existing Claude Code tests still pass
+- [x] New tests for pi-zai session type pass (9 test cases added)
+- [ ] At least one scheduler task running on `pi-zai` stably for 48h (deferred to follow-up)
+
+## Testing Plan
+
+### Unit Tests
+```python
+def test_build_agent_command_pi_zai_basic():
+    cmd = build_agent_command("pi-zai").command
+    assert "pi --provider zai" in cmd
+    assert "ZAI_API_KEY=" in cmd
+
+def test_build_agent_command_pi_zai_with_role():
+    role = RoleConfig(name="worker", tools=["Read", "Bash"], instructions="Be concise")
+    cmd = build_agent_command("pi-zai", [role])
+    assert "--tools read,bash" in cmd.command
+    assert "--append-system-prompt" in cmd.command
+
+def test_build_agent_command_pi_zai_restricted():
+    cmd = build_agent_command("pi-zai-restricted").command
+    assert "--tools read,grep,find,bash" in cmd
+
+def test_build_agent_command_pi_zai_readonly():
+    cmd = build_agent_command("pi-zai-readonly").command
+    assert "--tools read,grep,find" in cmd
+    assert "edit" not in cmd and "write" not in cmd
+
+def test_build_agent_command_pi_zai_model_override():
+    cmd = build_agent_command("pi-zai", model="glm-5.1").command
+    assert "--model glm-5.1" in cmd
+```
+
+### Integration Tests
+- Spawn session, send message, read output, kill session
+- Spawn with role, verify role is applied (grep for known string in output)
+- Spawn with invalid API key, verify graceful error
+- Spawn in /tmp dir with CLAUDE.md, verify pi loads it
+
+### Manual QA
+- Dev for a day using pi-zai session for a real task
+- Voice summary test — does alert/notify work when pi session goes idle?
+- Fork test — copy session JSONL, start new pi with `--continue`, verify context preserved
+
+## Open Questions
+
+- **Idle detection edge case:** If user runs `node` for something unrelated in the pane (not pi), will we falsely detect it as an agent? Answer: probably yes, but pane 0 in agentwire sessions is always the agent, so this is fine. Document limitation.
+- **Binary location:** Pi is installed via nvm (`~/.nvm/versions/node/v20.19.4/bin/pi`). What if user has it elsewhere? Config `pi.binary` override should handle this.
+- **`--disallowedTools` gap:** Some roles use disallowed tool lists. For pi-zai, we lose this. Log a warning when merged.disallowed_tools is non-empty for pi-zai sessions. Consider: translate to tool whitelist minus disallowed.
+- **Session fork:** Claude Code has `--resume <id> --fork-session`. Pi has `--session <file> --continue`. Fork (create new session that starts from existing) needs a helper that copies the JSONL file first. Defer to a follow-up task or Phase 2.
+
+## Rollout
+
+1. Merge — session types are additive, no behavior change to existing sessions
+2. Update one personal scheduler task (low stakes) to pi-zai
+3. Monitor output/cost for 48h
+4. Confirm CLAUDE.md marks pi-zai as the canonical Z.AI path
+
+## Notes
+
+Pi v0.66.1 is the tested baseline. Pin expectations to that version in docs until we know upgrade compatibility. Pi is pre-1.0 — breaking changes possible between minors.

--- a/docs/missions/pi-workflow-advanced.md
+++ b/docs/missions/pi-workflow-advanced.md
@@ -1,0 +1,288 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Phase 4 — Advanced Workflow Patterns
+
+Extend the Phase 2 workflow engine with patterns that require more sophistication: parallel execution, loops with accumulators, human-in-the-loop pauses, cost circuit breakers, and cross-workflow composition.
+
+**Phase of:** `pi-harness-overview.md`
+**Status:** planned
+**Estimated effort:** 2–3 weeks
+**Depends on:** Phase 2, Phase 3 (real-world usage validates what's actually needed)
+**Blocks:** none (Phase 5 depends on some patterns for visualization)
+
+## Goal
+
+Unlock workflow patterns that are currently impossible with sequential DAGs: fan-out/fan-in, iterative refinement, human approval gates, and composition.
+
+## Why This Phase Is Later
+
+Phases 1–3 establish the foundation. Only after real scheduler tasks run as workflows for weeks do we know which advanced patterns are actually needed. Premature sophistication = wrong abstractions. This mission should be revisited after Phase 3 has been live for 30+ days.
+
+## Scope
+
+### In Scope
+
+- **Parallel execution:** Nodes without interdependencies run concurrently
+- **Fan-out / fan-in:** `for_each` spawns N parallel instances of a node, join barrier collects all
+- **Loop with accumulator:** `while` or `until` conditions with state carried between iterations
+- **Human-in-the-loop:** Node pauses, sends notification, waits for user response, resumes
+- **Cost circuit breakers:** Per-workflow cost cap; abort with cleanup if exceeded
+- **Cross-workflow calls:** Node can invoke another workflow as a sub-step
+- **Shared state store:** Optional sqlite-backed key-value store for cross-run memory
+- **Rollback hooks:** On failure, declared rollback nodes run to undo changes
+- **Event-driven triggers:** Workflows triggered by file changes, webhooks, git hooks
+
+### Out of Scope
+
+- Distributed execution across machines (separate mission if needed)
+- Real-time collaborative editing of running workflows
+- GUI-based workflow authoring (Phase 5 handles visualization, not authoring)
+
+## Approach
+
+### 1. Parallel Execution
+
+Refactor `runner.py` to async. Identify independent nodes per topological layer, execute via `asyncio.gather()`.
+
+```yaml
+nodes:
+  fetch-a:
+    prompt: "Read file A"
+    # No depends_on — runs in layer 0
+  
+  fetch-b:
+    prompt: "Read file B"
+    # No depends_on — runs in layer 0 (in parallel with fetch-a)
+  
+  merge:
+    depends_on: [fetch-a, fetch-b]
+    prompt: "Combine: {{ fetch-a.text }} and {{ fetch-b.text }}"
+    # Runs in layer 1 after both complete
+```
+
+Key constraints:
+- Limit concurrency via `max_parallel` config (default 4 — respect Z.AI rate limits)
+- Stream events from all parallel nodes, interleave in event log with node_id tags
+
+### 2. Fan-out / Fan-in
+
+```yaml
+nodes:
+  list-files:
+    prompt: "List all .ts files as JSON array"
+    outputs: [files]
+  
+  check-each:
+    depends_on: [list-files]
+    for_each: "{{ list-files.files }}"   # Spawns N instances
+    as: file                             # Loop variable name
+    max_parallel: 3
+    prompt: "Check {{ file }} for issues"
+    outputs: [issues]
+  
+  aggregate:
+    depends_on: [check-each]
+    prompt: |
+      All issues found:
+      {% for issue in check-each.all_outputs.issues %}
+        - {{ issue }}
+      {% endfor %}
+```
+
+Semantics: `check-each` produces a collection (`all_outputs`) indexed across iterations. Downstream nodes access aggregated view.
+
+### 3. Loops With State
+
+```yaml
+nodes:
+  iterate:
+    loop:
+      until: "{{ complexity < 10 or iterations >= 5 }}"
+      initial: { complexity: 100, iterations: 0 }
+    prompt: |
+      Current complexity: {{ state.complexity }}
+      Refactor the next-worst function. Report new complexity as JSON: {"complexity": N}
+    outputs:
+      - name: complexity
+        source: jsonpath
+        pattern: $.complexity
+    loop_update:
+      complexity: "{{ outputs.complexity }}"
+      iterations: "{{ state.iterations + 1 }}"
+```
+
+Bounds: loop max iterations config (default 10) to prevent runaway.
+
+### 4. Human-in-the-Loop
+
+```yaml
+nodes:
+  propose:
+    prompt: "Generate refactoring plan"
+    outputs: [plan]
+  
+  approve:
+    depends_on: [propose]
+    type: human_gate
+    notify:
+      channel: slack
+      text: |
+        Refactor plan ready:
+        {{ propose.plan }}
+        
+        Reply "approve" or "reject" to this thread.
+    timeout: 3600       # 1 hour
+    expected_responses: [approve, reject]
+    on_timeout: reject
+  
+  execute:
+    depends_on: [approve]
+    when: "{{ approve.response == 'approve' }}"
+    prompt: "Apply the refactorings"
+```
+
+Implementation: node writes a "waiting" marker file, scheduler/daemon monitors for response from channel, unblocks.
+
+### 5. Cost Circuit Breaker
+
+```yaml
+workflow:
+  cost_cap_usd: 2.00           # Abort if exceeds
+  cost_cap_action: rollback    # rollback | halt | warn
+```
+
+Every node accumulates cost from pi's JSONL `usage` events. Before each node, check cumulative — abort if over.
+
+### 6. Cross-Workflow Calls
+
+```yaml
+nodes:
+  verify:
+    type: workflow_call
+    workflow: test-suite
+    inputs:
+      test_pattern: "src/api/**"
+    outputs: [passed, failed_tests]
+```
+
+Implementation: `workflow_call` nodes spawn a sub-runner with shared storage. Keep call graph flat — no deep nesting.
+
+### 7. Shared State Store
+
+Simple sqlite-backed k-v store at `~/.agentwire/workflows/state.db`:
+
+```yaml
+nodes:
+  remember:
+    prompt: "Process events"
+    state_write:
+      last_processed_id: "{{ outputs.latest_id }}"
+  
+  use-later:
+    prompt: "Continue from {{ state.last_processed_id }}"
+    state_read: [last_processed_id]
+```
+
+Scope of state: per-workflow-name by default, or `shared_state_scope: global`.
+
+### 8. Rollback Hooks
+
+```yaml
+nodes:
+  modify:
+    prompt: "Apply changes"
+    on_failure_call: undo-modifications   # Another node id
+
+  undo-modifications:
+    prompt: "Git reset --hard"
+    tools: [bash]
+```
+
+Semantics: if `modify` fails after retries exhausted, `undo-modifications` runs before workflow halts.
+
+### 9. Event-Driven Triggers
+
+New daemon: `agentwire workflow-trigger serve`
+
+Triggers config:
+```yaml
+# ~/.agentwire/workflow-triggers.yaml
+triggers:
+  on-pr-opened:
+    event: webhook
+    endpoint: /pr-opened
+    workflow: pr-triage
+    inputs:
+      pr_url: "{{ event.pr.url }}"
+  
+  on-file-change:
+    event: fswatch
+    paths: [docs/]
+    debounce: 60
+    workflow: doc-drift-check
+```
+
+Defer unless there's real demand — don't build speculative infrastructure.
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `agentwire/workflows/runner.py` | Async refactor, parallel layer execution |
+| `agentwire/workflows/node.py` | New node types: LoopNode, HumanGateNode, WorkflowCallNode |
+| `agentwire/workflows/state.py` | New: sqlite k-v store |
+| `agentwire/workflows/cost.py` | New: cost tracker + circuit breaker |
+| `agentwire/workflows/triggers.py` | New: event-driven trigger daemon |
+| `agentwire/workflows/cli.py` | New commands: `workflow state ls/get/set`, `workflow pause/resume <run-id>` |
+| `docs/workflows-advanced.md` | New doc covering all Phase 4 patterns |
+
+## Success Criteria
+
+- [ ] Parallel nodes demonstrably run concurrently (wall clock < sum of durations)
+- [ ] `for_each` works with collection outputs, respects `max_parallel`
+- [ ] Loop with `until` terminates on condition and on max iterations
+- [ ] Human-in-the-loop: workflow pauses, Slack message received, resumes on reply
+- [ ] Cost cap: workflow aborts when cost exceeded, runs rollback nodes
+- [ ] `workflow_call` nodes work, sub-workflow outputs accessible in parent
+- [ ] State store persists across runs of the same workflow
+- [ ] Rollback runs on failure before workflow halts
+
+## Testing Plan
+
+### Parallel / Fan-out
+- Workflow with 5 independent nodes — verify wall clock ≈ max(durations), not sum
+- `for_each` over 10-item array with `max_parallel: 3` — verify throttling works
+
+### Loops
+- Loop terminates on condition
+- Loop hits max iterations and halts with proper error
+- Loop state updates correctly between iterations
+
+### Human-in-the-Loop
+- Mock Slack reply in test, verify workflow resumes
+- Timeout without reply, verify `on_timeout` behavior
+
+### Cost
+- Workflow with artificial high-cost node, verify cap triggers abort
+- Verify partial results are still preserved
+
+## Open Questions
+
+- **Async vs thread-pool:** Pi is a subprocess, so OS-level parallelism works. asyncio.subprocess is cleaner than ThreadPoolExecutor.
+- **Z.AI rate limits:** What's the actual concurrent request limit? Default `max_parallel: 4` conservative; may need per-model tuning.
+- **Human gate implementation:** Use existing channel bridges (Slack/Discord) with a "waiting workflow" marker, or build a dedicated gate service? Start with bridge + marker file; refactor if noisy.
+- **State store consistency:** Single-writer assumption for sqlite is fine until workflows run on multiple machines. Defer multi-machine state.
+- **Backwards compat:** Do Phase 2 workflow definitions still work unchanged? They must. All Phase 4 features are opt-in via new YAML fields.
+
+## Risk Mitigation
+
+- **Async bugs:** Async Python has sharp edges. Write tests for cancellation, exception propagation, task cleanup.
+- **Cost runaway in loops:** Hard-cap loop iterations, require explicit opt-in above default.
+- **Human gate timeouts hanging forever:** Default timeout is mandatory; error out if not set.
+- **State race conditions:** Writes within a node are single-threaded; parallel nodes writing to same key is undefined — document + detect in validator.
+
+## Notes
+
+This is the mission that makes pi + workflows genuinely novel in the agent tooling space. Most workflow engines either lack LLM-specific primitives (n8n, Airflow) or lack general-purpose plumbing (Langgraph). Pi + our engine hits both.
+
+Revisit after Phase 3 live data. Some of these patterns may be unnecessary; others we haven't imagined yet may prove essential.

--- a/docs/missions/pi-workflow-engine.md
+++ b/docs/missions/pi-workflow-engine.md
@@ -1,0 +1,326 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Phase 2 — Pi Workflow Engine
+
+Build a programmable workflow system where pi invocations are nodes in a directed graph. Each node is a one-shot `pi -p --mode json` call with structured inputs and outputs. Nodes chain into DAGs for complex automation that's impossible with today's single-prompt scheduler tasks.
+
+**Phase of:** `pi-harness-overview.md`
+**Status:** planned
+**Estimated effort:** 2–3 weeks
+**Depends on:** Phase 1 (validates pi invocation path, config, install)
+**Blocks:** Phase 3 (scheduler workflows), Phase 4 (advanced patterns), Phase 5 (UI)
+
+## Goal
+
+Ship `agentwire workflow run <name>` that executes a YAML-defined DAG of pi invocations, with inputs/outputs flowing between nodes, conditional branching, retries, and full event log for debugging.
+
+## Why This Unlocks Something New
+
+**Today:** Scheduler tasks are one prompt. Complex logic lives inside that prompt as natural-language instructions. Debugging = guessing. Conditionals = hoping the model interprets correctly.
+
+**With workflows:** Each step is discrete, testable, cheap (pi minimal tool surface), and observable (JSONL event stream). You compose small reliable nodes instead of praying a giant prompt works.
+
+## Scope
+
+### In Scope
+
+- New module: `agentwire/workflows/`
+- Node abstraction (`ActionNode`, `ConditionalNode`, `ParallelNode`)
+- Pi runner: subprocess wrapper around `pi -p --mode json --no-session`
+- JSONL event stream parser → structured outputs
+- Jinja2-style template rendering for prompts (`{{ var }}`)
+- YAML workflow definition format + validator
+- DAG executor with topological sort + dependency resolution
+- CLI commands: `agentwire workflow {list, run, show, validate}`
+- Persistent run storage: `~/.agentwire/workflows/runs/<id>/events.jsonl`
+- Per-node timeout, retry, on_error handling
+- Variable extraction via JSON path (node outputs → workflow context)
+
+### Out of Scope (Later Phases)
+
+- Scheduler integration (Phase 3)
+- Parallel fan-out / fan-in with join barriers (Phase 4)
+- Human-in-the-loop pause/resume (Phase 4)
+- Cost circuit breakers (Phase 4)
+- Workflow canvas UI (Phase 5)
+- Remote workflow execution across machines (deferred)
+
+## Approach
+
+### Module Layout
+
+```
+agentwire/workflows/
+├── __init__.py
+├── node.py           # Node dataclasses and validators
+├── pi_runner.py      # Pi subprocess wrapper + JSONL parser
+├── runner.py         # DAG executor
+├── context.py        # Template rendering + variable store
+├── definitions.py    # YAML parser and schema validator
+├── storage.py        # Run persistence (events, outputs, metadata)
+└── cli.py            # agentwire workflow command handlers
+```
+
+### Node Abstraction
+
+```python
+@dataclass
+class ActionNode:
+    id: str                          # Unique within workflow
+    prompt: str                      # Jinja2 template
+    provider: str = "zai"
+    model: str = "glm-5"
+    tools: list[str] = field(default_factory=lambda: ["read", "bash", "edit", "write"])
+    thinking: str = "medium"         # off | minimal | low | medium | high | xhigh
+    
+    depends_on: list[str] = field(default_factory=list)
+    when: str | None = None          # Jinja2 expression for conditional
+    
+    outputs: list[OutputSpec] = field(default_factory=list)
+    timeout: int = 300               # Seconds
+    retries: int = 0
+    retry_delay: int = 10
+    on_error: Literal["fail", "continue", "branch"] = "fail"
+    on_error_goto: str | None = None # Node id to jump to on error
+    
+    workdir: str | None = None       # cwd for pi (default: workflow cwd)
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+@dataclass
+class OutputSpec:
+    name: str                        # Variable name in context
+    source: Literal["text", "regex", "jsonpath", "tool_result"]
+    pattern: str                     # Regex or JSONPath expression
+    required: bool = True            # Fail node if extraction fails?
+```
+
+### Pi Runner Contract
+
+```python
+def run_node(node: ActionNode, context: Context) -> NodeResult:
+    """Execute one node. Synchronous. Streams JSONL to file."""
+    
+    prompt = context.render(node.prompt)
+    
+    cmd = [
+        "pi", "-p", prompt,
+        "--provider", node.provider,
+        "--model", node.model,
+        "--tools", ",".join(node.tools),
+        "--thinking", node.thinking,
+        "--mode", "json",
+        "--no-session",
+    ]
+    
+    env = {**os.environ, "ZAI_API_KEY": get_zai_key(), **node.extra_env}
+    
+    events = []
+    with open(event_log_path, "w") as log:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env,
+                                cwd=node.workdir or context.cwd)
+        for line in proc.stdout:
+            log.write(line.decode())
+            event = json.loads(line)
+            events.append(event)
+            # Emit progress event to CLI/UI...
+    
+    # Extract outputs per node.outputs spec
+    outputs = extract_outputs(events, node.outputs)
+    
+    return NodeResult(
+        node_id=node.id,
+        status="success" if proc.returncode == 0 else "failure",
+        outputs=outputs,
+        events=events,
+        final_text=extract_final_assistant_message(events),
+        tool_calls=extract_tool_calls(events),
+        files_modified=extract_file_changes(events),
+        tokens_used=extract_token_usage(events),
+        duration_ms=...,
+    )
+```
+
+### Workflow Definition (YAML)
+
+```yaml
+name: refactor-and-verify
+description: Analyze file, apply refactorings, verify via tests
+version: 1
+
+inputs:
+  file:
+    type: string
+    required: true
+    description: Path to file to refactor
+
+nodes:
+  analyze:
+    prompt: |
+      Read {{ inputs.file }} and identify refactoring opportunities.
+      Output JSON: {"issues": [{"description": "...", "severity": "high|medium|low"}]}
+    tools: [read, grep]
+    thinking: high
+    outputs:
+      - name: issues
+        source: jsonpath
+        pattern: $.issues[*]
+
+  refactor:
+    depends_on: [analyze]
+    prompt: |
+      Apply these refactorings to {{ inputs.file }}:
+      {% for issue in analyze.issues %}
+        - {{ issue.description }} ({{ issue.severity }})
+      {% endfor %}
+    tools: [read, edit]
+    retries: 2
+    timeout: 600
+
+  verify:
+    depends_on: [refactor]
+    prompt: "Run tests and report pass/fail"
+    tools: [bash]
+    outputs:
+      - name: test_status
+        source: regex
+        pattern: "(PASS|FAIL)"
+
+  rollback:
+    depends_on: [verify]
+    when: "{{ verify.test_status == 'FAIL' }}"
+    prompt: "Git reset --hard HEAD to undo refactorings"
+    tools: [bash]
+
+outputs:
+  - verify.test_status
+  - refactor.files_modified
+```
+
+### DAG Executor
+
+- Topological sort of nodes by `depends_on`
+- Sequential execution initially (parallel in Phase 4)
+- Context object carries: `inputs`, per-node outputs, `env` (global variables)
+- When a node has `when`, evaluate expression against current context; skip if false
+- On `on_error: fail`, halt workflow; on `continue`, proceed; on `branch`, jump to `on_error_goto`
+- Emit lifecycle events: workflow_start, node_start, node_tool_call, node_end, workflow_end
+
+### CLI Commands
+
+```bash
+# List available workflows
+agentwire workflow list
+agentwire workflow list --json
+
+# Validate YAML without running
+agentwire workflow validate <path-or-name>
+
+# Run workflow with inputs
+agentwire workflow run refactor-and-verify --input file=src/api.ts
+agentwire workflow run <name> --input-file inputs.json
+agentwire workflow run <name> --dry-run   # Print execution plan only
+
+# Inspect past runs
+agentwire workflow history
+agentwire workflow show <run-id>
+agentwire workflow show <run-id> --events  # Full JSONL replay
+agentwire workflow show <run-id> --node analyze  # Just one node
+```
+
+### Storage
+
+```
+~/.agentwire/workflows/
+├── defs/                        # Workflow YAML files (discoverable)
+│   ├── refactor-and-verify.yaml
+│   └── ...
+└── runs/
+    └── <workflow>-<timestamp>-<id>/
+        ├── metadata.json        # Inputs, start/end, status
+        ├── context.json         # Final context (all variables)
+        ├── events.jsonl         # Combined event log across all nodes
+        └── nodes/
+            ├── analyze.events.jsonl
+            ├── refactor.events.jsonl
+            └── ...
+```
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `agentwire/workflows/__init__.py` | Module init, public API |
+| `agentwire/workflows/node.py` | Node dataclasses |
+| `agentwire/workflows/pi_runner.py` | Pi subprocess + JSONL parser |
+| `agentwire/workflows/runner.py` | DAG executor |
+| `agentwire/workflows/context.py` | Jinja2 rendering, variable store |
+| `agentwire/workflows/definitions.py` | YAML loader + JSON schema validator |
+| `agentwire/workflows/storage.py` | Run persistence |
+| `agentwire/workflows/cli.py` | CLI handlers for `agentwire workflow *` |
+| `agentwire/__main__.py` | Wire `workflow` subcommand into argparse |
+| `agentwire/mcp_server.py` | Add `workflow_run` / `workflow_list` MCP tools |
+| `docs/workflows.md` | Full developer docs |
+| `workflows/examples/` | Ship 3–5 example workflows in repo |
+| `tests/workflows/test_*.py` | Unit + integration tests |
+
+## Success Criteria
+
+- [ ] `agentwire workflow run <name>` executes a simple 3-node workflow end-to-end
+- [ ] Jinja2 templating works: node B receives node A's outputs
+- [ ] `when` conditionals correctly skip nodes
+- [ ] `retries` actually retries on pi failure
+- [ ] Event log is replayable: can reconstruct workflow state from `events.jsonl`
+- [ ] Dry-run mode prints execution plan without running pi
+- [ ] At least one example workflow ships in repo (`refactor-and-verify`)
+- [ ] MCP tools work: orchestrator sessions can trigger workflows
+- [ ] Documentation explains: how to write a workflow, how to test one, how to debug a failed run
+- [ ] Workflow YAML schema is versioned (`version: 1`) and validated
+
+## Testing Plan
+
+### Unit Tests
+- Node dataclass validation (required fields, enum checks)
+- OutputSpec extraction: regex, jsonpath, text patterns
+- Template rendering: variables, loops, conditionals
+- DAG topological sort
+- Dependency cycle detection (should raise)
+
+### Integration Tests (with real pi + Z.AI)
+- 2-node workflow: analyze → report
+- 3-node workflow with conditional: analyze → refactor → (verify | rollback)
+- Retry behavior: force a failure, verify retry happens
+- Timeout behavior: set low timeout, verify kill + cleanup
+- Output extraction: JSON response → parsed into context
+
+### Example Workflows (ship with repo)
+1. **refactor-and-verify** — as above
+2. **dependency-audit** — scan package.json, check versions, open issues
+3. **doc-drift-check** — compare CLAUDE.md claims against actual code
+4. **pr-triage** — read PR diff, generate review comment
+5. **test-recovery** — when test fails, diagnose → propose fix → verify
+
+## Open Questions
+
+- **Templating engine:** Jinja2 is heavy — consider minijinja or a lightweight alternative. But devs know Jinja, so familiarity wins.
+- **Parallel execution:** Ship sequential first. Parallel needs asyncio refactor — Phase 4.
+- **Secrets:** How do nodes access secrets (API keys, tokens)? Pass via `extra_env`, source from config/env.
+- **Streaming output:** Should CLI stream JSONL as it runs, or batch-display at end? Stream with live progress.
+- **Fork within workflow:** Can a node spawn a pi session with context from earlier? Yes — use `--session <file>` with copied JSONL.
+- **Cross-workflow coordination:** Can workflow A trigger workflow B? Phase 4 concern.
+- **State between runs:** Do workflows have persistent state (e.g., "last seen issue"), or are they stateless? Stateless by default; persistence via writing to files is allowed.
+
+## Risk Mitigation
+
+- **Pi stability:** Pi is pre-1.0. If JSONL schema changes, parser breaks. Mitigation: pin pi version in docs, add schema version check, warn on unknown event types.
+- **Token cost runaway:** A workflow with many retries + xhigh thinking could get expensive. Mitigation: per-run cost accumulator, abort if exceeds config cap (Phase 4).
+- **Runaway bash:** Pi's `bash` tool runs anything. Workflows triggered by scheduler need same damage-control hooks Claude Code uses. Mitigation: run pi nodes under same safety scripts, or add `--bash-deny` via extension.
+
+## Prior Art
+
+- **n8n** — node-based workflow automation, too GUI-centric
+- **Temporal** — robust but too heavy for dev workflows
+- **GitHub Actions** — YAML DAGs, good reference for syntax decisions
+- **Prefect** — Python workflow orchestration, good for DAG patterns
+- **Langgraph** — LLM-specific DAGs, closest conceptual match
+
+We're building a minimal version optimized for pi specifically. Don't reinvent what we don't need.

--- a/docs/missions/pi-workflow-ui.md
+++ b/docs/missions/pi-workflow-ui.md
@@ -1,0 +1,207 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Phase 5 — Workflow Desktop UI
+
+Add visual workflow authoring, live run monitoring, and replay capability to the agentwire portal. Make workflows approachable for users who prefer GUIs over YAML, and make debugging failed runs drastically easier.
+
+**Phase of:** `pi-harness-overview.md`
+**Status:** planned
+**Estimated effort:** 2–3 weeks
+**Depends on:** Phase 2 (engine), Phase 3 (real runs to visualize), Phase 4 (parallel/loop patterns to render)
+**Blocks:** none
+
+## Goal
+
+Ship a workflow canvas view in the portal where users can:
+1. See all workflows in the system
+2. Open a workflow and view its DAG visually
+3. Watch a workflow run live: nodes light up as they execute
+4. Replay past runs from the event log
+5. Edit workflow YAML with syntax help (not full visual authoring — that's overkill)
+
+## Why This Is Phase 5
+
+YAML-first is correct. Users who author workflows are devs who prefer text. But **debugging** is where GUI shines — staring at a JSONL event log is awful; a visual DAG with per-node status + drill-down is transformative.
+
+This phase ships when there are enough workflows in real use that the UX friction from pure-CLI debugging becomes a real pain point.
+
+## Scope
+
+### In Scope
+
+- **Workflow list view** in sidebar (like existing sessions/services sections)
+- **Workflow canvas view** — opened as a desktop window (WinBox)
+  - DAG visualization with nodes (rectangles) and edges (dependencies)
+  - Node color by status: pending (gray), running (blue pulse), success (green), failure (red), skipped (dashed)
+  - Click node → detail pane with prompt, outputs, events
+- **Live run monitor** — subscribes to WebSocket events, updates node states in real time
+- **Run history** — list of past runs per workflow with status/duration/cost
+- **Replay mode** — step through events in a past run, node states evolve as if live
+- **YAML editor** — Monaco editor inline in the portal with JSON schema validation for workflow files
+
+### Out of Scope
+
+- Drag-and-drop visual authoring (overkill — YAML is fine)
+- Collaborative editing
+- Workflow marketplace / sharing (far future)
+- Mobile view (portal is desktop-first)
+
+## Approach
+
+### 1. Backend: WebSocket Workflow Events
+
+Extend `agentwire/server.py`:
+
+```python
+# New WebSocket endpoint: /ws/workflow-events
+# Clients subscribe to run IDs, receive event stream
+
+# On workflow runner event, broadcast to subscribers:
+{
+  "type": "node_start",
+  "run_id": "abc-123",
+  "node_id": "analyze",
+  "timestamp": "..."
+}
+```
+
+Runner emits these via a channel the server listens on (asyncio queue or file watch on events.jsonl).
+
+### 2. New REST endpoints
+
+```
+GET  /api/workflows                      # List all workflow definitions
+GET  /api/workflows/:name                # Load definition (YAML + parsed)
+GET  /api/workflows/:name/runs           # Run history for a workflow
+GET  /api/workflow-runs/:id              # Run metadata + context
+GET  /api/workflow-runs/:id/events       # Full event log (JSONL)
+GET  /api/workflow-runs/:id/nodes/:nid   # Single node detail
+POST /api/workflows/:name/run            # Trigger a run (returns run_id)
+POST /api/workflows/:name                # Save definition (YAML)
+```
+
+### 3. Frontend: Workflow Sidebar Section
+
+`static/js/sidebar/workflows-section.js`:
+- Lists workflows (names from `/api/workflows`)
+- Each item shows latest run status indicator
+- Click: opens canvas window
+
+### 4. Frontend: Canvas Window
+
+`static/js/windows/workflow-canvas.js`:
+- Renders with a lightweight DAG library (e.g., dagre for layout + vanilla SVG for rendering — avoid heavy deps like react-flow)
+- Responsive to workflow complexity (grid layout for small, force-directed for large)
+- Event subscription: connects WebSocket, updates node statuses
+- Detail pane: right side of canvas, shows selected node info
+
+### 5. Run Detail Drill-Down
+
+Click node during/after a run:
+- Left column: prompt template + rendered prompt
+- Middle column: pi event log (timeline of tool calls, thinking, response)
+- Right column: outputs, cost, duration
+
+Similar UX to browser devtools: collapsible, searchable, resizable.
+
+### 6. YAML Editor
+
+For workflow authoring:
+- Monaco editor (already used in the portal for session config?)
+- JSON schema validation with inline errors
+- Autocomplete for node fields
+- "Save" button persists to `~/.agentwire/workflows/defs/<name>.yaml`
+- "Validate" button calls `agentwire workflow validate <path>`
+
+### 7. Replay Mode
+
+For debugging failed runs:
+- Scrubber bar at the bottom of the canvas
+- As you scrub, node states evolve to match that point in the event log
+- Pause/play/step controls
+- Detail pane shows state at that scrubbed moment
+
+## Files to Change
+
+### Backend
+| File | Changes |
+|------|---------|
+| `agentwire/server.py` | New REST endpoints for workflows |
+| `agentwire/server.py` | WebSocket endpoint `/ws/workflow-events` |
+| `agentwire/workflows/runner.py` | Emit events to server queue as they occur |
+| `agentwire/workflows/storage.py` | Add API for querying run history |
+
+### Frontend
+| File | Changes |
+|------|---------|
+| `static/js/sidebar/workflows-section.js` | New sidebar section |
+| `static/js/windows/workflow-canvas.js` | New canvas window component |
+| `static/js/workflow-events.js` | WebSocket subscriber for live events |
+| `static/js/workflow-yaml-editor.js` | Monaco-based editor |
+| `static/css/workflow.css` | Styles for canvas, node states, detail pane |
+
+### Dependencies
+- `dagre` or `elkjs` for DAG layout (npm — included via esbuild or CDN)
+- Monaco editor (likely already available)
+
+## Success Criteria
+
+- [ ] Workflow list appears in sidebar with status indicators
+- [ ] Clicking a workflow opens a canvas window showing the DAG
+- [ ] Running a workflow live updates node colors in real time
+- [ ] Clicking a node shows prompt, events, outputs
+- [ ] Replay mode scrubs through a completed run accurately
+- [ ] YAML editor validates on save, surfaces errors inline
+- [ ] Workflow UI uses same patterns as existing portal (WinBox windows, sidebar accordion)
+- [ ] Performance: canvas handles workflows with 20+ nodes without lag
+
+## Testing Plan
+
+### Manual
+- Open a simple 3-node workflow, run it, watch live updates
+- Open a 10-node workflow with branching, verify layout is readable
+- Load a completed run, replay it, verify state matches expectation
+- Edit a workflow YAML, introduce a syntax error, verify editor catches it
+- Run 50+ workflows, verify history list stays performant
+
+### Automated
+- Puppeteer / Playwright: render workflow, simulate WebSocket events, assert node colors update
+- API contract tests for all new endpoints
+
+## Open Questions
+
+- **DAG layout engine:** dagre is simpler and smaller; ELK is more sophisticated but heavier. Start with dagre.
+- **Authoring depth:** Do we want a true "click to add node" mode, or keep authoring in YAML only? Keep YAML-first.
+- **Multi-run comparison:** Can users diff two runs of the same workflow side-by-side? Nice-to-have, defer.
+- **Canvas interactivity:** Zoom, pan, fit-to-screen standard. Minimap? Only if workflows grow large.
+- **Permission model:** Anyone with portal access can trigger workflows? Same as current session trigger permissions — no new model.
+
+## Risk Mitigation
+
+- **Rendering performance:** Large DAGs (50+ nodes) may lag. Mitigation: virtualize offscreen nodes, use SVG not canvas.
+- **Event flood:** High-frequency events from pi (tool calls, thinking chunks) could overwhelm WebSocket. Mitigation: server-side throttling, client-side batching.
+- **Frontend complexity creep:** A workflow canvas wants to become an IDE. Resist feature creep. Ship "read + replay" first, add "write" incrementally.
+
+## Prior Art Reference
+
+- **n8n canvas** — nice node-and-edge UI, but too GUI-centric for our authoring ethos
+- **Airflow DAG view** — good for monitoring, weak for auth
+- **GitHub Actions run view** — inspiration for per-node event drill-down
+- **Temporal Web UI** — good example of replay from event log
+- **Langsmith** — LLM-specific observability, good UX for prompt/output inspection
+
+Borrow UX patterns, avoid their complexity.
+
+## Rollout
+
+1. Ship the sidebar section + list view (stub detail for now)
+2. Ship the canvas window with static layout (no live updates yet)
+3. Add WebSocket live updates
+4. Add run history + replay
+5. Add YAML editor last — it's the highest-risk / lowest-value piece of UX and can wait until real demand
+
+## Notes
+
+If Phases 3–4 data shows workflow adoption is strong, this phase is high-value — it 10x's debuggability and approachability. If adoption is slow, this phase may not be worth building; invest in better CLI output instead.
+
+Decide whether to proceed with Phase 5 after Phase 3 has been live for 60+ days.

--- a/docs/pi-zai.md
+++ b/docs/pi-zai.md
@@ -1,0 +1,222 @@
+> Living document. Update this, don't create new versions.
+
+# Pi-ZAI Session Types
+
+Run AgentWire sessions backed by [pi coding agent](https://github.com/badlogic/pi-mono) and Z.AI's GLM models instead of Claude Code. Keeps Claude Code pure for Anthropic subscription, uses pi for cost-sensitive Z.AI work.
+
+## When to Use pi-zai vs Other Session Types
+
+| Use Case | Session Type | Why |
+|----------|-------------|-----|
+| Human-directed work, orchestration, MCP tools needed | `claude-bypass` / `claude-auto` | Full Claude Code ecosystem |
+| Cost-sensitive interactive sessions, no MCP needed | **`pi-zai`** | Native Z.AI, minimal overhead |
+| Worker panes doing bounded tasks | **`pi-zai-restricted`** | Read + search + bash, no edits |
+| Read-only audit / inspection sessions | **`pi-zai-readonly`** | No bash, pure file inspection |
+| Anthropic subscription overnight work | `claude-auto` | Classifier safety net |
+
+## Prerequisites
+
+### Install Pi
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+Verify installation:
+
+```bash
+agentwire doctor  # Should show: [ok] pi: /path/to/pi (v0.66.1)
+```
+
+### Configure Z.AI
+
+Add Z.AI credentials to `~/.agentwire/config.yaml`:
+
+```yaml
+zai:
+  api_key: "your-zai-api-key"
+  base_url: "https://api.z.ai/api/anthropic"  # Kept for future consumers; pi uses native ZAI provider
+  timeout_ms: 3000000
+```
+
+Optionally configure pi defaults:
+
+```yaml
+pi:
+  default_model: "glm-5"   # glm-5 | glm-5.1 | glm-5-turbo | glm-4.7 | glm-4.7-flash | ...
+  binary: "pi"             # Override if pi is installed somewhere other than $PATH
+```
+
+## Session Types
+
+### `pi-zai`
+
+Full tool access (read, bash, edit, write). Closest equivalent of `claude-bypass`.
+
+```bash
+agentwire new -s myproject --type pi-zai -p ~/projects/myproject
+```
+
+Uses the `default_model` from config (default: `glm-5`).
+
+### `pi-zai-restricted`
+
+Whitelists `read, grep, find, bash`. Can inspect and run commands but **cannot modify files**. Use for worker panes that investigate without changing things.
+
+```bash
+agentwire new -s audit --type pi-zai-restricted -p ~/projects/myproject
+```
+
+Role-provided tool whitelists are ignored for this type (curated list takes precedence).
+
+### `pi-zai-readonly`
+
+Whitelists `read, grep, find`. **No bash, no edits.** Pure inspection. Use for sessions that should only look, never touch.
+
+```bash
+agentwire new -s inspect --type pi-zai-readonly -p ~/projects/myproject
+```
+
+Role instructions are also ignored for this type.
+
+## `.agentwire.yml` Example
+
+```yaml
+type: pi-zai
+roles:
+  - agentwire
+  - worker
+voice: may
+parent: main
+```
+
+All existing `.agentwire.yml` fields work identically. Roles inject via `--append-system-prompt` — same mechanism as Claude Code.
+
+## Model Override
+
+Pick a different GLM model per-session:
+
+```bash
+agentwire new -s fast --type pi-zai --model glm-4.7-flash -p ~/projects/myproject
+```
+
+Available Z.AI models (as of 2026-04-13):
+
+| Model | Context | Max Output | Thinking | Vision |
+|-------|---------|-----------|----------|--------|
+| glm-5.1 | 200K | 131K | yes | no |
+| glm-5 | 205K | 131K | yes | no |
+| glm-5-turbo | 200K | 131K | yes | no |
+| glm-5v-turbo | 200K | 131K | yes | yes |
+| glm-4.7 | 205K | 131K | yes | no |
+| glm-4.7-flash | 200K | 131K | yes | no |
+| glm-4.6 | 205K | 131K | yes | no |
+| glm-4.5 | 131K | 98K | yes | no |
+
+Use `pi --list-models zai` to see the current list.
+
+## Roles and Tools
+
+Pi supports fewer tools than Claude Code. Role tool lists are **translated** to pi's names:
+
+| Claude Code Tool | Pi Tool |
+|------------------|---------|
+| Read | read |
+| Bash | bash |
+| Edit | edit |
+| Write | write |
+| Grep | grep |
+| Glob | find |
+| LS | ls |
+| Task, WebFetch, WebSearch, MCP tools, etc. | **not supported** |
+
+Unsupported tools in a role's tool list are silently filtered out. If your role depends on a tool pi doesn't have, the session will still start but that tool won't be available.
+
+### Disallowed Tools
+
+Pi has no `--disallowedTools` flag. It can only whitelist. If a role specifies `disallowed_tools`, it's **ignored** for pi-zai sessions. Use `pi-zai-restricted` or `pi-zai-readonly` variants for tool restrictions instead.
+
+## Architecture Notes
+
+### CLI Flag Mapping
+
+| Feature | Claude Code | Pi |
+|---------|------------|-----|
+| System prompt injection | `--append-system-prompt "text"` | `--append-system-prompt "text"` |
+| Tool whitelist | `--tools Bash,Read` | `--tools bash,read` |
+| Tool blacklist | `--disallowedTools X` | Not supported |
+| Model override | `--model haiku` | `--model glm-5` |
+| Skip permissions | `--dangerously-skip-permissions` | Not needed (no permission system) |
+| JSON output | Not available | `--mode json` |
+| Non-interactive | Via tmux | `-p "prompt"` |
+
+### Idle Detection
+
+Pi runs as a `node` process in tmux. AgentWire's idle detection (in `completion.py`) recognizes any non-shell process as an active agent, so pi is detected correctly without changes.
+
+When pi exits (triple Ctrl+C), the pane falls back to the shell (`zsh`/`bash`), and idle detection fires normally.
+
+### What Pi Doesn't Do
+
+- **No MCP client.** Pi sessions cannot call agentwire's MCP tools (`sessions_list`, `pane_spawn`, `say`, etc.). Use Claude Code for orchestrator sessions that need MCP. Workflow nodes (Phase 2) will call agentwire CLI via bash instead.
+- **No session forking.** Pi has `--session <file> --continue` for resuming, but no equivalent to Claude Code's `--resume <id> --fork-session`. If you need forking, use Claude Code. Pi sessions can still save + resume linearly.
+- **No hook directory.** Pi uses an extension system (`~/.pi/agent/extensions/`) rather than the hooks pattern. AgentWire's idle-handler and damage-control hooks don't integrate with pi. Workers that need those must use Claude Code session types.
+
+## Troubleshooting
+
+### "pi: command not found"
+
+Pi isn't installed or isn't in `$PATH`. Install it:
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+Or override the binary path in config:
+
+```yaml
+pi:
+  binary: "/full/path/to/pi"
+```
+
+### "No models available. Set API keys in environment variables."
+
+`ZAI_API_KEY` isn't set. Check `~/.agentwire/config.yaml` has the `zai.api_key` field filled in. AgentWire passes it to pi via env var prefix in the launch command.
+
+> **Security note:** the key is embedded in the command string (`ZAI_API_KEY=xxx pi ...`), so it's visible in `ps auxwww` and ends up in shell history. This matches the pattern the removed claudeGLM wrapper used — acceptable on single-user dev machines, but don't run pi-zai sessions on multi-user hosts without first moving the key to `tmux set-environment` or a sourced file. See `agentwire-pi-zai` skill for details.
+
+### Pi shows changelog on startup
+
+Normal on first launch after version upgrade. Pi displays its changelog once per new version. Safe to ignore — the session is ready to take input.
+
+### Role instructions not taking effect
+
+Roles with only `disallowed_tools` (no `tools` or `instructions`) will appear to do nothing for pi-zai sessions — pi doesn't support disallowed tools. Check you have `instructions:` or `tools:` set in your role.
+
+### Session forks without context
+
+Pi's forking is manual (copy JSONL, run with `--session <copy> --continue`). AgentWire's `fork` command is optimized for Claude Code's `--resume --fork-session` flow and doesn't currently fork pi sessions with inherited context. Start a fresh pi session instead, or re-enter context manually.
+
+## Compatibility Matrix
+
+| Feature | claude-* | pi-zai | pi-zai-restricted | pi-zai-readonly |
+|---------|----------|--------|-------------------|-----------------|
+| Model backend | Anthropic | Z.AI (native) | Z.AI (native) | Z.AI (native) |
+| Interactive (tmux send-keys) | ✓ | ✓ | ✓ | ✓ |
+| Role instructions | ✓ | ✓ | curated | curated |
+| Role tool whitelist | ✓ | ✓ | fixed | fixed |
+| Role tool blacklist | ✓ | ✗ | ✗ | ✗ |
+| MCP tools | ✓ | ✗ | ✗ | ✗ |
+| Session forking (`--resume --fork-session`) | ✓ | ✗ (manual only) | ✗ | ✗ |
+| AgentWire hooks (idle, damage) | ✓ | ✗ | ✗ | ✗ |
+| CLAUDE.md / AGENTS.md loading | ✓ | ✓ | ✓ | ✓ |
+| Print mode / headless | via tmux | ✓ (`-p`) | ✓ (`-p`) | ✓ (`-p`) |
+| JSON event stream | ✗ | ✓ (`--mode json`) | ✓ | ✓ |
+
+## See Also
+
+- Mission plan: `docs/missions/pi-session-type.md` (this phase)
+- Overall roadmap: `docs/missions/pi-harness-overview.md`
+- Technology evaluation: `~/.agentwire/wiki/wiki/research/pi-coding-agent-zai-harness.md`
+- Pi upstream: https://github.com/badlogic/pi-mono
+- Z.AI docs: https://docs.z.ai/

--- a/docs/pi-zai.md
+++ b/docs/pi-zai.md
@@ -181,9 +181,9 @@ pi:
 
 ### "No models available. Set API keys in environment variables."
 
-`ZAI_API_KEY` isn't set. Check `~/.agentwire/config.yaml` has the `zai.api_key` field filled in. AgentWire passes it to pi via env var prefix in the launch command.
+`ZAI_API_KEY` isn't set on the tmux session. Check `~/.agentwire/config.yaml` has the `zai.api_key` field filled in. AgentWire injects the key via `tmux set-environment -t <session>` at creation time, so it's available to pi as an env var but doesn't appear in `ps auxwww` or shell history.
 
-> **Security note:** the key is embedded in the command string (`ZAI_API_KEY=xxx pi ...`), so it's visible in `ps auxwww` and ends up in shell history. This matches the pattern the removed claudeGLM wrapper used — acceptable on single-user dev machines, but don't run pi-zai sessions on multi-user hosts without first moving the key to `tmux set-environment` or a sourced file. See `agentwire-pi-zai` skill for details.
+If you spawn pi manually (outside of `agentwire new`), you'll need to `export ZAI_API_KEY=...` yourself first.
 
 ### Pi shows changelog on startup
 

--- a/tests/integration/test_build_agent_command.py
+++ b/tests/integration/test_build_agent_command.py
@@ -87,13 +87,20 @@ class TestBuildAgentCommand:
     def test_pi_zai_basic(self):
         """pi-zai launches pi binary with Z.AI provider and default model."""
         cmd = self._build("pi-zai")
-        assert "pi --provider zai" in cmd.command
-        assert "ZAI_API_KEY=" in cmd.command
+        assert cmd.command.startswith("pi --provider zai")
+        # Key is injected via tmux set-environment, NOT on the command line
+        assert "ZAI_API_KEY" not in cmd.command
+        assert cmd.env == {"ZAI_API_KEY": "test-key-123"}
         assert "--model glm-5" in cmd.command
         # Pi has no --dangerously-skip-permissions (no permission system)
         assert "--dangerously-skip-permissions" not in cmd.command
-        # Pi uses --append-system-prompt, identical to Claude Code
         assert cmd.temp_file is None
+
+    def test_pi_zai_key_not_in_command(self):
+        """Regression: ZAI_API_KEY must live in cmd.env, never in cmd.command."""
+        cmd = self._build("pi-zai")
+        assert "test-key-123" not in cmd.command
+        assert cmd.env.get("ZAI_API_KEY") == "test-key-123"
 
     def test_pi_zai_restricted(self):
         """pi-zai-restricted whitelists read-only tools + bash."""
@@ -157,8 +164,7 @@ class TestBuildAgentCommand:
         cmd = self._build("pi-zai-restricted", roles=roles)
         # Should have restricted's tool list, not role's
         assert "--tools read,grep,find,bash" in cmd.command
-        # Role's Write should not leak in
-        assert "write" not in cmd.command.lower().split("--tools read,grep,find,bash")[1][:50]
+
 
     def test_pi_zai_readonly_ignores_role_instructions(self):
         """pi-zai-readonly is a curated context, skips role instructions."""
@@ -166,3 +172,26 @@ class TestBuildAgentCommand:
         cmd = self._build("pi-zai-readonly", roles=roles)
         assert "--append-system-prompt" not in cmd.command
         assert cmd.temp_file is None
+
+
+class TestSessionEnvInjection:
+    def test_build_session_env_shell_fragment_empty(self):
+        from agentwire.__main__ import build_session_env_shell_fragment
+        assert build_session_env_shell_fragment("s", {}) == ""
+
+    def test_build_session_env_shell_fragment_quoted(self):
+        from agentwire.__main__ import build_session_env_shell_fragment
+        frag = build_session_env_shell_fragment("my-session", {"ZAI_API_KEY": "abc 123"})
+        # Must end with trailing ` && ` so it can splice into a compound command
+        assert frag.endswith(" && ")
+        assert "set-environment -t my-session" in frag
+        assert "ZAI_API_KEY" in frag
+        # Value with spaces must be shell-quoted
+        assert "'abc 123'" in frag
+
+    def test_build_session_env_shell_fragment_multiple(self):
+        from agentwire.__main__ import build_session_env_shell_fragment
+        frag = build_session_env_shell_fragment("s", {"A": "1", "B": "2"})
+        assert "A 1" in frag
+        assert "B 2" in frag
+        assert frag.count("set-environment") == 2

--- a/tests/integration/test_build_agent_command.py
+++ b/tests/integration/test_build_agent_command.py
@@ -8,6 +8,26 @@ import pytest
 from agentwire.roles import RoleConfig
 
 
+# Mock for load_config() in __main__ used by pi-zai branch.
+FAKE_CONFIG = {
+    "zai": {
+        "api_key": "test-key-123",
+        "base_url": "https://api.z.ai/api/anthropic",
+        "timeout_ms": 3000000,
+    },
+    "pi": {
+        "default_model": "glm-5",
+        "binary": "pi",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_main_load_config():
+    with patch("agentwire.__main__.load_config", return_value=FAKE_CONFIG):
+        yield
+
+
 class TestBuildAgentCommand:
     def _build(self, session_type, roles=None, model=None):
         from agentwire.__main__ import build_agent_command
@@ -61,3 +81,88 @@ class TestBuildAgentCommand:
     def test_unknown_type_empty(self):
         cmd = self._build("nonexistent-type")
         assert cmd.command == ""
+
+    # === pi-zai session types ===
+
+    def test_pi_zai_basic(self):
+        """pi-zai launches pi binary with Z.AI provider and default model."""
+        cmd = self._build("pi-zai")
+        assert "pi --provider zai" in cmd.command
+        assert "ZAI_API_KEY=" in cmd.command
+        assert "--model glm-5" in cmd.command
+        # Pi has no --dangerously-skip-permissions (no permission system)
+        assert "--dangerously-skip-permissions" not in cmd.command
+        # Pi uses --append-system-prompt, identical to Claude Code
+        assert cmd.temp_file is None
+
+    def test_pi_zai_restricted(self):
+        """pi-zai-restricted whitelists read-only tools + bash."""
+        cmd = self._build("pi-zai-restricted")
+        assert "pi --provider zai" in cmd.command
+        assert "--tools read,grep,find,bash" in cmd.command
+
+    def test_pi_zai_readonly(self):
+        """pi-zai-readonly has no bash, no edits — pure inspection."""
+        cmd = self._build("pi-zai-readonly")
+        assert "pi --provider zai" in cmd.command
+        assert "--tools read,grep,find" in cmd.command
+        # No bash, no edit, no write
+        assert "bash" not in cmd.command.split("--tools")[1]
+        assert "edit" not in cmd.command.split("--tools")[1]
+        assert "write" not in cmd.command.split("--tools")[1]
+
+    def test_pi_zai_model_override(self):
+        cmd = self._build("pi-zai", model="glm-5.1")
+        assert "--model glm-5.1" in cmd.command
+        # Default should not also appear
+        assert "--model glm-5 " not in cmd.command
+
+    def test_pi_zai_with_role_instructions(self):
+        """pi-zai with role.instructions uses --append-system-prompt."""
+        roles = [RoleConfig(name="worker", instructions="You are a worker agent.")]
+        cmd = self._build("pi-zai", roles=roles)
+        assert "--append-system-prompt" in cmd.command
+        assert cmd.temp_file is not None
+        with open(cmd.temp_file) as f:
+            content = f.read()
+        assert "You are a worker agent." in content
+        os.unlink(cmd.temp_file)
+
+    def test_pi_zai_with_role_tools(self):
+        """pi-zai translates Claude tool names (CamelCase) to pi's lowercase."""
+        roles = [RoleConfig(name="test", tools=["Read", "Bash", "Edit"])]
+        cmd = self._build("pi-zai", roles=roles)
+        assert "--tools" in cmd.command
+        # Extracted tool list section
+        tools_section = cmd.command.split("--tools")[1].split()[0]
+        assert "read" in tools_section
+        assert "bash" in tools_section
+        assert "edit" in tools_section
+
+    def test_pi_zai_filters_unknown_tools(self):
+        """pi-zai drops tool names pi doesn't support (e.g., Glob, WebFetch)."""
+        roles = [RoleConfig(name="test", tools=["Read", "Glob", "WebFetch", "Bash"])]
+        cmd = self._build("pi-zai", roles=roles)
+        tools_section = cmd.command.split("--tools")[1].split()[0]
+        # Glob → find (but only if we translated; current impl filters out unknowns)
+        # WebFetch → not supported by pi
+        assert "webfetch" not in tools_section.lower()
+        # Read and Bash are valid
+        assert "read" in tools_section
+        assert "bash" in tools_section
+
+    def test_pi_zai_restricted_ignores_role_tools(self):
+        """pi-zai-restricted keeps its curated tool list regardless of roles."""
+        roles = [RoleConfig(name="test", tools=["Edit", "Write"])]
+        cmd = self._build("pi-zai-restricted", roles=roles)
+        # Should have restricted's tool list, not role's
+        assert "--tools read,grep,find,bash" in cmd.command
+        # Role's Write should not leak in
+        assert "write" not in cmd.command.lower().split("--tools read,grep,find,bash")[1][:50]
+
+    def test_pi_zai_readonly_ignores_role_instructions(self):
+        """pi-zai-readonly is a curated context, skips role instructions."""
+        roles = [RoleConfig(name="test", instructions="Be creative")]
+        cmd = self._build("pi-zai-readonly", roles=roles)
+        assert "--append-system-prompt" not in cmd.command
+        assert cmd.temp_file is None

--- a/tests/integration/test_build_agent_command.py
+++ b/tests/integration/test_build_agent_command.py
@@ -195,3 +195,43 @@ class TestSessionEnvInjection:
         assert "A 1" in frag
         assert "B 2" in frag
         assert frag.count("set-environment") == 2
+
+
+class TestParseEnvArgs:
+    def test_none_returns_empty(self):
+        from agentwire.__main__ import parse_env_args
+        assert parse_env_args(None) == {}
+        assert parse_env_args([]) == {}
+
+    def test_single_pair(self):
+        from agentwire.__main__ import parse_env_args
+        assert parse_env_args(["FOO=bar"]) == {"FOO": "bar"}
+
+    def test_multiple_pairs(self):
+        from agentwire.__main__ import parse_env_args
+        result = parse_env_args(["A=1", "B=2", "C=3"])
+        assert result == {"A": "1", "B": "2", "C": "3"}
+
+    def test_value_with_equals_sign_preserved(self):
+        from agentwire.__main__ import parse_env_args
+        # Values can contain `=` (e.g. base64 payloads) — only split on the first.
+        assert parse_env_args(["TOKEN=abc=def=xyz"]) == {"TOKEN": "abc=def=xyz"}
+
+    def test_empty_value_allowed(self):
+        from agentwire.__main__ import parse_env_args
+        assert parse_env_args(["DEBUG="]) == {"DEBUG": ""}
+
+    def test_missing_equals_exits(self):
+        from agentwire.__main__ import parse_env_args
+        with pytest.raises(SystemExit):
+            parse_env_args(["BROKEN"])
+
+    def test_empty_key_exits(self):
+        from agentwire.__main__ import parse_env_args
+        with pytest.raises(SystemExit):
+            parse_env_args(["=value"])
+
+    def test_later_value_wins(self):
+        from agentwire.__main__ import parse_env_args
+        # If the same key appears twice, last one wins (standard dict semantics).
+        assert parse_env_args(["K=1", "K=2"]) == {"K": "2"}


### PR DESCRIPTION
## Summary

- Adds three pi-zai session types (`pi-zai`, `pi-zai-restricted`, `pi-zai-readonly`) backed by [pi coding agent](https://github.com/badlogic/pi-mono) with native Z.AI provider support
- Replaces the claudeGLM wrapper that was removed in `27c8d8d` — unlike env-var hijacking, pi is a standalone binary with `--provider zai` built-in
- Ships the full 5-phase mission roadmap as docs for Phases 2–5 (workflow engine, scheduler workflows, advanced patterns, desktop UI)

## Session types

| Type | Tools | Use case |
|------|-------|----------|
| `pi-zai` | read, bash, edit, write | Cost-sensitive interactive work, Z.AI subscription |
| `pi-zai-restricted` | read, grep, find, bash | Worker panes — commands allowed, no edits |
| `pi-zai-readonly` | read, grep, find | Audit / inspection |

Role injection works via `--append-system-prompt` (same mechanism as Claude Code). Tool names translated from Claude CamelCase → pi lowercase. Config: `pi.default_model` (default `glm-5`), `pi.binary` override. `agentwire doctor` reports pi version.

## What this unlocks

Pi is dual-mode (REPL + programmable JSON/RPC), which positions us for the planned phases:

- **Phase 2** — Workflow engine (pi as action node in DAGs)
- **Phase 3** — Scheduler workflow integration
- **Phase 4** — Advanced patterns (fan-out/fan-in, HITL, cost caps)
- **Phase 5** — Desktop workflow canvas UI

Mission docs for all five phases are included (`docs/missions/pi-*.md`). Phase 1 marked complete.

## Test plan

- [x] 9 new unit tests in `test_build_agent_command.py` (basic, restricted, readonly, model override, role injection, tool translation, unknown tool filtering)
- [x] Full suite: **633 passing** (was 624 on main — 9 additions)
- [x] Smoke: `agentwire new --type pi-zai --help` reports new types correctly
- [x] Manual: real pi session run end-to-end (built a small HTML game, verified session JSONL is preserved for recovery)
- [ ] Long-term: one scheduler task on pi-zai for 48h (deferred to follow-up, non-blocking)

## Notes

- Pi v0.66.1 is the tested baseline (pre-1.0, minor breakage possible on upgrade — pinned expectations in docs)
- `pi` binary must be installed via `npm install -g @mariozechner/pi-coding-agent`
- Limitations vs Claude Code: no MCP client, no `--disallowedTools`, no `--resume --fork-session`, no idle/damage-control hook integration. Documented in `docs/pi-zai.md`.

Built by [dotdev.dev](https://dotdev.dev)