### PR TITLE
feat(repl): phase 3 pr 3 — voice + role layering + .agentwire.yml awareness

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3443,6 +3443,7 @@ def cmd_repl(args) -> int:
         system_prompt=args.append_system_prompt,
         session_name=getattr(args, "session_name", None),
         resume=getattr(args, "resume", None),
+        roles=getattr(args, "roles", None),
     )
 
 
@@ -10186,6 +10187,10 @@ def main() -> int:
     repl_parser.add_argument(
         "--resume", dest="resume", default=None, metavar="NAME",
         help="Resume the saved session NAME (reuses its sdk_session_id to continue the prior conversation)",
+    )
+    repl_parser.add_argument(
+        "--role", dest="roles", action="append", metavar="NAME",
+        help="Role name to compose into the system prompt (repeatable). Overrides .agentwire.yml roles.",
     )
     repl_parser.set_defaults(func=cmd_repl)
 

--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from agentwire.repl.commands import CONTINUE, EXIT, RESTART, RESUME, dispatch_command
 from agentwire.repl import persistence
+from agentwire.repl.context import SessionContext, load_session_context
 from agentwire.repl.damage_control import make_pre_tool_hook
 from agentwire.repl.mentions import expand_mentions
 from agentwire.repl.state import ReplState, reset_for_restart, track_result, track_system_init
@@ -94,6 +95,7 @@ def run_repl(
     system_prompt: str | None = None,
     session_name: str | None = None,
     resume: str | None = None,
+    roles: list[str] | None = None,
 ) -> int:
     """Run the REPL. Returns exit code.
 
@@ -101,10 +103,13 @@ def run_repl(
       transcript (print mode is fire-and-forget).
     - Interactive: persistent loop with full transcript persistence under
       `~/.agentwire/sessions/repl/<session_name>/`.
+
+    `roles` overrides the role list from `.agentwire.yml` for this session;
+    when None, project config wins.
     """
     if print_prompt is not None:
-        return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt))
-    return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume))
+        return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt, roles))
+    return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume, roles))
 
 
 # -------- print mode (SDK-backed) --------
