### PR TITLE
feat(repl): phase 1 pr 1 — sdk-* session types + repl scaffold

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -218,6 +218,38 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
             env={"ZAI_API_KEY": zai.get("api_key", "")},
         )
 
+    # === Agentwire REPL (claude-agent-sdk) ===
+    # sdk-bypass / sdk-prompted / sdk-restricted — Python REPL running in a
+    # tmux pane, auth via Claude subscription. See docs/missions/agentwire-repl.md.
+    if session_type.startswith("sdk-"):
+        # Permission mode maps to SDK's permission_mode parameter
+        mode_map = {
+            "sdk-bypass": "bypass",
+            "sdk-prompted": "prompted",
+            "sdk-restricted": "restricted",
+        }
+        mode = mode_map.get(session_type, "bypass")
+
+        parts = ["agentwire", "repl", "--mode", mode]
+        if model:
+            parts.extend(["--model", model])
+
+        # Role-based system prompt (same temp-file pattern as claude-* / pi-zai
+        # to avoid shell escaping on multiline content; --append-system-prompt
+        # must be last).
+        temp_file = None
+        if merged and merged.instructions:
+            f = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+            f.write(merged.instructions)
+            f.close()
+            temp_file = f.name
+            parts.append(f'--append-system-prompt "$(<{temp_file})"')
+
+        return AgentCommand(
+            command=" ".join(parts),
+            temp_file=temp_file,
+        )
+
     # === Claude Code ===
     if session_type.startswith("claude"):
         parts = ["claude"]
@@ -3393,6 +3425,25 @@ def cmd_list(args) -> int:
         print()
 
     return 0
+
+
+def cmd_repl(args) -> int:
+    """Agentwire REPL — interactive harness built on claude-agent-sdk.
+
+    Invoked by build_agent_command when a session is spawned with --type sdk-*.
+    The user never calls this directly; it runs inside a tmux pane created by
+    `agentwire new -s <name> --type sdk-bypass`.
+
+    Phase 1 scaffold — proves the session-type plumbing works end-to-end.
+    SDK integration lands in PR 2.
+    """
+    from agentwire.repl.app import run_repl
+    return run_repl(
+        mode=args.mode,
+        model=args.model,
+        print_prompt=args.print,
+        system_prompt=args.append_system_prompt,
+    )
 
 
 def cmd_new(args) -> int:
@@ -10108,12 +10159,34 @@ def main() -> int:
     list_parser.set_defaults(func=cmd_list)
 
     # === new command (top-level) ===
+    # === repl command (top-level, internal — invoked by build_agent_command) ===
+    # Users spawn it via `agentwire new -s <name> --type sdk-bypass`; this is
+    # the process that runs inside the tmux pane. See docs/missions/agentwire-repl.md.
+    repl_parser = subparsers.add_parser(
+        "repl",
+        help="Agentwire REPL (internal — runs inside tmux pane for sdk-* session types)",
+    )
+    repl_parser.add_argument(
+        "--mode", choices=["bypass", "prompted", "restricted"], default="bypass",
+        help="Permission mode (bypass=run tools without asking, prompted=ask, restricted=read-only)",
+    )
+    repl_parser.add_argument("--model", default=None, help="Model override (default: claude-opus-4-7)")
+    repl_parser.add_argument(
+        "-p", "--print", dest="print", default=None, metavar="PROMPT",
+        help="One-shot mode: run PROMPT, emit output, exit (no interactive loop)",
+    )
+    repl_parser.add_argument(
+        "--append-system-prompt", dest="append_system_prompt", default=None, metavar="TEXT",
+        help="Additional system prompt content (appended after base prompt)",
+    )
+    repl_parser.set_defaults(func=cmd_repl)
+
     new_parser = subparsers.add_parser("new", help="Create new Claude Code session")
     new_parser.add_argument("-s", "--session", required=True, help="Session name (project, project/branch, or project/branch@machine)")
     new_parser.add_argument("-p", "--path", help="Working directory (default: ~/projects/<name>)")
     new_parser.add_argument("-f", "--force", action="store_true", help="Replace existing session")
     # Session type
