### PR TITLE
fix(repl): detect StreamEvent dataclass + add tool-input byte counter

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -356,14 +356,21 @@ def render_message(
     AssistantMessage that arrives at message_stop would otherwise re-render
     everything. We track which content indices were streamed and skip them.
     """
-    # StreamEvent is a TypedDict (`{uuid, session_id, event, parent_tool_use_id}`)
-    # delivered when include_partial_messages=True. The `event` payload mirrors
-    # Anthropic's streaming API. We render thinking_delta + text_delta inline so
-    # users see reasoning + reply assembling in real time. Other event types
-    # (input_json_delta, message_delta, message_stop) are noise here.
-    if isinstance(message, dict) and "event" in message and "uuid" in message:
+    # StreamEvent is a `@dataclass` with fields {uuid, session_id, event,
+    # parent_tool_use_id}, delivered when include_partial_messages=True. The
+    # `event` payload mirrors Anthropic's streaming API. We render
+    # thinking_delta + text_delta inline so users see reasoning + reply
+    # assembling in real time. Other event types (input_json_delta,
+    # message_delta, message_stop) are noise here.
+    #
+    # Detection by duck-type rather than isinstance — keeps render_message
+    # decoupled from claude-agent-sdk's exact class (and matches the rest
+    # of the renderer's pattern of accepting structurally-typed fakes).
+    if hasattr(message, "event") and hasattr(message, "uuid") and not hasattr(message, "content"):
         if stream_state is not None:
-            stream_state.handle_partial(message["event"], out)
+            payload = getattr(message, "event", None)
+            if isinstance(payload, dict):
+                stream_state.handle_partial(payload, out)
         return
 
     # Any non-partial message arriving — close out a pending heartbeat line so
@@ -953,6 +960,22 @@ async def _heartbeat_iter(async_iter, idle_timeout: float):
             pending.cancel()
 
 
+def _flush(out: Any) -> None:
+    """Best-effort flush — StringIO has flush, real stdout has flush, fakes may not."""
+    flush = getattr(out, "flush", None)
+    if callable(flush):
+        flush()
+
+
+def _format_bytes(n: int) -> str:
+    """Human-readable byte count: `42 bytes`, `1.2 KB`, `3.4 MB`."""
+    if n < 1024:
+        return f"{n} bytes"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"
+
+
 class _StreamRenderState:
     """Per-turn bookkeeping for partial-message rendering.
 
@@ -966,9 +989,11 @@ class _StreamRenderState:
     def __init__(self) -> None:
         self.streamed_text = False
         self.streamed_thinking = False
-        self.open_block: str | None = None  # "thinking" | "text" | None
+        self.open_block: str | None = None  # "thinking" | "text" | "tool_use" | None
         self._heartbeat_count = 0
         self._heartbeat_started_inline = False
+        self._tool_use_name: str | None = None
+        self._tool_use_bytes: int = 0
 
     @property
     def partials_active(self) -> bool:
@@ -997,9 +1022,18 @@ class _StreamRenderState:
                 out.write("\n")
                 self.open_block = "text"
                 self.streamed_text = True
-            # tool_use partials surface their input via input_json_delta —
-            # we don't show JSON bytes mid-stream; the snapshot AssistantMessage
-            # gives the formatted summary at end of turn.
+            elif btype == "tool_use":
+                # Long tool inputs (e.g. Write with 10KB of HTML) used to
+                # generate in silence for ~100s. Show a live byte counter so
+                # the user knows the model is still working. We don't dump
+                # the raw JSON bytes — the snapshot AssistantMessage that
+                # follows gives the formatted [→ Write file.html] summary.
+                name = block.get("name") or "tool"
+                self._tool_use_name = name
+                self._tool_use_bytes = 0
+                self.open_block = "tool_use"
+                out.write(f"[writing {name} input · 0 bytes")
+                _flush(out)
 
         elif etype == "content_block_delta":
             delta = event.get("delta") or {}
@@ -1009,14 +1043,33 @@ class _StreamRenderState:
                 if text:
                     # Collapse newlines inside thinking to keep the line flowing.
                     out.write(text.replace("\n", " "))
+                    _flush(out)
             elif dtype == "text_delta" and self.open_block == "text":
                 out.write(delta.get("text", "") or "")
+                _flush(out)
+            elif dtype == "input_json_delta" and self.open_block == "tool_use":
+                partial = delta.get("partial_json") or ""
+                self._tool_use_bytes += len(partial)
+                # Refresh the line in place via CR+clear-to-EOL so the byte
+                # count ticks live without spamming new lines.
+                out.write(
+                    f"\r\033[K[writing {self._tool_use_name} input · "
+                    f"{_format_bytes(self._tool_use_bytes)}"
+                )
+                _flush(out)
 
         elif etype == "content_block_stop":
             if self.open_block == "thinking":
                 out.write("]\n")
             elif self.open_block == "text":
                 out.write("\n")
+            elif self.open_block == "tool_use":
+                out.write(
+                    f"\r\033[K[wrote {self._tool_use_name} input · "
+                    f"{_format_bytes(self._tool_use_bytes)}]\n"
+                )
+                self._tool_use_name = None
+                self._tool_use_bytes = 0
             self.open_block = None
 
     def close_open_block(self, out: Any) -> None:
@@ -1025,6 +1078,13 @@ class _StreamRenderState:
             out.write("]\n")
         elif self.open_block == "text":
             out.write("\n")
+        elif self.open_block == "tool_use":
+            out.write(
+                f"\r\033[K[wrote {self._tool_use_name} input · "
+                f"{_format_bytes(self._tool_use_bytes)}]\n"
+            )
+            self._tool_use_name = None
+            self._tool_use_bytes = 0
         self.open_block = None
 
     def reset_for_next_assistant_turn(self) -> None:
@@ -1035,24 +1095,29 @@ class _StreamRenderState:
         self.open_block = None
         self._heartbeat_count = 0
         self._heartbeat_started_inline = False
+        self._tool_use_name = None
+        self._tool_use_bytes = 0
 
     def heartbeat(self, out: Any) -> None:
         """Called when the SDK has been silent past `idle_timeout` seconds."""
         self._heartbeat_count += 1
         elapsed = self._heartbeat_count * 5
-        # If we're mid-stream inside an open block, append a tiny "·" to that
+        # tool_use already has its own live byte counter — leave it alone.
+        if self.open_block == "tool_use":
+            return
+        # If we're mid-stream inside thinking/text, append a tiny "·" to that
         # line so the user sees liveness without breaking flow. Otherwise
         # write a standalone status line.
         if self.open_block is not None:
             out.write("·")
-            out.flush() if hasattr(out, "flush") else None
+            _flush(out)
             return
         if not self._heartbeat_started_inline:
             out.write(f"[…still working · {elapsed}s")
             self._heartbeat_started_inline = True
         else:
             out.write(f" · {elapsed}s")
-        out.flush() if hasattr(out, "flush") else None
+        _flush(out)
 
     def _consume_heartbeat(self, out: Any) -> None:
         if self._heartbeat_started_inline:

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -1060,10 +1060,11 @@ class TestStreamRenderState:
         assert "[thinking: let me plan this]" in rendered
         assert s.streamed_thinking is True
 
-    def test_input_json_delta_ignored(self):
+    def test_input_json_delta_shows_byte_counter(self):
         # Tool input streaming via input_json_delta would dump raw JSON bytes
-        # into the chat — we deliberately swallow these and rely on the
-        # snapshot AssistantMessage's [→ Write file.html] formatted summary.
+        # into the chat. Instead we show a live byte counter — the snapshot
+        # AssistantMessage that follows gives the formatted [→ Write file.html]
+        # summary with parsed args.
         s = self._state()
         out = io.StringIO()
         s.handle_partial(
@@ -1076,8 +1077,90 @@ class TestStreamRenderState:
              "delta": {"type": "input_json_delta", "partial_json": '{"file_path": "x"}'}},
             out,
         )
