### PR TITLE
feat(workflows): when conditionals, retries, on_error branching

### DIFF
--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -159,13 +159,15 @@ def cmd_workflow_run(args) -> int:
                     "status": r.status,
                     "final_text": r.final_text,
                     "duration_ms": r.duration_ms,
+                    "attempts": r.attempts,
                     "tokens": r.tokens_used,
                     "error": r.error,
                 }
                 for r in result.node_results
             ],
         }, indent=2))
-        return 0 if result.status == "success" else 1
+        # partial workflows exit 0 — they completed, just not cleanly.
+        return 0 if result.status in ("success", "partial") else 1
 
     print(f"\n=== Workflow {result.workflow!r} → {result.status} ===")
     print(f"  run_id: {result.run_id}")
@@ -174,8 +176,15 @@ def cmd_workflow_run(args) -> int:
         print(f"  error: {result.error}")
 
     for node_result in result.node_results:
+        attempts_note = (
+            f" [attempts={node_result.attempts}]" if node_result.attempts > 1 else ""
+        )
         print(f"\n  --- node[{node_result.node_id}] → {node_result.status} "
-              f"({node_result.duration_ms}ms) ---")
+              f"({node_result.duration_ms}ms){attempts_note} ---")
+        if node_result.status == "skipped":
+            if node_result.error:
+                print(f"  reason: {node_result.error}")
+            continue
         if node_result.tool_calls:
             tools = ", ".join(tc["name"] for tc in node_result.tool_calls)
             print(f"  tools used: {tools}")
@@ -188,4 +197,4 @@ def cmd_workflow_run(args) -> int:
         if node_result.error:
             print(f"  error: {node_result.error}")
 
-    return 0 if result.status == "success" else 1
+    return 0 if result.status in ("success", "partial") else 1

--- a/agentwire/workflows/context.py
+++ b/agentwire/workflows/context.py
@@ -4,6 +4,9 @@ Carries `inputs` (workflow-level CLI args) and per-node `outputs`, and
 renders Jinja2 templates like `{{ inputs.file }}` or `{{ analyze.issues }}`.
 Strict undefined — referencing an unknown variable raises, surfacing typos
 instead of silently producing `""`.