-    new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, standard, worker, voice)")
+    new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-zai, pi-zai-restricted, pi-zai-readonly, sdk-bypass, sdk-prompted, sdk-restricted, standard, worker, voice)")
     # Roles
     new_parser.add_argument("--roles", help="Comma-separated list of roles (preserves existing config, defaults to agentwire for new projects)")
     new_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -22,6 +22,9 @@ class SessionType(str, Enum):
     PI_ZAI = "pi-zai"                      # Pi coding agent via Z.AI GLM (full tools)
     PI_ZAI_RESTRICTED = "pi-zai-restricted"  # Pi via Z.AI, read+search+bash (no edits)
     PI_ZAI_READONLY = "pi-zai-readonly"      # Pi via Z.AI, read-only inspection
+    SDK_BYPASS = "sdk-bypass"          # Agentwire REPL (claude-agent-sdk), bypass permissions
+    SDK_PROMPTED = "sdk-prompted"      # Agentwire REPL, ask before each tool call
+    SDK_RESTRICTED = "sdk-restricted"  # Agentwire REPL, plan / read-only
     # Universal types (agent-agnostic, map to agent-specific types)
     STANDARD = "standard"  # Full automation -> claude-bypass
     WORKER = "worker"      # Worker pane -> claude-restricted
@@ -74,6 +77,7 @@ def normalize_session_type(session_type: str, agent_type: str) -> str:
     agent_specific_types = [
         "claude-bypass", "claude-auto", "claude-prompted", "claude-restricted",
         "pi-zai", "pi-zai-restricted", "pi-zai-readonly",
+        "sdk-bypass", "sdk-prompted", "sdk-restricted",
         "bare"
     ]
     if session_type in agent_specific_types:

--- a/agentwire/repl/__init__.py
+++ b/agentwire/repl/__init__.py
@@ -1,0 +1,12 @@
+"""Agentwire REPL — interactive harness built on claude-agent-sdk.
+
+See docs/missions/agentwire-repl.md for the full mission scope.
+
+This package is the implementation of the `sdk-bypass`, `sdk-prompted`, and
+`sdk-restricted` session types. It is invoked by build_agent_command when a
+session is spawned via `agentwire new --type sdk-*`; users do not call it
+directly.
+
+Phase 1 (this PR) — scaffolding only. Proves session-type plumbing works.
+SDK integration, streaming, tools, and the real REPL loop land in PR 2+.
+"""

