### PR TITLE
feat: default model → glm-5.1, provider → zai

### DIFF
--- a/.claude/skills/agentwire-pi-zai/SKILL.md
+++ b/.claude/skills/agentwire-pi-zai/SKILL.md
@@ -57,7 +57,7 @@ zai:
   timeout_ms: 3000000
 
 pi:
-  default_model: "glm-5"   # glm-5 | glm-5.1 | glm-4.7 | glm-4.7-flash | ...
+  default_model: "glm-5.1"   # default. glm-5.1 | glm-5 | glm-4.7 | glm-4.7-flash | ...
   binary: "pi"             # override if not on PATH (e.g., nvm path)
 ```
 

--- a/.claude/skills/agentwire-workflows/SKILL.md
+++ b/.claude/skills/agentwire-workflows/SKILL.md
@@ -14,7 +14,7 @@ name: hello
 nodes:
   greet:
     prompt: "Say hi in one word."
-    model: glm-4.7-flash
+    # model defaults to glm-5.1 on provider zai — both optional
     tools: [read]
     thinking: "off"
 ```

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -149,7 +149,7 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
     Args:
         session_type: Session type (e.g., "claude-bypass", "claude-auto", "pi-zai", "bare")
         roles: Optional list of roles to apply
-        model: Optional model override (e.g., "haiku", "sonnet", "opus", "glm-5")
+        model: Optional model override (e.g., "haiku", "sonnet", "opus", "glm-5.1")
 
     Returns:
         AgentCommand with the command string and metadata
@@ -170,7 +170,7 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
         # Pi reads ZAI_API_KEY from env. We inject it via `tmux set-environment`
         # (see inject_session_env) so the key never appears in `ps auxwww`.
         pi_binary = pi_config.get("binary", "pi")
-        default_model = pi_config.get("default_model", "glm-5")
+        default_model = pi_config.get("default_model", "glm-5.1")
 
         parts = [pi_binary, "--provider", "zai"]
         parts.extend(["--model", model or default_model])

--- a/agentwire/workflows/examples/doc-drift-check.yaml
+++ b/agentwire/workflows/examples/doc-drift-check.yaml
@@ -32,6 +32,5 @@ nodes:
 
       Return a one-paragraph review indicating which 1–2 claims are
       most likely to become stale over time and why. Be concrete.
-    model: glm-4.7-flash
     tools: [read]
     thinking: "medium"

--- a/agentwire/workflows/examples/echo-chain.yaml
+++ b/agentwire/workflows/examples/echo-chain.yaml
@@ -13,7 +13,6 @@ nodes:
     prompt: |
       Return ONLY a JSON object (no prose, no code fences) in this exact shape:
       {"fact": "<one-sentence fun fact about {{ inputs.topic }}>"}
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
     outputs:
@@ -25,6 +24,5 @@ nodes:
     depends_on: [fact]
     prompt: |
       Restate this fact in exactly five words: "{{ fact.fact }}"
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"

--- a/agentwire/workflows/examples/fan-in-summary.yaml
+++ b/agentwire/workflows/examples/fan-in-summary.yaml
@@ -10,7 +10,6 @@ inputs:
 nodes:
   angle_technical:
     prompt: "Write one sentence about {{ inputs.topic }} from a technical angle."
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
     outputs:
@@ -19,7 +18,6 @@ nodes:
 
   angle_historical:
     prompt: "Write one sentence about {{ inputs.topic }} from a historical angle."
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
     outputs:
@@ -28,7 +26,6 @@ nodes:
 
   angle_practical:
     prompt: "Write one sentence about {{ inputs.topic }} from a practical-use angle."
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
     outputs:
@@ -43,6 +40,5 @@ nodes:
       - Technical: {{ angle_technical.text }}
       - Historical: {{ angle_historical.text }}
       - Practical: {{ angle_practical.text }}
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"

--- a/agentwire/workflows/examples/hello-world.yaml
+++ b/agentwire/workflows/examples/hello-world.yaml
@@ -6,6 +6,5 @@ nodes:
   greet:
     prompt: |
       Reply with exactly one friendly greeting sentence. No code, no tools.
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"

