### PR TITLE
feat(repl): phase 3 pr 2 — python damage control via SDK PreToolUse hook

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from agentwire.repl.commands import CONTINUE, EXIT, RESTART, RESUME, dispatch_command
 from agentwire.repl import persistence
+from agentwire.repl.damage_control import make_pre_tool_hook
 from agentwire.repl.mentions import expand_mentions
 from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
 from agentwire.workflows.runners.sdk_errors import classify as _classify_sdk_error
@@ -68,6 +69,11 @@ def _agentwire_mcp_config() -> dict:
 
 def _mcp_enabled() -> bool:
     return os.environ.get("AGENTWIRE_REPL_MCP", "1") != "0"
+
+
+def _damage_control_enabled() -> bool:
+    """`AGENTWIRE_REPL_DAMAGE_CONTROL=0` opts out (used by tests)."""
+    return os.environ.get("AGENTWIRE_REPL_DAMAGE_CONTROL", "1") != "0"
 
 
 def _thinking_config(mode: str) -> dict | None:
@@ -198,6 +204,26 @@ def build_options(
         kwargs["resume"] = resume_sdk_session_id
     if can_use_tool is not None:
         kwargs["can_use_tool"] = can_use_tool
+
+    # Phase 3 PR 2 — Python-side damage control. Mirrors the shell hooks at
+    # ~/.agentwire/hooks/damage-control/*.py, but runs in-process via the
+    # SDK's PreToolUse callback so direct SDK tool dispatch can't bypass it.
+    if _damage_control_enabled():
+        try:
+            from claude_agent_sdk import HookMatcher
+        except ImportError:
+            HookMatcher = None  # SDK absent → render path will refuse anyway
+        if HookMatcher is not None:
+            hook = make_pre_tool_hook(mode=mode)
+            if hook is not None:
+                kwargs["hooks"] = {
+                    "PreToolUse": [
+                        HookMatcher(
+                            matcher="Bash|Edit|MultiEdit|Write",
+                            hooks=[hook],
+                        )
+                    ]
+                }
 
     append_parts: list[str] = []
     if cwd is not None:

--- a/agentwire/repl/damage_control.py
+++ b/agentwire/repl/damage_control.py
@@ -1,0 +1,147 @@
+"""Python-side damage control for the agentwire SDK REPL.
+
+Mirror of `~/.agentwire/hooks/damage-control/*` for the SDK. Shell hooks
+fire for tools that go through the bundled `claude` binary, but the REPL's
+SDK can call tools directly in Python — so we run the same pattern checks
+in-process via a `PreToolUse` SDK hook.
+
+Single source of truth: `~/.agentwire/hooks/damage-control/patterns.yaml`.
+The shell scripts also load this file, so updates land in both places.
+
+Returns shape match the SDK's PreToolUseHookSpecificOutput
+(`decision: 'block' | 'allow' | 'ask'`). The hook is wired in
+`agentwire.repl.app.build_options`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PATTERNS_PATH = Path.home() / ".agentwire" / "hooks" / "damage-control" / "patterns.yaml"
+
+
+_TOOL_TO_KEY = {
+    "Bash": "bashToolPatterns",
+    "Edit": "editToolPatterns",
+    "Write": "writeToolPatterns",
+    "MultiEdit": "editToolPatterns",
+}
+
+
+def load_patterns(path: Path | None = None) -> dict:
+    """Load and parse the patterns YAML. Returns empty dict on any failure.
+
+    Damage control should never bring the REPL down — if patterns can't
+    load, the SDK still has its own permission_mode gate and the user's
+    shell hooks (if installed) still fire from the bundled binary.
+    """
+    target = path or DEFAULT_PATTERNS_PATH
+    try:
+        import yaml  # local import: pyyaml is already a hooks dep
+    except ImportError:
+        return {}
+    try:
+        return yaml.safe_load(target.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+def check_bash(command: str, patterns: dict, *, mode: str) -> tuple[str, str] | None:
+    """Match `command` against bashToolPatterns. Returns (decision, reason) or None.
+
+    `decision` is 'deny' for hard rules and 'ask' for rules with `ask: true`.
+    `bypassable: true` rules pass through silently when mode == 'bypass'
+    (user explicitly opted into that semantics by picking sdk-bypass) and
+    block otherwise.
+
+    'deny' / 'ask' match the SDK's PreToolUseHookSpecificOutput contract.
+    """
+    if not command:
+        return None
+    rules = patterns.get("bashToolPatterns") or []
+    for rule in rules:
+        pattern = rule.get("pattern")
+        if not pattern:
+            continue
+        try:
+            if not re.search(pattern, command):
+                continue
+        except re.error:
+            continue
+        bypassable = bool(rule.get("bypassable"))
+        ask = bool(rule.get("ask"))
+        reason = rule.get("reason") or "blocked by damage-control"
+        if bypassable and mode == "bypass":
+            return None
+        if ask:
+            return "ask", reason
+        return "deny", reason
+    return None
+
+
+def check_path(file_path: str, patterns: dict, key: str) -> tuple[str, str] | None:
+    """Edit/Write path checks. Returns ('deny', reason) or None."""
+    if not file_path:
+        return None
+    rules = patterns.get(key) or []
+    for rule in rules:
+        pattern = rule.get("pattern")
+        if not pattern:
+            continue
+        try:
+            if not re.search(pattern, file_path):
+                continue
+        except re.error:
+            continue
+        return "deny", rule.get("reason") or "blocked by damage-control"
+    return None
+
+
+def make_pre_tool_hook(*, mode: str, patterns_path: Path | None = None):
+    """Build the SDK `PreToolUse` hook callback.
+
+    The hook runs in-process before each tool call, regardless of whether
+    the SDK's bundled binary would have surfaced the same shell hook. This
+    is the safety net Phase 3 PR 2 promises in the mission doc — SDK tool
+    calls bypass `~/.claude/hooks/*.sh`, so we re-implement the patterns
+    here.
+    """
+    patterns = load_patterns(patterns_path)
+    if not patterns:
+        return None
+
+    async def _hook(input_data: dict, tool_use_id: str | None, ctx: Any):
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input") or {}
+        decision: tuple[str, str] | None = None
+
+        if tool_name == "Bash":
+            decision = check_bash(tool_input.get("command", ""), patterns, mode=mode)
+        elif tool_name in ("Edit", "MultiEdit"):
+            decision = check_path(
+                tool_input.get("file_path", ""),
+                patterns,
+                _TOOL_TO_KEY[tool_name],
+            )
+        elif tool_name == "Write":
+            decision = check_path(
+                tool_input.get("file_path", ""),
+                patterns,
+                _TOOL_TO_KEY[tool_name],
+            )
+
+        if decision is None:
+            return {}
+        verdict, reason = decision
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": verdict,
+                "permissionDecisionReason": f"damage-control: {reason}",
+            }
+        }
+
+    return _hook

--- a/tests/unit/test_repl_damage_control.py
+++ b/tests/unit/test_repl_damage_control.py
@@ -1,0 +1,188 @@
+"""Tests for the REPL's Python-side damage control (Phase 3 PR 2).
+
+Mirrors the shell-hook patterns from ~/.agentwire/hooks/damage-control/ but
+runs in-process via the SDK's PreToolUse hook.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agentwire.repl.damage_control import (
+    check_bash,
+    check_path,
+    load_patterns,
+    make_pre_tool_hook,
+)
+
+
+@pytest.fixture
+def patterns_file(tmp_path):
+    p = tmp_path / "patterns.yaml"
+    p.write_text(
+        """
+bashToolPatterns:
+  - pattern: '\\brm\\s+-[rRf]'
+    reason: rm -rf
+  - pattern: '\\bgit\\s+push\\s+.*--force(?!-with-lease)'
+    reason: git push --force
+  - pattern: '\\brm\\s+[^-]'
+    reason: rm bypassable
+    bypassable: true
+  - pattern: '\\bsudo\\s+apt\\s+install'
+    reason: package install (ask)
+    ask: true
+
+editToolPatterns:
+  - pattern: '/etc/passwd'
+    reason: editing system file
+
+writeToolPatterns:
+  - pattern: '\\.env$'
+    reason: writing dotenv file
+"""
+    )
+    return p
+
+
+@pytest.fixture
+def patterns(patterns_file):
+    return load_patterns(patterns_file)
+
+
+class TestLoadPatterns:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_patterns(tmp_path / "nope.yaml") == {}
+
+    def test_garbage_yaml_returns_empty(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("{not yaml")
+        assert load_patterns(bad) == {}
+
+    def test_valid_loads(self, patterns_file):
+        result = load_patterns(patterns_file)
+        assert "bashToolPatterns" in result
+        assert "editToolPatterns" in result
+
+
+class TestCheckBash:
+    def test_clean_command_passes(self, patterns):
+        assert check_bash("ls -la", patterns, mode="bypass") is None
+        assert check_bash("git status", patterns, mode="prompted") is None
+
+    def test_rm_rf_blocks_in_any_mode(self, patterns):
+        verdict, reason = check_bash("rm -rf /tmp/foo", patterns, mode="bypass")
+        assert verdict == "deny"
+        assert "rm -rf" in reason
+
+    def test_force_push_blocks(self, patterns):
+        verdict, reason = check_bash("git push --force origin main", patterns, mode="bypass")
+        assert verdict == "deny"
+
+    def test_force_with_lease_passes(self, patterns):
+        assert check_bash("git push --force-with-lease origin main", patterns, mode="bypass") is None
+
+    def test_bypassable_passes_in_bypass_mode(self, patterns):
+        assert check_bash("rm somefile.txt", patterns, mode="bypass") is None
+
+    def test_bypassable_blocks_in_prompted_mode(self, patterns):
+        verdict, reason = check_bash("rm somefile.txt", patterns, mode="prompted")
+        assert verdict == "deny"
+
+    def test_ask_returns_ask(self, patterns):
+        verdict, reason = check_bash("sudo apt install vim", patterns, mode="bypass")
+        assert verdict == "ask"
+
+    def test_empty_command(self, patterns):
+        assert check_bash("", patterns, mode="bypass") is None
+
+    def test_invalid_regex_skipped(self, tmp_path):
+        # Pattern with broken regex shouldn't crash; it should just be skipped
+        p = tmp_path / "p.yaml"
+        p.write_text("bashToolPatterns:\n  - pattern: '['\n    reason: broken\n")
+        patterns = load_patterns(p)
+        assert check_bash("rm -rf /", patterns, mode="bypass") is None
+
+
+class TestCheckPath:
+    def test_clean_path(self, patterns):
+        assert check_path("/home/user/code.py", patterns, "editToolPatterns") is None
+
+    def test_blocked_path(self, patterns):
+        verdict, reason = check_path("/etc/passwd", patterns, "editToolPatterns")
+        assert verdict == "deny"
+
+    def test_dotenv_blocked_in_write(self, patterns):
+        verdict, reason = check_path(".env", patterns, "writeToolPatterns")
+        assert verdict == "deny"
+
+    def test_no_pattern_set_returns_none(self):
+        assert check_path("/etc/passwd", {}, "editToolPatterns") is None
+
+
+class TestMakePreToolHook:
+    def test_bash_block(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}},
+            "tool-id-1", None,
+        ))
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "rm -rf" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    def test_bash_clean_returns_empty(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls -la"}},
+            "tool-id-1", None,
+        ))
+        assert out == {}
+
+    def test_edit_block(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/etc/passwd"}},
+            "tool-id-1", None,
+        ))
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_write_dotenv_block(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Write", "tool_input": {"file_path": ".env"}},
+            "tool-id-1", None,
+        ))
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_unknown_tool_passes(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Read", "tool_input": {"file_path": "/etc/passwd"}},
+            "tool-id-1", None,
+        ))
+        assert out == {}
+
+    def test_no_patterns_returns_none(self, tmp_path):
+        # No file → load_patterns returns {} → make_pre_tool_hook returns None
+        # so no hook is registered (rather than a no-op hook hogging cycles).
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=tmp_path / "missing.yaml")
+        assert hook is None
+
+    def test_bypassable_in_bypass(self, patterns_file):
+        hook = make_pre_tool_hook(mode="bypass", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Bash", "tool_input": {"command": "rm somefile.txt"}},
+            "tool-id-1", None,
+        ))
+        assert out == {}
+
+    def test_bypassable_in_prompted_blocks(self, patterns_file):
+        hook = make_pre_tool_hook(mode="prompted", patterns_path=patterns_file)
+        out = asyncio.run(hook(
+            {"tool_name": "Bash", "tool_input": {"command": "rm somefile.txt"}},
+            "tool-id-1", None,
+        ))
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -44,6 +44,8 @@ class TestBuildOptions:
         # agentwire MCP server so allowed_tools matches the static FULL_TOOLS /
         # RESTRICTED_TOOLS arrays. MCP attachment has its own dedicated tests.
         monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+        # Same reasoning for damage control: separate dedicated tests.
