### PR TITLE
feat(repl): partial-message streaming + heartbeat + textual revamp mission

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -78,14 +78,22 @@ def _damage_control_enabled() -> bool:
 
 
 def _thinking_config(mode: str) -> dict | None:
-    """Translate the REPL's `/thinking` mode into an SDK thinking config."""
+    """Translate the REPL's `/thinking` mode into an SDK thinking config.
+
+    `adaptive` defaults to `display: "summarized"` so users see reasoning
+    progress rather than a long silent pause — Opus 4.7 omits thinking
+    content by default, which made the REPL look frozen during a long
+    write-the-whole-html-file turn (real user report 2026-04-25). Set
+    `/thinking off` to disable thinking entirely; there's no separate
+    "adaptive but hidden" mode anymore — wasn't useful in practice.
+    """
     if mode == "adaptive":
-        return {"type": "adaptive"}
+        return {"type": "adaptive", "display": "summarized"}
     if mode == "summarized":
         return {"type": "adaptive", "display": "summarized"}
     if mode == "off":
         return {"type": "disabled"}
-    return {"type": "adaptive"}
+    return {"type": "adaptive", "display": "summarized"}
 
 
 def run_repl(
@@ -154,7 +162,13 @@ async def _run_print_mode(
     try:
         async with ClaudeSDKClient(options=options) as client:
             await client.query(prompt)
-            async for message in client.receive_response():
+            stream_state = _StreamRenderState()
+            async for message in _heartbeat_iter(
+                client.receive_response(), idle_timeout=5.0,
+            ):
+                if message is _HEARTBEAT:
+                    stream_state.heartbeat(sys.stdout)
+                    continue
                 try:
                     render_message(
                         message,
@@ -163,6 +177,7 @@ async def _run_print_mode(
                         SystemMessage=SystemMessage,
                         ResultMessage=ResultMessage,
                         out=sys.stdout,
+                        stream_state=stream_state,
                     )
                     if isinstance(message, ResultMessage) and getattr(message, "is_error", False):
                         exit_code = 1
@@ -210,7 +225,12 @@ def build_options(
         "permission_mode": PERMISSION_MODE_MAP.get(mode, "bypassPermissions"),
         "allowed_tools": allowed,
         "setting_sources": ["user"],       # load ~/.claude/hooks — damage-control
-        "include_partial_messages": False,
+        # Partial messages stream incremental thinking text and tool input
+        # as it's generated. Without this, an Opus 4.7 turn that writes a
+        # 10KB HTML file inside a Write tool input shows nothing for ~120s
+        # between [→ Write ...] and the final result. With it, the user
+        # sees thinking summaries and tool input streaming in real time.
+        "include_partial_messages": True,
         "effort": effort,
         "thinking": _thinking_config(thinking_mode),
     }
@@ -322,13 +342,35 @@ def render_message(
     SystemMessage: Any,
     ResultMessage: Any,
     out: Any = sys.stdout,
+    stream_state: "_StreamRenderState | None" = None,
 ) -> None:
     """Render one SDK message to the terminal.
 
     Compact, human-readable output matching the spirit of pi's JSONL but for
     a terminal reader. Tools like `Read`/`Bash` show the target; tool results
     show a one-line preview.
+
+    `stream_state` carries cross-message bookkeeping for the partial-message
+    stream (Phase 3 PR ?, 2026-04-25): when partial events have already
+    streamed text/thinking content for an assistant turn, the final
+    AssistantMessage that arrives at message_stop would otherwise re-render
+    everything. We track which content indices were streamed and skip them.
     """
+    # StreamEvent is a TypedDict (`{uuid, session_id, event, parent_tool_use_id}`)
+    # delivered when include_partial_messages=True. The `event` payload mirrors
+    # Anthropic's streaming API. We render thinking_delta + text_delta inline so
+    # users see reasoning + reply assembling in real time. Other event types
+    # (input_json_delta, message_delta, message_stop) are noise here.
+    if isinstance(message, dict) and "event" in message and "uuid" in message:
+        if stream_state is not None:
+            stream_state.handle_partial(message["event"], out)
+        return
+
+    # Any non-partial message arriving — close out a pending heartbeat line so
+    # the upcoming render starts on a clean line.
+    if stream_state is not None:
+        stream_state._consume_heartbeat(out)
+
     if isinstance(message, SystemMessage):
         if getattr(message, "subtype", None) == "init":
             data = getattr(message, "data", {}) or {}
@@ -339,9 +381,15 @@ def render_message(
         return
 
     if isinstance(message, AssistantMessage):
+        # Close any open partial line so the snapshot render starts cleanly.
+        if stream_state is not None and stream_state.partials_active:
+            stream_state.close_open_block(out)
         for block in getattr(message, "content", []) or []:
             btype = _block_type(block)
             if btype == "text":
+                # Text already streamed via partials → skip redundant snapshot render.
+                if stream_state is not None and stream_state.streamed_text:
+                    continue
                 text = _block_attr(block, "text", "") or ""
                 if text:
                     out.write(text)
@@ -353,11 +401,16 @@ def render_message(
                 summary = _format_tool_input(name, inp)
                 out.write(f"[→ {name}{' ' + summary if summary else ''}]\n")
             elif btype == "thinking":
+                # Thinking already streamed live via partials → skip snapshot.
+                if stream_state is not None and stream_state.streamed_thinking:
+                    continue
                 thinking = _block_attr(block, "thinking", "") or ""
                 first = thinking.split("\n", 1)[0].strip()
                 if first:
                     preview = first if len(first) <= 80 else first[:77] + "..."
                     out.write(f"[thinking: {preview}]\n")
+        if stream_state is not None:
+            stream_state.reset_for_next_assistant_turn()
         return
 
     if isinstance(message, UserMessage):
@@ -743,7 +796,13 @@ async def _run_sdk_session(
 
             try:
                 await client.query(expanded_text)
-                async for message in client.receive_response():
+                stream_state = _StreamRenderState()
+                async for message in _heartbeat_iter(
+                    client.receive_response(), idle_timeout=5.0,
+                ):
+                    if message is _HEARTBEAT:
+                        stream_state.heartbeat(sys.stdout)
+                        continue
                     try:
                         render_message(
                             message,
@@ -752,6 +811,7 @@ async def _run_sdk_session(
                             SystemMessage=SystemMessage,
                             ResultMessage=ResultMessage,
                             out=sys.stdout,
+                            stream_state=stream_state,
                         )
                         sys.stdout.flush()
                         _persist_sdk_message(
@@ -854,3 +914,148 @@ def _prompt_sync(prompt: str) -> str:
     sys.stdout.write(prompt)
     sys.stdout.flush()
     return sys.stdin.readline()
+
+
+# -------- streaming visibility (2026-04-25) --------
+
+# Sentinel yielded by _heartbeat_iter when the inner async iter has stalled
+# past idle_timeout. The render loop watches for this and prints a heartbeat.
+_HEARTBEAT = object()
+
+
+async def _heartbeat_iter(async_iter, idle_timeout: float):
+    """Yield items from `async_iter`; yield `_HEARTBEAT` when idle.
+
+    `client.receive_response()` is an async iterator that may sit silent for
+    tens of seconds while the model thinks or writes a long tool input.
+    On each idle timeout we yield `_HEARTBEAT` so the renderer can show
+    progress, but we keep the underlying `__anext__` task pending — using
+    `asyncio.wait_for` would cancel it and lose the pending event.
+    """
+    iterator = async_iter.__aiter__()
+    pending: asyncio.Task | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.ensure_future(iterator.__anext__())
+            done, _ = await asyncio.wait({pending}, timeout=idle_timeout)
+            if pending in done:
+                try:
+                    yield pending.result()
+                except StopAsyncIteration:
+                    pending = None
+                    return
+                pending = None
+            else:
+                yield _HEARTBEAT
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+
+
+class _StreamRenderState:
+    """Per-turn bookkeeping for partial-message rendering.
+
+    The SDK delivers StreamEvents (TypedDict with a `uuid` + `event` payload)
+    when `include_partial_messages=True`. We render thinking_delta and
+    text_delta deltas inline so the user sees progress; the snapshot
+    AssistantMessage at message_stop then skips re-rendering anything we
+    already showed.
+    """
+
+    def __init__(self) -> None:
+        self.streamed_text = False
+        self.streamed_thinking = False
+        self.open_block: str | None = None  # "thinking" | "text" | None
+        self._heartbeat_count = 0
+        self._heartbeat_started_inline = False
+
+    @property
+    def partials_active(self) -> bool:
+        return self.streamed_text or self.streamed_thinking or self.open_block is not None
+
+    def handle_partial(self, event: dict, out: Any) -> None:
+        """Render one StreamEvent.event payload."""
+        if not isinstance(event, dict):
+            return
+        etype = event.get("type")
+        # Heartbeat may have left a `[…still working]` line that we want to
+        # consume before showing real content.
+        if etype in ("content_block_start", "content_block_delta", "message_delta"):
+            self._consume_heartbeat(out)
+
+        if etype == "content_block_start":
+            block = event.get("content_block") or {}
+            btype = block.get("type")
+            if btype == "thinking":
+                out.write("[thinking: ")
+                self.open_block = "thinking"
+                self.streamed_thinking = True
+            elif btype == "text":
+                # Newline before assistant text so it doesn't pile onto the
+                # previous line (often a tool result preview).
+                out.write("\n")
+                self.open_block = "text"
+                self.streamed_text = True
+            # tool_use partials surface their input via input_json_delta —
+            # we don't show JSON bytes mid-stream; the snapshot AssistantMessage
+            # gives the formatted summary at end of turn.
+
+        elif etype == "content_block_delta":
+            delta = event.get("delta") or {}
+            dtype = delta.get("type")
+            if dtype == "thinking_delta" and self.open_block == "thinking":
+                text = delta.get("thinking", "") or ""
+                if text:
+                    # Collapse newlines inside thinking to keep the line flowing.
+                    out.write(text.replace("\n", " "))
+            elif dtype == "text_delta" and self.open_block == "text":
+                out.write(delta.get("text", "") or "")
+
+        elif etype == "content_block_stop":
+            if self.open_block == "thinking":
+                out.write("]\n")
+            elif self.open_block == "text":
+                out.write("\n")
+            self.open_block = None
+
+    def close_open_block(self, out: Any) -> None:
+        """Force-close any in-flight open block (e.g. before snapshot render)."""
+        if self.open_block == "thinking":
+            out.write("]\n")
+        elif self.open_block == "text":
+            out.write("\n")
+        self.open_block = None
+
+    def reset_for_next_assistant_turn(self) -> None:
+        """Snapshot rendered → flags reset so the next assistant turn (within
+        the same SDK call, if it tool-uses then text-replies) is unambiguous."""
+        self.streamed_text = False
+        self.streamed_thinking = False
+        self.open_block = None
+        self._heartbeat_count = 0
+        self._heartbeat_started_inline = False
+
+    def heartbeat(self, out: Any) -> None:
+        """Called when the SDK has been silent past `idle_timeout` seconds."""
+        self._heartbeat_count += 1
+        elapsed = self._heartbeat_count * 5
+        # If we're mid-stream inside an open block, append a tiny "·" to that
+        # line so the user sees liveness without breaking flow. Otherwise
+        # write a standalone status line.
+        if self.open_block is not None:
+            out.write("·")
+            out.flush() if hasattr(out, "flush") else None
+            return
+        if not self._heartbeat_started_inline:
+            out.write(f"[…still working · {elapsed}s")
+            self._heartbeat_started_inline = True
+        else:
+            out.write(f" · {elapsed}s")
+        out.flush() if hasattr(out, "flush") else None
+
+    def _consume_heartbeat(self, out: Any) -> None:
+        if self._heartbeat_started_inline:
+            out.write("]\n")
+            self._heartbeat_started_inline = False
+            self._heartbeat_count = 0

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -1,0 +1,149 @@
+> Living document. Update this, don't create new versions.
+
+# Mission: Agentwire REPL — Textual TUI Rewrite
+
+A from-scratch rendering layer for `agentwire repl` built on [Textual](https://github.com/textualize/textual). The current `prompt_toolkit` line-oriented loop hit its ceiling: there's no way to keep streaming partial output visible without flooding the chat history, no proportional layout, no borders/titles, no docked status line, no scrollable subregion for "what claude is doing right now". Textual gives all of that out of the box.
+
+**Phase of:** own mission (sibling of `agentwire-repl.md`)
+**Status:** **draft — scoping (2026-04-25). No code yet.**
+**Depends on:** `agentwire-repl.md` Phases 1-5 (complete)
+**Blocks:** future REPL feature work that needs richer layout (mode badges, modal permission prompts, inline waveform for /say, etc.)
+
+## Why this rewrite
+
+The user's framing (2026-04-25): *"we can stream the partials, but we need a way to keep them contained, they should get only some percentage of total height lines we have in the current display, so the input is always ideal near the bottom (with maybe a status line under it if we add one) and the chat history above and all the way to the top. But we could add the 'current action' as like 20% of the height we have to work with and have the text scroll there like in a subpane."*
+
+That's a layout requirement, not a rendering tweak. `prompt_toolkit` *can* express it — `HSplit([history, Frame(action, title="..."), input], weights=[6, 2, 1])` — but our current code uses prompt_toolkit as a line-oriented prompt only (events go to raw stdout, prompt_toolkit owns just the input buffer). Adding a real layout means rewriting the rendering loop end-to-end. If we're rewriting it anyway, Textual is the better target:
+
+| | prompt_toolkit (current) | Textual (proposed) |
+|---|---|---|
+| Layout primitives | low-level (HSplit/VSplit/Window) | declarative (Vertical/Horizontal/Grid + CSS) |
+| Borders + titles | `Frame` widget | `Static`/`Container` + CSS border |
+| Scrollable subregion | manual | `RichLog` built for it |
+| Status line | manual | `Footer` + dock="bottom" |
+| Modals (e.g. permission prompts) | hand-rolled | `Screen.push_screen` |
+| Async event integration | yes | first-class |
+| Dev tools | none | `textual console`, snapshot tests |
+| Stars / momentum | 9k, mature | 25k, very active |
+| Cost of "do nothing fancy" | high | medium |
+
+Textual loses terminal scrollback by default (it's a full-screen app), but inside a tmux pane that doesn't matter — and the in-app history widget is its own infinite scroll. We gain way more than we lose.
+
+## Architecture sketch
+
+```
+┌─ AgentwireREPL (Textual App) ─────────────────────────────┐
+│ ┌─ Header ───────────────────────────────────────────────┐ │
+│ │ agentwire repl · sdk-bypass · claude-opus-4-7 · roles… │ │
+│ └────────────────────────────────────────────────────────┘ │
+│ ┌─ ChatHistory (RichLog, fr=6) ──────────────────────────┐ │
+│ │ > previous user turn                                   │ │
+│ │ assistant final text                                   │ │
+│ │ [tool: Bash → ls /tmp]                                 │ │
+│ │ [tool result: ...]                                     │ │
+│ │ assistant final text                                   │ │
+│ │ ↑ scrolls; pinned to bottom on new content             │ │
+│ └────────────────────────────────────────────────────────┘ │
+│ ┌─ CurrentAction (RichLog, fr=2, border, title) ─────────┐ │
+│ │ ╭─ Current action ─────────────────────────────────╮   │ │
+│ │ │ thinking: planning the file structure...        │   │ │
+│ │ │ thinking: deciding section ordering...          │   │ │
+│ │ │ tool input (Write fanfic.html):                  │   │ │
+│ │ │   <!doctype html><html><head><meta charset...   │   │ │
+│ │ │   <style>body { font-family: ... }</style>      │   │ │
+│ │ │   ↑ streams in real time, scrolls within frame  │   │ │
+│ │ ╰──────────────────────────────────────────────────╯   │ │
+│ └────────────────────────────────────────────────────────┘ │
+│ ┌─ Input (TextArea, dock=bottom) ────────────────────────┐ │
+│ │ > tell me about prompt caching                         │ │
+│ └────────────────────────────────────────────────────────┘ │
+│ ┌─ StatusLine (Footer, dock=bottom) ─────────────────────┐ │
+│ │ 3 turns · 1.2k tok · $0.04 · effort=high · af_heart    │ │
+│ └────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────┘
+```
+
+- **ChatHistory** — finalized turns. Tool calls collapse to one-line summaries.
+- **CurrentAction** — live partial-message stream. Cleared at end of turn (the assistant block + tool result get appended to ChatHistory in collapsed form).
+- **Input** — multi-line `TextArea`, Alt+Enter newline, Enter submit. `@`-mention auto-complete from `Glob` against cwd would be a nice phase-2 add.
+- **StatusLine** — running totals, mode, role, voice. Replaces the bottom_toolbar.
+- **Modals** — `sdk-prompted` permission prompts pop a `ModalScreen` instead of inline y/n/a.
+
+## Phases
+
+### Phase 1 — Parity (target: 1 wk)
+
+Reach feature parity with the current prompt_toolkit REPL.
+
+- Textual app skeleton (`agentwire/repl/textual_app.py`)
+- ChatHistory + Input wired; SDK client streams events into ChatHistory
+- All slash commands work (`/help`, `/cost`, `/tools`, `/model`, `/clear`, `/save`, `/resume`, `/effort`, `/thinking`, `/say`, `/run-workflow`, `/exit`)
+- @-mention expansion (existing `agentwire.repl.mentions` reused)
+- Transcript persistence (existing `agentwire.repl.persistence` reused)
+- MCP, damage-control, role layering, voice (all already in `build_options`, no changes)
+- Print mode (`-p`) keeps the existing single-shot path — Textual app only fires for interactive
+- TTY detection: non-TTY (piped stdin, scheduler) falls back to a non-Textual path that mimics today's behavior. **Required** — otherwise we break workflow `human_gate` and the print-mode contract.
+- **Success criteria:** every test in `tests/unit/test_repl_*.py` still passes (with adjusted fixtures); the seeded smoke test (echo prompt | agentwire repl) prints assistant content; an interactive Opus 4.7 session feels at least as good as today's.
+
+### Phase 2 — Layout features (target: 1 wk)
+
+What this rewrite was actually for.
+
+- **CurrentAction RichLog** with border + title — partial messages stream here in real time, cleared on turn complete
+- **Proportional weights** — chat=6 / action=2 / input=1 by default, configurable via `/layout` slash command
+- **Header** — session metadata pinned at top
+- **StatusLine (Footer)** — running totals, refreshed every event
+- **Tool-call collapse** — finished tool calls in ChatHistory show `[Bash · ls -la · 12 files]` not the full streamed input
+- **Permission prompts as modal** — `sdk-prompted` pops `ModalScreen` with allow/deny/always buttons
+- **Color theming** — pull `tts.theme` (or new `repl.theme`) from `~/.agentwire/config.yaml`
+- **Success criteria:** the 120-second silent gap that prompted this mission is gone; user always knows what claude is doing
+
+### Phase 3 — Polish (target: ~1 wk)
+
+- @-mention autocomplete (Glob against cwd, dropdown overlay)
+- Slash-command palette (`Ctrl+P` opens fuzzy command picker)
+- Inline cost graph (sparkline of per-turn cost)
+- Transcript scrubber (jump to any prior turn)
+- Snapshot tests using Textual's snapshot framework
+- Doc: short `docs/repl-tui.md` walkthrough with screenshots
+- **Success criteria:** the REPL is good enough to use over Claude Code for agentwire-network-flavored work — that's the original mission's bar
+
+### Phase 4+ — Trigger-driven
+
+Same posture as `agentwire-repl.md` Phase 6+. Don't pre-build:
+
+- Multiplexer view (multiple SDK sessions in one Textual app)
+- Workflow-run inline (run a workflow inside the REPL with live node-state cards)
+- Inline waveform for /say
+- Plugin widgets
+
+## Open questions
+
+- **Migration strategy:** ship Textual behind a flag (`AGENTWIRE_REPL_TUI=textual`) and run side-by-side until parity is proven, then flip default? Or branch-and-replace? Leaning side-by-side — the current REPL is good enough that we don't need to remove it on day 1.
+- **Print mode:** stays on the prompt_toolkit / stdout path? It has no UX requirements that need Textual. Likely yes — print mode is fire-and-forget, no benefit from a TUI.
+- **Workflow human_gate:** does it spawn the Textual app or stay on the simple line-mode? Probably needs Textual for parity once Textual is the default — humans reviewing a gate want the same UX they get in standalone REPL. But Textual-from-inside-a-workflow has tmux/TTY constraints to think through.
+- **Resume / scroll-back of long transcripts:** `RichLog` handles this natively; verify with a 10K-line transcript.
+- **Snapshot tests:** Textual has `pytest-textual-snapshot`. Worth adding to the test stack as part of Phase 3.
+
+## Non-goals
+
+- Replacing `pi` or `claude` REPLs — agentwire repl stays the agentwire-native harness; the others stay as they are.
+- Cross-platform Windows-native polish — best-effort, but Linux + macOS terminals are the target.
+- Rewriting the workflow `human_gate` runner — it just calls `run_repl(seed_message=...)`, which will route to whichever REPL implementation is active.
+
+## Code references (for the rewrite)
+
+- `agentwire/repl/app.py` — current entry point. The `_run_interactive` function is what gets replaced; everything from `build_options` downward is reused.
+- `agentwire/repl/state.py` — `ReplState` dataclass; carries through unchanged.
+- `agentwire/repl/commands.py` — slash commands; reused unchanged.
+- `agentwire/repl/persistence.py` — transcript JSONL; reused unchanged.
+- `agentwire/repl/mentions.py` — @-mention expansion; reused unchanged.
+- `agentwire/repl/damage_control.py` — `make_pre_tool_hook`; reused unchanged.
+- `agentwire/repl/context.py` — role/voice loading; reused unchanged.
+
+The rewrite is the rendering layer only. Everything below is intact.
+
+## Dependencies
+
+- `textual >= 0.80` (latest stable as of 2026-04)
+- `pytest-textual-snapshot` (test-only, Phase 3)

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -53,7 +53,7 @@ class TestBuildOptions:
         assert opts.kwargs["allowed_tools"] == FULL_TOOLS
         assert opts.kwargs["model"] == DEFAULT_MODEL
         assert opts.kwargs["effort"] == DEFAULT_EFFORT
-        assert opts.kwargs["thinking"] == {"type": "adaptive"}
+        assert opts.kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
         assert opts.kwargs["setting_sources"] == ["user"]
 
     def test_prompted_mode(self, tmp_path):
@@ -1015,10 +1015,193 @@ class TestInteractiveLoop:
         assert "prompt_toolkit not installed" in err
 
 
+class TestStreamRenderState:
+    """Partial-message rendering — added 2026-04-25 to fix the silent gap."""
+
+    def _state(self):
+        from agentwire.repl.app import _StreamRenderState
+        return _StreamRenderState()
+
+    def test_text_delta_streams_inline(self):
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "text"}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello "}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "world"}},
+            out,
+        )
+        s.handle_partial({"type": "content_block_stop"}, out)
+        rendered = out.getvalue()
+        assert "Hello world" in rendered
+        assert s.streamed_text is True
+        assert s.open_block is None
+
+    def test_thinking_delta_streams_inline(self):
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "thinking"}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "thinking_delta", "thinking": "let me\nplan this"}},
+            out,
+        )
+        s.handle_partial({"type": "content_block_stop"}, out)
+        rendered = out.getvalue()
+        assert "[thinking: let me plan this]" in rendered
+        assert s.streamed_thinking is True
+
+    def test_input_json_delta_ignored(self):
+        # Tool input streaming via input_json_delta would dump raw JSON bytes
+        # into the chat — we deliberately swallow these and rely on the
+        # snapshot AssistantMessage's [→ Write file.html] formatted summary.
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start",
+             "content_block": {"type": "tool_use", "name": "Write"}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "input_json_delta", "partial_json": '{"file_path": "x"}'}},
+            out,
+        )
+        # No raw JSON in output
+        assert '"file_path"' not in out.getvalue()
+
+    def test_assistant_skips_streamed_text(self, monkeypatch):
+        # When partials already streamed text, the snapshot AssistantMessage
+        # text block should NOT re-render.
+        from agentwire.repl.app import render_message, _StreamRenderState
+        s = _StreamRenderState()
+        s.streamed_text = True
+        out = io.StringIO()
+
+        msg = FakeAssistantMessage(content=[{"type": "text", "text": "full reply"}])
+        render_message(
+            msg,
+            AssistantMessage=FakeAssistantMessage,
+            UserMessage=FakeUserMessage,
+            SystemMessage=FakeSystemMessage,
+            ResultMessage=FakeResultMessage,
+            out=out,
+            stream_state=s,
+        )
+        assert "full reply" not in out.getvalue()
+        # state resets after snapshot
+        assert s.streamed_text is False
+
+    def test_assistant_renders_when_no_partials(self):
+        from agentwire.repl.app import render_message, _StreamRenderState
+        s = _StreamRenderState()
+        out = io.StringIO()
+        msg = FakeAssistantMessage(content=[{"type": "text", "text": "full reply"}])
+        render_message(
+            msg,
+            AssistantMessage=FakeAssistantMessage,
+            UserMessage=FakeUserMessage,
+            SystemMessage=FakeSystemMessage,
+            ResultMessage=FakeResultMessage,
+            out=out,
+            stream_state=s,
+        )
+        assert "full reply" in out.getvalue()
+
+    def test_heartbeat_inline_when_open_block(self):
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "thinking"}},
+            out,
+        )
+        s.heartbeat(out)
+        s.heartbeat(out)
+        # Two dots appended to the open thinking line.
+        rendered = out.getvalue()
+        assert rendered.count("·") == 2
+
+    def test_heartbeat_standalone_when_idle(self):
+        s = self._state()
+        out = io.StringIO()
+        s.heartbeat(out)
+        s.heartbeat(out)
+        # Forms a single status line: "[…still working · 5s · 10s"
+        # (no trailing ] until a real event consumes it)
+        rendered = out.getvalue()
+        assert "still working" in rendered
+        assert "5s" in rendered and "10s" in rendered
+
+    def test_heartbeat_consumed_by_real_event(self):
+        s = self._state()
+        out = io.StringIO()
+        s.heartbeat(out)
+        # Real event arrives → consumes the open heartbeat line
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "text"}},
+            out,
+        )
+        rendered = out.getvalue()
+        # Heartbeat line was closed (saw "]\n" before any content).
+        assert "still working" in rendered
+        assert rendered.index("]") < rendered.rindex("\n")
+
+
+class TestHeartbeatIter:
+    def test_emits_heartbeat_on_idle(self):
+        from agentwire.repl.app import _heartbeat_iter, _HEARTBEAT
+        import asyncio
+
+        async def slow_source():
+            await asyncio.sleep(0.15)
+            yield "done"
+
+        async def collect():
+            results = []
+            async for x in _heartbeat_iter(slow_source(), idle_timeout=0.05):
+                results.append(x)
+                if x == "done":
+                    break
+            return results
+
+        results = asyncio.run(collect())
+        assert _HEARTBEAT in results
+        assert "done" in results
+
+    def test_no_heartbeat_when_fast(self):
+        from agentwire.repl.app import _heartbeat_iter, _HEARTBEAT
+        import asyncio
+
+        async def fast_source():
+            yield 1
+            yield 2
+
+        async def collect():
+            results = []
+            async for x in _heartbeat_iter(fast_source(), idle_timeout=1.0):
+                results.append(x)
+            return results
+
+        results = asyncio.run(collect())
+        assert results == [1, 2]
+        assert _HEARTBEAT not in results
+
+
 class TestThinkingConfig:
     def test_adaptive_default(self):
