### PR TITLE
feat(workflows): multi-node DAG + Jinja2 templating + output extraction

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10143,6 +10143,14 @@ def main() -> int:
 
     wf_run = workflow_subparsers.add_parser("run", help="Execute a workflow")
     wf_run.add_argument("workflow", help="Workflow name or path to YAML")
+    wf_run.add_argument(
+        "--input", action="append", metavar="KEY=VALUE",
+        help="Workflow input (repeatable). Overrides --input-file."
+    )
+    wf_run.add_argument(
+        "--input-file", metavar="PATH",
+        help="JSON file with inputs (object mapping name → value)"
+    )
     wf_run.add_argument("--dry-run", action="store_true", help="Print plan without running")
     wf_run.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     wf_run.add_argument("--json", action="store_true", help="Output as JSON")

--- a/agentwire/workflows/__init__.py
+++ b/agentwire/workflows/__init__.py
@@ -1,19 +1,23 @@
 """AgentWire workflow engine.
 
-Phase 2 MVP scope (this package): single-node execution only. See
-`docs/missions/pi-workflow-engine.md` for the full roadmap — DAG
-dependencies, templating, output extraction, retries, storage,
-and MCP tools land in subsequent PRs.
+Ships DAG execution, Jinja2 templating, and output extraction. See
+`docs/missions/pi-workflow-engine.md` for the full roadmap — retries,
+`when` conditionals, on_error branching, storage, and MCP tools land
+in subsequent PRs.
 """
 
