### PR TITLE
feat(workflows): persistent run storage + history/show + MCP tools

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10123,8 +10123,10 @@ def main() -> int:
 
     # === workflow command group ===
     from agentwire.workflows.cli import (
+        cmd_workflow_history,
         cmd_workflow_list,
         cmd_workflow_run,
+        cmd_workflow_show,
         cmd_workflow_validate,
     )
 
@@ -10155,6 +10157,33 @@ def main() -> int:
     wf_run.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     wf_run.add_argument("--json", action="store_true", help="Output as JSON")
     wf_run.set_defaults(func=cmd_workflow_run)
+
+    wf_history = workflow_subparsers.add_parser(
+        "history", help="List past workflow runs"
+    )
+    wf_history.add_argument(
+        "--workflow", metavar="NAME", help="Filter by workflow name"
+    )
+    wf_history.add_argument(
+        "--limit", type=int, default=20, help="Max runs to show (default: 20)"
+    )
+    wf_history.add_argument("--json", action="store_true", help="Output as JSON")
+    wf_history.set_defaults(func=cmd_workflow_history)
+
+    wf_show = workflow_subparsers.add_parser(
+        "show", help="Inspect a past workflow run"
+    )
+    wf_show.add_argument("run_id", help="Run ID (from `workflow history`)")
+    wf_show.add_argument(
+        "--events", action="store_true",
+        help="Dump raw event JSONL for all nodes",
+    )
+    wf_show.add_argument(
+        "--node", metavar="ID",
+        help="Filter events to one node id (implies --events)",
+    )
+    wf_show.add_argument("--json", action="store_true", help="Output as JSON")
+    wf_show.set_defaults(func=cmd_workflow_show)
 
     # === listen command group ===
     listen_parser = subparsers.add_parser("listen", help="Voice input recording")

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2483,6 +2483,118 @@ def portal_notify(text: str, session: str | None = None, priority: str = "normal
 
 
 # =============================================================================
+# Workflow engine tools
+# =============================================================================
+
+
+@mcp.tool()
+def workflow_list() -> str:
+    """List discoverable pi workflows.
+
+    Returns workflow names, descriptions, and node counts. Workflows live in
+    ~/.agentwire/workflows/defs/ or the bundled examples dir.
+    """
+    data = run_agentwire_cmd(["workflow", "list"])
+    if not data.get("success"):
+        return f"Failed to list workflows: {data.get('error', 'Unknown error')}"
+
+    items = data.get("items", [])
+    if not items:
+        return "No workflows found."
+
+    lines = ["Available workflows:"]
+    for wf in items:
+        name = wf.get("name", "?")
+        desc = wf.get("description", "")
+        count = len(wf.get("nodes", []))
+        lines.append(f"  - {name} ({count} node{'s' if count != 1 else ''})"
+                     + (f" — {desc}" if desc else ""))
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def workflow_validate(name_or_path: str) -> str:
+    """Parse + validate a workflow YAML without running it.
+
+    Args:
+        name_or_path: Workflow name (e.g. "echo-chain") or path to YAML file.
+    """
+    data = run_agentwire_cmd(["workflow", "validate", name_or_path])
+    if data.get("success"):
+        return data.get("output", f"Workflow {name_or_path!r} is valid.")
+    return f"Validation failed: {data.get('output', data.get('error', 'Unknown error'))}"
+
+
+@mcp.tool()
+def workflow_run(
+    name: str,
+    inputs: dict | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Execute a pi workflow end-to-end.
+
+    Args:
+        name: Workflow name or path to YAML.
+        inputs: Optional map of input name → value, forwarded as --input KEY=VAL.
+        dry_run: If true, print the execution plan without invoking pi.
+
+    Returns:
+        Full run result as a dict: workflow, run_id, status
+        (success|partial|failure), duration_ms, error, nodes[].
+    """
+    args = ["workflow", "run", name]
+    for key, value in (inputs or {}).items():
+        args.extend(["--input", f"{key}={value}"])
+    if dry_run:
+        args.append("--dry-run")
+    # pi calls routinely take minutes; default 30s is not enough.
+    return run_agentwire_cmd(args, timeout=600)
+
+
+@mcp.tool()
+def workflow_history(workflow: str | None = None, limit: int = 20) -> str:
+    """List past workflow runs, newest first.
+
+    Args:
+        workflow: Filter to a single workflow name (optional).
+        limit: Max runs to return (default 20).
+    """
+    args = ["workflow", "history", "--limit", str(limit)]
+    if workflow:
+        args.extend(["--workflow", workflow])
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to list runs: {data.get('error', 'Unknown error')}"
+
+    runs = data.get("items", [])
+    if not runs:
+        return "No past runs found."
+
+    lines = ["Past runs:"]
+    for run in runs:
+        rid = run.get("run_id", "?")
+        name = run.get("workflow", "?")
+        status = run.get("status", "?")
+        duration_ms = run.get("duration_ms", 0)
+        lines.append(f"  - {rid}  [{name}]  {status}  {duration_ms}ms")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def workflow_show(run_id: str) -> dict:
+    """Fetch metadata for a single past workflow run.
+
+    Args:
+        run_id: Run identifier from `workflow_history`.
+
+    Returns:
+        The run's metadata.json contents (workflow, status, inputs, node
+        summaries with timing + tokens + errors).
+    """
+    return run_agentwire_cmd(["workflow", "show", run_id])
+
+
+# =============================================================================
 # Server Entry Point
 # =============================================================================
 

--- a/agentwire/workflows/__init__.py
+++ b/agentwire/workflows/__init__.py
@@ -1,9 +1,8 @@
 """AgentWire workflow engine.
 
-Ships DAG execution, Jinja2 templating, and output extraction. See
-`docs/missions/pi-workflow-engine.md` for the full roadmap — retries,
-`when` conditionals, on_error branching, storage, and MCP tools land
-in subsequent PRs.
+Ships DAG execution, Jinja2 templating, output extraction, retries,
+`when` conditionals, on_error branching, and persistent run storage.
+See `docs/missions/pi-workflow-engine.md` for the roadmap.
 """
 
 from agentwire.workflows.context import Context
@@ -11,6 +10,7 @@ from agentwire.workflows.definitions import InputSpec, WorkflowDef, load_workflo
 from agentwire.workflows.node import ActionNode, NodeResult, OutputSpec
 from agentwire.workflows.pi_runner import run_node
 from agentwire.workflows.runner import run_workflow
+from agentwire.workflows.storage import list_runs, load_run, write_run
 
 __all__ = [
     "ActionNode",
@@ -19,7 +19,10 @@ __all__ = [
     "NodeResult",
     "OutputSpec",
     "WorkflowDef",
+    "list_runs",
+    "load_run",
     "load_workflow",
     "run_node",
     "run_workflow",
+    "write_run",
 ]

--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -4,15 +4,19 @@ Subcommands:
   list     - discover and print available workflows
   validate - parse + validate a workflow without running it
   run      - execute a workflow end-to-end
+  history  - list past runs
+  show     - inspect a past run (metadata, per-node events)
 """
 
 from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
+from agentwire.workflows import storage
 from agentwire.workflows.definitions import (
     discover_workflows,
     resolve_workflow,
@@ -20,6 +24,25 @@ from agentwire.workflows.definitions import (
 from agentwire.workflows.runner import run_workflow
 
 RUNS_DIR = Path.home() / ".agentwire" / "workflows" / "runs"
+
+
+def _fmt_duration(ms: int | None) -> str:
+    """Compact human-ish duration: 120ms / 3.2s / 1m04s."""
+    if not ms:
+        return "0ms"
+    if ms < 1000:
+        return f"{ms}ms"
+    seconds = ms / 1000.0
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    mins, secs = divmod(int(seconds), 60)
+    return f"{mins}m{secs:02d}s"
+
+
+def _fmt_started_at(ts: float | None) -> str:
+    if not ts:
+        return "-"
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
 
 
 def _parse_input_pairs(pairs: list[str] | None) -> tuple[dict[str, Any], list[str]]:
@@ -198,3 +221,108 @@ def cmd_workflow_run(args) -> int:
             print(f"  error: {node_result.error}")
 
     return 0 if result.status in ("success", "partial") else 1
+
+
+def cmd_workflow_history(args) -> int:
+    """`agentwire workflow history` — list past runs."""
+    workflow = getattr(args, "workflow", None)
+    limit = getattr(args, "limit", 20) or 20
+    runs = storage.list_runs(RUNS_DIR, workflow=workflow, limit=limit)
+
+    if getattr(args, "json", False):
+        print(json.dumps(runs, indent=2))
+        return 0
+
+    if not runs:
+        if workflow:
+            print(f"No runs found for workflow {workflow!r}.")
+        else:
+            print("No runs found.")
+            print(f"  (searched {RUNS_DIR})")
+        return 0
+
+    # Fixed-width columns for quick scanning. run_id is long; truncate gracefully.
+    print(f"  {'run_id':<52}  {'workflow':<24}  {'status':<8}  {'duration':>8}  started")
+    print(f"  {'-' * 52}  {'-' * 24}  {'-' * 8}  {'-' * 8}  {'-' * 19}")
+    for run in runs:
+        rid = run.get("run_id", "")
+        if len(rid) > 52:
+            rid = rid[:49] + "..."
+        name = run.get("workflow", "")
+        if len(name) > 24:
+            name = name[:21] + "..."
+        status = run.get("status", "")
+        duration = _fmt_duration(run.get("duration_ms"))
+        started = _fmt_started_at(run.get("started_at"))
+        print(f"  {rid:<52}  {name:<24}  {status:<8}  {duration:>8}  {started}")
+
+    return 0
+
+
+def cmd_workflow_show(args) -> int:
+    """`agentwire workflow show <run-id>` — inspect a past run."""
+    run_id = args.run_id
+    node_filter = getattr(args, "node", None)
+    want_events = getattr(args, "events", False)
+    want_json = getattr(args, "json", False)
+
+    meta = storage.load_run(RUNS_DIR, run_id)
+    if meta is None:
+        print(f"Error: run {run_id!r} not found.", file=sys.stderr)
+        print(f"  (searched {RUNS_DIR / run_id})", file=sys.stderr)
+        return 1
+
+    # --node <id> or --events ⇒ dump event JSONL
+    if node_filter or want_events:
+        events = storage.load_events(RUNS_DIR, run_id, node_id=node_filter)
+        if want_json:
+            print(json.dumps(
+                [{"node": nid, "event": evt} for nid, evt in events],
+                indent=2,
+            ))
+            return 0
+        # Raw JSONL — one line per event. Prefix with [node-id] when showing all.
+        for nid, evt in events:
+            line = json.dumps(evt)
+            if node_filter:
+                print(line)
+            else:
+                print(f"[{nid}] {line}")
+        return 0
+
+    if want_json:
+        print(json.dumps(meta, indent=2))
+        return 0
+
+    print(f"Workflow: {meta.get('workflow', '?')}")
+    print(f"Run ID:   {meta.get('run_id', run_id)}")
+    print(f"Status:   {meta.get('status', '?')}")
+    print(f"Started:  {_fmt_started_at(meta.get('started_at'))}")
+    print(f"Duration: {_fmt_duration(meta.get('duration_ms'))}")
+    if meta.get("error"):
+        print(f"Error:    {meta['error']}")
+    inputs = meta.get("inputs") or {}
+    if inputs:
+        print(f"Inputs:   {json.dumps(inputs)}")
+
+    nodes = meta.get("nodes") or []
+    if nodes:
+        print("\nNodes:")
+        for n in nodes:
+            nid = n.get("id", "?")
+            status = n.get("status", "?")
+            dur = _fmt_duration(n.get("duration_ms"))
+            attempts = n.get("attempts", 1)
+            attempts_note = f" attempts={attempts}" if attempts > 1 else ""
+            tokens = n.get("tokens") or {}
+            token_note = ""
+            if tokens:
+                token_note = (
+                    f", in={tokens.get('input', 0)} out={tokens.get('output', 0)} "
+                    f"cost=${tokens.get('cost', 0):.4f}"
+                )
+            print(f"  {nid:<20} → {status:<8} ({dur}{attempts_note}{token_note})")
+            if n.get("error"):
+                print(f"    reason: {n['error']}")
+
+    return 0

--- a/agentwire/workflows/runner.py
+++ b/agentwire/workflows/runner.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
+from agentwire.workflows import storage
 from agentwire.workflows.context import Context
 from agentwire.workflows.definitions import InputSpec, WorkflowDef, topological_sort
 from agentwire.workflows.node import ActionNode, NodeResult
@@ -346,7 +347,7 @@ def run_workflow(
 
     duration_ms = int((time.monotonic() - started_mono) * 1000)
 
-    return WorkflowRun(
+    run_result = WorkflowRun(
         workflow=workflow.name,
         run_id=run_id,
         status=overall_status,
@@ -356,3 +357,8 @@ def run_workflow(
         context=context,
         error=overall_error,
     )
+
+    if runs_dir is not None:
+        storage.write_run(runs_dir, run_id, run_result, context)
+
+    return run_result

--- a/agentwire/workflows/storage.py
+++ b/agentwire/workflows/storage.py
@@ -1,0 +1,186 @@
+"""Persistent storage for workflow runs.
+
+Each run dir under `~/.agentwire/workflows/runs/<run-id>/` holds:
+  metadata.json    — run manifest (workflow, status, inputs, node summaries)
+  context.json     — final Context (inputs + per-node extracted outputs)
+  nodes/<id>.events.jsonl  — raw pi JSONL stream per node (written by pi_runner)
+
+`metadata.json` is the authoritative index for `workflow history` / `show`.
+Runs missing `metadata.json` are silently skipped by listings — they're
+crashed/incomplete runs whose per-node logs may still be useful for manual
+debugging but don't belong in the history view.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentwire.workflows.context import Context
+    from agentwire.workflows.runner import WorkflowRun
+
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+METADATA_FILE = "metadata.json"
+CONTEXT_FILE = "context.json"
+NODES_DIR = "nodes"
+
+
+def write_run(
+    runs_dir: Path,
+    run_id: str,
+    run: WorkflowRun,
+    context: Context,
+) -> None:
+    """Persist metadata + final context for a completed workflow run.
+
+    Disk errors are logged but don't raise — the in-memory WorkflowRun
+    is authoritative for the CLI caller that just executed.
+    """
+    run_dir = runs_dir / run_id
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("workflow storage: could not create %s: %s", run_dir, e)
+        return
+
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": run.workflow,
+        "run_id": run.run_id,
+        "status": run.status,
+        "started_at": run.started_at,
+        "duration_ms": run.duration_ms,
+        "error": run.error,
+        "inputs": dict(context.inputs),
+        "nodes": [
+            {
+                "id": r.node_id,
+                "status": r.status,
+                "attempts": r.attempts,
+                "duration_ms": r.duration_ms,
+                "tokens": r.tokens_used,
+                "error": r.error,
+            }
+            for r in run.node_results
+        ],
+    }
+
+    try:
+        (run_dir / METADATA_FILE).write_text(json.dumps(metadata, indent=2))
+    except OSError as e:
+        logger.warning("workflow storage: could not write metadata: %s", e)
+
+    try:
+        (run_dir / CONTEXT_FILE).write_text(
+            json.dumps(
+                {"inputs": context.inputs, "outputs": context.outputs},
+                indent=2,
+                default=str,
+            )
+        )
+    except OSError as e:
+        logger.warning("workflow storage: could not write context: %s", e)
+
+
+def list_runs(
+    runs_dir: Path,
+    workflow: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Scan runs_dir for runs with metadata, sorted newest first.
+
+    Silently skips directories without a readable metadata.json.
+    """
+    if not runs_dir.is_dir():
+        return []
+
+    entries: list[dict] = []
+    for child in runs_dir.iterdir():
+        if not child.is_dir():
+            continue
+        meta_path = child / METADATA_FILE
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(meta, dict):
+            continue
+        if workflow is not None and meta.get("workflow") != workflow:
+            continue
+        entries.append(meta)
+
+    entries.sort(key=lambda m: m.get("started_at", 0), reverse=True)
+    if limit and limit > 0:
+        entries = entries[:limit]
+    return entries
+
+
+def load_run(runs_dir: Path, run_id: str) -> dict | None:
+    """Load metadata.json for a specific run. None if missing/unreadable."""
+    meta_path = runs_dir / run_id / METADATA_FILE
+    if not meta_path.is_file():
+        return None
+    try:
+        data = json.loads(meta_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_context(runs_dir: Path, run_id: str) -> dict | None:
+    """Load context.json for a specific run. None if missing/unreadable."""
+    path = runs_dir / run_id / CONTEXT_FILE
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_events(
+    runs_dir: Path,
+    run_id: str,
+    node_id: str | None = None,
+) -> list[tuple[str, dict]]:
+    """Load per-node events. Returns [(node_id, event_dict), ...].
+
+    If node_id is given, returns only that node's events. If the run or node
+    has no events file, returns an empty list.
+    """
+    nodes_dir = runs_dir / run_id / NODES_DIR
+    if not nodes_dir.is_dir():
+        return []
+
+    if node_id is not None:
+        files = [nodes_dir / f"{node_id}.events.jsonl"]
+    else:
+        files = sorted(nodes_dir.glob("*.events.jsonl"))
+
+    out: list[tuple[str, dict]] = []
+    for file in files:
+        if not file.is_file():
+            continue
+        # Filename: "<node_id>.events.jsonl"
+        nid = file.name.removesuffix(".events.jsonl")
+        try:
+            for line in file.read_text().splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append((nid, json.loads(line)))
+                except json.JSONDecodeError:
+                    continue
+        except OSError:
+            continue
+    return out


### PR DESCRIPTION
## Summary

PR D of the pi workflow engine (see `docs/missions/pi-workflow-engine.md`). Closes the loop between "workflow ran" and "I can come back and look at it later" — and exposes the whole engine through MCP so in-session agents can actually drive it.

### What's new

- **Storage module (`storage.py`)** — writes `metadata.json` (schema_version: 1) and `context.json` per run; reads them back for `history` / `show`. Orphan dirs missing metadata are silently skipped in listings.
- **`workflow history`** — lists past runs newest-first; supports `--workflow NAME`, `--limit N`, `--json`.
- **`workflow show <run-id>`** — summary view by default; `--events` dumps per-node JSONL with `[node-id]` prefix; `--node <id>` narrows to one node; `--json` dumps metadata.
- **5 MCP tools** — `workflow_list`, `workflow_validate`, `workflow_run`, `workflow_history`, `workflow_show`. All shell out via `run_agentwire_cmd()` (CLI-as-SSOT per CLAUDE.md). `workflow_run` bumps the subprocess timeout to 600s since pi calls routinely take minutes.
- **Storage export** — `agentwire.workflows` re-exports `write_run`, `list_runs`, `load_run` for any future Python consumers.

### Metadata shape

```json
{
  "schema_version": 1,
  "workflow": "echo-chain",
  "run_id": "echo-chain-20260415T080302-e7e2ff62",
  "status": "success",
  "started_at": 1776254582.37,
  "duration_ms": 4203,
  "error": null,
  "inputs": {"topic": "ferrets"},
  "nodes": [{"id": "fact", "status": "success", "attempts": 1, ...}, ...]
}
```

Field names match `workflow run --json` so consumers treating those two as interchangeable Just Work.

### What's still deferred

- PR E: more example workflows (dependency-audit, doc-drift-check, pr-triage, test-recovery) + `docs/workflows.md`
- Phase 4: run retention policy (nothing auto-cleans `~/.agentwire/workflows/runs/` yet), cost circuit breakers, parallel execution

## Test plan

- [x] `uv run ruff check agentwire/workflows/` clean (`mcp_server.py` has one pre-existing I001 at line 636, unrelated)
- [x] `workflow run echo-chain --input topic=ferrets` → `metadata.json` + `context.json` appear in run dir alongside `nodes/*.events.jsonl`
- [x] `workflow history` lists the new run, formatted columns, past orphan dirs (from earlier PRs) silently hidden
- [x] `workflow history --workflow does-not-exist` → \"No runs found for workflow 'does-not-exist'.\"
- [x] `workflow history --json` → valid JSON array, sorted newest-first
- [x] `workflow show <run-id>` → human summary with nodes, tokens, timing
- [x] `workflow show <run-id> --node fact` → that node's raw JSONL events, unprefixed
- [x] `workflow show <run-id> --events` → all nodes' events prefixed with `[node-id]`
- [x] `workflow show nonexistent` → clean error, exit 1

MCP tool verification requires `agentwire rebuild && agentwire portal restart --dev` plus a Claude session restart — reviewer to verify after merge.

Built by [dotdev.dev](https://dotdev.dev)