### PR TITLE
docs: document workflow-backed scheduler tasks (Phase 3)

### DIFF
--- a/.claude/skills/agentwire-workflows/SKILL.md
+++ b/.claude/skills/agentwire-workflows/SKILL.md
@@ -72,12 +72,30 @@ Runs without `metadata.json` (crashed mid-run) are silently hidden from `history
 - **`when: "{{ x == 'y' }}"`** — wrong. `when:` is a Jinja *expression*, not a template. Write `when: "x == 'y'"`.
 - **Adding MCP tool doesn't appear** — requires `agentwire rebuild && agentwire portal restart --dev` *plus* a Claude session restart.
 
+## Scheduler integration
+
+Workflows can be wired into `~/.agentwire/scheduler.yaml` with `workflow:` + `inputs:` fields (instead of `task:`). The scheduler dispatches them in-process via `run_workflow()` — no tmux, no ensure subprocess.
+
+```yaml
+tasks:
+  nightly-doc-drift:
+    schedule: { every: day, at: "23:00" }
+    workflow: doc-drift-check
+    inputs:
+      paths: "docs/,{{ project }}"  # {{ task }}, {{ project }}, {{ session }}, {{ workflow }} expand
+```
+
+Status maps `success→complete`, `partial→incomplete`, `failure→failed`. `agentwire scheduler run <name> --dry-run` works for workflow tasks. The morning report renders per-node status badges.
+
+Full reference in `docs/workflows.md` → "Scheduler integration" section.
+
 ## When to pick which tool
 
 | Need | Tool |
 |---|---|
 | Single interactive prompt | `claude` / `pi -p` |
-| Recurring prompt on a schedule | `agentwire-scheduler` skill |
+| Recurring single Claude prompt on a schedule | `agentwire-scheduler` skill with `task:` |
+| Recurring multi-step DAG on a schedule | `agentwire-scheduler` skill with `workflow:` (this skill for the DAG itself) |
 | Multi-step logic, variables between steps, conditionals, retries | workflows |
 
 ## Full reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-04-16
+
 ### Added
 
+- **Workflow-backed scheduler tasks** — scheduler can now dispatch a pi workflow DAG in-process instead of shelling out to `agentwire ensure` (Phase 3 of the pi workflow roadmap)
+  - New `workflow:` + `inputs:` fields on scheduler tasks in `~/.agentwire/scheduler.yaml` (mutually exclusive with `task:`)
+  - `dispatch_task()` routes automatically: ensure path unchanged, new `_dispatch_workflow_task` calls `run_workflow()` in-process — no tmux, no Claude Code subprocess
+  - Status mapping: workflow `success→complete`, `partial→incomplete`, `failure→failed`
+  - Scheduler `{{ task }}`, `{{ project }}`, `{{ session }}`, `{{ workflow }}` variables expand in string `inputs:` values
+  - `agentwire scheduler run <name> --dry-run` prints the workflow plan without touching state
+  - `task_completed` events now carry `workflow`, `run_id`, and per-node `nodes[]` when the task is workflow-backed
+  - Morning report (`agentwire scheduler report --artifact`) renders per-node status badges + run-id breadcrumb for workflow rows
+  - `agentwire scheduler history --json` includes the `workflow` name per task
+  - Full reference: `docs/workflows.md` → "Scheduler integration"; compare/contrast: `docs/scheduled-workloads.md`
 - **Kokoro TTS engine** — CPU-only ultra-lightweight backend (`kokoro`)
   - Kokoro 82M ONNX model via `kokoro-onnx`, auto-downloads ~170 MB from HuggingFace on first use
   - No GPU required — pure ONNX CPU inference, near real-time on Apple Silicon / modern Intel CPU
   - 30+ preset voices across 8 languages (English, Spanish, French, Hindi, Italian, Japanese, Portuguese, Chinese); `af_heart` is the default and highest quality voice
   - Streaming support via `create_stream()`
   - Runs in dedicated `.venv-kokoro` with CPU-only PyTorch (~250 MB vs 2 GB+ CUDA builds)
+
+### Fixed
+
+- `cmd_scheduler_report` was calling `read_events(limit=500)` with the wrong kwarg name; the `except` silently caught the `TypeError` so morning reports quietly returned 0 events. Now calls `read_events(tail=500)`.
 
 ## [1.9.0] - 2026-03-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Reference detail lives in skills under `.claude/skills/` — invoke as needed:
 | `agentwire-mcp-tools` | Picking the right MCP tool from inside an agent session |
 | `agentwire-config` | Editing `~/.agentwire/config.yaml` (TTS, channels, services, etc.) |
 | `agentwire-project-config` | Editing `.agentwire.yml`, defining tasks, roles, idle notifications |
-| `agentwire-scheduler` | Scheduled task gates/schedule/priority + overnight queue |
+| `agentwire-scheduler` | Scheduled task gates/schedule/priority + overnight queue + workflow-backed tasks |
 | `agentwire-desktop-ui` | Editing portal static files (sidebar, windows, artifacts) |
 | `agentwire-pi-zai` | Setting up Z.AI sessions via pi coding agent |
 | `agentwire-workflows` | Authoring or debugging pi workflow YAMLs (`agentwire workflow ...`) |
@@ -126,7 +126,8 @@ Reference detail lives in skills under `.claude/skills/` — invoke as needed:
 
 - CLI: `agentwire --help` or `agentwire <cmd> --help`
 - `docs/pi-zai.md` - Pi coding agent + Z.AI session types
-- `docs/workflows.md` - Pi workflow engine user guide
+- `docs/workflows.md` - Pi workflow engine user guide (incl. scheduler integration)
+- `docs/scheduled-workloads.md` - Ensure vs workflow scheduled tasks, `.agentwire.yml` reference
 - `docs/missions/pi-harness-overview.md` - Pi integration roadmap across phases
 - `docs/channels.md` - Channel developer guide
 - `docs/PORTAL.md` - Portal modes and API reference

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10619,7 +10619,12 @@ def main() -> int:
     scheduler_parser = subparsers.add_parser(
         "scheduler",
         help="Manage the task scheduler",
-        description="Centralized daemon that dispatches tasks across projects on a shared cadence.",
+        description=(
+            "Centralized daemon that dispatches tasks across projects on a shared cadence. "
+            "Tasks in ~/.agentwire/scheduler.yaml are either ensure tasks (task: + session:) "
+            "or workflow tasks (workflow: + inputs:) — the scheduler routes each automatically. "
+            "See docs/scheduled-workloads.md."
+        ),
     )
     scheduler_subparsers = scheduler_parser.add_subparsers(dest="scheduler_command")
 

--- a/docs/scheduled-workloads.md
+++ b/docs/scheduled-workloads.md
@@ -8,12 +8,32 @@ Reliable headless task execution for overnight and automated agent workflows.
 
 ## Overview
 
-Two primitives work together:
+Three paths for running scheduled work, picked per task:
 
-1. **`agentwire ensure`** — Reliable session management + task execution with lifecycle hooks
-2. **Tasks in `.agentwire.yml`** — Named workflows with pre/prompt/post phases and branch management
+1. **`agentwire ensure` tasks** — Reliable session management + task execution with lifecycle hooks. A full Claude Code session runs a single prompt from `.agentwire.yml`. Best for multi-step agent work that needs its own branch / PR / MCP tools.
+2. **Pi workflow tasks** — A YAML DAG of `pi -p --mode json` invocations runs in-process. No tmux session, no project required. Best for deterministic pipelines where each step has clear inputs/outputs and you want cheap per-node retries.
+3. **Tasks in `.agentwire.yml`** — Named tasks with pre/prompt/post phases and branch management — the substrate for path #1.
 
-For scheduled execution, combine with `~/.agentwire/scheduler.yaml` and the AgentWire scheduler daemon.
+All three are orchestrated by `~/.agentwire/scheduler.yaml` and the AgentWire scheduler daemon. A single board can mix ensure tasks and workflow tasks freely.
+
+---
+
+## Choosing ensure vs workflow
+
+| | ensure task | workflow task |
+|---|---|---|
+| Schedule field | `task: <name>` + `session:` | `workflow: <name-or-path>` + `inputs:` |
+| Dispatch | `agentwire ensure` subprocess → tmux session → Claude Code | `run_workflow()` in-process → pi subprocesses per node |
+| Model family | Claude (subscription via session type) | Z.AI glm-5 / flash-tier pi (per-node choice) |
+| Session needed | yes | no |
+| Project needed | yes (for branch mgmt) | optional (only for git gates / auto-commit) |
+| Multi-step logic | inside one Claude prompt | first-class DAG with retries, branches, outputs |
+| Dry-run | no | `scheduler run <name> --dry-run` prints the plan |
+| Cost profile | subscription-covered | Z.AI credits (or free flash tier) |
+
+A task must set exactly one of `task:` or `workflow:`. Everything else (gates, priority, `max_runs`, `once`, `cooldown`, `not_before`/`not_after`) applies to both.
+
+Full workflow task reference: [`docs/workflows.md#scheduler-integration`](workflows.md#scheduler-integration).
 
 ---
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -259,6 +259,130 @@ No retention policy yet — if `runs/` grows too large, clear it manually.
 
 ---
 
