### PR TITLE
Phase 6 PR 3: anthropic runner tool use + damage-control verification

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -24,7 +24,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 

--- a/agentwire/workflows/examples/claude-tool-use.yaml
+++ b/agentwire/workflows/examples/claude-tool-use.yaml
@@ -1,0 +1,20 @@
+name: claude-tool-use
+description: |
+  Single-node Anthropic-runner example showing Claude's Read tool in action.
+  Reads the repo's README.md and produces a two-sentence summary.
+
+  Prerequisites:
+    - `claude` CLI authenticated (`claude --version` works)
+    - Run from the agentwire-dev repo root so README.md is in CWD
+version: 1
+
+nodes:
+  summarize_readme:
+    runner: anthropic
+    model: claude-opus-4-7
+    tools: [Read]
+    thinking: { type: adaptive }
+    effort: high
+    prompt: |
+      Read README.md in the current directory. In two sentences,
+      describe what AgentWire does and who it is for.

--- a/agentwire/workflows/runners/anthropic.py
+++ b/agentwire/workflows/runners/anthropic.py
@@ -3,8 +3,10 @@
 Uses subscription auth — the same credentials the `claude` CLI uses from
 `~/.claude/.credentials.json`. Tool execution is owned by Claude Code itself;
 this runner configures `allowed_tools` + `permission_mode="bypassPermissions"`
-+ `setting_sources=["user"]` so damage-control hooks fire automatically via
-`~/.claude/hooks/*`. Pi's tool path is not touched by any of this.
++ `setting_sources=["user"]` so PreToolUse hooks referenced from
+`~/.claude/settings.json` fire automatically — including AgentWire's
+damage-control hooks at `~/.agentwire/hooks/damage-control/*`. Pi's tool path
+is not touched by any of this.
 
 The runner is sync on the outside (to match `NodeRunner` Protocol) and async
 on the inside (claude-agent-sdk is async-only). `asyncio.run()` bridges them.
@@ -17,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -26,6 +29,35 @@ from agentwire.workflows.runners import anthropic_events as ev
 from agentwire.workflows.runners.anthropic_capabilities import validate_node_settings
 
 logger = logging.getLogger("agentwire.workflows.anthropic")
+
+
+# Error-message substrings that mark a failure as transient (worth retrying
+# via the workflow-level node.retries loop). Classification only — we don't
+# add an inner retry loop here; outer retry handles all failure kinds, and
+# this prefix is purely informational so users see at a glance why a node
+# failed. PR 6 canary data will tell us whether inner backoff pays.
+_TRANSIENT_MARKERS = (
+    "overloaded", "rate_limit", "rate limit", " 429", " 529", " 503",
+)
+_AUTH_MARKERS = ("authentication", "unauthorized", " 401", " 403")
+_INVALID_MARKERS = ("invalid_request", " 400", "validation")
+
+
+def _classify(err_type: str, err_msg: str) -> str:
+    """Return a prefix category for an SDK-side error.
+
+    Not a retry decision — just a human-readable tag on NodeResult.error so
+    logs and morning reports can distinguish rate-limited runs from genuine
+    bugs.
+    """
+    haystack = f"{err_type} {err_msg}".lower()
+    if any(m in haystack for m in _TRANSIENT_MARKERS):
+        return "transient"
+    if any(m in haystack for m in _AUTH_MARKERS):
+        return "permanent"
+    if any(m in haystack for m in _INVALID_MARKERS):
+        return "invalid"
+    return "error"
 
 
 class AnthropicRunner:
@@ -120,8 +152,7 @@ class AnthropicRunner:
         # a Claude Code session (CLAUDECODE=1), the spawned `claude` subprocess
         # aborts with "cannot be launched inside another Claude Code session".
         # Temporarily unset it for the duration of the SDK call; restore after.
-        import os as _os
-        saved_claudecode = _os.environ.pop("CLAUDECODE", None)
+        saved_claudecode = os.environ.pop("CLAUDECODE", None)
 
         try:
             async with ClaudeSDKClient(options=options) as client:
@@ -143,12 +174,13 @@ class AnthropicRunner:
                     except Exception:
                         logger.exception("event translation failed for %s", type(message).__name__)
         except Exception as e:
-            error_msg = f"{type(e).__name__}: {e}"
+            err_type = type(e).__name__
+            error_msg = f"{_classify(err_type, str(e))}: {err_type}: {e}"
         finally:
             if log_file:
                 log_file.close()
             if saved_claudecode is not None:
-                _os.environ["CLAUDECODE"] = saved_claudecode
+                os.environ["CLAUDECODE"] = saved_claudecode
 
         duration_ms = int((time.monotonic() - started) * 1000)
         final_text = ev.extract_final_text_from_assistants(events)

--- a/tests/integration/test_anthropic_runner_live.py
+++ b/tests/integration/test_anthropic_runner_live.py
@@ -10,6 +10,10 @@ To run locally:
 from __future__ import annotations
 
 import os
+import shlex
+import shutil
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +22,22 @@ from agentwire.workflows.runners.anthropic import AnthropicRunner
 
 LIVE = os.environ.get("AGENTWIRE_LIVE_SDK_TESTS") == "1"
 pytestmark = pytest.mark.skipif(not LIVE, reason="AGENTWIRE_LIVE_SDK_TESTS!=1")
