### PR TITLE
feat(scheduler,overnight): phase 5 — sdk-* task + overnight queue support

### DIFF
--- a/agentwire/overnight.py
+++ b/agentwire/overnight.py
@@ -90,6 +90,29 @@ def generate_id() -> str:
     return uuid.uuid4().hex[:6]
 
 
+def _inject_resume_flags(agent_cmd: str, session_type: str, resume_session_id: str) -> str:
+    """Insert `--resume <id> --fork-session` after the `claude` binary token.
+
+    Phase 5: claude-* only. Other session types (sdk-*, pi-zai-*) have their
+    own resume conventions and the claude-style UUID we record doesn't apply.
+    A no-op when there's nothing to resume or the type doesn't qualify.
+
+    The previous form used `rfind("claude")` which was buggy for commands
+    that also carry `--model claude-opus-4-7` — it would match inside the
+    model arg and produce a malformed command.
+    """
+    if not resume_session_id or not session_type.startswith("claude"):
+        return agent_cmd
+    if not agent_cmd.startswith("claude "):
+        return agent_cmd
+    insert_pos = len("claude")
+    return (
+        agent_cmd[:insert_pos]
+        + f" --resume {resume_session_id} --fork-session"
+        + agent_cmd[insert_pos:]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Queue CRUD
 # ---------------------------------------------------------------------------
@@ -540,16 +563,7 @@ def dispatch_item(item: OvernightItem, config) -> bool:
         _log_event("dispatch_failed", item_id=item.id, error=item.error)
         return False
 
-    # Inject --resume <id> --fork-session
-    if item.resume_session_id:
-        claude_pos = agent_cmd.rfind("claude")
-        if claude_pos >= 0:
-            insert_pos = claude_pos + len("claude")
-            agent_cmd = (
-                agent_cmd[:insert_pos]
-                + f" --resume {item.resume_session_id} --fork-session"
-                + agent_cmd[insert_pos:]
-            )
+    agent_cmd = _inject_resume_flags(agent_cmd, item.session_type, item.resume_session_id)
 
     # Launch agent
     subprocess.run(

--- a/docs/missions/agentwire-repl.md
+++ b/docs/missions/agentwire-repl.md
@@ -5,9 +5,25 @@
 A clean-room interactive harness built on `claude-agent-sdk`, living inside agentwire as a session type. Complementary to Claude Code, not a replacement. The differentiator is **agentwire-native integration** — MCP baked in, workflow bridging, voice, damage control, role layering — things Anthropic has no reason to build into Claude Code because they're long-tail specialized cases.
 
 **Phase of:** own mission (peer to `pi-harness-overview.md`)
-**Status:** **draft — scoping phase (2026-04-22). No code yet.**
+**Status:** **Phases 1-5 shipped (2026-04-25).** Phase 6+ is trigger-driven. See "Shipping log" below.
 **Depends on:** Phase 6 Anthropic SDK workflow runner — complete
-**Blocks:** nothing immediate; implementation PRs gated on user approval of this scope
+**Blocks:** nothing
+
+## Shipping log
+
+| Phase | What landed | PRs |
+|---|---|---|
+| 1 | MVP loop, print mode, sdk-* session types, banner, model + adaptive thinking + effort defaults | merged earlier |
+| 2 PR 1 | `/help`, `/exit`, `/clear`, `/cost`, `/tools`, `/model` | #111 |
+| 2 PR 2 | Transcript persistence + `/save` + `/resume` | #112 |
+| 2 PR 3 | Multi-line input + `@`-mention expansion (with TTY fallback) | #113 |
+| 2 PR 4 | Cost-line bottom toolbar + `/effort` + `/thinking` + sdk-prompted inline y/n/a + classify | #114 |
+| 3 PR 1 | Agentwire MCP server auto-attached (~87 tools first-class) | #115 |
+| 3 PR 2 | Python damage control via SDK PreToolUse hook (mirror of shell hook patterns) | #116 |
+| 3 PR 3 | `.agentwire.yml` roles + voice + `--role` + `/say` | #117 |
+| 3 PR 4 | Portal sidebar SDK type-tag (teal) + artifact hint | #118 |
+| 4 | `human_gate` workflow runner + `/run-workflow` slash command + `seed_message` | #119 |
+| 5 | Scheduler accepts sdk-* task type; overnight resume injection guarded to claude-* (also fixed a latent rfind bug) | (this PR) |
 
 ## Why build this
 

--- a/tests/unit/test_overnight_resume_flags.py
+++ b/tests/unit/test_overnight_resume_flags.py
@@ -1,0 +1,72 @@
+"""Tests for overnight queue resume-flag injection (Phase 5 hardening).
+
+The dispatch path injects `--resume <id> --fork-session` after the agent
+binary token. Phase 5 added a session-type guard so sdk-* and pi-zai-*
+items don't get malformed claude flags shoved at them, and switched the
+locator from rfind("claude") (buggy when `--model claude-opus-4-7` is in
+the args) to a startswith check on the leading binary token.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentwire.overnight import _inject_resume_flags
+
+
+class TestClaudeTypes:
+    def test_basic_claude_bypass(self):
+        cmd = "claude --dangerously-skip-permissions --model claude-opus-4-7"
+        out = _inject_resume_flags(cmd, "claude-bypass", "abc123")
+        assert out == (
+            "claude --resume abc123 --fork-session "
+            "--dangerously-skip-permissions --model claude-opus-4-7"
+        )
+
+    def test_claude_prompted(self):
+        cmd = "claude --model claude-opus-4-7"
+        out = _inject_resume_flags(cmd, "claude-prompted", "uuid-x")
+        assert "--resume uuid-x --fork-session" in out
+        # Resume flags inserted right after `claude`, not inside `claude-opus-4-7`
+        assert out.startswith("claude --resume uuid-x --fork-session ")
+
+    def test_no_resume_id_passthrough(self):
+        cmd = "claude --model claude-opus-4-7"
+        assert _inject_resume_flags(cmd, "claude-bypass", "") == cmd
+
+
+class TestSdkTypes:
+    @pytest.mark.parametrize("sdk_type", ["sdk-bypass", "sdk-prompted", "sdk-restricted"])
+    def test_sdk_passthrough_even_with_resume_id(self, sdk_type):
+        # SDK has its own --resume NAME convention; the claude UUID isn't usable.
+        cmd = "agentwire repl --mode bypass --model claude-opus-4-7"
+        out = _inject_resume_flags(cmd, sdk_type, "abc123")
+        assert out == cmd
+        assert "--fork-session" not in out
+
+    def test_sdk_with_no_resume_id_passthrough(self):
+        cmd = "agentwire repl --mode bypass"
+        assert _inject_resume_flags(cmd, "sdk-bypass", "") == cmd
+
+
+class TestPiTypes:
+    @pytest.mark.parametrize("pi_type", ["pi-zai", "pi-zai-restricted", "pi-zai-readonly"])
+    def test_pi_passthrough(self, pi_type):
+        cmd = "pi --provider zai"
+        out = _inject_resume_flags(cmd, pi_type, "abc123")
+        assert out == cmd
+
+
+class TestEdgeCases:
+    def test_unknown_type_passthrough(self):
+        cmd = "claude --model x"
+        # Unknown types don't get the claude treatment, even if they happen to
+        # start with the claude binary.
+        assert _inject_resume_flags(cmd, "bare", "abc") == cmd
+
+    def test_command_not_starting_with_claude_is_passthrough(self):
+        # Wrapper command — don't try to be clever about embedded `claude`
+        # tokens; only inject for the canonical leading token.
+        cmd = "env CLAUDECODE=1 claude --model x"
+        out = _inject_resume_flags(cmd, "claude-bypass", "abc")
+        assert out == cmd

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -195,6 +195,18 @@ class TestValidateTaskPayload:
         )
         assert any("not found" in e for e in errors)
 
+    @pytest.mark.parametrize("session_type", [
+        "sdk-bypass", "sdk-prompted", "sdk-restricted",
+    ])
+    def test_sdk_session_types_validate(self, session_type):
+        # Phase 5: scheduled tasks accept the new SDK REPL session types.
+        from agentwire.scheduler import _validate_task_payload
+        errors = _validate_task_payload(
+            "t",
+            self._task(type=session_type),
+        )
+        assert errors == [], f"sdk type {session_type} should pass: {errors}"
+
 
 class TestWorkflowStatusMapping:
     @pytest.mark.parametrize("wf_status,sched_status", [


### PR DESCRIPTION
## Summary
Closes Phase 5 of `docs/missions/agentwire-repl.md`. Bonus: fixes a latent overnight-queue bug surfaced while reading the code.

- Scheduler tasks already accepted any session type via the existing flow; this PR adds explicit parametrised tests for `sdk-bypass` / `sdk-prompted` / `sdk-restricted`.
- Overnight queue's `--resume <id> --fork-session` injection is now guarded to claude-* session types. SDK and pi-zai have their own resume conventions; the claude-style UUID we record doesn't apply to them.
- Same change replaces buggy `rfind("claude")` locator (which would match inside `--model claude-opus-4-7` and produce a malformed command) with a startswith check. Logic factored into `_inject_resume_flags()` so it's directly unit-testable.
- Mission doc gets a Phase 1-5 shipping log.

## Test plan
- [x] `uv run pytest` — 1077 passed, 4 skipped
- [x] new parametrised scheduler test: 3 sdk-* task types validate
- [x] new `test_overnight_resume_flags.py`: 12 cases — claude-bypass injects correctly with model arg present, sdk-* / pi-zai-* / bare passthrough, no-resume passthrough, wrapper-prefixed command passthrough

Built by [dotdev.dev](https://dotdev.dev)
