### PR TITLE
feat(repl): phase 2 pr 4 — cost line, /thinking, /effort, prompted UX, classify

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -18,6 +18,7 @@ from agentwire.repl.commands import CONTINUE, EXIT, RESTART, RESUME, dispatch_co
 from agentwire.repl import persistence
 from agentwire.repl.mentions import expand_mentions
 from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
+from agentwire.workflows.runners.sdk_errors import classify as _classify_sdk_error
 
 
 BANNER = """\
@@ -40,6 +41,18 @@ RESTRICTED_TOOLS = ["Read", "Grep", "Glob", "WebFetch", "WebSearch"]
 
 DEFAULT_MODEL = "claude-opus-4-7"
 DEFAULT_EFFORT = "high"
+DEFAULT_THINKING_MODE = "adaptive"
+
+
+def _thinking_config(mode: str) -> dict | None:
+    """Translate the REPL's `/thinking` mode into an SDK thinking config."""
+    if mode == "adaptive":
+        return {"type": "adaptive"}
+    if mode == "summarized":
+        return {"type": "adaptive", "display": "summarized"}
+    if mode == "off":
+        return {"type": "disabled"}
+    return {"type": "adaptive"}
 
 
 def run_repl(
@@ -122,6 +135,9 @@ def build_options(
     system_prompt: str | None,
     cwd: Path | None = None,
     resume_sdk_session_id: str | None = None,
+    effort: str = DEFAULT_EFFORT,
+    thinking_mode: str = DEFAULT_THINKING_MODE,
+    can_use_tool: Any = None,
 ) -> Any:
     """Compose `ClaudeAgentOptions` for a REPL session.
 
@@ -136,13 +152,15 @@ def build_options(
         "allowed_tools": RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS,
         "setting_sources": ["user"],       # load ~/.claude/hooks — damage-control
         "include_partial_messages": False,
-        "effort": DEFAULT_EFFORT,
-        "thinking": {"type": "adaptive"},
+        "effort": effort,
+        "thinking": _thinking_config(thinking_mode),
     }
     if cwd is not None:
         kwargs["cwd"] = str(cwd)
     if resume_sdk_session_id:
         kwargs["resume"] = resume_sdk_session_id
+    if can_use_tool is not None:
+        kwargs["can_use_tool"] = can_use_tool
 
     append_parts: list[str] = []
     if cwd is not None:
@@ -281,7 +299,8 @@ def render_message(
         suffix = f" · {' · '.join(parts)}" if parts else ""
         if getattr(message, "is_error", False):
             err = getattr(message, "result", None) or "unknown error"
-            out.write(f"[error{suffix}] {err}\n")
+            category = _classify_sdk_error("ResultMessage", str(err))
+            out.write(f"[error · {category}{suffix}] {err}\n")
         else:
             out.write(f"[done{suffix}]\n")
         return
@@ -403,9 +422,22 @@ async def _run_interactive(
         else:
             resume_sdk_session_id = ids[-1]  # most recent
 
+    # ReplState built up-front so the permission callback (and the bottom
+    # toolbar) can close over it before the first SDK options bake.
+    placeholder_tools = (RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS).copy()
+    state = ReplState(
+        mode=mode,
+        model=model or DEFAULT_MODEL,
+        allowed_tools=placeholder_tools,
+    )
+
+    can_use_tool = _make_can_use_tool(state) if mode == "prompted" else None
+
     options = build_options(
         ClaudeAgentOptions, mode, model, system_prompt,
         cwd=Path.cwd(), resume_sdk_session_id=resume_sdk_session_id,
+        effort=state.effort, thinking_mode=state.thinking_mode,
+        can_use_tool=can_use_tool,
     )
 
     model_display = model or f"{DEFAULT_MODEL} (default)"
@@ -414,7 +446,7 @@ async def _run_interactive(
         sys.stdout.write(f"Resuming {resume!r} (sdk session {resume_sdk_session_id[:8]}…)\n")
     sys.stdout.write(
         "Interactive mode. Enter to send · Alt+Enter for newline · Ctrl+D to exit · Ctrl+C to cancel.\n"
-        "Type /help for commands. @path/to/file expands inline.\n\n"
+        "Type /help for commands. @path/to/file expands inline. /effort and /thinking tune SDK knobs.\n\n"
     )
     sys.stdout.flush()
 
@@ -423,11 +455,7 @@ async def _run_interactive(
         if hasattr(options, "allowed_tools")
         else list(getattr(options, "kwargs", {}).get("allowed_tools", []))
     )
-    state = ReplState(
-        mode=mode,
-        model=model or DEFAULT_MODEL,
-        allowed_tools=allowed_tools,
-    )
+    state.allowed_tools = allowed_tools
 
     transcript = persistence.create_session(
         mode=mode,
@@ -444,6 +472,7 @@ async def _run_interactive(
     # multi-line mode treats every \n as literal and never submits on EOF,
     # so we fall back to single-line in that case.
     is_tty = sys.stdin.isatty()
+    bottom_toolbar = _make_bottom_toolbar(state) if is_tty else None
     if is_tty:
         kb = KeyBindings()
 
@@ -464,6 +493,8 @@ async def _run_interactive(
             multiline=True,
             key_bindings=kb,
             prompt_continuation="… ",
+            bottom_toolbar=bottom_toolbar,
+            refresh_interval=0.5,
         )
     else:
         prompt_session = PromptSession(history=InMemoryHistory())
@@ -493,12 +524,14 @@ async def _run_interactive(
                 break
             if not restart_requested:
                 break
-            # Rebuild options for /clear vs /resume.
+            # Rebuild options for /clear vs /resume vs /effort vs /thinking.
             next_resume_id = state.pending_resume_sdk_session_id
             state.pending_resume_sdk_session_id = None
             options = build_options(
                 ClaudeAgentOptions, mode, model, system_prompt,
                 cwd=Path.cwd(), resume_sdk_session_id=next_resume_id,
+                effort=state.effort, thinking_mode=state.thinking_mode,
+                can_use_tool=can_use_tool,
             )
             transcript.write_event({
                 "type": "restart",
@@ -616,5 +649,83 @@ async def _run_sdk_session(
                 sys.stdout.flush()
                 continue
             except Exception as exc:
-                print(f"[repl: {type(exc).__name__}: {exc}]", file=sys.stderr)
+                category = _classify_sdk_error(type(exc).__name__, str(exc))
+                print(
+                    f"[repl: {category} · {type(exc).__name__}: {exc}]",
+                    file=sys.stderr,
+                )
                 continue
+
+
+# -------- Phase 2 PR 4 helpers: bottom toolbar + permission prompt --------
+
+
+def _make_bottom_toolbar(state: ReplState):
+    """Return a callable rendered by prompt_toolkit at the bottom of the prompt.
+
+    Reads from `state` directly so token/cost totals refresh after every turn
+    without us pushing into prompt_toolkit. Falls back to a config-only line
+    before the first response lands.
+    """
+    def _render():
+        if state.turn_count == 0:
+            return (
+                f"{state.mode} · {state.model} · effort={state.effort} · "
+                f"thinking={state.thinking_mode}"
+            )
+        total = state.total_input_tokens + state.total_output_tokens
+        return (
+            f"{state.turn_count} turn{'s' if state.turn_count != 1 else ''} · "
+            f"{total} tok ({state.total_input_tokens} in / {state.total_output_tokens} out) · "
+            f"${state.total_cost_usd:.4f} · effort={state.effort} · "
+            f"thinking={state.thinking_mode}"
+        )
+    return _render
+
+
+def _make_can_use_tool(state: ReplState):
+    """Build a `can_use_tool` async callback for `sdk-prompted` mode.
+
+    Prints a one-line tool-use prompt (`Read /etc/passwd?`) and reads y/n/a
+    from stdin in a worker thread so the SDK's async loop isn't blocked. 'a'
+    adds the tool name to a per-session always-allow set kept on `state`.
+    Reset by `/clear`.
+    """
+    async def _can_use_tool(tool_name: str, tool_input: dict, ctx: Any):
+        # Lazy import — keeps SDK absence from breaking module import.
+        from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
+
+        if tool_name in state.always_allow_tools:
+            return PermissionResultAllow()
+
+        summary = _format_tool_input(tool_name, tool_input or {})
+        prompt = f"\n[? allow {tool_name}{' ' + summary if summary else ''}? (y/n/a=always)] "
+
+        loop = asyncio.get_event_loop()
+        try:
+            answer = await loop.run_in_executor(None, _prompt_sync, prompt)
+        except (EOFError, KeyboardInterrupt):
+            sys.stdout.write("\n[denied via Ctrl+C/EOF]\n")
+            sys.stdout.flush()
+            return PermissionResultDeny(message="user denied (interrupt)")
+
+        answer = (answer or "").strip().lower()
+        if answer in ("a", "always"):
+            state.always_allow_tools.add(tool_name)
+            sys.stdout.write(f"[allow · {tool_name} now always allowed this session]\n")
+            sys.stdout.flush()
+            return PermissionResultAllow()
+        if answer in ("", "y", "yes"):
+            return PermissionResultAllow()
+        sys.stdout.write(f"[deny · {tool_name}]\n")
+        sys.stdout.flush()
+        return PermissionResultDeny(message="user denied")
+
+    return _can_use_tool
+
+
+def _prompt_sync(prompt: str) -> str:
+    """Blocking prompt for the permission callback. Runs off-loop."""
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    return sys.stdin.readline()

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -105,6 +105,55 @@ def _model(state: ReplState, args: str, out: TextIO) -> str:
     return CONTINUE
 
 
+# Effort + thinking are SDK-side knobs. Changing them mid-session means the
+# next conversation needs new options, so the handlers also signal RESTART.
+# The user is told the conversation will reset; this is the same UX as
+# /clear.
+_EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+_THINKING_MODES = ("adaptive", "summarized", "off")
+
+
+def _effort(state: ReplState, args: str, out: TextIO) -> str:
+    target = args.strip().lower()
+    if not target:
+        out.write(
+            f"[effort={state.effort} · choices: {', '.join(_EFFORT_LEVELS)}]\n"
+            "Usage: /effort <level>\n"
+        )
+        return CONTINUE
+    if target not in _EFFORT_LEVELS:
+        out.write(f"[unknown effort {target!r}; choices: {', '.join(_EFFORT_LEVELS)}]\n")
+        return CONTINUE
+    if target == state.effort:
+        out.write(f"[effort already {target}]\n")
+        return CONTINUE
+    state.effort = target
+    out.write(f"[effort → {target} · restarting conversation]\n")
+    return RESTART
+
+
+def _thinking(state: ReplState, args: str, out: TextIO) -> str:
+    target = args.strip().lower()
+    if not target:
+        out.write(
+            f"[thinking={state.thinking_mode} · choices: {', '.join(_THINKING_MODES)}]\n"
+            "Usage: /thinking <mode>\n"
+            "  adaptive   — Claude decides budget; reasoning hidden (Opus 4.7 default)\n"
+            "  summarized — Claude decides budget; show summarized reasoning\n"
+            "  off        — disable extended thinking\n"
+        )
+        return CONTINUE
+    if target not in _THINKING_MODES:
+        out.write(f"[unknown thinking {target!r}; choices: {', '.join(_THINKING_MODES)}]\n")
+        return CONTINUE
+    if target == state.thinking_mode:
+        out.write(f"[thinking already {target}]\n")
+        return CONTINUE
+    state.thinking_mode = target
+    out.write(f"[thinking → {target} · restarting conversation]\n")
+    return RESTART
+
+
 def _save(state: ReplState, args: str, out: TextIO) -> str:
     """Confirm where the transcript is being written. Every turn is already
     auto-persisted, so `/save` is a UX affirmation, not a flush-on-demand."""
@@ -180,6 +229,8 @@ def _build_registry() -> dict[str, Command]:
         Command(name="/model", handler=_model, summary="Show current model + session id"),
         Command(name="/save", handler=_save, summary="Show transcript path + resume hint"),
         Command(name="/resume", handler=_resume, summary="Resume a saved session (or list)"),
+        Command(name="/effort", handler=_effort, summary="Show or set thinking effort (low/medium/high/xhigh/max)"),
+        Command(name="/thinking", handler=_thinking, summary="Show or set thinking display (adaptive/summarized/off)"),
         exit_cmd,
     ]
     registry: dict[str, Command] = {}

--- a/agentwire/repl/state.py
+++ b/agentwire/repl/state.py
@@ -34,6 +34,15 @@ class ReplState:
     # Set by `/resume NAME` handler; outer loop reads this to build the next
     # SDK client's options with `resume=<sdk_session_id>`.
     pending_resume_sdk_session_id: str | None = None
+    # Phase 2 PR 4 — tunable knobs surfaced as /effort and /thinking. Changes
+    # don't take effect until the next conversation starts, so the slash
+    # handlers also signal RESTART.
+    effort: str = "high"
+    thinking_mode: str = "adaptive"
+    # `sdk-prompted` per-session "always allow" set, populated by the inline
+    # permission prompt when the user picks 'a'. Survives across turns; reset
+    # on /clear via reset_for_restart.
+    always_allow_tools: set[str] = field(default_factory=set)
 
 
 def track_system_init(state: ReplState, message: Any) -> None:
@@ -70,3 +79,4 @@ def reset_for_restart(state: ReplState) -> None:
     state.turn_count = 0
     state.session_id = None
     state.restart_count += 1
+    state.always_allow_tools = set()

--- a/agentwire/workflows/runners/anthropic.py
+++ b/agentwire/workflows/runners/anthropic.py
@@ -27,37 +27,9 @@ from typing import Any, Callable
 from agentwire.workflows.node import ActionNode, NodeResult
 from agentwire.workflows.runners import anthropic_events as ev
 from agentwire.workflows.runners.anthropic_capabilities import validate_node_settings
+from agentwire.workflows.runners.sdk_errors import classify as _classify
 
 logger = logging.getLogger("agentwire.workflows.anthropic")
-
-
-# Error-message substrings that mark a failure as transient (worth retrying
-# via the workflow-level node.retries loop). Classification only — we don't
-# add an inner retry loop here; outer retry handles all failure kinds, and
-# this prefix is purely informational so users see at a glance why a node
-# failed. PR 6 canary data will tell us whether inner backoff pays.
-_TRANSIENT_MARKERS = (
-    "overloaded", "rate_limit", "rate limit", " 429", " 529", " 503",
-)
-_AUTH_MARKERS = ("authentication", "unauthorized", " 401", " 403")
-_INVALID_MARKERS = ("invalid_request", " 400", "validation")
-
-
-def _classify(err_type: str, err_msg: str) -> str:
-    """Return a prefix category for an SDK-side error.
-
-    Not a retry decision — just a human-readable tag on NodeResult.error so
-    logs and morning reports can distinguish rate-limited runs from genuine
-    bugs.
-    """
-    haystack = f"{err_type} {err_msg}".lower()
-    if any(m in haystack for m in _TRANSIENT_MARKERS):
-        return "transient"
-    if any(m in haystack for m in _AUTH_MARKERS):
-        return "permanent"
-    if any(m in haystack for m in _INVALID_MARKERS):
-        return "invalid"
-    return "error"
 
 
 class AnthropicRunner:

--- a/agentwire/workflows/runners/sdk_errors.py
+++ b/agentwire/workflows/runners/sdk_errors.py
@@ -1,0 +1,27 @@
+"""Shared classification of claude-agent-sdk errors.
+
+Both the workflow `anthropic` runner and the agentwire REPL surface SDK
+errors to humans (morning reports, terminal output). They benefit from the
+same one-word tag distinguishing rate-limit blips from real bugs, so the
+substring tables live here once.
+"""
+
+from __future__ import annotations
+
+_TRANSIENT_MARKERS = (
+    "overloaded", "rate_limit", "rate limit", " 429", " 529", " 503",
+)
+_AUTH_MARKERS = ("authentication", "unauthorized", " 401", " 403")
+_INVALID_MARKERS = ("invalid_request", " 400", "validation")
+
+
+def classify(err_type: str, err_msg: str) -> str:
+    """Return one of: 'transient', 'permanent', 'invalid', 'error'."""
+    haystack = f"{err_type} {err_msg}".lower()
+    if any(m in haystack for m in _TRANSIENT_MARKERS):
+        return "transient"
+    if any(m in haystack for m in _AUTH_MARKERS):
+        return "permanent"
+    if any(m in haystack for m in _INVALID_MARKERS):
+        return "invalid"
+    return "error"

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -337,6 +337,68 @@ class TestResume:
         assert "resuming good" in out.getvalue()
 
 
+class TestEffort:
+    def test_show_default(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/effort", state, out)
+        assert action == CONTINUE
+        assert f"effort={state.effort}" in out.getvalue()
+
+    def test_set_changes_state_and_restarts(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/effort low", state, out)
+        assert action == RESTART
+        assert state.effort == "low"
+
+    def test_unknown_value_continues(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/effort wat", state, out)
+        assert action == CONTINUE
+        assert "unknown effort" in out.getvalue()
+        assert state.effort == "high"  # unchanged
+
+    def test_same_value_noop_continues(self):
+        state = _state()
+        state.effort = "max"
+        out = io.StringIO()
+        action = dispatch_command("/effort max", state, out)
+        assert action == CONTINUE
+        assert "already" in out.getvalue()
+
+
+class TestThinking:
+    def test_show_default(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/thinking", state, out)
+        assert action == CONTINUE
+        assert f"thinking={state.thinking_mode}" in out.getvalue()
+
+    def test_summarized_restarts(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/thinking summarized", state, out)
+        assert action == RESTART
+        assert state.thinking_mode == "summarized"
+
+    def test_off_restarts(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/thinking off", state, out)
+        assert action == RESTART
+        assert state.thinking_mode == "off"
+
+    def test_unknown_value_continues(self):
+        state = _state()
+        out = io.StringIO()
+        action = dispatch_command("/thinking weird", state, out)
+        assert action == CONTINUE
+        assert "unknown thinking" in out.getvalue()
+
+
 class TestResetForRestart:
     def test_zeros_counters_preserves_config(self):
         state = _state()
@@ -363,3 +425,9 @@ class TestResetForRestart:
         reset_for_restart(state)
         reset_for_restart(state)
         assert state.restart_count == 3
+
+    def test_clears_always_allow(self):
+        state = _state()
+        state.always_allow_tools = {"Read", "Bash"}
+        reset_for_restart(state)
+        assert state.always_allow_tools == set()

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -5,6 +5,7 @@ Phase 1 PR 2. See docs/missions/agentwire-repl.md.
 
 from __future__ import annotations
 
+import asyncio
 import io
 from dataclasses import dataclass
 from pathlib import Path
@@ -525,8 +526,11 @@ def _install_fake_prompt_toolkit(monkeypatch, script):
             return deco
 
     class FakePromptSession:
-        def __init__(self, history=None, multiline=False, key_bindings=None, prompt_continuation=None):
+        def __init__(self, history=None, multiline=False, key_bindings=None,
+                     prompt_continuation=None, bottom_toolbar=None,
+                     refresh_interval=None):
             self.idx = 0
+            self.bottom_toolbar = bottom_toolbar
 
         async def prompt_async(self, text):
             if self.idx >= len(script):
@@ -981,6 +985,190 @@ class TestInteractiveLoop:
         err = capsys.readouterr().err
         assert rc == 1
         assert "prompt_toolkit not installed" in err
+
+
+class TestThinkingConfig:
+    def test_adaptive_default(self):
+        from agentwire.repl.app import _thinking_config
+        assert _thinking_config("adaptive") == {"type": "adaptive"}
+
+    def test_summarized_sets_display(self):
+        from agentwire.repl.app import _thinking_config
+        assert _thinking_config("summarized") == {"type": "adaptive", "display": "summarized"}
+
+    def test_off_disabled(self):
+        from agentwire.repl.app import _thinking_config
+        assert _thinking_config("off") == {"type": "disabled"}
+
+    def test_unknown_falls_back_adaptive(self):
+        from agentwire.repl.app import _thinking_config
+        assert _thinking_config("nonsense") == {"type": "adaptive"}
+
+
+class TestBottomToolbar:
+    def _state(self):
+        from agentwire.repl.state import ReplState
+        return ReplState(mode="bypass", model="claude-opus-4-7", allowed_tools=[])
+
+    def test_pre_first_turn_shows_config(self):
+        from agentwire.repl.app import _make_bottom_toolbar
+        s = self._state()
+        out = _make_bottom_toolbar(s)()
+        assert "bypass" in out
+        assert "claude-opus-4-7" in out
+        assert "effort=high" in out
+        assert "thinking=adaptive" in out
+        # No tokens before first turn
+        assert "tok" not in out
+
+    def test_after_first_turn_shows_totals(self):
+        from agentwire.repl.app import _make_bottom_toolbar
+        s = self._state()
+        s.turn_count = 2
+        s.total_input_tokens = 100
+        s.total_output_tokens = 50
+        s.total_cost_usd = 0.012
+        out = _make_bottom_toolbar(s)()
+        assert "2 turns" in out
+        assert "150 tok" in out
+        assert "100 in" in out
+        assert "50 out" in out
+        assert "$0.0120" in out
+
+    def test_singular_turn_pluralization(self):
+        from agentwire.repl.app import _make_bottom_toolbar
+        s = self._state()
+        s.turn_count = 1
+        out = _make_bottom_toolbar(s)()
+        assert "1 turn " in out  # not "1 turns"
+
+
+class TestPermissionCallback:
+    def _state(self):
+        from agentwire.repl.state import ReplState
+        return ReplState(mode="prompted", model="m", allowed_tools=[])
+
+    def _ctx(self):
+        from types import SimpleNamespace
+        return SimpleNamespace(signal=None, suggestions=[])
+
+    def test_yes_allows(self, monkeypatch):
+        import agentwire.repl.app as app
+        monkeypatch.setattr(app, "_prompt_sync", lambda prompt: "y\n")
+
+        s = self._state()
+        cb = app._make_can_use_tool(s)
+        result = asyncio.run(cb("Read", {"file_path": "/etc/hosts"}, self._ctx()))
+        from claude_agent_sdk import PermissionResultAllow
+        assert isinstance(result, PermissionResultAllow)
+        assert s.always_allow_tools == set()
+
+    def test_no_denies(self, monkeypatch):
+        import agentwire.repl.app as app
+        monkeypatch.setattr(app, "_prompt_sync", lambda prompt: "n\n")
+
+        s = self._state()
+        cb = app._make_can_use_tool(s)
+        result = asyncio.run(cb("Bash", {"command": "ls"}, self._ctx()))
+        from claude_agent_sdk import PermissionResultDeny
+        assert isinstance(result, PermissionResultDeny)
+
+    def test_always_remembers(self, monkeypatch):
+        import agentwire.repl.app as app
+        monkeypatch.setattr(app, "_prompt_sync", lambda prompt: "a\n")
+
+        s = self._state()
+        cb = app._make_can_use_tool(s)
+        result = asyncio.run(cb("Read", {"file_path": "/x"}, self._ctx()))
+        from claude_agent_sdk import PermissionResultAllow
+        assert isinstance(result, PermissionResultAllow)
+        assert "Read" in s.always_allow_tools
+
+        # Subsequent call should bypass _prompt_sync
+        def boom(prompt):
+            raise AssertionError("prompt_sync should not be called")
+        monkeypatch.setattr(app, "_prompt_sync", boom)
+        result2 = asyncio.run(cb("Read", {"file_path": "/y"}, self._ctx()))
+        assert isinstance(result2, PermissionResultAllow)
+
+    def test_blank_defaults_to_allow(self, monkeypatch):
+        import agentwire.repl.app as app
+        monkeypatch.setattr(app, "_prompt_sync", lambda prompt: "\n")
+        s = self._state()
+        cb = app._make_can_use_tool(s)
+        result = asyncio.run(cb("Read", {}, self._ctx()))
+        from claude_agent_sdk import PermissionResultAllow
+        assert isinstance(result, PermissionResultAllow)
+
+
+class TestSdkErrorClassify:
+    def test_transient_429(self):
+        from agentwire.workflows.runners.sdk_errors import classify
+        assert classify("HTTPError", "got 429 rate_limit") == "transient"
+
+    def test_auth_401(self):
+        from agentwire.workflows.runners.sdk_errors import classify
+        assert classify("AuthError", "401 unauthorized") == "permanent"
+
+    def test_invalid_400(self):
+        from agentwire.workflows.runners.sdk_errors import classify
+        assert classify("ValidationError", "invalid_request: bad field") == "invalid"
+
+    def test_generic(self):
+        from agentwire.workflows.runners.sdk_errors import classify
+        assert classify("RuntimeError", "something broke") == "error"
+
+
+class TestBuildOptionsThreadsKnobs:
+    def test_effort_and_thinking_passed_through(self):
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(
+            FakeOptions, mode="bypass", model="m", system_prompt=None,
+            cwd=None, effort="max", thinking_mode="summarized",
+        )
+        assert captured["effort"] == "max"
+        assert captured["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+    def test_can_use_tool_passed_through(self):
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        async def cb(*args, **kwargs): pass
+        build_options(
+            FakeOptions, mode="prompted", model="m", system_prompt=None,
+            cwd=None, can_use_tool=cb,
+        )
+        assert captured["can_use_tool"] is cb
+
+    def test_can_use_tool_omitted_when_none(self):
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(
+            FakeOptions, mode="bypass", model="m", system_prompt=None,
+            cwd=None,
+        )
+        assert "can_use_tool" not in captured
 
 
 class TestFormatToolResult:


### PR DESCRIPTION
## Summary
- Bottom-toolbar status line shows running tokens + cost + effort/thinking
- `/effort` and `/thinking` slash commands tune SDK knobs (restart conversation since SDK options are immutable per client)
- `sdk-prompted` mode now uses an inline `y/n/a` permission prompt with per-session always-allow
- Error classification extracted to `agentwire/workflows/runners/sdk_errors.py`; reused for both REPL turn errors and `ResultMessage` errors

Closes Phase 2 of `docs/missions/agentwire-repl.md`.

## Test plan
- [x] `uv run pytest` — 999 passed, 4 skipped, no regressions
- [x] new tests cover: `/effort`, `/thinking`, `_thinking_config`, bottom toolbar, can_use_tool y/n/a flow + always-allow memoization, classify, build_options threading

Built by [dotdev.dev](https://dotdev.dev)