+        monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
 
     def test_bypass_mode(self, tmp_path):
         opts = build_options(FakeOptions, "bypass", None, None, cwd=tmp_path)
@@ -578,6 +580,9 @@ class TestInteractiveLoop:
         # the attachment so allowed_tools / banner / /tools assertions match
         # the pre-Phase-3-PR-1 shape. MCP wiring has its own dedicated tests.
         monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+        # Same for damage control — fake SDK ignores hooks, but we don't want
+        # the patterns file loaded under tests.
+        monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
 
     def test_eof_exits_clean(self, monkeypatch, capsys):
         _install_fake_sdk(monkeypatch, [])
@@ -1162,6 +1167,75 @@ class TestMcpBakedIn:
 
         build_options(FakeOptions, mode="restricted", model="m", system_prompt=None, cwd=None)
         assert MCP_TOOL_PREFIX in captured["allowed_tools"]
+
+
+class TestDamageControlAttachment:
+    def test_hooks_attached_when_patterns_load(self, monkeypatch, tmp_path):
+        # Point damage_control at a known patterns file
+        from agentwire.repl import damage_control
+        patterns_file = tmp_path / "patterns.yaml"
+        patterns_file.write_text(
+            "bashToolPatterns:\n  - pattern: '\\brm\\s+-rf'\n    reason: rm -rf\n"
+        )
+        monkeypatch.setattr(damage_control, "DEFAULT_PATTERNS_PATH", patterns_file)
+        monkeypatch.delenv("AGENTWIRE_REPL_DAMAGE_CONTROL", raising=False)
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        assert "hooks" in captured
+        assert "PreToolUse" in captured["hooks"]
+        matchers = captured["hooks"]["PreToolUse"]
+        assert len(matchers) == 1
+        assert "Bash" in matchers[0].matcher
+
+    def test_no_hooks_when_disabled(self, monkeypatch, tmp_path):
+        from agentwire.repl import damage_control
+        patterns_file = tmp_path / "patterns.yaml"
+        patterns_file.write_text("bashToolPatterns: []\n")
+        monkeypatch.setattr(damage_control, "DEFAULT_PATTERNS_PATH", patterns_file)
+        monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        assert "hooks" not in captured
+
+    def test_no_hooks_when_patterns_missing(self, monkeypatch, tmp_path):
+        # Patterns file doesn't exist → make_pre_tool_hook returns None →
+        # no hooks attached.
+        from agentwire.repl import damage_control
+        monkeypatch.setattr(damage_control, "DEFAULT_PATTERNS_PATH", tmp_path / "nope.yaml")
+        monkeypatch.delenv("AGENTWIRE_REPL_DAMAGE_CONTROL", raising=False)
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+
+        from agentwire.repl.app import build_options
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        assert "hooks" not in captured
 
 
 class TestSdkErrorClassify:


### PR DESCRIPTION
## Summary
- SDK tool dispatch can bypass `~/.claude/hooks/*.sh` (the shell-based safety net) — so the REPL now re-implements pattern matching in-process via the SDK's `PreToolUse` callback
- Same patterns file as the shell hooks (`~/.agentwire/hooks/damage-control/patterns.yaml`); updates land in both places
- Bash, Edit, MultiEdit, Write covered. Hard rules return `permissionDecision: 'deny'`; `ask: true` rules return `'ask'`; `bypassable: true` rules pass silently in `sdk-bypass` and deny in `sdk-prompted`
- `AGENTWIRE_REPL_DAMAGE_CONTROL=0` opts out (tests)

## Test plan
- [x] `uv run pytest` — 1031 passed, 4 skipped
- [x] 24 new tests cover load_patterns, check_bash, check_path, hook factory, build_options wiring
- [x] Smoke test against real `~/.agentwire/hooks/damage-control/patterns.yaml`: Python hook denies destructive command and passes clean ones

Mission's "blocking, not optional" Phase 3 safety requirement.

Built by [dotdev.dev](https://dotdev.dev)
