### PR TITLE
fix(damage-control): honor bypassPermissions mode for ask-escalation

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -569,6 +569,14 @@ def main() -> None:
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
+    # Claude Code passes permission_mode in the hook input. When the session
+    # opted into bypassPermissions (`--dangerously-skip-permissions`), the
+    # user explicitly does not want ask-escalation friction — hard blocks
+    # still fire for genuine destruction patterns, but `ask:true` patterns
+    # (generated from tooldef write-tier commands and a few git ops) become
+    # allow. This prevents the hook from forcing prompts that defeat the
+    # whole point of the bypass flag.
+    permission_mode = input_data.get("permission_mode", "")
 
     # Only check Bash commands
     if tool_name != "Bash":
@@ -587,7 +595,7 @@ def main() -> None:
         print(f"SECURITY: {reason}", file=sys.stderr)
         print(f"Command: {command[:100]}{'...' if len(command) > 100 else ''}", file=sys.stderr)
         sys.exit(2)
-    elif should_ask:
+    elif should_ask and permission_mode != "bypassPermissions":
         # Log ask pattern
         log_asked("Bash", command, reason)
         # Output JSON to trigger confirmation dialog
@@ -601,7 +609,7 @@ def main() -> None:
         print(json.dumps(output))
         sys.exit(0)
     else:
-        # Log allowed command
+        # Log allowed command (either no ask needed, or bypass mode active)
         log_allowed("Bash", command, user_approved=False)
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

The damage-control Bash hook was auto-generating `permissionDecision: "ask"` for ~100 write-tier commands (git checkout/pull/add/commit/merge/rebase/push, plus every `access: write` entry in `tooldefs/*.yaml`). Claude Code honors `ask` responses from hooks even in `bypassPermissions` mode — so launching with `--dangerously-skip-permissions` got prompts on every write op anyway, defeating the whole point of the flag.

## Fix

Read `permission_mode` from the PreToolUse hook input (Claude Code passes it in). When it equals `"bypassPermissions"`, skip the ask escalation and allow the command. Hard blocks still fire — those represent catastrophic irreversible damage that should not be bypassed.

Non-bypass sessions keep prior behavior unchanged.

## Test plan

- [x] bypass-mode JSON input → exit 0 silent (allow)
- [x] default JSON input → exit 0 with ask JSON (preserved)
- [x] Hard-block patterns still exit 2 under bypass (verified by PR 3 regression test `test_bash_chmod_777_blocked_by_damage_control`)
- [ ] After merge: run a session with `--dangerously-skip-permissions` and confirm no prompts on routine git/gh/uv/npm commands

## Context

Noticed while working on Phase 6 PR 3: after PR 3 fixed a NameError in the hook that had been failing open, damage-control started working correctly — which revealed that its `ask` behavior was too aggressive for bypass-mode sessions.

Built by [dotdev.dev](https://dotdev.dev)