--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -1,0 +1,67 @@
+"""Agentwire REPL application entry point.
+
+Phase 1 scaffold — prints a greeting and echoes stdin so we can verify the
+session-type plumbing (enum dispatch, build_agent_command, tmux pane spawn)
+works end-to-end before the SDK integration lands in PR 2.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+BANNER = """\
+╭─────────────────────────────────────────────────────────╮
+│  agentwire repl — SDK-based interactive harness         │
+│  Phase 1 scaffold · mode={mode} · model={model}
+╰─────────────────────────────────────────────────────────╯
+"""
+
+
+def run_repl(
+    mode: str = "bypass",
+    model: str | None = None,
+    print_prompt: str | None = None,
+    system_prompt: str | None = None,
+) -> int:
+    """Run the REPL. Returns exit code.
+
+    Phase 1: no claude-agent-sdk integration yet. Just proves plumbing.
+    - Interactive: print banner, echo stdin lines with "scaffold" marker,
+      exit on Ctrl+D.
+    - Print mode (-p PROMPT): print the prompt back, exit.
+
+    SDK client, tool runner, event streaming all land in subsequent PRs.
+    """
+    model_display = model or "claude-opus-4-7 (default)"
+
+    if print_prompt is not None:
+        print(f"[agentwire repl · scaffold · mode={mode} · model={model_display}]")
+        print(f"prompt received: {print_prompt}")
+        if system_prompt:
+            preview = system_prompt.splitlines()[0][:80] if system_prompt else ""
+            print(f"system prompt: {len(system_prompt)} chars (first line: {preview!r})")
+        print("[Phase 1 scaffold — SDK integration lands in PR 2]")
+        return 0
+
+    sys.stdout.write(BANNER.format(mode=mode, model=model_display))
+    if system_prompt:
+        sys.stdout.write(f"system prompt loaded: {len(system_prompt)} chars\n")
+    sys.stdout.write("Phase 1 scaffold — type anything and it echoes back. Ctrl+D to exit.\n\n")
+    sys.stdout.flush()
+
+    try:
+        while True:
+            try:
+                line = input("> ")
+            except EOFError:
+                sys.stdout.write("\n[exit]\n")
+                return 0
+            except KeyboardInterrupt:
+                sys.stdout.write("\n[interrupt — use Ctrl+D to exit]\n")
+                continue
+            sys.stdout.write(f"scaffold received: {line!r}\n")
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[agentwire repl: unexpected error: {exc}]\n")
+        return 1

--- a/tests/unit/test_sdk_session_types.py
+++ b/tests/unit/test_sdk_session_types.py
@@ -1,0 +1,134 @@
+"""Tests for sdk-* session types + build_agent_command dispatch + REPL scaffold.
+
+Phase 1 PR 1 — covers the session-type plumbing end-to-end.
+See docs/missions/agentwire-repl.md for the mission scope.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from agentwire.project_config import SessionType, normalize_session_type
+from agentwire.__main__ import build_agent_command
+from agentwire.repl.app import run_repl
+
+
+# --- SessionType enum round-trip ---
+
+class TestSdkSessionTypes:
+    @pytest.mark.parametrize("value,member", [
+        ("sdk-bypass", SessionType.SDK_BYPASS),
+        ("sdk-prompted", SessionType.SDK_PROMPTED),
+        ("sdk-restricted", SessionType.SDK_RESTRICTED),
+    ])
+    def test_from_str(self, value, member):
+        assert SessionType.from_str(value) == member
+
+    def test_from_str_case_insensitive(self):
+        assert SessionType.from_str("SDK-BYPASS") == SessionType.SDK_BYPASS
+
+    def test_from_str_underscore_to_hyphen(self):
+        assert SessionType.from_str("sdk_bypass") == SessionType.SDK_BYPASS
+
+    def test_to_cli_flags_empty(self):
+        # sdk-* types don't produce Claude CLI flags (they spawn `agentwire repl`).
+        # to_cli_flags is Claude-specific; sdk-* returns empty to avoid collision.
+        assert SessionType.SDK_BYPASS.to_cli_flags() == []
+        assert SessionType.SDK_PROMPTED.to_cli_flags() == []
+        assert SessionType.SDK_RESTRICTED.to_cli_flags() == []
+
+
+# --- normalize_session_type passthrough ---
+
+class TestNormalizeSdk:
+    @pytest.mark.parametrize("sdk_type", [
+        "sdk-bypass", "sdk-prompted", "sdk-restricted",
+    ])
+    def test_passthrough(self, sdk_type):
+        assert normalize_session_type(sdk_type, "claude") == sdk_type
+
+
+# --- build_agent_command dispatch ---
+
+class TestBuildAgentCommandSdk:
+    def test_bypass(self):
+        cmd = build_agent_command("sdk-bypass")
+        assert cmd.command == "agentwire repl --mode bypass"
+        assert cmd.temp_file is None
+        assert cmd.env == {}
+
+    def test_prompted(self):
+        cmd = build_agent_command("sdk-prompted")
+        assert cmd.command == "agentwire repl --mode prompted"
+
+    def test_restricted(self):
+        cmd = build_agent_command("sdk-restricted")
+        assert cmd.command == "agentwire repl --mode restricted"
+
+    def test_with_model(self):
+        cmd = build_agent_command("sdk-bypass", model="claude-opus-4-7")
+        assert cmd.command == "agentwire repl --mode bypass --model claude-opus-4-7"
+
+    def test_with_role_instructions_appends_system_prompt(self, tmp_path):
+        # merge_roles is called inside build_agent_command; we simulate a role
+        # with instructions to exercise the temp-file path.
+        from agentwire.roles import RoleConfig
+        role = RoleConfig(
+            name="test",
+            description="t",
+            tools=[],
+            disallowed_tools=[],
+            instructions="you are a test role",
+            color=None,
+        )
+        cmd = build_agent_command("sdk-bypass", roles=[role])
+        assert cmd.command.startswith("agentwire repl --mode bypass")
+        assert "--append-system-prompt" in cmd.command
+        assert cmd.temp_file is not None
+        # cleanup
+        import os
+        if cmd.temp_file and os.path.exists(cmd.temp_file):
+            os.unlink(cmd.temp_file)
+
+
+# --- REPL scaffold ---
+
+class TestReplScaffold:
+    def test_print_mode_returns_zero(self, capsys):
+        rc = run_repl(mode="bypass", print_prompt="hello")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "prompt received: hello" in captured.out
+        assert "mode=bypass" in captured.out
+
+    def test_print_mode_with_system_prompt(self, capsys):
+        rc = run_repl(mode="bypass", print_prompt="x", system_prompt="system context")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "system prompt:" in captured.out
+
+    def test_interactive_exits_on_eof(self, monkeypatch, capsys):
+        # Simulate Ctrl+D immediately.
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        monkeypatch.setattr("builtins.input", lambda prompt="": (_ for _ in ()).throw(EOFError))
+        rc = run_repl(mode="bypass")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "agentwire repl" in captured.out
+
+    def test_interactive_echoes_input(self, monkeypatch, capsys):
+        lines = iter(["hello world", "second line"])
+        def fake_input(prompt=""):
+            try:
+                return next(lines)
+            except StopIteration:
+                raise EOFError
+        monkeypatch.setattr("builtins.input", fake_input)
+        rc = run_repl(mode="bypass")
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "scaffold received: 'hello world'" in captured.out
+        assert "scaffold received: 'second line'" in captured.out


