### PR TITLE
fix(email): accept multiple --to recipients

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10040,7 +10040,10 @@ def main() -> int:
     # === email command ===
     from agentwire.channels.email import cmd_email
     email_parser = subparsers.add_parser("email", help="Send branded email notification via Resend")
-    email_parser.add_argument("--to", type=str, help="Recipient email (default: from config)")
+    email_parser.add_argument(
+        "--to", action="append", default=None,
+        help="Recipient email. Repeat or pass comma-separated for multiple recipients (default: from config).",
+    )
     email_parser.add_argument("--subject", "-s", type=str, help="Email subject")
     email_parser.add_argument("--body", "-b", type=str, help="Email body - markdown supported (or pipe via stdin)")
     email_parser.add_argument("--attach", "-a", type=str, action="append", help="Attach file (can use multiple times)")

--- a/agentwire/channels/email.py
+++ b/agentwire/channels/email.py
@@ -166,8 +166,34 @@ def _get_email_config() -> EmailConfig:
     return EmailConfig()
 
 
+def _normalize_recipients(to: Optional[str | list[str]], default_to: str) -> list[str]:
+    """Flatten `to` (str | list[str]) into a deduped list, splitting on commas.
+
+    Accepts: None, "a@x.com", "a@x.com,b@y.com", ["a@x.com"], ["a,b", "c"].
+    Falls back to `default_to` (also comma-split) when `to` is None/empty.
+    Preserves order, drops duplicates and empty entries.
+    """
+    raw: list[str] = []
+    if not to:
+        raw = [default_to] if default_to else []
+    elif isinstance(to, str):
+        raw = [to]
+    else:
+        raw = list(to)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for entry in raw:
+        for part in str(entry).split(","):
+            addr = part.strip()
+            if addr and addr not in seen:
+                seen.add(addr)
+                out.append(addr)
+    return out
+
+
 def send_email(
-    to: Optional[str] = None,
+    to: Optional[str | list[str]] = None,
     subject: str = "",
     body: str = "",
     attachments: Optional[list[Path | str]] = None,
@@ -178,7 +204,8 @@ def send_email(
     """Send a branded email via Resend.
 
     Args:
-        to: Recipient email address. Uses config default_to if not specified.
+        to: Recipient email(s). Accepts a single address, a comma-separated
+            string, or a list of either. Uses config default_to if not specified.
         subject: Email subject line.
         body: Email body (markdown supported, converted to HTML).
         attachments: List of file paths to attach.
@@ -202,9 +229,9 @@ def send_email(
             "or set channels.email.api_key in ~/.agentwire/config.yaml"
         )
 
-    # Determine recipient
-    recipient = to or email_config.default_to
-    if not recipient:
+    # Determine recipients (list form — Resend's `to` field accepts an array)
+    recipients = _normalize_recipients(to, email_config.default_to)
+    if not recipients:
         raise EmailConfigError(
             "No recipient specified and no default_to configured in "
             "channels.email.default_to"
@@ -247,7 +274,7 @@ def send_email(
 
     params: dict = {
         "from": sender,
-        "to": [recipient],
+        "to": recipients,
         "subject": email_subject,
     }
 

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -1923,7 +1923,7 @@ def channels_list() -> str:
 @mcp.tool()
 def email_send(
     body: str,
-    to: str | None = None,
+    to: str | list[str] | None = None,
     subject: str | None = None,
     attachments: list[str] | None = None,
     plain_text: bool = False,
@@ -1934,7 +1934,8 @@ def email_send(
 
     Args:
         body: Email body (markdown supported)
-        to: Recipient email address (default: from config)
+        to: Recipient email(s). Accepts a single address, a comma-separated
+            string, or a list (default: from config).
         subject: Email subject line (optional)
         attachments: List of file paths to attach (optional)
         plain_text: Send plain text only, no HTML template (default: false)
@@ -1944,7 +1945,9 @@ def email_send(
     """
     args = ["email", "--body", body]
     if to:
-        args.extend(["--to", to])
+        recipients = to if isinstance(to, list) else [to]
+        for addr in recipients:
+            args.extend(["--to", addr])
     if subject:
         args.extend(["--subject", subject])
     if attachments:

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -246,6 +246,43 @@ class TestEmailChannel:
         finally:
             config_mod._config = old
 
+    def test_normalize_recipients_single_str(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients("a@x.com", "fallback@x.com") == ["a@x.com"]
+
+    def test_normalize_recipients_comma_split(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients("a@x.com, b@x.com ,c@x.com", "") == [
+            "a@x.com", "b@x.com", "c@x.com"
+        ]
+
+    def test_normalize_recipients_list(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients(["a@x.com", "b@x.com"], "") == ["a@x.com", "b@x.com"]
+
+    def test_normalize_recipients_list_with_commas(self):
+        from agentwire.channels.email import _normalize_recipients
+        # argparse --to a,b --to c produces ["a,b", "c"]; we split each on commas
+        assert _normalize_recipients(["a@x.com,b@x.com", "c@x.com"], "") == [
+            "a@x.com", "b@x.com", "c@x.com"
+        ]
+
+    def test_normalize_recipients_dedupes_preserving_order(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients(["a@x.com", "b@x.com", "a@x.com"], "") == [
+            "a@x.com", "b@x.com"
+        ]
+
+    def test_normalize_recipients_fallback_to_default(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients(None, "default@x.com") == ["default@x.com"]
+        assert _normalize_recipients("", "default@x.com") == ["default@x.com"]
+
+    def test_normalize_recipients_empty_returns_empty(self):
+        from agentwire.channels.email import _normalize_recipients
+        assert _normalize_recipients(None, "") == []
+        assert _normalize_recipients([], "") == []
+
     def test_greetings_list(self):
         from agentwire.channels.email import GREETINGS
         assert len(GREETINGS) == 8


### PR DESCRIPTION
## Summary

Stargazing-forecast has been sending to only one of its two configured recipients since the workflow was built, because the CLI `--to` flag was scalar — `agentwire email --to A --to B` silently dropped one of them (argparse keeps only the last). Resend's API supports an array for `to`; the bottleneck was agentwire's own CLI and helper.

## Changes

- `--to` argparse flag: `action="append"` so repeated flags collect into a list
- `send_email(to)` now accepts `str | list[str] | None`
- New `_normalize_recipients()` helper: flattens, comma-splits, dedupes, preserves order
- Resend params pass the full list instead of wrapping one recipient
- MCP `email_send` tool forwards each recipient as its own `--to` flag

All three input forms now work:
```bash
agentwire email --to a@x.com
agentwire email --to a@x.com,b@x.com
agentwire email --to a@x.com --to b@x.com
```

## Test plan

- [x] 7 new unit tests covering normalizer (single str, comma-split, list, list with comma entries, dedup, fallback, empty)
- [x] 121/121 channel tests pass
- [x] Smoke test: `agentwire email --to A --to B` → single Resend message with both recipients in `To:` header

Built by [dotdev.dev](https://dotdev.dev)