### PR TITLE
feat(workflows): PR 5 — --runner override + docs for both runners

### DIFF
--- a/.claude/skills/agentwire-workflows/SKILL.md
+++ b/.claude/skills/agentwire-workflows/SKILL.md
@@ -5,7 +5,7 @@ description: Pi workflow engine — YAML-defined DAGs of pi invocations chained 
 
 # Pi workflow engine — quick reference
 
-Workflows live in `agentwire/workflows/examples/` (bundled) or `~/.agentwire/workflows/defs/` (user). Each node is a one-shot `pi -p --mode json` invocation.
+Workflows live in `agentwire/workflows/examples/` (bundled) or `~/.agentwire/workflows/defs/` (user). Each node runs against one of two backends via `runner:` — `pi` (subprocess per node, default) or `anthropic` (`claude-agent-sdk` in-process, subscription auth). Both return the same `NodeResult` shape. See `docs/workflows.md` → "Runners" for the full per-runner field table; quick reference below is pi-focused.
 
 ## Minimum viable YAML
 
@@ -28,15 +28,16 @@ nodes:
 - **Retries** — `retries: N` (default 0), `retry_delay: S` (default 10). Triggered on status in `{failure, timeout}` only. Template/extraction errors never retry.
 - **on_error** (after retries exhausted) — `fail` (halt) | `continue` (downstream gets `None` outputs, workflow → partial) | `branch` (requires `on_error_goto`; skip normal dependents, rescue target).
 - **Skipping** — `when:` false OR upstream skipped/branched → node is `skipped`; dependents propagated unless rescued by a branch `on_error_goto`.
-- **Tools** — subset of `{read, bash, edit, write, grep, find, ls}`. Default `[read, bash, edit, write]`. Empty list → `--no-tools`.
-- **Thinking** — `off | minimal | low | medium | high | xhigh`. Default `medium`. Use `off` for flash-tier cheap nodes.
+- **Tools (pi)** — subset of `{read, bash, edit, write, grep, find, ls}`. Default `[read, bash, edit, write]`. Empty list → `--no-tools`.
+- **Thinking (pi)** — `off | minimal | low | medium | high | xhigh`. Default `medium`. Use `off` for flash-tier cheap nodes.
+- **Anthropic runner** — uses `model` (required, e.g. `claude-opus-4-7`), `effort` (low|medium|high|max|xhigh), `thinking_config` (dict), CamelCase tools (`Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch`). See `docs/workflows.md` → Runners for the full table.
 
 ## CLI
 
 ```bash
 agentwire workflow list [--json]
 agentwire workflow validate <name-or-path>
-agentwire workflow run <name> [--input KEY=VAL]... [--input-file FILE] [--dry-run] [--verbose] [--json]
+agentwire workflow run <name> [--input KEY=VAL]... [--input-file FILE] [--runner pi|anthropic] [--dry-run] [--verbose] [--json]
 agentwire workflow history [--workflow NAME] [--limit N] [--json]
 agentwire workflow show <run-id> [--events] [--node ID] [--json]
 ```
@@ -58,9 +59,9 @@ Agents should prefer MCP tools over shelling out.
 ## Storage
 
 Runs live at `~/.agentwire/workflows/runs/<run-id>/`:
-- `metadata.json` — workflow, status, inputs, node summaries (schema_version: 1)
+- `metadata.json` — workflow, status, inputs, node summaries (schema_version: 2 — includes `runner` at run level and per node)
 - `context.json` — final inputs + per-node extracted outputs
-- `nodes/<id>.events.jsonl` — raw pi JSONL stream
+- `nodes/<id>.events.jsonl` — raw event stream (pi JSONL for pi runner, pi-shaped translated events for anthropic)
 
 Runs without `metadata.json` (crashed mid-run) are silently hidden from `history`.
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10222,6 +10222,10 @@ def main() -> int:
         "--input-file", metavar="PATH",
         help="JSON file with inputs (object mapping name → value)"
     )
