### PR TITLE
feat(repl): phase 2 pr 2 — transcript persistence + /save + /resume

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3431,11 +3431,9 @@ def cmd_repl(args) -> int:
     """Agentwire REPL — interactive harness built on claude-agent-sdk.
 
     Invoked by build_agent_command when a session is spawned with --type sdk-*.
-    The user never calls this directly; it runs inside a tmux pane created by
-    `agentwire new -s <name> --type sdk-bypass`.
-
-    Phase 1 scaffold — proves the session-type plumbing works end-to-end.
-    SDK integration lands in PR 2.
+    Interactive mode auto-persists every turn under
+    `~/.agentwire/sessions/repl/<session-name>/`; `--resume NAME` continues a
+    prior session by reusing its sdk_session_id.
     """
     from agentwire.repl.app import run_repl
     return run_repl(
@@ -3443,6 +3441,8 @@ def cmd_repl(args) -> int:
         model=args.model,
         print_prompt=args.print,
         system_prompt=args.append_system_prompt,
+        session_name=getattr(args, "session_name", None),
+        resume=getattr(args, "resume", None),
     )
 
 
@@ -10178,6 +10178,14 @@ def main() -> int:
     repl_parser.add_argument(
         "--append-system-prompt", dest="append_system_prompt", default=None, metavar="TEXT",
         help="Additional system prompt content (appended after base prompt)",
+    )
+    repl_parser.add_argument(
+        "--session-name", dest="session_name", default=None, metavar="NAME",
+        help="Transcript directory name under ~/.agentwire/sessions/repl/ (default: auto-generated timestamp+hash)",
+    )
+    repl_parser.add_argument(
+        "--resume", dest="resume", default=None, metavar="NAME",
+        help="Resume the saved session NAME (reuses its sdk_session_id to continue the prior conversation)",
     )
     repl_parser.set_defaults(func=cmd_repl)
 

--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -1,9 +1,9 @@
 """Agentwire REPL application entry point.
 
-Phase 1 PR 2 — wires claude-agent-sdk into print mode (`agentwire repl -p ...`).
-Interactive mode stays on the PR 1 scaffold until PR 3 replaces it with a real
-prompt_toolkit-backed loop. Splitting keeps SDK wiring isolated from terminal-UI
-concerns.
+Print mode: one-shot SDK call, stream events, exit.
+Interactive: persistent prompt_toolkit loop holding one ClaudeSDKClient open
+across turns. Ctrl+D exits; Ctrl+C cancels the current turn. Slash commands
+live in `commands.py`; transcript persistence lives in `persistence.py`.
 """
 
 from __future__ import annotations
@@ -14,7 +14,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from agentwire.repl.commands import CONTINUE, EXIT, RESTART, dispatch_command
+from agentwire.repl.commands import CONTINUE, EXIT, RESTART, RESUME, dispatch_command
+from agentwire.repl import persistence
 from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
 
 
@@ -45,17 +46,19 @@ def run_repl(
     model: str | None = None,
     print_prompt: str | None = None,
     system_prompt: str | None = None,
+    session_name: str | None = None,
+    resume: str | None = None,
 ) -> int:
     """Run the REPL. Returns exit code.
 
-    - Print mode (`-p PROMPT`): wire up claude-agent-sdk, run one turn, stream
-      events to stdout, exit.
-    - Interactive: persistent prompt_toolkit loop holding one SDK client open
-      across turns. Ctrl+D exits; Ctrl+C cancels the current turn.
+    - Print mode (`-p PROMPT`): one SDK call, stream events, exit. No
+      transcript (print mode is fire-and-forget).
+    - Interactive: persistent loop with full transcript persistence under
+      `~/.agentwire/sessions/repl/<session_name>/`.
     """
     if print_prompt is not None:
         return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt))
-    return asyncio.run(_run_interactive(mode, model, system_prompt))
+    return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume))
 
 
 # -------- print mode (SDK-backed) --------
