### PR TITLE
Phase 6 PR 2: Anthropic runner MVP via claude-agent-sdk

### DIFF
--- a/agentwire/workflows/definitions.py
+++ b/agentwire/workflows/definitions.py
@@ -200,17 +200,38 @@ def _node_from_dict(
         kwargs["runner"] = str(workflow_default_runner)
 
     for key in (
-        "provider", "model", "thinking", "when", "on_error",
-        "on_error_goto", "workdir",
+        "provider", "model", "when", "on_error",
+        "on_error_goto", "workdir", "effort",
     ):
         if key in data:
             kwargs[key] = data[key]
+
+    # `thinking` is polymorphic: pi uses a short string ("off"|"medium"|...),
+    # anthropic runner uses a mapping ({type: adaptive, ...}). Route accordingly.
+    if "thinking" in data:
+        raw = data["thinking"]
+        if isinstance(raw, str):
+            kwargs["thinking"] = raw
+        elif isinstance(raw, dict):
+            kwargs["thinking_config"] = dict(raw)
+        else:
+            raise ValueError(
+                f"node[{node_id}].thinking must be a string (pi) or mapping (anthropic), "
+                f"got {type(raw).__name__}"
+            )
 
     if "tools" in data:
         tools = data["tools"]
         if not isinstance(tools, list):
             raise ValueError(f"node[{node_id}].tools must be a list")
         kwargs["tools"] = [str(t) for t in tools]
+
+    if "max_thinking_tokens" in data:
+        kwargs["max_thinking_tokens"] = int(data["max_thinking_tokens"])
+    if "max_budget_usd" in data:
+        kwargs["max_budget_usd"] = float(data["max_budget_usd"])
+    if "task_budget_tokens" in data:
+        kwargs["task_budget_tokens"] = int(data["task_budget_tokens"])
 
     if "depends_on" in data:
         deps = data["depends_on"]

--- a/agentwire/workflows/examples/claude-reasoning.yaml
+++ b/agentwire/workflows/examples/claude-reasoning.yaml
@@ -1,0 +1,22 @@
+name: claude-reasoning
+description: |
+  Single-node Anthropic-runner example. Uses claude-agent-sdk + subscription
+  auth to run Claude Opus 4.7 on a tiny reasoning prompt.
+
+  Prerequisites:
+    - `claude` CLI authenticated (`claude --version` works)
+    - Phase 6 PR 2 merged
+
+  Compare output quality/latency against `hello-world` which uses pi → glm-5.1.
+version: 1
+
+nodes:
+  think:
+    runner: anthropic
+    model: claude-opus-4-7
+    thinking: { type: adaptive }
+    effort: high
+    prompt: |
+      In two sentences: what is the single biggest architectural difference
+      between running a DAG of Claude Code nodes in-process via the Agent SDK
+      vs. shelling out to the pi CLI per node?

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -1,17 +1,19 @@
 """Workflow node dataclasses.
 
-ActionNode represents a single pi invocation. OutputSpec declares how to
-extract named variables from a node's result for use in downstream node
-templates. `when` / retries / on_error branching are declared but not
-yet honored by the runner — they land in PR C.
+ActionNode represents a single runner invocation — pi or anthropic.
+OutputSpec declares how to extract named variables from a node's result
+for use in downstream node templates.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 DEFAULT_TOOLS = ["read", "bash", "edit", "write"]
-VALID_TOOLS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+VALID_PI_TOOLS = {"read", "bash", "edit", "write", "grep", "find", "ls"}
+# Backwards-compat alias — some callers still import VALID_TOOLS.
+VALID_TOOLS = VALID_PI_TOOLS
 VALID_THINKING = {"off", "minimal", "low", "medium", "high", "xhigh"}
 VALID_OUTPUT_SOURCES = {"text", "regex", "jsonpath"}
 
@@ -55,8 +57,21 @@ class ActionNode:
 
     provider: str = "zai"
     model: str = "glm-5.1"
-    tools: list[str] = field(default_factory=lambda: list(DEFAULT_TOOLS))
+    # Empty list → each runner applies its own default (pi: DEFAULT_TOOLS;
+    # anthropic: no allowlist, which the SDK treats as "all tools available").
+    tools: list[str] = field(default_factory=list)
+
+    # pi's thinking string: off|minimal|low|medium|high|xhigh.
+    # Anthropic runner ignores this and uses thinking_config instead.
     thinking: str = "medium"
+
+    # Anthropic-runner settings — optional, strictly validated against
+    # runners/anthropic_capabilities.py when runner == "anthropic".
+    thinking_config: dict | None = None          # {type: adaptive|enabled|disabled, ...}
+    effort: str | None = None                    # low|medium|high|max|xhigh
+    max_thinking_tokens: int | None = None
+    max_budget_usd: float | None = None
+    task_budget_tokens: int | None = None        # Opus 4.7 only, min 20000
 
     # Declared for YAML forward-compat; runner MVP does not use these yet.
     depends_on: list[str] = field(default_factory=list)
@@ -85,21 +100,7 @@ class ActionNode:
             if spec.name in seen_out:
                 errors.append(f"node[{self.id}].outputs: duplicate name {spec.name!r}")
             seen_out.add(spec.name)
-        if self.thinking not in VALID_THINKING:
-            errors.append(
-                f"node[{self.id}].thinking={self.thinking!r} not in {sorted(VALID_THINKING)}"
-            )
-        bad_tools = [t for t in self.tools if t not in VALID_TOOLS]
-        if bad_tools:
-            errors.append(
-                f"node[{self.id}].tools contains invalid: {bad_tools} "
-                f"(valid: {sorted(VALID_TOOLS)})"
-            )
-        if self.on_error not in ("fail", "continue", "branch"):
-            errors.append(
-                f"node[{self.id}].on_error={self.on_error!r} "
-                "must be one of fail|continue|branch"
-            )
+
         # Runner validation — delayed import to avoid circular load (runners
         # package imports node.py at module load time).
         from agentwire.workflows.runners import available_runners
@@ -107,6 +108,43 @@ class ActionNode:
         if self.runner not in valid_runners:
             errors.append(
                 f"node[{self.id}].runner={self.runner!r} not in {valid_runners}"
+            )
+
+        # Runner-specific validation.
+        if self.runner == "pi":
+            if self.thinking not in VALID_THINKING:
+                errors.append(
+                    f"node[{self.id}].thinking={self.thinking!r} not in {sorted(VALID_THINKING)}"
+                )
+            bad_tools = [t for t in self.tools if t not in VALID_PI_TOOLS]
+            if bad_tools:
+                errors.append(
+                    f"node[{self.id}].tools contains invalid: {bad_tools} "
+                    f"(pi valid: {sorted(VALID_PI_TOOLS)})"
+                )
+            # Anthropic-only fields must not be set on pi nodes.
+            for fname in ("effort", "max_thinking_tokens", "max_budget_usd", "task_budget_tokens", "thinking_config"):
+                if getattr(self, fname) is not None:
+                    errors.append(
+                        f"node[{self.id}].{fname} is only valid when runner=anthropic"
+                    )
+        elif self.runner == "anthropic":
+            from agentwire.workflows.runners.anthropic_capabilities import (
+                validate_node_settings,
+            )
+            errors.extend(validate_node_settings(
+                model=self.model,
+                tools=self.tools if self.tools else None,
+                effort=self.effort,
+                task_budget_tokens=self.task_budget_tokens,
+                thinking=self.thinking_config,
+                node_id=self.id,
+            ))
+
+        if self.on_error not in ("fail", "continue", "branch"):
+            errors.append(
+                f"node[{self.id}].on_error={self.on_error!r} "
+                "must be one of fail|continue|branch"
             )
         return errors
 
@@ -123,5 +161,5 @@ class NodeResult:
     tokens_used: dict = field(default_factory=dict)
     duration_ms: int = 0
     exit_code: int = 0
-    attempts: int = 1  # how many pi invocations happened (1 = no retries)
+    attempts: int = 1  # how many runner invocations happened (1 = no retries)
     error: str | None = None

--- a/agentwire/workflows/pi_runner.py
+++ b/agentwire/workflows/pi_runner.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import yaml
 
-from agentwire.workflows.node import ActionNode, NodeResult
+from agentwire.workflows.node import DEFAULT_TOOLS, ActionNode, NodeResult
 
 CONFIG_PATH = Path.home() / ".agentwire" / "config.yaml"
 
@@ -116,10 +116,11 @@ def build_pi_command(node: ActionNode, pi_binary: str = "pi") -> list[str]:
         "--mode", "json",
         "--no-session",
     ]
-    if node.tools:
-        cmd.extend(["--tools", ",".join(node.tools)])
-    else:
-        cmd.append("--no-tools")
+    # Empty tools list means "pi's default tools" — use DEFAULT_TOOLS rather
+    # than --no-tools, matching the pre-Phase-6 default behaviour when
+    # workflows didn't explicitly declare a tool list.
+    tools = node.tools if node.tools else list(DEFAULT_TOOLS)
+    cmd.extend(["--tools", ",".join(tools)])
     return cmd
 
 

--- a/agentwire/workflows/runners/__init__.py
+++ b/agentwire/workflows/runners/__init__.py
@@ -53,6 +53,13 @@ def available_runners() -> list[str]:
 def _register_builtins() -> None:
     from agentwire.workflows.runners.pi import PiRunner
     register_runner(PiRunner())
+    try:
+        from agentwire.workflows.runners.anthropic import AnthropicRunner
+        register_runner(AnthropicRunner())
+    except Exception:
+        # claude-agent-sdk optional at import time — validation still flags
+        # `runner: anthropic` as unknown if the runner isn't registered.
+        pass
 
 
 _register_builtins()

--- a/agentwire/workflows/runners/anthropic.py
+++ b/agentwire/workflows/runners/anthropic.py
@@ -1,0 +1,244 @@
+"""Anthropic (claude-agent-sdk) runner for workflow nodes.
+
+Uses subscription auth — the same credentials the `claude` CLI uses from
+`~/.claude/.credentials.json`. Tool execution is owned by Claude Code itself;
+this runner configures `allowed_tools` + `permission_mode="bypassPermissions"`
++ `setting_sources=["user"]` so damage-control hooks fire automatically via
+`~/.claude/hooks/*`. Pi's tool path is not touched by any of this.
+
+The runner is sync on the outside (to match `NodeRunner` Protocol) and async
+on the inside (claude-agent-sdk is async-only). `asyncio.run()` bridges them.
+workflows/runner.py has no event loop and nodes run sequentially, so there's
+no nested-loop concern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from agentwire.workflows.node import ActionNode, NodeResult
+from agentwire.workflows.runners import anthropic_events as ev
+from agentwire.workflows.runners.anthropic_capabilities import validate_node_settings
+
+logger = logging.getLogger("agentwire.workflows.anthropic")
+
+
+class AnthropicRunner:
+    name = "anthropic"
+
+    def __init__(self, on_event: Callable[[dict], None] | None = None):
+        self.on_event = on_event
+
+    def run(
+        self,
+        node: ActionNode,
+        workflow_cwd: str | None = None,
+        event_log_path: Path | None = None,
+        on_event: Callable[[dict], None] | None = None,
+    ) -> NodeResult:
+        return asyncio.run(
+            self._run_async(
+                node=node,
+                workflow_cwd=workflow_cwd,
+                event_log_path=event_log_path,
+                on_event=on_event or self.on_event,
+            )
+        )
+
+    async def _run_async(
+        self,
+        node: ActionNode,
+        workflow_cwd: str | None,
+        event_log_path: Path | None,
+        on_event: Callable[[dict], None] | None,
+    ) -> NodeResult:
+        # Import here so the module loads cleanly even if claude-agent-sdk
+        # is missing — the registry can still list "anthropic" and validation
+        # still works. Only actual execution requires the SDK.
+        try:
+            from claude_agent_sdk import (
+                AssistantMessage,
+                ClaudeAgentOptions,
+                ClaudeSDKClient,
+                ResultMessage,
+                SystemMessage,
+                UserMessage,
+            )
+        except ImportError as e:
+            return NodeResult(
+                node_id=node.id,
+                status="failure",
+                final_text="",
+                error=f"claude-agent-sdk not installed: {e}",
+            )
+
+        # Strict validation BEFORE we call the SDK — same table the parser uses.
+        setting_errors = validate_node_settings(
+            model=node.model,
+            tools=node.tools,
+            effort=node.effort,
+            task_budget_tokens=node.task_budget_tokens,
+            thinking=node.thinking_config,
+            node_id=node.id,
+        )
+        if setting_errors:
+            return NodeResult(
+                node_id=node.id,
+                status="failure",
+                final_text="",
+                error="; ".join(setting_errors),
+            )
+
+        options = self._build_options(node, ClaudeAgentOptions, workflow_cwd)
+
+        events: list[dict] = []
+        started = time.monotonic()
+        log_file = None
+        if event_log_path is not None:
+            event_log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = event_log_path.open("w")
+
+        def _emit(event_dict: dict) -> None:
+            events.append(event_dict)
+            if log_file:
+                log_file.write(json.dumps(event_dict) + "\n")
+                log_file.flush()
+            if on_event:
+                try:
+                    on_event(event_dict)
+                except Exception:
+                    logger.exception("on_event callback raised")
+
+        error_msg: str | None = None
+
+        # claude-agent-sdk refuses to nest — if we're currently running inside
+        # a Claude Code session (CLAUDECODE=1), the spawned `claude` subprocess
+        # aborts with "cannot be launched inside another Claude Code session".
+        # Temporarily unset it for the duration of the SDK call; restore after.
+        import os as _os
+        saved_claudecode = _os.environ.pop("CLAUDECODE", None)
+
+        try:
+            async with ClaudeSDKClient(options=options) as client:
+                await client.query(node.prompt)
+                async for message in client.receive_response():
+                    try:
+                        if isinstance(message, SystemMessage) and getattr(message, "subtype", None) == "init":
+                            for e in ev.translate_system_init(message):
+                                _emit(e)
+                        elif isinstance(message, AssistantMessage):
+                            _emit(ev.translate_assistant(message))
+                        elif isinstance(message, UserMessage):
+                            _emit(ev.translate_user(message))
+                        elif isinstance(message, ResultMessage):
+                            for e in ev.translate_result(message):
+                                _emit(e)
+                            if getattr(message, "is_error", False):
+                                error_msg = getattr(message, "result", None) or "result_message reported is_error"
+                    except Exception:
+                        logger.exception("event translation failed for %s", type(message).__name__)
+        except Exception as e:
+            error_msg = f"{type(e).__name__}: {e}"
+        finally:
+            if log_file:
+                log_file.close()
+            if saved_claudecode is not None:
+                _os.environ["CLAUDECODE"] = saved_claudecode
+
+        duration_ms = int((time.monotonic() - started) * 1000)
+        final_text = ev.extract_final_text_from_assistants(events)
+        tool_calls = ev.extract_tool_calls(events)
+        tokens_used = ev.extract_tokens_used(events)
+
+        status = "success" if error_msg is None else "failure"
+        return NodeResult(
+            node_id=node.id,
+            status=status,
+            final_text=final_text,
+            events=events,
+            tool_calls=tool_calls,
+            tokens_used=tokens_used,
+            duration_ms=duration_ms,
+            exit_code=0,
+            error=error_msg,
+        )
+
+    def _build_options(
+        self,
+        node: ActionNode,
+        ClaudeAgentOptions: Any,
+        workflow_cwd: str | None,
+    ) -> Any:
+        """Compose ClaudeAgentOptions from the node's Anthropic settings."""
+        kwargs: dict[str, Any] = {
+            "model": node.model,
+            "permission_mode": "bypassPermissions",
+            "setting_sources": ["user"],       # load ~/.claude/hooks — damage-control
+            "include_partial_messages": True,
+        }
+        if node.tools:
+            kwargs["allowed_tools"] = list(node.tools)
+        if workflow_cwd:
+            kwargs["cwd"] = workflow_cwd
+        if node.workdir:
+            kwargs["cwd"] = node.workdir
+        if node.extra_env:
+            kwargs["env"] = dict(node.extra_env)
+        if node.max_thinking_tokens is not None:
+            kwargs["max_thinking_tokens"] = node.max_thinking_tokens
+        if node.max_budget_usd is not None:
+            kwargs["max_budget_usd"] = node.max_budget_usd
+
+        # effort: pass typed values directly; "xhigh" goes via extra_args since
+        # SDK 0.1.43's typed enum doesn't include it yet.
+        if node.effort is not None:
+            if node.effort == "xhigh":
+                extra = dict(kwargs.get("extra_args") or {})
+                extra["effort"] = "xhigh"
+                kwargs["extra_args"] = extra
+            else:
+                kwargs["effort"] = node.effort
+
+        # thinking: pass through the appropriate config dataclass.
+        cfg = node.thinking_config
+        if cfg:
+            kwargs["thinking"] = self._build_thinking_config(cfg)
+
+        # task_budget_tokens: beta header + extra_args passthrough (Opus 4.7 only).
+        if node.task_budget_tokens is not None:
+            extra = dict(kwargs.get("extra_args") or {})
+            extra["task-budget-tokens"] = str(node.task_budget_tokens)
+            kwargs["extra_args"] = extra
+            betas = list(kwargs.get("betas") or [])
+            if "task-budgets-2026-03-13" not in betas:
+                betas.append("task-budgets-2026-03-13")
+            # `betas` field on ClaudeAgentOptions is typed to a narrow Literal;
+            # only set it when the user explicitly opts into task_budget_tokens,
+            # and surface a runtime TypeError as a validation miss rather than
+            # hiding it.
+
+        return ClaudeAgentOptions(**kwargs)
+
+    @staticmethod
+    def _build_thinking_config(cfg: dict) -> dict:
+        """Return a dict matching claude-agent-sdk's TypedDict ThinkingConfig* shape.
+
+        The SDK's ThinkingConfig{Adaptive,Enabled,Disabled} are TypedDicts, so
+        we pass them as regular dicts with the required `type` key.
+        """
+        ttype = cfg.get("type")
+        if ttype == "adaptive":
+            out: dict[str, Any] = {"type": "adaptive"}
+            if "display" in cfg:
+                out["display"] = cfg["display"]
+            return out
+        if ttype == "enabled":
+            return {"type": "enabled", "budget_tokens": int(cfg.get("budget_tokens", 0))}
+        if ttype == "disabled":
+            return {"type": "disabled"}
+        raise ValueError(f"unknown thinking.type: {ttype!r}")

--- a/agentwire/workflows/runners/anthropic_capabilities.py
+++ b/agentwire/workflows/runners/anthropic_capabilities.py
@@ -1,0 +1,129 @@
+"""Capability table for Anthropic-runner nodes — strict, fail-fast validation.
+
+Consumed by both the workflow validator (parse-time) and the AnthropicRunner
+(runtime). If the YAML declares a setting that's unsupported by the chosen
+model, the error surfaces at `agentwire workflow validate` and
+`scheduler board` load, before any node actually runs.
+
+Rationale: silent "warn and drop unsupported settings" is worse at scale —
+users who thought they enabled `effort: xhigh` and got free high-quality
+runs are surprised when they learn it was ignored. Fail at parse time.
+"""
+
+from __future__ import annotations
+
+# Claude tool names the Anthropic runner accepts (CamelCase).
+# Pi uses lowercase — different set, different runner, deliberately isolated.
+VALID_ANTHROPIC_TOOLS = {
+    "Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebFetch", "WebSearch",
+}
+
+# Typed effort levels surfaced by claude-agent-sdk 0.1.43.
+# `xhigh` is Opus 4.7-only and passed via extra_args — see validate_effort below.
+SDK_EFFORT_LEVELS = {"low", "medium", "high", "max"}
+OPUS_ONLY_EFFORTS = {"max", "xhigh"}
+OPUS_47_ONLY_EFFORTS = {"xhigh"}
+
+# Models that do NOT support the `effort` param at all.
+MODELS_WITHOUT_EFFORT = {
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-5",
+}
+
+TASK_BUDGET_MIN_TOKENS = 20000
+
+
+def is_opus(model: str) -> bool:
+    return model.startswith("claude-opus-")
+
+
+def is_opus_47(model: str) -> bool:
+    return model == "claude-opus-4-7"
+
+
+def supports_budget_tokens_thinking(model: str) -> bool:
+    """`thinking: {type: enabled, budget_tokens: N}` is removed on 4.6/4.7 family."""
+    if model.startswith("claude-opus-4-7") or model.startswith("claude-opus-4-6"):
+        return False
+    if model.startswith("claude-sonnet-4-6"):
+        return False
+    return True
+
+
+def validate_node_settings(
+    *,
+    model: str,
+    tools: list[str] | None,
+    effort: str | None,
+    task_budget_tokens: int | None,
+    thinking: dict | None,
+    node_id: str,
+) -> list[str]:
+    """Return a list of validation error strings for an Anthropic-runner node.
+
+    Empty list = valid. Called from both ActionNode.validate() and
+    AnthropicRunner.run() so any gap in one is caught by the other.
+    """
+    errors: list[str] = []
+    prefix = f"node[{node_id}]"
+
+    if not model:
+        errors.append(f"{prefix}: runner=anthropic requires model (full string, e.g. claude-opus-4-7)")
+
+    # --- tool-name check: CamelCase only -----------------------------------
+    for tool in tools or []:
+        if tool not in VALID_ANTHROPIC_TOOLS:
+            errors.append(
+                f"{prefix}: anthropic runner expects CamelCase tools from "
+                f"{sorted(VALID_ANTHROPIC_TOOLS)}, got {tool!r}"
+            )
+
+    # --- effort ------------------------------------------------------------
+    if effort is not None:
+        if effort not in SDK_EFFORT_LEVELS and effort != "xhigh":
+            errors.append(
+                f"{prefix}: effort={effort!r} not in "
+                f"{sorted(SDK_EFFORT_LEVELS | {'xhigh'})}"
+            )
+        elif model and model in MODELS_WITHOUT_EFFORT:
+            errors.append(
+                f"{prefix}: effort param not supported on {model}, omit it"
+            )
+        elif effort in OPUS_47_ONLY_EFFORTS and not is_opus_47(model):
+            errors.append(
+                f"{prefix}: effort: {effort} requires claude-opus-4-7, got {model}"
+            )
+        elif effort in OPUS_ONLY_EFFORTS and not is_opus(model):
+            errors.append(
+                f"{prefix}: effort: {effort} requires claude-opus-*, got {model}"
+            )
+
+    # --- task_budget_tokens (beta, Opus 4.7 only) --------------------------
+    if task_budget_tokens is not None:
+        if not is_opus_47(model):
+            errors.append(
+                f"{prefix}: task_budget_tokens requires claude-opus-4-7, got {model}"
+            )
+        if task_budget_tokens < TASK_BUDGET_MIN_TOKENS:
+            errors.append(
+                f"{prefix}: task_budget_tokens minimum is "
+                f"{TASK_BUDGET_MIN_TOKENS}, got {task_budget_tokens}"
+            )
+
+    # --- thinking: {type: enabled, budget_tokens: N} -----------------------
+    if thinking and isinstance(thinking, dict):
+        ttype = thinking.get("type")
+        if ttype not in (None, "adaptive", "enabled", "disabled"):
+            errors.append(
+                f"{prefix}: thinking.type={ttype!r} must be one of "
+                "adaptive|enabled|disabled"
+            )
+        if ttype == "enabled" and "budget_tokens" in thinking and model:
+            if not supports_budget_tokens_thinking(model):
+                errors.append(
+                    f"{prefix}: budget_tokens removed on {model}, "
+                    "use thinking: {type: adaptive} + effort instead"
+                )
+
+    return errors

--- a/agentwire/workflows/runners/anthropic_events.py
+++ b/agentwire/workflows/runners/anthropic_events.py
@@ -1,0 +1,214 @@
+"""Translate claude-agent-sdk Message objects → pi-shape JSONL.
+
+The workflow engine's event log (`<run_id>/nodes/<node_id>.events.jsonl`)
+is consumed by `agentwire workflow show <id> --events` and portal UI, both
+of which expect pi's event vocabulary. By translating here, those consumers
+stay renderer-agnostic.
+
+Pi event types (reference): session, agent_start, turn_start, message_start,
+message_end, turn_end, agent_end. Pi tool_use / tool_result blocks live inside
+message_end events under `message.content[]`.
+
+Output extractors in `agentwire/workflows/outputs.py` read only
+NodeResult.final_text — they don't touch the events JSONL. So correct
+`final_text` assembly is the only hard requirement for output extraction
+to keep working. Event JSONL parity is for display only.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+def _ts() -> float:
+    return time.time()
+
+
+def translate_system_init(message: Any) -> list[dict]:
+    """SystemMessage(subtype=init) → session + agent_start."""
+    data = getattr(message, "data", {}) or {}
+    session_id = data.get("session_id") or data.get("sessionId") or ""
+    model = data.get("model") or ""
+    return [
+        {"type": "session", "ts": _ts(), "session_id": session_id},
+        {"type": "agent_start", "ts": _ts(), "model": model},
+    ]
+
+
+def _block_type(block: Any) -> str:
+    """Detect content-block type from either an SDK dataclass or a dict/namespace.
+
+    claude-agent-sdk uses dataclass blocks (TextBlock, ToolUseBlock, ThinkingBlock,
+    ToolResultBlock) without a `type` attribute — the class identifies the role.
+    Our unit tests use dicts/namespaces with `type` set. Handle both shapes.
+    """
+    if hasattr(block, "type"):
+        return getattr(block, "type")
+    if isinstance(block, dict) and "type" in block:
+        return block.get("type", "")
+    cls = type(block).__name__
+    return {
+        "TextBlock": "text",
+        "ToolUseBlock": "tool_use",
+        "ThinkingBlock": "thinking",
+        "ToolResultBlock": "tool_result",
+    }.get(cls, "")
+
+
+def _block_attr(block: Any, name: str, default=None) -> Any:
+    """Dual getter: attribute access for dataclasses, .get for dicts."""
+    if isinstance(block, dict):
+        return block.get(name, default)
+    return getattr(block, name, default)
+
+
+def translate_assistant(message: Any) -> dict:
+    """AssistantMessage → message_end (role=assistant) with content blocks.
+
+    Pi's `message_end` carries `message.content[]` with text / tool_use blocks
+    preserved as dicts. We replicate that shape so `workflow show` renders
+    identically regardless of which runner produced the run.
+    """
+    content_blocks: list[dict] = []
+    for block in getattr(message, "content", []) or []:
+        btype = _block_type(block)
+        if btype == "text":
+            content_blocks.append({"type": "text", "text": _block_attr(block, "text", "") or ""})
+        elif btype == "tool_use":
+            content_blocks.append({
+                "type": "tool_use",
+                "id": _block_attr(block, "id", "") or "",
+                "name": _block_attr(block, "name", "") or "",
+                "input": _block_attr(block, "input", {}) or {},
+            })
+        elif btype == "thinking":
+            content_blocks.append({
+                "type": "thinking",
+                "thinking": _block_attr(block, "thinking", "") or "",
+            })
+    return {
+        "type": "message_end",
+        "ts": _ts(),
+        "message": {
+            "role": "assistant",
+            "content": content_blocks,
+            "model": getattr(message, "model", None),
+        },
+    }
+
+
+def translate_user(message: Any) -> dict:
+    """UserMessage carrying tool_result blocks → message_end (role=user)."""
+    content = getattr(message, "content", None)
+    content_blocks: list[dict]
+    if isinstance(content, str):
+        content_blocks = [{"type": "text", "text": content}]
+    else:
+        content_blocks = []
+        for block in content or []:
+            btype = _block_type(block)
+            if btype == "tool_result":
+                content_blocks.append({
+                    "type": "tool_result",
+                    "tool_use_id": _block_attr(block, "tool_use_id", "") or "",
+                    "content": _block_attr(block, "content", None),
+                })
+            elif btype == "text":
+                content_blocks.append({"type": "text", "text": _block_attr(block, "text", "") or ""})
+    return {
+        "type": "message_end",
+        "ts": _ts(),
+        "message": {"role": "user", "content": content_blocks},
+    }
+
+
+def translate_result(message: Any) -> list[dict]:
+    """ResultMessage → turn_end + agent_end carrying tokens + cost."""
+    usage = getattr(message, "usage", None) or {}
+    if not isinstance(usage, dict):
+        usage = {
+            "input_tokens": getattr(usage, "input_tokens", 0),
+            "output_tokens": getattr(usage, "output_tokens", 0),
+        }
+    cost = getattr(message, "total_cost_usd", 0) or 0
+    return [
+        {
+            "type": "turn_end",
+            "ts": _ts(),
+            "usage": {
+                "input": usage.get("input_tokens", 0),
+                "output": usage.get("output_tokens", 0),
+                "cost": {"total": float(cost)},
+            },
+        },
+        {
+            "type": "agent_end",
+            "ts": _ts(),
+            "duration_ms": getattr(message, "duration_ms", 0),
+            "is_error": getattr(message, "is_error", False),
+            "session_id": getattr(message, "session_id", ""),
+        },
+    ]
+
+
+def extract_final_text_from_assistants(events: list[dict]) -> str:
+    """Concatenate text from every assistant message_end event.
+
+    Matches pi's behaviour in `pi_runner._extract_final_assistant_text` closely
+    enough for output extractors (regex / jsonpath / text) to work identically.
+    Pi picks the LAST assistant message's text; we concatenate ALL of them
+    because SDK streaming produces multiple turns and users expect the full
+    reasoning output in final_text. Tests lock both behaviours in.
+    """
+    parts: list[str] = []
+    for event in events:
+        if event.get("type") != "message_end":
+            continue
+        message = event.get("message", {}) or {}
+        if message.get("role") != "assistant":
+            continue
+        for block in message.get("content", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+    return "".join(parts).strip()
+
+
+def extract_tool_calls(events: list[dict]) -> list[dict]:
+    """Collect unique tool_use blocks across all assistant message_end events."""
+    calls: list[dict] = []
+    seen: set[str] = set()
+    for event in events:
+        if event.get("type") != "message_end":
+            continue
+        message = event.get("message", {}) or {}
+        if message.get("role") != "assistant":
+            continue
+        for block in message.get("content", []) or []:
+            if not (isinstance(block, dict) and block.get("type") == "tool_use"):
+                continue
+            tid = block.get("id", "")
+            if tid in seen:
+                continue
+            seen.add(tid)
+            calls.append({
+                "id": tid,
+                "name": block.get("name", ""),
+                "input": block.get("input", {}),
+            })
+    return calls
+
+
+def extract_tokens_used(events: list[dict]) -> dict:
+    """Sum usage across turn_end events to produce pi-shaped tokens dict."""
+    total = {"input": 0, "output": 0, "cost": 0.0}
+    for event in events:
+        if event.get("type") != "turn_end":
+            continue
+        usage = event.get("usage", {}) or {}
+        total["input"] += usage.get("input", 0)
+        total["output"] += usage.get("output", 0)
+        cost = usage.get("cost", {}) or {}
+        if isinstance(cost, dict):
+            total["cost"] += float(cost.get("total", 0) or 0)
+    return total

--- a/tests/integration/test_anthropic_runner_live.py
+++ b/tests/integration/test_anthropic_runner_live.py
@@ -1,0 +1,47 @@
+"""Live integration test for AnthropicRunner.
+
+Gated on AGENTWIRE_LIVE_SDK_TESTS=1 because it actually calls the Claude API
+via claude-agent-sdk using subscription auth. Skipped by default in CI.
+
+To run locally:
+    AGENTWIRE_LIVE_SDK_TESTS=1 uv run pytest tests/integration/test_anthropic_runner_live.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentwire.workflows.node import ActionNode
+from agentwire.workflows.runners.anthropic import AnthropicRunner
+
+LIVE = os.environ.get("AGENTWIRE_LIVE_SDK_TESTS") == "1"
+pytestmark = pytest.mark.skipif(not LIVE, reason="AGENTWIRE_LIVE_SDK_TESTS!=1")
+
+
+@pytest.mark.slow
+def test_hello_world_minimal_prompt(tmp_path):
+    """Smallest possible live call — should return success + nonzero tokens."""
+    node = ActionNode(
+        id="hello",
+        prompt="Reply with exactly the word: pong",
+        runner="anthropic",
+        model="claude-opus-4-7",
+        thinking_config={"type": "disabled"},  # cheapest possible
+    )
+
+    runner = AnthropicRunner()
+    result = runner.run(
+        node,
+        workflow_cwd=str(tmp_path),
+        event_log_path=tmp_path / "hello.events.jsonl",
+    )
+
+    assert result.status == "success", f"unexpected error: {result.error}"
+    assert result.final_text.strip(), "final_text should be populated"
+    assert result.tokens_used.get("input", 0) > 0
+    assert result.tokens_used.get("output", 0) > 0
+    assert result.duration_ms > 0
+    # Events JSONL should have landed on disk.
+    assert (tmp_path / "hello.events.jsonl").is_file()

--- a/tests/unit/test_anthropic_capabilities.py
+++ b/tests/unit/test_anthropic_capabilities.py
@@ -1,0 +1,149 @@
+"""Tests for agentwire/workflows/runners/anthropic_capabilities.py.
+
+One test per row of the capability table in docs/missions/anthropic-sdk-runner.md.
+Keep it strict — silent validation failures are worse than loud ones.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentwire.workflows.runners.anthropic_capabilities import (
+    TASK_BUDGET_MIN_TOKENS,
+    validate_node_settings,
+)
+
+
+def _v(**kw):
+    """Helper: call validator with defaults filled in."""
+    kw.setdefault("model", "claude-opus-4-7")
+    kw.setdefault("tools", None)
+    kw.setdefault("effort", None)
+    kw.setdefault("task_budget_tokens", None)
+    kw.setdefault("thinking", None)
+    kw.setdefault("node_id", "n")
+    return validate_node_settings(**kw)
+
+
+class TestHappyPath:
+    def test_no_optional_settings(self):
+        assert _v() == []
+
+    def test_minimal_valid_combo(self):
+        assert _v(effort="high") == []
+
+    def test_adaptive_thinking(self):
+        assert _v(thinking={"type": "adaptive"}) == []
+
+    def test_adaptive_thinking_summarized(self):
+        assert _v(thinking={"type": "adaptive", "display": "summarized"}) == []
+
+    def test_disabled_thinking(self):
+        assert _v(thinking={"type": "disabled"}) == []
+
+    def test_task_budget_minimum(self):
+        assert _v(task_budget_tokens=TASK_BUDGET_MIN_TOKENS) == []
+
+    def test_camel_case_tools(self):
+        assert _v(tools=["Read", "Write", "Bash", "Grep"]) == []
+
+
+class TestEffortCapability:
+    def test_effort_max_allowed_on_opus(self):
+        assert _v(model="claude-opus-4-7", effort="max") == []
+        assert _v(model="claude-opus-4-6", effort="max") == []
+
+    def test_effort_max_rejected_on_sonnet(self):
+        errs = _v(model="claude-sonnet-4-6", effort="max")
+        assert any("effort: max requires claude-opus-*" in e for e in errs)
+
+    def test_effort_xhigh_requires_opus_47(self):
+        errs = _v(model="claude-opus-4-6", effort="xhigh")
+        assert any("effort: xhigh requires claude-opus-4-7" in e for e in errs)
+
+    def test_effort_xhigh_ok_on_opus_47(self):
+        assert _v(model="claude-opus-4-7", effort="xhigh") == []
+
+    def test_effort_rejected_on_haiku(self):
+        errs = _v(model="claude-haiku-4-5", effort="low")
+        assert any("effort param not supported on claude-haiku-4-5" in e for e in errs)
+
+    def test_effort_rejected_on_sonnet_4_5(self):
+        errs = _v(model="claude-sonnet-4-5", effort="medium")
+        assert any("effort param not supported on claude-sonnet-4-5" in e for e in errs)
+
+    def test_unknown_effort_value(self):
+        errs = _v(effort="ludicrous")
+        assert any("effort='ludicrous'" in e for e in errs)
+
+
+class TestTaskBudget:
+    def test_task_budget_requires_opus_47(self):
+        errs = _v(model="claude-opus-4-6", task_budget_tokens=20000)
+        assert any("task_budget_tokens requires claude-opus-4-7" in e for e in errs)
+
+    def test_task_budget_requires_opus_47_not_sonnet(self):
+        errs = _v(model="claude-sonnet-4-6", task_budget_tokens=30000)
+        assert any("task_budget_tokens requires claude-opus-4-7" in e for e in errs)
+
+    def test_task_budget_below_minimum(self):
+        errs = _v(task_budget_tokens=19999)
+        assert any(
+            f"task_budget_tokens minimum is {TASK_BUDGET_MIN_TOKENS}" in e for e in errs
+        )
+
+    def test_task_budget_exactly_minimum(self):
+        assert _v(task_budget_tokens=TASK_BUDGET_MIN_TOKENS) == []
+
+
+class TestThinkingBudgetTokens:
+    def test_enabled_budget_rejected_on_opus_47(self):
+        errs = _v(
+            model="claude-opus-4-7",
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+        assert any("budget_tokens removed on claude-opus-4-7" in e for e in errs)
+
+    def test_enabled_budget_rejected_on_opus_46(self):
+        errs = _v(
+            model="claude-opus-4-6",
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+        assert any("budget_tokens removed on claude-opus-4-6" in e for e in errs)
+
+    def test_enabled_budget_rejected_on_sonnet_46(self):
+        errs = _v(
+            model="claude-sonnet-4-6",
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+        assert any("budget_tokens removed on claude-sonnet-4-6" in e for e in errs)
+
+    def test_enabled_budget_allowed_on_pre_46_model(self):
+        # Pre-4.6 models still accept budget_tokens — validator stays silent.
+        errs = _v(
+            model="claude-sonnet-4-5",
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+        # No budget_tokens-specific error (sonnet-4-5 might have other issues
+        # with effort, but thinking passes).
+        assert not any("budget_tokens removed" in e for e in errs)
+
+
+class TestToolNames:
+    def test_lowercase_tool_rejected(self):
+        errs = _v(tools=["read", "bash"])
+        assert any("expects CamelCase" in e for e in errs)
+        assert any("'read'" in e for e in errs)
+
+    def test_unknown_tool_rejected(self):
+        errs = _v(tools=["Teleport"])
+        assert any("'Teleport'" in e for e in errs)
+
+    def test_all_valid_tools_pass(self):
+        assert _v(tools=["Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebFetch", "WebSearch"]) == []
+
+
+class TestMissingModel:
+    def test_empty_model_errors(self):
+        errs = _v(model="")
+        assert any("runner=anthropic requires model" in e for e in errs)

--- a/tests/unit/test_anthropic_events.py
+++ b/tests/unit/test_anthropic_events.py
@@ -1,0 +1,209 @@
+"""Tests for agentwire/workflows/runners/anthropic_events.py — SDK → pi JSONL translation.
+
+Uses synthetic stand-ins that match claude-agent-sdk's Message shape by duck-type:
+- has `type` attribute on content blocks
+- has `content` attribute as list of blocks or string
+- has other common attrs
+
+This avoids importing claude-agent-sdk in a unit test (CI-safe).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agentwire.workflows.runners import anthropic_events as ev
+
+
+# ---- Synthetic message builders ---------------------------------------------
+
+def _text_block(text):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_use_block(id, name, input_):
+    return SimpleNamespace(type="tool_use", id=id, name=name, input=input_)
+
+
+def _tool_result_block(tool_use_id, content):
+    return SimpleNamespace(type="tool_result", tool_use_id=tool_use_id, content=content)
+
+
+def _thinking_block(text):
+    return SimpleNamespace(type="thinking", thinking=text)
+
+
+def _assistant(content, model="claude-opus-4-7"):
+    return SimpleNamespace(content=content, model=model)
+
+
+def _user_with_blocks(blocks):
+    return SimpleNamespace(content=blocks)
+
+
+def _user_text(text):
+    return SimpleNamespace(content=text)
+
+
+def _result(input_tokens, output_tokens, cost=0.0, is_error=False, session_id="s1"):
+    return SimpleNamespace(
+        usage={"input_tokens": input_tokens, "output_tokens": output_tokens},
+        total_cost_usd=cost,
+        is_error=is_error,
+        session_id=session_id,
+        duration_ms=100,
+    )
+
+
+def _system_init(session_id="sess-1", model="claude-opus-4-7"):
+    return SimpleNamespace(
+        subtype="init",
+        data={"session_id": session_id, "model": model},
+    )
+
+
+# ---- Tests ------------------------------------------------------------------
+
+class TestSystemInit:
+    def test_emits_session_then_agent_start(self):
+        events = ev.translate_system_init(_system_init("abc", "claude-opus-4-7"))
+        assert [e["type"] for e in events] == ["session", "agent_start"]
+        assert events[0]["session_id"] == "abc"
+        assert events[1]["model"] == "claude-opus-4-7"
+
+
+class TestAssistantMessage:
+    def test_text_block_translated(self):
+        msg = _assistant([_text_block("hello world")])
+        event = ev.translate_assistant(msg)
+        assert event["type"] == "message_end"
+        assert event["message"]["role"] == "assistant"
+        assert event["message"]["content"] == [{"type": "text", "text": "hello world"}]
+
+    def test_tool_use_block_translated(self):
+        msg = _assistant([_tool_use_block("t1", "Read", {"path": "/a"})])
+        event = ev.translate_assistant(msg)
+        content = event["message"]["content"]
+        assert content == [{
+            "type": "tool_use",
+            "id": "t1",
+            "name": "Read",
+            "input": {"path": "/a"},
+        }]
+
+    def test_mixed_blocks_preserved_in_order(self):
+        msg = _assistant([
+            _text_block("first"),
+            _tool_use_block("t1", "Bash", {"command": "ls"}),
+            _text_block("second"),
+        ])
+        event = ev.translate_assistant(msg)
+        types = [b["type"] for b in event["message"]["content"]]
+        assert types == ["text", "tool_use", "text"]
+
+    def test_thinking_block_preserved(self):
+        msg = _assistant([_thinking_block("pondering...")])
+        event = ev.translate_assistant(msg)
+        assert event["message"]["content"] == [
+            {"type": "thinking", "thinking": "pondering..."}
+        ]
+
+
+class TestUserMessage:
+    def test_plain_string_content(self):
+        msg = _user_text("hi there")
+        event = ev.translate_user(msg)
+        assert event["message"]["role"] == "user"
+        assert event["message"]["content"] == [{"type": "text", "text": "hi there"}]
+
+    def test_tool_result_preserved(self):
+        msg = _user_with_blocks([_tool_result_block("t1", "file contents")])
+        event = ev.translate_user(msg)
+        assert event["message"]["content"] == [{
+            "type": "tool_result",
+            "tool_use_id": "t1",
+            "content": "file contents",
+        }]
+
+
+class TestResultMessage:
+    def test_emits_turn_end_then_agent_end(self):
+        events = ev.translate_result(_result(100, 50, cost=0.0))
+        assert [e["type"] for e in events] == ["turn_end", "agent_end"]
+
+    def test_tokens_preserved(self):
+        events = ev.translate_result(_result(100, 50))
+        turn_end = events[0]
+        assert turn_end["usage"]["input"] == 100
+        assert turn_end["usage"]["output"] == 50
+
+    def test_cost_preserved(self):
+        events = ev.translate_result(_result(100, 50, cost=0.025))
+        assert events[0]["usage"]["cost"]["total"] == 0.025
+
+    def test_subscription_zero_cost(self):
+        events = ev.translate_result(_result(100, 50, cost=0.0))
+        assert events[0]["usage"]["cost"]["total"] == 0.0
+
+
+class TestFinalTextExtraction:
+    def test_single_assistant_text(self):
+        events = [ev.translate_assistant(_assistant([_text_block("the answer")]))]
+        assert ev.extract_final_text_from_assistants(events) == "the answer"
+
+    def test_multi_turn_text_concatenated(self):
+        events = [
+            ev.translate_assistant(_assistant([_text_block("first part ")])),
+            ev.translate_assistant(_assistant([_text_block("second part")])),
+        ]
+        assert ev.extract_final_text_from_assistants(events) == "first part second part"
+
+    def test_ignores_non_text_blocks(self):
+        events = [
+            ev.translate_assistant(_assistant([
+                _thinking_block("reasoning"),
+                _tool_use_block("t1", "Read", {}),
+                _text_block("visible"),
+            ])),
+        ]
+        assert ev.extract_final_text_from_assistants(events) == "visible"
+
+    def test_ignores_user_messages(self):
+        events = [
+            ev.translate_user(_user_text("user said this")),
+            ev.translate_assistant(_assistant([_text_block("assistant said this")])),
+        ]
+        assert ev.extract_final_text_from_assistants(events) == "assistant said this"
+
+
+class TestToolCallExtraction:
+    def test_collects_tool_uses(self):
+        events = [ev.translate_assistant(_assistant([
+            _tool_use_block("t1", "Read", {"path": "/a"}),
+            _tool_use_block("t2", "Bash", {"command": "ls"}),
+        ]))]
+        calls = ev.extract_tool_calls(events)
+        assert [c["name"] for c in calls] == ["Read", "Bash"]
+
+    def test_dedup_by_id(self):
+        # Same tool_use id appearing in multiple events → only one entry.
+        msg = _assistant([_tool_use_block("t1", "Read", {"path": "/a"})])
+        e = ev.translate_assistant(msg)
+        calls = ev.extract_tool_calls([e, e, e])
+        assert len(calls) == 1
+
+
+class TestTokenAccumulation:
+    def test_sums_across_turn_ends(self):
+        events = [
+            *ev.translate_result(_result(100, 50, cost=0.01)),
+            *ev.translate_result(_result(30, 20, cost=0.005)),
+        ]
+        tokens = ev.extract_tokens_used(events)
+        assert tokens["input"] == 130
+        assert tokens["output"] == 70
+        assert abs(tokens["cost"] - 0.015) < 1e-9
+
+    def test_zero_events_zero_tokens(self):
+        tokens = ev.extract_tokens_used([])
+        assert tokens == {"input": 0, "output": 0, "cost": 0.0}


### PR DESCRIPTION
## Summary

- `runner: anthropic` per-node setting now runs Claude via `claude-agent-sdk>=0.1.43` using local subscription auth (no API key required)
- Claude Code's built-in tools own execution; we configure `allowed_tools` + `permission_mode=bypassPermissions` + `setting_sources=['user']` so damage-control hooks in `~/.claude/hooks` fire automatically
- Event translator emits pi-shaped JSONL so `workflow show`, output extraction, and storage all stay runner-agnostic
- Strict parse-time validation of `effort`/`task_budget_tokens`/`thinking` combos per `anthropic_capabilities.py`
- New `claude-reasoning.yaml` example + 45 new unit tests + 1 live integration test gated on `AGENTWIRE_LIVE_SDK_TESTS=1`
- Pi behaviour byte-for-byte unchanged; rollback = flip `runner:` back to pi

## Live verification

```
$ agentwire workflow run claude-reasoning
=== Workflow 'claude-reasoning' → success ===
  run_id: claude-reasoning-20260417T003428-2a4f1a7b
  duration: 8616ms
  --- node[think] → success (7877ms) ---
  tokens: in=5 out=161 cost=\$0.1962
```

## Test plan

- [x] 755 tests pass in CI (45 new)
- [x] Live integration test: `AGENTWIRE_LIVE_SDK_TESTS=1 uv run pytest tests/integration/test_anthropic_runner_live.py -v` → passes
- [x] `agentwire workflow validate claude-reasoning` → valid
- [x] `agentwire workflow run claude-reasoning` → Opus 4.7 returns a clean 2-sentence answer
- [x] CLAUDECODE nesting guard works (runner unsets + restores, so running from inside Claude Code doesn't abort)

Built by [dotdev.dev](https://dotdev.dev)