### PR TITLE
feat(repl): phase 1 pr 2 — claude-agent-sdk print mode

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -1,13 +1,18 @@
 """Agentwire REPL application entry point.
 
-Phase 1 scaffold — prints a greeting and echoes stdin so we can verify the
-session-type plumbing (enum dispatch, build_agent_command, tmux pane spawn)
-works end-to-end before the SDK integration lands in PR 2.
+Phase 1 PR 2 — wires claude-agent-sdk into print mode (`agentwire repl -p ...`).
+Interactive mode stays on the PR 1 scaffold until PR 3 replaces it with a real
+prompt_toolkit-backed loop. Splitting keeps SDK wiring isolated from terminal-UI
+concerns.
 """
 
 from __future__ import annotations
 
+import asyncio
+import os
 import sys
+from pathlib import Path
+from typing import Any
 
 
 BANNER = """\
@@ -18,6 +23,20 @@ BANNER = """\
 """
 
 
+PERMISSION_MODE_MAP = {
+    "bypass": "bypassPermissions",
+    "prompted": "default",
+    "restricted": "plan",
+}
+
+# Tool surface per variant. Restricted is read-only (no Write/Edit/Bash).
+FULL_TOOLS = ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebFetch", "WebSearch"]
+RESTRICTED_TOOLS = ["Read", "Grep", "Glob", "WebFetch", "WebSearch"]
+
+DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_EFFORT = "high"
+
+
 def run_repl(
     mode: str = "bypass",
     model: str | None = None,
@@ -26,28 +45,283 @@ def run_repl(
 ) -> int:
     """Run the REPL. Returns exit code.
 