@@ -117,12 +120,14 @@ def build_options(
     model: str | None,
     system_prompt: str | None,
     cwd: Path | None = None,
+    resume_sdk_session_id: str | None = None,
 ) -> Any:
     """Compose `ClaudeAgentOptions` for a REPL session.
 
     Permission mode + tool surface are derived from the session-type variant
     (`sdk-bypass`/`sdk-prompted`/`sdk-restricted`). System prompt layers project
-    CLAUDE.md + AGENTS.md + an optional explicit append.
+    CLAUDE.md + AGENTS.md + an optional explicit append. `resume_sdk_session_id`
+    passes through to the SDK's `resume` field to continue a prior conversation.
     """
     kwargs: dict[str, Any] = {
         "model": model or DEFAULT_MODEL,
@@ -135,6 +140,8 @@ def build_options(
     }
     if cwd is not None:
         kwargs["cwd"] = str(cwd)
+    if resume_sdk_session_id:
+        kwargs["resume"] = resume_sdk_session_id
 
     append_parts: list[str] = []
     if cwd is not None:
@@ -164,6 +171,37 @@ def _find_ancestor_file(start: Path, name: str) -> Path | None:
         if candidate.is_file():
             return candidate
     return None
+
+
+def _persist_sdk_message(
+    message: Any,
+    transcript: Any,
+    AssistantMessage: Any,
+    UserMessage: Any,
+    SystemMessage: Any,
+    ResultMessage: Any,
+) -> None:
+    """Translate one SDK message to event shape and append to the transcript.
+
+    Reuses `agentwire.workflows.runners.anthropic_events` so REPL events and
+    workflow events share vocabulary (portal history window can render both
+    without a separate codepath).
+    """
+    try:
+        from agentwire.workflows.runners import anthropic_events as ev
+    except ImportError:
+        return
+
+    if isinstance(message, SystemMessage) and getattr(message, "subtype", None) == "init":
+        for event in ev.translate_system_init(message):
+            transcript.write_event(event)
+    elif isinstance(message, AssistantMessage):
+        transcript.write_event(ev.translate_assistant(message))
+    elif isinstance(message, UserMessage):
+        transcript.write_event(ev.translate_user(message))
+    elif isinstance(message, ResultMessage):
+        for event in ev.translate_result(message):
+            transcript.write_event(event)
 
 
 # -------- event rendering --------
@@ -317,6 +355,8 @@ async def _run_interactive(
     mode: str,
     model: str | None,
     system_prompt: str | None,
+    session_name: str | None = None,
+    resume: str | None = None,
 ) -> int:
     """Run the interactive REPL.
 
@@ -347,37 +387,70 @@ async def _run_interactive(
         print(f"error: prompt_toolkit not installed: {e}", file=sys.stderr)
         return 1
 
-    options = build_options(ClaudeAgentOptions, mode, model, system_prompt, cwd=Path.cwd())
+    # Resume handling — look up the SDK session_id to pass to the first
+    # ClaudeSDKClient.
+    resume_sdk_session_id: str | None = None
+    if resume:
+        prior = persistence.load_session(resume)
+        if prior is None:
+            print(f"error: no session named {resume!r} under {persistence.DEFAULT_REPL_HOME}", file=sys.stderr)
+            return 1
+        ids = prior.get("sdk_session_ids") or []
+        if not ids:
+            print(f"warning: session {resume!r} has no recorded sdk_session_id; starting fresh conversation", file=sys.stderr)
+        else:
+            resume_sdk_session_id = ids[-1]  # most recent
+
+    options = build_options(
+        ClaudeAgentOptions, mode, model, system_prompt,
+        cwd=Path.cwd(), resume_sdk_session_id=resume_sdk_session_id,
+    )
 
     model_display = model or f"{DEFAULT_MODEL} (default)"
     sys.stdout.write(BANNER.format(mode=mode, model=model_display))
+    if resume_sdk_session_id:
+        sys.stdout.write(f"Resuming {resume!r} (sdk session {resume_sdk_session_id[:8]}…)\n")
     sys.stdout.write(
         "Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.\n"
         "Type /help for commands.\n\n"
     )
     sys.stdout.flush()
 
+    allowed_tools = (
+        list(options.allowed_tools)
+        if hasattr(options, "allowed_tools")
+        else list(getattr(options, "kwargs", {}).get("allowed_tools", []))
+    )
     state = ReplState(
         mode=mode,
         model=model or DEFAULT_MODEL,
-        allowed_tools=list(options.allowed_tools)
-        if hasattr(options, "allowed_tools")
-        else list(getattr(options, "kwargs", {}).get("allowed_tools", [])),
+        allowed_tools=allowed_tools,
     )
 
-    session = PromptSession(history=InMemoryHistory())
+    transcript = persistence.create_session(
+        mode=mode,
+        model=model or DEFAULT_MODEL,
+        allowed_tools=allowed_tools,
+        name=session_name,
+    )
+    sys.stdout.write(f"[transcript → {transcript.session_dir}]\n\n")
+    state.session_dir = str(transcript.session_dir)
+    state.transcript_name = transcript.name
+
+    prompt_session = PromptSession(history=InMemoryHistory())
 
     saved_claudecode = os.environ.pop("CLAUDECODE", None)
     exit_code = 0
 
-    # Outer loop wraps the SDK client so /clear can close+reopen it for a
-    # fresh conversation while the REPL itself keeps running.
+    # Outer loop wraps the SDK client so /clear and /resume can close+reopen
+    # it for a different conversation while the REPL keeps running.
     try:
         while True:
             restart_requested, should_exit, loop_exit_code = await _run_sdk_session(
                 options=options,
                 state=state,
-                prompt_session=session,
+                transcript=transcript,
+                prompt_session=prompt_session,
                 ClaudeSDKClient=ClaudeSDKClient,
                 AssistantMessage=AssistantMessage,
                 UserMessage=UserMessage,
@@ -391,10 +464,23 @@ async def _run_interactive(
                 break
             if not restart_requested:
                 break
+            # Rebuild options for /clear vs /resume.
+            next_resume_id = state.pending_resume_sdk_session_id
+            state.pending_resume_sdk_session_id = None
+            options = build_options(
+                ClaudeAgentOptions, mode, model, system_prompt,
+                cwd=Path.cwd(), resume_sdk_session_id=next_resume_id,
+            )
+            transcript.write_event({
+                "type": "restart",
+                "resume_sdk_session_id": next_resume_id,
+            })
             reset_for_restart(state)
     finally:
         if saved_claudecode is not None:
             os.environ["CLAUDECODE"] = saved_claudecode
+        persistence.finalize(transcript, state)
+        transcript.close()
     return exit_code
 
 
@@ -402,6 +488,7 @@ async def _run_sdk_session(
     *,
     options: Any,
     state: ReplState,
+    transcript: Any,
     prompt_session: Any,
     ClaudeSDKClient: Any,
     AssistantMessage: Any,
@@ -412,8 +499,10 @@ async def _run_sdk_session(
 ) -> tuple[bool, bool, int]:
     """Run one ClaudeSDKClient lifecycle. Returns (restart, exit, exit_code).
 
-    A slash-command `/clear` signals restart — outer loop reopens the client.
-    EOF or `/exit` signals exit.
+    A slash-command `/clear` or `/resume` signals restart — outer loop
+    reopens the client (with a resume session_id if /resume fired). EOF or
+    `/exit` signals exit. Every turn + tool event is written to
+    `transcript.events_path` as JSONL.
     """
     exit_code = 0
     async with ClaudeSDKClient(options=options) as client:
@@ -436,9 +525,12 @@ async def _run_sdk_session(
                 action = dispatch_command(text, state, sys.stdout)
                 if action == EXIT:
                     return False, True, exit_code
-                if action == RESTART:
+                if action in (RESTART, RESUME):
                     return True, False, exit_code
                 continue
+
+            # Record the user's input as a first-class event.
+            transcript.write_event({"type": "user_input", "text": text})
 
             try:
                 await client.query(text)
@@ -453,8 +545,15 @@ async def _run_sdk_session(
                             out=sys.stdout,
                         )
                         sys.stdout.flush()
+                        _persist_sdk_message(
+                            message, transcript,
+                            AssistantMessage, UserMessage,
+                            SystemMessage, ResultMessage,
+                        )
                         if isinstance(message, SystemMessage):
                             track_system_init(state, message)
+                            if state.session_id:
+                                persistence.record_session_id(transcript, state.session_id)
                         elif isinstance(message, ResultMessage):
                             track_result(state, message)
                             if getattr(message, "is_error", False):

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -19,6 +19,7 @@ from agentwire.repl.state import ReplState
 CONTINUE = "continue"
 EXIT = "exit"
 RESTART = "restart"
+RESUME = "resume"
 
 
 Handler = Callable[[ReplState, str, TextIO], str]
@@ -104,6 +105,68 @@ def _model(state: ReplState, args: str, out: TextIO) -> str:
     return CONTINUE
 
 
+def _save(state: ReplState, args: str, out: TextIO) -> str:
+    """Confirm where the transcript is being written. Every turn is already
+    auto-persisted, so `/save` is a UX affirmation, not a flush-on-demand."""
+    if not state.session_dir:
+        out.write("[no transcript dir yet — persistence starts with the first turn]\n")
+        return CONTINUE
+    out.write(
+        f"[transcript · {state.transcript_name} · "
+        f"{state.turn_count} turn{'s' if state.turn_count != 1 else ''}]\n"
+        f"[path · {state.session_dir}]\n"
+    )
+    if state.session_id:
+        out.write(f"[resume with · /resume {state.transcript_name}]\n")
+    return CONTINUE
+
+
+def _resume(state: ReplState, args: str, out: TextIO) -> str:
+    """`/resume` lists recent sessions; `/resume NAME` restarts with that
+    session's sdk_session_id to continue the prior conversation.
+
+    Looks up metadata in `~/.agentwire/sessions/repl/` and defers the
+    actual SDK re-open to the outer loop (via RESUME + pending_resume_*).
+    """
+    # Local import — commands.py stays lightweight + avoids circular imports
+    # through app.py.
+    from agentwire.repl import persistence
+
+    target = args.strip()
+    if not target:
+        sessions = persistence.list_sessions(limit=10)
+        if not sessions:
+            out.write("[no saved sessions found]\n")
+            return CONTINUE
+        out.write("Recent sessions (most recent first):\n")
+        for meta in sessions:
+            name = meta.get("name", "?")
+            turns = meta.get("turn_count", 0)
+            mode = meta.get("mode", "?")
+            started = meta.get("started_at", 0)
+            from datetime import datetime, timezone
+            try:
+                when = datetime.fromtimestamp(started, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                when = "?"
+            out.write(f"  {name}  ({turns} turn{'s' if turns != 1 else ''} · mode={mode} · {when} UTC)\n")
+        out.write("\nUsage: /resume <name>\n")
+        return CONTINUE
+
+    meta = persistence.load_session(target)
+    if meta is None:
+        out.write(f"[no session found: {target}]\n")
+        return CONTINUE
+    ids = meta.get("sdk_session_ids") or []
+    if not ids:
+        out.write(f"[session {target!r} has no recorded sdk_session_id; cannot resume]\n")
+        return CONTINUE
+
+    state.pending_resume_sdk_session_id = ids[-1]
+    out.write(f"[resuming {target} (sdk session {ids[-1][:8]}…) — reopening client]\n")
+    return RESUME
+
+
 # -------- registry --------
 
 def _build_registry() -> dict[str, Command]:
@@ -115,6 +178,8 @@ def _build_registry() -> dict[str, Command]:
         Command(name="/cost", handler=_cost, summary="Show session token + cost totals"),
         Command(name="/tools", handler=_tools, summary="List allowed tools for this mode"),
         Command(name="/model", handler=_model, summary="Show current model + session id"),
+        Command(name="/save", handler=_save, summary="Show transcript path + resume hint"),
+        Command(name="/resume", handler=_resume, summary="Resume a saved session (or list)"),
         exit_cmd,
     ]
     registry: dict[str, Command] = {}

--- a/agentwire/repl/persistence.py
+++ b/agentwire/repl/persistence.py
@@ -1,0 +1,192 @@
+"""Transcript persistence for agentwire REPL sessions.
+
+Every REPL session creates a directory under `~/.agentwire/sessions/repl/`
+containing:
+  - metadata.json — session-level config + running totals, updated on close
+  - transcript.jsonl — one JSON object per line, event stream
+
+Event shape mirrors `agentwire/workflows/storage.py` where possible so the
+portal history window can render REPL sessions alongside workflow runs.
+
+We add two REPL-specific event types on top of the workflow vocabulary:
+  - `user_input` — the literal text the user typed for a turn
+  - `restart` — emitted when /clear resets the SDK conversation
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, IO
+
+from agentwire.repl.state import ReplState
+
+
+SCHEMA_VERSION = 1
+DEFAULT_REPL_HOME = Path.home() / ".agentwire" / "sessions" / "repl"
+
+
+@dataclass
+class Transcript:
+    """Handle for an open transcript file + metadata state.
+
+    Hold onto one of these for the life of the REPL session. `/clear` calls
+    `record_restart()` to mark the boundary but keeps writing to the same
+    file (a session is the REPL's lifetime; restarts are events within it).
+    """
+    name: str
+    session_dir: Path
+    events_path: Path
+    metadata_path: Path
+    _events_file: IO[str] = field(repr=False)
+    started_at: float = field(default_factory=time.time)
+
+    def write_event(self, event: dict[str, Any]) -> None:
+        payload = {"ts": time.time(), **event}
+        self._events_file.write(json.dumps(payload, default=str) + "\n")
+        self._events_file.flush()
+
+    def close(self) -> None:
+        try:
+            self._events_file.close()
+        except Exception:
+            pass
+
+
+def _session_name(now: datetime | None = None) -> str:
+    """Auto-generate a session name: YYYY-MM-DDTHH-MM-SS-<6 hex>."""
+    now = now or datetime.now(timezone.utc)
+    stamp = now.strftime("%Y-%m-%dT%H-%M-%S")
+    return f"{stamp}-{secrets.token_hex(3)}"
+
+
+def create_session(
+    mode: str,
+    model: str,
+    allowed_tools: list[str],
+    name: str | None = None,
+    home: Path | None = None,
+) -> Transcript:
+    """Create a session directory + open the events file for append.
+
+    Writes the initial `metadata.json`. If `name` is given and already exists,
+    a numeric suffix is added to avoid clobbering.
+    """
+    base = home or DEFAULT_REPL_HOME
+    base.mkdir(parents=True, exist_ok=True)
+
+    chosen = name or _session_name()
+    session_dir = base / chosen
+    if session_dir.exists():
+        # Avoid overwriting; pick a suffix.
+        i = 2
+        while (base / f"{chosen}-{i}").exists():
+            i += 1
+        chosen = f"{chosen}-{i}"
+        session_dir = base / chosen
+
+    session_dir.mkdir(parents=True)
+    events_path = session_dir / "transcript.jsonl"
+    metadata_path = session_dir / "metadata.json"
+
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "name": chosen,
+        "started_at": time.time(),
+        "mode": mode,
+        "model": model,
+        "allowed_tools": list(allowed_tools),
+        "sdk_session_ids": [],
+        "turn_count": 0,
+        "restart_count": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_cost_usd": 0.0,
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2))
+
+    events_file = events_path.open("a")
+    return Transcript(
+        name=chosen,
+        session_dir=session_dir,
+        events_path=events_path,
+        metadata_path=metadata_path,
+        _events_file=events_file,
+        started_at=metadata["started_at"],
+    )
+
+
+def finalize(transcript: Transcript, state: ReplState) -> None:
+    """Update metadata.json with final state + ended_at. Idempotent."""
+    try:
+        current = json.loads(transcript.metadata_path.read_text())
+    except Exception:
+        current = {}
+    current.update({
+        "turn_count": state.turn_count,
+        "restart_count": state.restart_count,
+        "total_input_tokens": state.total_input_tokens,
+        "total_output_tokens": state.total_output_tokens,
+        "total_cost_usd": state.total_cost_usd,
+        "ended_at": time.time(),
+    })
+    # Append session_id if tracked and not already recorded.
+    if state.session_id:
+        ids = current.get("sdk_session_ids") or []
+        if state.session_id not in ids:
+            ids.append(state.session_id)
+        current["sdk_session_ids"] = ids
+    transcript.metadata_path.write_text(json.dumps(current, indent=2))
+
+
+def record_session_id(transcript: Transcript, session_id: str | None) -> None:
+    """Append an SDK session_id to metadata as soon as we learn it."""
+    if not session_id:
+        return
+    try:
+        current = json.loads(transcript.metadata_path.read_text())
+    except Exception:
+        current = {}
+    ids = current.get("sdk_session_ids") or []
+    if session_id in ids:
+        return
+    ids.append(session_id)
+    current["sdk_session_ids"] = ids
+    transcript.metadata_path.write_text(json.dumps(current, indent=2))
+
+
+def list_sessions(home: Path | None = None, limit: int = 20) -> list[dict[str, Any]]:
+    """Return recent sessions' metadata, newest first."""
+    base = home or DEFAULT_REPL_HOME
+    if not base.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for d in base.iterdir():
+        if not d.is_dir():
+            continue
+        meta_path = d / "metadata.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except Exception:
+            continue
+        entries.append(meta)
+    entries.sort(key=lambda m: m.get("started_at", 0), reverse=True)
+    return entries[:limit]
+
+
+def load_session(name: str, home: Path | None = None) -> dict[str, Any] | None:
+    """Load metadata.json for a named session. None if missing / corrupt."""
+    base = home or DEFAULT_REPL_HOME
+    meta = base / name / "metadata.json"
+    if not meta.is_file():
+        return None
+    try:
+        return json.loads(meta.read_text())
+    except Exception:
+        return None

