### PR TITLE
feat(workflows): PR 4 — observability + storage

### DIFF
--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -14,7 +14,7 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from agentwire.workflows import storage
 from agentwire.workflows.definitions import (
@@ -128,6 +128,45 @@ def cmd_workflow_validate(args) -> int:
     return 0
 
 
+def _make_verbose_printer() -> Callable[[dict], None]:
+    """Return a per-event printer for --verbose runs.
+
+    Anthropic runner events land here live via the NodeRunner `on_event`
+    callback. Pi runner doesn't invoke the callback (see runners/pi.py),
+    so pi nodes stay silent under --verbose.
+    """
+    def _print(ev: dict) -> None:
+        etype = ev.get("type")
+        nid = ev.get("node_id") or "?"
+        if etype == "message_end":
+            msg = ev.get("message") or {}
+            role = msg.get("role")
+            for block in msg.get("content") or []:
+                btype = block.get("type")
+                if btype == "tool_use":
+                    name = block.get("name", "?")
+                    inp = block.get("input") or {}
+                    args = " ".join(f"{k}={v!r}" for k, v in list(inp.items())[:2])
+                    print(f"  [{nid}] → tool_use {name} {args}")
+                elif btype == "tool_result":
+                    content = block.get("content", "")
+                    is_err = block.get("is_error", False)
+                    tag = "err" if is_err else "ok"
+                    snippet = str(content)[:60].replace("\n", " ")
+                    print(f"  [{nid}] ← tool_result ({tag}) {snippet}")
+                elif btype == "text" and role == "assistant":
+                    t = (block.get("text") or "").strip()
+                    if t:
+                        print(f"  [{nid}] ▓ {t[:80]}")
+        elif etype == "turn_end":
+            u = ev.get("usage") or {}
+            print(f"  [{nid}] ✓ turn {u.get('input', 0)}+{u.get('output', 0)} tok")
+        elif etype == "agent_end":
+            ms = ev.get("duration_ms", 0)
+            print(f"  [{nid}] ■ agent_end {ms/1000:.1f}s")
+    return _print
+
+
 def cmd_workflow_run(args) -> int:
     """`agentwire workflow run <name-or-path>` — execute a workflow."""
     try:
@@ -167,6 +206,7 @@ def cmd_workflow_run(args) -> int:
         runs_dir=RUNS_DIR,
         dry_run=dry_run,
         inputs=merged_inputs,
+        on_event=_make_verbose_printer() if getattr(args, "verbose", False) else None,
     )
 
     if getattr(args, "json", False):