+## Scheduler integration
+
+A scheduler task in `~/.agentwire/scheduler.yaml` can reference a workflow with `workflow:` + `inputs:` instead of declaring a `task:` that runs via `agentwire ensure`. The scheduler dispatches the workflow **in-process** — no tmux session, no Claude Code subprocess, no project required (unless you want git gates or auto-commit).
+
+### Minimum example
+
+```yaml
+# ~/.agentwire/scheduler.yaml
+tasks:
+  nightly-doc-drift:
+    schedule:
+      every: day
+      at: "23:00"
+    workflow: doc-drift-check        # name from `agentwire workflow list` OR absolute YAML path
+    inputs:
+      paths: "docs/,agentwire/"
+```
+
+### Ensure tasks vs workflow tasks
+
+| | ensure task | workflow task |
+|---|---|---|
+| Field used | `task: <name-from-.agentwire.yml>` | `workflow: <name-or-path>` |
+| Dispatch | `agentwire ensure` subprocess in a tmux session | `run_workflow()` in-process, no tmux |
+| Session field | required (`session:`) | omitted (no session is created) |
+| Project field | required | optional; required only if you use git gates or want auto-commit |
+| Model | Claude (whatever the session type is) | Whatever each workflow node specifies — per-node pi models |
+| Lifecycle hooks | `.agentwire.yml` pre/prompt/post | workflow DAG nodes with retries, branching, outputs |
+
+A task must set **either** `task:` **or** `workflow:` — not both. `inputs:` is only valid with `workflow:`.
+
+### Input templating
+
+String values in `inputs:` expand four built-in variables from the scheduler's task context:
+
+```yaml
+tasks:
+  my-wf:
+    schedule: { every: 4h }
+    workflow: summarize-project
+    inputs:
+      who: "{{ task }}"              # → "my-wf"
+      where: "{{ project }}"         # → expanded project path (if set)
+      session_hint: "{{ session }}"  # → session name (if set)
+      self: "{{ workflow }}"         # → "summarize-project"
+```
+
+Unknown variables pass through untouched so workflow-node Jinja (`{{ inputs.x }}`, `{{ upstream.y }}`) still works. This is deliberately simpler than the full Jinja engine used inside workflow nodes — `{{ task }}`, `{{ project }}`, `{{ session }}`, `{{ workflow }}` are the only scheduler-context vars recognised at this layer.
+
+### Status mapping
+
+The workflow engine's three statuses map to scheduler status:
+
+| Workflow | Scheduler | Exit intent |
+|---|---|---|
+| `success` | `complete` | Everything ran cleanly |
+| `partial` | `incomplete` | ≥1 node skipped or failed-continue; workflow didn't halt |
+| `failure` | `failed` | A node with `on_error: fail` failed and halted the workflow |
+
+Workflow-load failures (bad YAML, missing workflow) also record as `failed` with a single-line blocker in the event log.
+
+### Dry-run a workflow task
+
+```bash
+agentwire scheduler run my-wf --dry-run
+```
+
+Resolves the workflow, renders inputs, and prints the execution plan — no pi calls, no state update. Works for workflow tasks only (ensure tasks exit with a message).
+
+### What lands in the morning report
+
+Every `task_completed` event from a workflow task carries the workflow name, run id, and a compact node list:
+
+```json
+{
+  "event": "task_completed",
+  "task": "nightly-doc-drift",
+  "status": "complete",
+  "workflow": "doc-drift-check",
+  "run_id": "doc-drift-check-20260416T230000-abc...",
+  "nodes": [
+    {"id": "scan", "status": "success", "duration_ms": 4201, "attempts": 1},
+    {"id": "report", "status": "success", "duration_ms": 2104, "attempts": 1}
+  ],
+  ...
+}
+```
+
+`agentwire scheduler report --artifact` renders per-node status badges alongside each workflow row, plus a run-id breadcrumb you can pass to `agentwire workflow show <run_id>` for the full event drill-down.
+
+### Gates, priority, max_runs, once
+
+All scheduler primitives work identically for workflow tasks. A workflow task can:
+- Use `gate: { git_diff: [paths...] }` (requires `project:`)
+- Set `priority`, `cooldown`, `not_before`/`not_after`
+- Auto-disable with `max_runs: N` or `once: true`
+
+### Auto-commit caveat
+
+The scheduler's auto-commit step only runs for workflow tasks when `project:` is set. Workflow tasks without a project skip auto-commit; the expectation is that any filesystem mutations the workflow made are either intentional (pi's `bash` / `edit` / `write` tools) and will be committed by the workflow itself, or are transient and don't need capture.
+
+### End-to-end smoke
+
+```bash
+# 1. Add a workflow task to ~/.agentwire/scheduler.yaml (see minimum example above)
+# 2. Verify board parses
+agentwire scheduler board
+
+# 3. Dry-run to see the plan
+agentwire scheduler run nightly-doc-drift --dry-run
+
+# 4. Fire it
+agentwire scheduler run nightly-doc-drift
+
+# 5. Check the run
+agentwire workflow history --limit 1
+agentwire workflow show <run_id>
+
+# 6. Morning report
+agentwire scheduler report --since 1h --artifact
+```
+
+---
+
 ## Writing good pi prompts
 
 Pi is a one-shot, stateless agent per node. These tips keep nodes cheap and reliable:


### PR DESCRIPTION
## Summary
- New **Scheduler integration** section in `docs/workflows.md` covering: ensure vs workflow dispatch paths, `{{ task }}`/`{{ project }}`/`{{ session }}`/`{{ workflow }}` input templating, status mapping, `--dry-run`, morning report output, and an end-to-end smoke recipe
- Rewrote the intro of `docs/scheduled-workloads.md` to describe both dispatch paths with a comparison table
- Added the 1.23.0 entry to `CHANGELOG.md` — Phase 3 feature + the `read_events(limit=)` fix
- Cross-references: CLAUDE.md, `agentwire-scheduler` skill (already updated), `agentwire-workflows` skill, scheduler CLI parser description

No code changes besides the one-liner help-text update in `agentwire scheduler`'s parser description. All 701 tests still pass.

## Test plan
- [x] `uv run pytest -x -q` — 701 passed
- [x] `agentwire scheduler --help` shows the new description
- [x] Markdown renders cleanly on GitHub

Built by [dotdev.dev](https://dotdev.dev)