+
+
+@pytest.fixture
+def neutral_tmpdir():
+    """A tempdir with a neutral-looking prefix — pytest's default tmp_path
+    uses paths like `pytest-of-dotdev/test_bash_rm_blocked_by0/` which Opus
+    4.7 spots and preemptively refuses to act on, thinking it's a test probe.
+    Using `tempfile.mkdtemp(prefix="agentwire-workspace-")` gives Claude a
+    neutral CWD so the damage-control hook is what stops the command, not
+    the model's own suspicion.
+    """
+    path = Path(tempfile.mkdtemp(prefix="agentwire-workspace-"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.mark.slow
@@ -45,3 +65,154 @@ def test_hello_world_minimal_prompt(tmp_path):
     assert result.duration_ms > 0
     # Events JSONL should have landed on disk.
     assert (tmp_path / "hello.events.jsonl").is_file()
+
+
+@pytest.mark.slow
+def test_read_tool_on_tempfile(tmp_path):
+    """Read tool should round-trip a tempfile — tool_use + tool_result land in events."""
+    # Embed a random-looking token the model couldn't guess, so the assertion
+    # forces a real Read call rather than a paraphrase.
+    sentinel_token = "SENTINEL_CONTENT_A7F3_LIVE_TEST"
+    target = tmp_path / "target.txt"
+    target.write_text(sentinel_token + "\n")
+
+    node = ActionNode(
+        id="read_target",
+        prompt=(
+            "Read the file named target.txt in the current directory and "
+            "reply with its exact contents — no commentary, no quotes."
+        ),
+        runner="anthropic",
+        model="claude-opus-4-7",
+        tools=["Read"],
+        thinking_config={"type": "disabled"},
+    )
+
+    runner = AnthropicRunner()
+    result = runner.run(
+        node,
+        workflow_cwd=str(tmp_path),
+        event_log_path=tmp_path / "read.events.jsonl",
+    )
+
+    assert result.status == "success", f"unexpected error: {result.error}"
+    assert sentinel_token in result.final_text, (
+        f"expected sentinel token in final_text, got: {result.final_text!r}"
+    )
+    tool_names = [c["name"] for c in result.tool_calls]
+    assert "Read" in tool_names, f"expected Read tool_call, got: {tool_names}"
+
+    # Event JSONL should carry both a tool_use (assistant) and a tool_result
+    # (user) referencing the same id.
+    tool_use_ids: set[str] = set()
+    tool_result_ids: set[str] = set()
+    for event in result.events:
+        if event.get("type") != "message_end":
+            continue
+        for block in (event.get("message", {}) or {}).get("content", []) or []:
+            if block.get("type") == "tool_use":
+                tool_use_ids.add(block.get("id", ""))
+            elif block.get("type") == "tool_result":
+                tool_result_ids.add(block.get("tool_use_id", ""))
+    assert tool_use_ids, "no tool_use blocks in events"
+    assert tool_use_ids & tool_result_ids, (
+        f"tool_use ids {tool_use_ids} did not match any tool_result ids {tool_result_ids}"
+    )
+
+
+@pytest.mark.slow
+def test_bash_chmod_777_blocked_by_damage_control(neutral_tmpdir):
+    """`chmod 777` on a file is blocked by damage-control; mode is unchanged.
+
+    `chmod 777` is in the damage-control ruleset (core.yaml: world-writable)
+    but is low-salience enough that Opus 4.7 doesn't preemptively refuse on
+    principle — unlike `rm -rf` which the model may decline regardless of
+    hooks. Combined with a neutral tempdir name (see neutral_tmpdir fixture),
+    this lets us verify the hook itself fires end-to-end.
+    """
+    target = neutral_tmpdir / "data.txt"
+    target.write_text("mode-check\n")
+    original_mode = target.stat().st_mode & 0o777
+
+    quoted = shlex.quote(str(target))
+    node = ActionNode(
+        id="try_chmod",
+        prompt=(
+            f"Use the Bash tool to run exactly this command once, then stop: "
+            f"chmod 777 {quoted}"
+        ),
+        runner="anthropic",
+        model="claude-opus-4-7",
+        tools=["Bash"],
+        thinking_config={"type": "disabled"},
+    )
+
+    runner = AnthropicRunner()
+    result = runner.run(
+        node,
+        workflow_cwd=str(neutral_tmpdir),
+        event_log_path=neutral_tmpdir / "chmod.events.jsonl",
+    )
+
+    # Primary assertion: damage-control must have stopped the chmod.
+    current_mode = target.stat().st_mode & 0o777
+    assert current_mode == original_mode, (
+        f"file mode changed from {oct(original_mode)} to {oct(current_mode)} — "
+        "damage-control did NOT fire"
+    )
+    assert current_mode != 0o777, "chmod 777 succeeded — damage-control did NOT fire"
+
+    # Secondary: event stream should carry a tool_result whose content
+    # references the hook's block reason. Reason from core.yaml is
+    # "chmod 777 (world writable)".
+    blocked_reason_found = False
+    for event in result.events:
+        if event.get("type") != "message_end":
+            continue
+        for block in (event.get("message", {}) or {}).get("content", []) or []:
+            if block.get("type") != "tool_result":
+                continue
+            content = block.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(
+                    str(b.get("text", "")) if isinstance(b, dict) else str(b)
+                    for b in content
+                )
+            if isinstance(content, str) and (
+                "world writable" in content.lower()
+                or "777" in content
+                or "damage" in content.lower()
+            ):
+                blocked_reason_found = True
+                break
+        if blocked_reason_found:
+            break
+    assert blocked_reason_found, (
+        "no tool_result mentioned the damage-control block reason — "
+        "check ~/.claude/settings.json wires bash-tool-damage-control.py"
+    )
+
+
+@pytest.mark.slow
+def test_bash_mkdir_allowed(tmp_path):
+    """Positive control — Bash works when damage-control does not block."""
+    target = tmp_path / "made-by-claude"
+    quoted = shlex.quote(str(target))
+    node = ActionNode(
+        id="make_dir",
+        prompt=f"Run exactly this command using the Bash tool: mkdir -p {quoted}",
+        runner="anthropic",
+        model="claude-opus-4-7",
+        tools=["Bash"],
+        thinking_config={"type": "disabled"},
+    )
+
+    runner = AnthropicRunner()
+    result = runner.run(
+        node,
+        workflow_cwd=str(tmp_path),
+        event_log_path=tmp_path / "mkdir.events.jsonl",
+    )
+
+    assert result.status == "success", f"unexpected error: {result.error}"
+    assert target.is_dir(), "mkdir did not create the target directory"

--- a/tests/unit/test_anthropic_classify.py
+++ b/tests/unit/test_anthropic_classify.py
@@ -1,0 +1,36 @@
+"""Tests for the error-classification helper in anthropic.py.
+
+Pure Python — no claude-agent-sdk import needed. Verifies that SDK-side
+failures are tagged with a category prefix so users and canary reports can
+distinguish rate-limited runs from genuine bugs.
+"""
+
+from __future__ import annotations
+
+from agentwire.workflows.runners.anthropic import _classify
+
+
+class TestClassify:
+    def test_rate_limit_is_transient(self):
+        assert _classify("RateLimitError", "rate_limit exceeded") == "transient"
+
+    def test_overloaded_is_transient(self):
+        assert _classify("APIStatusError", "overloaded_error: please retry") == "transient"
+
+    def test_529_is_transient(self):
+        assert _classify("APIStatusError", "status 529: service overloaded") == "transient"
+
+    def test_503_is_transient(self):
+        assert _classify("ProcessError", "backend returned 503") == "transient"
+
+    def test_auth_is_permanent(self):
+        assert _classify("AuthenticationError", "401 unauthorized") == "permanent"
+
+    def test_invalid_request_is_invalid(self):
+        assert _classify("BadRequestError", "400 invalid_request: bad model id") == "invalid"
+
+    def test_generic_is_error(self):
+        assert _classify("RuntimeError", "something unexpected happened") == "error"
+
+    def test_empty_strings_fall_through(self):
+        assert _classify("", "") == "error"


### PR DESCRIPTION
## Summary

Phase 6 PR 3. Three shipped items:

- **Error classification** in AnthropicRunner — NodeResult.error now carries a `transient:` / `permanent:` / `invalid:` / `error:` prefix so PR 6 canary data can distinguish rate-limited runs from genuine bugs. Not a retry decision (outer `node.retries` loop handles that); pure observability.
- **Live integration tests** gated on `AGENTWIRE_LIVE_SDK_TESTS=1`:
  - `test_read_tool_on_tempfile` — Read round-trips a sentinel, tool_use + tool_result land in events with matching ids.
  - `test_bash_chmod_777_blocked_by_damage_control` — a world-writable mode-change is blocked; file mode unchanged, block reason in event stream.
  - `test_bash_mkdir_allowed` — positive control confirming Bash works when not blocked.
- **Damage-control hook fix** — `bash-tool-damage-control.py` used `Optional[str]` without importing it, crashing at module load and failing open (exits 0 = allow). PR 3 verification caught this. The hook has been a no-op for an unknown window of time.

New example YAML: `claude-tool-use.yaml` showing `tools: [Read]` against the repo README.

## Why three things in one PR

The damage-control fix is technically pre-existing but PR 3's verification goal cannot succeed without it, and the fix is one character. Shipping separately would leave PR 3 with no way to verify.

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 568 pass
- [x] `AGENTWIRE_LIVE_SDK_TESTS=1 uv run pytest tests/integration/test_anthropic_runner_live.py -v -s` — 4 live tests pass (hello + read + blocked + mkdir)
- [x] Manual: fixed hook blocks world-writable chmod (`exit 2` + block reason to stderr)
- [ ] Follow-up after merge: verify installed hooks at `~/.agentwire/hooks/damage-control/` are synced — this PR patched source + copied the fixed bash hook to the install location, but the `agentwire hooks install` command doesn't currently sync damage-control scripts (only the permission hook + slash commands). That sync flow should be added in a later PR.

## Out of scope (deferred)

- Inner retry-on-529 with exponential backoff → post-canary (PR 6+)
- Runner metadata on run directory → PR 4
- `docs/workflows.md` Runners section → PR 5

Built by [dotdev.dev](https://dotdev.dev)