### PR TITLE
feat(repl): phase 2 pr 3 — multi-line input + @-mention expansion

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from agentwire.repl.commands import CONTINUE, EXIT, RESTART, RESUME, dispatch_command
 from agentwire.repl import persistence
+from agentwire.repl.mentions import expand_mentions
 from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
 
 
@@ -382,6 +383,7 @@ async def _run_interactive(
     try:
         from prompt_toolkit import PromptSession
         from prompt_toolkit.history import InMemoryHistory
+        from prompt_toolkit.key_binding import KeyBindings
         from prompt_toolkit.patch_stdout import patch_stdout
     except ImportError as e:
         print(f"error: prompt_toolkit not installed: {e}", file=sys.stderr)
@@ -411,8 +413,8 @@ async def _run_interactive(
     if resume_sdk_session_id:
         sys.stdout.write(f"Resuming {resume!r} (sdk session {resume_sdk_session_id[:8]}…)\n")
     sys.stdout.write(
-        "Interactive mode. Enter to send · Ctrl+D to exit · Ctrl+C to cancel current turn.\n"
-        "Type /help for commands.\n\n"
+        "Interactive mode. Enter to send · Alt+Enter for newline · Ctrl+D to exit · Ctrl+C to cancel.\n"
+        "Type /help for commands. @path/to/file expands inline.\n\n"
     )
     sys.stdout.flush()
 
@@ -437,7 +439,34 @@ async def _run_interactive(
     state.session_dir = str(transcript.session_dir)
     state.transcript_name = transcript.name
 
-    prompt_session = PromptSession(history=InMemoryHistory())
+    # Multi-line input: only meaningful when stdin is a real TTY. With piped
+    # stdin (smoke tests, scripts, scheduler invocations) prompt_toolkit's
+    # multi-line mode treats every \n as literal and never submits on EOF,
+    # so we fall back to single-line in that case.
+    is_tty = sys.stdin.isatty()
+    if is_tty:
+        kb = KeyBindings()
+
+        @kb.add("escape", "enter")
+        def _(event):
+            event.current_buffer.insert_text("\n")
+
+        @kb.add("c-j")  # Ctrl-J fallback for terminals that don't pass Alt
+        def _(event):
+            event.current_buffer.insert_text("\n")
+
+        @kb.add("enter")
+        def _(event):
+            event.current_buffer.validate_and_handle()
+
+        prompt_session = PromptSession(
+            history=InMemoryHistory(),
+            multiline=True,
+            key_bindings=kb,
+            prompt_continuation="… ",
+        )
+    else:
+        prompt_session = PromptSession(history=InMemoryHistory())
 
     saved_claudecode = os.environ.pop("CLAUDECODE", None)
     exit_code = 0
@@ -529,11 +558,33 @@ async def _run_sdk_session(
                     return True, False, exit_code
                 continue
 
-            # Record the user's input as a first-class event.
-            transcript.write_event({"type": "user_input", "text": text})
+            # Expand @path mentions before sending. Record both raw and
+            # expanded text so transcripts capture user intent + what the
+            # model actually saw.
+            expanded_text, expansions = expand_mentions(text, cwd=Path.cwd())
+            if expansions:
+                sys.stdout.write(
+                    f"[expanded {len(expansions)} mention"
+                    f"{'s' if len(expansions) != 1 else ''}: "
+                    f"{', '.join(e.raw for e in expansions)}]\n"
+                )
+                sys.stdout.flush()
+
+            transcript.write_event({
+                "type": "user_input",
+                "text": text,
+                **(
+                    {
+                        "expanded_text": expanded_text,
+                        "mentions": [{"raw": e.raw, "target": e.target} for e in expansions],
+                    }
+                    if expansions
+                    else {}
+                ),
+            })
 
             try:
-                await client.query(text)
+                await client.query(expanded_text)
                 async for message in client.receive_response():
                     try:
                         render_message(

--- a/agentwire/repl/mentions.py
+++ b/agentwire/repl/mentions.py
@@ -1,0 +1,165 @@
+"""@-mention expansion for the agentwire REPL.
+
+Users can include file contents inline by typing `@path/to/file.py` in their
+turn. Before the prompt is sent to the SDK, every mention is expanded to a
+fenced block carrying the file's contents. Globs are supported (`@src/*.py`).
+
+Design choices:
+- Strings inside backticks or quotes are skipped — `@foo` in code stays
+  literal so the user can talk about a token like "@decorator" without
+  triggering expansion.
+- Mentions cap at MAX_FILE_BYTES per file (default 64 KiB); larger files
+  are clipped with a marker. Keeps the prompt-token bill bounded.
+- Globs cap at MAX_GLOB_FILES (default 10); above that we list the matched
+  paths instead of expanding (the user can refine).
+- Missing files turn into an `@<path> (not found)` marker so the model
+  isn't silently confused about why expected content didn't arrive.
+"""
+
+from __future__ import annotations
+
+import glob as glob_mod
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+MAX_FILE_BYTES = 64 * 1024
+MAX_GLOB_FILES = 10
+
+# A mention is `@` followed by one or more path-y characters. We accept
+# letters/digits/`._-/*?[]~` (no spaces). The leading `@` must not be
+# inside backticks (handled by stripping code spans first) and must be
+# preceded by start-of-line or whitespace so emails like `foo@bar.com`
+# don't trigger.
+_MENTION_RE = re.compile(r"(?:(?<=^)|(?<=\s))@([A-Za-z0-9._\-/~][A-Za-z0-9._\-/*?\[\]~]*)")
+
+
+@dataclass
+class ExpandedMention:
+    raw: str        # e.g. "@src/main.py"
+    target: str     # the path string after @
+    rendered: str   # the substitution text (fenced code block, list, or marker)
+
+
+def expand_mentions(text: str, cwd: Path | None = None) -> tuple[str, list[ExpandedMention]]:
+    """Expand `@path` mentions inline. Returns (new_text, list_of_expansions).
+
+    Mentions inside backtick code spans are left untouched.
+    """
+    if not text or "@" not in text:
+        return text, []
+
+    cwd = cwd or Path.cwd()
+    placeholders, scrubbed = _strip_code_spans(text)
+
+    expansions: list[ExpandedMention] = []
+
+    def _replace(match: re.Match) -> str:
+        raw = match.group(0)
+        target = match.group(1)
+        # Heuristic skip — bare alphanumerics with no separator are probably
+        # not paths (e.g. "@somebody" mentions). Require a `.`, `/`, or glob
+        # char somewhere; otherwise leave alone.
+        if not any(c in target for c in "./*?[~"):
+            return raw
+        rendered = _render_mention(target, cwd)
+        expansions.append(ExpandedMention(raw=raw, target=target, rendered=rendered))
+        return rendered
+
+    expanded = _MENTION_RE.sub(_replace, scrubbed)
+    restored = _restore_code_spans(expanded, placeholders)
+    return restored, expansions
+
+
+def _render_mention(target: str, cwd: Path) -> str:
+    """Resolve `target` to a rendered substitution string."""
+    if any(c in target for c in "*?[") :
+        return _render_glob(target, cwd)
+    p = (cwd / target).expanduser().resolve() if not target.startswith("/") else Path(target).expanduser()
+    if not p.exists():
+        return f"`@{target}` (not found)"
+    if p.is_dir():
+        return _render_directory(p, target)
+    return _render_file(p, target)
+
+
+def _render_file(path: Path, target: str) -> str:
+    try:
+        raw = path.read_bytes()
+    except Exception as exc:
+        return f"`@{target}` (read error: {exc})"
+    truncated = False
+    if len(raw) > MAX_FILE_BYTES:
+        raw = raw[:MAX_FILE_BYTES]
+        truncated = True
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return f"`@{target}` (binary file, {len(raw)} bytes)"
+    fence = _pick_fence(text)
+    suffix = path.suffix.lstrip(".") or ""
+    header = f"\n{fence}{suffix}\n# {target}\n{text}"
+    if not text.endswith("\n"):
+        header += "\n"
+    header += fence
+    if truncated:
+        header += f"\n(truncated to {MAX_FILE_BYTES} bytes; full file is larger)"
+    return header
+
+
+def _render_directory(path: Path, target: str) -> str:
+    entries = sorted(p.name + ("/" if p.is_dir() else "") for p in path.iterdir())
+    if not entries:
+        return f"`@{target}/` (empty directory)"
+    return f"`@{target}/` (directory: {', '.join(entries[:30])}{'…' if len(entries) > 30 else ''})"
+
+
+def _render_glob(pattern: str, cwd: Path) -> str:
+    matches = sorted(
+        glob_mod.glob(pattern, root_dir=str(cwd), recursive="**" in pattern)
+    )
+    if not matches:
+        return f"`@{pattern}` (no matches)"
+    if len(matches) > MAX_GLOB_FILES:
+        listing = "\n".join(f"- {m}" for m in matches[:MAX_GLOB_FILES])
+        return (
+            f"`@{pattern}` matched {len(matches)} files; first {MAX_GLOB_FILES}:\n"
+            f"{listing}\n(use a tighter pattern to expand inline)"
+        )
+    rendered_parts = [_render_file(cwd / m, m) for m in matches]
+    return "\n".join(rendered_parts)
+
+
+def _pick_fence(text: str) -> str:
+    """Choose a code fence longer than any backtick run inside `text`."""
+    longest = 0
+    run = 0
+    for ch in text:
+        if ch == "`":
+            run += 1
+            longest = max(longest, run)
+        else:
+            run = 0
+    return "`" * max(3, longest + 1)
+
+
+# -- code-span scrubbing (so @ inside `code` is ignored) --
+
+_CODE_SPAN_RE = re.compile(r"(`+)([^`]*)\1")
+_PLACEHOLDER_FMT = "\x00CSPAN{}\x00"
+
+
+def _strip_code_spans(text: str) -> tuple[list[str], str]:
+    placeholders: list[str] = []
+
+    def _take(m: re.Match) -> str:
+        placeholders.append(m.group(0))
+        return _PLACEHOLDER_FMT.format(len(placeholders) - 1)
+
+    return placeholders, _CODE_SPAN_RE.sub(_take, text)
+
+
+def _restore_code_spans(text: str, placeholders: list[str]) -> str:
+    for i, original in enumerate(placeholders):
+        text = text.replace(_PLACEHOLDER_FMT.format(i), original)
+    return text

--- a/tests/unit/test_repl_mentions.py
+++ b/tests/unit/test_repl_mentions.py
@@ -1,0 +1,117 @@
+"""Tests for @-mention expansion (Phase 2 PR 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentwire.repl.mentions import (
+    MAX_FILE_BYTES,
+    MAX_GLOB_FILES,
+    expand_mentions,
+)
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A small project tree to mention against."""
+    (tmp_path / "README.md").write_text("# Project\nHello world.\n")
+    (tmp_path / "main.py").write_text("def main():\n    return 1\n")
+    sub = tmp_path / "src"
+    sub.mkdir()
+    (sub / "a.py").write_text("a = 1\n")
+    (sub / "b.py").write_text("b = 2\n")
+    return tmp_path
+
+
+class TestNoExpansion:
+    def test_no_at_sign(self, project):
+        out, exp = expand_mentions("hello world", cwd=project)
+        assert out == "hello world"
+        assert exp == []
+
+    def test_email_not_expanded(self, project):
+        # foo@bar.com — `@` preceded by alphanum, no whitespace → ignored
+        out, exp = expand_mentions("Email: foo@bar.com please", cwd=project)
+        assert out == "Email: foo@bar.com please"
+        assert exp == []
+
+    def test_at_with_no_path_chars_ignored(self, project):
+        # `@somebody` looks like an @-mention but has no `.` `/` glob
+        out, exp = expand_mentions("Hi @somebody what's up", cwd=project)
+        assert out == "Hi @somebody what's up"
+        assert exp == []
+
+    def test_inside_backticks_skipped(self, project):
+        out, exp = expand_mentions("the `@README.md` syntax expands files", cwd=project)
+        assert "@README.md" in out
+        assert "Hello world" not in out  # not expanded
+        assert exp == []
+
+
+class TestFileExpansion:
+    def test_expands_file(self, project):
+        out, exp = expand_mentions("look at @README.md", cwd=project)
+        assert len(exp) == 1
+        assert exp[0].raw == "@README.md"
+        assert "Hello world" in out
+        assert "# README.md" in out  # path comment in fence
+
+    def test_missing_file_marker(self, project):
+        out, exp = expand_mentions("see @nope.txt", cwd=project)
+        assert "(not found)" in out
+        assert len(exp) == 1
+
+    def test_directory_listing(self, project):
+        # `@src` (no path-y char) is heuristically treated as a non-path
+        # to avoid colliding with @username mentions; users use `@src/`
+        # or `@./src` to reference a directory.
+        out, exp = expand_mentions("contents of @src/", cwd=project)
+        assert "directory" in out
+        assert "a.py" in out and "b.py" in out
+
+    def test_truncates_large_file(self, project):
+        big = project / "big.txt"
+        big.write_bytes(b"x" * (MAX_FILE_BYTES + 1000))
+        out, exp = expand_mentions("@big.txt", cwd=project)
+        assert "truncated" in out
+
+    def test_multiple_mentions(self, project):
+        out, exp = expand_mentions("@README.md and @main.py side by side", cwd=project)
+        assert len(exp) == 2
+        assert "Hello world" in out
+        assert "def main()" in out
+
+
+class TestGlobs:
+    def test_glob_under_limit_expands_each(self, project):
+        out, exp = expand_mentions("@src/*.py", cwd=project)
+        assert "a = 1" in out
+        assert "b = 2" in out
+        assert len(exp) == 1  # one mention, multiple files inlined
+
+    def test_glob_over_limit_lists(self, project):
+        # Make MAX_GLOB_FILES + 5 matching files
+        for i in range(MAX_GLOB_FILES + 5):
+            (project / "src" / f"big{i}.py").write_text(f"x{i}=1\n")
+        out, exp = expand_mentions("@src/*.py", cwd=project)
+        assert "matched" in out
+        assert "tighter pattern" in out
+
+    def test_glob_no_matches(self, project):
+        out, exp = expand_mentions("@nothing/*.xyz", cwd=project)
+        assert "no matches" in out
+
+
+class TestFenceSelection:
+    def test_avoids_collision_with_inner_backticks(self, project):
+        bad = project / "tricky.md"
+        bad.write_text("```code inside```\n")
+        out, exp = expand_mentions("@tricky.md", cwd=project)
+        # Outer fence must be at least 4 backticks since inner has 3.
+        assert "````" in out
+
+    def test_binary_file_marker(self, project):
+        bin_path = project / "bin.dat"
+        bin_path.write_bytes(b"\x00\x01\x02\xff")
+        out, exp = expand_mentions("@bin.dat", cwd=project)
+        assert "binary file" in out

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -512,12 +512,20 @@ def _install_fake_prompt_toolkit(monkeypatch, script):
     fake_pt = types.ModuleType("prompt_toolkit")
     fake_history = types.ModuleType("prompt_toolkit.history")
     fake_patch = types.ModuleType("prompt_toolkit.patch_stdout")
+    fake_kb = types.ModuleType("prompt_toolkit.key_binding")
 
     class FakeInMemoryHistory:
         def __init__(self): pass
 
+    class FakeKeyBindings:
+        def __init__(self): pass
+        def add(self, *a, **kw):
+            # Returns a decorator that just returns the function unchanged.
+            def deco(fn): return fn
+            return deco
+
     class FakePromptSession:
-        def __init__(self, history=None):
+        def __init__(self, history=None, multiline=False, key_bindings=None, prompt_continuation=None):
             self.idx = 0
 
         async def prompt_async(self, text):
@@ -538,10 +546,12 @@ def _install_fake_prompt_toolkit(monkeypatch, script):
 
     fake_pt.PromptSession = FakePromptSession
     fake_history.InMemoryHistory = FakeInMemoryHistory
+    fake_kb.KeyBindings = FakeKeyBindings
     fake_patch.patch_stdout = patch_stdout
 
     monkeypatch.setitem(_sys.modules, "prompt_toolkit", fake_pt)
     monkeypatch.setitem(_sys.modules, "prompt_toolkit.history", fake_history)
+    monkeypatch.setitem(_sys.modules, "prompt_toolkit.key_binding", fake_kb)
     monkeypatch.setitem(_sys.modules, "prompt_toolkit.patch_stdout", fake_patch)
 
 
@@ -871,6 +881,82 @@ class TestInteractiveLoop:
         # First had no resume; second should.
         assert all_opts[0].kwargs.get("resume") is None
         assert all_opts[1].kwargs.get("resume") == "prior-sdk-id"
+
+    def test_mention_expanded_before_sdk_query(self, monkeypatch, capsys, tmp_path):
+        # File in CWD that the user mentions
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "note.txt").write_text("the secret is bananas")
+        monkeypatch.chdir(proj)
+
+        turn = [
+            FakeResultMessage(usage={"input_tokens": 5, "output_tokens": 1}, duration_ms=10),
+        ]
+        state = _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["summarize @note.txt please"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", session_name="mention-test")
+        assert rc == 0
+        # The string sent to the SDK includes the expanded file contents.
+        assert len(state["queries"]) == 1
+        sent = state["queries"][0]
+        assert "the secret is bananas" in sent
+        assert "@note.txt" not in sent  # original mention replaced
+        # Notice line shown
+        out = capsys.readouterr().out
+        assert "expanded 1 mention" in out
+
+    def test_mention_recorded_in_transcript(self, monkeypatch, capsys, tmp_path):
+        import json
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "data.txt").write_text("payload-text")
+        monkeypatch.chdir(proj)
+
+        turn = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["check @data.txt"])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="bypass", session_name="mention-record")
+
+        events_path = self._repl_home / "mention-record" / "transcript.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        ui = next(e for e in events if e["type"] == "user_input")
+        # Raw text preserved
+        assert ui["text"] == "check @data.txt"
+        # Expanded text + mentions metadata recorded
+        assert "payload-text" in ui["expanded_text"]
+        assert ui["mentions"] == [{"raw": "@data.txt", "target": "data.txt"}]
+
+    def test_no_mention_no_expanded_field(self, monkeypatch, capsys):
+        # Plain text → no expanded_text/mentions keys in user_input event.
+        import json
+        turn = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["plain hello"])
+
+        from agentwire.repl.app import run_repl
+        run_repl(mode="bypass", session_name="no-mention")
+
+        events_path = self._repl_home / "no-mention" / "transcript.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        ui = next(e for e in events if e["type"] == "user_input")
+        assert "expanded_text" not in ui
+        assert "mentions" not in ui
+
+    def test_multiline_input_sent_as_one_turn(self, monkeypatch, capsys):
+        # The fake PromptSession just returns a string — so a multi-line
+        # string acts like the user typed Alt+Enter then hit Enter.
+        turn = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        state = _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, ["line one\nline two\nline three"])
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass")
+        assert rc == 0
+        assert state["queries"] == ["line one\nline two\nline three"]
 
     def test_missing_prompt_toolkit_returns_one(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])


