### PR TITLE
feat(workflows): examples + docs + skill + unit tests (Phase 2 finale)

### DIFF
--- a/.claude/skills/agentwire-workflows/SKILL.md
+++ b/.claude/skills/agentwire-workflows/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: agentwire-workflows
+description: Pi workflow engine — YAML-defined DAGs of pi invocations chained by Jinja2 templating + output extraction. Covers YAML anatomy (inputs, nodes, outputs, when, retries, on_error), CLI (`agentwire workflow list/validate/run/history/show`), MCP tools (`workflow_list/validate/run/history/show`), storage layout (metadata.json, context.json, per-node event logs), and debugging. Use when authoring a new workflow YAML, debugging a failed workflow run, explaining workflow concepts, or choosing between a workflow and a scheduler task. Full reference lives in docs/workflows.md.
+---
+
+# Pi workflow engine — quick reference
+
+Workflows live in `agentwire/workflows/examples/` (bundled) or `~/.agentwire/workflows/defs/` (user). Each node is a one-shot `pi -p --mode json` invocation.
+
+## Minimum viable YAML
+
+```yaml
+name: hello
+nodes:
+  greet:
+    prompt: "Say hi in one word."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+```
+
+## Everything the runner honors
+
+- **Templating** — Jinja2 with `StrictUndefined` in `prompt:` and in workflow-level `when:` expressions (no `{{ }}` for `when`).
+- **DAG** — `depends_on: [...]` (string or list). Topological sort + cycle detection at validate time.
+- **Inputs** — declared under workflow-level `inputs:` with `type` (string|int|float|bool|json), `required`, `default`. Passed via `--input KEY=VAL` or `--input-file path.json`.
+- **Output extraction** — per-node `outputs:` with `source: text | regex | jsonpath`. JSONPath subset: `$.a`, `$.a.b`, `$.a[*]`, `$.a[*].b`, `$.a[0]`. Nodes without declared outputs expose `{{ node_id.text }}`.
+- **Retries** — `retries: N` (default 0), `retry_delay: S` (default 10). Triggered on status in `{failure, timeout}` only. Template/extraction errors never retry.
+- **on_error** (after retries exhausted) — `fail` (halt) | `continue` (downstream gets `None` outputs, workflow → partial) | `branch` (requires `on_error_goto`; skip normal dependents, rescue target).
+- **Skipping** — `when:` false OR upstream skipped/branched → node is `skipped`; dependents propagated unless rescued by a branch `on_error_goto`.
+- **Tools** — subset of `{read, bash, edit, write, grep, find, ls}`. Default `[read, bash, edit, write]`. Empty list → `--no-tools`.
+- **Thinking** — `off | minimal | low | medium | high | xhigh`. Default `medium`. Use `off` for flash-tier cheap nodes.
+
+## CLI
+
+```bash
+agentwire workflow list [--json]
+agentwire workflow validate <name-or-path>
+agentwire workflow run <name> [--input KEY=VAL]... [--input-file FILE] [--dry-run] [--verbose] [--json]
+agentwire workflow history [--workflow NAME] [--limit N] [--json]
+agentwire workflow show <run-id> [--events] [--node ID] [--json]
+```
+
+`run` exits 0 on success|partial, 1 on failure.
+
+## MCP
+
+```
+workflow_list()
+workflow_validate(name_or_path)
+workflow_run(name, inputs={}, dry_run=False)      # 600s timeout
+workflow_history(workflow=None, limit=20)
+workflow_show(run_id)
+```
+
+Agents should prefer MCP tools over shelling out.
+
+## Storage
+
+Runs live at `~/.agentwire/workflows/runs/<run-id>/`:
+- `metadata.json` — workflow, status, inputs, node summaries (schema_version: 1)
+- `context.json` — final inputs + per-node extracted outputs
+- `nodes/<id>.events.jsonl` — raw pi JSONL stream
+
+Runs without `metadata.json` (crashed mid-run) are silently hidden from `history`.
+
+## Common authoring pitfalls
+
+- **Typo in `{{ analyze.issues }}`** → StrictUndefined raises. Check the node's `outputs:` names.
+- **`source: jsonpath` but model emits fences** — extractor handles ` ```json ... ``` ` fences automatically; if extraction still fails, tighten the prompt ("no fences, no prose") and lower `thinking`.
+- **on_error: branch without on_error_goto** — validate catches this. Target must exist as a node in the same workflow.
+- **`when: "{{ x == 'y' }}"`** — wrong. `when:` is a Jinja *expression*, not a template. Write `when: "x == 'y'"`.
+- **Adding MCP tool doesn't appear** — requires `agentwire rebuild && agentwire portal restart --dev` *plus* a Claude session restart.
+
+## When to pick which tool
+
+| Need | Tool |
+|---|---|
+| Single interactive prompt | `claude` / `pi -p` |
+| Recurring prompt on a schedule | `agentwire-scheduler` skill |
+| Multi-step logic, variables between steps, conditionals, retries | workflows |
+
+## Full reference
+
+`docs/workflows.md` — concept intro, full YAML anatomy, per-field semantics, debugging guide, FAQ.
+
+## Mission
+
+Phase 2 status + roadmap lives in `docs/missions/pi-workflow-engine.md`. Sub-missions for later phases: `pi-scheduler-workflows.md` (Phase 3), `pi-workflow-advanced.md` (Phase 4), `pi-workflow-ui.md` (Phase 5).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,13 @@ Reference detail lives in skills under `.claude/skills/` — invoke as needed:
 | `agentwire-scheduler` | Scheduled task gates/schedule/priority + overnight queue |
 | `agentwire-desktop-ui` | Editing portal static files (sidebar, windows, artifacts) |
 | `agentwire-pi-zai` | Setting up Z.AI sessions via pi coding agent |
