### PR TITLE
fix(hooks): permission hook honors bypass + auto session modes

### DIFF
--- a/agentwire/hooks/agentwire-permission.sh
+++ b/agentwire/hooks/agentwire-permission.sh
@@ -15,6 +15,25 @@ set -e
 # Read JSON from stdin
 input=$(cat)
 
+# Honor session-level permission bypass — when Claude Code was launched with
+# --dangerously-skip-permissions (permission_mode: "bypassPermissions") or is
+# running in autonomous mode (permission_mode: "auto"), the user has explicitly
+# opted out of permission friction. Short-circuit with an immediate allow so
+# the portal is never consulted. Python used for JSON parsing — no jq dep,
+# matches the stack the damage-control hooks run on.
+permission_mode=$(printf '%s' "$input" | python3 -c "import json,sys
+try:
+    print(json.load(sys.stdin).get('permission_mode',''))
+except Exception:
+    pass" 2>/dev/null || true)
+
+case "$permission_mode" in
+    bypassPermissions|auto)
+        echo '{"decision":"allow","message":"bypass mode: permission auto-approved"}'
+        exit 0
+        ;;
+esac
+
 # Find .agentwire.yml in current or parent directories
 find_agentwire_config() {
     local dir="$PWD"


### PR DESCRIPTION
## Summary
Root cause of "every action asks for permission in a bypass session": the PermissionRequest hook (`agentwire-permission.sh`) unconditionally POSTed every permission check to the portal, regardless of the session's `permission_mode`. When the session was launched with `--dangerously-skip-permissions` (`"bypassPermissions"`) or is running in autonomous mode (`"auto"`), the portal prompt shouldn't fire at all.

PRs #93 and #95 fixed the PreToolUse **Bash** hook to honor bypass/auto — but `PermissionRequest` is a separate hook, and it was still driving the portal prompt UI for every permission check. This closes the final gap.

Fix: parse `permission_mode` at the top of the hook (python3 — no jq dependency, matches the stack damage-control hooks already use) and short-circuit with `{"decision":"allow"}` before the curl call. Default/plan modes fall through to the existing portal flow unchanged.

## Test plan
- [x] `permission_mode: "auto"` → exit 0 with `{"decision":"allow",...}` instantly (no portal call)
- [x] `permission_mode: "bypassPermissions"` → same
- [x] `permission_mode: "default"` / absent → falls through to portal call (unchanged)

Built by [dotdev.dev](https://dotdev.dev)
