### PR TITLE
feat(repl): phase 3 pr 1 — agentwire MCP server baked into every REPL

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -43,6 +43,32 @@ DEFAULT_MODEL = "claude-opus-4-7"
 DEFAULT_EFFORT = "high"
 DEFAULT_THINKING_MODE = "adaptive"
 
+# Agentwire MCP server, auto-attached to every REPL session. The differentiator
+# we promise in docs/missions/agentwire-repl.md Phase 3: ~87 agentwire tools
+# (panes, voice, scheduler, channels, etc.) available first-class without any
+# per-session configuration. Set AGENTWIRE_REPL_MCP=0 to opt out.
+MCP_SERVER_NAME = "agentwire"
+MCP_TOOL_PREFIX = f"mcp__{MCP_SERVER_NAME}"
+
+
+def _agentwire_mcp_config() -> dict:
+    """Stdio MCP server config that re-invokes this same Python interpreter.
+
+    Using sys.executable + `-m agentwire mcp` (rather than spawning the
+    `agentwire` console script) keeps the REPL and the MCP server pinned to
+    the exact same install. Avoids a second `agentwire` on PATH starting a
+    different version mid-session.
+    """
+    return {
+        "type": "stdio",
+        "command": sys.executable,
+        "args": ["-m", "agentwire", "mcp"],
+    }
+
+
+def _mcp_enabled() -> bool:
+    return os.environ.get("AGENTWIRE_REPL_MCP", "1") != "0"
+
 
 def _thinking_config(mode: str) -> dict | None:
     """Translate the REPL's `/thinking` mode into an SDK thinking config."""
