### PR TITLE
feat(repl): phase 1 pr 3 — prompt_toolkit interactive loop

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -17,8 +17,8 @@ from typing import Any
 
 BANNER = """\
 ╭─────────────────────────────────────────────────────────╮
-│  agentwire repl — SDK-based interactive harness         │
-│  Phase 1 scaffold · mode={mode} · model={model}
+│  agentwire repl — Anthropic SDK harness                 │
+│  mode={mode} · model={model}
 ╰─────────────────────────────────────────────────────────╯
 """
 
@@ -47,11 +47,12 @@ def run_repl(
 
     - Print mode (`-p PROMPT`): wire up claude-agent-sdk, run one turn, stream
       events to stdout, exit.
-    - Interactive: PR 1 scaffold until PR 3 replaces with prompt_toolkit.
+    - Interactive: persistent prompt_toolkit loop holding one SDK client open
+      across turns. Ctrl+D exits; Ctrl+C cancels the current turn.
     """
     if print_prompt is not None:
         return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt))
-    return _run_interactive_scaffold(mode, model, system_prompt)
+    return asyncio.run(_run_interactive(mode, model, system_prompt))
 
 
 # -------- print mode (SDK-backed) --------
@@ -306,36 +307,107 @@ def _format_tool_result(content: Any) -> str:
     return text if len(text) <= 120 else text[:117] + "..."
 
 
-# -------- interactive (PR 1 scaffold, replaced in PR 3) --------
+# -------- interactive (prompt_toolkit + persistent SDK client) --------
 
 
-def _run_interactive_scaffold(
+async def _run_interactive(
     mode: str,
     model: str | None,
     system_prompt: str | None,
 ) -> int:
+    """Run the interactive REPL.
+
+    Holds one `ClaudeSDKClient` open across the whole session so each turn
+    extends the same conversation (model keeps short-term context, session_id
+    stays stable). Ctrl+D exits cleanly; Ctrl+C cancels the current turn.
+    Slash commands are Phase 2 — here we only honor `/exit` and `/quit` as
+    conveniences for users who prefer explicit exit to Ctrl+D.
+    """
+    try:
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ClaudeAgentOptions,
+            ClaudeSDKClient,
+            ResultMessage,
+            SystemMessage,
+            UserMessage,
+        )
+    except ImportError as e:
+        print(f"error: claude-agent-sdk not installed: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.history import InMemoryHistory
+        from prompt_toolkit.patch_stdout import patch_stdout
+    except ImportError as e:
+        print(f"error: prompt_toolkit not installed: {e}", file=sys.stderr)
+        return 1
+
+    options = build_options(ClaudeAgentOptions, mode, model, system_prompt, cwd=Path.cwd())
+
     model_display = model or f"{DEFAULT_MODEL} (default)"
     sys.stdout.write(BANNER.format(mode=mode, model=model_display))
-    if system_prompt:
-        sys.stdout.write(f"system prompt loaded: {len(system_prompt)} chars\n")
     sys.stdout.write(
-        "Phase 1 scaffold — type anything and it echoes back. Ctrl+D to exit.\n"
-        "[interactive SDK loop lands in PR 3; use `-p` for real SDK turns today]\n\n"
+        "Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.\n\n"
     )
     sys.stdout.flush()
 
+    session = PromptSession(history=InMemoryHistory())
+
+    saved_claudecode = os.environ.pop("CLAUDECODE", None)
+    exit_code = 0
     try:
-        while True:
-            try:
-                line = input("> ")
-            except EOFError:
-                sys.stdout.write("\n[exit]\n")
-                return 0
-            except KeyboardInterrupt:
-                sys.stdout.write("\n[interrupt — use Ctrl+D to exit]\n")
-                continue
-            sys.stdout.write(f"scaffold received: {line!r}\n")
-            sys.stdout.flush()
-    except Exception as exc:
-        sys.stderr.write(f"[agentwire repl: unexpected error: {exc}]\n")
-        return 1
+        async with ClaudeSDKClient(options=options) as client:
+            while True:
+                try:
+                    with patch_stdout():
+                        user_input = await session.prompt_async("> ")
+                except EOFError:
+                    sys.stdout.write("\n[exit]\n")
+                    break
+                except KeyboardInterrupt:
+                    # At the prompt: just start a fresh line.
+                    sys.stdout.write("\n")
+                    continue
+
+                text = user_input.strip()
+                if not text:
+                    continue
+                if text in ("/exit", "/quit"):
+                    sys.stdout.write("[exit]\n")
+                    break
+
+                # Send the turn and stream the response until a ResultMessage.
+                try:
+                    await client.query(text)
+                    async for message in client.receive_response():
+                        try:
+                            render_message(
+                                message,
+                                AssistantMessage=AssistantMessage,
+                                UserMessage=UserMessage,
+                                SystemMessage=SystemMessage,
+                                ResultMessage=ResultMessage,
+                                out=sys.stdout,
+                            )
+                            sys.stdout.flush()
+                            if isinstance(message, ResultMessage) and getattr(message, "is_error", False):
+                                exit_code = 1
+                        except Exception as exc:
+                            print(f"[repl: render error: {exc}]", file=sys.stderr)
+                except (KeyboardInterrupt, asyncio.CancelledError):
+                    # Ctrl+C mid-turn: leave a marker and give the user the
+                    # prompt back. The SDK's own cancellation semantics handle
+                    # the in-flight request.
+                    sys.stdout.write("\n[turn cancelled]\n")
+                    sys.stdout.flush()
+                    continue
+                except Exception as exc:
+                    print(f"[repl: {type(exc).__name__}: {exc}]", file=sys.stderr)
+                    # Don't break the loop for one bad turn — let the user retry.
+                    continue
+    finally:
+        if saved_claudecode is not None:
+            os.environ["CLAUDECODE"] = saved_claudecode
+    return exit_code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "resend>=2.0.0",
     "markdown>=3.5",
     "claude-agent-sdk>=0.1.0",
+    "prompt_toolkit>=3.0.40",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -448,6 +448,215 @@ class TestPrintModeIntegration:
         assert "claude-agent-sdk not installed" in err
 
 
+# --- interactive loop (mocked prompt_toolkit + SDK) ---
+
+def _install_fake_sdk(monkeypatch, messages_per_turn):
+    """Install a fake claude_agent_sdk module. messages_per_turn is a list of
+    lists; one inner list per .query() call, each yielded by receive_response."""
+    import sys as _sys
+    import types
+
+    fake_sdk = types.ModuleType("claude_agent_sdk")
+    fake_sdk.AssistantMessage = FakeAssistantMessage
+    fake_sdk.UserMessage = FakeUserMessage
+    fake_sdk.SystemMessage = FakeSystemMessage
+    fake_sdk.ResultMessage = FakeResultMessage
+    fake_sdk.ClaudeAgentOptions = FakeOptions
+
+    state = {"queries": [], "turn_idx": 0}
+
+    class MockClient:
+        def __init__(self, options):
+            state["options"] = options
+            state["closed"] = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            state["closed"] = True
+            return False
+
+        async def query(self, prompt):
+            state["queries"].append(prompt)
+
+        async def receive_response(self):
+            idx = state["turn_idx"]
+            state["turn_idx"] += 1
+            msgs = messages_per_turn[idx] if idx < len(messages_per_turn) else []
+            for m in msgs:
+                yield m
+
+    fake_sdk.ClaudeSDKClient = MockClient
+    monkeypatch.setitem(_sys.modules, "claude_agent_sdk", fake_sdk)
+    return state
+
+
+def _install_fake_prompt_toolkit(monkeypatch, script):
+    """Install a fake prompt_toolkit module. script is a list of inputs — each
+    is either a string (returned by prompt_async) or an exception class (raised)."""
+    import sys as _sys
+    import types
+
+    fake_pt = types.ModuleType("prompt_toolkit")
+    fake_history = types.ModuleType("prompt_toolkit.history")
+    fake_patch = types.ModuleType("prompt_toolkit.patch_stdout")
+
+    class FakeInMemoryHistory:
+        def __init__(self): pass
+
+    class FakePromptSession:
+        def __init__(self, history=None):
+            self.idx = 0
+
+        async def prompt_async(self, text):
+            if self.idx >= len(script):
+                raise EOFError
+            item = script[self.idx]
+            self.idx += 1
+            if isinstance(item, type) and issubclass(item, BaseException):
+                raise item
+            return item
+
+    class _PatchStdout:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def patch_stdout():
+        return _PatchStdout()
+
+    fake_pt.PromptSession = FakePromptSession
+    fake_history.InMemoryHistory = FakeInMemoryHistory
+    fake_patch.patch_stdout = patch_stdout
+
+    monkeypatch.setitem(_sys.modules, "prompt_toolkit", fake_pt)
+    monkeypatch.setitem(_sys.modules, "prompt_toolkit.history", fake_history)
+    monkeypatch.setitem(_sys.modules, "prompt_toolkit.patch_stdout", fake_patch)
+
+
+class TestInteractiveLoop:
+    def test_eof_exits_clean(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, [])  # empty → EOFError
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[exit]" in out
+        assert "Interactive mode" in out
+
+    def test_slash_exit_command(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/exit"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[exit]" in out
+
+    def test_slash_quit_command(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/quit"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+
+    def test_empty_input_skipped(self, monkeypatch, capsys):
+        # Empty + whitespace-only lines should not call query, then EOF exits.
+        state = _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["", "   ", "\t"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+        assert state["queries"] == []
+
+    def test_multi_turn_sends_each_prompt(self, monkeypatch, capsys):
+        turn1 = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "s1"}),
+            FakeAssistantMessage([{"type": "text", "text": "response one"}]),
+            FakeResultMessage(usage={"input_tokens": 10, "output_tokens": 5}, duration_ms=100),
+        ]
+        turn2 = [
+            FakeAssistantMessage([{"type": "text", "text": "response two"}]),
+            FakeResultMessage(usage={"input_tokens": 12, "output_tokens": 7}, duration_ms=120),
+        ]
+        state = _install_fake_sdk(monkeypatch, [turn1, turn2])
+        _install_fake_prompt_toolkit(monkeypatch, ["first prompt", "second prompt"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert state["queries"] == ["first prompt", "second prompt"]
+        assert "response one" in out
+        assert "response two" in out
+        assert "agent started" in out
+        assert state["closed"] is True
+
+    def test_error_result_sets_exit_code_but_continues_loop(self, monkeypatch, capsys):
+        # One bad turn followed by clean exit should exit with 1 (from the error).
+        bad = [FakeResultMessage(is_error=True, result="oh no")]
+        state = _install_fake_sdk(monkeypatch, [bad])
+        _install_fake_prompt_toolkit(monkeypatch, ["trigger the bad turn"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "[error" in out
+
+    def test_keyboard_interrupt_at_prompt_continues(self, monkeypatch, capsys):
+        # Ctrl+C at prompt → clear line, continue. Next EOF exits clean.
+        state = _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, [KeyboardInterrupt])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+        assert state["queries"] == []
+
+    def test_passes_mode_and_model_to_options(self, monkeypatch, capsys):
+        state = _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, [])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="restricted", model="claude-sonnet-4-6")
+
+        opts = state["options"]
+        assert opts.kwargs["permission_mode"] == "plan"
+        assert opts.kwargs["model"] == "claude-sonnet-4-6"
+        assert "Bash" not in opts.kwargs["allowed_tools"]
+
+    def test_missing_prompt_toolkit_returns_one(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        # Scrub prompt_toolkit from sys.modules AND block future imports.
+        import sys as _sys
+        for mod in list(_sys.modules):
+            if mod.startswith("prompt_toolkit"):
+                monkeypatch.delitem(_sys.modules, mod, raising=False)
+
+        import builtins
+        original_import = builtins.__import__
+
+        def fail_import(name, *a, **kw):
+            if name.startswith("prompt_toolkit"):
+                raise ImportError(f"No module named {name!r}")
+            return original_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", fail_import)
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "prompt_toolkit not installed" in err
+
+
 class TestFormatToolResult:
     def test_none(self):
         assert _format_tool_result(None) == "(no content)"

--- a/tests/unit/test_sdk_session_types.py
+++ b/tests/unit/test_sdk_session_types.py
@@ -6,14 +6,10 @@ See docs/missions/agentwire-repl.md for the mission scope.
 
 from __future__ import annotations
 
-import io
-import sys
-
 import pytest
 
 from agentwire.project_config import SessionType, normalize_session_type
 from agentwire.__main__ import build_agent_command
-from agentwire.repl.app import run_repl
 
 
 # --- SessionType enum round-trip ---
@@ -94,30 +90,7 @@ class TestBuildAgentCommandSdk:
             os.unlink(cmd.temp_file)
 
 
-# --- REPL interactive scaffold ---
-# Print mode is tested in test_repl_sdk.py (mocked SDK). Interactive mode
-# still runs the PR 1 scaffold loop until PR 3 replaces it.
-
-class TestReplScaffold:
-    def test_interactive_exits_on_eof(self, monkeypatch, capsys):
-        # Simulate Ctrl+D immediately.
-        monkeypatch.setattr("sys.stdin", io.StringIO(""))
-        monkeypatch.setattr("builtins.input", lambda prompt="": (_ for _ in ()).throw(EOFError))
-        rc = run_repl(mode="bypass")
-        captured = capsys.readouterr()
-        assert rc == 0
-        assert "agentwire repl" in captured.out
-
-    def test_interactive_echoes_input(self, monkeypatch, capsys):
-        lines = iter(["hello world", "second line"])
-        def fake_input(prompt=""):
-            try:
-                return next(lines)
-            except StopIteration:
-                raise EOFError
-        monkeypatch.setattr("builtins.input", fake_input)
-        rc = run_repl(mode="bypass")
-        captured = capsys.readouterr()
-        assert rc == 0
-        assert "scaffold received: 'hello world'" in captured.out
-        assert "scaffold received: 'second line'" in captured.out
+# --- REPL interactive loop ---
+# The full interactive loop (prompt_toolkit + persistent SDK client) is tested
+# in test_repl_sdk.py with both subsystems mocked. This file still covers the
+# session-type + build_agent_command dispatch surface.

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "markdown" },
     { name = "mcp" },
+    { name = "prompt-toolkit" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -66,6 +67,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "markdown", specifier = ">=3.5" },
     { name = "mcp", specifier = ">=1.2.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.40" },
     { name = "pydantic", marker = "extra == 'tts'", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -767,6 +769,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },


### PR DESCRIPTION
## Summary
Replaces the PR 1 echo scaffold with a real interactive REPL on \`prompt_toolkit\`. Holds one \`ClaudeSDKClient\` open across the session so each turn extends the same conversation (stable session_id, the model keeps short-term context). **Phase 1 is now end-to-end functional** — \`agentwire new -s x --type sdk-bypass\` spawns a tmux pane running a real interactive Anthropic SDK session.

## Behavior

- **Enter** sends the current line as a user turn
- **Ctrl+C at the prompt**: clear line, next prompt
- **Ctrl+C mid-turn**: print \`[turn cancelled]\`, return to prompt
- **Ctrl+D**: clean exit
- **\`/exit\` or \`/quit\`**: clean exit (convenience; full slash-command set is Phase 2)
- Empty / whitespace-only input silently skipped
- Bad turns print the error but don't kill the loop — user can retry

## Plumbing

- \`prompt_toolkit>=3.0.40\` added as a hard dependency
- \`patch_stdout()\` wraps \`prompt_async\` so streamed SDK events don't mangle the prompt
- \`InMemoryHistory\` gives in-session up-arrow history (persistent history is Phase 2's \`/resume\`)
- Same \`build_options\` / \`render_message\` shared with print mode — CLAUDE.md + AGENTS.md auto-discovery, permission-mode mapping, per-variant tool surface, default \`claude-opus-4-7\` + adaptive thinking + \`effort=high\`

## Manual smoke (real Opus 4.7)

\`\`\`bash
$ echo 'respond with only the word "working"' | uv run python -m agentwire repl --mode bypass
╭─────────────────────────────────────────────────────────╮
│  agentwire repl — Anthropic SDK harness                 │
│  mode=bypass · model=claude-opus-4-7 (default)
╰─────────────────────────────────────────────────────────╯
Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.

> respond with only the word "working"
[agent started · claude-opus-4-7 · session 7c4e82b6]
working
[done · 6+5 tok · \$0.6969 · 2.6s]
\`\`\`

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_sdk.py\` — 40/40 pass incl 7 new interactive-loop tests (EOF exit, /exit, /quit, empty input, multi-turn, error recovery, KeyboardInterrupt, options pass-through)
- [x] \`uv run pytest\` — 889 passed / 4 skipped (up 7 from PR 2)
- [x] Pipe-input smoke against real Opus 4.7 returns valid session_id + tokens
- [ ] After rebuild: \`agentwire new -s repl-test --type sdk-bypass\` and interact in a real tmux pane

## Phase 1 status after merge

End-to-end functional per the mission success criterion:
> user can \`agentwire new -s test --type sdk-bypass\`, see the pane in tmux, chat with Opus 4.7, watch Read/Bash/Edit tool calls stream, and exit cleanly

What's next (Phase 2+):
- Slash commands (\`/help\`, \`/clear\`, \`/model\`, \`/cost\`, \`/tools\`, \`/save\`, \`/resume\`, etc.)
- Transcript persistence + \`/resume\`
- Multi-line input (Alt+Enter)
- Permission UX for \`sdk-prompted\` (inline allow/deny)
- Cost accounting status line

Built by [dotdev.dev](https://dotdev.dev)