### PR TITLE
feat(search): add agentwire brave — Brave Search helper for research workflows

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -10051,6 +10051,22 @@ def main() -> int:
     email_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress success output")
     email_parser.set_defaults(func=cmd_email)
 
+    # === brave command ===
+    from agentwire.search import cmd_brave
+    brave_parser = subparsers.add_parser(
+        "brave",
+        help="Brave Search helper — run a web search and print results optimized for LLM consumption.",
+    )
+    brave_parser.add_argument("query", nargs="+", help="Search query (all remaining args joined with spaces)")
+    brave_parser.add_argument("--count", "-n", type=int, default=10, help="Max results (1-20, default 10)")
+    brave_parser.add_argument(
+        "--freshness", "-f", type=str, default="pd",
+        choices=["pd", "pw", "pm", "py"],
+        help="Time window: pd=past day (default), pw=past week, pm=past month, py=past year",
+    )
+    brave_parser.add_argument("--json", action="store_true", help="Output raw JSON instead of compact text")
+    brave_parser.set_defaults(func=cmd_brave)
+
     # === notify command ===
     notify_parser = subparsers.add_parser("notify", help="Notify portal of session/pane state changes")
     notify_parser.add_argument(

--- a/agentwire/search.py
+++ b/agentwire/search.py
@@ -1,0 +1,164 @@
+"""Brave Search helper — `agentwire brave <query>`.
+
+A thin CLI wrapper around the Brave Search API, optimized for LLM consumption
+inside workflow prompts. Returns compact text or JSON that includes just the
+fields a research agent needs (title, url, age, description) — avoiding the
+full-JSON token dump that inflates context when workflows curl the API directly.
+
+Token-efficiency was the whole point of the three-way A/B in 2026-04-21:
+`curl | parse` beat raw `curl` by ~100× on input tokens. This helper codifies
+that pattern so every research workflow gets it for free.
+
+Usage from inside a workflow prompt:
+
+    # Default: compact text output
+    agentwire brave "GPT-5 release"
+
+    # Raw JSON (full Brave API response) when you need image URLs, location data, etc.
+    agentwire brave "GPT-5 release" --json
+
+    # Tighten the count and widen the freshness window
+    agentwire brave "open source LLM" --count 5 --freshness pw
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+import urllib.error
+from dataclasses import dataclass
+
+
+BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+DEFAULT_COUNT = 10
+DEFAULT_FRESHNESS = "pd"  # past day — best default for "fresh news" workflows
+VALID_FRESHNESS = {"pd", "pw", "pm", "py"}  # past day/week/month/year
+
+
+class BraveSearchError(Exception):
+    """Raised for any Brave Search failure (missing key, API error, etc.)."""
+
+
+@dataclass
+class BraveResult:
+    """Compact per-result record — the fields LLMs actually read."""
+    title: str
+    url: str
+    age: str           # human string like "2 hours ago" — empty if Brave doesn't return it
+    description: str   # Brave's snippet; usually enough without fetching the page
+
+
+def brave_search(
+    query: str,
+    count: int = DEFAULT_COUNT,
+    freshness: str = DEFAULT_FRESHNESS,
+    api_key: str | None = None,
+) -> list[BraveResult]:
+    """Hit Brave Search API and return a compact list of results.
+
+    Args:
+        query: Free-text search query.
+        count: Max results (Brave caps at 20).
+        freshness: pd/pw/pm/py for past day/week/month/year.
+        api_key: Override the BRAVE_SEARCH_API_KEY env var.
+
+    Raises:
+        BraveSearchError: Missing API key, HTTP error, or malformed response.
+    """
+    key = api_key or os.environ.get("BRAVE_SEARCH_API_KEY", "")
+    if not key:
+        raise BraveSearchError(
+            "BRAVE_SEARCH_API_KEY not set. Add it to ~/.agentwire/.env or export "
+            "it in your environment. Get a key at https://brave.com/search/api/."
+        )
+    if freshness not in VALID_FRESHNESS:
+        raise BraveSearchError(
+            f"Invalid freshness '{freshness}'. Use one of: {', '.join(sorted(VALID_FRESHNESS))}"
+        )
+    # Brave caps count at 20 — silently clamp rather than erroring so workflows
+    # don't break on "count: 50" mistakes.
+    count = max(1, min(int(count), 20))
+
+    params = urllib.parse.urlencode({
+        "q": query,
+        "count": count,
+        "freshness": freshness,
+    })
+    url = f"{BRAVE_SEARCH_ENDPOINT}?{params}"
+    req = urllib.request.Request(url, headers={
+        "X-Subscription-Token": key,
+        "Accept": "application/json",
+    })
+
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace") if e.fp else str(e)
+        raise BraveSearchError(f"Brave API HTTP {e.code}: {msg[:300]}") from e
+    except urllib.error.URLError as e:
+        raise BraveSearchError(f"Brave API network error: {e.reason}") from e
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise BraveSearchError(f"Brave API returned invalid JSON: {e}") from e
+
+    web_results = (data.get("web") or {}).get("results") or []
+    return [
+        BraveResult(
+            title=r.get("title", "") or "",
+            url=r.get("url", "") or "",
+            age=r.get("age", "") or r.get("page_age", "") or "",
+            description=r.get("description", "") or "",
+        )
+        for r in web_results
+    ]
+
+
+def format_results_text(results: list[BraveResult]) -> str:
+    """Compact pipe-separated format: `title | url | age | description`.
+
+    One result per line. No headers — the caller is usually an LLM that
+    already knows the schema from its prompt.
+    """
+    lines = []
+    for r in results:
+        lines.append(f"{r.title} | {r.url} | {r.age} | {r.description}")
+    return "\n".join(lines)
+
+
+def format_results_json(results: list[BraveResult]) -> str:
+    """Pretty JSON of the compact records."""
+    return json.dumps(
+        [{"title": r.title, "url": r.url, "age": r.age, "description": r.description}
+         for r in results],
+        indent=2,
+    )
+
+
+def cmd_brave(args) -> int:
+    """CLI handler for `agentwire brave <query>`."""
+    query = " ".join(args.query).strip() if isinstance(args.query, list) else str(args.query or "").strip()
+    if not query:
+        print("Error: query is required. Usage: agentwire brave <query...>", file=sys.stderr)
+        return 2
+
+    try:
+        results = brave_search(query, count=args.count, freshness=args.freshness)
+    except BraveSearchError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not results:
+        print("(no results)")
+        return 0
+
+    if args.json:
+        print(format_results_json(results))
+    else:
+        print(format_results_text(results))
+    return 0

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -129,6 +129,47 @@ Pi nodes are silent under `--verbose` (pi parses stdout after the subprocess exi
 
 ---
 
+## Research tools — `agentwire brave`
+
+For workflows that need fresh web data (news digests, trend scans, "what happened today" reports), **don't use the SDK's built-in WebSearch/WebFetch tools**. A three-way A/B on `ai-morning-briefing` (2026-04-21) showed they were the quality bottleneck — even Opus 4.7 produced repetitive, thin output when the research came from WebSearch. The same model produced dramatically better output when research went through Brave Search API.
+
+The `agentwire brave` CLI wraps the Brave API and emits results in an LLM-friendly compact format. Use it from any workflow via the `Bash` tool:
+
+```bash
+# Default: compact pipe-separated output (title | url | age | description)
+agentwire brave "GPT-5 release"
+
+# Tighter result set, wider time window
+agentwire brave "open source LLM release" --count 5 --freshness pw
+# --freshness: pd=past day (default), pw=past week, pm=past month, py=past year
+
+# Raw JSON when you need structured parsing
+agentwire brave "Anthropic funding" --json
+```
+
+Add `BRAVE_SEARCH_API_KEY` to `~/.agentwire/.env` (free tier: $5 credits/month ≈ 1000 searches).
+
+Pattern for a research workflow node:
+
+```yaml
+nodes:
+  research_and_send:
+    runner: anthropic
+    model: claude-opus-4-7
+    effort: high
+    thinking_config: { type: adaptive }
+    tools: [Bash, Write]     # NO WebSearch/WebFetch
+    prompt: |
+      Run 5-7 queries via `agentwire brave "..." --count 5` to cover your
+      topics. Compose from the compact output. Fetch specific URLs with
+      `curl -sL | python3 -c "strip html"` only if Brave's description
+      field is too thin.
+```
+
+The pattern is deliberately runner-agnostic — pi workflows can call `agentwire brave` through their `bash` tool identically.
+
+---
+
 ## History, persistence, and notifications
 
 Every run persists **independently of notifications**. Whether the workflow emails, posts to Slack, or does nothing at all, you always get:

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -120,3 +120,77 @@ class TestFormatters:
         out = format_results_json(results)
         parsed = json.loads(out)
         assert parsed == [{"title": "A", "url": "u", "age": "1h", "description": "d"}]
+
+
+class TestCmdBrave:
+    """Tests for the cmd_brave CLI handler — argparse-to-func wiring."""
+
+    def _make_args(self, query, count=10, freshness="pd", json_out=False):
+        args = MagicMock()
+        # argparse with nargs="+" produces a list
+        args.query = query if isinstance(query, list) else [query]
+        args.count = count
+        args.freshness = freshness
+        args.json = json_out
+        return args
+
+    def test_empty_query_returns_2(self, capsys):
+        from agentwire.search import cmd_brave
+        rc = cmd_brave(self._make_args([]))
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "query is required" in err
+
+    def test_brave_error_returns_1_and_prints_stderr(self, monkeypatch, capsys):
+        from agentwire.search import cmd_brave
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        rc = cmd_brave(self._make_args(["hello"]))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "BRAVE_SEARCH_API_KEY" in err
+
+    def test_no_results_prints_placeholder_and_returns_0(self, capsys):
+        from agentwire.search import cmd_brave
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b'{"web":{"results":[]}}'
+            with patch.dict("os.environ", {"BRAVE_SEARCH_API_KEY": "fake"}):
+                rc = cmd_brave(self._make_args(["anything"]))
+        assert rc == 0
+        assert "(no results)" in capsys.readouterr().out
+
+    def test_text_output_default(self, capsys):
+        from agentwire.search import cmd_brave
+        api = {"web": {"results": [
+            {"title": "T", "url": "http://u", "age": "1h", "description": "d"},
+        ]}}
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = json.dumps(api).encode()
+            with patch.dict("os.environ", {"BRAVE_SEARCH_API_KEY": "fake"}):
+                rc = cmd_brave(self._make_args(["hello"]))
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "T | http://u | 1h | d"
+
+    def test_json_output_when_flagged(self, capsys):
+        from agentwire.search import cmd_brave
+        api = {"web": {"results": [
+            {"title": "T", "url": "http://u", "age": "1h", "description": "d"},
+        ]}}
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = json.dumps(api).encode()
+            with patch.dict("os.environ", {"BRAVE_SEARCH_API_KEY": "fake"}):
+                rc = cmd_brave(self._make_args(["hello"], json_out=True))
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed[0]["title"] == "T"
+
+    def test_multiword_query_joined(self):
+        """argparse's nargs='+' passes query words as a list; we join with spaces."""
+        from agentwire.search import cmd_brave
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b'{"web":{"results":[]}}'
+            with patch.dict("os.environ", {"BRAVE_SEARCH_API_KEY": "fake"}):
+                cmd_brave(self._make_args(["open", "source", "LLM"]))
+            # Query string sent to Brave should be "open source LLM" URL-encoded
+            url_called = m.call_args[0][0].full_url
+            assert "q=open+source+LLM" in url_called or "q=open%20source%20LLM" in url_called

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,122 @@
+"""Tests for agentwire/search.py — Brave Search helper."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agentwire.search import (
+    BraveResult,
+    BraveSearchError,
+    brave_search,
+    format_results_json,
+    format_results_text,
+)
+
+
+class TestBraveSearch:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+        with pytest.raises(BraveSearchError, match="BRAVE_SEARCH_API_KEY"):
+            brave_search("anything")
+
+    def test_invalid_freshness_raises(self):
+        with pytest.raises(BraveSearchError, match="Invalid freshness"):
+            brave_search("q", freshness="pz", api_key="fake")
+
+    def test_count_clamped_to_brave_cap(self):
+        """Count > 20 should silently clamp to 20, not error."""
+        # We can't easily mock urlopen without getting network-y, so we just
+        # verify the clamp logic at the brave_search level by intercepting the
+        # URL builder — but since the helper builds URL internally, simpler is
+        # to assert no ValueError from count out of range.
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b'{"web":{"results":[]}}'
+            brave_search("q", count=50, api_key="fake")
+            url_called = m.call_args[0][0].full_url
+            assert "count=20" in url_called
+
+    def test_parses_results(self):
+        api_response = {
+            "web": {
+                "results": [
+                    {
+                        "title": "Story One",
+                        "url": "https://example.com/1",
+                        "age": "2 hours ago",
+                        "description": "A summary of story one.",
+                    },
+                    {
+                        "title": "Story Two",
+                        "url": "https://example.com/2",
+                        "description": "No age field here.",
+                    },
+                ],
+            },
+        }
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = json.dumps(api_response).encode()
+            results = brave_search("q", api_key="fake")
+
+        assert len(results) == 2
+        assert results[0].title == "Story One"
+        assert results[0].age == "2 hours ago"
+        assert results[1].age == ""  # missing field → empty string, not None
+
+    def test_falls_back_to_page_age(self):
+        """If `age` is missing but `page_age` is present, use page_age."""
+        api_response = {"web": {"results": [
+            {"title": "T", "url": "u", "page_age": "2026-04-20", "description": "d"},
+        ]}}
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = json.dumps(api_response).encode()
+            results = brave_search("q", api_key="fake")
+        assert results[0].age == "2026-04-20"
+
+    def test_empty_results_returns_empty_list(self):
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b'{"web":{"results":[]}}'
+            results = brave_search("q", api_key="fake")
+        assert results == []
+
+    def test_missing_web_field_returns_empty(self):
+        """Brave sometimes returns just discussion/faq without web results."""
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b'{"type":"search"}'
+            results = brave_search("q", api_key="fake")
+        assert results == []
+
+    def test_http_error_wraps_as_brave_error(self):
+        import urllib.error
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            err = urllib.error.HTTPError(
+                url="x", code=429, msg="Too Many Requests", hdrs=None, fp=MagicMock(read=lambda: b"rate limited"),
+            )
+            m.side_effect = err
+            with pytest.raises(BraveSearchError, match="HTTP 429"):
+                brave_search("q", api_key="fake")
+
+    def test_malformed_json_wraps_as_brave_error(self):
+        with patch("agentwire.search.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.read.return_value = b"not json"
+            with pytest.raises(BraveSearchError, match="invalid JSON"):
+                brave_search("q", api_key="fake")
+
+
+class TestFormatters:
+    def test_format_text_compact(self):
+        results = [
+            BraveResult(title="A", url="http://a.com", age="1h", description="first"),
+            BraveResult(title="B", url="http://b.com", age="", description="second"),
+        ]
+        out = format_results_text(results)
+        assert out == "A | http://a.com | 1h | first\nB | http://b.com |  | second"
+
+    def test_format_text_empty(self):
+        assert format_results_text([]) == ""
+
+    def test_format_json_shape(self):
+        results = [BraveResult(title="A", url="u", age="1h", description="d")]
+        out = format_results_json(results)
+        parsed = json.loads(out)
+        assert parsed == [{"title": "A", "url": "u", "age": "1h", "description": "d"}]


### PR DESCRIPTION
## Summary

New CLI `agentwire brave <query>` wraps the Brave Search API and returns LLM-optimized output. Codifies the pattern that won the 2026-04-21 three-way A/B: raw Brave via bash beat the SDK's WebSearch tool by a large margin on research quality, regardless of model.

```bash
agentwire brave "GPT-5 release"                  # compact text (title | url | age | desc)
agentwire brave "news" --count 5 --freshness pw  # past week
agentwire brave "query" --json                    # full structured JSON
```

## Why

The SDK's built-in `WebSearch` was the research-quality bottleneck in the ai-morning-briefing A/B — Opus + WebSearch produced the worst output of three variants. Opus + Brave-via-bash produced the best. This wraps that pattern behind a clean command so any workflow can use it uniformly.

## Design

- urllib-only, no new deps
- Default output is compact one-result-per-line — keeps input tokens low across multi-search workflows
- `--json` for raw structured access
- `BRAVE_SEARCH_API_KEY` from env (already loaded from `~/.agentwire/.env`)
- Count clamped to Brave's 20 cap, freshness validated

## Test plan

- [x] 12 new unit tests covering missing key, invalid freshness, count clamp, parsing, empty results, page_age fallback, HTTP/JSON errors, both formatters
- [x] 817 / 821 tests pass (4 unchanged skips)
- [x] Smoke test: live Brave API calls return fresh results through `agentwire brave`

## Not in this PR

- Retooling live workflows. `stargazing-forecast` was updated in `~/.agentwire/workflows/defs/` (user config, not repo). `ai-morning-briefing` (Opus+WebSearch) left alone pending more days of A/B data to confirm retirement.

Built by [dotdev.dev](https://dotdev.dev)