-from agentwire.workflows.node import ActionNode, NodeResult
-from agentwire.workflows.definitions import WorkflowDef, load_workflow
+from agentwire.workflows.context import Context
+from agentwire.workflows.definitions import InputSpec, WorkflowDef, load_workflow
+from agentwire.workflows.node import ActionNode, NodeResult, OutputSpec
 from agentwire.workflows.pi_runner import run_node
 from agentwire.workflows.runner import run_workflow
 
 __all__ = [
     "ActionNode",
+    "Context",
+    "InputSpec",
     "NodeResult",
+    "OutputSpec",
     "WorkflowDef",
     "load_workflow",
     "run_node",

--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from agentwire.workflows.definitions import (
     discover_workflows,
@@ -18,8 +19,37 @@ from agentwire.workflows.definitions import (
 )
 from agentwire.workflows.runner import run_workflow
 
-
 RUNS_DIR = Path.home() / ".agentwire" / "workflows" / "runs"
+
+
+def _parse_input_pairs(pairs: list[str] | None) -> tuple[dict[str, Any], list[str]]:
+    """Parse --input key=value flags into a dict. Last wins on duplicates."""
+    result: dict[str, Any] = {}
+    errors: list[str] = []
+    for pair in pairs or []:
+        if "=" not in pair:
+            errors.append(f"--input expects KEY=VALUE, got: {pair!r}")
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if not key:
+            errors.append(f"--input missing key: {pair!r}")
+            continue
+        result[key] = value
+    return result, errors
+
+
+def _load_input_file(path: str | None) -> tuple[dict[str, Any], list[str]]:
+    if not path:
+        return {}, []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception as e:
+        return {}, [f"--input-file {path!r}: {e}"]
+    if not isinstance(data, dict):
+        return {}, [f"--input-file {path!r}: must be a JSON object"]
+    return data, []
 
 
 def cmd_workflow_list(args) -> int:
@@ -92,16 +122,29 @@ def cmd_workflow_run(args) -> int:
 
     dry_run = getattr(args, "dry_run", False)
 
+    # Collect inputs: --input-file first (base), then --input overrides.
+    file_inputs, file_errors = _load_input_file(getattr(args, "input_file", None))
+    cli_inputs, pair_errors = _parse_input_pairs(getattr(args, "input", None))
+    input_errors = file_errors + pair_errors
+    if input_errors:
+        for err in input_errors:
+            print(f"Error: {err}", file=sys.stderr)
+        return 1
+    merged_inputs: dict[str, Any] = {**file_inputs, **cli_inputs}
+
     if getattr(args, "verbose", False):
         print(f"Running workflow {workflow.name!r} ({len(workflow.nodes)} node(s))...")
         if dry_run:
             print("  (dry-run)")
+        if merged_inputs:
+            print(f"  inputs: {merged_inputs}")
 
-    try:
-        result = run_workflow(workflow, runs_dir=RUNS_DIR, dry_run=dry_run)
-    except NotImplementedError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 2
+    result = run_workflow(
+        workflow,
+        runs_dir=RUNS_DIR,
+        dry_run=dry_run,
+        inputs=merged_inputs,
+    )
 
     if getattr(args, "json", False):
         print(json.dumps({

--- a/agentwire/workflows/context.py
+++ b/agentwire/workflows/context.py
@@ -1,0 +1,37 @@
+"""Workflow execution context + Jinja2 template rendering.
+
+Carries `inputs` (workflow-level CLI args) and per-node `outputs`, and
+renders Jinja2 templates like `{{ inputs.file }}` or `{{ analyze.issues }}`.
+Strict undefined — referencing an unknown variable raises, surfacing typos
+instead of silently producing `""`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import jinja2
+
+
+@dataclass
+class Context:
+    """Per-run state: workflow inputs + outputs accumulated across nodes."""
+
+    inputs: dict[str, Any] = field(default_factory=dict)
+    # Each node's extracted outputs live under its node id:
+    #   outputs["analyze"]["issues"] → extracted list
+    outputs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    cwd: str | None = None
+
+    def render(self, template: str) -> str:
+        """Render a Jinja2 template against the current context."""
+        env = jinja2.Environment(
+            undefined=jinja2.StrictUndefined,
+            keep_trailing_newline=True,
+        )
+        tmpl = env.from_string(template)
+        return tmpl.render(inputs=self.inputs, **self.outputs)
+
+    def set_node_outputs(self, node_id: str, values: dict[str, Any]) -> None:
+        self.outputs[node_id] = values

--- a/agentwire/workflows/definitions.py
+++ b/agentwire/workflows/definitions.py
@@ -1,20 +1,20 @@
 """Workflow YAML loader + schema validator.
 
-MVP: supports `name`, `description`, `version`, and a `nodes` map. Each node
-builds into an ActionNode. Multi-node DAGs are declared legally here (so
-future PRs don't break existing files) but only single-node workflows
-actually execute in the MVP runner.
+Supports `name`, `description`, `version`, `inputs` (CLI-supplied
+variables), and a `nodes` map. Each node builds into an ActionNode with
+optional `outputs` extraction specs. DAG dependencies via `depends_on`
+are validated here (cycle detection) and executed by the runner.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-from agentwire.workflows.node import ActionNode
-
+from agentwire.workflows.node import ActionNode, OutputSpec
 
 # Where workflow YAML files are discovered by `agentwire workflow list` / run.
 # Order matters: first match wins.
@@ -26,6 +26,36 @@ DISCOVERY_DIRS = [
 
 
 @dataclass
+class InputSpec:
+    """Workflow-level input: a CLI-supplied variable bound into the context."""
+
+    name: str
+    type: str = "string"     # "string" | "int" | "float" | "bool" | "json"
+    required: bool = True
+    default: Any = None
+    description: str = ""
+
+    def coerce(self, raw: str | Any) -> Any:
+        """Turn a CLI --input value (always a string) into the declared type."""
+        if raw is None:
+            return None
+        if self.type == "string":
+            return str(raw)
+        if self.type == "int":
+            return int(raw)
+        if self.type == "float":
+            return float(raw)
+        if self.type == "bool":
+            if isinstance(raw, bool):
+                return raw
+            return str(raw).strip().lower() in ("1", "true", "yes", "y", "on")
+        if self.type == "json":
+            import json as _json
+            return _json.loads(raw) if isinstance(raw, str) else raw
+        raise ValueError(f"input[{self.name}]: unknown type {self.type!r}")
+
+
+@dataclass
 class WorkflowDef:
     """Parsed workflow definition."""
 
@@ -33,6 +63,7 @@ class WorkflowDef:
     nodes: list[ActionNode]
     description: str = ""
     version: int = 1
+    inputs: list[InputSpec] = field(default_factory=list)
     source_path: Path | None = None
 
     def validate(self) -> list[str]:
@@ -54,7 +85,84 @@ class WorkflowDef:
                     errors.append(
                         f"node[{node.id}].depends_on references unknown node: {dep}"
                     )
+        # Cycle detection (only meaningful once refs resolve)
+        if not errors:
+            cycle = _find_cycle(self.nodes)
+            if cycle:
+                errors.append(f"dependency cycle detected: {' -> '.join(cycle)}")
+        # Duplicate input names
+        seen_inputs: set[str] = set()
+        for inp in self.inputs:
+            if inp.name in seen_inputs:
+                errors.append(f"duplicate input name: {inp.name}")
+            seen_inputs.add(inp.name)
         return errors
+
+
+_UNVISITED, _IN_PROGRESS, _DONE = 0, 1, 2
+
+
+def _find_cycle(nodes: list[ActionNode]) -> list[str] | None:
+    """Return the first cycle found as a list of node ids, or None if acyclic."""
+    graph = {n.id: list(n.depends_on) for n in nodes}
+    color = {nid: _UNVISITED for nid in graph}
+    parent: dict[str, str | None] = {nid: None for nid in graph}
+
+    def dfs(start: str) -> list[str] | None:
+        stack = [start]
+        while stack:
+            nid = stack[-1]
+            if color[nid] == _UNVISITED:
+                color[nid] = _IN_PROGRESS
+            advanced = False
+            for dep in graph.get(nid, []):
+                if color.get(dep) == _UNVISITED:
+                    parent[dep] = nid
+                    stack.append(dep)
+                    advanced = True
+                    break
+                if color.get(dep) == _IN_PROGRESS:
+                    # Reconstruct cycle path: dep ... nid -> dep
+                    cycle = [dep]
+                    cur: str | None = nid
+                    while cur is not None and cur != dep:
+                        cycle.append(cur)
+                        cur = parent.get(cur)
+                    cycle.append(dep)
+                    return list(reversed(cycle))
+            if not advanced:
+                color[nid] = _DONE
+                stack.pop()
+        return None
+
+    for nid in graph:
+        if color[nid] == _UNVISITED:
+            result = dfs(nid)
+            if result:
+                return result
+    return None
+
+
+def topological_sort(nodes: list[ActionNode]) -> list[ActionNode]:
+    """Kahn's algorithm. Assumes validate() already ran (no cycles, deps resolve)."""
+    by_id = {n.id: n for n in nodes}
+    indegree = {n.id: len(n.depends_on) for n in nodes}
+    dependents: dict[str, list[str]] = {n.id: [] for n in nodes}
+    for n in nodes:
+        for dep in n.depends_on:
+            dependents[dep].append(n.id)
+
+    # Use insertion order among tied nodes (YAML node ordering = authoring intent)
+    ready = [n.id for n in nodes if indegree[n.id] == 0]
+    ordered: list[ActionNode] = []
+    while ready:
+        nid = ready.pop(0)
+        ordered.append(by_id[nid])
+        for child in dependents[nid]:
+            indegree[child] -= 1
+            if indegree[child] == 0:
+                ready.append(child)
+    return ordered
 
 
 def _node_from_dict(node_id: str, data: dict) -> ActionNode:
@@ -93,7 +201,47 @@ def _node_from_dict(node_id: str, data: dict) -> ActionNode:
             raise ValueError(f"node[{node_id}].extra_env must be a mapping")
         kwargs["extra_env"] = {str(k): str(v) for k, v in env.items()}
 
+    if "outputs" in data:
+        outputs_raw = data["outputs"]
+        if not isinstance(outputs_raw, list):
+            raise ValueError(f"node[{node_id}].outputs must be a list")
+        specs: list[OutputSpec] = []
+        for idx, entry in enumerate(outputs_raw):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"node[{node_id}].outputs[{idx}] must be a mapping, "
+                    f"got {type(entry).__name__}"
+                )
+            spec_name = entry.get("name")
+            if not spec_name:
+                raise ValueError(f"node[{node_id}].outputs[{idx}] missing 'name'")
+            specs.append(OutputSpec(
+                name=str(spec_name),
+                source=str(entry.get("source", "text")),
+                pattern=str(entry.get("pattern", "")),
+                required=bool(entry.get("required", True)),
+            ))
+        kwargs["outputs"] = specs
+
     return ActionNode(**kwargs)
+
+
+def _input_from_dict(input_name: str, data: Any) -> InputSpec:
+    """Build an InputSpec. Accepts either a mapping or a bare type string."""
+    if isinstance(data, str):
+        return InputSpec(name=input_name, type=data)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"input[{input_name}] must be a mapping or type string, "
+            f"got {type(data).__name__}"
+        )
+    return InputSpec(
+        name=input_name,
+        type=str(data.get("type", "string")),
+        required=bool(data.get("required", True)),
+        default=data.get("default"),
+        description=str(data.get("description", "")),
+    )
 
 
 def load_workflow(path: Path) -> WorkflowDef:
@@ -114,11 +262,20 @@ def load_workflow(path: Path) -> WorkflowDef:
     for node_id, node_data in raw_nodes.items():
         nodes.append(_node_from_dict(str(node_id), node_data))
 
+    raw_inputs = data.get("inputs", {})
+    inputs: list[InputSpec] = []
+    if raw_inputs:
+        if not isinstance(raw_inputs, dict):
+            raise ValueError(f"{path}: 'inputs' must be a mapping of name → spec")
+        for input_name, input_data in raw_inputs.items():
+            inputs.append(_input_from_dict(str(input_name), input_data))
+
     return WorkflowDef(
         name=name,
         nodes=nodes,
         description=description,
         version=version,
+        inputs=inputs,
         source_path=path,
     )
 

--- a/agentwire/workflows/examples/echo-chain.yaml
+++ b/agentwire/workflows/examples/echo-chain.yaml
@@ -1,0 +1,30 @@
+name: echo-chain
+description: Two-node DAG that exercises templating + JSONPath output extraction.
+version: 1
+
+inputs:
+  topic:
+    type: string
+    required: true
+    description: Subject for the generated fact
+
+nodes:
+  fact:
+    prompt: |
+      Return ONLY a JSON object (no prose, no code fences) in this exact shape:
+      {"fact": "<one-sentence fun fact about {{ inputs.topic }}>"}
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+    outputs:
+      - name: fact
+        source: jsonpath
+        pattern: $.fact
+
+  summarize:
+    depends_on: [fact]
+    prompt: |
+      Restate this fact in exactly five words: "{{ fact.fact }}"
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -1,19 +1,45 @@
 """Workflow node dataclasses.
 
-MVP: ActionNode represents a single pi invocation. Future PRs extend with
-ConditionalNode, ParallelNode. OutputSpec / depends_on / when / retries
-fields are declared here so YAML parsing validates forward-compatibly,
-but are not yet honored by the MVP runner.
+ActionNode represents a single pi invocation. OutputSpec declares how to
+extract named variables from a node's result for use in downstream node
+templates. `when` / retries / on_error branching are declared but not
+yet honored by the runner — they land in PR C.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-
 DEFAULT_TOOLS = ["read", "bash", "edit", "write"]
 VALID_TOOLS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
 VALID_THINKING = {"off", "minimal", "low", "medium", "high", "xhigh"}
+VALID_OUTPUT_SOURCES = {"text", "regex", "jsonpath"}
+
+
+@dataclass
+class OutputSpec:
+    """How to extract one named variable from a node's final output."""
+
+    name: str
+    source: str            # "text" | "regex" | "jsonpath"
+    pattern: str = ""      # regex pattern, jsonpath expr, or fence marker for text
+    required: bool = True  # if False, extraction failure → value is None
+
+    def validate(self, node_id: str) -> list[str]:
+        errors: list[str] = []
+        if not self.name or not self.name.strip():
+            errors.append(f"node[{node_id}].outputs: each output needs a name")
+        if self.source not in VALID_OUTPUT_SOURCES:
+            errors.append(
+                f"node[{node_id}].outputs[{self.name}].source={self.source!r} "
+                f"not in {sorted(VALID_OUTPUT_SOURCES)}"
+            )
+        if self.source in ("regex", "jsonpath") and not self.pattern:
+            errors.append(
+                f"node[{node_id}].outputs[{self.name}] requires pattern "
+                f"for source={self.source!r}"
+            )
+        return errors
 
 
 @dataclass
@@ -40,6 +66,8 @@ class ActionNode:
     workdir: str | None = None
     extra_env: dict[str, str] = field(default_factory=dict)
 
+    outputs: list[OutputSpec] = field(default_factory=list)
+
     def validate(self) -> list[str]:
         """Return a list of validation error strings (empty = valid)."""
         errors: list[str] = []
@@ -47,6 +75,12 @@ class ActionNode:
             errors.append("node.id is required")
         if not self.prompt or not self.prompt.strip():
             errors.append(f"node[{self.id}].prompt is required")
+        seen_out: set[str] = set()
+        for spec in self.outputs:
+            errors.extend(spec.validate(self.id))
+            if spec.name in seen_out:
+                errors.append(f"node[{self.id}].outputs: duplicate name {spec.name!r}")
+            seen_out.add(spec.name)
         if self.thinking not in VALID_THINKING:
             errors.append(
                 f"node[{self.id}].thinking={self.thinking!r} not in {sorted(VALID_THINKING)}"

--- a/agentwire/workflows/outputs.py
+++ b/agentwire/workflows/outputs.py
@@ -1,0 +1,149 @@
+"""Extract named outputs from a NodeResult into the workflow context.
+
+Supported sources:
+  text     — whole final assistant message (with optional strip)
+  regex    — first regex match group against final text
+  jsonpath — simple JSONPath-lite against final text parsed as JSON
+
+tool_result extraction is planned (needs content-block walking); out of
+scope for PR B — fail validation if anyone declares it for now.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from agentwire.workflows.node import NodeResult, OutputSpec
+
+
+class OutputExtractionError(Exception):
+    """Raised when a required output cannot be extracted."""
+
+
+def _apply_jsonpath(data: Any, path: str) -> Any:
+    """Tiny JSONPath: supports $.a, $.a.b, $.a[*], $.a[*].b, $.a[0].
+
+    Not a full JSONPath implementation — just what's needed for node outputs.
+    Use jsonpath-ng later if we grow into it.
+    """
+    if not path.startswith("$"):
+        raise ValueError(f"jsonpath must start with $, got: {path!r}")
+
+    cursor: Any = data
+    # Strip leading $ and optional .
+    rest = path[1:]
+    if rest.startswith("."):
+        rest = rest[1:]
+
+    # Tokenize: split by '.' but keep [*] and [N] attached
+    tokens: list[str] = []
+    buf = ""
+    i = 0
+    while i < len(rest):
+        ch = rest[i]
+        if ch == ".":
+            if buf:
+                tokens.append(buf)
+                buf = ""
+        elif ch == "[":
+            close = rest.index("]", i)
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            tokens.append(rest[i:close + 1])
+            i = close
+        else:
+            buf += ch
+        i += 1
+    if buf:
+        tokens.append(buf)
+
+    for tok in tokens:
+        if tok == "[*]":
+            if not isinstance(cursor, list):
+                raise ValueError(f"[*] applied to non-list at {path!r}")
+            # Downstream tokens apply to each element
+            cursor = list(cursor)
+        elif tok.startswith("[") and tok.endswith("]"):
+            idx_str = tok[1:-1]
+            try:
+                idx = int(idx_str)
+            except ValueError as e:
+                raise ValueError(f"bad index {tok!r} in {path!r}") from e
+            if isinstance(cursor, list) and isinstance(cursor, list):
+                cursor = cursor[idx]
+            else:
+                raise ValueError(f"{tok} applied to non-list at {path!r}")
+        else:
+            if isinstance(cursor, list):
+                # Apply key lookup to every element (e.g. $.a[*].b)
+                cursor = [(c.get(tok) if isinstance(c, dict) else None) for c in cursor]
+            elif isinstance(cursor, dict):
+                cursor = cursor.get(tok)
+            else:
+                raise ValueError(f"cannot get {tok!r} from {type(cursor).__name__} at {path!r}")
+    return cursor
+
+
+def _extract_one(spec: OutputSpec, node_result: NodeResult) -> Any:
+    text = node_result.final_text or ""
+
+    if spec.source == "text":
+        if spec.pattern:
+            # pattern acts as a strip-to-fence hint, e.g. "```json" → strip fences
+            stripped = text.strip()
+            if spec.pattern and spec.pattern in stripped:
+                parts = stripped.split(spec.pattern)
+                if len(parts) >= 2:
+                    return parts[1].split("```")[0].strip()
+            return stripped
+        return text.strip()
+
+    if spec.source == "regex":
+        match = re.search(spec.pattern, text, re.DOTALL | re.MULTILINE)
+        if not match:
+            raise OutputExtractionError(
+                f"regex {spec.pattern!r} did not match output of node[{node_result.node_id}]"
+            )
+        return match.group(1) if match.groups() else match.group(0)
+
+    if spec.source == "jsonpath":
+        # Try to locate a JSON blob: prefer fenced ```json ... ```,
+        # fall back to the whole text (trimmed).
+        candidate = text.strip()
+        fence = re.search(r"```(?:json)?\s*\n(.*?)```", candidate, re.DOTALL)
+        if fence:
+            candidate = fence.group(1).strip()
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError as e:
+            raise OutputExtractionError(
+                f"node[{node_result.node_id}] output is not valid JSON: {e}"
+            ) from e
+        return _apply_jsonpath(parsed, spec.pattern)
+
+    raise OutputExtractionError(f"unknown source: {spec.source!r}")
+
+
+def extract_outputs(
+    specs: list[OutputSpec],
+    node_result: NodeResult,
+) -> tuple[dict[str, Any], list[str]]:
+    """Extract all declared outputs; return (values, soft_errors).
+
+    Required-output failures raise OutputExtractionError immediately.
+    Optional (required=False) failures are collected as soft_errors.
+    """
+    values: dict[str, Any] = {}
+    soft_errors: list[str] = []
+    for spec in specs:
+        try:
+            values[spec.name] = _extract_one(spec, node_result)
+        except OutputExtractionError as e:
+            if spec.required:
+                raise
+            soft_errors.append(f"{spec.name}: {e}")
+            values[spec.name] = None
+    return values, soft_errors

--- a/agentwire/workflows/pi_runner.py
+++ b/agentwire/workflows/pi_runner.py
@@ -18,7 +18,6 @@ import yaml
 
 from agentwire.workflows.node import ActionNode, NodeResult
 
-
 CONFIG_PATH = Path.home() / ".agentwire" / "config.yaml"
 
 

--- a/agentwire/workflows/runner.py
+++ b/agentwire/workflows/runner.py
@@ -1,18 +1,26 @@
 """Workflow DAG executor.
 
-MVP: supports a single ActionNode. Multi-node DAGs raise NotImplementedError
-until PR B lands topological sort + dependency resolution.
+Runs nodes in topological order. For each node:
+  1. Render its Jinja2 prompt against the current Context
+     (`{{ inputs.x }}`, `{{ upstream_node.var }}`).
+  2. Invoke pi via `run_node`.
+  3. Extract declared outputs into the Context for downstream nodes.
+
+`when`, retries, and on_error branching ship in PR C.
 """
 
 from __future__ import annotations
 
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Any
 
-from agentwire.workflows.definitions import WorkflowDef
+from agentwire.workflows.context import Context
+from agentwire.workflows.definitions import InputSpec, WorkflowDef, topological_sort
 from agentwire.workflows.node import NodeResult
+from agentwire.workflows.outputs import OutputExtractionError, extract_outputs
 from agentwire.workflows.pi_runner import run_node
 
 
@@ -26,6 +34,7 @@ class WorkflowRun:
     started_at: float
     duration_ms: int
     node_results: list[NodeResult] = field(default_factory=list)
+    context: Context | None = None
     error: str | None = None
 
 
@@ -34,16 +43,43 @@ def _generate_run_id(workflow_name: str) -> str:
     return f"{workflow_name}-{ts}-{uuid.uuid4().hex[:8]}"
 
 
+def _resolve_inputs(
+    specs: list[InputSpec],
+    provided: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Coerce + validate provided CLI inputs against declared specs.
+
+    Unknown inputs are rejected; missing required inputs without defaults are errors.
+    """
+    errors: list[str] = []
+    by_name = {s.name: s for s in specs}
+    for key in provided:
+        if key not in by_name:
+            errors.append(f"unknown input: {key!r}")
+
+    resolved: dict[str, Any] = {}
+    for spec in specs:
+        if spec.name in provided:
+            try:
+                resolved[spec.name] = spec.coerce(provided[spec.name])
+            except Exception as e:
+                errors.append(f"input[{spec.name}]: {e}")
+        elif spec.default is not None:
+            resolved[spec.name] = spec.default
+        elif spec.required:
+            errors.append(f"missing required input: {spec.name}")
+        else:
+            resolved[spec.name] = None
+    return resolved, errors
+
+
 def run_workflow(
     workflow: WorkflowDef,
     runs_dir: Path | None = None,
     dry_run: bool = False,
+    inputs: dict[str, Any] | None = None,
 ) -> WorkflowRun:
-    """Execute a workflow end-to-end.
-
-    MVP: runs the first (and only) node. Raises NotImplementedError for
-    multi-node workflows — Phase 2 PR B ships DAG support.
-    """
+    """Execute a workflow end-to-end."""
     errors = workflow.validate()
     if errors:
         return WorkflowRun(
@@ -55,49 +91,114 @@ def run_workflow(
             error="; ".join(errors),
         )
 
-    if len(workflow.nodes) > 1:
-        raise NotImplementedError(
-            "multi-node workflows land in Phase 2 PR B. "
-            f"workflow {workflow.name!r} has {len(workflow.nodes)} nodes."
+    resolved_inputs, input_errors = _resolve_inputs(workflow.inputs, inputs or {})
+    if input_errors:
+        return WorkflowRun(
+            workflow=workflow.name,
+            run_id="",
+            status="failure",
+            started_at=time.time(),
+            duration_ms=0,
+            error="; ".join(input_errors),
         )
+
+    ordered_nodes = topological_sort(workflow.nodes)
+    context = Context(inputs=resolved_inputs)
 
     run_id = _generate_run_id(workflow.name)
     started_at = time.time()
     started_mono = time.monotonic()
 
-    node = workflow.nodes[0]
-
     if dry_run:
+        plan_results = [
+            NodeResult(
+                node_id=n.id,
+                status="success",
+                final_text=f"[dry-run] would execute node {n.id!r} "
+                           f"(depends_on={n.depends_on or '[]'})",
+            )
+            for n in ordered_nodes
+        ]
         return WorkflowRun(
             workflow=workflow.name,
             run_id=run_id,
             status="success",
             started_at=started_at,
             duration_ms=0,
-            node_results=[
-                NodeResult(
-                    node_id=node.id,
-                    status="success",
-                    final_text=f"[dry-run] would execute node {node.id!r}",
-                )
-            ],
+            node_results=plan_results,
+            context=context,
         )
 
-    event_log_path: Path | None = None
-    if runs_dir is not None:
-        event_log_path = runs_dir / run_id / "nodes" / f"{node.id}.events.jsonl"
+    node_results: list[NodeResult] = []
+    overall_status = "success"
+    overall_error: str | None = None
 
-    result = run_node(node, event_log_path=event_log_path)
+    for node in ordered_nodes:
+        # Render prompt against current context. A template error here is a
+        # definition-level bug (undefined var, bad syntax) — surface it as a
+        # node failure and stop.
+        try:
+            rendered_prompt = context.render(node.prompt)
+        except Exception as e:
+            node_results.append(NodeResult(
+                node_id=node.id,
+                status="failure",
+                final_text="",
+                error=f"prompt template error: {e}",
+            ))
+            overall_status = "failure"
+            overall_error = f"node[{node.id}] template error: {e}"
+            break
+
+        rendered_node = replace(node, prompt=rendered_prompt)
+
+        event_log_path: Path | None = None
+        if runs_dir is not None:
+            event_log_path = runs_dir / run_id / "nodes" / f"{node.id}.events.jsonl"
+
+        result = run_node(
+            rendered_node,
+            workflow_cwd=context.cwd,
+            event_log_path=event_log_path,
+        )
+        node_results.append(result)
+
+        if result.status != "success":
+            overall_status = "failure"
+            overall_error = result.error
+            break
+
+        # Extract declared outputs into context for downstream nodes.
+        # If the node didn't declare outputs, expose `{{ node_id.text }}`
+        # so downstream prompts can at least reference the final message.
+        if node.outputs:
+            try:
+                values, soft_errors = extract_outputs(node.outputs, result)
+                context.set_node_outputs(node.id, values)
+                if soft_errors:
+                    result.error = (
+                        (result.error + "; " if result.error else "")
+                        + "optional output failures: "
+                        + "; ".join(soft_errors)
+                    )
+            except OutputExtractionError as e:
+                result.status = "failure"
+                result.error = f"output extraction failed: {e}"
+                overall_status = "failure"
+                overall_error = f"node[{node.id}] {result.error}"
+                break
+        else:
+            context.set_node_outputs(node.id, {"text": result.final_text})
 
     duration_ms = int((time.monotonic() - started_mono) * 1000)
-    status = "success" if result.status == "success" else "failure"
 
     return WorkflowRun(
         workflow=workflow.name,
         run_id=run_id,
-        status=status,
+        status=overall_status,
         started_at=started_at,
         duration_ms=duration_ms,
-        node_results=[result],
-        error=result.error,
+        node_results=node_results,
+        context=context,
+        error=overall_error,
     )


### PR DESCRIPTION
## Summary

PR B of the pi workflow engine (see `docs/missions/pi-workflow-engine.md`). Unlocks workflows that actually flow — node outputs become downstream prompt variables via Jinja2 templating.

### What's new

- **DAG execution** — topological sort over `depends_on`, cycle detection at validate time.
- **Jinja2 templating** — `StrictUndefined` so typos fail loudly. `{{ inputs.x }}` and `{{ upstream_node.var }}` both work.
- **Output extraction** — `source: text | regex | jsonpath`. JSONPath is a small hand-rolled subset (`$.a`, `$.a.b`, `$.a[*]`, `$.a[*].b`, `$.a[0]`) — enough for node outputs today, upgrade to `jsonpath-ng` later if we outgrow it.
- **Workflow inputs** — `inputs:` schema with `type` (string/int/float/bool/json), `required`, `default`.
- **CLI flags** — `--input KEY=VALUE` (repeatable) + `--input-file path.json`. `--input` wins on overlap.
- **Second example** — `echo-chain.yaml`: pi emits JSON, JSONPath pulls `$.fact`, downstream node restates it in five words.

### What's still deferred

- `when` conditionals, retries, `on_error` branching — PR C (declared forward-compat in the dataclass, ignored at runtime).
- Run metadata/history storage, `workflow show`/`history` commands, MCP tools — PR D.
- Remaining example workflows + `docs/workflows.md` — PR E.

## Test plan

- [x] `uv run ruff check agentwire/workflows/` clean
- [x] `agentwire workflow validate echo-chain` passes
- [x] `agentwire workflow validate hello-world` still passes
- [x] `agentwire workflow list` finds both examples
- [x] Dry-run shows topo order with `depends_on` annotations
- [x] Missing required input → clean error, exit 1
- [x] **Real run:** `agentwire workflow run echo-chain --input topic=otters` → success (22.8s, both nodes OK, JSONPath round-tripped the fact into the summarize prompt, final 5-word output delivered)
- [x] Per-node event logs written to `~/.agentwire/workflows/runs/<run-id>/nodes/<node-id>.events.jsonl`
- [x] Cycle detection: `ActionNode(a→b) + ActionNode(b→a)` returns `['a','b','a']`

Built by [dotdev.dev](https://dotdev.dev)