@@ -179,6 +219,7 @@ def cmd_workflow_run(args) -> int:
             "nodes": [
                 {
                     "id": r.node_id,
+                    "runner": r.runner,
                     "status": r.status,
                     "final_text": r.final_text,
                     "duration_ms": r.duration_ms,
@@ -242,19 +283,20 @@ def cmd_workflow_history(args) -> int:
         return 0
 
     # Fixed-width columns for quick scanning. run_id is long; truncate gracefully.
-    print(f"  {'run_id':<52}  {'workflow':<24}  {'status':<8}  {'duration':>8}  started")
-    print(f"  {'-' * 52}  {'-' * 24}  {'-' * 8}  {'-' * 8}  {'-' * 19}")
+    print(f"  {'run_id':<52}  {'workflow':<18}  {'runner':<9}  {'status':<8}  {'duration':>8}  started")
+    print(f"  {'-' * 52}  {'-' * 18}  {'-' * 9}  {'-' * 8}  {'-' * 8}  {'-' * 19}")
     for run in runs:
         rid = run.get("run_id", "")
         if len(rid) > 52:
             rid = rid[:49] + "..."
         name = run.get("workflow", "")
-        if len(name) > 24:
-            name = name[:21] + "..."
+        if len(name) > 18:
+            name = name[:15] + "..."
+        rnr = (run.get("runner") or "?")[:9]
         status = run.get("status", "")
         duration = _fmt_duration(run.get("duration_ms"))
         started = _fmt_started_at(run.get("started_at"))
-        print(f"  {rid:<52}  {name:<24}  {status:<8}  {duration:>8}  {started}")
+        print(f"  {rid:<52}  {name:<18}  {rnr:<9}  {status:<8}  {duration:>8}  {started}")
 
     return 0
 
@@ -297,6 +339,7 @@ def cmd_workflow_show(args) -> int:
     print(f"Workflow: {meta.get('workflow', '?')}")
     print(f"Run ID:   {meta.get('run_id', run_id)}")
     print(f"Status:   {meta.get('status', '?')}")
+    print(f"Runner:   {meta.get('runner') or '?'}")
     print(f"Started:  {_fmt_started_at(meta.get('started_at'))}")
     print(f"Duration: {_fmt_duration(meta.get('duration_ms'))}")
     if meta.get("error"):
@@ -310,6 +353,7 @@ def cmd_workflow_show(args) -> int:
         print("\nNodes:")
         for n in nodes:
             nid = n.get("id", "?")
+            rnr = (n.get("runner") or "?")
             status = n.get("status", "?")
             dur = _fmt_duration(n.get("duration_ms"))
             attempts = n.get("attempts", 1)
@@ -321,8 +365,14 @@ def cmd_workflow_show(args) -> int:
                     f", in={tokens.get('input', 0)} out={tokens.get('output', 0)} "
                     f"cost=${tokens.get('cost', 0):.4f}"
                 )
-            print(f"  {nid:<20} → {status:<8} ({dur}{attempts_note}{token_note})")
+            print(f"  {nid:<20} ({rnr:<9}) → {status:<8} ({dur}{attempts_note}{token_note})")
             if n.get("error"):
                 print(f"    reason: {n['error']}")
+
+        total_in = sum((n.get("tokens") or {}).get("input", 0) for n in nodes)
+        total_out = sum((n.get("tokens") or {}).get("output", 0) for n in nodes)
+        total_cost = sum((n.get("tokens") or {}).get("cost", 0.0) for n in nodes)
+        if total_in or total_out or total_cost:
+            print(f"\nTotals: in={total_in} out={total_out} cost=${total_cost:.4f}")
 
     return 0

--- a/agentwire/workflows/node.py
+++ b/agentwire/workflows/node.py
@@ -163,3 +163,4 @@ class NodeResult:
     exit_code: int = 0
     attempts: int = 1  # how many runner invocations happened (1 = no retries)
     error: str | None = None
+    runner: str = ""  # populated by the workflow loop from node.runner after run()

--- a/agentwire/workflows/runner.py
+++ b/agentwire/workflows/runner.py
@@ -23,7 +23,7 @@ import time
 import uuid
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from agentwire.workflows import storage
 from agentwire.workflows.context import Context
@@ -116,6 +116,7 @@ def _run_one_node_with_retries(
     context: Context,
     runs_dir: Path | None,
     run_id: str,
+    on_event: Callable[[dict], None] | None = None,
 ) -> NodeResult:
     """Invoke the node's runner; retry on failure|timeout per node.retries / retry_delay."""
     attempts = 0
@@ -127,12 +128,21 @@ def _run_one_node_with_retries(
     rendered_node = replace(node, prompt=rendered_prompt)
     runner = get_runner(node.runner)
 
+    # Wrap so every event carries node_id — anthropic_events.py doesn't stamp
+    # it, and keeping it out of the runner API matches how workflow_cwd /
+    # event_log_path flow in rather than being read from the node.
+    wrapped: Callable[[dict], None] | None = None
+    if on_event is not None:
+        def wrapped(ev: dict, _nid: str = node.id) -> None:
+            on_event({**ev, "node_id": _nid})
+
     while True:
         attempts += 1
         result = runner.run(
             rendered_node,
             workflow_cwd=context.cwd,
             event_log_path=event_log_path,
+            on_event=wrapped,
         )
         if result.status == "success":
             break
@@ -144,6 +154,7 @@ def _run_one_node_with_retries(
 
     assert result is not None
     result.attempts = attempts
+    result.runner = node.runner
     return result
 
 
@@ -152,6 +163,7 @@ def run_workflow(
     runs_dir: Path | None = None,
     dry_run: bool = False,
     inputs: dict[str, Any] | None = None,
+    on_event: Callable[[dict], None] | None = None,
 ) -> WorkflowRun:
     """Execute a workflow end-to-end."""
     errors = workflow.validate()
@@ -268,7 +280,8 @@ def run_workflow(
 
         # 4. Run pi with retry loop.
         result = _run_one_node_with_retries(
-            node, rendered_prompt, context, runs_dir, run_id
+            node, rendered_prompt, context, runs_dir, run_id,
+            on_event=on_event,
         )
         results_by_id[node.id] = result
 

--- a/agentwire/workflows/runners/pi.py
+++ b/agentwire/workflows/runners/pi.py
@@ -26,7 +26,8 @@ class PiRunner:
     ) -> NodeResult:
         # `on_event` is accepted for Protocol conformance but pi emits events
         # only after the subprocess exits (JSONL parsed post-hoc). Live streaming
-        # is an Anthropic-runner feature; for pi we ignore the callback.
+        # is an Anthropic-runner feature; retrofitting pi is deferred — the PR 4
+        # --verbose path gives live output for anthropic nodes only.
         return _pi_run_node(
             node,
             workflow_cwd=workflow_cwd,

--- a/agentwire/workflows/storage.py
+++ b/agentwire/workflows/storage.py
@@ -25,10 +25,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 METADATA_FILE = "metadata.json"
 CONTEXT_FILE = "context.json"
 NODES_DIR = "nodes"
+
+
+def _summarize_runner(node_results) -> str:
+    """Run-level runner tag: single runner name, 'mixed', or '' for no results."""
+    runners = {r.runner for r in node_results if r.runner}
+    if not runners:
+        return ""
+    if len(runners) == 1:
+        return next(iter(runners))
+    return "mixed"
 
 
 def write_run(
@@ -54,6 +64,7 @@ def write_run(
         "workflow": run.workflow,
         "run_id": run.run_id,
         "status": run.status,
+        "runner": _summarize_runner(run.node_results),
         "started_at": run.started_at,
         "duration_ms": run.duration_ms,
         "error": run.error,
@@ -61,6 +72,7 @@ def write_run(
         "nodes": [
             {
                 "id": r.node_id,
+                "runner": r.runner,
                 "status": r.status,
                 "attempts": r.attempts,
                 "duration_ms": r.duration_ms,

--- a/tests/unit/test_runner_on_event.py
+++ b/tests/unit/test_runner_on_event.py
@@ -1,0 +1,86 @@
+"""on_event callback threading: run_workflow → _run_one_node_with_retries → runner.run.
+
+Uses a fake runner that emits a couple of events during run(). Verifies that:
+  - the callback receives every emitted event
+  - each event carries a `node_id` stamp injected by the runner loop
+  - NodeResult.runner is populated from node.runner
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from agentwire.workflows.context import Context
+from agentwire.workflows.definitions import WorkflowDef
+from agentwire.workflows.node import ActionNode, NodeResult
+from agentwire.workflows.runner import run_workflow
+from agentwire.workflows.runners import RUNNERS, register_runner
+
+
+class _FakeRunner:
+    name = "fake_event_runner"
+
+    def run(
+        self,
+        node: ActionNode,
+        workflow_cwd: str | None = None,
+        event_log_path: Path | None = None,
+        on_event: Callable[[dict], None] | None = None,
+    ) -> NodeResult:
+        if on_event is not None:
+            on_event({"type": "agent_start"})
+            on_event({"type": "message_end", "message": {"role": "assistant", "content": []}})
+            on_event({"type": "agent_end", "duration_ms": 42})
+        return NodeResult(
+            node_id=node.id,
+            status="success",
+            final_text="ok",
+            duration_ms=42,
+        )
+
+
+@pytest.fixture
+def fake_runner_registered():
+    register_runner(_FakeRunner())
+    yield
+    RUNNERS.pop(_FakeRunner.name, None)
+
+
+class TestOnEventThreading:
+    def test_callback_receives_events_with_node_id(self, tmp_path, fake_runner_registered):
+        collected: list[dict] = []
+
+        # Patch node.py validation: register a fake runner + use it.
+        node = ActionNode(id="n1", prompt="hi", runner="fake_event_runner")
+        wf = WorkflowDef(name="test-cb", nodes=[node])
+
+        result = run_workflow(
+            wf,
+            runs_dir=tmp_path / "runs",
+            inputs={},
+            on_event=collected.append,
+        )
+
+        assert result.status == "success"
+        types = [e["type"] for e in collected]
+        assert types == ["agent_start", "message_end", "agent_end"]
+        assert all(e.get("node_id") == "n1" for e in collected)
+
+    def test_no_callback_when_none(self, tmp_path, fake_runner_registered):
+        """Absence of callback must not crash the runner loop."""
+        node = ActionNode(id="n1", prompt="hi", runner="fake_event_runner")
+        wf = WorkflowDef(name="test-cb-none", nodes=[node])
+
+        result = run_workflow(wf, runs_dir=tmp_path / "runs", inputs={})
+        assert result.status == "success"
+
+    def test_node_result_runner_populated(self, tmp_path, fake_runner_registered):
+        """result.runner should be set from node.runner after the runner returns."""
+        node = ActionNode(id="n1", prompt="hi", runner="fake_event_runner")
+        wf = WorkflowDef(name="test-rnr-field", nodes=[node])
+
+        result = run_workflow(wf, runs_dir=tmp_path / "runs", inputs={})
+        assert result.node_results[0].runner == "fake_event_runner"

--- a/tests/unit/test_workflow_cli.py
+++ b/tests/unit/test_workflow_cli.py
@@ -1,0 +1,172 @@
+"""CLI output assertions for workflow show / history with runner fields."""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire.workflows import cli as wf_cli
+from agentwire.workflows.context import Context
+from agentwire.workflows.node import NodeResult
+from agentwire.workflows.runner import WorkflowRun
+from agentwire.workflows.storage import write_run
+
+
+def _make_run(run_id: str, runner_name: str, tokens: dict | None = None) -> WorkflowRun:
+    return WorkflowRun(
+        workflow="demo",
+        run_id=run_id,
+        status="success",
+        started_at=time.time(),
+        duration_ms=500,
+        node_results=[
+            NodeResult(
+                node_id="a",
+                status="success",
+                final_text="",
+                duration_ms=100,
+                runner=runner_name,
+                tokens_used=tokens or {},
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def runs_dir(tmp_path, monkeypatch):
+    d = tmp_path / "runs"
+    d.mkdir()
+    # cli.py reads RUNS_DIR module-level constant; point it at tmp.
+    monkeypatch.setattr(wf_cli, "RUNS_DIR", d)
+    return d
+
+
+class TestShow:
+    def test_show_renders_runner_and_totals(self, runs_dir, capsys):
+        run = _make_run(
+            "demo-r1",
+            "anthropic",
+            tokens={"input": 100, "output": 50, "cost": 0.0023},
+        )
+        write_run(runs_dir, run.run_id, run, Context())
+
+        args = SimpleNamespace(run_id="demo-r1", node=None, events=False, json=False)
+        rc = wf_cli.cmd_workflow_show(args)
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        assert "Runner:   anthropic" in out
+        assert "(anthropic" in out   # per-node row
+        assert "Totals: in=100 out=50 cost=$0.0023" in out
+
+    def test_show_pi_run_no_totals_when_no_tokens(self, runs_dir, capsys):
+        run = _make_run("demo-r2", "pi", tokens={})
+        write_run(runs_dir, run.run_id, run, Context())
+
+        args = SimpleNamespace(run_id="demo-r2", node=None, events=False, json=False)
+        wf_cli.cmd_workflow_show(args)
+
+        out = capsys.readouterr().out
+        assert "Runner:   pi" in out
+        # No Totals line when every node has empty tokens.
+        assert "Totals:" not in out
+
+    def test_show_json_includes_runner(self, runs_dir, capsys):
+        run = _make_run("demo-r3", "anthropic", tokens={"input": 1, "output": 2})
+        write_run(runs_dir, run.run_id, run, Context())
+
+        args = SimpleNamespace(run_id="demo-r3", node=None, events=False, json=True)
+        wf_cli.cmd_workflow_show(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["runner"] == "anthropic"
+        assert payload["nodes"][0]["runner"] == "anthropic"
+
+
+class TestHistory:
+    def test_history_table_has_runner_column(self, runs_dir, capsys):
+        run_a = _make_run("demo-r4", "pi")
+        run_b = _make_run("demo-r5", "anthropic")
+        write_run(runs_dir, run_a.run_id, run_a, Context())
+        write_run(runs_dir, run_b.run_id, run_b, Context())
+
+        args = SimpleNamespace(workflow=None, limit=20, json=False)
+        rc = wf_cli.cmd_workflow_history(args)
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        assert "runner" in out       # header row
+        assert "pi" in out
+        assert "anthropic" in out
+
+    def test_history_json_carries_runner(self, runs_dir, capsys):
+        run = _make_run("demo-r6", "anthropic")
+        write_run(runs_dir, run.run_id, run, Context())
+
+        args = SimpleNamespace(workflow=None, limit=20, json=True)
+        wf_cli.cmd_workflow_history(args)
+
+        rows = json.loads(capsys.readouterr().out)
+        assert rows[0]["runner"] == "anthropic"
+
+
+class TestVerbosePrinter:
+    """Directly exercise _make_verbose_printer — no live runner needed."""
+
+    def test_prints_tool_use(self, capsys):
+        printer = wf_cli._make_verbose_printer()
+        printer({
+            "type": "message_end",
+            "node_id": "n1",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/x.txt"},
+                }],
+            },
+        })
+        out = capsys.readouterr().out
+        assert "[n1]" in out
+        assert "tool_use Read" in out
+        assert "file_path" in out
+
+    def test_prints_tool_result_ok_and_err(self, capsys):
+        printer = wf_cli._make_verbose_printer()
+        printer({
+            "type": "message_end",
+            "node_id": "n1",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "content": "hello\nworld", "is_error": False}],
+            },
+        })
+        printer({
+            "type": "message_end",
+            "node_id": "n1",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "content": "boom", "is_error": True}],
+            },
+        })
+        out = capsys.readouterr().out
+        assert "(ok)" in out
+        assert "(err)" in out
+        assert "hello world" in out    # newline collapsed
+
+    def test_prints_turn_and_agent_end(self, capsys):
+        printer = wf_cli._make_verbose_printer()
+        printer({"type": "turn_end", "node_id": "n1", "usage": {"input": 100, "output": 42}})
+        printer({"type": "agent_end", "node_id": "n1", "duration_ms": 3100})
+        out = capsys.readouterr().out
+        assert "turn 100+42 tok" in out
+        assert "agent_end 3.1s" in out
+
+    def test_silently_drops_unknown_events(self, capsys):
+        printer = wf_cli._make_verbose_printer()
+        printer({"type": "made_up_event", "node_id": "n1"})
+        assert capsys.readouterr().out == ""

--- a/tests/unit/test_workflow_storage.py
+++ b/tests/unit/test_workflow_storage.py
@@ -1,0 +1,128 @@
+"""Storage schema v2 tests — runner field + back-compat reads."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from agentwire.workflows.context import Context
+from agentwire.workflows.node import NodeResult
+from agentwire.workflows.runner import WorkflowRun
+from agentwire.workflows.storage import (
+    METADATA_FILE,
+    SCHEMA_VERSION,
+    _summarize_runner,
+    list_runs,
+    load_run,
+    write_run,
+)
+
+
+def _run_with_nodes(*pairs: tuple[str, str]) -> WorkflowRun:
+    """pairs: (node_id, runner). Returns a success WorkflowRun."""
+    return WorkflowRun(
+        workflow="multi",
+        run_id="multi-20260417T000000-zzzz",
+        status="success",
+        started_at=time.time(),
+        duration_ms=123,
+        node_results=[
+            NodeResult(
+                node_id=nid,
+                status="success",
+                final_text="",
+                duration_ms=10,
+                runner=rnr,
+            )
+            for nid, rnr in pairs
+        ],
+    )
+
+
+class TestSummarizeRunner:
+    def test_empty(self):
+        assert _summarize_runner([]) == ""
+
+    def test_all_pi(self):
+        results = [NodeResult(node_id="a", status="success", final_text="", runner="pi")]
+        assert _summarize_runner(results) == "pi"
+
+    def test_all_anthropic(self):
+        results = [
+            NodeResult(node_id="a", status="success", final_text="", runner="anthropic"),
+            NodeResult(node_id="b", status="success", final_text="", runner="anthropic"),
+        ]
+        assert _summarize_runner(results) == "anthropic"
+
+    def test_mixed(self):
+        results = [
+            NodeResult(node_id="a", status="success", final_text="", runner="pi"),
+            NodeResult(node_id="b", status="success", final_text="", runner="anthropic"),
+        ]
+        assert _summarize_runner(results) == "mixed"
+
+    def test_ignores_blanks(self):
+        # A skipped node has runner="" because the runner loop never touched it.
+        results = [
+            NodeResult(node_id="a", status="skipped", final_text="", runner=""),
+            NodeResult(node_id="b", status="success", final_text="", runner="pi"),
+        ]
+        assert _summarize_runner(results) == "pi"
+
+
+class TestSchemaV2:
+    def test_write_round_trip_single_runner(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        run = _run_with_nodes(("a", "anthropic"))
+        write_run(runs_dir, run.run_id, run, Context())
+
+        meta = load_run(runs_dir, run.run_id)
+        assert meta is not None
+        assert meta["schema_version"] == SCHEMA_VERSION == 2
+        assert meta["runner"] == "anthropic"
+        assert meta["nodes"][0]["runner"] == "anthropic"
+
+    def test_write_round_trip_mixed(self, tmp_path):
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        run = _run_with_nodes(("a", "pi"), ("b", "anthropic"))
+        write_run(runs_dir, run.run_id, run, Context())
+
+        meta = load_run(runs_dir, run.run_id)
+        assert meta["runner"] == "mixed"
+        runners = [n["runner"] for n in meta["nodes"]]
+        assert runners == ["pi", "anthropic"]
+
+    def test_v1_backcompat_load(self, tmp_path):
+        """A v1-era metadata.json (no runner fields) still loads cleanly."""
+        runs_dir = tmp_path / "runs"
+        runs_dir.mkdir()
+        run_dir = runs_dir / "old-run-id"
+        run_dir.mkdir()
+        (run_dir / METADATA_FILE).write_text(json.dumps({
+            "schema_version": 1,
+            "workflow": "legacy",
+            "run_id": "old-run-id",
+            "status": "success",
+            "started_at": 1000.0,
+            "duration_ms": 50,
+            "error": None,
+            "inputs": {},
+            "nodes": [
+                {"id": "a", "status": "success", "attempts": 1,
+                 "duration_ms": 10, "tokens": {}, "error": None},
+            ],
+        }))
+
+        meta = load_run(runs_dir, "old-run-id")
+        assert meta is not None
+        assert meta["schema_version"] == 1
+        # Missing runner field — consumers .get() this with "" default.
+        assert meta.get("runner", "") == ""
+        assert meta["nodes"][0].get("runner", "") == ""
+
+        # list_runs tolerates it too.
+        rows = list_runs(runs_dir)
+        assert len(rows) == 1
+        assert rows[0]["workflow"] == "legacy"

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -203,6 +203,7 @@ def _make_workflow_run(runs_dir, **overrides):
                 final_text="hi",
                 duration_ms=50,
                 attempts=1,
+                runner="pi",
             ),
         ],
     )
@@ -225,6 +226,9 @@ class TestStorage:
         assert rows[0]["run_id"] == run.run_id
         assert rows[0]["inputs"] == {"x": 1}
         assert rows[0]["nodes"][0]["id"] == "a"
+        assert rows[0]["nodes"][0]["runner"] == "pi"
+        assert rows[0]["runner"] == "pi"
+        assert rows[0]["schema_version"] == 2
 
     def test_list_runs_sorted_newest_first(self, tmp_path):
         runs_dir = tmp_path / "runs"


### PR DESCRIPTION
## Summary
- Thread `on_event` callback through `run_workflow` → `_run_one_node_with_retries` → `runner.run`; `--verbose` now streams live `[node] → tool_use / ← tool_result / ▓ text / ✓ turn / ■ agent_end` lines for anthropic nodes. Pi nodes still silent (deferred).
- Bump `metadata.json` schema 1 → 2: add `runner` at run-level (single name or `"mixed"`) and per-node. Surfaces in `workflow show` (Runner: line + per-node tag + Totals aggregation), `workflow history` (new runner column), and `workflow run --json` (per-node).
- `NodeResult.runner` field populated by the loop from `node.runner`; runners stay oblivious to their own identity. Callback is wrapped to stamp `node_id` onto every event.
- v1 runs on disk keep rendering cleanly (every consumer `.get()`s with defaults). No dependency changes, no breaking API changes.

## Test plan
- [x] `uv run pytest tests/unit/` → 588 pass (20 new across 3 files: `test_workflow_storage.py`, `test_runner_on_event.py`, `test_workflow_cli.py`; 1 extended existing storage test)
- [x] `agentwire workflow run echo-chain -v --input topic=testing` → runner=pi, schema v2 in metadata
- [x] `agentwire workflow run claude-reasoning -v` → live `[think] ▓/✓/■` stream during run, `Runner: anthropic` + `Totals:` in `show`
- [x] `workflow history --limit 3` → new runs show `pi`/`anthropic`, v1 runs show `?`

Built by [dotdev.dev](https://dotdev.dev)