+| `agentwire-workflows` | Authoring or debugging pi workflow YAMLs (`agentwire workflow ...`) |
 
 ## Docs
 
 - CLI: `agentwire --help` or `agentwire <cmd> --help`
 - `docs/pi-zai.md` - Pi coding agent + Z.AI session types
+- `docs/workflows.md` - Pi workflow engine user guide
 - `docs/missions/pi-harness-overview.md` - Pi integration roadmap across phases
 - `docs/channels.md` - Channel developer guide
 - `docs/PORTAL.md` - Portal modes and API reference

--- a/agentwire/workflows/examples/doc-drift-check.yaml
+++ b/agentwire/workflows/examples/doc-drift-check.yaml
@@ -1,0 +1,37 @@
+name: doc-drift-check
+description: Skim a document, extract factual claims as JSON, flag stale ones. Bring your own file.
+version: 1
+
+inputs:
+  file:
+    type: string
+    required: true
+    description: Path to the document to scan
+
+nodes:
+  scan:
+    prompt: |
+      Read the file at {{ inputs.file }}. Return ONLY a JSON object
+      (no prose, no code fences) with this exact shape, listing up to
+      10 factual claims the document makes:
+
+      {"claims": ["claim 1", "claim 2", "..."]}
+    tools: [read]
+    thinking: "low"
+    outputs:
+      - name: claims
+        source: jsonpath
+        pattern: $.claims[*]
+
+  summarize:
+    depends_on: [scan]
+    prompt: |
+      Factual claims extracted from {{ inputs.file }}:
+      {% for claim in scan.claims %}  - {{ claim }}
+      {% endfor %}
+
+      Return a one-paragraph review indicating which 1–2 claims are
+      most likely to become stale over time and why. Be concrete.
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "medium"

--- a/agentwire/workflows/examples/fan-in-summary.yaml
+++ b/agentwire/workflows/examples/fan-in-summary.yaml
@@ -1,0 +1,48 @@
+name: fan-in-summary
+description: Diamond DAG — three angle nodes fan in to one synthesizer.
+version: 1
+
+inputs:
+  topic:
+    type: string
+    required: true
+
+nodes:
+  angle_technical:
+    prompt: "Write one sentence about {{ inputs.topic }} from a technical angle."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+    outputs:
+      - name: text
+        source: text
+
+  angle_historical:
+    prompt: "Write one sentence about {{ inputs.topic }} from a historical angle."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+    outputs:
+      - name: text
+        source: text
+
+  angle_practical:
+    prompt: "Write one sentence about {{ inputs.topic }} from a practical-use angle."
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"
+    outputs:
+      - name: text
+        source: text
+
+  synthesize:
+    depends_on: [angle_technical, angle_historical, angle_practical]
+    prompt: |
+      Combine these three perspectives on {{ inputs.topic }} into one
+      three-sentence paragraph.
+      - Technical: {{ angle_technical.text }}
+      - Historical: {{ angle_historical.text }}
+      - Practical: {{ angle_practical.text }}
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"

--- a/agentwire/workflows/examples/pr-triage.yaml
+++ b/agentwire/workflows/examples/pr-triage.yaml
@@ -1,0 +1,35 @@
+name: pr-triage
+description: Fetch a GitHub PR via `gh`, summarize into reviewer notes. Requires `gh` on PATH.
+version: 1
+
+inputs:
+  pr_number:
+    type: int
+    required: true
+    description: GitHub PR number in the current repo
+
+nodes:
+  fetch:
+    prompt: |
+      Run these two commands with the bash tool and return their combined
+      output verbatim, no commentary:
+        gh pr view {{ inputs.pr_number }}
+        gh pr diff {{ inputs.pr_number }}
+    tools: [bash]
+    thinking: "low"
+    timeout: 60
+    outputs:
+      - name: text
+        source: text
+
+  triage:
+    depends_on: [fetch]
+    prompt: |
+      Summarize this PR into bullet-point review notes for a human reviewer.
+      Focus on: scope, risky changes, missing tests, unclear logic.
+
+      PR view + diff:
+      {{ fetch.text }}
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "medium"

