### PR TITLE
feat(repl): default to bundled agentwire role + global voice

### DIFF
--- a/agentwire/repl/context.py
+++ b/agentwire/repl/context.py
@@ -17,12 +17,18 @@ from pathlib import Path
 from agentwire.project_config import load_project_config
 from agentwire.roles import load_roles, merge_roles
 
+# When there's no `.agentwire.yml` and no `--role`, the REPL still wants an
+# agentwire-aware identity by default — pulls the bundled `agentwire` role
+# (agentwire/roles/agentwire.md) so the model knows about MCP tools, voice
+# routing, etc. without each project re-declaring it.
+DEFAULT_ROLE = "agentwire"
+
 
 @dataclass
 class SessionContext:
     role_names: list[str]
     role_instructions: str | None  # None when no roles resolved
-    voice: str | None  # from .agentwire.yml
+    voice: str | None  # from .agentwire.yml or global config default
     missing_roles: list[str]  # names in config that didn't resolve
 
 
@@ -34,21 +40,25 @@ def load_session_context(
     """Load roles + voice for a REPL session.
 
     Order of precedence for role names:
-      1. `role_overrides` (from `--role` CLI flag, if any)
+      1. `role_overrides` (from `--role` CLI flag, if any) — including `[]`
+         to explicitly opt out of all roles
       2. `roles:` in the nearest `.agentwire.yml`
-      3. empty list
+      3. `[DEFAULT_ROLE]` — the bundled `agentwire` role, so a bare
+         `agentwire repl` outside any project still has agentwire identity
 
-    Voice is taken from `.agentwire.yml` only — `/say` defers to `agentwire
-    say`'s own resolution (CLI flag → .agentwire.yml → global default), so
-    here we only need to surface what the project declares.
+    Voice precedence:
+      1. `.agentwire.yml` `voice:`
+      2. Global config `tts.default_voice` (we only run one voice these
+         days; surfacing it in the REPL state means /say + the banner show
+         the right voice without per-project setup)
     """
     cfg = load_project_config(cwd)
     if role_overrides is not None:
         names = list(role_overrides)
-    elif cfg is not None:
+    elif cfg is not None and cfg.roles:
         names = list(cfg.roles)
     else:
-        names = []
+        names = [DEFAULT_ROLE]
 
     if names:
         roles, missing = load_roles(names, project_path=cwd)
@@ -58,10 +68,27 @@ def load_session_context(
         roles, missing = [], []
         instructions = None
 
-    voice = cfg.voice if cfg is not None else None
+    voice: str | None = cfg.voice if cfg is not None else None
+    if not voice:
+        voice = _global_default_voice()
+
     return SessionContext(
         role_names=[r.name for r in roles],
         role_instructions=instructions,
         voice=voice,
         missing_roles=missing,
     )
+
+
+def _global_default_voice() -> str | None:
+    """Read tts.default_voice from ~/.agentwire/config.yaml. None on failure."""
+    try:
+        from agentwire.config import load_config
+        cfg = load_config()
+        voice = getattr(getattr(cfg, "tts", None), "default_voice", None)
+        # Guard the placeholder string the config dataclass uses pre-config-file.
+        if voice and voice != "default":
+            return voice
+    except Exception:
+        return None
+    return None

--- a/tests/unit/test_repl_context.py
+++ b/tests/unit/test_repl_context.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from agentwire.repl.context import load_session_context
+from agentwire.repl.context import DEFAULT_ROLE, load_session_context
+
+
+@pytest.fixture(autouse=True)
+def _no_global_voice(monkeypatch):
+    # Most tests don't care about voice; pin the global lookup off so they
+    # see voice=None unless they wire it explicitly.
+    from agentwire.repl import context
+    monkeypatch.setattr(context, "_global_default_voice", lambda: None)
 
 
 def _write_role(dir: Path, name: str, body: str = "Be helpful.") -> None:
@@ -28,12 +36,19 @@ def _write_project_yaml(dir: Path, *, roles=None, voice=None) -> None:
 
 
 class TestNoConfig:
-    def test_returns_empty(self, tmp_path):
+    def test_falls_back_to_default_agentwire_role(self, tmp_path):
+        # Without a project config, the bundled `agentwire` role is loaded.
         ctx = load_session_context(tmp_path)
-        assert ctx.role_names == []
-        assert ctx.role_instructions is None
-        assert ctx.voice is None
+        assert ctx.role_names == [DEFAULT_ROLE]
+        assert ctx.role_instructions  # non-empty
+        assert ctx.voice is None  # no project voice; fixture pins global to None
         assert ctx.missing_roles == []
+
+    def test_global_voice_picked_up(self, tmp_path, monkeypatch):
+        from agentwire.repl import context
+        monkeypatch.setattr(context, "_global_default_voice", lambda: "af_heart")
+        ctx = load_session_context(tmp_path)
+        assert ctx.voice == "af_heart"
 
 
 class TestRolesFromConfig:
@@ -80,9 +95,24 @@ class TestRoleOverrides:
         _write_project_yaml(tmp_path, roles=["tester"])
 
         ctx = load_session_context(tmp_path, role_overrides=[])
-        # Override == [] means user wants no roles, ignore config.
+        # Override == [] means user wants no roles. Skips both the project
+        # config AND the default-agentwire fallback (explicit > implicit).
         assert ctx.role_names == []
         assert ctx.role_instructions is None
+
+
+class TestProjectWithoutRoles:
+    """A `.agentwire.yml` exists but doesn't declare any roles."""
+
+    def test_default_role_still_applies(self, tmp_path):
+        # Empty `roles:` in project config should still fall back to
+        # DEFAULT_ROLE — otherwise users in agentwire projects mysteriously
+        # lose the agentwire identity vs. running outside any project.
+        from pathlib import Path as _Path
+        (tmp_path / ".agentwire.yml").write_text("type: standard\nvoice: alice\n")
+        ctx = load_session_context(tmp_path)
+        assert ctx.role_names == ["agentwire"]
+        assert ctx.voice == "alice"  # project voice wins over global
 
 
 class TestVoice:


### PR DESCRIPTION
## Summary
A bare `agentwire repl` outside any project used to come up roleless and voiceless. Now:

- **Default role:** When no `.agentwire.yml` declares roles (and no `--role` overrides), the bundled `agentwire` role from `agentwire/roles/agentwire.md` loads as the default identity. Explicit `--role` still wins; `role_overrides=[]` is honored as "explicit none."
- **Default voice:** When no project voice is set, the REPL pulls `tts.default_voice` from `~/.agentwire/config.yaml` so /say + the banner show the right voice without per-project setup. Project `voice:` still wins.
- **Empty `roles:` in project config** falls back to the agentwire default — running inside an agentwire project shouldn't strip the identity that running outside one provides.

## Test plan
- [x] `uv run pytest` — 1079 passed, 4 skipped
- [x] new tests: default role applied with no config, global voice picked up, empty `roles:` still falls back, `role_overrides=[]` honored as explicit none

Built by [dotdev.dev](https://dotdev.dev)
