### PR TITLE
feat(repl): phase 3 pr 4 — portal sidebar visibility + artifact hint

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -541,7 +541,10 @@ async def _run_interactive(
         "Type /help for commands. @path/to/file expands inline. /effort, /thinking, /say tune session.\n"
     )
     if _mcp_enabled():
-        sys.stdout.write("agentwire MCP server attached — /tools to see what's wired in.\n")
+        sys.stdout.write(
+            "agentwire MCP server attached — /tools to see what's wired in. "
+            "(write HTML artifacts via mcp__agentwire__desktop_write_artifact)\n"
+        )
     if state.role_names:
         sys.stdout.write(f"Roles: {', '.join(state.role_names)}\n")
     if state.voice:

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -440,6 +440,13 @@ body {
     color: #c084fc;
 }
 
+/* SDK session types — distinct teal, called out as the agentwire-native
+   harness vs. claude-* (orange/green/blue). */
+.sidebar-tag.sidebar-tag-sdk {
+    background: rgba(45, 212, 191, 0.18);
+    color: #5eead4;
+}
+
 .sidebar-status-dot {
     width: 8px;
     height: 8px;
@@ -1450,6 +1457,14 @@ body .winbox.max {
 .type-tag.type-claude-restricted {
     background: rgba(248, 113, 113, 0.15);
     color: var(--error);
+}
+
+/* SDK variants — agentwire-native Python REPL on claude-agent-sdk */
+.type-tag.type-sdk-bypass,
+.type-tag.type-sdk-prompted,
+.type-tag.type-sdk-restricted {
+    background: rgba(45, 212, 191, 0.18);
+    color: #5eead4;
 }
 
 /* Bare / other */

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -32,7 +32,10 @@ export function renderCard(s) {
     const activity = activityStates.get(name) || s.activity || 'idle';
     const dotClass = activity === 'idle' ? 'dot-idle' : activity === 'processing' ? 'dot-processing' : activity === 'generating' ? 'dot-generating' : 'dot-playing';
     const tags = [];
-    if (s.type) tags.push(`<span class="sidebar-tag">${s.type}</span>`);
+    if (s.type) {
+        const typeClass = String(s.type).startsWith('sdk-') ? 'sidebar-tag sidebar-tag-sdk' : 'sidebar-tag';
+        tags.push(`<span class="${typeClass}">${s.type}</span>`);
+    }
     if (machine) tags.push(`<span class="sidebar-tag">@${machine}</span>`);
     const roles = (s.roles || []).map(r => `<span class="sidebar-tag sidebar-tag-role">${r}</span>`).join('');
     const path = s.path ? s.path.replace(/^\/Users\/[^/]+\//, '~/') : '';


### PR DESCRIPTION
## Summary
- SDK session types render with a teal `sidebar-tag-sdk` class in the portal sidebar, visually distinct from claude-* (orange/green/blue) and pi-zai (default gray)
- Matching `.type-tag.type-sdk-bypass|prompted|restricted` styles for use anywhere TypeTag is rendered
- Sidebar `renderCard` applies the variant class when `s.type.startsWith('sdk-')`
- REPL banner points users at `mcp__agentwire__desktop_write_artifact`; no new artifact path needed because the agentwire MCP server (Phase 3 PR 1) already exposes that tool and the existing artifacts API watches `~/.agentwire/artifacts/`

Closes Phase 3 of `docs/missions/agentwire-repl.md`.

## Test plan
- [x] `uv run pytest` — 1047 passed, 4 skipped
- [x] No new tests required — `tests/unit/test_sdk_session_types.py` already covers SDK type wiring; CSS + 1-line JS class change is visual-only

Built by [dotdev.dev](https://dotdev.dev)