--- a/agentwire/workflows/examples/pr-triage.yaml
+++ b/agentwire/workflows/examples/pr-triage.yaml
@@ -30,6 +30,5 @@ nodes:
 
       PR view + diff:
       {{ fetch.text }}
-    model: glm-4.7-flash
     tools: [read]
     thinking: "medium"

--- a/agentwire/workflows/examples/retry-resilient.yaml
+++ b/agentwire/workflows/examples/retry-resilient.yaml
@@ -19,6 +19,5 @@ nodes:
     prompt: |
       In one sentence, describe what a 'partial' workflow run means:
       some nodes failed but the workflow completed.
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"

--- a/agentwire/workflows/examples/verify-or-rollback.yaml
+++ b/agentwire/workflows/examples/verify-or-rollback.yaml
@@ -16,7 +16,6 @@ nodes:
     prompt: |
       Return ONLY a JSON object (no prose, no code fences) in this exact shape:
       {"status": "{{ inputs.target }}"}
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
     retries: 1
@@ -31,7 +30,6 @@ nodes:
     when: "verify.status == 'pass'"
     prompt: |
       Reply with exactly: "All checks passed."
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"
 
@@ -40,6 +38,5 @@ nodes:
     when: "verify.status == 'fail'"
     prompt: |
       Reply with exactly: "Rolling back changes."
-    model: glm-4.7-flash
     tools: [read]
     thinking: "off"

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -50,7 +50,7 @@ class ActionNode:
     prompt: str
 
     provider: str = "zai"
-    model: str = "glm-5"
+    model: str = "glm-5.1"
     tools: list[str] = field(default_factory=lambda: list(DEFAULT_TOOLS))
     thinking: str = "medium"
 

--- a/docs/pi-zai.md
+++ b/docs/pi-zai.md
@@ -43,7 +43,7 @@ Optionally configure pi defaults:
 
 ```yaml
 pi:
-  default_model: "glm-5"   # glm-5 | glm-5.1 | glm-5-turbo | glm-4.7 | glm-4.7-flash | ...
+  default_model: "glm-5.1"   # default. glm-5.1 | glm-5 | glm-5-turbo | glm-4.7 | glm-4.7-flash | ...
   binary: "pi"             # Override if pi is installed somewhere other than $PATH
 ```
 
@@ -57,7 +57,7 @@ Full tool access (read, bash, edit, write). Closest equivalent of `claude-bypass
 agentwire new -s myproject --type pi-zai -p ~/projects/myproject
 ```
 
-Uses the `default_model` from config (default: `glm-5`).
+Uses the `default_model` from config (default: `glm-5.1`).
 
 ### `pi-zai-restricted`
 