-    Phase 1: no claude-agent-sdk integration yet. Just proves plumbing.
-    - Interactive: print banner, echo stdin lines with "scaffold" marker,
-      exit on Ctrl+D.
-    - Print mode (-p PROMPT): print the prompt back, exit.
-
-    SDK client, tool runner, event streaming all land in subsequent PRs.
+    - Print mode (`-p PROMPT`): wire up claude-agent-sdk, run one turn, stream
+      events to stdout, exit.
+    - Interactive: PR 1 scaffold until PR 3 replaces with prompt_toolkit.
     """
-    model_display = model or "claude-opus-4-7 (default)"
-
     if print_prompt is not None:
-        print(f"[agentwire repl · scaffold · mode={mode} · model={model_display}]")
-        print(f"prompt received: {print_prompt}")
-        if system_prompt:
-            preview = system_prompt.splitlines()[0][:80] if system_prompt else ""
-            print(f"system prompt: {len(system_prompt)} chars (first line: {preview!r})")
-        print("[Phase 1 scaffold — SDK integration lands in PR 2]")
-        return 0
+        return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt))
+    return _run_interactive_scaffold(mode, model, system_prompt)
 
+
+# -------- print mode (SDK-backed) --------
+
+
+async def _run_print_mode(
+    prompt: str,
+    mode: str,
+    model: str | None,
+    system_prompt: str | None,
+) -> int:
+    try:
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ClaudeAgentOptions,
+            ClaudeSDKClient,
+            ResultMessage,
+            SystemMessage,
+            UserMessage,
+        )
+    except ImportError as e:
+        print(f"error: claude-agent-sdk not installed: {e}", file=sys.stderr)
+        return 1
+
+    options = build_options(ClaudeAgentOptions, mode, model, system_prompt, cwd=Path.cwd())
+
+    # claude-agent-sdk refuses to nest — same CLAUDECODE unset as the workflow runner.
+    saved_claudecode = os.environ.pop("CLAUDECODE", None)
+    exit_code = 0
+    try:
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(prompt)
+            async for message in client.receive_response():
+                try:
+                    render_message(
+                        message,
+                        AssistantMessage=AssistantMessage,
+                        UserMessage=UserMessage,
+                        SystemMessage=SystemMessage,
+                        ResultMessage=ResultMessage,
+                        out=sys.stdout,
+                    )
+                    if isinstance(message, ResultMessage) and getattr(message, "is_error", False):
+                        exit_code = 1
+                except Exception as exc:
+                    print(f"[repl: render error: {exc}]", file=sys.stderr)
+    except Exception as exc:
+        print(f"[repl: {type(exc).__name__}: {exc}]", file=sys.stderr)
+        return 1
+    finally:
+        if saved_claudecode is not None:
+            os.environ["CLAUDECODE"] = saved_claudecode
+    return exit_code
+
+
+def build_options(
+    ClaudeAgentOptions: Any,
+    mode: str,
+    model: str | None,
+    system_prompt: str | None,
+    cwd: Path | None = None,
+) -> Any:
+    """Compose `ClaudeAgentOptions` for a REPL session.
+
+    Permission mode + tool surface are derived from the session-type variant
+    (`sdk-bypass`/`sdk-prompted`/`sdk-restricted`). System prompt layers project
+    CLAUDE.md + AGENTS.md + an optional explicit append.
+    """
+    kwargs: dict[str, Any] = {
+        "model": model or DEFAULT_MODEL,
+        "permission_mode": PERMISSION_MODE_MAP.get(mode, "bypassPermissions"),
+        "allowed_tools": RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS,
+        "setting_sources": ["user"],       # load ~/.claude/hooks — damage-control
+        "include_partial_messages": False,
+        "effort": DEFAULT_EFFORT,
+        "thinking": {"type": "adaptive"},
+    }
+    if cwd is not None:
+        kwargs["cwd"] = str(cwd)
+
+    append_parts: list[str] = []
+    if cwd is not None:
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            found = _find_ancestor_file(cwd, name)
+            if found is not None:
+                try:
+                    append_parts.append(f"--- {found} ---\n{found.read_text()}")
+                except Exception:
+                    pass
+    if system_prompt:
+        append_parts.append(system_prompt)
+
+    if append_parts:
+        kwargs["system_prompt"] = {
+            "type": "preset",
+            "preset": "claude_code",
+            "append": "\n\n".join(append_parts),
+        }
+
+    return ClaudeAgentOptions(**kwargs)
+
+
+def _find_ancestor_file(start: Path, name: str) -> Path | None:
+    for ancestor in [start, *start.parents]:
+        candidate = ancestor / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# -------- event rendering --------
+
+
+def render_message(
+    message: Any,
+    AssistantMessage: Any,
+    UserMessage: Any,
+    SystemMessage: Any,
+    ResultMessage: Any,
+    out: Any = sys.stdout,
+) -> None:
+    """Render one SDK message to the terminal.
+
+    Compact, human-readable output matching the spirit of pi's JSONL but for
+    a terminal reader. Tools like `Read`/`Bash` show the target; tool results
+    show a one-line preview.
+    """
+    if isinstance(message, SystemMessage):
+        if getattr(message, "subtype", None) == "init":
+            data = getattr(message, "data", {}) or {}
+            model = data.get("model", "") or ""
+            sid = (data.get("session_id") or data.get("sessionId") or "")[:8]
+            parts = [p for p in [model, f"session {sid}" if sid else ""] if p]
+            out.write(f"[agent started · {' · '.join(parts)}]\n")
+        return
+
+    if isinstance(message, AssistantMessage):
+        for block in getattr(message, "content", []) or []:
+            btype = _block_type(block)
+            if btype == "text":
+                text = _block_attr(block, "text", "") or ""
+                if text:
+                    out.write(text)
+                    if not text.endswith("\n"):
+                        out.write("\n")
+            elif btype == "tool_use":
+                name = _block_attr(block, "name", "") or ""
+                inp = _block_attr(block, "input", {}) or {}
+                summary = _format_tool_input(name, inp)
+                out.write(f"[→ {name}{' ' + summary if summary else ''}]\n")
+            elif btype == "thinking":
+                thinking = _block_attr(block, "thinking", "") or ""
+                first = thinking.split("\n", 1)[0].strip()
+                if first:
+                    preview = first if len(first) <= 80 else first[:77] + "..."
+                    out.write(f"[thinking: {preview}]\n")
+        return
+
+    if isinstance(message, UserMessage):
+        content = getattr(message, "content", None)
+        if isinstance(content, list):
+            for block in content:
+                btype = _block_type(block)
+                if btype == "tool_result":
+                    result_content = _block_attr(block, "content", None)
+                    preview = _format_tool_result(result_content)
+                    out.write(f"[← result: {preview}]\n")
+        return
+
+    if isinstance(message, ResultMessage):
+        usage = getattr(message, "usage", {}) or {}
+        cost = getattr(message, "total_cost_usd", None)
+        duration = getattr(message, "duration_ms", None)
+        parts: list[str] = []
+        if isinstance(usage, dict):
+            in_tok = usage.get("input_tokens", 0) or 0
+            out_tok = usage.get("output_tokens", 0) or 0
+            if in_tok or out_tok:
+                parts.append(f"{in_tok}+{out_tok} tok")
+        if cost is not None:
+            parts.append(f"${cost:.4f}")
+        if duration is not None:
+            parts.append(f"{duration / 1000:.1f}s")
+        suffix = f" · {' · '.join(parts)}" if parts else ""
+        if getattr(message, "is_error", False):
+            err = getattr(message, "result", None) or "unknown error"
+            out.write(f"[error{suffix}] {err}\n")
+        else:
+            out.write(f"[done{suffix}]\n")
+        return
+
+
+def _block_type(block: Any) -> str:
+    if hasattr(block, "type"):
+        return getattr(block, "type") or ""
+    if isinstance(block, dict):
+        return block.get("type", "")
+    return {
+        "TextBlock": "text",
+        "ToolUseBlock": "tool_use",
+        "ThinkingBlock": "thinking",
+        "ToolResultBlock": "tool_result",
+    }.get(type(block).__name__, "")
+
+
+def _block_attr(block: Any, name: str, default: Any = None) -> Any:
+    if isinstance(block, dict):
+        return block.get(name, default)
+    return getattr(block, name, default)
+
+
+def _format_tool_input(name: str, inp: dict) -> str:
+    if not isinstance(inp, dict):
+        return ""
+    if name in ("Read", "Write", "Edit"):
+        fp = inp.get("file_path", "")
+        if fp:
+            return str(fp)
+    if name == "Bash":
+        cmd = inp.get("command", "") or ""
+        if cmd:
+            return cmd if len(cmd) <= 80 else cmd[:77] + "..."
+    if name in ("Grep", "Glob"):
+        return str(inp.get("pattern", "") or "")
+    if name == "WebFetch":
+        return str(inp.get("url", "") or "")
+    if name == "WebSearch":
+        return str(inp.get("query", "") or "")
+    rendered = str(inp)
+    return rendered if len(rendered) <= 80 else rendered[:77] + "..."
+
+
+def _format_tool_result(content: Any) -> str:
+    if content is None:
+        return "(no content)"
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = ""
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                text = b.get("text", "") or ""
+                break
+            if hasattr(b, "text"):
+                text = str(getattr(b, "text", "") or "")
+                break
+        if not text:
+            text = str(content)
+    else:
+        text = str(content)
+    text = text.replace("\n", " ")
+    return text if len(text) <= 120 else text[:117] + "..."
+
+
+# -------- interactive (PR 1 scaffold, replaced in PR 3) --------
+
+
+def _run_interactive_scaffold(
+    mode: str,
+    model: str | None,
+    system_prompt: str | None,
+) -> int:
+    model_display = model or f"{DEFAULT_MODEL} (default)"
     sys.stdout.write(BANNER.format(mode=mode, model=model_display))
     if system_prompt:
         sys.stdout.write(f"system prompt loaded: {len(system_prompt)} chars\n")
-    sys.stdout.write("Phase 1 scaffold — type anything and it echoes back. Ctrl+D to exit.\n\n")
+    sys.stdout.write(
+        "Phase 1 scaffold — type anything and it echoes back. Ctrl+D to exit.\n"
+        "[interactive SDK loop lands in PR 3; use `-p` for real SDK turns today]\n\n"
+    )
     sys.stdout.flush()
 
     try:

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -1,0 +1,468 @@
+"""Tests for the SDK-backed REPL — build_options, render_message, print mode.
+
+Phase 1 PR 2. See docs/missions/agentwire-repl.md.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentwire.repl.app import (
+    DEFAULT_EFFORT,
+    DEFAULT_MODEL,
+    FULL_TOOLS,
+    PERMISSION_MODE_MAP,
+    RESTRICTED_TOOLS,
+    build_options,
+    render_message,
+    _find_ancestor_file,
+    _format_tool_input,
+    _format_tool_result,
+)
+
+
+# A fake ClaudeAgentOptions that records kwargs rather than validating them,
+# so we can assert on shape without depending on the real SDK at test time.
+class FakeOptions:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+# --- build_options ---
+
+class TestBuildOptions:
+    def test_bypass_mode(self, tmp_path):
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
+        assert opts.kwargs["permission_mode"] == "bypassPermissions"
+        assert opts.kwargs["allowed_tools"] == FULL_TOOLS
+        assert opts.kwargs["model"] == DEFAULT_MODEL
+        assert opts.kwargs["effort"] == DEFAULT_EFFORT
+        assert opts.kwargs["thinking"] == {"type": "adaptive"}
+        assert opts.kwargs["setting_sources"] == ["user"]
+
+    def test_prompted_mode(self, tmp_path):
+        opts = build_options(FakeOptions, "prompted", None, None, cwd=tmp_path)
+        assert opts.kwargs["permission_mode"] == "default"
+        assert opts.kwargs["allowed_tools"] == FULL_TOOLS
+
+    def test_restricted_mode(self, tmp_path):
+        opts = build_options(FakeOptions, "restricted", None, None, cwd=tmp_path)
+        assert opts.kwargs["permission_mode"] == "plan"
+        assert opts.kwargs["allowed_tools"] == RESTRICTED_TOOLS
+        # Restricted drops Write/Edit/Bash
+        for tool in ("Write", "Edit", "Bash"):
+            assert tool not in opts.kwargs["allowed_tools"]
+
+    def test_model_override(self, tmp_path):
+        opts = build_options(FakeOptions, "bypass", "claude-sonnet-4-6", None, cwd=tmp_path)
+        assert opts.kwargs["model"] == "claude-sonnet-4-6"
+
+    def test_unknown_mode_defaults_bypass(self, tmp_path):
+        opts = build_options(FakeOptions, "whatever", None, None, cwd=tmp_path)
+        assert opts.kwargs["permission_mode"] == "bypassPermissions"
+
+    def test_cwd_passed_as_str(self, tmp_path):
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
+        assert opts.kwargs["cwd"] == str(tmp_path)
+
+    def test_no_system_prompt_no_field(self, tmp_path):
+        # Empty cwd dir, no system_prompt → no system_prompt kwarg emitted
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
+        assert "system_prompt" not in opts.kwargs
+
+    def test_explicit_system_prompt_appended(self, tmp_path):
+        opts = build_options(FakeOptions, "bypass", None, "custom role text", cwd=tmp_path)
+        sp = opts.kwargs["system_prompt"]
+        assert sp["type"] == "preset"
+        assert sp["preset"] == "claude_code"
+        assert "custom role text" in sp["append"]
+
+    def test_claude_md_auto_discovery(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("Project CLAUDE.md content")
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
+        sp = opts.kwargs["system_prompt"]
+        assert "Project CLAUDE.md content" in sp["append"]
+
+    def test_agents_md_auto_discovery(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Agent context from AGENTS.md")
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
+        sp = opts.kwargs["system_prompt"]
+        assert "Agent context from AGENTS.md" in sp["append"]
+
+    def test_both_files_and_explicit_all_concatenated(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("AAA")
+        (tmp_path / "AGENTS.md").write_text("BBB")
+        opts = build_options(FakeOptions, "bypass", None, "CCC", cwd=tmp_path)
+        append = opts.kwargs["system_prompt"]["append"]
+        assert "AAA" in append and "BBB" in append and "CCC" in append
+
+    def test_ancestor_walk(self, tmp_path):
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        (tmp_path / "CLAUDE.md").write_text("from parent")
+        opts = build_options(FakeOptions, "bypass", None, None, cwd=nested)
+        assert "from parent" in opts.kwargs["system_prompt"]["append"]
+
+
+class TestFindAncestorFile:
+    def test_finds_in_current_dir(self, tmp_path):
+        f = tmp_path / "CLAUDE.md"
+        f.write_text("x")
+        assert _find_ancestor_file(tmp_path, "CLAUDE.md") == f
+
+    def test_walks_up(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        f = tmp_path / "CLAUDE.md"
+        f.write_text("x")
+        assert _find_ancestor_file(nested, "CLAUDE.md") == f
+
+    def test_missing_returns_none(self, tmp_path):
+        assert _find_ancestor_file(tmp_path, "CLAUDE.md") is None
+
+
+# --- render_message ---
+
+# Fake SDK message types (structural). The renderer uses isinstance, so we
+# pass the same fake classes both to render_message and to the messages.
+class FakeAssistantMessage:
+    def __init__(self, content, model=None):
+        self.content = content
+        self.model = model
+
+
+class FakeUserMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeSystemMessage:
+    def __init__(self, subtype, data=None):
+        self.subtype = subtype
+        self.data = data or {}
+
+
+class FakeResultMessage:
+    def __init__(self, usage=None, total_cost_usd=None, duration_ms=None, is_error=False, result=None):
+        self.usage = usage or {}
+        self.total_cost_usd = total_cost_usd
+        self.duration_ms = duration_ms
+        self.is_error = is_error
+        self.result = result
+
+
+RENDER_KWARGS = dict(
+    AssistantMessage=FakeAssistantMessage,
+    UserMessage=FakeUserMessage,
+    SystemMessage=FakeSystemMessage,
+    ResultMessage=FakeResultMessage,
+)
+
+
+def _render(msg) -> str:
+    buf = io.StringIO()
+    render_message(msg, out=buf, **RENDER_KWARGS)
+    return buf.getvalue()
+
+
+class TestRenderSystem:
+    def test_init_shows_model_and_session(self):
+        msg = FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "abc123xyz456"})
+        out = _render(msg)
+        assert "claude-opus-4-7" in out
+        assert "abc123xy" in out  # 8-char truncation
+
+    def test_non_init_silent(self):
+        msg = FakeSystemMessage("whatever", {})
+        assert _render(msg) == ""
+
+
+class TestRenderAssistant:
+    def test_text_block(self):
+        msg = FakeAssistantMessage([{"type": "text", "text": "Hello, world!"}])
+        assert "Hello, world!" in _render(msg)
+
+    def test_tool_use_bash(self):
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "Bash", "input": {"command": "ls -la"},
+        }])
+        out = _render(msg)
+        assert "→ Bash ls -la" in out
+
+    def test_tool_use_read_shows_file_path(self):
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "Read", "input": {"file_path": "/tmp/x.txt"},
+        }])
+        out = _render(msg)
+        assert "/tmp/x.txt" in out
+
+    def test_tool_use_grep(self):
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "Grep", "input": {"pattern": "TODO"},
+        }])
+        assert "→ Grep TODO" in _render(msg)
+
+    def test_tool_use_websearch(self):
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "WebSearch", "input": {"query": "brave search API"},
+        }])
+        assert "brave search API" in _render(msg)
+
+    def test_thinking_block_shows_preview(self):
+        msg = FakeAssistantMessage([{
+            "type": "thinking", "thinking": "First line of reasoning\nSecond line here",
+        }])
+        out = _render(msg)
+        assert "First line of reasoning" in out
+        assert "Second line" not in out  # only first line shown
+
+    def test_bash_long_command_truncated(self):
+        long_cmd = "echo " + "x" * 200
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "Bash", "input": {"command": long_cmd},
+        }])
+        out = _render(msg)
+        assert "..." in out
+
+
+class TestRenderUser:
+    def test_tool_result_shown(self):
+        msg = FakeUserMessage([{
+            "type": "tool_result", "tool_use_id": "tu_1", "content": "hello output",
+        }])
+        out = _render(msg)
+        assert "← result: hello output" in out
+
+    def test_tool_result_list_content(self):
+        msg = FakeUserMessage([{
+            "type": "tool_result",
+            "tool_use_id": "tu_1",
+            "content": [{"type": "text", "text": "from block list"}],
+        }])
+        assert "from block list" in _render(msg)
+
+    def test_text_content_not_rendered_as_tool_result(self):
+        msg = FakeUserMessage("plain user text")  # string-only content
+        assert _render(msg) == ""
+
+
+class TestRenderResult:
+    def test_success_with_tokens_and_cost(self):
+        msg = FakeResultMessage(
+            usage={"input_tokens": 1000, "output_tokens": 200},
+            total_cost_usd=0.0123,
+            duration_ms=4500,
+        )
+        out = _render(msg)
+        assert "done" in out
+        assert "1000+200 tok" in out
+        assert "$0.0123" in out
+        assert "4.5s" in out
+
+    def test_error_shows_error(self):
+        msg = FakeResultMessage(is_error=True, result="rate limit hit")
+        out = _render(msg)
+        assert "[error" in out
+        assert "rate limit hit" in out
+
+    def test_minimal_result(self):
+        msg = FakeResultMessage()
+        out = _render(msg)
+        assert "[done" in out
+
+
+# --- format helpers ---
+
+class TestFormatToolInput:
+    def test_read_file_path(self):
+        assert _format_tool_input("Read", {"file_path": "x.py"}) == "x.py"
+
+    def test_bash_command(self):
+        assert _format_tool_input("Bash", {"command": "pwd"}) == "pwd"
+
+    def test_bash_long_truncated(self):
+        long = "a" * 150
+        out = _format_tool_input("Bash", {"command": long})
+        assert out.endswith("...")
+        assert len(out) == 80
+
+    def test_unknown_tool_fallback(self):
+        out = _format_tool_input("Mystery", {"key": "value"})
+        assert "key" in out
+
+    def test_non_dict_input(self):
+        assert _format_tool_input("Bash", "not a dict") == ""
+
+
+# --- print mode end-to-end (mocked SDK) ---
+
+class FakeAsyncContextManager:
+    """Minimal async-context fake for ClaudeSDKClient."""
+
+    def __init__(self, messages, options=None):
+        self._messages = messages
+        self.options = options
+        self.queried_prompts: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def query(self, prompt):
+        self.queried_prompts.append(prompt)
+
+    async def receive_response(self):
+        for m in self._messages:
+            yield m
+
+
+class TestPrintModeIntegration:
+    """End-to-end print-mode test with claude-agent-sdk mocked out.
+
+    Installs a fake `claude_agent_sdk` module in sys.modules BEFORE `run_repl`
+    imports it, so the real SDK is never touched.
+    """
+
+    def test_prints_and_returns_zero(self, monkeypatch, capsys):
+        import sys as _sys
+        import types
+
+        # Build the fake module
+        fake_sdk = types.ModuleType("claude_agent_sdk")
+
+        fake_sdk.AssistantMessage = FakeAssistantMessage
+        fake_sdk.UserMessage = FakeUserMessage
+        fake_sdk.SystemMessage = FakeSystemMessage
+        fake_sdk.ResultMessage = FakeResultMessage
+        fake_sdk.ClaudeAgentOptions = FakeOptions
+
+        messages = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "abc12345def"}),
+            FakeAssistantMessage([
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "x.py"}},
+            ]),
+            FakeUserMessage([{"type": "tool_result", "tool_use_id": "t1", "content": "file contents here"}]),
+            FakeAssistantMessage([{"type": "text", "text": "Here's the summary."}]),
+            FakeResultMessage(
+                usage={"input_tokens": 100, "output_tokens": 50},
+                total_cost_usd=0.001,
+                duration_ms=1500,
+                is_error=False,
+            ),
+        ]
+
+        captured_options = {}
+
+        class MockClient:
+            def __init__(self, options):
+                captured_options["options"] = options
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def query(self, prompt):
+                captured_options["prompt"] = prompt
+
+            async def receive_response(self):
+                for m in messages:
+                    yield m
+
+        fake_sdk.ClaudeSDKClient = MockClient
+        monkeypatch.setitem(_sys.modules, "claude_agent_sdk", fake_sdk)
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", print_prompt="summarize x.py")
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert captured_options["prompt"] == "summarize x.py"
+        assert "agent started" in out
+        assert "claude-opus-4-7" in out
+        assert "→ Read x.py" in out
+        assert "← result: file contents here" in out
+        assert "Here's the summary." in out
+        assert "[done" in out
+        assert "100+50 tok" in out
+
+    def test_error_result_returns_nonzero(self, monkeypatch, capsys):
+        import sys as _sys
+        import types
+        fake_sdk = types.ModuleType("claude_agent_sdk")
+        fake_sdk.AssistantMessage = FakeAssistantMessage
+        fake_sdk.UserMessage = FakeUserMessage
+        fake_sdk.SystemMessage = FakeSystemMessage
+        fake_sdk.ResultMessage = FakeResultMessage
+        fake_sdk.ClaudeAgentOptions = FakeOptions
+
+        messages = [FakeResultMessage(is_error=True, result="rate limited")]
+
+        class MockClient:
+            def __init__(self, options): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def query(self, prompt): pass
+            async def receive_response(self):
+                for m in messages:
+                    yield m
+
+        fake_sdk.ClaudeSDKClient = MockClient
+        monkeypatch.setitem(_sys.modules, "claude_agent_sdk", fake_sdk)
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", print_prompt="x")
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "[error" in out
+
+    def test_missing_sdk_returns_one(self, monkeypatch, capsys):
+        """If claude-agent-sdk isn't importable, print mode exits 1 with message."""
+        import sys as _sys
+        import builtins
+
+        original_import = builtins.__import__
+
+        def fail_import(name, *a, **kw):
+            if name == "claude_agent_sdk":
+                raise ImportError("No module named 'claude_agent_sdk'")
+            return original_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", fail_import)
+        # Also ensure cached module is cleared
+        monkeypatch.delitem(_sys.modules, "claude_agent_sdk", raising=False)
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", print_prompt="x")
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "claude-agent-sdk not installed" in err
+
+
+class TestFormatToolResult:
+    def test_none(self):
+        assert _format_tool_result(None) == "(no content)"
+
+    def test_string(self):
+        assert _format_tool_result("hello") == "hello"
+
+    def test_newlines_flattened(self):
+        assert _format_tool_result("a\nb\nc") == "a b c"
+
+    def test_truncated(self):
+        long = "x" * 200
+        out = _format_tool_result(long)
+        assert out.endswith("...")
+        assert len(out) == 120
+
+    def test_list_of_blocks(self):
+        assert _format_tool_result([{"type": "text", "text": "from block"}]) == "from block"