@@ -146,15 +172,26 @@ def build_options(
     CLAUDE.md + AGENTS.md + an optional explicit append. `resume_sdk_session_id`
     passes through to the SDK's `resume` field to continue a prior conversation.
     """
+    base_tools = RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS
+    allowed = list(base_tools)
+    mcp_servers: dict[str, Any] = {}
+    if _mcp_enabled():
+        mcp_servers[MCP_SERVER_NAME] = _agentwire_mcp_config()
+        # `mcp__<server>` allows all tools from that server in claude-agent-sdk's
+        # tool gating (same convention Claude Code uses).
+        allowed.append(MCP_TOOL_PREFIX)
+
     kwargs: dict[str, Any] = {
         "model": model or DEFAULT_MODEL,
         "permission_mode": PERMISSION_MODE_MAP.get(mode, "bypassPermissions"),
-        "allowed_tools": RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS,
+        "allowed_tools": allowed,
         "setting_sources": ["user"],       # load ~/.claude/hooks — damage-control
         "include_partial_messages": False,
         "effort": effort,
         "thinking": _thinking_config(thinking_mode),
     }
+    if mcp_servers:
+        kwargs["mcp_servers"] = mcp_servers
     if cwd is not None:
         kwargs["cwd"] = str(cwd)
     if resume_sdk_session_id:
@@ -446,8 +483,11 @@ async def _run_interactive(
         sys.stdout.write(f"Resuming {resume!r} (sdk session {resume_sdk_session_id[:8]}…)\n")
     sys.stdout.write(
         "Interactive mode. Enter to send · Alt+Enter for newline · Ctrl+D to exit · Ctrl+C to cancel.\n"
-        "Type /help for commands. @path/to/file expands inline. /effort and /thinking tune SDK knobs.\n\n"
+        "Type /help for commands. @path/to/file expands inline. /effort and /thinking tune SDK knobs.\n"
     )
+    if _mcp_enabled():
+        sys.stdout.write("agentwire MCP server attached — /tools to see what's wired in.\n")
+    sys.stdout.write("\n")
     sys.stdout.flush()
 
     allowed_tools = (

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -96,6 +96,11 @@ def _tools(state: ReplState, args: str, out: TextIO) -> str:
         out.write("[no tools allowed]\n")
         return CONTINUE
     out.write(f"[allowed tools (mode={state.mode}): {', '.join(state.allowed_tools)}]\n")
+    if any(t.startswith("mcp__agentwire") for t in state.allowed_tools):
+        out.write(
+            "[agentwire MCP server attached — sessions, panes, voice, scheduler, "
+            "channels, workflows, etc. are first-class tool calls]\n"
+        )
     return CONTINUE
 
 

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -148,6 +148,17 @@ class TestTools:
         dispatch_command("/tools", state, out)
         assert "mode=restricted" in out.getvalue()
 
+    def test_mcp_attachment_called_out(self):
+        out = io.StringIO()
+        dispatch_command("/tools", _state(allowed_tools=["Read", "mcp__agentwire"]), out)
+        rendered = out.getvalue()
+        assert "MCP server attached" in rendered
+
+    def test_mcp_not_present_no_extra_line(self):
+        out = io.StringIO()
+        dispatch_command("/tools", _state(allowed_tools=["Read", "Bash"]), out)
+        assert "MCP server attached" not in out.getvalue()
+
 
 # --- /model ---
 

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -38,6 +38,13 @@ class FakeOptions:
 # --- build_options ---
 
 class TestBuildOptions:
+    @pytest.fixture(autouse=True)
+    def _disable_mcp(self, monkeypatch):
+        # These tests assert exact tool-list shape — turn off the auto-attached
+        # agentwire MCP server so allowed_tools matches the static FULL_TOOLS /
+        # RESTRICTED_TOOLS arrays. MCP attachment has its own dedicated tests.
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+
     def test_bypass_mode(self, tmp_path):
         opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
         assert opts.kwargs["permission_mode"] == "bypassPermissions"
@@ -567,6 +574,10 @@ class TestInteractiveLoop:
         from agentwire.repl import persistence
         monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl_home")
         self._repl_home = tmp_path / "repl_home"
+        # The fake SDK doesn't actually spawn the MCP subprocess, but disable
+        # the attachment so allowed_tools / banner / /tools assertions match
+        # the pre-Phase-3-PR-1 shape. MCP wiring has its own dedicated tests.
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
 
     def test_eof_exits_clean(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])
@@ -1099,6 +1110,58 @@ class TestPermissionCallback:
         result = asyncio.run(cb("Read", {}, self._ctx()))
         from claude_agent_sdk import PermissionResultAllow
         assert isinstance(result, PermissionResultAllow)
+
+
+class TestMcpBakedIn:
+    def test_mcp_servers_attached_by_default(self, monkeypatch):
+        from agentwire.repl.app import build_options, MCP_SERVER_NAME, MCP_TOOL_PREFIX
+        monkeypatch.delenv("AGENTWIRE_REPL_MCP", raising=False)
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        assert MCP_SERVER_NAME in captured["mcp_servers"]
+        cfg = captured["mcp_servers"][MCP_SERVER_NAME]
+        assert cfg["type"] == "stdio"
+        assert cfg["args"] == ["-m", "agentwire", "mcp"]
+        assert MCP_TOOL_PREFIX in captured["allowed_tools"]
+
+    def test_mcp_disabled_via_env(self, monkeypatch):
+        from agentwire.repl.app import build_options, MCP_TOOL_PREFIX
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        assert "mcp_servers" not in captured
+        assert MCP_TOOL_PREFIX not in captured["allowed_tools"]
+
+    def test_restricted_mode_keeps_mcp(self, monkeypatch):
+        # MCP tools include lots of read-only inspection tools (sessions_list,
+        # panes_list); blocking the entire server in restricted mode loses too
+        # much. Plan-mode permission_mode still gates execution.
+        from agentwire.repl.app import build_options, MCP_TOOL_PREFIX
+        monkeypatch.delenv("AGENTWIRE_REPL_MCP", raising=False)
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="restricted", model="m", system_prompt=None, cwd=None)
+        assert MCP_TOOL_PREFIX in captured["allowed_tools"]
 
 
 class TestSdkErrorClassify:


### PR DESCRIPTION
## Summary
- Auto-attaches the agentwire MCP server (~87 tools: sessions, panes, voice, scheduler, workflows, channels, etc.) on every interactive and print-mode session
- Spawned via stdio with `<sys.executable> -m agentwire mcp` so the REPL and its MCP server are always pinned to the same install
- `AGENTWIRE_REPL_MCP=0` opts out (used by tests)
- `/tools` and the banner surface the attachment

## Test plan
- [x] `uv run pytest` — 1004 passed, 4 skipped
- [x] new tests cover: default attachment, env-var opt-out, MCP visible in restricted mode, /tools messaging
- [x] smoke-verified end-to-end: `agentwire repl -p "..."` triggered `mcp__agentwire__panes_list` and got a real server response

Built by [dotdev.dev](https://dotdev.dev)