+        # adaptive now defaults to display:summarized (Opus 4.7 hides
+        # thinking by default; we always want it visible in the REPL).
         from agentwire.repl.app import _thinking_config
-        assert _thinking_config("adaptive") == {"type": "adaptive"}
+        assert _thinking_config("adaptive") == {"type": "adaptive", "display": "summarized"}
 
     def test_summarized_sets_display(self):
         from agentwire.repl.app import _thinking_config
@@ -1030,7 +1213,7 @@ class TestThinkingConfig:
 
     def test_unknown_falls_back_adaptive(self):
         from agentwire.repl.app import _thinking_config
-        assert _thinking_config("nonsense") == {"type": "adaptive"}
+        assert _thinking_config("nonsense") == {"type": "adaptive", "display": "summarized"}
 
 
 class TestBottomToolbar:


### PR DESCRIPTION
## Summary
Closes the silent-gap UX bug surfaced today: an Opus 4.7 turn that writes ~10KB inside a Write tool input sat silent for ~120s. Three changes:

- **Partial messages enabled** — `include_partial_messages: True`. Renderer handles StreamEvent payloads: `text_delta` and `thinking_delta` stream into the terminal in real time. Snapshot AssistantMessage at message_stop skips re-rendering anything already shown.
- **Adaptive thinking → summarized display by default** — Opus 4.7 omits thinking content by default; summarized display restores visible reasoning. `/thinking off` still disables.
- **Heartbeat adapter** — `_heartbeat_iter` wraps `receive_response()` and emits a sentinel every 5 idle seconds. Renders `[…still working · 5s · 10s]` standalone, or a single `·` dot appended to an open thinking/text block. Closes cleanly when the next real event arrives.

Also lands **`docs/missions/agentwire-repl-textual.md`** — a separate scoped mission for the eventual full Textual TUI rewrite (proportional layout, scrollable Current-Action subpane, docked status line, modal permission prompts). Future work; this PR is the in-place quick fix.

## Test plan
- [x] `uv run pytest` — 1090 passed, 4 skipped
- [x] new tests cover: text_delta + thinking_delta streaming, input_json_delta swallowed, AssistantMessage skip-on-streamed, heartbeat inline-vs-standalone, heartbeat consumed by next event, _heartbeat_iter idle + fast paths
- [x] real smoke test against MCP server — text streamed live, heartbeat fired during MCP wait (`[…still working · 5s · 10s`), final summary rendered correctly

Built by [dotdev.dev](https://dotdev.dev)