--- a/agentwire/repl/state.py
+++ b/agentwire/repl/state.py
@@ -28,6 +28,12 @@ class ReplState:
     turn_count: int = 0
     restart_count: int = 0
     session_id: str | None = None
+    # Phase 2 PR 2 — transcript + resume plumbing
+    session_dir: str | None = None
+    transcript_name: str | None = None
+    # Set by `/resume NAME` handler; outer loop reads this to build the next
+    # SDK client's options with `resume=<sdk_session_id>`.
+    pending_resume_sdk_session_id: str | None = None
 
 
 def track_system_init(state: ReplState, message: Any) -> None:

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -15,6 +15,7 @@ from agentwire.repl.commands import (
     CONTINUE,
     EXIT,
     RESTART,
+    RESUME,
     dispatch_command,
 )
 from agentwire.repl.state import (
@@ -235,6 +236,105 @@ class TestTrackResult:
         m = SimpleNamespace(usage=None, total_cost_usd=None)
         track_result(state, m)
         assert state.turn_count == 1
+
+
+class TestSave:
+    def test_no_session_dir(self):
+        out = io.StringIO()
+        dispatch_command("/save", _state(), out)
+        assert "no transcript dir yet" in out.getvalue()
+
+    def test_with_session_dir_and_session_id(self):
+        out = io.StringIO()
+        state = _state()
+        state.session_dir = "/tmp/foo"
+        state.transcript_name = "s-001"
+        state.turn_count = 4
+        state.session_id = "sdk-xyz"
+        dispatch_command("/save", state, out)
+        rendered = out.getvalue()
+        assert "s-001" in rendered
+        assert "4 turns" in rendered
+        assert "/tmp/foo" in rendered
+        assert "/resume s-001" in rendered
+
+    def test_singular_turn(self):
+        out = io.StringIO()
+        state = _state()
+        state.session_dir = "/tmp/x"
+        state.transcript_name = "s"
+        state.turn_count = 1
+        dispatch_command("/save", state, out)
+        assert "1 turn]" in out.getvalue()
+        assert "1 turns" not in out.getvalue()
+
+
+class TestResume:
+    def test_no_sessions_found(self, tmp_path, monkeypatch):
+        from agentwire.repl import persistence
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "empty")
+        out = io.StringIO()
+        action = dispatch_command("/resume", _state(), out)
+        assert action == CONTINUE
+        assert "no saved sessions" in out.getvalue()
+
+    def test_lists_available(self, tmp_path, monkeypatch):
+        from agentwire.repl import persistence
+        home = tmp_path / "repl"
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", home)
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="alpha", home=home,
+        )
+        t.close()
+
+        out = io.StringIO()
+        action = dispatch_command("/resume", _state(), out)
+        assert action == CONTINUE
+        rendered = out.getvalue()
+        assert "alpha" in rendered
+        assert "Usage: /resume" in rendered
+
+    def test_missing_named_session(self, tmp_path, monkeypatch):
+        from agentwire.repl import persistence
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "empty")
+        out = io.StringIO()
+        action = dispatch_command("/resume not-there", _state(), out)
+        assert action == CONTINUE
+        assert "no session found" in out.getvalue()
+
+    def test_session_without_sdk_id(self, tmp_path, monkeypatch):
+        from agentwire.repl import persistence
+        home = tmp_path / "repl"
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", home)
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="no-id", home=home,
+        )
+        t.close()
+
+        out = io.StringIO()
+        action = dispatch_command("/resume no-id", _state(), out)
+        assert action == CONTINUE  # not RESUME, since nothing to resume to
+        assert "no recorded sdk_session_id" in out.getvalue()
+
+    def test_resume_sets_pending_and_returns_resume(self, tmp_path, monkeypatch):
+        from agentwire.repl import persistence
+        home = tmp_path / "repl"
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", home)
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="good", home=home,
+        )
+        persistence.record_session_id(t, "sdk-target-id")
+        t.close()
+
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/resume good", state, out)
+        assert action == RESUME
+        assert state.pending_resume_sdk_session_id == "sdk-target-id"
+        assert "resuming good" in out.getvalue()
 
 
 class TestResetForRestart:

