### PR TITLE
feat(repl): phase 2 pr 1 — slash command framework

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -14,6 +14,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from agentwire.repl.commands import CONTINUE, EXIT, RESTART, dispatch_command
+from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
+
 
 BANNER = """\
 ╭─────────────────────────────────────────────────────────╮
@@ -349,65 +352,119 @@ async def _run_interactive(
     model_display = model or f"{DEFAULT_MODEL} (default)"
     sys.stdout.write(BANNER.format(mode=mode, model=model_display))
     sys.stdout.write(
-        "Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.\n\n"
+        "Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.\n"
+        "Type /help for commands.\n\n"
     )
     sys.stdout.flush()
+
+    state = ReplState(
+        mode=mode,
+        model=model or DEFAULT_MODEL,
+        allowed_tools=list(options.allowed_tools)
+        if hasattr(options, "allowed_tools")
+        else list(getattr(options, "kwargs", {}).get("allowed_tools", [])),
+    )
 
     session = PromptSession(history=InMemoryHistory())
 
     saved_claudecode = os.environ.pop("CLAUDECODE", None)
     exit_code = 0
+
+    # Outer loop wraps the SDK client so /clear can close+reopen it for a
+    # fresh conversation while the REPL itself keeps running.
     try:
-        async with ClaudeSDKClient(options=options) as client:
-            while True:
-                try:
-                    with patch_stdout():
-                        user_input = await session.prompt_async("> ")
-                except EOFError:
-                    sys.stdout.write("\n[exit]\n")
-                    break
-                except KeyboardInterrupt:
-                    # At the prompt: just start a fresh line.
-                    sys.stdout.write("\n")
-                    continue
-
-                text = user_input.strip()
-                if not text:
-                    continue
-                if text in ("/exit", "/quit"):
-                    sys.stdout.write("[exit]\n")
-                    break
-
-                # Send the turn and stream the response until a ResultMessage.
-                try:
-                    await client.query(text)
-                    async for message in client.receive_response():
-                        try:
-                            render_message(
-                                message,
-                                AssistantMessage=AssistantMessage,
-                                UserMessage=UserMessage,
-                                SystemMessage=SystemMessage,
-                                ResultMessage=ResultMessage,
-                                out=sys.stdout,
-                            )
-                            sys.stdout.flush()
-                            if isinstance(message, ResultMessage) and getattr(message, "is_error", False):
-                                exit_code = 1
-                        except Exception as exc:
-                            print(f"[repl: render error: {exc}]", file=sys.stderr)
-                except (KeyboardInterrupt, asyncio.CancelledError):
-                    # Ctrl+C mid-turn: leave a marker and give the user the
-                    # prompt back. The SDK's own cancellation semantics handle
-                    # the in-flight request.
-                    sys.stdout.write("\n[turn cancelled]\n")
-                    sys.stdout.flush()
-                    continue
-                except Exception as exc:
-                    print(f"[repl: {type(exc).__name__}: {exc}]", file=sys.stderr)
-                    # Don't break the loop for one bad turn — let the user retry.
-                    continue
+        while True:
+            restart_requested, should_exit, loop_exit_code = await _run_sdk_session(
+                options=options,
+                state=state,
+                prompt_session=session,
+                ClaudeSDKClient=ClaudeSDKClient,
+                AssistantMessage=AssistantMessage,
+                UserMessage=UserMessage,
+                SystemMessage=SystemMessage,
+                ResultMessage=ResultMessage,
+                patch_stdout=patch_stdout,
+            )
+            if loop_exit_code != 0:
+                exit_code = loop_exit_code
+            if should_exit:
+                break
+            if not restart_requested:
+                break
+            reset_for_restart(state)
     finally:
         if saved_claudecode is not None:
             os.environ["CLAUDECODE"] = saved_claudecode
     return exit_code
+
+
+async def _run_sdk_session(
+    *,
+    options: Any,
+    state: ReplState,
+    prompt_session: Any,
+    ClaudeSDKClient: Any,
+    AssistantMessage: Any,
+    UserMessage: Any,
+    SystemMessage: Any,
+    ResultMessage: Any,
+    patch_stdout: Any,
+) -> tuple[bool, bool, int]:
+    """Run one ClaudeSDKClient lifecycle. Returns (restart, exit, exit_code).
+
+    A slash-command `/clear` signals restart — outer loop reopens the client.
+    EOF or `/exit` signals exit.
+    """
+    exit_code = 0
+    async with ClaudeSDKClient(options=options) as client:
+        while True:
+            try:
+                with patch_stdout():
+                    user_input = await prompt_session.prompt_async("> ")
+            except EOFError:
+                sys.stdout.write("\n[exit]\n")
+                return False, True, exit_code
+            except KeyboardInterrupt:
+                sys.stdout.write("\n")
+                continue
+
+            text = user_input.strip()
+            if not text:
+                continue
+
+            if text.startswith("/"):
+                action = dispatch_command(text, state, sys.stdout)
+                if action == EXIT:
+                    return False, True, exit_code
+                if action == RESTART:
+                    return True, False, exit_code
+                continue
+
+            try:
+                await client.query(text)
+                async for message in client.receive_response():
+                    try:
+                        render_message(
+                            message,
+                            AssistantMessage=AssistantMessage,
+                            UserMessage=UserMessage,
+                            SystemMessage=SystemMessage,
+                            ResultMessage=ResultMessage,
+                            out=sys.stdout,
+                        )
+                        sys.stdout.flush()
+                        if isinstance(message, SystemMessage):
+                            track_system_init(state, message)
+                        elif isinstance(message, ResultMessage):
+                            track_result(state, message)
+                            if getattr(message, "is_error", False):
+                                exit_code = 1
+                    except Exception as exc:
+                        print(f"[repl: render error: {exc}]", file=sys.stderr)
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                sys.stdout.write("\n[turn cancelled]\n")
+                sys.stdout.flush()
+                continue
+            except Exception as exc:
+                print(f"[repl: {type(exc).__name__}: {exc}]", file=sys.stderr)
+                continue

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -1,0 +1,128 @@
+"""Slash command registry for the agentwire REPL.
+
+The loop hands each line starting with `/` to `dispatch_command()`. Handlers
+receive the session state and return a `CommandResult` telling the loop what
+to do next: keep going, exit cleanly, or restart the SDK client (fresh
+conversation). New commands are added by adding an entry to `COMMANDS`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, TextIO
+
+from agentwire.repl.state import ReplState
+
+
+# Sentinel return values. Strings over an Enum so test expectations read
+# literally and new actions can be added without enum churn.
+CONTINUE = "continue"
+EXIT = "exit"
+RESTART = "restart"
+
+
+Handler = Callable[[ReplState, str, TextIO], str]
+
+
+@dataclass
+class Command:
+    name: str
+    handler: Handler
+    summary: str
+    aliases: tuple[str, ...] = ()
+
+
+def dispatch_command(line: str, state: ReplState, out: TextIO) -> str | None:
+    """Dispatch `/foo args` to its handler, return the action.
+
+    Returns `None` if `line` isn't a recognized slash command (caller falls
+    back to sending it as a user turn). Returns `CONTINUE`, `EXIT`, or
+    `RESTART` for recognized commands.
+    """
+    if not line.startswith("/"):
+        return None
+    parts = line.split(None, 1)
+    name = parts[0]
+    args = parts[1] if len(parts) > 1 else ""
+
+    cmd = COMMANDS.get(name)
+    if cmd is None:
+        out.write(f"[unknown command: {name} — try /help]\n")
+        return CONTINUE
+    return cmd.handler(state, args, out)
+
+
+# -------- handlers --------
+
+
+def _help(state: ReplState, args: str, out: TextIO) -> str:
+    out.write("Available commands:\n")
+    seen = set()
+    for cmd in COMMANDS.values():
+        if cmd.name in seen:
+            continue
+        seen.add(cmd.name)
+        alias_part = f"  (aliases: {', '.join(cmd.aliases)})" if cmd.aliases else ""
+        out.write(f"  {cmd.name:<12} {cmd.summary}{alias_part}\n")
+    return CONTINUE
+
+
+def _exit(state: ReplState, args: str, out: TextIO) -> str:
+    out.write("[exit]\n")
+    return EXIT
+
+
+def _clear(state: ReplState, args: str, out: TextIO) -> str:
+    out.write("[restarting conversation — session history cleared]\n")
+    return RESTART
+
+
+def _cost(state: ReplState, args: str, out: TextIO) -> str:
+    if state.turn_count == 0:
+        out.write("[no turns yet this conversation]\n")
+        return CONTINUE
+    total_tok = state.total_input_tokens + state.total_output_tokens
+    out.write(
+        f"[session · {state.turn_count} turn{'s' if state.turn_count != 1 else ''} · "
+        f"{state.total_input_tokens}+{state.total_output_tokens}={total_tok} tok · "
+        f"${state.total_cost_usd:.4f}]\n"
+    )
+    return CONTINUE
+
+
+def _tools(state: ReplState, args: str, out: TextIO) -> str:
+    if not state.allowed_tools:
+        out.write("[no tools allowed]\n")
+        return CONTINUE
+    out.write(f"[allowed tools (mode={state.mode}): {', '.join(state.allowed_tools)}]\n")
+    return CONTINUE
+
+
+def _model(state: ReplState, args: str, out: TextIO) -> str:
+    sid = state.session_id or "(not yet started)"
+    out.write(f"[model={state.model} · mode={state.mode} · session={sid[:8] if state.session_id else sid}]\n")
+    return CONTINUE
+
+
+# -------- registry --------
+
+def _build_registry() -> dict[str, Command]:
+    """Build the command dict. `/quit` maps to the same Command as `/exit`."""
+    exit_cmd = Command(name="/exit", handler=_exit, summary="Exit the REPL", aliases=("/quit",))
+    commands = [
+        Command(name="/help", handler=_help, summary="Show available commands"),
+        Command(name="/clear", handler=_clear, summary="Reset conversation (fresh context)"),
+        Command(name="/cost", handler=_cost, summary="Show session token + cost totals"),
+        Command(name="/tools", handler=_tools, summary="List allowed tools for this mode"),
+        Command(name="/model", handler=_model, summary="Show current model + session id"),
+        exit_cmd,
+    ]
+    registry: dict[str, Command] = {}
+    for cmd in commands:
+        registry[cmd.name] = cmd
+        for alias in cmd.aliases:
+            registry[alias] = cmd
+    return registry
+
+
+COMMANDS: dict[str, Command] = _build_registry()

