### PR TITLE
feat(workflows,repl): phase 4 — human_gate workflow node + /run-workflow

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -96,6 +96,7 @@ def run_repl(
     session_name: str | None = None,
     resume: str | None = None,
     roles: list[str] | None = None,
+    seed_message: str | None = None,
 ) -> int:
     """Run the REPL. Returns exit code.
 
@@ -106,10 +107,14 @@ def run_repl(
 
     `roles` overrides the role list from `.agentwire.yml` for this session;
     when None, project config wins.
+
+    `seed_message` is sent as the first user turn before the prompt loop
+    starts — used by the workflow human_gate runner to pre-load context.
+    Has no effect in print mode (use `print_prompt` instead).
     """
     if print_prompt is not None:
         return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt, roles))
-    return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume, roles))
+    return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume, roles, seed_message))
 
 
 # -------- print mode (SDK-backed) --------
@@ -462,6 +467,7 @@ async def _run_interactive(
     session_name: str | None = None,
     resume: str | None = None,
     roles: list[str] | None = None,
+    seed_message: str | None = None,
 ) -> int:
     """Run the interactive REPL.
 
@@ -606,6 +612,7 @@ async def _run_interactive(
 
     # Outer loop wraps the SDK client so /clear and /resume can close+reopen
     # it for a different conversation while the REPL keeps running.
+    pending_seed = seed_message
     try:
         while True:
             restart_requested, should_exit, loop_exit_code = await _run_sdk_session(
@@ -619,7 +626,9 @@ async def _run_interactive(
                 SystemMessage=SystemMessage,
                 ResultMessage=ResultMessage,
                 patch_stdout=patch_stdout,
+                seed_message=pending_seed,
             )
+            pending_seed = None  # only seed the first conversation
             if loop_exit_code != 0:
                 exit_code = loop_exit_code
             if should_exit:
@@ -661,6 +670,7 @@ async def _run_sdk_session(
     SystemMessage: Any,
     ResultMessage: Any,
     patch_stdout: Any,
+    seed_message: str | None = None,
 ) -> tuple[bool, bool, int]:
     """Run one ClaudeSDKClient lifecycle. Returns (restart, exit, exit_code).
 