--- a/tests/unit/test_repl_persistence.py
+++ b/tests/unit/test_repl_persistence.py
@@ -1,0 +1,256 @@
+"""Tests for REPL transcript persistence (Phase 2 PR 2).
+
+Covers agentwire/repl/persistence.py — create_session, write_event,
+record_session_id, finalize, list_sessions, load_session.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire.repl import persistence
+from agentwire.repl.state import ReplState
+
+
+@pytest.fixture
+def repl_home(tmp_path):
+    return tmp_path / "repl_home"
+
+
+class TestCreateSession:
+    def test_basic_layout(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="claude-opus-4-7",
+            allowed_tools=["Read", "Bash"], home=repl_home,
+        )
+        try:
+            assert t.session_dir.is_dir()
+            assert t.events_path.is_file()
+            assert t.metadata_path.is_file()
+            meta = json.loads(t.metadata_path.read_text())
+            assert meta["mode"] == "bypass"
+            assert meta["model"] == "claude-opus-4-7"
+            assert meta["allowed_tools"] == ["Read", "Bash"]
+            assert meta["schema_version"] == 1
+            assert meta["turn_count"] == 0
+            assert meta["sdk_session_ids"] == []
+        finally:
+            t.close()
+
+    def test_explicit_name_honored(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="my-session", home=repl_home,
+        )
+        try:
+            assert t.session_dir.name == "my-session"
+        finally:
+            t.close()
+
+    def test_name_collision_suffixed(self, repl_home):
+        t1 = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="same", home=repl_home,
+        )
+        t2 = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="same", home=repl_home,
+        )
+        try:
+            assert t1.session_dir.name == "same"
+            assert t2.session_dir.name == "same-2"
+        finally:
+            t1.close()
+            t2.close()
+
+    def test_auto_name_is_iso_plus_hex(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        try:
+            name = t.session_dir.name
+            # "YYYY-MM-DDTHH-MM-SS-xxxxxx" → split by - ≥ 6 parts
+            assert len(name.split("-")) >= 6
+            # Last part is 6 hex chars
+            assert len(name.split("-")[-1]) == 6
+        finally:
+            t.close()
+
+
+class TestWriteEvent:
+    def test_appends_jsonl(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        try:
+            t.write_event({"type": "user_input", "text": "hello"})
+            t.write_event({"type": "user_input", "text": "second"})
+        finally:
+            t.close()
+
+        lines = t.events_path.read_text().splitlines()
+        assert len(lines) == 2
+        e1 = json.loads(lines[0])
+        e2 = json.loads(lines[1])
+        assert e1["type"] == "user_input"
+        assert e1["text"] == "hello"
+        assert "ts" in e1
+        assert e2["text"] == "second"
+
+    def test_handles_non_serializable_via_default_str(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        try:
+            t.write_event({"type": "x", "weird": object()})
+        finally:
+            t.close()
+        # Just verify it didn't raise; line exists.
+        assert len(t.events_path.read_text().splitlines()) == 1
+
+
+class TestRecordSessionId:
+    def test_adds_once(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        persistence.record_session_id(t, "sess-abc")
+        persistence.record_session_id(t, "sess-abc")  # dupe ignored
+        persistence.record_session_id(t, "sess-xyz")
+        t.close()
+        meta = json.loads(t.metadata_path.read_text())
+        assert meta["sdk_session_ids"] == ["sess-abc", "sess-xyz"]
+
+    def test_empty_id_noop(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        persistence.record_session_id(t, None)
+        persistence.record_session_id(t, "")
+        t.close()
+        meta = json.loads(t.metadata_path.read_text())
+        assert meta["sdk_session_ids"] == []
+
+
+class TestFinalize:
+    def test_writes_totals_and_ended_at(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=["Read"], home=repl_home,
+        )
+        state = ReplState(mode="bypass", model="m", allowed_tools=["Read"])
+        state.total_input_tokens = 100
+        state.total_output_tokens = 50
+        state.total_cost_usd = 0.005
+        state.turn_count = 3
+        state.session_id = "sdk-abc"
+
+        persistence.finalize(t, state)
+        t.close()
+
+        meta = json.loads(t.metadata_path.read_text())
+        assert meta["total_input_tokens"] == 100
+        assert meta["total_output_tokens"] == 50
+        assert meta["total_cost_usd"] == pytest.approx(0.005)
+        assert meta["turn_count"] == 3
+        assert "ended_at" in meta
+        assert "sdk-abc" in meta["sdk_session_ids"]
+
+    def test_idempotent(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[], home=repl_home,
+        )
+        state = ReplState(mode="bypass", model="m", allowed_tools=[])
+        state.turn_count = 1
+        persistence.finalize(t, state)
+        persistence.finalize(t, state)  # second call shouldn't explode
+        t.close()
+        meta = json.loads(t.metadata_path.read_text())
+        assert meta["turn_count"] == 1
+
+
+class TestListSessions:
+    def test_empty_home(self, repl_home):
+        assert persistence.list_sessions(home=repl_home) == []
+
+    def test_orders_by_started_at_desc(self, repl_home, monkeypatch):
+        # Create three sessions with staggered timestamps.
+        import time
+        stamps = [1000.0, 2000.0, 1500.0]
+        for i, ts in enumerate(stamps):
+            t = persistence.create_session(
+                mode="bypass", model="m", allowed_tools=[],
+                name=f"s{i}", home=repl_home,
+            )
+            t.close()
+            # Rewrite started_at to our deterministic value.
+            meta = json.loads(t.metadata_path.read_text())
+            meta["started_at"] = ts
+            t.metadata_path.write_text(json.dumps(meta))
+
+        listed = persistence.list_sessions(home=repl_home)
+        names = [m["name"] for m in listed]
+        assert names == ["s1", "s2", "s0"]  # 2000 > 1500 > 1000
+
+    def test_limit_applied(self, repl_home):
+        for i in range(5):
+            t = persistence.create_session(
+                mode="bypass", model="m", allowed_tools=[],
+                name=f"n{i}", home=repl_home,
+            )
+            t.close()
+        listed = persistence.list_sessions(home=repl_home, limit=3)
+        assert len(listed) == 3
+
+    def test_skips_corrupt_metadata(self, repl_home):
+        good = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="good", home=repl_home,
+        )
+        good.close()
+        # Create a dir with garbage metadata
+        bad_dir = repl_home / "bad"
+        bad_dir.mkdir()
+        (bad_dir / "metadata.json").write_text("{not valid json")
+        listed = persistence.list_sessions(home=repl_home)
+        names = [m["name"] for m in listed]
+        assert "good" in names
+        assert "bad" not in names
+
+    def test_skips_dirs_without_metadata(self, repl_home):
+        good = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=[],
+            name="good", home=repl_home,
+        )
+        good.close()
+        (repl_home / "no-metadata").mkdir()
+        listed = persistence.list_sessions(home=repl_home)
+        names = [m["name"] for m in listed]
+        assert names == ["good"]
+
+
+class TestLoadSession:
+    def test_missing_returns_none(self, repl_home):
+        assert persistence.load_session("nope", home=repl_home) is None
+
+    def test_corrupt_returns_none(self, repl_home):
+        bad = repl_home / "bad"
+        bad.mkdir(parents=True)
+        (bad / "metadata.json").write_text("not json")
+        assert persistence.load_session("bad", home=repl_home) is None
+
+    def test_round_trip(self, repl_home):
+        t = persistence.create_session(
+            mode="bypass", model="m", allowed_tools=["Read"],
+            name="rt", home=repl_home,
+        )
+        persistence.record_session_id(t, "sdk-x")
+        t.close()
+        meta = persistence.load_session("rt", home=repl_home)
+        assert meta is not None
+        assert meta["name"] == "rt"
+        assert meta["allowed_tools"] == ["Read"]
+        assert meta["sdk_session_ids"] == ["sdk-x"]

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -450,9 +450,13 @@ class TestPrintModeIntegration:
 
 # --- interactive loop (mocked prompt_toolkit + SDK) ---
 
-def _install_fake_sdk(monkeypatch, messages_per_turn):
+def _install_fake_sdk(monkeypatch, messages_per_turn, tmp_path=None):
     """Install a fake claude_agent_sdk module. messages_per_turn is a list of