+    wf_run.add_argument(
+        "--runner", choices=["pi", "anthropic"], default=None,
+        help="Override runner for every node in this run (YAML declarations ignored)."
+    )
     wf_run.add_argument("--dry-run", action="store_true", help="Print plan without running")
     wf_run.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     wf_run.add_argument("--json", action="store_true", help="Output as JSON")

--- a/agentwire/workflows/cli.py
+++ b/agentwire/workflows/cli.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 from agentwire.workflows import storage
 from agentwire.workflows.definitions import (
+    apply_runner_override,
     discover_workflows,
     resolve_workflow,
 )
@@ -174,6 +175,8 @@ def cmd_workflow_run(args) -> int:
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+    workflow = apply_runner_override(workflow, getattr(args, "runner", None))
 
     errors = workflow.validate()
     if errors:

--- a/agentwire/workflows/definitions.py
+++ b/agentwire/workflows/definitions.py
@@ -8,7 +8,7 @@ are validated here (cycle detection) and executed by the runner.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -153,6 +153,23 @@ def _find_cycle(nodes: list[ActionNode]) -> list[str] | None:
             if result:
                 return result
     return None
+
+
+def apply_runner_override(
+    workflow: WorkflowDef,
+    runner: str | None,
+) -> WorkflowDef:
+    """Return a copy of `workflow` with every node's `runner` set to `runner`.
+
+    Pass-through when `runner is None`. Uses `dataclasses.replace` to avoid
+    mutating the input — `discover_workflows()` hands out cached instances,
+    and an in-place mutation would poison subsequent invocations in the
+    same process.
+    """
+    if runner is None:
+        return workflow
+    new_nodes = [replace(n, runner=runner) for n in workflow.nodes]
+    return replace(workflow, nodes=new_nodes)
 
 
 def topological_sort(nodes: list[ActionNode]) -> list[ActionNode]:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -35,14 +35,15 @@ inputs:                              # CLI-supplied variables, optional
 
 nodes:                               # at least one required
   analyze:
+    runner: pi                       # pi | anthropic (default: pi). See "Runners" below.
     prompt: |                        # Jinja2 template — required
       Look at {{ inputs.target }}. Return JSON: {"issues": [...]}
     # provider + model are optional — default to zai + glm-5.1
     # set explicitly only when you need a different model/provider
-    model: glm-5.1                   # default: glm-5.1
-    provider: zai                    # default: zai
-    tools: [read, grep]              # subset of {read, bash, edit, write, grep, find, ls}
-    thinking: "low"                  # off|minimal|low|medium|high|xhigh
+    model: glm-5.1                   # default: glm-5.1 (pi); anthropic needs e.g. claude-opus-4-7
+    provider: zai                    # default: zai (pi-only)
+    tools: [read, grep]              # pi: lowercase {read, bash, edit, write, grep, find, ls}
+    thinking: "low"                  # pi: off|minimal|low|medium|high|xhigh
     timeout: 300                     # seconds per attempt (default 300)
     retries: 2                       # extra attempts on failure|timeout (default 0)
     retry_delay: 10                  # seconds between attempts (default 10)
@@ -66,6 +67,68 @@ Bundled examples live in `agentwire/workflows/examples/` and are always discover
 
 ---
 