-        # No raw JSON in output
-        assert '"file_path"' not in out.getvalue()
+        rendered = out.getvalue()
+        # Counter line is written, raw JSON is not.
+        assert "writing Write input" in rendered
+        assert '"file_path"' not in rendered
+        assert s.open_block == "tool_use"
+        assert s._tool_use_bytes == len('{"file_path": "x"}')
+
+    def test_tool_use_close_finalizes_byte_counter(self):
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start",
+             "content_block": {"type": "tool_use", "name": "Write"}},
+            out,
+        )
+        # 2 KB of fake JSON across two deltas
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "input_json_delta", "partial_json": "x" * 1024}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "input_json_delta", "partial_json": "x" * 1024}},
+            out,
+        )
+        s.handle_partial({"type": "content_block_stop"}, out)
+        rendered = out.getvalue()
+        assert "wrote Write input" in rendered
+        assert "2.0 KB" in rendered
+        assert s.open_block is None
+        assert s._tool_use_bytes == 0  # reset after close
+
+    def test_streamevent_dataclass_detected_by_render_message(self, monkeypatch):
+        # StreamEvent is a @dataclass, not a dict. Earlier code did
+        # `isinstance(message, dict)` and silently dropped every partial event.
+        # Verify duck-type detection works for dataclass-shaped objects.
+        from dataclasses import dataclass
+        from agentwire.repl.app import render_message, _StreamRenderState
+
+        @dataclass
+        class FakeStreamEvent:
+            uuid: str
+            session_id: str
+            event: dict
+            parent_tool_use_id: str | None = None
+
+        s = _StreamRenderState()
+        out = io.StringIO()
+        evt = FakeStreamEvent(
+            uuid="abc",
+            session_id="s",
+            event={"type": "content_block_start", "content_block": {"type": "text"}},
+        )
+        render_message(
+            evt,
+            AssistantMessage=FakeAssistantMessage,
+            UserMessage=FakeUserMessage,
+            SystemMessage=FakeSystemMessage,
+            ResultMessage=FakeResultMessage,
+            out=out,
+            stream_state=s,
+        )
+        # text block opened — render_message routed the partial through
+        # handle_partial. (Before the duck-type fix this was a no-op.)
+        assert s.open_block == "text"
+        assert s.streamed_text is True
+
+    def test_heartbeat_silent_during_tool_use(self):
+        # The byte counter IS the liveness signal during tool_use — adding
+        # `·` dots would corrupt the in-place CR rewrite.
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start",
+             "content_block": {"type": "tool_use", "name": "Write"}},
+            out,
+        )
+        before = out.getvalue()
+        s.heartbeat(out)
+        s.heartbeat(out)
+        after = out.getvalue()
+        # Heartbeat is a no-op during tool_use.
+        assert before == after
 
     def test_assistant_skips_streamed_text(self, monkeypatch):
         # When partials already streamed text, the snapshot AssistantMessage