--- a/agentwire/repl/state.py
+++ b/agentwire/repl/state.py
@@ -1,0 +1,66 @@
+"""Per-session state tracked across turns of an agentwire REPL.
+
+Holds the running token/cost totals and the current configuration so slash
+commands like `/cost`, `/tools`, `/model` can report it without reaching back
+into the options dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ReplState:
+    """Mutable session-wide state for an interactive REPL.
+
+    Reset (not deleted) when `/clear` fires — the session persists but the
+    SDK conversation restarts, so we keep mode/model/tools but zero the
+    running totals and bump `restart_count`.
+    """
+    mode: str
+    model: str
+    allowed_tools: list[str]
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost_usd: float = 0.0
+    turn_count: int = 0
+    restart_count: int = 0
+    session_id: str | None = None
+
+
+def track_system_init(state: ReplState, message: Any) -> None:
+    """Capture session_id from a SystemMessage(subtype=init)."""
+    data = getattr(message, "data", {}) or {}
+    sid = data.get("session_id") or data.get("sessionId")
+    if sid:
+        state.session_id = sid
+
+
+def track_result(state: ReplState, message: Any) -> None:
+    """Fold a ResultMessage's usage + cost into the session totals."""
+    usage = getattr(message, "usage", None) or {}
+    if isinstance(usage, dict):
+        state.total_input_tokens += int(usage.get("input_tokens", 0) or 0)
+        state.total_output_tokens += int(usage.get("output_tokens", 0) or 0)
+    cost = getattr(message, "total_cost_usd", None)
+    if cost is not None:
+        try:
+            state.total_cost_usd += float(cost)
+        except (TypeError, ValueError):
+            pass
+    state.turn_count += 1
+
+
+def reset_for_restart(state: ReplState) -> None:
+    """Zero the per-conversation counters and bump restart_count.
+
+    Preserves mode/model/tools since those don't change across /clear.
+    """
+    state.total_input_tokens = 0
+    state.total_output_tokens = 0
+    state.total_cost_usd = 0.0
+    state.turn_count = 0
+    state.session_id = None
+    state.restart_count += 1

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -1,0 +1,265 @@
+"""Tests for the REPL slash command registry + state tracking.
+
+Phase 2 PR 1. See docs/missions/agentwire-repl.md.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire.repl.commands import (
+    COMMANDS,
+    CONTINUE,
+    EXIT,
+    RESTART,
+    dispatch_command,
+)
+from agentwire.repl.state import (
+    ReplState,
+    reset_for_restart,
+    track_result,
+    track_system_init,
+)
+
+
+def _state(**overrides) -> ReplState:
+    defaults = dict(
+        mode="bypass",
+        model="claude-opus-4-7",
+        allowed_tools=["Read", "Bash", "Edit"],
+    )
+    defaults.update(overrides)
+    return ReplState(**defaults)
+
+
+# --- dispatch ---
+
+class TestDispatch:
+    def test_non_slash_returns_none(self):
+        state = _state()
+        out = io.StringIO()
+        assert dispatch_command("hello world", state, out) is None
+
+    def test_unknown_command_continues_with_notice(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/nonexistent", state, out)
+        assert action == CONTINUE
+        assert "unknown command" in out.getvalue()
+        assert "/nonexistent" in out.getvalue()
+
+    def test_help_continues(self):
+        state = _state()
+        out = io.StringIO()
+        assert dispatch_command("/help", state, out) == CONTINUE
+
+    def test_exit_returns_exit(self):
+        out = io.StringIO()
+        assert dispatch_command("/exit", _state(), out) == EXIT
+
+    def test_quit_alias_returns_exit(self):
+        out = io.StringIO()
+        assert dispatch_command("/quit", _state(), out) == EXIT
+
+    def test_clear_returns_restart(self):
+        out = io.StringIO()
+        assert dispatch_command("/clear", _state(), out) == RESTART
+
+    def test_args_passed_through(self):
+        # No current commands take args, but the dispatcher must not error when
+        # a user types extra words. `/help foo bar` should still run /help.
+        state = _state()
+        out = io.StringIO()
+        assert dispatch_command("/help some extra", state, out) == CONTINUE
+
+
+# --- /help ---
+
+class TestHelp:
+    def test_lists_every_command_once(self):
+        out = io.StringIO()
+        dispatch_command("/help", _state(), out)
+        rendered = out.getvalue()
+        for name in ("/help", "/clear", "/cost", "/tools", "/model", "/exit"):
+            assert name in rendered
+        # /quit is an alias, not a row
+        assert rendered.count("Exit the REPL") == 1
+
+    def test_shows_aliases(self):
+        out = io.StringIO()
+        dispatch_command("/help", _state(), out)
+        assert "/quit" in out.getvalue()
+
+
+# --- /cost ---
+
+class TestCost:
+    def test_no_turns(self):
+        out = io.StringIO()
+        dispatch_command("/cost", _state(), out)
+        assert "no turns yet" in out.getvalue()
+
+    def test_with_turns(self):
+        state = _state()
+        state.total_input_tokens = 1000
+        state.total_output_tokens = 500
+        state.total_cost_usd = 0.025
+        state.turn_count = 3
+        out = io.StringIO()
+        dispatch_command("/cost", state, out)
+        rendered = out.getvalue()
+        assert "3 turns" in rendered
+        assert "1000+500=1500 tok" in rendered
+        assert "$0.0250" in rendered
+
+    def test_singular_turn(self):
+        state = _state()
+        state.turn_count = 1
+        state.total_input_tokens = 10
+        state.total_output_tokens = 5
+        out = io.StringIO()
+        dispatch_command("/cost", state, out)
+        assert "1 turn " in out.getvalue()  # singular, with trailing space
+
+
+# --- /tools ---
+
+class TestTools:
+    def test_shows_list(self):
+        out = io.StringIO()
+        dispatch_command("/tools", _state(allowed_tools=["Read", "Bash"]), out)
+        rendered = out.getvalue()
+        assert "Read" in rendered
+        assert "Bash" in rendered
+        assert "mode=bypass" in rendered
+
+    def test_empty(self):
+        out = io.StringIO()
+        dispatch_command("/tools", _state(allowed_tools=[]), out)
+        assert "no tools allowed" in out.getvalue()
+
+    def test_restricted_mode(self):
+        out = io.StringIO()
+        state = _state(mode="restricted", allowed_tools=["Read", "Grep"])
+        dispatch_command("/tools", state, out)
+        assert "mode=restricted" in out.getvalue()
+
+
+# --- /model ---
+
+class TestModel:
+    def test_shows_model_and_mode(self):
+        out = io.StringIO()
+        state = _state(model="claude-opus-4-7", mode="bypass")
+        state.session_id = "abc12345def"
+        dispatch_command("/model", state, out)
+        rendered = out.getvalue()
+        assert "claude-opus-4-7" in rendered
+        assert "bypass" in rendered
+        assert "abc12345" in rendered  # 8-char truncation
+
+    def test_no_session_yet(self):
+        out = io.StringIO()
+        dispatch_command("/model", _state(), out)
+        assert "not yet started" in out.getvalue()
+
+
+# --- /clear state reset ---
+
+class TestClearSemantics:
+    def test_clear_returns_restart(self):
+        out = io.StringIO()
+        state = _state()
+        state.total_input_tokens = 100
+        state.turn_count = 5
+        action = dispatch_command("/clear", state, out)
+        assert action == RESTART
+        # /clear itself doesn't zero the state — the outer loop does that
+        # via reset_for_restart(). Separation keeps the handler pure.
+        assert state.total_input_tokens == 100
+        assert state.turn_count == 5
+
+
+# --- ReplState trackers ---
+
+class TestTrackSystemInit:
+    def test_captures_session_id(self):
+        state = _state()
+        msg = SimpleNamespace(data={"session_id": "sess-xyz"})
+        track_system_init(state, msg)
+        assert state.session_id == "sess-xyz"
+
+    def test_camelcase_session_id(self):
+        state = _state()
+        msg = SimpleNamespace(data={"sessionId": "camel-id"})
+        track_system_init(state, msg)
+        assert state.session_id == "camel-id"
+
+    def test_missing_data_noop(self):
+        state = _state()
+        msg = SimpleNamespace(data=None)
+        track_system_init(state, msg)
+        assert state.session_id is None
+
+
+class TestTrackResult:
+    def test_accumulates_tokens(self):
+        state = _state()
+        m1 = SimpleNamespace(usage={"input_tokens": 10, "output_tokens": 5}, total_cost_usd=0.01)
+        m2 = SimpleNamespace(usage={"input_tokens": 20, "output_tokens": 15}, total_cost_usd=0.02)
+        track_result(state, m1)
+        track_result(state, m2)
+        assert state.total_input_tokens == 30
+        assert state.total_output_tokens == 20
+        assert state.total_cost_usd == pytest.approx(0.03)
+        assert state.turn_count == 2
+
+    def test_missing_cost_ignored(self):
+        state = _state()
+        m = SimpleNamespace(usage={"input_tokens": 10, "output_tokens": 5}, total_cost_usd=None)
+        track_result(state, m)
+        assert state.total_cost_usd == 0.0
+        assert state.turn_count == 1
+
+    def test_non_numeric_cost_ignored(self):
+        state = _state()
+        m = SimpleNamespace(usage={}, total_cost_usd="not a number")
+        track_result(state, m)
+        assert state.total_cost_usd == 0.0
+
+    def test_missing_usage_still_increments_turn(self):
+        state = _state()
+        m = SimpleNamespace(usage=None, total_cost_usd=None)
+        track_result(state, m)
+        assert state.turn_count == 1
+
+
+class TestResetForRestart:
+    def test_zeros_counters_preserves_config(self):
+        state = _state()
+        state.total_input_tokens = 100
+        state.total_output_tokens = 50
+        state.total_cost_usd = 0.5
+        state.turn_count = 4
+        state.session_id = "old"
+        reset_for_restart(state)
+        assert state.total_input_tokens == 0
+        assert state.total_output_tokens == 0
+        assert state.total_cost_usd == 0.0
+        assert state.turn_count == 0
+        assert state.session_id is None
+        assert state.restart_count == 1
+        # Config preserved
+        assert state.mode == "bypass"
+        assert state.model == "claude-opus-4-7"
+        assert state.allowed_tools == ["Read", "Bash", "Edit"]
+
+    def test_multiple_restarts_increment(self):
+        state = _state()
+        reset_for_restart(state)
+        reset_for_restart(state)
+        reset_for_restart(state)
+        assert state.restart_count == 3

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -632,6 +632,103 @@ class TestInteractiveLoop:
         assert opts.kwargs["model"] == "claude-sonnet-4-6"
         assert "Bash" not in opts.kwargs["allowed_tools"]
 
+    def test_help_command(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/help"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "/help" in out
+        assert "/clear" in out
+        assert "/cost" in out
+
+    def test_cost_command_after_turn(self, monkeypatch, capsys):
+        turn = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "abc"}),
+            FakeAssistantMessage([{"type": "text", "text": "hi"}]),
+            FakeResultMessage(
+                usage={"input_tokens": 100, "output_tokens": 50},
+                total_cost_usd=0.003,
+                duration_ms=100,
+            ),
+        ]
+        _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["hello", "/cost"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "100+50=150 tok" in out
+        assert "$0.0030" in out
+        assert "1 turn" in out
+
+    def test_tools_command(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/tools"])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        # bypass gets the full tool set
+        for tool in ("Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebFetch", "WebSearch"):
+            assert tool in out
+
+    def test_tools_restricted(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/tools"])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="restricted")
+        out = capsys.readouterr().out
+        assert "mode=restricted" in out
+        # Write/Edit/Bash NOT in restricted
+        assert "Write" not in out.split("\n")[-3]  # check near the tools line
+
+    def test_clear_restarts_session(self, monkeypatch, capsys):
+        # Two turns, /clear between them should reopen the SDK client
+        # (second "agent started" line), and cost reset.
+        turn1 = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "sess1"}),
+            FakeResultMessage(usage={"input_tokens": 10, "output_tokens": 5}, duration_ms=100),
+        ]
+        turn2 = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "sess2"}),
+            FakeResultMessage(usage={"input_tokens": 20, "output_tokens": 10}, duration_ms=100),
+        ]
+        state = _install_fake_sdk(monkeypatch, [turn1, turn2])
+        _install_fake_prompt_toolkit(monkeypatch, [
+            "first turn",   # sent on client 1
+            "/clear",       # close client 1, open client 2
+            "/cost",        # should say no turns yet (reset)
+            "second turn",  # sent on client 2
+        ])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert state["queries"] == ["first turn", "second turn"]
+        assert out.count("agent started") == 2  # opened twice
+        assert "restarting conversation" in out
+        assert "no turns yet" in out  # /cost after /clear before any turn
+
+    def test_unknown_command_continues(self, monkeypatch, capsys):
+        # /foo is not a command — should print "unknown command" and continue
+        # to EOF exit, never touching the SDK.
+        state = _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/foo"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "unknown command" in out
+        assert "/foo" in out
+        assert state["queries"] == []
+
     def test_missing_prompt_toolkit_returns_one(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])
         # Scrub prompt_toolkit from sys.modules AND block future imports.


### PR DESCRIPTION
## Summary
Pluggable slash-command registry + the first batch of built-in commands. Replaces the hardcoded \`/exit\` + \`/quit\` checks in the interactive loop. This is the foundation piece of Phase 2 — transcript persistence / \`/resume\` (PR 2) and multi-line input + \`@\`-mention (PR 3) build on it.

## Commands shipped

| Command | Behavior |
|---|---|
| \`/help\` | Lists all registered commands with descriptions + aliases |
| \`/clear\` | Closes the SDK client and reopens a fresh one (new conversation, same session-level config); zeroes per-conversation counters while preserving mode/model/tools |
| \`/cost\` | Current conversation's token totals + cost |
| \`/tools\` | Lists allowed tools for the current mode |
| \`/model\` | Shows model, mode, and session_id |
| \`/exit\` (+ \`/quit\` alias) | Clean exit |

Unknown commands produce a helpful \`[unknown command: /foo — try /help]\` notice instead of being sent to the SDK as a user turn.

## Refactor highlights

- **\`agentwire/repl/state.py\`** — \`ReplState\` dataclass + pure \`track_system_init\` / \`track_result\` / \`reset_for_restart\` helpers so state updates are testable separately from the event loop.
- **\`agentwire/repl/commands.py\`** — \`dispatch_command\` returns a \`CONTINUE\` / \`EXIT\` / \`RESTART\` sentinel. Adding a command = one \`Command\` entry; no loop changes needed.
- **\`agentwire/repl/app.py\`** — interactive loop split into outer (handles \`/clear\` restarts) and inner (\`_run_sdk_session\` — one SDK client lifecycle).

## Manual smoke (piped stdin, real Opus 4.7)

\`\`\`bash
$ printf '/help\n/tools\n/model\nwhat is 2+2?\n/cost\n/clear\n/cost\n' \\
    | uv run python -m agentwire repl --mode bypass
...
/help renders 6 commands, /tools shows full bypass set, /model reports
pre-session state, real turn returns "4" with token accounting, /cost
reports 1 turn · 6+6=12 tok, /clear resets, /cost then says
"no turns yet"
\`\`\`

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_commands.py tests/unit/test_repl_sdk.py\` — 85/85 pass
- [x] \`uv run pytest\` — 922 passed / 4 skipped (up 33 from Phase 1 baseline)
- [x] Piped-stdin smoke against real Opus 4.7
- [ ] After rebuild: manual in a real tmux pane via \`agentwire new -s x --type sdk-bypass\`

## Coverage

- 27 new unit tests in \`test_repl_commands.py\` — dispatch (non-slash returns None, unknown commands, alias routing), every command handler (help row count + aliases, /cost singular/plural, /tools empty + restricted, /model pre-session), state trackers (token accumulation, missing usage, non-numeric cost, session_id capture from both \`session_id\` and \`sessionId\` shapes, restart_count bump)
- 6 new integration tests in \`test_repl_sdk.py\` — end-to-end \`/help\` / \`/cost\` / \`/tools\` (bypass + restricted) / \`/clear\` (SDK reopen + counter reset) / unknown-command continuation

## Next

Phase 2 PR 2: transcript persistence to \`~/.agentwire/sessions/<name>/transcript.jsonl\` + \`/save\` + \`/resume\`.

Built by [dotdev.dev](https://dotdev.dev)