+
+`eval_condition()` evaluates Jinja expressions (no `{{ }}` braces needed)
+used by `when:` on nodes — e.g. `when: "verify.status == 'fail'"`.
 """
 
 from __future__ import annotations
@@ -12,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import jinja2
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 
 @dataclass
@@ -32,6 +36,17 @@ class Context:
         )
         tmpl = env.from_string(template)
         return tmpl.render(inputs=self.inputs, **self.outputs)
+
+    def eval_condition(self, expr: str) -> bool:
+        """Evaluate a Jinja expression against the context. Returns Python truthiness.
+
+        Used for `when:` on workflow nodes. Uses a sandboxed env so even if a
+        workflow YAML author gets creative, attribute access to dunders is blocked.
+        StrictUndefined surfaces typos (`veriyf.status`) as errors.
+        """
+        env = ImmutableSandboxedEnvironment(undefined=jinja2.StrictUndefined)
+        compiled = env.compile_expression(expr)
+        return bool(compiled(inputs=self.inputs, **self.outputs))
 
     def set_node_outputs(self, node_id: str, values: dict[str, Any]) -> None:
         self.outputs[node_id] = values

--- a/agentwire/workflows/definitions.py
+++ b/agentwire/workflows/definitions.py
@@ -90,6 +90,18 @@ class WorkflowDef:
             cycle = _find_cycle(self.nodes)
             if cycle:
                 errors.append(f"dependency cycle detected: {' -> '.join(cycle)}")
+        # on_error=branch requires on_error_goto pointing at a real node
+        for node in self.nodes:
+            if node.on_error == "branch":
+                if not node.on_error_goto:
+                    errors.append(
+                        f"node[{node.id}].on_error=branch requires on_error_goto"
+                    )
+                elif node.on_error_goto not in seen_ids:
+                    errors.append(
+                        f"node[{node.id}].on_error_goto references unknown node: "
+                        f"{node.on_error_goto}"
+                    )
         # Duplicate input names
         seen_inputs: set[str] = set()
         for inp in self.inputs:

--- a/agentwire/workflows/examples/verify-or-rollback.yaml
+++ b/agentwire/workflows/examples/verify-or-rollback.yaml
@@ -1,0 +1,45 @@
+name: verify-or-rollback
+description: |
+  3-node example: verify → (restate on pass | rollback on fail).
+  Exercises `when:` conditionals against upstream JSONPath outputs.
+  Run with `--input target=pass` or `--input target=fail` to pick a branch.
+version: 1
+
+inputs:
+  target:
+    type: string
+    required: true
+    description: "pass or fail — controls which branch runs"
+
+nodes:
+  verify:
+    prompt: |
+      Return ONLY a JSON object (no prose, no code fences) in this exact shape:
+      {"status": "{{ inputs.target }}"}
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+    retries: 1
+    retry_delay: 2
+    outputs:
+      - name: status
+        source: jsonpath
+        pattern: $.status
+
+  restate:
+    depends_on: [verify]
+    when: "verify.status == 'pass'"
+    prompt: |
+      Reply with exactly: "All checks passed."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+
+  rollback:
+    depends_on: [verify]
+    when: "verify.status == 'fail'"
+    prompt: |
+      Reply with exactly: "Rolling back changes."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -104,11 +104,12 @@ class NodeResult:
     """Outcome of executing a single node."""
 
     node_id: str
-    status: str  # "success" | "failure" | "timeout"
+    status: str  # "success" | "failure" | "timeout" | "skipped"
     final_text: str  # Final assistant message text
     events: list[dict] = field(default_factory=list)
     tool_calls: list[dict] = field(default_factory=list)
     tokens_used: dict = field(default_factory=dict)
     duration_ms: int = 0
     exit_code: int = 0
+    attempts: int = 1  # how many pi invocations happened (1 = no retries)
     error: str | None = None

--- a/agentwire/workflows/runner.py
+++ b/agentwire/workflows/runner.py
@@ -1,12 +1,20 @@
 """Workflow DAG executor.
 
 Runs nodes in topological order. For each node:
-  1. Render its Jinja2 prompt against the current Context
-     (`{{ inputs.x }}`, `{{ upstream_node.var }}`).
-  2. Invoke pi via `run_node`.
-  3. Extract declared outputs into the Context for downstream nodes.
+  1. Skip-check: was an upstream node skipped/branched past us?
+  2. `when:` eval — Jinja expression. Falsy → skip (propagate to dependents).
+  3. Render Jinja2 prompt (`{{ inputs.x }}`, `{{ upstream.var }}`).
+  4. Run pi; retry on failure|timeout up to `retries` times with `retry_delay`.
+  5. On success: extract outputs into context.
+  6. On failure after retries: consult `on_error`:
+       - fail     → halt workflow
+       - continue → mark outputs None, keep going (dependents see Nones)
+       - branch   → skip normal dependents, preserve `on_error_goto` target
 