+## Runners
+
+Each node runs against one of two backends, selected per-node via `runner:`. Both runners return the same `NodeResult` shape — the rest of the workflow engine (DAG, templating, outputs, retries, `on_error`, scheduler hookup) is identical.
+
+| Runner | Default model | Process model | Tool namespace | When to pick |
+|---|---|---|---|---|
+| `pi` (default) | `glm-5.1` on Z.AI | Subprocess per node (`pi -p --mode json`) | lowercase: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls` | Cheap, fast, deterministic for one-shot extraction/transform nodes. Flash-tier (`glm-4.7-flash`) is free. |
+| `anthropic` | (none — required) | In-process via `claude-agent-sdk`, subscription auth | CamelCase: `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch` | Quality-sensitive reasoning, Claude's richer toolset, anywhere the pi subprocess overhead dominates. Events stream live under `--verbose`. |
+
+### Anthropic-only fields
+
+| Field | Values | Notes |
+|---|---|---|
+| `model` | `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`, … | Required. No default. |
+| `effort` | `low`, `medium`, `high`, `max`, `xhigh` | `max` = Opus-only. `xhigh` = Opus 4.7-only. Not valid on Haiku 4.5 or Sonnet 4.5. |
+| `thinking_config` | `{type: adaptive}` (recommended), `{type: disabled}`, `{type: enabled, budget_tokens: N}` | `enabled` removed on 4.6/4.7 — use `adaptive` + `effort`. |
+| `task_budget_tokens` | int ≥ 20000 | Opus 4.7 only. Beta. |
+| `max_thinking_tokens`, `max_budget_usd` | int / float | Passed through to the SDK. |
+
+Pi ignores these; setting them on a pi node is a parse-time validation error.
+
+### Pi-only fields
+
+| Field | Values | Notes |
+|---|---|---|
+| `thinking` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | String. Default `medium`. Use `off` for flash-tier cheap nodes. |
+| `provider` | `zai` (default) | Leave default unless routing through a different Z.AI deployment. |
+
+Anthropic uses `thinking_config` (dict) instead; the pi string `thinking:` field is simply ignored when `runner: anthropic`. No auto-translation — if you switch a node from pi to anthropic, rewrite the thinking field too.
+
+### `--runner` override
+
+To run an entire workflow on the other runner without editing YAML:
+
+```bash
+# Force every node to anthropic (YAML declarations ignored)
+agentwire workflow run daily-book-report --runner anthropic
+
+# Or force to pi
+agentwire workflow run claude-tool-use --runner pi
+```
+
+Override applies to **every node** in the workflow. Field/runner mismatches surface as normal validation errors — e.g. overriding an anthropic workflow to pi rejects any `effort:`, `task_budget_tokens:`, or `thinking_config:` fields. Fix the YAML or pick a different override.
+
+This is the canary / A-B flag: "run the same workflow on both runners, see which wins." Past runs record which runner executed them — `agentwire workflow show <run-id>` prints a `Runner:` line, and `workflow history` has a `runner` column — so comparing outcomes after the fact is direct.
+
+### Live event output (`--verbose`)
+
+`agentwire workflow run … -v` streams a one-line summary per event as nodes execute. Anthropic nodes emit live tool calls, tool results, text fragments, token counts, and agent-end timings:
+
+```
+[summarize] → tool_use Read file_path='README.md'
+[summarize] ← tool_result (ok) # AgentWire - Voice interface for…
+[summarize] ▓ AgentWire is a voice interface for AI coding agents…
+[summarize] ✓ turn 1342+187 tok
+[summarize] ■ agent_end 4.2s
+```
+
+Pi nodes are silent under `--verbose` (pi parses stdout after the subprocess exits — retrofitting live streaming is deferred).
+
+---
+
 ## CLI reference
 
 ```bash
@@ -82,8 +145,9 @@ agentwire workflow run my-workflow
 agentwire workflow run my-workflow --input target=src/api.ts
 agentwire workflow run my-workflow --input target=src/api.ts --input verbose=true
 agentwire workflow run my-workflow --input-file inputs.json
+agentwire workflow run my-workflow --runner anthropic   # override runner for every node
 agentwire workflow run my-workflow --dry-run            # plan only, no pi calls
-agentwire workflow run my-workflow --verbose            # show plan + inputs
+agentwire workflow run my-workflow --verbose            # show plan + live events
 agentwire workflow run my-workflow --json               # structured result
 
 # Inspect past runs

