### PR TITLE
docs(phase-6): record Phase 6 + canary findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Anthropic workflow runner** — `runner: anthropic` alongside the existing pi runner (Phase 6, PRs 1–6)
+  - Pluggable runner registry (`agentwire/workflows/runners/`) with a shared `NodeRunner` Protocol; pi kept byte-for-byte identical behind a thin shim
+  - `AnthropicRunner` uses `claude-agent-sdk>=0.1.43` with subscription auth — no `ANTHROPIC_API_KEY` required, inherits `~/.claude/.credentials.json` (subscription-covered, no per-run billing)
+  - Tool execution is owned by Claude Code itself: `setting_sources=["user"]` loads `~/.claude/settings.json` so AgentWire's damage-control PreToolUse hooks fire on every Bash call (verified end-to-end by a live integration test that chmod 777's a sentinel file — hook blocks, file mode unchanged)
+  - Per-runner tool namespaces: pi stays lowercase (`read`, `bash`, `edit`, …), anthropic uses CamelCase (`Read`, `Bash`, `Edit`, …); parse-time validation rejects cross-namespace mixups
+  - Anthropic-only fields validated at parse time: `model` (required), `effort` (low|medium|high|max|xhigh — with Opus/Opus-4.7 gating), `thinking_config` (adaptive|enabled|disabled), `task_budget_tokens` (Opus 4.7 beta, min 20000), `max_thinking_tokens`, `max_budget_usd`
+  - Error classification: anthropic runner tags `NodeResult.error` with `transient:` / `permanent:` / `invalid:` / `error:` prefixes so rate-limited runs are distinguishable from genuine bugs
+- **Live event streaming under `--verbose`** — `agentwire workflow run … -v` now streams per-event output for anthropic nodes: `[node] → tool_use Read …`, `← tool_result (ok/err)`, `▓ text`, `✓ turn 42+18 tok`, `■ agent_end 3.1s`
+- **Runner recorded in metadata** — `metadata.json` bumped to `schema_version: 2` with run-level and per-node `runner` fields; `workflow show` renders a `Runner:` line + per-node tag + `Totals:` aggregation; `workflow history` gains a `runner` column
+- **`--runner {pi,anthropic}` CLI override** — `agentwire workflow run` accepts `--runner` to flip every node's runner for one invocation; runner/field mismatches surface as normal validation errors
+- **Canary live** — `daily-book-report` (daily 13:30) flipped to anthropic on 2026-04-17 (Sonnet 4.6 for fetch, Opus 4.7 for compose_and_send). Findings tracked in `docs/missions/anthropic-sdk-runner.md`
+- **Damage-control honors session bypass modes** — `permission_mode: "bypassPermissions"` and `"auto"` now skip `ask:true` escalations for write-tier commands; hard blocks still fire. Fixes `--dangerously-skip-permissions` and autonomous-mode sessions being prompted per Bash call
+
+### Documentation
+
+- New "Runners" section in `docs/workflows.md` covering per-runner fields, `--runner` usage, and live-event output
+- `agentwire-workflows` skill updated — no longer claims pi-only; links to full Runners reference
+
 ## [1.23.0] - 2026-04-16
 
 ### Added

--- a/docs/missions/anthropic-sdk-runner.md
+++ b/docs/missions/anthropic-sdk-runner.md
@@ -389,3 +389,32 @@ Zero changes to `scheduler.py`. Workflow tasks still just call `run_workflow(wf,
 - Pi path is byte-for-byte unchanged the entire time
 - Rollback for any production issue = flip the offending workflow's `runner:` field back to `pi` (one-line YAML edit — `pi` is the default runner so even deletion works)
 - If the Anthropic path underdelivers, we keep pi as the default indefinitely — no forced migration
+
+---
+
+## Canary Results — `daily-book-report` (flipped 2026-04-17)
+
+**Both nodes flipped** (not just `compose_and_send`). The pi version of `fetch` had been truncating its JSON re-emission of the large NYT bash output — `thinking: off` + GLM-5.1 ran out of output budget mid-string, blocking the DAG. Cleaner canary was to flip both nodes at once.
+
+| Node | Model | Thinking | Tools | Duration | Tokens in/out |
+|---|---|---|---|---|---|
+| `fetch` | `claude-sonnet-4-6` | disabled | `[Bash]` | 18s | 3 / 1610 |
+| `compose_and_send` | `claude-opus-4-7` | adaptive, `effort: high` | `[Bash, Write, Read]` | 114s | 9 / 9565 |
+
+**Subscription-covered** — SDK reports nominal API-rate cost ($0.12 + $0.50 = $0.62/run) but actual billing is $0. All runs land under `~/.claude/.credentials.json` auth, same quota pool as interactive Claude Code.
+
+**Output quality (first canary run, 2026-04-17, delivered to test recipient):**
+- Clean HTML email, dark theme, three top-5 bestseller tables (Fiction / Nonfiction / Advice) with rank, movement, weeks
+- Five Writing Articles with proper hyperlinks + dates, one Trending entry
+- "Daily Writing Spark" tied to a real pattern in *this week's* data (three new debuts in top-5 Fiction) with a concrete 15-minute micro-goal, signed off as Echo
+- Markdown report saved to `/Users/dotdev/reports/book-sales/YYYY-MM-DD.md`
+
+**Live `--verbose` output worked end-to-end** — per-event stream showed Bash tool calls, tool results, text fragments, token counts, agent-end timings for both nodes.
+
+**Observations to watch over the ≥2 week canary window:**
+- Rate-limit behavior under the 5-hour subscription quota when this runs alongside interactive Claude Code sessions
+- Consistency of the "Daily Writing Spark" across days — does Opus 4.7 always tie it to a concrete data observation?
+- Any `transient:` or `permanent:` error prefixes surfacing in morning reports
+- Output token variance — first run hit 9565 out; flag if we drift toward context-window limits
+
+**Rollback path**: `~/.agentwire/workflows/defs/daily-book-report.yaml` — delete the `runner:`/`model:`/`effort:`/`thinking_config:` lines and replace `tools: [Bash, Write, Read]` → `tools: [bash, write, read]` and add back `thinking: medium`. `pi` is the default runner, so field absence reverts.


### PR DESCRIPTION
## Summary
Phase 6 wrap — the `daily-book-report` canary is live and the first run (2026-04-17, delivered to a test recipient) came through clean. This PR records findings, no code changes.

- **CHANGELOG [Unreleased]**: full Phase 6 summary (PRs 1–5 + damage-control bypass/auto fix). Calls out subscription-covered auth — SDK reports nominal API-rate cost but actual billing is $0.
- **Mission doc**: new "Canary Results" section in `docs/missions/anthropic-sdk-runner.md`. Flipped both nodes (not just `compose_and_send` — pi's `fetch` was truncating its JSON re-emission of the large NYT bash output, blocking the DAG). Fetch on Sonnet 4.6 / thinking disabled; compose_and_send on Opus 4.7 / effort high / adaptive thinking.
- **No code changes** — all Phase 6 code landed in PRs 1–5; canary is a live config flip in `~/.agentwire/workflows/defs/daily-book-report.yaml` (outside the repo).

## Test plan
- [x] First canary run succeeded end-to-end: fetch (18s, 3→1610 tok) → compose_and_send (114s, 9→9565 tok), HTML email delivered, markdown report saved, live `--verbose` event stream worked
- [x] Rollback path documented in mission doc; `pi` is still the default runner
- [ ] Watch ≥2 week window for rate-limit interactions, output consistency, any `transient:`/`permanent:` prefixes in morning reports

Built by [dotdev.dev](https://dotdev.dev)