-`when`, retries, and on_error branching ship in PR C.
+Workflow status:
+  success — every node succeeded
+  partial — some nodes skipped or failed-continue, but nothing halted
+  failure — a node with on_error=fail failed (execution halted)
 """
 
 from __future__ import annotations
@@ -19,7 +27,7 @@ from typing import Any
 
 from agentwire.workflows.context import Context
 from agentwire.workflows.definitions import InputSpec, WorkflowDef, topological_sort
-from agentwire.workflows.node import NodeResult
+from agentwire.workflows.node import ActionNode, NodeResult
 from agentwire.workflows.outputs import OutputExtractionError, extract_outputs
 from agentwire.workflows.pi_runner import run_node
 
@@ -30,7 +38,7 @@ class WorkflowRun:
 
     workflow: str
     run_id: str
-    status: str  # "success" | "failure" | "partial"
+    status: str  # "success" | "partial" | "failure"
     started_at: float
     duration_ms: int
     node_results: list[NodeResult] = field(default_factory=list)
@@ -47,10 +55,7 @@ def _resolve_inputs(
     specs: list[InputSpec],
     provided: dict[str, Any],
 ) -> tuple[dict[str, Any], list[str]]:
-    """Coerce + validate provided CLI inputs against declared specs.
-
-    Unknown inputs are rejected; missing required inputs without defaults are errors.
-    """
+    """Coerce + validate provided CLI inputs against declared specs."""
     errors: list[str] = []
     by_name = {s.name: s for s in specs}
     for key in provided:
@@ -71,6 +76,73 @@ def _resolve_inputs(
         else:
             resolved[spec.name] = None
     return resolved, errors
+
+
+def _build_dependents_map(nodes: list[ActionNode]) -> dict[str, list[str]]:
+    """dep_id → [nodes that depend on dep_id]."""
+    dependents: dict[str, list[str]] = {n.id: [] for n in nodes}
+    for n in nodes:
+        for dep in n.depends_on:
+            dependents.setdefault(dep, []).append(n.id)
+    return dependents
+
+
+def _mark_transitive_skipped(
+    start_id: str,
+    dependents: dict[str, list[str]],
+    skipped: set[str],
+    rescue: set[str] | None = None,
+) -> None:
+    """BFS-mark everything downstream of `start_id` as skipped.
+
+    Nodes in `rescue` are NOT marked (used by on_error=branch to preserve the
+    fallback target). Their own dependents are also not propagated through the
+    rescued node.
+    """
+    rescue = rescue or set()
+    queue = list(dependents.get(start_id, []))
+    while queue:
+        nid = queue.pop(0)
+        if nid in rescue or nid in skipped:
+            continue
+        skipped.add(nid)
+        queue.extend(dependents.get(nid, []))
+
+
+def _run_one_node_with_retries(
+    node: ActionNode,
+    rendered_prompt: str,
+    context: Context,
+    runs_dir: Path | None,
+    run_id: str,
+) -> NodeResult:
+    """Invoke pi; retry on failure|timeout per node.retries / retry_delay."""
+    attempts = 0
+    result: NodeResult | None = None
+    event_log_path: Path | None = None
+    if runs_dir is not None:
+        event_log_path = runs_dir / run_id / "nodes" / f"{node.id}.events.jsonl"
+
+    rendered_node = replace(node, prompt=rendered_prompt)
+
+    while True:
+        attempts += 1
+        result = run_node(
+            rendered_node,
+            workflow_cwd=context.cwd,
+            event_log_path=event_log_path,
+        )
+        if result.status == "success":
+            break
+        if result.status not in ("failure", "timeout"):
+            break
+        if attempts > node.retries:
+            break
+        time.sleep(node.retry_delay)
+
+    assert result is not None
+    result.attempts = attempts
+    return result
 
 
 def run_workflow(
@@ -103,6 +175,7 @@ def run_workflow(
         )
 
     ordered_nodes = topological_sort(workflow.nodes)
+    dependents = _build_dependents_map(workflow.nodes)
     context = Context(inputs=resolved_inputs)
 
     run_id = _generate_run_id(workflow.name)
@@ -115,7 +188,9 @@ def run_workflow(
                 node_id=n.id,
                 status="success",
                 final_text=f"[dry-run] would execute node {n.id!r} "
-                           f"(depends_on={n.depends_on or '[]'})",
+                           f"(depends_on={n.depends_on or '[]'}"
+                           + (f", when={n.when!r}" if n.when else "")
+                           + ")",
             )
             for n in ordered_nodes
         ]
@@ -129,66 +204,145 @@ def run_workflow(
             context=context,
         )
 
-    node_results: list[NodeResult] = []
+    skipped: set[str] = set()
+    results_by_id: dict[str, NodeResult] = {}
     overall_status = "success"
     overall_error: str | None = None
+    halted = False
 
     for node in ordered_nodes:
-        # Render prompt against current context. A template error here is a
-        # definition-level bug (undefined var, bad syntax) — surface it as a
-        # node failure and stop.
+        # 1. Was this node already marked skipped by an upstream event?
+        if node.id in skipped:
+            results_by_id[node.id] = NodeResult(
+                node_id=node.id,
+                status="skipped",
+                final_text="",
+                error="upstream skipped or branched",
+            )
+            overall_status = "partial"
+            continue
+
+        # 2. when: conditional. Eval errors are treated as node failures
+        # (not retryable — a bad expression won't fix itself).
+        if node.when:
+            try:
+                active = context.eval_condition(node.when)
+            except Exception as e:
+                results_by_id[node.id] = NodeResult(
+                    node_id=node.id,
+                    status="failure",
+                    final_text="",
+                    error=f"when expression error: {e}",
+                )
+                overall_status = "failure"
+                overall_error = f"node[{node.id}] when error: {e}"
+                halted = True
+                break
+            if not active:
+                _mark_transitive_skipped(node.id, dependents, skipped)
+                results_by_id[node.id] = NodeResult(
+                    node_id=node.id,
+                    status="skipped",
+                    final_text="",
+                    error=f"when={node.when!r} → false",
+                )
+                overall_status = "partial"
+                continue
+
+        # 3. Render prompt (not retryable on failure).
         try:
             rendered_prompt = context.render(node.prompt)
         except Exception as e:
-            node_results.append(NodeResult(
+            results_by_id[node.id] = NodeResult(
                 node_id=node.id,
                 status="failure",
                 final_text="",
                 error=f"prompt template error: {e}",
-            ))
+            )
             overall_status = "failure"
             overall_error = f"node[{node.id}] template error: {e}"
+            halted = True
             break
 
-        rendered_node = replace(node, prompt=rendered_prompt)
-
-        event_log_path: Path | None = None
-        if runs_dir is not None:
-            event_log_path = runs_dir / run_id / "nodes" / f"{node.id}.events.jsonl"
-
-        result = run_node(
-            rendered_node,
-            workflow_cwd=context.cwd,
-            event_log_path=event_log_path,
+        # 4. Run pi with retry loop.
+        result = _run_one_node_with_retries(
+            node, rendered_prompt, context, runs_dir, run_id
         )
-        node_results.append(result)
+        results_by_id[node.id] = result
 
-        if result.status != "success":
+        if result.status == "success":
+            # 5. Extract outputs for downstream nodes.
+            if node.outputs:
+                try:
+                    values, soft_errors = extract_outputs(node.outputs, result)
+                    context.set_node_outputs(node.id, values)
+                    if soft_errors:
+                        result.error = (
+                            (result.error + "; " if result.error else "")
+                            + "optional output failures: "
+                            + "; ".join(soft_errors)
+                        )
+                except OutputExtractionError as e:
+                    result.status = "failure"
+                    result.error = f"output extraction failed: {e}"
+                    # Extraction failure is a hard failure — consult on_error
+                    # using the same policy as pi failures.
+                    _apply_failure_policy = True
+                else:
+                    _apply_failure_policy = False
+            else:
+                context.set_node_outputs(node.id, {"text": result.final_text})
+                _apply_failure_policy = False
+
+            if not _apply_failure_policy:
+                continue
+
+        # 6. Node failed even after retries (or extraction failed). on_error policy:
+        if node.on_error == "fail":
             overall_status = "failure"
-            overall_error = result.error
+            overall_error = (
+                f"node[{node.id}] failed after {result.attempts} attempt(s): "
+                f"{result.error}"
+            )
+            halted = True
             break
 
-        # Extract declared outputs into context for downstream nodes.
-        # If the node didn't declare outputs, expose `{{ node_id.text }}`
-        # so downstream prompts can at least reference the final message.
-        if node.outputs:
-            try:
-                values, soft_errors = extract_outputs(node.outputs, result)
-                context.set_node_outputs(node.id, values)
-                if soft_errors:
-                    result.error = (
-                        (result.error + "; " if result.error else "")
-                        + "optional output failures: "
-                        + "; ".join(soft_errors)
-                    )
-            except OutputExtractionError as e:
-                result.status = "failure"
-                result.error = f"output extraction failed: {e}"
-                overall_status = "failure"
-                overall_error = f"node[{node.id}] {result.error}"
-                break
-        else:
-            context.set_node_outputs(node.id, {"text": result.final_text})
+        if node.on_error == "continue":
+            overall_status = "partial"
+            null_outputs: dict[str, Any] = (
+                {spec.name: None for spec in node.outputs}
+                if node.outputs
+                else {"text": ""}
+            )
+            context.set_node_outputs(node.id, null_outputs)
+            continue
+
+        if node.on_error == "branch":
+            overall_status = "partial"
+            rescue = {node.on_error_goto} if node.on_error_goto else set()
+            _mark_transitive_skipped(node.id, dependents, skipped, rescue=rescue)
+            continue
+
+        # Unreachable given node.validate() enforces the enum, but be safe.
+        overall_status = "failure"
+        overall_error = f"node[{node.id}] unknown on_error: {node.on_error!r}"
+        halted = True
+        break
+
+    # Nodes not reached after a halt should appear as skipped in the output,
+    # in topological order, so CLI output stays coherent.
+    if halted:
+        for node in ordered_nodes:
+            if node.id not in results_by_id:
+                results_by_id[node.id] = NodeResult(
+                    node_id=node.id,
+                    status="skipped",
+                    final_text="",
+                    error="not reached (upstream halt)",
+                )
+
+    # Preserve topological order in the returned list.
+    node_results = [results_by_id[n.id] for n in ordered_nodes]
 
     duration_ms = int((time.monotonic() - started_mono) * 1000)
 


### PR DESCRIPTION
## Summary

PR C of the pi workflow engine (see `docs/missions/pi-workflow-engine.md`). Activates the `when`, `retries`/`retry_delay`, and `on_error`/`on_error_goto` fields that PRs A/B declared forward-compat on `ActionNode`.

### What's new

- **`when:` conditionals** — per-node Jinja expression (no `{{ }}` braces) evaluated against inputs + upstream outputs. Falsy → node skipped, all transitive dependents also skipped. Uses `ImmutableSandboxedEnvironment` + `StrictUndefined` so typos raise instead of silently being falsy.
- **Retries** — `retries: N, retry_delay: S` retries pi on status in `{failure, timeout}` with a linear delay. `NodeResult.attempts` surfaces in CLI output as `[attempts=N]`.
- **`on_error`** — post-retry policy:
  - `fail` (default) — halt workflow; unreached nodes appear as `skipped (not reached)`.
  - `continue` — set downstream-visible outputs to None (or `{text: \"\"}`), keep going. Workflow status → `partial`.
  - `branch` — skip normal transitive dependents but rescue `on_error_goto` target. Validated: target must exist.
- **Workflow status** — adds `partial` alongside `success`/`failure`. `partial` exits 0 (workflow completed, just not cleanly).
- **New example** — `verify-or-rollback.yaml`: 3-node DAG where the same YAML drives either branch via `--input target={pass|fail}`.

### What's still deferred

- Run metadata/history, `workflow show`/`history` commands, MCP tools — PR D
- Full `docs/workflows.md` + more examples — PR E
- Exponential backoff, per-attempt event logs, cost circuit breakers — Phase 4

## Test plan

- [x] `uv run ruff check agentwire/workflows/` clean
- [x] `eval_condition` smoke test: `a.status == 'fail'` on preset outputs; typos → UndefinedError
- [x] `workflow validate verify-or-rollback` passes (includes new on_error=branch validation)
- [x] `workflow list` / dry-run: new example appears, dry-run shows `when=` annotations
- [x] **Real run, pass branch:** `--input target=pass` → verify succeeds, restate runs (\"All checks passed.\"), rollback skipped with reason shown
- [x] **Real run, fail branch:** `--input target=fail` → verify succeeds, restate skipped, rollback runs (\"Rolling back changes.\")
- [x] **Retry + on_error=continue:** bad provider + retries=2 → `[attempts=3]` shown, downstream node still succeeds, workflow status=partial, exit 0

Built by [dotdev.dev](https://dotdev.dev)