### PR TITLE
feat(portal): workflow history sidebar + detail window

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -230,6 +230,9 @@ class AgentWireServer:
         self.app.router.add_post("/api/scheduler/start", self.api_scheduler_start)
         self.app.router.add_post("/api/scheduler/stop", self.api_scheduler_stop)
         self.app.router.add_get("/api/scheduler/output", self.api_scheduler_session_output)
+        # Workflow history endpoints
+        self.app.router.add_get("/api/workflows/runs", self.api_workflows_runs_list)
+        self.app.router.add_get("/api/workflows/runs/{run_id}", self.api_workflows_run_detail)
         # Artifact windows: upload and serve agent-generated HTML
         self.app.router.add_post("/api/artifacts/upload", self.api_artifacts_upload)
         self.app.router.add_get("/api/artifacts", self.api_artifacts_list)
@@ -4199,6 +4202,135 @@ projects:
             tail = int(request.query.get("tail", "100"))
             events = read_events(tail=tail, task_filter=name)
             return web.json_response({"events": events})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_workflows_runs_list(self, request: web.Request) -> web.Response:
+        """GET /api/workflows/runs?workflow=X&limit=N - Recent workflow runs.
+
+        Reads ~/.agentwire/workflows/runs/*/metadata.json. Sorted newest first.
+        Optional `workflow` filters to a specific workflow name.
+        """
+        try:
+            from .workflows.cli import RUNS_DIR
+            from .workflows.storage import list_runs
+            workflow_name = request.query.get("workflow")
+            try:
+                limit = int(request.query.get("limit", "50"))
+            except ValueError:
+                limit = 50
+            loop = asyncio.get_event_loop()
+            runs = await loop.run_in_executor(
+                None, lambda: list_runs(RUNS_DIR, workflow=workflow_name, limit=limit)
+            )
+            # Slim each run to only the fields the sidebar needs — full metadata
+            # lives in the detail endpoint. Keeps the list response small.
+            # Totals aren't stored at run level; aggregate from per-node tokens.
+            slim = []
+            for r in runs:
+                nodes = r.get("nodes", []) or []
+                tokens_in = sum((n.get("tokens") or {}).get("input", 0) for n in nodes)
+                tokens_out = sum((n.get("tokens") or {}).get("output", 0) for n in nodes)
+                cost = sum((n.get("tokens") or {}).get("cost", 0.0) for n in nodes)
+                slim.append({
+                    "run_id": r.get("run_id"),
+                    "workflow": r.get("workflow"),
+                    "status": r.get("status"),
+                    "runner": r.get("runner", ""),
+                    "started_at": r.get("started_at"),
+                    "duration_ms": r.get("duration_ms"),
+                    "total_cost": cost,
+                    "total_tokens_in": tokens_in,
+                    "total_tokens_out": tokens_out,
+                    "node_count": len(nodes),
+                })
+            return web.json_response({"runs": slim})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_workflows_run_detail(self, request: web.Request) -> web.Response:
+        """GET /api/workflows/runs/{run_id} - Full run detail with normalized node schema.
+
+        Merges metadata.json's per-node records with event-stream-derived tool
+        call summaries, returning a single flat `nodes: [...]` list. The raw
+        `metadata` dict is also returned (minus the nodes array) for run-level
+        fields. Full event streams aren't included — fetch those separately
+        from the JSONL files on disk if needed.
+        """
+        run_id = request.match_info["run_id"]
+        try:
+            from .workflows.cli import RUNS_DIR
+            from .workflows.storage import load_run, load_context, load_events
+
+            loop = asyncio.get_event_loop()
+            meta = await loop.run_in_executor(None, lambda: load_run(RUNS_DIR, run_id))
+            if meta is None:
+                return web.json_response({"error": f"run '{run_id}' not found"}, status=404)
+
+            context = await loop.run_in_executor(None, lambda: load_context(RUNS_DIR, run_id))
+
+            # Walk event streams once to build per-node summaries: tool calls and
+            # final assistant text (last non-empty text block).
+            def _event_summaries() -> dict[str, dict]:
+                all_events = load_events(RUNS_DIR, run_id)
+                per_node: dict[str, dict] = {}
+                for node_id, ev in all_events:
+                    bucket = per_node.setdefault(
+                        node_id, {"event_count": 0, "tool_calls": [], "final_text": ""}
+                    )
+                    bucket["event_count"] += 1
+                    msg = ev.get("message") if isinstance(ev, dict) else None
+                    if not isinstance(msg, dict):
+                        continue
+                    if msg.get("role") != "assistant":
+                        continue
+                    for block in msg.get("content", []) or []:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "tool_use":
+                            bucket["tool_calls"].append({
+                                "name": block.get("name", ""),
+                                "input_preview": str(block.get("input", ""))[:200],
+                            })
+                        elif block.get("type") == "text":
+                            text = (block.get("text") or "").strip()
+                            if text:
+                                bucket["final_text"] = text  # last non-empty wins
+                return per_node
+
+            summaries = await loop.run_in_executor(None, _event_summaries)
+
+            # Merge metadata node records with event summaries into a single flat
+            # shape for the frontend. Metadata uses `id` + nested `tokens.{input,output,cost}`;
+            # we flatten to `node_id` + `tokens_in` / `tokens_out` / `cost` for a cleaner API.
+            nodes_merged: list[dict] = []
+            for n in meta.get("nodes", []) or []:
+                node_id = n.get("id", "")
+                tokens = n.get("tokens") or {}
+                summary = summaries.get(node_id, {})
+                nodes_merged.append({
+                    "node_id": node_id,
+                    "status": n.get("status"),
+                    "runner": n.get("runner", ""),
+                    "duration_ms": n.get("duration_ms", 0),
+                    "attempts": n.get("attempts", 1),
+                    "tokens_in": tokens.get("input", 0),
+                    "tokens_out": tokens.get("output", 0),
+                    "cost": tokens.get("cost", 0.0),
+                    "error": n.get("error"),
+                    "event_count": summary.get("event_count", 0),
+                    "tool_calls": summary.get("tool_calls", []),
+                    "final_text": summary.get("final_text", ""),
+                })
+
+            # Run-level metadata without the nodes array (it's in `nodes` above)
+            meta_summary = {k: v for k, v in meta.items() if k != "nodes"}
+
+            return web.json_response({
+                "metadata": meta_summary,
+                "context": context or {},
+                "nodes": nodes_merged,
+            })
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -3873,3 +3873,207 @@ body.sidebar-pinned .sidebar-tab {
 .notification-toast-body:hover {
     color: #fff;
 }
+
+/* ========= Workflows sidebar + window ========= */
+
+.sidebar-workflow-run {
+    cursor: pointer;
+}
+
+.sidebar-workflow-runner {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: var(--surface-2, #2a2a2a);
+    color: var(--text-muted, #888);
+    margin-left: auto;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+}
+.sidebar-workflow-runner[data-runner="anthropic"] {
+    background: rgba(204, 120, 80, 0.18);
+    color: #d89478;
+}
+.sidebar-workflow-runner[data-runner="pi"] {
+    background: rgba(80, 140, 200, 0.18);
+    color: #7fa8d4;
+}
+.sidebar-workflow-runner[data-runner="mixed"] {
+    background: rgba(150, 120, 200, 0.18);
+    color: #a994d4;
+}
+
+.workflow-window-content {
+    padding: 16px 20px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+    overflow-y: auto;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+.wf-loading,
+.wf-error,
+.wf-empty {
+    padding: 20px;
+    color: var(--text-muted, #888);
+    text-align: center;
+}
+.wf-error { color: var(--error, #dc2626); }
+
+.wf-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: 16px;
+    row-gap: 4px;
+    padding: 8px 12px;
+    background: var(--surface-2, rgba(255,255,255,0.02));
+    border-radius: 6px;
+    margin-bottom: 16px;
+}
+.wf-meta-label {
+    color: var(--text-muted, #888);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-top: 2px;
+}
+.wf-meta-value {
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+}
+.wf-meta-runid { font-size: 11px; word-break: break-all; color: var(--text-muted, #888); }
+.wf-status-success { color: var(--accent, #5fc572); }
+.wf-status-failed,
+.wf-status-error { color: var(--error, #dc2626); }
+.wf-status-running { color: var(--warning, #e5a96c); }
+
+.wf-section {
+    margin: 12px 0;
+}
+.wf-section summary {
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--text-muted, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 4px 0;
+}
+.wf-pre {
+    background: rgba(0,0,0,0.25);
+    padding: 8px 12px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.wf-section-header {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted, #888);
+    margin: 20px 0 8px 0;
+    border-bottom: 1px solid var(--border, #2a2a2a);
+    padding-bottom: 4px;
+}
+
+.wf-node {
+    padding: 10px 12px;
+    margin-bottom: 10px;
+    background: var(--surface-2, rgba(255,255,255,0.02));
+    border-radius: 6px;
+    border-left: 2px solid var(--surface-3, #2a2a2a);
+}
+.wf-node-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    flex-wrap: wrap;
+}
+.wf-status-dot {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.wf-status-dot.wf-status-success { background: var(--accent, #5fc572); }
+.wf-status-dot.wf-status-failed,
+.wf-status-dot.wf-status-error { background: var(--error, #dc2626); }
+.wf-status-dot.wf-status-running { background: var(--warning, #e5a96c); }
+
+.wf-node-id {
+    font-weight: 600;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+}
+.wf-node-runner,
+.wf-node-dur,
+.wf-node-tokens,
+.wf-node-events {
+    color: var(--text-muted, #888);
+    font-size: 11px;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+}
+.wf-node-runner {
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(255,255,255,0.04);
+}
+
+.wf-node-error {
+    margin-top: 6px;
+    padding: 6px 10px;
+    background: rgba(220, 38, 38, 0.1);
+    border-radius: 4px;
+    color: var(--error, #dc2626);
+    font-size: 12px;
+}
+
+.wf-node-tools {
+    margin-top: 8px;
+}
+.wf-node-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted, #888);
+    margin-bottom: 4px;
+}
+.wf-tool-call {
+    display: flex;
+    gap: 8px;
+    padding: 3px 0;
+    font-size: 11px;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+}
+.wf-tool-name {
+    color: var(--accent, #5fc572);
+    font-weight: 600;
+    min-width: 80px;
+}
+.wf-tool-input {
+    color: var(--text-muted, #888);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+
+.wf-node-final {
+    margin-top: 8px;
+}
+.wf-node-final summary {
+    cursor: pointer;
+    font-size: 11px;
+    color: var(--text-muted, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 4px 0;
+}

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -18,6 +18,7 @@ import { machinesSection } from './sidebar/machines-section.js';
 import { sessionsSection } from './sidebar/sessions-section.js';
 import { projectsSection } from './sidebar/projects-section.js';
 import { schedulerSection } from './sidebar/scheduler-section.js';
+import { workflowsSection } from './sidebar/workflows-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { socialsSection } from './sidebar/socials-section.js';
 import { notificationsPanel } from './notifications-panel.js';
@@ -58,6 +59,7 @@ async function init() {
     sidebar.addSection('projects', projectsSection);
     sidebar.addSection('artifacts', artifactsSection);
     sidebar.addSection('scheduler', schedulerSection);
+    sidebar.addSection('workflows', workflowsSection);
     sidebar.addSection('config', configSection);
     setupClock();
     setupPageUnload();

--- a/agentwire/static/js/sidebar/workflows-section.js
+++ b/agentwire/static/js/sidebar/workflows-section.js
@@ -1,0 +1,114 @@
+/**
+ * Workflows sidebar section — lists recent workflow runs.
+ *
+ * Clicking a run opens the WorkflowWindow detail view. Independent of the
+ * Scheduler section (scheduler shows *what will fire*, this shows *what ran*).
+ */
+
+import { openWorkflowWindow } from '../windows/workflow-window.js';
+
+function _fmtTime(ts) {
+    if (!ts) return '';
+    const d = new Date(ts * 1000);
+    const now = new Date();
+    const sameDay = d.toDateString() === now.toDateString();
+    if (sameDay) {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+        + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function _fmtDuration(ms) {
+    if (!ms) return '';
+    const s = Math.round(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    return rem ? `${m}m${rem}s` : `${m}m`;
+}
+
+function _statusDot(status) {
+    if (status === 'success') return 'dot-online';
+    if (status === 'failed' || status === 'error') return 'dot-offline';
+    if (status === 'running') return 'dot-processing';
+    return 'dot-idle';
+}
+
+export const workflowsSection = {
+    title: 'Workflows',
+    autoRefreshMs: 10000,  // poll every 10s while expanded
+    _body: null,
+    _runs: null,
+
+    actions: [
+        { id: 'refresh', label: '↻', title: 'Refresh' },
+    ],
+
+    onAction(actionId, body) {
+        if (actionId === 'refresh') this.refresh(body);
+    },
+
+    async mount(body) {
+        this._body = body;
+        await this.refresh(body);
+    },
+
+    async refresh(body) {
+        try {
+            const res = await fetch('/api/workflows/runs?limit=30');
+            const data = await res.json();
+            this._runs = Array.isArray(data.runs) ? data.runs : [];
+        } catch (e) {
+            this._runs = null;
+        }
+        this._render(body);
+    },
+
+    _render(body) {
+        if (this._runs === null) {
+            body.innerHTML = '<div class="sidebar-empty">Failed to load runs</div>';
+            return;
+        }
+        if (this._runs.length === 0) {
+            body.innerHTML = '<div class="sidebar-empty">No runs yet</div>';
+            return;
+        }
+
+        // Group by workflow name — scannable with multiple runs per workflow
+        const byWorkflow = new Map();
+        for (const r of this._runs) {
+            const wf = r.workflow || '(unknown)';
+            if (!byWorkflow.has(wf)) byWorkflow.set(wf, []);
+            byWorkflow.get(wf).push(r);
+        }
+
+        let html = '';
+        for (const [wf, runs] of byWorkflow) {
+            html += `<div class="sidebar-section-subheader">${wf}</div>`;
+            for (const r of runs) {
+                const dot = _statusDot(r.status);
+                const when = _fmtTime(r.started_at);
+                const dur = _fmtDuration(r.duration_ms);
+                const runner = r.runner || '';
+                const runnerBadge = runner
+                    ? `<span class="sidebar-workflow-runner" data-runner="${runner}">${runner}</span>`
+                    : '';
+                html += `<div class="sidebar-list-item sidebar-workflow-run" data-run-id="${r.run_id}" title="${r.run_id}">
+                    <span class="sidebar-status-dot ${dot}"></span>
+                    <span class="sidebar-list-item-title">${when} · ${dur}</span>
+                    ${runnerBadge}
+                </div>`;
+            }
+        }
+
+        body.innerHTML = html;
+        body.onclick = (e) => this._handleClick(e);
+    },
+
+    _handleClick(e) {
+        const item = e.target.closest('[data-run-id]');
+        if (!item) return;
+        openWorkflowWindow(item.dataset.runId);
+    },
+};

--- a/agentwire/static/js/windows/workflow-window.js
+++ b/agentwire/static/js/windows/workflow-window.js
@@ -1,0 +1,166 @@
+/**
+ * workflow-window.js
+ *
+ * WorkflowWindow — shows detail for a single workflow run: metadata,
+ * per-node status/tokens/cost, tool calls, and final text.
+ *
+ * Read-only historical view. Live-streaming in-flight runs is a later
+ * enhancement — this window just reloads on open.
+ */
+
+import { desktop } from '../desktop-manager.js';
+
+// Cache open windows by run_id so repeat clicks focus the existing one.
+const _openWindows = new Map();
+
+function _escape(s) {
+    if (s === null || s === undefined) return '';
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function _fmtDuration(ms) {
+    if (!ms) return '—';
+    const s = Math.round(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    return rem ? `${m}m${rem}s` : `${m}m`;
+}
+
+function _fmtCost(n) {
+    if (!n) return '$0.00';
+    return '$' + n.toFixed(4);
+}
+
+function _fmtTokens(n) {
+    return (n || 0).toLocaleString();
+}
+
+function _renderDetail(data) {
+    const meta = data.metadata || {};
+    const context = data.context || {};
+    const nodes = data.nodes || [];
+
+    // Run-level totals aren't stored in metadata — sum from nodes.
+    const totalIn = nodes.reduce((a, n) => a + (n.tokens_in || 0), 0);
+    const totalOut = nodes.reduce((a, n) => a + (n.tokens_out || 0), 0);
+    const totalCost = nodes.reduce((a, n) => a + (n.cost || 0), 0);
+
+    const metaHtml = `
+        <div class="wf-meta">
+            <div class="wf-meta-row"><span class="wf-meta-label">Workflow</span><span class="wf-meta-value">${_escape(meta.workflow)}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Run ID</span><span class="wf-meta-value wf-meta-runid">${_escape(meta.run_id)}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Status</span><span class="wf-meta-value wf-status-${_escape(meta.status)}">${_escape(meta.status)}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Runner</span><span class="wf-meta-value">${_escape(meta.runner || '—')}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Duration</span><span class="wf-meta-value">${_fmtDuration(meta.duration_ms)}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Tokens in/out</span><span class="wf-meta-value">${_fmtTokens(totalIn)} / ${_fmtTokens(totalOut)}</span></div>
+            <div class="wf-meta-row"><span class="wf-meta-label">Cost (nominal)</span><span class="wf-meta-value">${_fmtCost(totalCost)}</span></div>
+        </div>
+    `;
+
+    const inputsHtml = Object.keys(context.inputs || {}).length
+        ? `<details class="wf-section"><summary>Inputs</summary><pre class="wf-pre">${_escape(JSON.stringify(context.inputs, null, 2))}</pre></details>`
+        : '';
+
+    const errorHtml = meta.error
+        ? `<div class="wf-node-error"><strong>Run error:</strong> ${_escape(meta.error)}</div>`
+        : '';
+
+    const nodesHtml = nodes.map(n => {
+        const toolCallsHtml = (n.tool_calls || []).length
+            ? `<div class="wf-node-tools"><div class="wf-node-label">Tool calls (${n.tool_calls.length})</div>` +
+              n.tool_calls.map(tc =>
+                  `<div class="wf-tool-call"><span class="wf-tool-name">${_escape(tc.name)}</span><span class="wf-tool-input">${_escape(tc.input_preview)}</span></div>`
+              ).join('') + '</div>'
+            : '';
+
+        const finalTextHtml = n.final_text
+            ? `<details class="wf-node-final"><summary>Final text</summary><pre class="wf-pre">${_escape(n.final_text)}</pre></details>`
+            : '';
+
+        const nodeErrorHtml = n.error
+            ? `<div class="wf-node-error"><strong>Error:</strong> ${_escape(n.error)}</div>`
+            : '';
+
+        return `
+            <div class="wf-node">
+                <div class="wf-node-header">
+                    <span class="wf-status-dot wf-status-${_escape(n.status)}"></span>
+                    <span class="wf-node-id">${_escape(n.node_id)}</span>
+                    <span class="wf-node-runner">${_escape(n.runner || '')}</span>
+                    <span class="wf-node-dur">${_fmtDuration(n.duration_ms)}</span>
+                    <span class="wf-node-tokens">${_fmtTokens(n.tokens_in)} / ${_fmtTokens(n.tokens_out)} tok</span>
+                    <span class="wf-node-events">${n.event_count || 0} events</span>
+                </div>
+                ${nodeErrorHtml}
+                ${toolCallsHtml}
+                ${finalTextHtml}
+            </div>
+        `;
+    }).join('');
+
+    return `
+        <div class="wf-window-content">
+            ${metaHtml}
+            ${inputsHtml}
+            ${errorHtml}
+            <div class="wf-nodes">
+                <div class="wf-section-header">Nodes</div>
+                ${nodesHtml || '<div class="wf-empty">No nodes recorded</div>'}
+            </div>
+        </div>
+    `;
+}
+
+export function openWorkflowWindow(runId) {
+    if (_openWindows.has(runId)) {
+        _openWindows.get(runId).focus();
+        return;
+    }
+
+    const container = document.createElement('div');
+    container.className = 'workflow-window-content';
+    container.innerHTML = '<div class="wf-loading">Loading run…</div>';
+
+    const winbox = new WinBox({
+        title: `Workflow · ${runId}`,
+        icon: '<span style="font-size:14px">&#x26A1;</span>',
+        mount: container,
+        root: document.body,
+        width: '70%',
+        height: '80%',
+        x: 'center',
+        y: 'center',
+        minwidth: 480,
+        minheight: 320,
+        class: ['workflow-window'],
+        onclose: () => {
+            _openWindows.delete(runId);
+            desktop.unregisterWindow(`workflow:${runId}`);
+            return false;
+        },
+        onfocus: () => {},
+    });
+
+    desktop.registerWindow(`workflow:${runId}`, winbox);
+    _openWindows.set(runId, winbox);
+
+    // Fetch and render
+    fetch(`/api/workflows/runs/${encodeURIComponent(runId)}`)
+        .then(r => r.json())
+        .then(data => {
+            if (data.error) {
+                container.innerHTML = `<div class="wf-error">${_escape(data.error)}</div>`;
+                return;
+            }
+            container.innerHTML = _renderDetail(data);
+        })
+        .catch(e => {
+            container.innerHTML = `<div class="wf-error">Failed to load: ${_escape(e.message || e)}</div>`;
+        });
+}

--- a/agentwire/workflows/examples/silent-save.yaml
+++ b/agentwire/workflows/examples/silent-save.yaml
@@ -1,0 +1,42 @@
+name: silent-save
+description: Demonstrates a no-notification workflow. Writes a timestamped markdown file and exits — no email, no Slack, no webhook.
+version: 1
+
+# Notification is a *prompt-level* choice — there's no "notification" field in
+# the workflow engine itself. If the prompt doesn't call `agentwire email` or
+# any other channel, nothing is sent. The run's metadata, events, tool calls,
+# and final text are still persisted under ~/.agentwire/workflows/runs/<id>/
+# regardless, so you can always audit via `agentwire workflow show <id>` or
+# the portal's Workflows sidebar.
+
+inputs:
+  out_dir:
+    type: string
+    default: /tmp/silent-save
+    description: Where to write the markdown snapshot
+  topic:
+    type: string
+    default: today
+    description: What to snapshot — passed to the prompt as context
+
+nodes:
+  snapshot:
+    runner: anthropic
+    model: claude-sonnet-4-6
+    thinking_config: { type: disabled }
+    tools: [Bash, Write]
+    timeout: 300
+    retries: 0
+    prompt: |
+      Write a one-paragraph reflection about {{ inputs.topic }} to
+      {{ inputs.out_dir }}/YYYY-MM-DD.md (create the directory if needed).
+
+      Steps:
+      1. Run `date '+%Y-%m-%d'` via Bash to get today's date.
+      2. Create the output directory via `mkdir -p {{ inputs.out_dir }}`.
+      3. Write the file with a short (~120 word) reflection using the Write tool.
+
+      Do NOT send an email or any notification. This workflow deliberately
+      has no side effect beyond the file on disk.
+
+      After writing, reply with one line: the full path of the file you created.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -129,6 +129,28 @@ Pi nodes are silent under `--verbose` (pi parses stdout after the subprocess exi
 
 ---
 
+## History, persistence, and notifications
+
+Every run persists **independently of notifications**. Whether the workflow emails, posts to Slack, or does nothing at all, you always get:
+
+```
+~/.agentwire/workflows/runs/<run-id>/
+├── metadata.json                  # run manifest (workflow, status, runner, costs, inputs)
+├── context.json                   # final Context (inputs + per-node extracted outputs)
+└── nodes/
+    └── <node-id>.events.jsonl     # full event stream per node (tool calls, results, text)
+```
+
+**Notification is a prompt-level choice, not an engine feature.** If a prompt calls `agentwire email` or `agentwire webhook send` or `agentwire quo send`, that channel fires. If it doesn't, nothing goes out — but history is still there. See `agentwire/workflows/examples/silent-save.yaml` for an action-only workflow that produces a markdown file and zero notifications.
+
+You can inspect past runs three ways:
+
+1. **CLI** — `agentwire workflow history` lists recent runs (status, runner, duration, cost). `agentwire workflow show <run-id>` drills into a single run.
+2. **Portal** — open the sidebar, expand **Workflows**, click a run. Shows metadata, per-node tool calls, tokens, and final text.
+3. **Raw files** — `cat ~/.agentwire/workflows/runs/<run-id>/nodes/<node-id>.events.jsonl` gives you every event the runner produced.
+
+---
+
 ## CLI reference
 
 ```bash

--- a/tests/unit/test_server_workflow_history.py
+++ b/tests/unit/test_server_workflow_history.py
@@ -1,0 +1,173 @@
+"""Tests for the /api/workflows/runs* endpoints in agentwire/server.py."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentwire.config import load_config
+
+
+@pytest.fixture
+def server(tmp_path):
+    config = load_config(tmp_path / "nonexistent.yaml")
+    from agentwire.server import AgentWireServer
+    return AgentWireServer(config)
+
+
+def _write_metadata(runs_dir, run_id: str, workflow: str, nodes=None, **overrides):
+    """Create a minimal metadata.json under runs_dir/<run_id>/.
+
+    Matches the actual on-disk schema: per-node `id` + nested `tokens: {input, output, cost}`.
+    """
+    run_dir = runs_dir / run_id
+    run_dir.mkdir(parents=True)
+    if nodes is None:
+        nodes = [{
+            "id": "n1",
+            "runner": "anthropic",
+            "status": "success",
+            "duration_ms": 5000,
+            "tokens": {"input": 100, "output": 200, "cost": 0.42},
+            "error": None,
+        }]
+    meta = {
+        "schema_version": 2,
+        "run_id": run_id,
+        "workflow": workflow,
+        "status": "success",
+        "runner": "anthropic",
+        "started_at": 1700000000.0,
+        "duration_ms": 5000,
+        "nodes": nodes,
+    }
+    meta.update(overrides)
+    (run_dir / "metadata.json").write_text(json.dumps(meta))
+    return meta
+
+
+def _mock_request(match_info=None, query=None):
+    req = MagicMock()
+    req.match_info = match_info or {}
+    req.query = query or {}
+    return req
+
+
+class TestWorkflowRunsList:
+    async def test_empty_runs_dir(self, server, tmp_path):
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request())
+        data = json.loads(resp.body)
+        assert data == {"runs": []}
+
+    async def test_lists_runs_newest_first(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-old", "wf-a", started_at=100.0)
+        _write_metadata(tmp_path, "run-new", "wf-b", started_at=200.0)
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request())
+        data = json.loads(resp.body)
+        assert [r["run_id"] for r in data["runs"]] == ["run-new", "run-old"]
+
+    async def test_slim_fields_only(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-1", "wf", extra_field="should_not_leak")
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request())
+        data = json.loads(resp.body)
+        row = data["runs"][0]
+        assert "extra_field" not in row
+        assert set(row.keys()) == {
+            "run_id", "workflow", "status", "runner", "started_at",
+            "duration_ms", "total_cost", "total_tokens_in",
+            "total_tokens_out", "node_count",
+        }
+        assert row["node_count"] == 1
+
+    async def test_totals_aggregated_from_nodes(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-multi", "wf", nodes=[
+            {"id": "a", "status": "success", "duration_ms": 100,
+             "tokens": {"input": 10, "output": 20, "cost": 0.1}},
+            {"id": "b", "status": "success", "duration_ms": 200,
+             "tokens": {"input": 30, "output": 40, "cost": 0.25}},
+        ])
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request())
+        data = json.loads(resp.body)
+        row = data["runs"][0]
+        assert row["total_tokens_in"] == 40
+        assert row["total_tokens_out"] == 60
+        assert row["total_cost"] == pytest.approx(0.35)
+
+    async def test_workflow_filter(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-a", "wf-a")
+        _write_metadata(tmp_path, "run-b", "wf-b")
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request(query={"workflow": "wf-a"}))
+        data = json.loads(resp.body)
+        assert len(data["runs"]) == 1
+        assert data["runs"][0]["workflow"] == "wf-a"
+
+    async def test_invalid_limit_defaults_to_50(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-1", "wf")
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_runs_list(_mock_request(query={"limit": "notanumber"}))
+        # Should not raise; just return the run
+        assert resp.status == 200
+
+
+class TestWorkflowRunDetail:
+    async def test_404_missing_run(self, server, tmp_path):
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_run_detail(
+                _mock_request(match_info={"run_id": "does-not-exist"})
+            )
+        assert resp.status == 404
+
+    async def test_returns_normalized_nodes_merged_with_events(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-1", "wf")
+        # Write context.json
+        (tmp_path / "run-1" / "context.json").write_text(json.dumps({"inputs": {"x": 1}}))
+        # Write a node events file with one tool_use event and a text block
+        nodes_dir = tmp_path / "run-1" / "nodes"
+        nodes_dir.mkdir()
+        event = {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "WebSearch", "input": {"query": "hi"}},
+                    {"type": "text", "text": "all done"},
+                ],
+            },
+        }
+        (nodes_dir / "n1.events.jsonl").write_text(json.dumps(event) + "\n")
+
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_run_detail(
+                _mock_request(match_info={"run_id": "run-1"})
+            )
+        data = json.loads(resp.body)
+        assert data["metadata"]["run_id"] == "run-1"
+        # metadata no longer carries the nodes array — nodes is top-level
+        assert "nodes" not in data["metadata"]
+        assert data["context"] == {"inputs": {"x": 1}}
+        assert len(data["nodes"]) == 1
+        node = data["nodes"][0]
+        # Flat normalized schema
+        assert node["node_id"] == "n1"
+        assert node["status"] == "success"
+        assert node["tokens_in"] == 100
+        assert node["tokens_out"] == 200
+        assert node["cost"] == pytest.approx(0.42)
+        # Event-derived fields
+        assert node["event_count"] == 1
+        assert node["tool_calls"][0]["name"] == "WebSearch"
+        assert node["final_text"] == "all done"
+
+    async def test_missing_context_returns_empty_dict(self, server, tmp_path):
+        _write_metadata(tmp_path, "run-1", "wf")
+        with patch("agentwire.workflows.cli.RUNS_DIR", tmp_path):
+            resp = await server.api_workflows_run_detail(
+                _mock_request(match_info={"run_id": "run-1"})
+            )
+        data = json.loads(resp.body)
+        assert data["context"] == {}


### PR DESCRIPTION
## Summary

Adds a **Workflows** section to the portal sidebar and a detail window so users can inspect past runs independently of email/CLI. Supports the "action-only, no-notification" workflow pattern — runs are persisted regardless of whether anything was sent. See `examples/silent-save.yaml` for the pattern.

Parallel-but-independent to the Scheduler section: scheduler shows *what will fire*, workflow history shows *what actually ran*.

## Backend

- `GET /api/workflows/runs?workflow=X&limit=N` — list recent runs, per-run totals aggregated from node tokens
- `GET /api/workflows/runs/{run_id}` — normalized flat node schema merging metadata + event-stream summaries

## Frontend

- Sidebar section with polling refresh (10s), runs grouped by workflow name, runner badge
- WinBox-based detail window showing metadata, per-node tool calls, tokens, final text, errors
- Runner badge styling: anthropic=orange, pi=blue, mixed=purple

## Docs

- New "History, persistence, and notifications" section in `docs/workflows.md` explaining that notification is prompt-level and runs are always persisted
- New `examples/silent-save.yaml` demonstrating no-notification pattern

## Test plan

- [x] 9 new unit tests for the 2 endpoints (empty, sort, slim, totals aggregation, filter, 404, merged schema)
- [x] 805/809 tests pass (4 unchanged skips)
- [x] Smoke test: `curl https://localhost:8765/api/workflows/runs` returns real runs with correct totals
- [x] Smoke test: detail endpoint returns normalized nodes with tool calls + final text for daily-book-report run
- [ ] Visual check in browser: open portal → sidebar → Workflows → click a run

Built by [dotdev.dev](https://dotdev.dev)