-    lists; one inner list per .query() call, each yielded by receive_response."""
+    lists; one inner list per .query() call, each yielded by receive_response.
+
+    If tmp_path is provided, persistence.DEFAULT_REPL_HOME is redirected there
+    so interactive-loop tests don't pollute ~/.agentwire/sessions/repl/.
+    """
     import sys as _sys
     import types
 
@@ -467,7 +471,8 @@ def _install_fake_sdk(monkeypatch, messages_per_turn):
 
     class MockClient:
         def __init__(self, options):
-            state["options"] = options
+            state.setdefault("all_options", []).append(options)
+            state["options"] = options  # last one
             state["closed"] = False
 
         async def __aenter__(self):
@@ -489,6 +494,12 @@ def _install_fake_sdk(monkeypatch, messages_per_turn):
 
     fake_sdk.ClaudeSDKClient = MockClient
     monkeypatch.setitem(_sys.modules, "claude_agent_sdk", fake_sdk)
+
+    # Redirect persistence to tmp_path so tests don't create real session dirs.
+    if tmp_path is not None:
+        from agentwire.repl import persistence as _persistence
+        monkeypatch.setattr(_persistence, "DEFAULT_REPL_HOME", tmp_path / "repl_home")
+
     return state
 
 
@@ -535,6 +546,14 @@ def _install_fake_prompt_toolkit(monkeypatch, script):
 
 
 class TestInteractiveLoop:
+    @pytest.fixture(autouse=True)
+    def _isolate_persistence(self, tmp_path, monkeypatch):
+        # Every interactive-loop test spawns a real transcript on disk — point
+        # persistence at a tmp_path so we don't pollute ~/.agentwire/sessions/.
+        from agentwire.repl import persistence
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl_home")
+        self._repl_home = tmp_path / "repl_home"
+
     def test_eof_exits_clean(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])
         _install_fake_prompt_toolkit(monkeypatch, [])  # empty → EOFError
@@ -728,6 +747,130 @@ class TestInteractiveLoop:
         assert "unknown command" in out
         assert "/foo" in out
         assert state["queries"] == []
+
+    def test_transcript_written_for_each_turn(self, monkeypatch, capsys):
+        import json
+        turn = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "sdk-abc"}),
+            FakeAssistantMessage([{"type": "text", "text": "hi"}]),
+            FakeResultMessage(usage={"input_tokens": 5, "output_tokens": 3}, duration_ms=100),
+        ]
+        _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["hello there"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+
+        # A session dir was created under the patched home
+        sessions = list(self._repl_home.iterdir())
+        assert len(sessions) == 1
+        sess = sessions[0]
+        meta = json.loads((sess / "metadata.json").read_text())
+        assert meta["mode"] == "bypass"
+        assert meta["turn_count"] == 1
+        assert meta["total_input_tokens"] == 5
+        assert meta["total_output_tokens"] == 3
+        assert "sdk-abc" in meta["sdk_session_ids"]
+
+        lines = (sess / "transcript.jsonl").read_text().splitlines()
+        events = [json.loads(line) for line in lines]
+        types = [e["type"] for e in events]
+        assert "user_input" in types
+        assert "session" in types
+        assert "agent_start" in types
+        assert "message_end" in types
+        assert "turn_end" in types
+        assert "agent_end" in types
+        # user_input has the literal text
+        ui = next(e for e in events if e["type"] == "user_input")
+        assert ui["text"] == "hello there"
+
+    def test_explicit_session_name(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, [])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="bypass", session_name="explicit-name")
+
+        assert (self._repl_home / "explicit-name").is_dir()
+
+    def test_save_command_reflects_transcript(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, ["/save"])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="bypass", session_name="save-test")
+        out = capsys.readouterr().out
+        assert "save-test" in out
+        assert str(self._repl_home / "save-test") in out
+
+    def test_resume_fails_gracefully_when_session_absent(self, monkeypatch, capsys):
+        _install_fake_sdk(monkeypatch, [])
+        _install_fake_prompt_toolkit(monkeypatch, [])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", resume="missing")
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "no session named 'missing'" in err
+
+    def test_resume_passes_sdk_session_id_to_options(self, monkeypatch, capsys):
+        # First run creates a session and records its sdk_session_id.
+        first_turn = [
+            FakeSystemMessage("init", {"model": "claude-opus-4-7", "session_id": "first-sdk-id"}),
+            FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10),
+        ]
+        state1 = _install_fake_sdk(monkeypatch, [first_turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["hi"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", session_name="resumable")
+        assert rc == 0
+
+        # Second run resumes — fake SDK should see `resume=first-sdk-id`
+        # in the options passed to ClaudeSDKClient.
+        state2 = _install_fake_sdk(monkeypatch, [[]])
+        _install_fake_prompt_toolkit(monkeypatch, [])
+
+        rc = run_repl(mode="bypass", resume="resumable")
+        assert rc == 0
+        # New FakeOptions built for this run should carry the resume id.
+        opts = state2["options"]
+        assert opts.kwargs.get("resume") == "first-sdk-id"
+
+    def test_in_repl_resume_reopens_sdk_with_resume_id(self, monkeypatch, capsys):
+        # Pre-seed a saved session
+        from agentwire.repl import persistence
+        seed = persistence.create_session(
+            mode="bypass", model="claude-opus-4-7",
+            allowed_tools=["Read"], name="prior",
+            home=self._repl_home,
+        )
+        persistence.record_session_id(seed, "prior-sdk-id")
+        seed.close()
+
+        # Now run with /resume prior → the second SDK client should have
+        # resume="prior-sdk-id" in its options.
+        turn1 = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        turn2 = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        state = _install_fake_sdk(monkeypatch, [turn1, turn2])
+        _install_fake_prompt_toolkit(monkeypatch, [
+            "first turn on fresh session",
+            "/resume prior",
+            "second turn on resumed session",
+        ])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+
+        # Two FakeOptions were created (one per SDK client open).
+        all_opts = state["all_options"]
+        assert len(all_opts) == 2
+        # First had no resume; second should.
+        assert all_opts[0].kwargs.get("resume") is None
+        assert all_opts[1].kwargs.get("resume") == "prior-sdk-id"
 
     def test_missing_prompt_toolkit_returns_one(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])


### PR DESCRIPTION
## Summary
Every interactive REPL session auto-persists to disk. \`/save\` shows where and how to resume; \`/resume NAME\` reopens a prior Claude conversation by reusing its \`sdk_session_id\`. Implements two of the Phase 2 mission bullets (transcript persistence + \`/resume\`).

## Layout

\`\`\`
~/.agentwire/sessions/repl/<name>/
├── metadata.json    # config, tokens/cost totals, sdk_session_ids
└── transcript.jsonl # one JSON event per line
\`\`\`

Event vocabulary mirrors \`workflows/storage.py\` + \`anthropic_events.py\` so the portal history window can render REPL sessions alongside workflow runs through the same code path. Per turn: \`user_input\` (new, REPL-specific) → \`session\` → \`agent_start\` → \`message_end\` (assistant / user / tool-result) → \`turn_end\` → \`agent_end\`. \`restart\` events mark \`/clear\` or \`/resume\` boundaries.

## Commands shipped

| Command | Behavior |
|---|---|
| \`/save\` | Shows transcript path, turn count, and the \`/resume NAME\` command to continue later |
| \`/resume\` (no args) | Lists recent sessions (timestamp, turns, mode) |
| \`/resume NAME\` | Closes current SDK client, reopens with \`resume=<sdk_session_id>\` so Claude picks up prior context |

## CLI args

| Flag | Default | Purpose |
|---|---|---|
| \`--session-name NAME\` | auto (\`YYYY-MM-DDTHH-MM-SS-<hex>\`) | Transcript dir name |
| \`--resume NAME\` | — | Start resuming NAME (SDK session_id reused) |

## Manual smoke (real Opus 4.7)

\`\`\`bash
# Establish context
$ echo 'my favorite color is teal. remember that.' \\
    | agentwire repl --mode bypass --session-name smoke-resume-test
→ Opus read memory, wrote teal preference via Edit, saved transcript

# Resume days/hours later
$ echo 'what was the color i told you to remember?' \\
    | agentwire repl --mode bypass --resume smoke-resume-test
[agent started · claude-opus-4-7 · session f9a65cc8]   ← same sdk_session_id
Teal.
[done · 6+8 tok · \$0.3383 · 2.6s]
\`\`\`

## Plumbing highlights

- \`agentwire/repl/persistence.py\` — \`create_session\` / \`write_event\` / \`record_session_id\` / \`finalize\` / \`list_sessions\` / \`load_session\`
- \`ReplState\` gained \`session_dir\`, \`transcript_name\`, \`pending_resume_sdk_session_id\`
- Outer loop of \`_run_interactive\` rebuilds \`ClaudeAgentOptions\` on RESTART/RESUME, passing the resume id when applicable
- \`build_options\` grew a \`resume_sdk_session_id\` kwarg mapping to the SDK's \`resume\` field
- Interactive-loop tests got an autouse fixture that redirects \`persistence.DEFAULT_REPL_HOME\` to \`tmp_path\` so test runs don't pollute real \`~/.agentwire/sessions/\`
- Event translation reuses \`anthropic_events.translate_{system_init,assistant,user,result}\` from the existing workflow runner — no duplication

## Design note

Each \`--resume\` invocation creates a fresh transcript dir (with a new name) that references the same \`sdk_session_id\`. Multiple dirs → same conversation is intentional for v1: cleaner filesystem semantics than appending, no file-locking, and \`/resume NAME\` still picks up context correctly. If this turns out to be confusing in real usage, PR 3+ can revisit (e.g., append-to-existing option).

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_*.py\` — 117/117 pass
- [x] \`uv run pytest\` — 954 passed / 4 skipped (up 32 from PR 1 baseline)
- [x] Smoke: first REPL writes transcript with 11 events (user_input + session + agent_start + thinking + 4 message_ends + turn_end + agent_end)
- [x] Smoke: \`--resume\` reuses sdk_session_id, model recalls context

Built by [dotdev.dev](https://dotdev.dev)