@@ -115,6 +120,7 @@ async def _run_print_mode(
     mode: str,
     model: str | None,
     system_prompt: str | None,
+    roles: list[str] | None = None,
 ) -> int:
     try:
         from claude_agent_sdk import (
@@ -129,7 +135,13 @@ async def _run_print_mode(
         print(f"error: claude-agent-sdk not installed: {e}", file=sys.stderr)
         return 1
 
-    options = build_options(ClaudeAgentOptions, mode, model, system_prompt, cwd=Path.cwd())
+    ctx = load_session_context(Path.cwd(), role_overrides=roles)
+    if ctx.missing_roles:
+        sys.stderr.write(f"[repl: roles not found: {', '.join(ctx.missing_roles)}]\n")
+    options = build_options(
+        ClaudeAgentOptions, mode, model, system_prompt, cwd=Path.cwd(),
+        session_context=ctx,
+    )
 
     # claude-agent-sdk refuses to nest — same CLAUDECODE unset as the workflow runner.
     saved_claudecode = os.environ.pop("CLAUDECODE", None)
@@ -170,6 +182,7 @@ def build_options(
     effort: str = DEFAULT_EFFORT,
     thinking_mode: str = DEFAULT_THINKING_MODE,
     can_use_tool: Any = None,
+    session_context: SessionContext | None = None,
 ) -> Any:
     """Compose `ClaudeAgentOptions` for a REPL session.
 
@@ -226,6 +239,14 @@ def build_options(
                 }
 
     append_parts: list[str] = []
+    # Roles first — they're identity and tool-permission posture, so they
+    # frame everything that follows. Then CLAUDE.md / AGENTS.md (project
+    # facts), then explicit override.
+    if session_context is not None and session_context.role_instructions:
+        append_parts.append(
+            f"--- roles: {', '.join(session_context.role_names)} ---\n"
+            f"{session_context.role_instructions}"
+        )
     if cwd is not None:
         for name in ("CLAUDE.md", "AGENTS.md"):
             found = _find_ancestor_file(cwd, name)
@@ -440,6 +461,7 @@ async def _run_interactive(
     system_prompt: str | None,
     session_name: str | None = None,
     resume: str | None = None,
+    roles: list[str] | None = None,
 ) -> int:
     """Run the interactive REPL.
 
@@ -494,6 +516,12 @@ async def _run_interactive(
         allowed_tools=placeholder_tools,
     )
 
+    ctx = load_session_context(Path.cwd(), role_overrides=roles)
+    state.role_names = list(ctx.role_names)
+    state.voice = ctx.voice
+    if ctx.missing_roles:
+        sys.stderr.write(f"[repl: roles not found: {', '.join(ctx.missing_roles)}]\n")
+
     can_use_tool = _make_can_use_tool(state) if mode == "prompted" else None
 
     options = build_options(
@@ -501,6 +529,7 @@ async def _run_interactive(
         cwd=Path.cwd(), resume_sdk_session_id=resume_sdk_session_id,
         effort=state.effort, thinking_mode=state.thinking_mode,
         can_use_tool=can_use_tool,
+        session_context=ctx,
     )
 
     model_display = model or f"{DEFAULT_MODEL} (default)"
@@ -509,10 +538,14 @@ async def _run_interactive(
         sys.stdout.write(f"Resuming {resume!r} (sdk session {resume_sdk_session_id[:8]}…)\n")
     sys.stdout.write(
         "Interactive mode. Enter to send · Alt+Enter for newline · Ctrl+D to exit · Ctrl+C to cancel.\n"
-        "Type /help for commands. @path/to/file expands inline. /effort and /thinking tune SDK knobs.\n"
+        "Type /help for commands. @path/to/file expands inline. /effort, /thinking, /say tune session.\n"
     )
     if _mcp_enabled():
         sys.stdout.write("agentwire MCP server attached — /tools to see what's wired in.\n")
+    if state.role_names:
+        sys.stdout.write(f"Roles: {', '.join(state.role_names)}\n")
+    if state.voice:
+        sys.stdout.write(f"Voice: {state.voice}\n")
     sys.stdout.write("\n")
     sys.stdout.flush()
 
@@ -598,6 +631,7 @@ async def _run_interactive(
                 cwd=Path.cwd(), resume_sdk_session_id=next_resume_id,
                 effort=state.effort, thinking_mode=state.thinking_mode,
                 can_use_tool=can_use_tool,
+                session_context=ctx,
             )
             transcript.write_event({
                 "type": "restart",

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -137,6 +137,41 @@ def _effort(state: ReplState, args: str, out: TextIO) -> str:
     return RESTART
 
 
+def _say(state: ReplState, args: str, out: TextIO) -> str:
+    """`/say <text>` speaks `text` via `agentwire say`.
+
+    Voice resolution is delegated to `agentwire say` (CLI flag → .agentwire.yml
+    → global config default). We pass `--voice` only if the project config
+    explicitly set one, so a user-level default doesn't get blown away.
+    """
+    text = args.strip()
+    if not text:
+        if state.voice:
+            out.write(f"[say · voice={state.voice}]\nUsage: /say <text>\n")
+        else:
+            out.write("Usage: /say <text>\n")
+        return CONTINUE
+
+    import subprocess
+    cmd = ["agentwire", "say"]
+    if state.voice:
+        cmd += ["--voice", state.voice]
+    cmd += ["--", text]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if proc.returncode != 0:
+            out.write(f"[say failed: {proc.stderr.strip() or 'unknown error'}]\n")
+        else:
+            out.write(f"[said · {len(text)} chars]\n")
+    except FileNotFoundError:
+        out.write("[say failed: `agentwire` not found on PATH]\n")
+    except subprocess.TimeoutExpired:
+        out.write("[say timed out after 30s]\n")
+    except Exception as exc:
+        out.write(f"[say error: {exc}]\n")
+    return CONTINUE
+
+
 def _thinking(state: ReplState, args: str, out: TextIO) -> str:
     target = args.strip().lower()
     if not target:
@@ -236,6 +271,7 @@ def _build_registry() -> dict[str, Command]:
         Command(name="/resume", handler=_resume, summary="Resume a saved session (or list)"),
         Command(name="/effort", handler=_effort, summary="Show or set thinking effort (low/medium/high/xhigh/max)"),
         Command(name="/thinking", handler=_thinking, summary="Show or set thinking display (adaptive/summarized/off)"),
+        Command(name="/say", handler=_say, summary="Speak text aloud via agentwire say (uses project voice)"),
         exit_cmd,
     ]
     registry: dict[str, Command] = {}

--- a/agentwire/repl/context.py
+++ b/agentwire/repl/context.py
@@ -1,0 +1,67 @@
+"""Project-level context loading for the agentwire REPL (Phase 3 PR 3).
+
+Surfaces .agentwire.yml + role files into a shape the REPL can consume:
+- merged role instructions (appended to system prompt)
+- per-session voice (used by /say)
+- effective role names (shown in banner)
+
+Lives in its own module so build_options stays a thin glue function and the
+business of "what does this project look like" can grow without crowding it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentwire.project_config import load_project_config
+from agentwire.roles import load_roles, merge_roles
+
+
+@dataclass
+class SessionContext:
+    role_names: list[str]
+    role_instructions: str | None  # None when no roles resolved
+    voice: str | None  # from .agentwire.yml
+    missing_roles: list[str]  # names in config that didn't resolve
+
+
+def load_session_context(
+    cwd: Path,
+    *,
+    role_overrides: list[str] | None = None,
+) -> SessionContext:
+    """Load roles + voice for a REPL session.
+
+    Order of precedence for role names:
+      1. `role_overrides` (from `--role` CLI flag, if any)
+      2. `roles:` in the nearest `.agentwire.yml`
+      3. empty list
+
+    Voice is taken from `.agentwire.yml` only — `/say` defers to `agentwire
+    say`'s own resolution (CLI flag → .agentwire.yml → global default), so
+    here we only need to surface what the project declares.
+    """
+    cfg = load_project_config(cwd)
+    if role_overrides is not None:
+        names = list(role_overrides)
+    elif cfg is not None:
+        names = list(cfg.roles)
+    else:
+        names = []
+
+    if names:
+        roles, missing = load_roles(names, project_path=cwd)
+        merged = merge_roles(roles)
+        instructions = merged.instructions or None
+    else:
+        roles, missing = [], []
+        instructions = None
+
+    voice = cfg.voice if cfg is not None else None
+    return SessionContext(
+        role_names=[r.name for r in roles],
+        role_instructions=instructions,
+        voice=voice,
+        missing_roles=missing,
+    )

--- a/agentwire/repl/state.py
+++ b/agentwire/repl/state.py
@@ -43,6 +43,11 @@ class ReplState:
     # permission prompt when the user picks 'a'. Survives across turns; reset
     # on /clear via reset_for_restart.
     always_allow_tools: set[str] = field(default_factory=set)
+    # Phase 3 PR 3 — project-level identity surfaced into slash commands and
+    # the banner. Both are static for the session: roles compose the system
+    # prompt at SDK init; voice routes /say.
+    role_names: list[str] = field(default_factory=list)
+    voice: str | None = None
 
 
 def track_system_init(state: ReplState, message: Any) -> None:

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -380,6 +380,88 @@ class TestEffort:
         assert "already" in out.getvalue()
 
 
+class TestSay:
+    def test_no_args_shows_usage(self):
+        out = io.StringIO()
+        action = dispatch_command("/say", _state(), out)
+        assert action == CONTINUE
+        assert "Usage" in out.getvalue()
+
+    def test_voice_in_no_args_when_set(self):
+        out = io.StringIO()
+        s = _state()
+        s.voice = "alice"
+        dispatch_command("/say", s, out)
+        assert "voice=alice" in out.getvalue()
+
+    def test_invokes_subprocess(self, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return FakeProc()
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        out = io.StringIO()
+        s = _state()
+        s.voice = "alice"
+        action = dispatch_command("/say hello world", s, out)
+        assert action == CONTINUE
+        assert captured["cmd"][:2] == ["agentwire", "say"]
+        assert "--voice" in captured["cmd"]
+        assert "alice" in captured["cmd"]
+        assert "hello world" in captured["cmd"]
+        assert "[said" in out.getvalue()
+
+    def test_no_voice_omits_voice_flag(self, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return FakeProc()
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        out = io.StringIO()
+        action = dispatch_command("/say hi", _state(), out)
+        assert "--voice" not in captured["cmd"]
+
+    def test_subprocess_error(self, monkeypatch):
+        class FakeProc:
+            returncode = 1
+            stdout = ""
+            stderr = "tts unreachable"
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: FakeProc())
+
+        out = io.StringIO()
+        dispatch_command("/say bad", _state(), out)
+        assert "say failed" in out.getvalue()
+        assert "tts unreachable" in out.getvalue()
+
+    def test_agentwire_not_on_path(self, monkeypatch):
+        import subprocess
+        def raise_fnf(*a, **kw):
+            raise FileNotFoundError("no agentwire")
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+
+        out = io.StringIO()
+        dispatch_command("/say hi", _state(), out)
+        assert "not found" in out.getvalue()
+
+
 class TestThinking:
     def test_show_default(self):
         state = _state()

--- a/tests/unit/test_repl_context.py
+++ b/tests/unit/test_repl_context.py
@@ -1,0 +1,97 @@
+"""Tests for the REPL session-context loader (Phase 3 PR 3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentwire.repl.context import load_session_context
+
+
+def _write_role(dir: Path, name: str, body: str = "Be helpful.") -> None:
+    role_dir = dir / ".agentwire" / "roles"
+    role_dir.mkdir(parents=True, exist_ok=True)
+    (role_dir / f"{name}.md").write_text(
+        f"---\nname: {name}\ndescription: test\n---\n\n{body}\n"
+    )
+
+
+def _write_project_yaml(dir: Path, *, roles=None, voice=None) -> None:
+    lines = ["type: standard"]
+    if roles:
+        lines.append("roles:")
+        lines.extend(f"  - {r}" for r in roles)
+    if voice:
+        lines.append(f"voice: {voice}")
+    (dir / ".agentwire.yml").write_text("\n".join(lines) + "\n")
+
+
+class TestNoConfig:
+    def test_returns_empty(self, tmp_path):
+        ctx = load_session_context(tmp_path)
+        assert ctx.role_names == []
+        assert ctx.role_instructions is None
+        assert ctx.voice is None
+        assert ctx.missing_roles == []
+
+
+class TestRolesFromConfig:
+    def test_resolves_project_role(self, tmp_path):
+        _write_role(tmp_path, "tester", "Write thorough tests.")
+        _write_project_yaml(tmp_path, roles=["tester"])
+
+        ctx = load_session_context(tmp_path)
+        assert ctx.role_names == ["tester"]
+        assert "thorough tests" in ctx.role_instructions
+        assert ctx.missing_roles == []
+
+    def test_multiple_roles_merged(self, tmp_path):
+        _write_role(tmp_path, "tester", "Test rigorously.")
+        _write_role(tmp_path, "reviewer", "Read critically.")
+        _write_project_yaml(tmp_path, roles=["tester", "reviewer"])
+
+        ctx = load_session_context(tmp_path)
+        assert set(ctx.role_names) == {"tester", "reviewer"}
+        assert "Test rigorously" in ctx.role_instructions
+        assert "Read critically" in ctx.role_instructions
+
+    def test_missing_role_reported(self, tmp_path):
+        _write_project_yaml(tmp_path, roles=["nope"])
+        ctx = load_session_context(tmp_path)
+        assert ctx.role_names == []
+        assert ctx.role_instructions is None
+        assert "nope" in ctx.missing_roles
+
+
+class TestRoleOverrides:
+    def test_override_replaces_config(self, tmp_path):
+        _write_role(tmp_path, "tester", "From project.")
+        _write_role(tmp_path, "reviewer", "From override.")
+        _write_project_yaml(tmp_path, roles=["tester"])
+
+        ctx = load_session_context(tmp_path, role_overrides=["reviewer"])
+        assert ctx.role_names == ["reviewer"]
+        assert "From override" in ctx.role_instructions
+        assert "From project" not in (ctx.role_instructions or "")
+
+    def test_empty_override_kills_config(self, tmp_path):
+        _write_role(tmp_path, "tester", "Should not appear.")
+        _write_project_yaml(tmp_path, roles=["tester"])
+
+        ctx = load_session_context(tmp_path, role_overrides=[])
+        # Override == [] means user wants no roles, ignore config.
+        assert ctx.role_names == []
+        assert ctx.role_instructions is None
+
+
+class TestVoice:
+    def test_loads_voice(self, tmp_path):
+        _write_project_yaml(tmp_path, voice="alice")
+        ctx = load_session_context(tmp_path)
+        assert ctx.voice == "alice"
+
+    def test_no_voice_in_config(self, tmp_path):
+        _write_project_yaml(tmp_path)
+        ctx = load_session_context(tmp_path)
+        assert ctx.voice is None

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -1169,6 +1169,52 @@ class TestMcpBakedIn:
         assert MCP_TOOL_PREFIX in captured["allowed_tools"]
 
 
+class TestSessionContextThreading:
+    def test_role_instructions_appended_to_system_prompt(self, monkeypatch):
+        from agentwire.repl.app import build_options
+        from agentwire.repl.context import SessionContext
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+        monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        ctx = SessionContext(
+            role_names=["tester"],
+            role_instructions="Test rigorously.",
+            voice="alice",
+            missing_roles=[],
+        )
+        build_options(
+            FakeOptions, mode="bypass", model="m", system_prompt=None,
+            cwd=None, session_context=ctx,
+        )
+        sp = captured["system_prompt"]
+        assert sp["type"] == "preset"
+        assert "tester" in sp["append"]
+        assert "Test rigorously" in sp["append"]
+
+    def test_no_session_context_no_change(self, monkeypatch):
+        from agentwire.repl.app import build_options
+        monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+        monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
+
+        captured = {}
+
+        class FakeOptions:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.allowed_tools = kwargs.get("allowed_tools", [])
+
+        build_options(FakeOptions, mode="bypass", model="m", system_prompt=None, cwd=None)
+        # No system_prompt key when nothing to append.
+        assert "system_prompt" not in captured
+
+
 class TestDamageControlAttachment:
     def test_hooks_attached_when_patterns_load(self, monkeypatch, tmp_path):
         # Point damage_control at a known patterns file


### PR DESCRIPTION
## Summary
- `.agentwire.yml` loaded on startup; `roles:` resolved via existing `parse_role_file` + `merge_roles` and prepended to the system prompt
- `--role NAME` (repeatable) overrides the project config for one-off sessions
- Banner now shows active roles and project voice
- `/say <text>` shells out to `agentwire say` with the project voice (voice resolution stays in `agentwire say` so user defaults still apply when no project voice is set)
- Missing roles print to stderr — don't fail the session

New module `agentwire/repl/context.py` keeps `build_options` thin.

## Test plan
- [x] `uv run pytest` — 1047 passed, 4 skipped
- [x] new tests cover load_session_context (no config / project / overrides / missing), `/say` slash command (usage / subprocess / errors / no-PATH), and build_options threading

Built by [dotdev.dev](https://dotdev.dev)