@@ -145,7 +145,7 @@ Pi has no `--disallowedTools` flag. It can only whitelist. If a role specifies `
 | System prompt injection | `--append-system-prompt "text"` | `--append-system-prompt "text"` |
 | Tool whitelist | `--tools Bash,Read` | `--tools bash,read` |
 | Tool blacklist | `--disallowedTools X` | Not supported |
-| Model override | `--model haiku` | `--model glm-5` |
+| Model override | `--model haiku` | `--model glm-5.1` |
 | Skip permissions | `--dangerously-skip-permissions` | Not needed (no permission system) |
 | JSON output | Not available | `--mode json` |
 | Non-interactive | Via tmux | `-p "prompt"` |

--- a/docs/scheduled-workloads.md
+++ b/docs/scheduled-workloads.md
@@ -24,7 +24,7 @@ All three are orchestrated by `~/.agentwire/scheduler.yaml` and the AgentWire sc
 |---|---|---|
 | Schedule field | `task: <name>` + `session:` | `workflow: <name-or-path>` + `inputs:` |
 | Dispatch | `agentwire ensure` subprocess → tmux session → Claude Code | `run_workflow()` in-process → pi subprocesses per node |
-| Model family | Claude (subscription via session type) | Z.AI glm-5 / flash-tier pi (per-node choice) |
+| Model family | Claude (subscription via session type) | Z.AI glm-5.1 by default (any pi-supported model per node) |
 | Session needed | yes | no |
 | Project needed | yes (for branch mgmt) | optional (only for git gates / auto-commit) |
 | Multi-step logic | inside one Claude prompt | first-class DAG with retries, branches, outputs |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -37,8 +37,10 @@ nodes:                               # at least one required
   analyze:
     prompt: |                        # Jinja2 template — required
       Look at {{ inputs.target }}. Return JSON: {"issues": [...]}
-    model: glm-4.7-flash             # any provider/model pi supports
-    provider: zai                    # default zai
+    # provider + model are optional — default to zai + glm-5.1
+    # set explicitly only when you need a different model/provider
+    model: glm-5.1                   # default: glm-5.1
+    provider: zai                    # default: zai
     tools: [read, grep]              # subset of {read, bash, edit, write, grep, find, ls}
     thinking: "low"                  # off|minimal|low|medium|high|xhigh
     timeout: 300                     # seconds per attempt (default 300)
@@ -390,7 +392,7 @@ Pi is a one-shot, stateless agent per node. These tips keep nodes cheap and reli
 - **Constrain tools.** If a node only reads files, set `tools: [read]`. Excess tools invite unnecessary calls.
 - **Dial thinking.** `thinking: "off"` for structured/obvious tasks, `"medium"` for analysis, `"high"+` only for deep reasoning. Each level up costs more tokens.
 - **Ask for JSON explicitly.** "Return ONLY a JSON object (no prose, no code fences) in this shape: …" works far better than assuming a schema.
-- **Use flash tier for cheap nodes.** `model: glm-4.7-flash` is free on Z.AI's flash tier and plenty for non-reasoning work.
+- **Default model is `glm-5.1` on provider `zai`** — you don't need to declare `model:` or `provider:` unless you want a different one. Override per-node for experiments (`model: glm-4.7-flash` for cheap throwaway work, etc.).
 - **Set timeouts for network-bound nodes.** `timeout: 60` for a `gh` command; default 300 for thinking tasks.
 
 ---

--- a/tests/integration/test_build_agent_command.py
+++ b/tests/integration/test_build_agent_command.py
@@ -16,7 +16,7 @@ FAKE_CONFIG = {
         "timeout_ms": 3000000,
     },
     "pi": {
-        "default_model": "glm-5",
+        "default_model": "glm-5.1",
         "binary": "pi",
     },
 }
@@ -91,7 +91,7 @@ class TestBuildAgentCommand:
         # Key is injected via tmux set-environment, NOT on the command line
         assert "ZAI_API_KEY" not in cmd.command
         assert cmd.env == {"ZAI_API_KEY": "test-key-123"}
-        assert "--model glm-5" in cmd.command
+        assert "--model glm-5.1" in cmd.command
         # Pi has no --dangerously-skip-permissions (no permission system)
         assert "--dangerously-skip-permissions" not in cmd.command
         assert cmd.temp_file is None
@@ -119,10 +119,10 @@ class TestBuildAgentCommand:
         assert "write" not in cmd.command.split("--tools")[1]
 
     def test_pi_zai_model_override(self):
-        cmd = self._build("pi-zai", model="glm-5.1")
-        assert "--model glm-5.1" in cmd.command
+        cmd = self._build("pi-zai", model="glm-4.7-flash")
+        assert "--model glm-4.7-flash" in cmd.command
         # Default should not also appear
-        assert "--model glm-5 " not in cmd.command
+        assert "--model glm-5.1 " not in cmd.command
 
     def test_pi_zai_with_role_instructions(self):
         """pi-zai with role.instructions uses --append-system-prompt."""


### PR DESCRIPTION
## Summary
- `ActionNode.model` default: `glm-5` → `glm-5.1`
- `pi-zai` session `default_model` fallback: `glm-5` → `glm-5.1`
- All example workflow YAMLs drop redundant \`model:\` / \`provider:\` lines — they rely on defaults now, which doubles as documentation that those fields are optional
- Docs + skills updated
- Test fixture + assertions updated (override test now uses \`glm-4.7-flash\` so override != default)

## Why
Pi → Z.AI is the primary inference path for workflows. glm-5.1 is the latest model available on the Z.AI subscription, and provider zai is already the node default — both should be the implicit choice, not something every YAML repeats.

## Test plan
- [x] 701 tests pass
- [x] Manual: \`agentwire workflow run echo-chain --input topic=defaults\` — both nodes run with no model/provider declared in YAML

Built by [dotdev.dev](https://dotdev.dev)