--- a/tests/unit/test_runner_override.py
+++ b/tests/unit/test_runner_override.py
@@ -1,0 +1,65 @@
+"""Tests for `apply_runner_override` — the helper behind `workflow run --runner`."""
+
+from __future__ import annotations
+
+from agentwire.workflows.definitions import WorkflowDef, apply_runner_override
+from agentwire.workflows.node import ActionNode
+
+
+class TestApplyRunnerOverride:
+    def test_none_returns_same_object(self):
+        """None means 'no override' — return the workflow as-is, no copy."""
+        wf = WorkflowDef(name="t", nodes=[ActionNode(id="a", prompt="p", runner="pi")])
+        assert apply_runner_override(wf, None) is wf
+
+    def test_flips_every_node(self):
+        wf = WorkflowDef(
+            name="t",
+            nodes=[
+                ActionNode(id="a", prompt="p", runner="pi"),
+                ActionNode(id="b", prompt="p", runner="pi"),
+            ],
+        )
+        out = apply_runner_override(wf, "anthropic")
+
+        assert [n.runner for n in out.nodes] == ["anthropic", "anthropic"]
+        # Original untouched — essential because discover_workflows() caches.
+        assert [n.runner for n in wf.nodes] == ["pi", "pi"]
+        assert out is not wf
+
+    def test_override_to_pi_surfaces_anthropic_field_errors(self):
+        """Overriding an anthropic node to pi leaves anthropic-only fields set,
+        which ActionNode.validate() rejects with a clear message."""
+        wf = WorkflowDef(
+            name="t",
+            nodes=[
+                ActionNode(
+                    id="a", prompt="p", runner="anthropic",
+                    model="claude-opus-4-7", effort="high",
+                ),
+            ],
+        )
+        overridden = apply_runner_override(wf, "pi")
+        errors = overridden.validate()
+        assert any(
+            "effort" in e and "only valid when runner=anthropic" in e
+            for e in errors
+        ), f"expected pi+effort validation error, got: {errors}"
+
+    def test_override_to_anthropic_rejects_lowercase_pi_tools(self):
+        """Pi tools are lowercase; anthropic expects CamelCase. After override,
+        validation surfaces the namespace mismatch."""
+        wf = WorkflowDef(
+            name="t",
+            nodes=[
+                ActionNode(
+                    id="a", prompt="p", runner="pi",
+                    tools=["read", "grep"], model="claude-opus-4-7",
+                ),
+            ],
+        )
+        overridden = apply_runner_override(wf, "anthropic")
+        errors = overridden.validate()
+        assert any("CamelCase" in e for e in errors), (
+            f"expected CamelCase tool-namespace error, got: {errors}"
+        )


### PR DESCRIPTION
## Summary
- Add `--runner {pi,anthropic}` to `workflow run` — overrides the runner for every node in one invocation, no YAML edit needed.
- Override helper `apply_runner_override(workflow, runner)` in `definitions.py` uses `dataclasses.replace` so `discover_workflows()`'s cached instances stay pristine across repeated runs.
- Applied right after `resolve_workflow()` and before the existing `workflow.validate()` so runner/field mismatches surface as normal validation errors (no new error paths).
- Docs: new "Runners" section in `docs/workflows.md` with per-runner field tables (anthropic-only: `model`, `effort`, `thinking_config`, `task_budget_tokens`; pi-only: `thinking`, `provider`), live event output explainer, `--runner` usage. YAML anatomy block now shows `runner:`.
- Skill doc no longer claims pi-only; mentions both backends + links to full table; bumps stale `schema_version: 1 → 2`.

## Test plan
- [x] `uv run pytest tests/unit/` → 592 pass (4 new in `test_runner_override.py`)
- [x] `agentwire workflow run --help` shows `--runner {pi,anthropic}`
- [x] `agentwire workflow run claude-reasoning --runner pi` → validation rejects `effort` and `thinking_config` with clear per-field errors
- [x] `agentwire workflow run claude-reasoning --runner anthropic -v` → runs, live `▓/✓/■` event stream intact

Built by [dotdev.dev](https://dotdev.dev)