--- a/tests/unit/test_sdk_session_types.py
+++ b/tests/unit/test_sdk_session_types.py
@@ -94,22 +94,11 @@ class TestBuildAgentCommandSdk:
             os.unlink(cmd.temp_file)
 
 
-# --- REPL scaffold ---
+# --- REPL interactive scaffold ---
+# Print mode is tested in test_repl_sdk.py (mocked SDK). Interactive mode
+# still runs the PR 1 scaffold loop until PR 3 replaces it.
 
 class TestReplScaffold:
-    def test_print_mode_returns_zero(self, capsys):
-        rc = run_repl(mode="bypass", print_prompt="hello")
-        captured = capsys.readouterr()
-        assert rc == 0
-        assert "prompt received: hello" in captured.out
-        assert "mode=bypass" in captured.out
-
-    def test_print_mode_with_system_prompt(self, capsys):
-        rc = run_repl(mode="bypass", print_prompt="x", system_prompt="system context")
-        captured = capsys.readouterr()
-        assert rc == 0
-        assert "system prompt:" in captured.out
-
     def test_interactive_exits_on_eof(self, monkeypatch, capsys):
         # Simulate Ctrl+D immediately.
         monkeypatch.setattr("sys.stdin", io.StringIO(""))


### PR DESCRIPTION
## Summary
Wires \`claude-agent-sdk\` into \`agentwire repl -p "prompt"\` so \`sdk-bypass\` / \`sdk-prompted\` / \`sdk-restricted\` can run real Opus 4.7 turns. Interactive mode stays on the PR 1 scaffold until PR 3 replaces it with \`prompt_toolkit\`. Splitting isolates SDK wiring from terminal-UI concerns.

## What works

- Permission-mode mapping per variant: \`sdk-bypass\` → \`bypassPermissions\`, \`sdk-prompted\` → \`default\`, \`sdk-restricted\` → \`plan\`
- Tool surface per variant: bypass/prompted get the full Claude Code CamelCase set (\`Read\`, \`Write\`, \`Edit\`, \`Bash\`, \`Grep\`, \`Glob\`, \`WebFetch\`, \`WebSearch\`); restricted is read-only (\`Read\`, \`Grep\`, \`Glob\`, \`WebFetch\`, \`WebSearch\` — no \`Write\`/\`Edit\`/\`Bash\`)
- Default \`claude-opus-4-7\` + adaptive thinking + \`effort=high\`
- \`CLAUDE.md\` and \`AGENTS.md\` auto-discovery walking up from cwd, injected via \`system_prompt\` preset=\`claude_code\` append
- Explicit \`--append-system-prompt TEXT\` layered on top (role merging from \`build_agent_command\` → repl args)
- \`setting_sources=["user"]\` so \`~/.claude\` hooks (damage-control) still fire
- \`CLAUDECODE\` env unset during SDK call (same pattern as workflow anthropic runner; SDK refuses to nest)
- Compact event rendering to terminal: \`[agent started]\` / text / \`[→ ToolName arg]\` / \`[← result: preview]\` / \`[thinking: first-line]\` / \`[done · tokens · cost · dur]\`
- Missing SDK returns exit 1 with clear message

## Manual smoke (against real Opus 4.7)

\`\`\`bash
$ uv run python -m agentwire repl --mode bypass -p "respond with exactly the word 'ok' and nothing else"
[agent started · claude-opus-4-7 · session 10797209]
ok
[done · 6+6 tok · \$0.4715 · 4.5s]
\`\`\`

(Note: the reported \`\$0.4715\` for 12 tokens is suspicious — would be ~2600x over Opus rates — but that's what \`total_cost_usd\` returns for subscription auth. Not a PR 2 blocker; the renderer just displays what the SDK reports. Worth investigating later whether subscription cost reporting is accurate or if we should compute from tokens ourselves.)

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_sdk.py\` — 33/33 pass (build_options, CLAUDE.md discovery, render_message, format helpers, end-to-end print mode with mocked SDK)
- [x] \`uv run pytest\` — 882 passed / 4 skipped (up 41 from PR 1 merged state)
- [x] Manual real-SDK smoke: print mode returns session_id, streams events, exits 0

## Scope deliberately excluded (PR 3+)

- Interactive loop (\`prompt_toolkit\`, slash commands, multi-line, Ctrl+C cancel)
- Transcript persistence / \`/resume\`
- Permission UX in \`sdk-prompted\` (inline allow/deny prompts)
- MCP client wiring (Phase 3)
- Python-level damage control (Phase 3)

Built by [dotdev.dev](https://dotdev.dev)