### PR TITLE
fix(repl): default to ['agentwire','voice'] roles + pass 'default' voice through

### DIFF
--- a/agentwire/repl/context.py
+++ b/agentwire/repl/context.py
@@ -18,10 +18,10 @@ from agentwire.project_config import load_project_config
 from agentwire.roles import load_roles, merge_roles
 
 # When there's no `.agentwire.yml` and no `--role`, the REPL still wants an
-# agentwire-aware identity by default — pulls the bundled `agentwire` role
-# (agentwire/roles/agentwire.md) so the model knows about MCP tools, voice
-# routing, etc. without each project re-declaring it.
-DEFAULT_ROLE = "agentwire"
+# agentwire-aware identity by default — pulls the bundled `agentwire` and
+# `voice` roles so the model knows about MCP tools, voice routing, /say,
+# etc. without each project re-declaring them.
+DEFAULT_ROLES = ["agentwire", "voice"]
 
 
 @dataclass
@@ -43,8 +43,9 @@ def load_session_context(
       1. `role_overrides` (from `--role` CLI flag, if any) — including `[]`
          to explicitly opt out of all roles
       2. `roles:` in the nearest `.agentwire.yml`
-      3. `[DEFAULT_ROLE]` — the bundled `agentwire` role, so a bare
-         `agentwire repl` outside any project still has agentwire identity
+      3. `DEFAULT_ROLES` — the bundled `agentwire` + `voice` roles, so a
+         bare `agentwire repl` outside any project still has agentwire +
+         voice identity
 
     Voice precedence:
       1. `.agentwire.yml` `voice:`
@@ -58,7 +59,7 @@ def load_session_context(
     elif cfg is not None and cfg.roles:
         names = list(cfg.roles)
     else:
-        names = [DEFAULT_ROLE]
+        names = list(DEFAULT_ROLES)
 
     if names:
         roles, missing = load_roles(names, project_path=cwd)
@@ -81,14 +82,15 @@ def load_session_context(
 
 
 def _global_default_voice() -> str | None:
-    """Read tts.default_voice from ~/.agentwire/config.yaml. None on failure."""
+    """Read tts.default_voice from ~/.agentwire/config.yaml. None on failure.
+
+    The string `"default"` is a real voice name (the system's default TTS
+    voice), not a placeholder — pass it through untouched.
+    """
     try:
         from agentwire.config import load_config
         cfg = load_config()
         voice = getattr(getattr(cfg, "tts", None), "default_voice", None)
-        # Guard the placeholder string the config dataclass uses pre-config-file.
-        if voice and voice != "default":
-            return voice
+        return voice or None
     except Exception:
         return None
-    return None

--- a/tests/unit/test_repl_context.py
+++ b/tests/unit/test_repl_context.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from agentwire.repl.context import DEFAULT_ROLE, load_session_context
+from agentwire.repl.context import DEFAULT_ROLES, load_session_context
 
 
 @pytest.fixture(autouse=True)
@@ -36,10 +36,13 @@ def _write_project_yaml(dir: Path, *, roles=None, voice=None) -> None:
 
 
 class TestNoConfig:
-    def test_falls_back_to_default_agentwire_role(self, tmp_path):
-        # Without a project config, the bundled `agentwire` role is loaded.
+    def test_falls_back_to_default_agentwire_and_voice_roles(self, tmp_path):
+        # Without a project config, both bundled roles load — agentwire +
+        # voice — so the model has identity AND knows /say works.
         ctx = load_session_context(tmp_path)
-        assert ctx.role_names == [DEFAULT_ROLE]
+        assert ctx.role_names == DEFAULT_ROLES
+        assert "agentwire" in ctx.role_names
+        assert "voice" in ctx.role_names
         assert ctx.role_instructions  # non-empty
         assert ctx.voice is None  # no project voice; fixture pins global to None
         assert ctx.missing_roles == []
@@ -49,6 +52,14 @@ class TestNoConfig:
         monkeypatch.setattr(context, "_global_default_voice", lambda: "af_heart")
         ctx = load_session_context(tmp_path)
         assert ctx.voice == "af_heart"
+
+    def test_literal_default_voice_passes_through(self, tmp_path, monkeypatch):
+        # The string "default" is a real voice name (system default TTS),
+        # not a placeholder — must surface in state, not get filtered.
+        from agentwire.repl import context
+        monkeypatch.setattr(context, "_global_default_voice", lambda: "default")
+        ctx = load_session_context(tmp_path)
+        assert ctx.voice == "default"
 
 
 class TestRolesFromConfig:
@@ -106,12 +117,11 @@ class TestProjectWithoutRoles:
 
     def test_default_role_still_applies(self, tmp_path):
         # Empty `roles:` in project config should still fall back to
-        # DEFAULT_ROLE — otherwise users in agentwire projects mysteriously
-        # lose the agentwire identity vs. running outside any project.
-        from pathlib import Path as _Path
+        # DEFAULT_ROLES — otherwise users in agentwire projects mysteriously
+        # lose the identity that running outside one provides.
         (tmp_path / ".agentwire.yml").write_text("type: standard\nvoice: alice\n")
         ctx = load_session_context(tmp_path)
-        assert ctx.role_names == ["agentwire"]
+        assert ctx.role_names == DEFAULT_ROLES
         assert ctx.voice == "alice"  # project voice wins over global
 
 


### PR DESCRIPTION
## Summary
Two clarifications on top of #121:

- `DEFAULT_ROLES` is now `["agentwire", "voice"]` — both bundled roles load by default so a bare `agentwire repl` knows about MCP tools AND that `/say` works
- `_global_default_voice()` no longer filters out the literal string `"default"` — that's the actual system-default TTS voice name, not a placeholder

## Test plan
- [x] `uv run pytest` — 1080 passed, 4 skipped
- [x] updated tests assert both default roles load
- [x] new test confirms `"default"` voice surfaces in state

Built by [dotdev.dev](https://dotdev.dev)