### PR DESCRIPTION
## Summary

Last PR (#123) shipped the partial-message scaffolding but the end-user experience didn't change because of two bugs in the renderer. This PR fixes both.

- **`StreamEvent` detection was a no-op.** `claude-agent-sdk` delivers `StreamEvent` as a `@dataclass`, not a dict — the `isinstance(message, dict)` guard rejected every partial event. Switched to a duck-type check on `event` + `uuid` attrs (and absence of `content`, which distinguishes from snapshot Message types). Thinking and text now actually stream character-by-character instead of falling back to the snapshot render at message_stop.
- **Long tool-input generation was silent on purpose.** We swallow `input_json_delta` to avoid dumping raw JSON bytes into the chat — but for a 20 KB Write tool input that means ~100s of `[…still working]` heartbeats with no progress. Added a live byte counter: `[writing Write input · 4.2 KB` ticks in place via CR+clear-EOL, finalizing as `[wrote Write input · 20.6 KB]` on `content_block_stop`. The byte counter is the liveness signal during tool_use, so the heartbeat is a no-op while a tool_use block is open (avoids corrupting the in-place rewrite with stray dots).

## Test plan

- [x] `uv run pytest` — 1093 passed, 4 skipped
- [x] new tests:
  - `test_input_json_delta_shows_byte_counter` — counter writes byte count, never raw JSON
  - `test_tool_use_close_finalizes_byte_counter` — `\r[wrote Write input · 2.0 KB]\n` on stop
  - `test_streamevent_dataclass_detected_by_render_message` — duck-type detection works for `@dataclass`-shaped fakes
  - `test_heartbeat_silent_during_tool_use` — heartbeat is a no-op while tool_use block is open
- [x] live test in test-repl with a "designer-quality cheatsheet" prompt: 20.6 KB Write input, byte counter ticked from 0 to 20.6 KB across the 106s turn, thinking + final assistant text both streamed live

Built by [dotdev.dev](https://dotdev.dev)