### PR DESCRIPTION
## Summary
Two of the remaining Phase 2 mission bullets: multi-line input and \`@path/to/file\` mention expansion. Cost status line + permission UX + error classification + \`/thinking\`/\`/effort\` commands roll up in PR 4.

## Multi-line input

In a real TTY:
- **Enter** submits
- **Alt+Enter** (or Esc-then-Enter) inserts a newline
- **Ctrl+J** fallback for terminals that don't pass Alt through
- Continuation prompt shows \`… \` on subsequent lines

Falls back to **single-line mode when stdin isn't a TTY** (piped input from scripts, smoke tests, scheduler invocations) so the existing piped-stdin contract keeps working — \`prompt_toolkit\`'s multi-line mode treats \`\\n\` as literal in non-TTY contexts.

## \`@\`-mention expansion

\`@path/to/file\` in a turn expands inline to a fenced code block carrying the file's contents before the prompt is sent to the SDK.

| Case | Behavior |
|---|---|
| Plain file | Fenced code block with extension as language hint |
| Glob (\`@src/*.py\`) | Each match expanded; over 10 matches → list paths instead |
| Directory (\`@src/\`) | Listing of contents (no recursive expansion) |
| Missing file | \`@<path> (not found)\` marker |
| Binary file | \`@<path> (binary file, N bytes)\` marker |
| Large file (>64 KiB) | Truncated with clear marker |
| Inside backticks | Left literal (so users can talk about \`@decorator\`) |
| \`foo@bar.com\` | Skipped (whitespace lookbehind on \`@\`) |
| \`@somebody\` (no \`.\`/\`/\`/glob) | Skipped (looks like chat-style mention) |

Fence picker scales backtick count to outrun any inner backticks in the file content (so the closing fence doesn't get clipped by markdown content).

Transcript captures **both** the raw user text and the expanded version + the list of mentions, so portal history (and future readers) can see what the user actually typed vs. what the model received.

## Real smoke (Opus 4.7)

\`\`\`bash
$ echo 'summarize @docs/missions/agentwire-repl.md in one sentence' \\
    | agentwire repl --mode bypass --session-name pr3-smoke
[expanded 1 mention: @docs/missions/agentwire-repl.md]
"The Agentwire REPL mission proposes building a Python claude-agent-sdk-based
 interactive harness as a tmux-pane session type … rolled out across 5+ phases…"
[done · 6+178 tok · \$0.82 · 5.5s]
\`\`\`

The transcript shows the raw \`@docs/missions/agentwire-repl.md\` plus a fully-expanded \`expanded_text\` field + a \`mentions: [{raw, target}]\` list.

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_*.py\` — 135/135 pass
- [x] \`uv run pytest\` — 990 passed / 4 skipped (up 18 from PR 2 baseline)
- [x] Smoke: real \`@\` expansion against the mission doc, Opus produces a coherent summary

## Coverage

- 14 new tests in \`test_repl_mentions.py\` covering files, dirs, globs at-and-over the limit, fence selection vs. inner backticks, binary-file marker, missing-file marker, email/code-span/bare-name negative cases, multiple mentions
- 4 new integration tests in \`test_repl_sdk.py\` — mention forwarded to SDK as expanded text, transcript records both raw + expanded, no-mention branch leaves \`user_input\` clean, multi-line input delivered as one turn

Built by [dotdev.dev](https://dotdev.dev)