@@ -670,17 +680,29 @@ async def _run_sdk_session(
     `transcript.events_path` as JSONL.
     """
     exit_code = 0
+    pending_seed = seed_message
     async with ClaudeSDKClient(options=options) as client:
         while True:
-            try:
-                with patch_stdout():
-                    user_input = await prompt_session.prompt_async("> ")
-            except EOFError:
-                sys.stdout.write("\n[exit]\n")
-                return False, True, exit_code
-            except KeyboardInterrupt:
-                sys.stdout.write("\n")
-                continue
+            if pending_seed is not None:
+                # Workflow human_gate (or any caller using seed_message) wants
+                # this turn injected without prompt_async firing first. After
+                # the seed runs, normal prompt loop resumes.
+                user_input = pending_seed
+                pending_seed = None
+                sys.stdout.write(f"> {user_input.splitlines()[0] if user_input else ''}\n")
+                if user_input.count("\n") > 0:
+                    sys.stdout.write("[seeded with multi-line context]\n")
+                sys.stdout.flush()
+            else:
+                try:
+                    with patch_stdout():
+                        user_input = await prompt_session.prompt_async("> ")
+                except EOFError:
+                    sys.stdout.write("\n[exit]\n")
+                    return False, True, exit_code
+                except KeyboardInterrupt:
+                    sys.stdout.write("\n")
+                    continue
 
             text = user_input.strip()
             if not text:

--- a/agentwire/repl/commands.py
+++ b/agentwire/repl/commands.py
@@ -137,6 +137,40 @@ def _effort(state: ReplState, args: str, out: TextIO) -> str:
     return RESTART
 
 
+def _run_workflow(state: ReplState, args: str, out: TextIO) -> str:
+    """`/run-workflow <name> [-v]` runs `agentwire workflow run <name>`.
+
+    Streaming the workflow's stdout into the REPL terminal in real time.
+    Phase 4 reverse-direction primitive — REPL spawns a workflow with the
+    current cwd; output is plain text (the workflow's own log lines), not
+    folded into the SDK conversation.
+    """
+    parts = args.split()
+    if not parts:
+        out.write("Usage: /run-workflow <name> [extra args]\n")
+        return CONTINUE
+
+    import subprocess
+    cmd = ["agentwire", "workflow", "run", *parts]
+    out.write(f"[running: {' '.join(cmd)}]\n")
+    out.flush() if hasattr(out, "flush") else None
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+        )
+        for line in proc.stdout:
+            out.write(line)
+        proc.wait()
+        out.write(f"[workflow exited with code {proc.returncode}]\n")
+    except FileNotFoundError:
+        out.write("[run-workflow failed: `agentwire` not found on PATH]\n")
+    except Exception as exc:
+        out.write(f"[run-workflow error: {exc}]\n")
+    return CONTINUE
+
+
 def _say(state: ReplState, args: str, out: TextIO) -> str:
     """`/say <text>` speaks `text` via `agentwire say`.
 
@@ -272,6 +306,7 @@ def _build_registry() -> dict[str, Command]:
         Command(name="/effort", handler=_effort, summary="Show or set thinking effort (low/medium/high/xhigh/max)"),
         Command(name="/thinking", handler=_thinking, summary="Show or set thinking display (adaptive/summarized/off)"),
         Command(name="/say", handler=_say, summary="Speak text aloud via agentwire say (uses project voice)"),
+        Command(name="/run-workflow", handler=_run_workflow, summary="Run an agentwire workflow and stream output here"),
         exit_cmd,
     ]
     registry: dict[str, Command] = {}

--- a/agentwire/workflows/examples/human-gate-review.yaml
+++ b/agentwire/workflows/examples/human-gate-review.yaml
@@ -1,0 +1,50 @@
+name: human-gate-review
+description: |
+  Demonstrates the human_gate runner. The first node generates a plan; the
+  second pauses the workflow and spawns a REPL where you can interrogate /
+  amend / approve before downstream nodes run.
+
+  Requires an interactive terminal — the gate hard-fails under the scheduler.
+version: 1
+
+inputs:
+  topic:
+    type: string
+    required: true
+    description: What to plan
+
+nodes:
+  draft_plan:
+    runner: anthropic
+    model: claude-opus-4-7
+    effort: high
+    prompt: |
+      Draft a 5-step plan for: {{ inputs.topic }}
+    outputs:
+      - name: plan
+        source: text
+
+  human_review:
+    runner: human_gate
+    prompt: |
+      Review the draft plan below. Ask Claude follow-ups, edit, or just
+      confirm — when you exit (Ctrl+D), your last assistant message becomes
+      the final approved plan that downstream nodes see as `human_review.plan`.
+
+      Draft plan:
+      ---
+      {{ draft_plan.plan }}
+      ---
+    outputs:
+      - name: plan
+        source: text
+
+  echo_approved:
+    runner: anthropic
+    model: claude-opus-4-7
+    effort: low
+    prompt: |
+      The human approved the following plan. Echo it back unchanged so it
+      ends up in the workflow run summary:
+
+      {{ human_review.plan }}

--- a/agentwire/workflows/runners/__init__.py
+++ b/agentwire/workflows/runners/__init__.py
@@ -60,6 +60,8 @@ def _register_builtins() -> None:
         # claude-agent-sdk optional at import time — validation still flags
         # `runner: anthropic` as unknown if the runner isn't registered.
         pass
+    from agentwire.workflows.runners.human_gate import HumanGateRunner
+    register_runner(HumanGateRunner())
 
 
 _register_builtins()

--- a/agentwire/workflows/runners/human_gate.py
+++ b/agentwire/workflows/runners/human_gate.py
@@ -1,0 +1,133 @@
+"""Human-in-the-loop workflow runner.
+
+Phase 4 of `docs/missions/agentwire-repl.md`. Pauses a workflow at the node,
+spawns an interactive REPL pre-loaded with the upstream context, and feeds
+the human's final assistant text back as `NodeResult.final_text` for
+downstream nodes.
+
+Boundaries:
+- Requires an interactive TTY. Scheduler / overnight-queue / piped runs fail
+  fast with a clear error rather than hang waiting for input.
+- Runs in-process via `agentwire.repl.app.run_repl(seed_message=...)`. No
+  tmux pane spawn — keeps the contract simple (one process, one stdin) and
+  avoids dragging in tmux as a workflow runtime dep.
+- The seed turn is the rendered `node.prompt`, which the workflow templating
+  layer has already filled with upstream node outputs. We don't add anything
+  to it here — what the YAML author wrote is what the human sees.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from agentwire.workflows.node import ActionNode, NodeResult
+
+logger = logging.getLogger("agentwire.workflows.human_gate")
+
+
+class HumanGateRunner:
+    name = "human_gate"
+
+    def __init__(self, on_event: Callable[[dict], None] | None = None):
+        self.on_event = on_event
+
+    def run(
+        self,
+        node: ActionNode,
+        workflow_cwd: str | None = None,
+        event_log_path: Path | None = None,
+        on_event: Callable[[dict], None] | None = None,
+    ) -> NodeResult:
+        if not sys.stdin.isatty():
+            return NodeResult(
+                node_id=node.id,
+                status="failure",
+                final_text="",
+                error=(
+                    "human_gate requires an interactive terminal; "
+                    "stdin is not a TTY (scheduler/overnight runs cannot use this node)"
+                ),
+            )
+
+        from agentwire.repl.app import run_repl
+        from agentwire.repl import persistence
+
+        session_name = f"workflow-{node.id}-{int(time.time())}"
+        started = time.monotonic()
+
+        sys.stdout.write(
+            f"\n[human_gate · node={node.id} · session={session_name}]\n"
+            "Pre-loading the prompt as your first turn. Reply, iterate, then "
+            "exit (Ctrl+D or /exit) to release the workflow. Final assistant "
+            "message becomes the node output.\n\n"
+        )
+        sys.stdout.flush()
+
+        rc = run_repl(
+            mode="bypass",
+            session_name=session_name,
+            seed_message=node.prompt,
+        )
+
+        # Read transcript for final assistant text + token totals.
+        meta = persistence.load_session(session_name)
+        events_path = persistence.DEFAULT_REPL_HOME / session_name / "events.jsonl"
+        final_text = _extract_final_assistant_text(events_path)
+        tokens_used = _extract_tokens(meta)
+        duration_ms = int((time.monotonic() - started) * 1000)
+
+        status = "success" if rc == 0 else "failure"
+        error = None if rc == 0 else f"REPL exited with code {rc}"
+        return NodeResult(
+            node_id=node.id,
+            status=status,
+            final_text=final_text,
+            tokens_used=tokens_used,
+            duration_ms=duration_ms,
+            exit_code=rc,
+            error=error,
+        )
+
+
+def _extract_final_assistant_text(events_path: Path) -> str:
+    """Walk the JSONL events, return the last assistant text content."""
+    if not events_path.exists():
+        return ""
+    last = ""
+    try:
+        import json
+        for line in events_path.read_text().splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Phase 2 PR 2 transcript shape: events translated by anthropic_events
+            # surface assistant content as type="assistant" with text under
+            # `text` or inside `content`.
+            if event.get("type") == "assistant":
+                t = event.get("text")
+                if not t:
+                    blocks = event.get("content") or []
+                    for b in blocks:
+                        if isinstance(b, dict) and b.get("type") == "text":
+                            t = b.get("text", "")
+                            break
+                if t:
+                    last = t
+    except OSError:
+        pass
+    return last
+
+
+def _extract_tokens(meta: dict | None) -> dict:
+    if not meta:
+        return {}
+    return {
+        "input_tokens": meta.get("total_input_tokens", 0) or 0,
+        "output_tokens": meta.get("total_output_tokens", 0) or 0,
+        "total_cost_usd": meta.get("total_cost_usd", 0.0) or 0.0,
+    }

--- a/tests/unit/test_human_gate_runner.py
+++ b/tests/unit/test_human_gate_runner.py
@@ -1,0 +1,151 @@
+"""Tests for the human_gate workflow runner (Phase 4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire.workflows.node import ActionNode
+from agentwire.workflows.runners.human_gate import (
+    HumanGateRunner,
+    _extract_final_assistant_text,
+    _extract_tokens,
+)
+
+
+class TestRegistration:
+    def test_human_gate_in_available_runners(self):
+        from agentwire.workflows.runners import available_runners
+        assert "human_gate" in available_runners()
+
+
+class TestRequiresTty:
+    def test_non_tty_fails_fast(self, monkeypatch):
+        # sys.stdin.isatty returns False under pytest by default
+        runner = HumanGateRunner()
+        node = ActionNode(id="n1", prompt="please review", runner="human_gate")
+        result = runner.run(node)
+        assert result.status == "failure"
+        assert "TTY" in result.error
+        assert "scheduler" in result.error
+
+
+class TestSeedAndOutputExtraction:
+    def test_run_invokes_run_repl_with_seed(self, monkeypatch, tmp_path):
+        # Force isatty True
+        import sys as _sys
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+
+        captured = {}
+
+        def fake_run_repl(**kwargs):
+            captured.update(kwargs)
+            # Simulate the REPL writing its transcript on the way out.
+            from agentwire.repl import persistence
+            sd = persistence.DEFAULT_REPL_HOME / kwargs["session_name"]
+            sd.mkdir(parents=True, exist_ok=True)
+            (sd / "metadata.json").write_text(json.dumps({
+                "name": kwargs["session_name"],
+                "total_input_tokens": 12,
+                "total_output_tokens": 34,
+                "total_cost_usd": 0.0042,
+            }))
+            (sd / "events.jsonl").write_text(
+                json.dumps({"type": "assistant", "text": "first response"}) + "\n"
+                + json.dumps({"type": "assistant", "text": "FINAL APPROVAL"}) + "\n"
+            )
+            return 0
+
+        # Redirect persistence and patch run_repl
+        from agentwire.repl import persistence
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl_home")
+        from agentwire.repl import app as repl_app
+        monkeypatch.setattr(repl_app, "run_repl", fake_run_repl)
+
+        runner = HumanGateRunner()
+        node = ActionNode(id="my-gate", prompt="approve this?", runner="human_gate")
+        result = runner.run(node)
+
+        assert result.status == "success"
+        assert result.final_text == "FINAL APPROVAL"
+        assert captured["seed_message"] == "approve this?"
+        assert captured["mode"] == "bypass"
+        assert captured["session_name"].startswith("workflow-my-gate-")
+        assert result.tokens_used["input_tokens"] == 12
+        assert result.tokens_used["output_tokens"] == 34
+        assert result.tokens_used["total_cost_usd"] == pytest.approx(0.0042)
+
+    def test_repl_nonzero_exit_marks_failure(self, monkeypatch, tmp_path):
+        import sys as _sys
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: True)
+        from agentwire.repl import persistence
+        monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl_home")
+
+        def fake_run_repl(**kwargs):
+            return 1
+
+        from agentwire.repl import app as repl_app
+        monkeypatch.setattr(repl_app, "run_repl", fake_run_repl)
+
+        runner = HumanGateRunner()
+        result = runner.run(ActionNode(id="x", prompt="p", runner="human_gate"))
+        assert result.status == "failure"
+        assert "REPL exited with code 1" in result.error
+
+
+class TestExtractFinalText:
+    def test_missing_file(self, tmp_path):
+        assert _extract_final_assistant_text(tmp_path / "nope.jsonl") == ""
+
+    def test_returns_last_assistant(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        path.write_text(
+            json.dumps({"type": "user", "text": "hi"}) + "\n"
+            + json.dumps({"type": "assistant", "text": "first"}) + "\n"
+            + json.dumps({"type": "system"}) + "\n"
+            + json.dumps({"type": "assistant", "text": "second"}) + "\n"
+        )
+        assert _extract_final_assistant_text(path) == "second"
+
+    def test_skips_garbage_lines(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        path.write_text(
+            "{not valid json\n"
+            + json.dumps({"type": "assistant", "text": "ok"}) + "\n"
+        )
+        assert _extract_final_assistant_text(path) == "ok"
+
+    def test_falls_back_to_content_blocks(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        path.write_text(
+            json.dumps({
+                "type": "assistant",
+                "content": [{"type": "tool_use"}, {"type": "text", "text": "hello"}],
+            }) + "\n"
+        )
+        assert _extract_final_assistant_text(path) == "hello"
+
+
+class TestExtractTokens:
+    def test_none_meta(self):
+        assert _extract_tokens(None) == {}
+
+    def test_empty_meta(self):
+        # Empty dict is treated like None — nothing to surface.
+        assert _extract_tokens({}) == {}
+
+    def test_only_some_fields(self):
+        out = _extract_tokens({"total_input_tokens": 5})
+        assert out["input_tokens"] == 5
+        assert out["output_tokens"] == 0
+        assert out["total_cost_usd"] == 0.0
+
+    def test_populated(self):
+        out = _extract_tokens({
+            "total_input_tokens": 10, "total_output_tokens": 20,
+            "total_cost_usd": 0.5,
+        })
+        assert out == {"input_tokens": 10, "output_tokens": 20, "total_cost_usd": 0.5}

--- a/tests/unit/test_repl_commands.py
+++ b/tests/unit/test_repl_commands.py
@@ -462,6 +462,42 @@ class TestSay:
         assert "not found" in out.getvalue()
 
 
+class TestRunWorkflow:
+    def test_no_args_shows_usage(self):
+        out = io.StringIO()
+        action = dispatch_command("/run-workflow", _state(), out)
+        assert action == CONTINUE
+        assert "Usage" in out.getvalue()
+
+    def test_invokes_subprocess(self, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            def __init__(self):
+                self.stdout = iter(["hello\n", "world\n"])
+
+            def wait(self):
+                return 0
+
+        def fake_popen(cmd, **kw):
+            captured["cmd"] = cmd
+            return FakeProc()
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+        out = io.StringIO()
+        action = dispatch_command("/run-workflow my-flow --runner anthropic", _state(), out)
+        assert action == CONTINUE
+        assert captured["cmd"] == ["agentwire", "workflow", "run", "my-flow", "--runner", "anthropic"]
+        rendered = out.getvalue()
+        assert "hello" in rendered
+        assert "world" in rendered
+        assert "exited with code 0" in rendered
+
+
 class TestThinking:
     def test_show_default(self):
         state = _state()

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -966,6 +966,18 @@ class TestInteractiveLoop:
         assert "expanded_text" not in ui
         assert "mentions" not in ui
 
+    def test_seed_message_runs_first_then_eof_exits(self, monkeypatch, capsys):
+        # Seed turn fires before prompt_async is consulted. Empty fake script
+        # → prompt_async raises EOFError on the second iteration → clean exit.
+        turn = [FakeResultMessage(usage={"input_tokens": 1, "output_tokens": 1}, duration_ms=10)]
+        state = _install_fake_sdk(monkeypatch, [turn])
+        _install_fake_prompt_toolkit(monkeypatch, [])  # next prompt → EOF
+
+        from agentwire.repl.app import run_repl
+        rc = run_repl(mode="bypass", seed_message="please review this plan")
+        assert rc == 0
+        assert state["queries"] == ["please review this plan"]
+
     def test_multiline_input_sent_as_one_turn(self, monkeypatch, capsys):
         # The fake PromptSession just returns a string — so a multi-line
         # string acts like the user typed Alt+Enter then hit Enter.


### PR DESCRIPTION
## Summary
Bidirectional bridge between workflows and the REPL.

- **`human_gate` workflow runner** — pauses a workflow at the node, spawns an interactive REPL pre-loaded with the rendered prompt as the first user turn (all upstream `{{ node.var }}` substitutions are baked in before the human reads it). When the user exits, the last assistant message becomes `NodeResult.final_text` and feeds downstream nodes.
- Hard-fails under non-TTY runs (scheduler / overnight queue) with a clear message — no silent hangs.
- **`/run-workflow <name> [args]`** REPL slash command — streams `agentwire workflow run` output into the REPL. The reverse-direction primitive.
- **`seed_message` param on `run_repl()`** — first turn injected before `prompt_async` fires, then normal turn loop resumes.
- **`examples/human-gate-review.yaml`** — draft → review → echo demo.

Closes Phase 4 of `docs/missions/agentwire-repl.md`.

## Test plan
- [x] `uv run pytest` — 1062 passed, 4 skipped
- [x] new tests: human_gate runner registration, non-TTY fail-fast, seed-and-extract end-to-end, exit code propagation, transcript-to-final-text extraction (incl. content-block fallback and garbage-line skip), token extraction edge cases, /run-workflow subprocess invocation, seeded interactive run
- [x] `agentwire workflow validate examples/human-gate-review.yaml` → valid

Built by [dotdev.dev](https://dotdev.dev)