--- a/agentwire/workflows/examples/retry-resilient.yaml
+++ b/agentwire/workflows/examples/retry-resilient.yaml
@@ -1,0 +1,24 @@
+name: retry-resilient
+description: Demonstrates retries + on_error=continue. Workflow exits 0 (partial) even though one node fails.
+version: 1
+
+nodes:
+  flaky:
+    prompt: "This prompt never executes — the provider is invalid by design."
+    provider: nonexistent-provider
+    model: fake-model
+    tools: [read]
+    thinking: "off"
+    timeout: 5
+    retries: 2
+    retry_delay: 1
+    on_error: continue
+
+  summary:
+    depends_on: [flaky]
+    prompt: |
+      In one sentence, describe what a 'partial' workflow run means:
+      some nodes failed but the workflow completed.
+    model: glm-4.7-flash
+    tools: [read]
+    thinking: "off"

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,317 @@
+> Living document. Update this, don't create new versions.
+
+# Pi Workflows
+
+Programmable automation for the pi coding agent. A workflow is a YAML file that chains one or more pi invocations into a DAG with templated prompts, structured inputs, and output extraction between nodes.
+
+**When to reach for workflows**
+
+| Use case | Tool |
+|---|---|
+| One-off interactive prompt | `claude` or `pi -p` |
+| Recurring prompt on a schedule | `agentwire scheduler` (see `agentwire-scheduler` skill) |
+| Multi-step logic with conditional branches, variables flowing between steps, retries | **workflows** |
+
+Workflows compose *small reliable nodes* instead of praying a single giant prompt does the right thing.
+
+---
+
+## Anatomy of a workflow YAML
+
+```yaml
+name: my-workflow                    # unique name, falls back to filename stem
+description: Short human summary.
+version: 1                           # schema version, always 1 today
+
+inputs:                              # CLI-supplied variables, optional
+  target:
+    type: string                     # string | int | float | bool | json
+    required: true
+    description: What we're targeting
+  verbose:
+    type: bool
+    default: false
+
+nodes:                               # at least one required
+  analyze:
+    prompt: |                        # Jinja2 template — required
+      Look at {{ inputs.target }}. Return JSON: {"issues": [...]}
+    model: glm-4.7-flash             # any provider/model pi supports
+    provider: zai                    # default zai
+    tools: [read, grep]              # subset of {read, bash, edit, write, grep, find, ls}
+    thinking: "low"                  # off|minimal|low|medium|high|xhigh
+    timeout: 300                     # seconds per attempt (default 300)
+    retries: 2                       # extra attempts on failure|timeout (default 0)
+    retry_delay: 10                  # seconds between attempts (default 10)
+    on_error: continue               # fail|continue|branch (default fail)
+    outputs:                         # extract named vars for downstream nodes
+      - name: issues
+        source: jsonpath
+        pattern: $.issues[*]
+
+  report:
+    depends_on: [analyze]            # DAG edge — can be string or list
+    when: "analyze.issues|length > 0"  # Jinja expression; skip if false
+    prompt: |
+      Found these issues:
+      {% for issue in analyze.issues %}  - {{ issue }}
+      {% endfor %}
+      Write a 3-bullet summary.
+```
+
+Bundled examples live in `agentwire/workflows/examples/` and are always discoverable. User-authored workflows go in `~/.agentwire/workflows/defs/` and override examples of the same name.
+
+---
+
+## CLI reference
+
+```bash
+# Discover
+agentwire workflow list
+agentwire workflow list --json
+
+# Validate without running
+agentwire workflow validate my-workflow
+agentwire workflow validate /path/to/custom.yaml
+
+# Execute
+agentwire workflow run my-workflow
+agentwire workflow run my-workflow --input target=src/api.ts
+agentwire workflow run my-workflow --input target=src/api.ts --input verbose=true
+agentwire workflow run my-workflow --input-file inputs.json
+agentwire workflow run my-workflow --dry-run            # plan only, no pi calls
+agentwire workflow run my-workflow --verbose            # show plan + inputs
+agentwire workflow run my-workflow --json               # structured result
+
+# Inspect past runs
+agentwire workflow history
+agentwire workflow history --workflow my-workflow --limit 5
+agentwire workflow history --json
+
+agentwire workflow show <run-id>                        # summary
+agentwire workflow show <run-id> --node analyze         # just that node's events
+agentwire workflow show <run-id> --events               # all nodes' events, prefixed
+agentwire workflow show <run-id> --json                 # raw metadata
+```
+
+`--input KEY=VALUE` is repeatable. `--input` wins over `--input-file` on conflicts.
+
+`workflow run` exits **0** on `success` or `partial`, **1** on `failure`.
+
+---
+
+## MCP tools
+
+Agents running inside agentwire sessions can drive workflows via MCP:
+
+| Tool | Purpose |
+|---|---|
+| `workflow_list` | List discoverable workflows |
+| `workflow_validate(name_or_path)` | Parse + validate YAML |
+| `workflow_run(name, inputs={}, dry_run=False)` | Execute; returns full run result dict |
+| `workflow_history(workflow=None, limit=20)` | List past runs |
+| `workflow_show(run_id)` | Fetch one run's metadata |
+
+`workflow_run` uses a 600s subprocess timeout — plenty for most pipelines. If yours exceeds that, split it into multiple workflows.
+
+---
+
+## Templating
+
+Prompts and node fields are rendered as [Jinja2](https://jinja.palletsprojects.com/) templates with `StrictUndefined` — typos raise `UndefinedError` loudly instead of becoming silent empty strings.
+
+Available in the namespace:
+- `inputs.X` — workflow-level inputs
+- `<node_id>.<output_name>` — extracted outputs of any upstream node
+
+```jinja
+{{ inputs.file }}
+{{ analyze.issues[0] }}
+{% for issue in analyze.issues %}  - {{ issue }}
+{% endfor %}
+{% if verify.status == 'pass' %}✓ passed{% endif %}
+```
+
+If a node doesn't declare explicit `outputs:`, its entire final assistant message is exposed as `{{ node_id.text }}`.
+
+---
+
+## Output extraction
+
+Each node can declare `outputs:` that extract named values from its final assistant message. Three sources are supported:
+
+### `source: text`
+```yaml
+outputs:
+  - name: reply
+    source: text                    # whole final message, trimmed
+```
+
+### `source: regex`
+```yaml
+outputs:
+  - name: ticket
+    source: regex
+    pattern: "TICKET-(\\d+)"        # group 1 if present, else full match
+```
+
+### `source: jsonpath`
+Expects the node's final message to be a JSON object (with or without a ```json fence).
+
+```yaml
+outputs:
+  - name: issues
+    source: jsonpath
+    pattern: $.issues[*]            # supports $.a, $.a.b, $.a[*], $.a[*].b, $.a[0]
+```
+
+Set `required: false` to keep the node successful even if extraction fails (the extracted value becomes `None` and surfaces in `NodeResult.error` as a soft failure).
+
+---
+
+## Conditionals: `when:`
+
+A node's `when:` is a Jinja **expression** (no `{{ }}` braces). It's evaluated against the current context in a sandboxed environment. Falsy → the node is skipped, and *all its transitive dependents are skipped too*.
+
+```yaml
+restate:
+  depends_on: [verify]
+  when: "verify.status == 'pass'"   # note: no braces
+
+rollback:
+  depends_on: [verify]
+  when: "verify.status == 'fail'"
+```
+
+Both branches evaluate independently; one skips, the other runs.
+
+An undefined variable in `when:` raises, same as in `prompt:`. Use `|default(...)` filters for optional paths.
+
+---
+
+## Retries + error handling
+
+```yaml
+flaky:
+  retries: 2            # up to 3 attempts total
+  retry_delay: 10       # seconds between attempts
+  on_error: continue    # fail | continue | branch
+```
+
+`retries` triggers on status in `{failure, timeout}`. Template and extraction errors are deterministic and not retried.
+
+`on_error` runs *after retries are exhausted*:
+
+- **`fail` (default)** — halt the workflow. All later nodes appear as `skipped (not reached)`.
+- **`continue`** — the node's outputs become `None` (or `{text: ""}` if none declared). Dependents still run and see those Nones. Workflow ends in `partial` status.
+- **`branch`** — skip normal dependents, but `on_error_goto` target still runs.
+  ```yaml
+  try_thing:
+    on_error: branch
+    on_error_goto: rollback       # must reference an existing node
+  ```
+
+Workflow status:
+- `success` — every node succeeded
+- `partial` — ≥1 node skipped or failed-continue, nothing halted
+- `failure` — a node with `on_error: fail` failed (execution halted)
+
+`partial` exits 0. `failure` exits 1.
+
+---
+
+## Storage layout
+
+Every run leaves a directory under `~/.agentwire/workflows/runs/<run-id>/`:
+
+```
+verify-or-rollback-20260415T...-abc/
+├── metadata.json               # workflow, status, inputs, node summaries
+├── context.json                # final Context: inputs + per-node outputs
+└── nodes/
+    ├── verify.events.jsonl     # raw pi JSONL stream for that node
+    ├── restate.events.jsonl
+    └── rollback.events.jsonl
+```
+
+`metadata.json` is the source of truth for `workflow history` and `workflow show`. Runs missing `metadata.json` (crashed mid-execution) are silently hidden from listings.
+
+```json
+{
+  "schema_version": 1,
+  "workflow": "verify-or-rollback",
+  "run_id": "verify-or-rollback-20260415T080302-e7e2ff62",
+  "status": "partial",
+  "started_at": 1776254582.37,
+  "duration_ms": 4203,
+  "error": null,
+  "inputs": {"target": "fail"},
+  "nodes": [
+    {"id": "verify", "status": "success", "attempts": 1,
+     "duration_ms": 2701, "tokens": {...}, "error": null},
+    ...
+  ]
+}
+```
+
+No retention policy yet — if `runs/` grows too large, clear it manually.
+
+---
+
+## Writing good pi prompts
+
+Pi is a one-shot, stateless agent per node. These tips keep nodes cheap and reliable:
+
+- **Constrain tools.** If a node only reads files, set `tools: [read]`. Excess tools invite unnecessary calls.
+- **Dial thinking.** `thinking: "off"` for structured/obvious tasks, `"medium"` for analysis, `"high"+` only for deep reasoning. Each level up costs more tokens.
+- **Ask for JSON explicitly.** "Return ONLY a JSON object (no prose, no code fences) in this shape: …" works far better than assuming a schema.
+- **Use flash tier for cheap nodes.** `model: glm-4.7-flash` is free on Z.AI's flash tier and plenty for non-reasoning work.
+- **Set timeouts for network-bound nodes.** `timeout: 60` for a `gh` command; default 300 for thinking tasks.
+
+---
+
+## Debugging
+
+### A node fails or produces the wrong output
+
+```bash
+# See the raw pi event stream for one node
+agentwire workflow show <run-id> --node analyze
+
+# See everything with node prefixes
+agentwire workflow show <run-id> --events
+```
+
+### Downstream template raises UndefinedError
+
+`StrictUndefined` surfaces typos. Check the failing node's declared `outputs:` names match what the downstream template references. The run's `context.json` shows what was actually in scope.
+
+### Output extraction failed
+
+If you declared `source: jsonpath` but the model wrapped its response in ```json fences, the extractor handles that — but if the JSON itself is malformed, extraction fails. Lower `thinking` and tighten the prompt to make the output more deterministic.
+
+### Retries never fired
+
+`retries` trigger on `failure` or `timeout` only. Template errors and output extraction errors are deterministic and won't retry — fix the YAML or the prompt.
+
+### MCP tool doesn't appear
+
+MCP tools ship in the same package. After any code change:
+```bash
+agentwire rebuild && agentwire portal restart --dev
+```
+Then restart your Claude session — the MCP server runs as a separate process started by Claude Code.
+
+---
+
+## FAQ
+
+**Can I run workflows in parallel?** Not yet. Nodes run sequentially in topological order. Parallel fan-out is Phase 4.
+
+**Can one workflow trigger another?** Not directly. You can invoke `agentwire workflow run` from a `bash`-tool prompt inside a node, but that's a composition hack. First-class sub-workflows are deferred.
+
+**What about untrusted workflow YAMLs?** The `when:` sandbox is `ImmutableSandboxedEnvironment` — dunders and most dangerous builtins are blocked — but workflow YAMLs are currently treated as trusted local code. Don't run YAMLs you haven't reviewed.
+
+**Can I see per-attempt events when a node retries?** Not yet. Only the final attempt's event log is kept on disk. If you need per-attempt observability, log from inside your prompt (pi will echo).
+
+**How do I share workflows across machines?** Copy the YAML file into `~/.agentwire/workflows/defs/` on each machine. No sync yet.

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,0 +1,467 @@
+"""Tests for agentwire/workflows/ — context, outputs, definitions, storage, runner."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+from agentwire.workflows import (
+    ActionNode,
+    Context,
+    NodeResult,
+    OutputSpec,
+    WorkflowDef,
+    list_runs,
+    run_workflow,
+)
+from agentwire.workflows.definitions import (
+    InputSpec,
+    _find_cycle,
+    topological_sort,
+)
+from agentwire.workflows.outputs import (
+    OutputExtractionError,
+    _apply_jsonpath,
+    extract_outputs,
+)
+from agentwire.workflows.storage import write_run
+
+# ---- Context ----------------------------------------------------------------
+
+class TestContext:
+    def test_render_with_input(self):
+        ctx = Context(inputs={"name": "world"})
+        assert ctx.render("hello {{ inputs.name }}").strip() == "hello world"
+
+    def test_render_with_upstream_output(self):
+        ctx = Context()
+        ctx.set_node_outputs("a", {"value": "result"})
+        assert ctx.render("got {{ a.value }}").strip() == "got result"
+
+    def test_render_strict_undefined_raises(self):
+        ctx = Context()
+        with pytest.raises(Exception):
+            ctx.render("{{ missing_var }}")
+
+    def test_eval_condition_equality(self):
+        ctx = Context()
+        ctx.set_node_outputs("a", {"status": "pass"})
+        assert ctx.eval_condition("a.status == 'pass'") is True
+        assert ctx.eval_condition("a.status == 'fail'") is False
+
+    def test_eval_condition_numeric(self):
+        ctx = Context(inputs={"count": 5})
+        assert ctx.eval_condition("inputs.count > 0") is True
+        assert ctx.eval_condition("inputs.count > 10") is False
+
+    def test_eval_condition_undefined_raises(self):
+        ctx = Context()
+        with pytest.raises(Exception):
+            ctx.eval_condition("bogus.thing")
+
+
+# ---- Output extraction ------------------------------------------------------
+
+def _make_result(text: str) -> NodeResult:
+    return NodeResult(node_id="x", status="success", final_text=text)
+
+
+class TestOutputs:
+    def test_text_source_trims(self):
+        spec = OutputSpec(name="r", source="text")
+        values, soft = extract_outputs([spec], _make_result("  hello  "))
+        assert values["r"] == "hello"
+        assert soft == []
+
+    def test_regex_group(self):
+        spec = OutputSpec(name="tid", source="regex", pattern=r"TICKET-(\d+)")
+        values, _ = extract_outputs([spec], _make_result("see TICKET-42 please"))
+        assert values["tid"] == "42"
+
+    def test_regex_no_match_raises_when_required(self):
+        spec = OutputSpec(name="tid", source="regex", pattern="ZZZ")
+        with pytest.raises(OutputExtractionError):
+            extract_outputs([spec], _make_result("no match here"))
+
+    def test_regex_no_match_soft_when_optional(self):
+        spec = OutputSpec(name="tid", source="regex", pattern="ZZZ", required=False)
+        values, soft = extract_outputs([spec], _make_result("nope"))
+        assert values["tid"] is None
+        assert soft and "tid" in soft[0]
+
+    def test_jsonpath_nested(self):
+        spec = OutputSpec(name="v", source="jsonpath", pattern="$.a.b")
+        values, _ = extract_outputs(
+            [spec], _make_result(json.dumps({"a": {"b": "x"}}))
+        )
+        assert values["v"] == "x"
+
+    def test_jsonpath_fenced_json(self):
+        spec = OutputSpec(name="v", source="jsonpath", pattern="$.n")
+        fenced = '```json\n{"n": 7}\n```'
+        values, _ = extract_outputs([spec], _make_result(fenced))
+        assert values["v"] == 7
+
+    def test_jsonpath_wildcard_map(self):
+        data = {"items": [{"k": 1}, {"k": 2}, {"k": 3}]}
+        assert _apply_jsonpath(data, "$.items[*].k") == [1, 2, 3]
+
+    def test_jsonpath_malformed_json_raises(self):
+        spec = OutputSpec(name="v", source="jsonpath", pattern="$.x")
+        with pytest.raises(OutputExtractionError):
+            extract_outputs([spec], _make_result("not json at all"))
+
+
+# ---- Definitions (topo sort, cycle, inputs) ---------------------------------
+
+class TestDefinitions:
+    def test_topological_sort_diamond(self):
+        nodes = [
+            ActionNode(id="a", prompt="p"),
+            ActionNode(id="b", prompt="p", depends_on=["a"]),
+            ActionNode(id="c", prompt="p", depends_on=["a"]),
+            ActionNode(id="d", prompt="p", depends_on=["b", "c"]),
+        ]
+        ordered = [n.id for n in topological_sort(nodes)]
+        assert ordered.index("a") < ordered.index("b")
+        assert ordered.index("a") < ordered.index("c")
+        assert ordered.index("b") < ordered.index("d")
+        assert ordered.index("c") < ordered.index("d")
+
+    def test_cycle_detection(self):
+        nodes = [
+            ActionNode(id="a", prompt="p", depends_on=["b"]),
+            ActionNode(id="b", prompt="p", depends_on=["a"]),
+        ]
+        cycle = _find_cycle(nodes)
+        assert cycle is not None and set(cycle) == {"a", "b"}
+
+    def test_no_cycle(self):
+        nodes = [
+            ActionNode(id="a", prompt="p"),
+            ActionNode(id="b", prompt="p", depends_on=["a"]),
+        ]
+        assert _find_cycle(nodes) is None
+
+    def test_input_coerce_types(self):
+        assert InputSpec(name="x", type="int").coerce("42") == 42
+        assert InputSpec(name="x", type="float").coerce("1.5") == 1.5
+        assert InputSpec(name="x", type="bool").coerce("true") is True
+        assert InputSpec(name="x", type="bool").coerce("0") is False
+        assert InputSpec(name="x", type="json").coerce('{"k":1}') == {"k": 1}
+
+    def test_workflow_validate_branch_requires_goto(self):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p", on_error="branch"),
+                ActionNode(id="b", prompt="p"),
+            ],
+        )
+        errors = wf.validate()
+        assert any("on_error_goto" in e for e in errors)
+
+    def test_workflow_validate_branch_goto_unknown(self):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p", on_error="branch",
+                           on_error_goto="nowhere"),
+                ActionNode(id="b", prompt="p"),
+            ],
+        )
+        errors = wf.validate()
+        assert any("unknown" in e for e in errors)
+
+    def test_output_validation_catches_missing_pattern(self):
+        node = ActionNode(
+            id="a",
+            prompt="p",
+            outputs=[OutputSpec(name="v", source="jsonpath", pattern="")],
+        )
+        errors = node.validate()
+        assert any("requires pattern" in e for e in errors)
+
+
+# ---- Storage round-trip -----------------------------------------------------
+
+def _make_workflow_run(runs_dir, **overrides):
+    from agentwire.workflows.runner import WorkflowRun
+    defaults = dict(
+        workflow="test-wf",
+        run_id="test-wf-20260415T000000-aaaa1111",
+        status="success",
+        started_at=time.time(),
+        duration_ms=100,
+        node_results=[
+            NodeResult(
+                node_id="a",
+                status="success",
+                final_text="hi",
+                duration_ms=50,
+                attempts=1,
+            ),
+        ],
+    )
+    defaults.update(overrides)
+    return WorkflowRun(**defaults)
+
+
+class TestStorage:
+    def test_write_and_list_roundtrip(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        run = _make_workflow_run(runs_dir)
+        ctx = Context(inputs={"x": 1})
+        ctx.set_node_outputs("a", {"text": "hi"})
+
+        write_run(runs_dir, run.run_id, run, ctx)
+
+        rows = list_runs(runs_dir)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == run.run_id
+        assert rows[0]["inputs"] == {"x": 1}
+        assert rows[0]["nodes"][0]["id"] == "a"
+
+    def test_list_runs_sorted_newest_first(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        older = _make_workflow_run(
+            runs_dir,
+            run_id="test-wf-20260101T000000-old",
+            started_at=1000.0,
+        )
+        newer = _make_workflow_run(
+            runs_dir,
+            run_id="test-wf-20260601T000000-new",
+            started_at=2000.0,
+        )
+        ctx = Context()
+        write_run(runs_dir, older.run_id, older, ctx)
+        write_run(runs_dir, newer.run_id, newer, ctx)
+
+        rows = list_runs(runs_dir)
+        assert [r["run_id"] for r in rows] == [newer.run_id, older.run_id]
+
+    def test_list_skips_orphan_dir(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        (runs_dir / "orphan-run").mkdir()  # no metadata.json
+        assert list_runs(runs_dir) == []
+
+    def test_list_skips_malformed_metadata(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        bad = runs_dir / "bad-run"
+        bad.mkdir()
+        (bad / "metadata.json").write_text("not json {{{")
+
+        # good one still listed
+        run = _make_workflow_run(runs_dir)
+        write_run(runs_dir, run.run_id, run, Context())
+
+        rows = list_runs(runs_dir)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == run.run_id
+
+    def test_filter_by_workflow(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        a = _make_workflow_run(runs_dir, workflow="alpha",
+                               run_id="alpha-1", started_at=1.0)
+        b = _make_workflow_run(runs_dir, workflow="beta",
+                               run_id="beta-1", started_at=2.0)
+        write_run(runs_dir, a.run_id, a, Context())
+        write_run(runs_dir, b.run_id, b, Context())
+
+        assert [r["run_id"] for r in list_runs(runs_dir, workflow="alpha")] == ["alpha-1"]
+        assert [r["run_id"] for r in list_runs(runs_dir, workflow="beta")] == ["beta-1"]
+
+
+# ---- Runner (mocked pi) -----------------------------------------------------
+
+def _canned(node_id: str, status: str = "success", final_text: str = "") -> NodeResult:
+    """Factory for NodeResult objects the fake run_node returns."""
+    return NodeResult(
+        node_id=node_id,
+        status=status,
+        final_text=final_text,
+        duration_ms=10,
+        attempts=1,
+    )
+
+
+class TestRunnerDryRun:
+    def test_dry_run_lists_all_nodes_in_topo_order(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p"),
+                ActionNode(id="b", prompt="p", depends_on=["a"]),
+            ],
+        )
+        run = run_workflow(wf, runs_dir=tmp_path, dry_run=True)
+        assert run.status == "success"
+        assert [r.node_id for r in run.node_results] == ["a", "b"]
+
+    def test_missing_required_input_errors(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[ActionNode(id="a", prompt="hi {{ inputs.x }}")],
+            inputs=[InputSpec(name="x", type="string", required=True)],
+        )
+        run = run_workflow(wf, runs_dir=tmp_path, dry_run=True)
+        assert run.status == "failure"
+        assert "missing required input" in (run.error or "")
+
+
+class TestRunnerWhen:
+    def test_when_false_skips_node_and_dependents(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p"),
+                ActionNode(id="b", prompt="p", depends_on=["a"],
+                           when="a.text == 'xxx'"),  # will be false
+                ActionNode(id="c", prompt="p", depends_on=["b"]),
+            ],
+        )
+
+        def fake_run_node(node, **kw):
+            return _canned(node.id, final_text="yyy")
+
+        with patch("agentwire.workflows.runner.run_node", side_effect=fake_run_node):
+            run = run_workflow(wf, runs_dir=tmp_path)
+
+        statuses = {r.node_id: r.status for r in run.node_results}
+        assert statuses == {"a": "success", "b": "skipped", "c": "skipped"}
+        assert run.status == "partial"
+
+    def test_when_true_runs_node(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p"),
+                ActionNode(id="b", prompt="p", depends_on=["a"],
+                           when="a.text == 'yes'"),
+            ],
+        )
+        with patch(
+            "agentwire.workflows.runner.run_node",
+            side_effect=lambda node, **kw: _canned(node.id, final_text="yes"),
+        ):
+            run = run_workflow(wf, runs_dir=tmp_path)
+        statuses = {r.node_id: r.status for r in run.node_results}
+        assert statuses == {"a": "success", "b": "success"}
+        assert run.status == "success"
+
+
+class TestRunnerOnError:
+    def test_on_error_fail_halts(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p"),  # default on_error=fail
+                ActionNode(id="b", prompt="p", depends_on=["a"]),
+            ],
+        )
+
+        def fake(node, **kw):
+            if node.id == "a":
+                return NodeResult(node_id="a", status="failure",
+                                  final_text="", error="boom", attempts=1)
+            return _canned(node.id)
+
+        with patch("agentwire.workflows.runner.run_node", side_effect=fake):
+            run = run_workflow(wf, runs_dir=tmp_path)
+
+        assert run.status == "failure"
+        statuses = {r.node_id: r.status for r in run.node_results}
+        assert statuses["a"] == "failure"
+        # b is unreached but still shows up in topo-ordered results as skipped.
+        assert statuses["b"] == "skipped"
+
+    def test_on_error_continue_provides_none_outputs(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(
+                    id="a",
+                    prompt="p",
+                    on_error="continue",
+                    outputs=[OutputSpec(name="val", source="text")],
+                ),
+                ActionNode(
+                    id="b",
+                    prompt="got={{ a.val }}",
+                    depends_on=["a"],
+                ),
+            ],
+        )
+
+        def fake(node, **kw):
+            if node.id == "a":
+                return NodeResult(node_id="a", status="failure",
+                                  final_text="", error="boom", attempts=1)
+            # The runner should render b's prompt with a.val == None
+            return _canned(node.id, final_text=node.prompt)
+
+        with patch("agentwire.workflows.runner.run_node", side_effect=fake):
+            run = run_workflow(wf, runs_dir=tmp_path)
+
+        assert run.status == "partial"
+        statuses = {r.node_id: r.status for r in run.node_results}
+        assert statuses == {"a": "failure", "b": "success"}
+        # b's final_text mirrors its rendered prompt — a.val was set to None
+        # by the on_error=continue path, and Jinja renders None as "None".
+        b_result = next(r for r in run.node_results if r.node_id == "b")
+        assert b_result.final_text == "got=None"
+
+
+class TestRunnerRetries:
+    def test_retries_happen_on_failure(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[
+                ActionNode(id="a", prompt="p", retries=2, retry_delay=0,
+                           on_error="continue"),
+            ],
+        )
+        call_count = {"n": 0}
+
+        def fake(node, **kw):
+            call_count["n"] += 1
+            return NodeResult(node_id=node.id, status="failure",
+                              final_text="", error="flaky", attempts=1)
+
+        with patch("agentwire.workflows.runner.run_node", side_effect=fake):
+            run = run_workflow(wf, runs_dir=tmp_path)
+
+        assert call_count["n"] == 3  # 1 initial + 2 retries
+        result = run.node_results[0]
+        assert result.attempts == 3
+        assert result.status == "failure"
+
+    def test_retries_stop_after_success(self, tmp_path):
+        wf = WorkflowDef(
+            name="wf",
+            nodes=[ActionNode(id="a", prompt="p", retries=5, retry_delay=0)],
+        )
+        state = {"n": 0}
+
+        def fake(node, **kw):
+            state["n"] += 1
+            if state["n"] < 2:
+                return NodeResult(node_id=node.id, status="failure",
+                                  final_text="", error="not yet", attempts=1)
+            return _canned(node.id, final_text="ok")
+
+        with patch("agentwire.workflows.runner.run_node", side_effect=fake):
+            run = run_workflow(wf, runs_dir=tmp_path)
+
+        result = run.node_results[0]
+        assert result.status == "success"
+        assert result.attempts == 2


### PR DESCRIPTION
## Summary

PR E of the pi workflow engine — closes Phase 2 (`docs/missions/pi-workflow-engine.md`). Ships the on-ramp that PR D was missing.

### What's new

**4 bundled examples** (each demonstrates a distinct capability):
- `fan-in-summary.yaml` — diamond DAG (3 angle nodes → 1 synthesizer). Exercises N→1 `depends_on` + Jinja upstream refs.
- `doc-drift-check.yaml` — reads a target file, extracts factual claims as JSON via jsonpath, flags stale ones.
- `pr-triage.yaml` — uses the `bash` tool to run `gh pr view` + `gh pr diff`, then summarizes into reviewer notes. Requires `gh` on PATH.
- `retry-resilient.yaml` — broken-provider node + `retries: 2` + `on_error: continue`. Demonstrates the `partial` status path.

**Docs** (`docs/workflows.md`) — full user guide: concepts, YAML anatomy, CLI reference, MCP tools, templating, extraction sources, `when`/retries/on_error semantics, storage layout, prompt-writing tips, debugging, FAQ.

**Skill** (`.claude/skills/agentwire-workflows/SKILL.md`) — compact cheat sheet + pointer to `docs/workflows.md`. Loads on demand when an agent is authoring or debugging a workflow.

**CLAUDE.md** — 1 row added to skills table + 1 bullet added to docs list. No bulk.

**Unit tests** (`tests/unit/test_workflows.py`) — 34 tests, <100ms:
- Context: render, eval_condition, StrictUndefined
- Outputs: text/regex/jsonpath, fenced JSON, required vs optional, malformed JSON
- Definitions: topological_sort diamond, cycle detection, InputSpec coercion, on_error=branch validation
- Storage: write/list roundtrip, sort order, orphan + malformed dirs skipped, filter by workflow
- Runner (pi mocked): dry-run, missing input, when=false skip propagation, on_error=fail halt, on_error=continue None outputs, retry loop

### What's NOT shipped

Mission-doc examples I deliberately dropped (too fragile as bundled demos that run anywhere):
- `refactor-and-verify` — mutates real code
- `dependency-audit` — JS-specific, volatile
- `test-recovery` — needs a pre-existing failing test

Real-pi integration tests in CI — require Z.AI key + cost money. Manual smoke tests during PRs A–E already exercised these paths. PR verified `fan-in-summary` end-to-end on "sourdough starters" (4 nodes, 2m40s, diamond fan-in produced a cohesive 3-sentence synthesis).

## Test plan

- [x] `uv run pytest tests/unit/test_workflows.py -v` → 34 passed in 0.05s
- [x] `uv run ruff check agentwire/workflows/ tests/unit/test_workflows.py` clean
- [x] All 7 examples (3 existing + 4 new) pass `agentwire workflow validate`
- [x] `workflow list` shows all 7 with correct descriptions
- [x] **Real run:** `workflow run fan-in-summary --input topic="sourdough starters"` → `success`, 4 nodes, diamond fan-in weaves all three angles into final synthesis
- [x] `docs/workflows.md` renders cleanly in Markdown preview
- [x] `CLAUDE.md` gained only 2 lines

## Phase 2 closeout

With this PR, every item from `docs/missions/pi-workflow-engine.md` Success Criteria is shipped:

- [x] `agentwire workflow run <name>` executes workflows end-to-end
- [x] Jinja2 templating works between nodes
- [x] `when` conditionals correctly skip nodes
- [x] `retries` retries on pi failure
- [x] Event log replayable (`workflow show --events`)
- [x] Dry-run prints execution plan
- [x] Example workflows bundled (7 total)
- [x] MCP tools work (`workflow_list`/`run`/`validate`/`history`/`show`)
- [x] Documentation (`docs/workflows.md` + skill)
- [x] Workflow YAML schema versioned + validated

Phase 3 (scheduler integration), Phase 4 (parallel, cost caps), Phase 5 (UI) remain for future work.

Built by [dotdev.dev](https://dotdev.dev)