### PR DESCRIPTION
## Summary
First step of the [agentwire-repl mission](docs/missions/agentwire-repl.md). Wires up the \`sdk-bypass\` / \`sdk-prompted\` / \`sdk-restricted\` session types so \`agentwire new -s foo --type sdk-bypass\` spawns a tmux pane running \`agentwire repl --mode bypass\`. **No SDK integration yet** — the REPL is a scaffold that echoes stdin to verify session-type plumbing end-to-end before \`claude-agent-sdk\` wiring lands in PR 2.

## What ships

- \`SessionType\` enum: \`SDK_BYPASS\` / \`SDK_PROMPTED\` / \`SDK_RESTRICTED\`
- \`normalize_session_type\` passthrough for \`sdk-*\` types
- \`build_agent_command\` dispatch: \`sdk-*\` → \`agentwire repl --mode <mode>\`; role instructions still layer via the existing \`--append-system-prompt\` temp-file pattern, so roles work unchanged
- \`agentwire/repl/\` package with \`run_repl()\` supporting interactive + print modes
- \`agentwire repl\` subcommand (internal — invoked by \`build_agent_command\`; users stay on \`agentwire new --type sdk-*\`)
- 18 new tests (enum round-trip, dispatch, role path, scaffold interactive + print modes)

## Why this shape for PR 1

Per the mission pitfall — **repeating the claudeGLM mistake** — shipping a whole REPL without first proving session-type plumbing works risks silent breakage. This PR deliberately proves only: can we spawn a pane, route to Python, accept args, loop on stdin. That's it. SDK primitives (\`ClaudeSDKClient\`, streaming events, tool runner) arrive in PR 2 where their failure modes are isolated.

## Smoke test (manual)

\`\`\`bash
agentwire rebuild
agentwire repl --mode bypass --print "hello"
# → echoes \"prompt received: hello\", exits 0

agentwire new -s sdk-test --type sdk-bypass
# → tmux pane attaches, shows the banner + \"> \" prompt; stdin echoes back
\`\`\`

## Test plan

- [x] \`uv run pytest tests/unit/test_sdk_session_types.py -v\` — 18/18 pass
- [x] \`uv run pytest\` — 841 passed / 4 skipped (up 18 from before)
- [x] \`agentwire repl --help\` renders cleanly
- [x] \`agentwire repl --print "..."\` exits 0 with expected output
- [ ] Manual: \`agentwire new --type sdk-bypass\` spawns a pane showing the REPL scaffold (verify after rebuild)

## Next

PR 2 — integrate \`claude-agent-sdk\` for real streaming + tool calls, still scaffolding for agentwire-native integration (MCP, damage control, voice) which arrives in Phase 3.

Built by [dotdev.dev](https://dotdev.dev)