### PR TITLE
feat: scaffold pi workflow engine (MVP, single-node)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10121,6 +10121,33 @@ def main() -> int:
     )
     dev_parser.set_defaults(func=cmd_dev)
 
+    # === workflow command group ===
+    from agentwire.workflows.cli import (
+        cmd_workflow_list,
+        cmd_workflow_run,
+        cmd_workflow_validate,
+    )
+
+    workflow_parser = subparsers.add_parser("workflow", help="Pi workflow engine")
+    workflow_subparsers = workflow_parser.add_subparsers(dest="workflow_command")
+
+    wf_list = workflow_subparsers.add_parser("list", help="List discoverable workflows")
+    wf_list.add_argument("--json", action="store_true", help="Output as JSON")
+    wf_list.set_defaults(func=cmd_workflow_list)
+
+    wf_validate = workflow_subparsers.add_parser(
+        "validate", help="Validate a workflow YAML without running it"
+    )
+    wf_validate.add_argument("workflow", help="Workflow name or path to YAML")
+    wf_validate.set_defaults(func=cmd_workflow_validate)
+
+    wf_run = workflow_subparsers.add_parser("run", help="Execute a workflow")
+    wf_run.add_argument("workflow", help="Workflow name or path to YAML")
+    wf_run.add_argument("--dry-run", action="store_true", help="Print plan without running")
+    wf_run.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    wf_run.add_argument("--json", action="store_true", help="Output as JSON")
+    wf_run.set_defaults(func=cmd_workflow_run)
+
     # === listen command group ===
     listen_parser = subparsers.add_parser("listen", help="Voice input recording")
     listen_parser.add_argument(

--- a/agentwire/workflows/__init__.py
+++ b/agentwire/workflows/__init__.py
@@ -1,0 +1,21 @@
+"""AgentWire workflow engine.
+
+Phase 2 MVP scope (this package): single-node execution only. See
+`docs/missions/pi-workflow-engine.md` for the full roadmap — DAG
+dependencies, templating, output extraction, retries, storage,
+and MCP tools land in subsequent PRs.
+"""
+
+from agentwire.workflows.node import ActionNode, NodeResult
+from agentwire.workflows.definitions import WorkflowDef, load_workflow
+from agentwire.workflows.pi_runner import run_node
+from agentwire.workflows.runner import run_workflow
+
+__all__ = [
+    "ActionNode",
+    "NodeResult",
+    "WorkflowDef",
+    "load_workflow",
+    "run_node",
+    "run_workflow",
+]

--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -1,0 +1,148 @@
+"""CLI handlers for `agentwire workflow *` subcommands.
+
+Subcommands:
+  list     - discover and print available workflows
+  validate - parse + validate a workflow without running it
+  run      - execute a workflow end-to-end
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from agentwire.workflows.definitions import (
+    discover_workflows,
+    resolve_workflow,
+)
+from agentwire.workflows.runner import run_workflow
+
+
+RUNS_DIR = Path.home() / ".agentwire" / "workflows" / "runs"
+
+
+def cmd_workflow_list(args) -> int:
+    """`agentwire workflow list` — discover available workflows."""
+    workflows = discover_workflows()
+
+    if getattr(args, "json", False):
+        payload = [
+            {
+                "name": wf.name,
+                "description": wf.description,
+                "version": wf.version,
+                "nodes": [n.id for n in wf.nodes],
+                "source": str(wf.source_path) if wf.source_path else None,
+            }
+            for wf in workflows
+        ]
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if not workflows:
+        print("No workflows found.")
+        print("  Drop YAML files in ~/.agentwire/workflows/defs/ or see workflows/examples/.")
+        return 0
+
+    for wf in workflows:
+        node_count = len(wf.nodes)
+        desc = f" — {wf.description}" if wf.description else ""
+        print(f"  {wf.name} ({node_count} node{'s' if node_count != 1 else ''}){desc}")
+
+    return 0
+
+
+def cmd_workflow_validate(args) -> int:
+    """`agentwire workflow validate <name-or-path>` — check a workflow YAML."""
+    try:
+        workflow = resolve_workflow(args.workflow)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error parsing workflow: {e}", file=sys.stderr)
+        return 1
+
+    errors = workflow.validate()
+    if errors:
+        print(f"Workflow {workflow.name!r} has {len(errors)} validation error(s):")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print(f"Workflow {workflow.name!r} is valid ({len(workflow.nodes)} node(s)).")
+    return 0
+
+
+def cmd_workflow_run(args) -> int:
+    """`agentwire workflow run <name-or-path>` — execute a workflow."""
+    try:
+        workflow = resolve_workflow(args.workflow)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    errors = workflow.validate()
+    if errors:
+        print(f"Workflow {workflow.name!r} has validation errors:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    dry_run = getattr(args, "dry_run", False)
+
+    if getattr(args, "verbose", False):
+        print(f"Running workflow {workflow.name!r} ({len(workflow.nodes)} node(s))...")
+        if dry_run:
+            print("  (dry-run)")
+
+    try:
+        result = run_workflow(workflow, runs_dir=RUNS_DIR, dry_run=dry_run)
+    except NotImplementedError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "workflow": result.workflow,
+            "run_id": result.run_id,
+            "status": result.status,
+            "duration_ms": result.duration_ms,
+            "error": result.error,
+            "nodes": [
+                {
+                    "id": r.node_id,
+                    "status": r.status,
+                    "final_text": r.final_text,
+                    "duration_ms": r.duration_ms,
+                    "tokens": r.tokens_used,
+                    "error": r.error,
+                }
+                for r in result.node_results
+            ],
+        }, indent=2))
+        return 0 if result.status == "success" else 1
+
+    print(f"\n=== Workflow {result.workflow!r} → {result.status} ===")
+    print(f"  run_id: {result.run_id}")
+    print(f"  duration: {result.duration_ms}ms")
+    if result.error:
+        print(f"  error: {result.error}")
+
+    for node_result in result.node_results:
+        print(f"\n  --- node[{node_result.node_id}] → {node_result.status} "
+              f"({node_result.duration_ms}ms) ---")
+        if node_result.tool_calls:
+            tools = ", ".join(tc["name"] for tc in node_result.tool_calls)
+            print(f"  tools used: {tools}")
+        if node_result.tokens_used:
+            t = node_result.tokens_used
+            print(f"  tokens: in={t.get('input', 0)} out={t.get('output', 0)} "
+                  f"cost=${t.get('cost', 0):.4f}")
+        if node_result.final_text:
+            print(f"\n{node_result.final_text}")
+        if node_result.error:
+            print(f"  error: {node_result.error}")
+
+    return 0 if result.status == "success" else 1

--- a/agentwire/workflows/definitions.py
+++ b/agentwire/workflows/definitions.py
@@ -1,0 +1,162 @@
+"""Workflow YAML loader + schema validator.
+
+MVP: supports `name`, `description`, `version`, and a `nodes` map. Each node
+builds into an ActionNode. Multi-node DAGs are declared legally here (so
+future PRs don't break existing files) but only single-node workflows
+actually execute in the MVP runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from agentwire.workflows.node import ActionNode
+
+
+# Where workflow YAML files are discovered by `agentwire workflow list` / run.
+# Order matters: first match wins.
+# User overrides live in `~/.agentwire/workflows/defs/`. Bundled examples are
+# resolved via `_repo_examples_dir()` at runtime (see discover_workflows).
+DISCOVERY_DIRS = [
+    Path.home() / ".agentwire" / "workflows" / "defs",
+]
+
+
+@dataclass
+class WorkflowDef:
+    """Parsed workflow definition."""
+
+    name: str
+    nodes: list[ActionNode]
+    description: str = ""
+    version: int = 1
+    source_path: Path | None = None
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.name:
+            errors.append("workflow.name is required")
+        if not self.nodes:
+            errors.append("workflow.nodes must contain at least one node")
+        seen_ids: set[str] = set()
+        for node in self.nodes:
+            errors.extend(node.validate())
+            if node.id in seen_ids:
+                errors.append(f"duplicate node id: {node.id}")
+            seen_ids.add(node.id)
+        # depends_on references must resolve
+        for node in self.nodes:
+            for dep in node.depends_on:
+                if dep not in seen_ids:
+                    errors.append(
+                        f"node[{node.id}].depends_on references unknown node: {dep}"
+                    )
+        return errors
+
+
+def _node_from_dict(node_id: str, data: dict) -> ActionNode:
+    """Build an ActionNode from a YAML node mapping."""
+    if not isinstance(data, dict):
+        raise ValueError(f"node[{node_id}] must be a mapping, got {type(data).__name__}")
+
+    kwargs: dict = {"id": node_id, "prompt": data.get("prompt", "")}
+
+    for key in (
+        "provider", "model", "thinking", "when", "on_error",
+        "on_error_goto", "workdir",
+    ):
+        if key in data:
+            kwargs[key] = data[key]
+
+    if "tools" in data:
+        tools = data["tools"]
+        if not isinstance(tools, list):
+            raise ValueError(f"node[{node_id}].tools must be a list")
+        kwargs["tools"] = [str(t) for t in tools]
+
+    if "depends_on" in data:
+        deps = data["depends_on"]
+        if isinstance(deps, str):
+            deps = [deps]
+        kwargs["depends_on"] = [str(d) for d in deps]
+
+    for int_key in ("timeout", "retries", "retry_delay"):
+        if int_key in data:
+            kwargs[int_key] = int(data[int_key])
+
+    if "extra_env" in data:
+        env = data["extra_env"]
+        if not isinstance(env, dict):
+            raise ValueError(f"node[{node_id}].extra_env must be a mapping")
+        kwargs["extra_env"] = {str(k): str(v) for k, v in env.items()}
+
+    return ActionNode(**kwargs)
+
+
+def load_workflow(path: Path) -> WorkflowDef:
+    """Load and parse a workflow YAML file. Does not validate."""
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: workflow root must be a mapping")
+
+    name = data.get("name") or path.stem
+    description = data.get("description", "")
+    version = int(data.get("version", 1))
+
+    raw_nodes = data.get("nodes", {})
+    if not isinstance(raw_nodes, dict):
+        raise ValueError(f"{path}: 'nodes' must be a mapping of id → node")
+
+    nodes: list[ActionNode] = []
+    for node_id, node_data in raw_nodes.items():
+        nodes.append(_node_from_dict(str(node_id), node_data))
+
+    return WorkflowDef(
+        name=name,
+        nodes=nodes,
+        description=description,
+        version=version,
+        source_path=path,
+    )
+
+
+def _repo_examples_dir() -> Path:
+    """Path to the bundled `agentwire/workflows/examples/` dir."""
+    return Path(__file__).resolve().parent / "examples"
+
+
+def discover_workflows() -> list[WorkflowDef]:
+    """Find all workflow YAMLs in known discovery dirs."""
+    search_dirs = [*DISCOVERY_DIRS, _repo_examples_dir()]
+    found: dict[str, WorkflowDef] = {}
+    for directory in search_dirs:
+        if not directory.is_dir():
+            continue
+        for yaml_file in sorted(directory.glob("*.yaml")):
+            try:
+                wf = load_workflow(yaml_file)
+            except Exception:
+                continue
+            # First match wins — user's ~/.agentwire dir overrides repo examples
+            if wf.name not in found:
+                found[wf.name] = wf
+    return list(found.values())
+
+
+def resolve_workflow(name_or_path: str) -> WorkflowDef:
+    """Resolve a workflow by name or path. Raises FileNotFoundError if not found."""
+    candidate = Path(name_or_path)
+    if candidate.exists() and candidate.is_file():
+        return load_workflow(candidate)
+
+    for wf in discover_workflows():
+        if wf.name == name_or_path:
+            return wf
+
+    raise FileNotFoundError(
+        f"workflow {name_or_path!r} not found. "
+        f"Searched: {[str(p) for p in [*DISCOVERY_DIRS, _repo_examples_dir()]]}"
+    )

--- a/agentwire/workflows/examples/hello-world.yaml
+++ b/agentwire/workflows/examples/hello-world.yaml
@@ -1,0 +1,11 @@
+name: hello-world
+description: Minimal single-node workflow that asks pi for a one-line greeting.
+version: 1
+
+nodes:
+  greet:
+    prompt: |
+      Reply with exactly one friendly greeting sentence. No code, no tools.
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -1,0 +1,80 @@
+"""Workflow node dataclasses.
+
+MVP: ActionNode represents a single pi invocation. Future PRs extend with
+ConditionalNode, ParallelNode. OutputSpec / depends_on / when / retries
+fields are declared here so YAML parsing validates forward-compatibly,
+but are not yet honored by the MVP runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+DEFAULT_TOOLS = ["read", "bash", "edit", "write"]
+VALID_TOOLS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+VALID_THINKING = {"off", "minimal", "low", "medium", "high", "xhigh"}
+
+
+@dataclass
+class ActionNode:
+    """A single pi invocation in a workflow."""
+
+    id: str
+    prompt: str
+
+    provider: str = "zai"
+    model: str = "glm-5"
+    tools: list[str] = field(default_factory=lambda: list(DEFAULT_TOOLS))
+    thinking: str = "medium"
+
+    # Declared for YAML forward-compat; runner MVP does not use these yet.
+    depends_on: list[str] = field(default_factory=list)
+    when: str | None = None
+    timeout: int = 300
+    retries: int = 0
+    retry_delay: int = 10
+    on_error: str = "fail"
+    on_error_goto: str | None = None
+
+    workdir: str | None = None
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> list[str]:
+        """Return a list of validation error strings (empty = valid)."""
+        errors: list[str] = []
+        if not self.id or not self.id.strip():
+            errors.append("node.id is required")
+        if not self.prompt or not self.prompt.strip():
+            errors.append(f"node[{self.id}].prompt is required")
+        if self.thinking not in VALID_THINKING:
+            errors.append(
+                f"node[{self.id}].thinking={self.thinking!r} not in {sorted(VALID_THINKING)}"
+            )
+        bad_tools = [t for t in self.tools if t not in VALID_TOOLS]
+        if bad_tools:
+            errors.append(
+                f"node[{self.id}].tools contains invalid: {bad_tools} "
+                f"(valid: {sorted(VALID_TOOLS)})"
+            )
+        if self.on_error not in ("fail", "continue", "branch"):
+            errors.append(
+                f"node[{self.id}].on_error={self.on_error!r} "
+                "must be one of fail|continue|branch"
+            )
+        return errors
+
+
+@dataclass
+class NodeResult:
+    """Outcome of executing a single node."""
+
+    node_id: str
+    status: str  # "success" | "failure" | "timeout"
+    final_text: str  # Final assistant message text
+    events: list[dict] = field(default_factory=list)
+    tool_calls: list[dict] = field(default_factory=list)
+    tokens_used: dict = field(default_factory=dict)
+    duration_ms: int = 0
+    exit_code: int = 0
+    error: str | None = None

--- a/agentwire/workflows/pi_runner.py
+++ b/agentwire/workflows/pi_runner.py
@@ -1,0 +1,239 @@
+"""Pi subprocess wrapper + JSONL event stream parser.
+
+Runs `pi -p <prompt> --mode json --no-session ...` and parses the streaming
+JSONL output into structured NodeResult. Event schema captured empirically
+from pi 0.67.1 (see `docs/missions/pi-workflow-engine.md`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import yaml
+
+from agentwire.workflows.node import ActionNode, NodeResult
+
+
+CONFIG_PATH = Path.home() / ".agentwire" / "config.yaml"
+
+
+# Pi's event types observed in `--mode json` output (pi 0.67.1):
+#   session, agent_start, turn_start, message_start, message_end,
+#   turn_end, agent_end
+# Assistant messages carry role=assistant with content blocks; tool calls
+# arrive as content blocks of type "tool_use" and results as "tool_result".
+
+
+def _get_zai_api_key() -> str:
+    """Load Z.AI API key from config (falls back to env if missing)."""
+    try:
+        data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    except FileNotFoundError:
+        data = {}
+    key = (data.get("zai") or {}).get("api_key", "") if isinstance(data, dict) else ""
+    return key or os.environ.get("ZAI_API_KEY", "")
+
+
+def _extract_final_assistant_text(events: list[dict]) -> str:
+    """Pick the last assistant message's text content."""
+    for event in reversed(events):
+        if event.get("type") != "message_end":
+            continue
+        message = event.get("message", {})
+        if message.get("role") != "assistant":
+            continue
+        parts: list[str] = []
+        for block in message.get("content", []):
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        text = "".join(parts).strip()
+        if text:
+            return text
+    return ""
+
+
+def _extract_tool_calls(events: list[dict]) -> list[dict]:
+    """Collect tool_use blocks from assistant messages."""
+    calls = []
+    seen_ids: set[str] = set()
+    for event in events:
+        if event.get("type") not in ("message_end", "turn_end"):
+            continue
+        message = event.get("message", {})
+        if message.get("role") != "assistant":
+            continue
+        for block in message.get("content", []):
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            tool_id = block.get("id", "")
+            if tool_id in seen_ids:
+                continue
+            seen_ids.add(tool_id)
+            calls.append({
+                "id": tool_id,
+                "name": block.get("name", ""),
+                "input": block.get("input", {}),
+            })
+    return calls
+
+
+def _extract_token_usage(events: list[dict]) -> dict:
+    """Sum usage across assistant message_end events."""
+    total = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 0}
+    cost_total = 0.0
+    for event in events:
+        if event.get("type") != "message_end":
+            continue
+        message = event.get("message", {})
+        if message.get("role") != "assistant":
+            continue
+        usage = message.get("usage", {}) or {}
+        for key in total:
+            if key in usage and isinstance(usage[key], (int, float)):
+                total[key] += usage[key]
+        cost = usage.get("cost", {}) or {}
+        if isinstance(cost.get("total"), (int, float)):
+            cost_total += cost["total"]
+    total["cost"] = cost_total
+    return total
+
+
+def build_pi_command(node: ActionNode, pi_binary: str = "pi") -> list[str]:
+    """Compose the pi CLI invocation for a node.
+
+    Separated so tests can assert on the command without running pi.
+    """
+    cmd = [
+        pi_binary,
+        "-p", node.prompt,
+        "--provider", node.provider,
+        "--model", node.model,
+        "--thinking", node.thinking,
+        "--mode", "json",
+        "--no-session",
+    ]
+    if node.tools:
+        cmd.extend(["--tools", ",".join(node.tools)])
+    else:
+        cmd.append("--no-tools")
+    return cmd
+
+
+def run_node(
+    node: ActionNode,
+    workflow_cwd: str | None = None,
+    event_log_path: Path | None = None,
+) -> NodeResult:
+    """Execute one node. Synchronous. Streams JSONL to `event_log_path` if provided."""
+    errors = node.validate()
+    if errors:
+        return NodeResult(
+            node_id=node.id,
+            status="failure",
+            final_text="",
+            error="; ".join(errors),
+        )
+
+    if shutil.which("pi") is None:
+        return NodeResult(
+            node_id=node.id,
+            status="failure",
+            final_text="",
+            error="pi binary not found on PATH. "
+                  "Install: npm install -g @mariozechner/pi-coding-agent",
+        )
+
+    cmd = build_pi_command(node)
+
+    env = {**os.environ, **node.extra_env}
+    api_key = _get_zai_api_key()
+    if api_key:
+        env["ZAI_API_KEY"] = api_key
+
+    cwd = node.workdir or workflow_cwd or os.getcwd()
+
+    events: list[dict] = []
+    started_at = time.monotonic()
+
+    log_file = None
+    if event_log_path is not None:
+        event_log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_file = event_log_path.open("w")
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=cwd,
+            text=True,
+        )
+
+        try:
+            stdout, stderr = proc.communicate(timeout=node.timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            return NodeResult(
+                node_id=node.id,
+                status="timeout",
+                final_text="",
+                events=events,
+                duration_ms=duration_ms,
+                exit_code=-1,
+                error=f"node exceeded timeout={node.timeout}s",
+            )
+
+        for line in (stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if log_file:
+                log_file.write(line + "\n")
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                # Tolerate non-JSON lines (shouldn't occur in --mode json, but don't crash)
+                continue
+
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        final_text = _extract_final_assistant_text(events)
+        tool_calls = _extract_tool_calls(events)
+        tokens_used = _extract_token_usage(events)
+
+        error_msg: str | None = None
+        if proc.returncode != 0:
+            error_msg = (stderr or "").strip() or f"pi exited with code {proc.returncode}"
+
+        # Pi emits stopReason=error on API failures while still exiting 0; surface it.
+        for event in events:
+            if event.get("type") == "message_end":
+                msg = event.get("message", {})
+                if msg.get("role") == "assistant" and msg.get("stopReason") == "error":
+                    api_error = msg.get("errorMessage", "") or "pi api error"
+                    if not error_msg:
+                        error_msg = f"pi api error: {api_error}"
+
+        status = "success" if proc.returncode == 0 and error_msg is None else "failure"
+
+        return NodeResult(
+            node_id=node.id,
+            status=status,
+            final_text=final_text,
+            events=events,
+            tool_calls=tool_calls,
+            tokens_used=tokens_used,
+            duration_ms=duration_ms,
+            exit_code=proc.returncode,
+            error=error_msg,
+        )
+    finally:
+        if log_file:
+            log_file.close()

--- a/agentwire/workflows/runner.py
+++ b/agentwire/workflows/runner.py
@@ -1,0 +1,103 @@
+"""Workflow DAG executor.
+
+MVP: supports a single ActionNode. Multi-node DAGs raise NotImplementedError
+until PR B lands topological sort + dependency resolution.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from agentwire.workflows.definitions import WorkflowDef
+from agentwire.workflows.node import NodeResult
+from agentwire.workflows.pi_runner import run_node
+
+
+@dataclass
+class WorkflowRun:
+    """Result of running a workflow."""
+
+    workflow: str
+    run_id: str
+    status: str  # "success" | "failure" | "partial"
+    started_at: float
+    duration_ms: int
+    node_results: list[NodeResult] = field(default_factory=list)
+    error: str | None = None
+
+
+def _generate_run_id(workflow_name: str) -> str:
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    return f"{workflow_name}-{ts}-{uuid.uuid4().hex[:8]}"
+
+
+def run_workflow(
+    workflow: WorkflowDef,
+    runs_dir: Path | None = None,
+    dry_run: bool = False,
+) -> WorkflowRun:
+    """Execute a workflow end-to-end.
+
+    MVP: runs the first (and only) node. Raises NotImplementedError for
+    multi-node workflows — Phase 2 PR B ships DAG support.
+    """
+    errors = workflow.validate()
+    if errors:
+        return WorkflowRun(
+            workflow=workflow.name,
+            run_id="",
+            status="failure",
+            started_at=time.time(),
+            duration_ms=0,
+            error="; ".join(errors),
+        )
+
+    if len(workflow.nodes) > 1:
+        raise NotImplementedError(
+            "multi-node workflows land in Phase 2 PR B. "
+            f"workflow {workflow.name!r} has {len(workflow.nodes)} nodes."
+        )
+
+    run_id = _generate_run_id(workflow.name)
+    started_at = time.time()
+    started_mono = time.monotonic()
+
+    node = workflow.nodes[0]
+
+    if dry_run:
+        return WorkflowRun(
+            workflow=workflow.name,
+            run_id=run_id,
+            status="success",
+            started_at=started_at,
+            duration_ms=0,
+            node_results=[
+                NodeResult(
+                    node_id=node.id,
+                    status="success",
+                    final_text=f"[dry-run] would execute node {node.id!r}",
+                )
+            ],
+        )
+
+    event_log_path: Path | None = None
+    if runs_dir is not None:
+        event_log_path = runs_dir / run_id / "nodes" / f"{node.id}.events.jsonl"
+
+    result = run_node(node, event_log_path=event_log_path)
+
+    duration_ms = int((time.monotonic() - started_mono) * 1000)
+    status = "success" if result.status == "success" else "failure"
+
+    return WorkflowRun(
+        workflow=workflow.name,
+        run_id=run_id,
+        status=status,
+        started_at=started_at,
+        duration_ms=duration_ms,
+        node_results=[result],
+        error=result.error,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ include = [
     "agentwire/hooks/**/*.sh",
     # Optional bundled voice samples
     "agentwire/voices/*.wav",
+    # Bundled workflow example YAMLs
+    "agentwire/workflows/examples/*.yaml",
     # Top-level docs to ship in wheel
     "LICENSE",
     "README.md",


### PR DESCRIPTION
## Summary

Phase 2 PR A of the [pi workflow engine mission](../blob/main/docs/missions/pi-workflow-engine.md) — ships the minimal skeleton that proves pi's JSON event contract and builds the scaffolding later PRs extend.

## What runs today

- `agentwire workflow list` — discovers YAMLs in `~/.agentwire/workflows/defs/` and bundled examples
- `agentwire workflow validate <name|path>` — schema check only, no pi call
- `agentwire workflow run <name|path>` — executes a single-node workflow end-to-end via `pi -p --mode json --no-session`
- Events stream to `~/.agentwire/workflows/runs/<run-id>/nodes/<id>.events.jsonl`
- Surfaces final assistant message, token usage, cost, duration, tool calls

## Module layout

Matches the mission doc:

| File | Purpose |
|------|---------|
| `agentwire/workflows/node.py` | `ActionNode` + `NodeResult` dataclasses |
| `agentwire/workflows/pi_runner.py` | subprocess wrapper, JSONL parser |
| `agentwire/workflows/definitions.py` | YAML loader + discovery |
| `agentwire/workflows/runner.py` | single-node executor |
| `agentwire/workflows/cli.py` | `workflow list/validate/run` handlers |
| `agentwire/workflows/examples/hello-world.yaml` | smoke test |

## Pi JSON event schema (captured empirically, pi 0.67.1)

Event types observed: `session`, `agent_start`, `turn_start`, `message_start`, `message_end`, `turn_end`, `agent_end`. Parser extracts final assistant text, tool calls, and summed token usage from `message_end` events. Surfaces API errors even when pi exits 0 (via `message.stopReason == "error"`).

## Intentional MVP limitations

Honored by parser, **not yet by runner** (land in PR B/C):
- `depends_on` — multi-node DAGs raise `NotImplementedError`
- `when` conditionals
- `retries` / `retry_delay`
- `on_error` branching
- `outputs` extraction (regex/jsonpath/text)
- Jinja2 templating for prompts

## Smoke test

```
$ agentwire workflow list
  hello-world (1 node) — Minimal single-node workflow that asks pi for a one-line greeting.

$ agentwire workflow validate hello-world
Workflow 'hello-world' is valid (1 node(s)).

$ agentwire workflow run hello-world --dry-run
=== Workflow 'hello-world' → success ===
  run_id: hello-world-20260414T184813-7b30c063
  --- node[greet] → success (0ms) ---
[dry-run] would execute node 'greet'

$ agentwire workflow run hello-world
=== Workflow 'hello-world' → success ===
  duration: 1859ms
  --- node[greet] → success (1857ms) ---
  tokens: in=1907 out=10 cost=\$0.0000
Hello! 👋 Nice to meet you!
```

## Test plan

- [x] `workflow list` discovers bundled example
- [x] `workflow validate` accepts valid YAML
- [x] `workflow validate` rejects invalid nodes (tested via unit on dataclass validators)
- [x] `workflow run --dry-run` prints plan without spawning pi
- [x] `workflow run` executes pi end-to-end, ~2s, writes events.jsonl
- [x] Multi-node workflows raise NotImplementedError (by design, PR B)

## Next up

PR B will add: topological sort for `depends_on`, Jinja2 templating (`{{ node.output_var }}`), and output extraction specs.

Built by [dotdev.dev](https://dotdev.dev)