### PR TITLE
fix(portal): drop inner scroll on sidebar sections

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -587,8 +587,8 @@ body {
 }
 
 .sidebar-section-body {
-    max-height: 400px;
-    overflow-y: auto;
+    /* No inner scroll — let sections grow to their natural content height.
+       The outer `.sidebar-sections` container handles the single scrollbar. */
 }
 
 /* Session cards — multi-row layout */


### PR DESCRIPTION
## Summary

`.sidebar-section-body` had its own `max-height: 400px` + `overflow-y: auto`, nested inside the outer `.sidebar-sections` which also scrolls. Any section taller than 400px (workflow history, long sessions lists) rendered two scrollbars side-by-side.

Fix: remove the inner scroll. Sections grow to natural content height, outer sidebar handles scrolling.

## Test plan

- [x] Portal restart, visually verify single scrollbar in sidebar with workflows section expanded
- [ ] Sanity check: sessions/scheduler sections also still behave correctly

Built by [dotdev.dev](https://dotdev.dev)