### PR TITLE
feat(repl): color-code output with rich for visual hierarchy

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -384,7 +384,7 @@ def render_message(
             model = data.get("model", "") or ""
             sid = (data.get("session_id") or data.get("sessionId") or "")[:8]
             parts = [p for p in [model, f"session {sid}" if sid else ""] if p]
-            out.write(f"[agent started · {' · '.join(parts)}]\n")
+            out.write(_styled(out, f"[agent started · {' · '.join(parts)}]", "dim cyan") + "\n")
         return
 
     if isinstance(message, AssistantMessage):
@@ -406,7 +406,8 @@ def render_message(
                 name = _block_attr(block, "name", "") or ""
                 inp = _block_attr(block, "input", {}) or {}
                 summary = _format_tool_input(name, inp)
-                out.write(f"[→ {name}{' ' + summary if summary else ''}]\n")
+                line = f"[→ {name}{' ' + summary if summary else ''}]"
+                out.write(_styled(out, line, "bold cyan") + "\n")
             elif btype == "thinking":
                 # Thinking already streamed live via partials → skip snapshot.
                 if stream_state is not None and stream_state.streamed_thinking:
@@ -415,7 +416,7 @@ def render_message(
                 first = thinking.split("\n", 1)[0].strip()
                 if first:
                     preview = first if len(first) <= 80 else first[:77] + "..."
-                    out.write(f"[thinking: {preview}]\n")
+                    out.write(_styled(out, f"[thinking: {preview}]", "dim") + "\n")
         if stream_state is not None:
             stream_state.reset_for_next_assistant_turn()
         return
@@ -428,7 +429,10 @@ def render_message(
                 if btype == "tool_result":
                     result_content = _block_attr(block, "content", None)
                     preview = _format_tool_result(result_content)
-                    out.write(f"[← result: {preview}]\n")
+                    is_err = bool(_block_attr(block, "is_error", False))
+                    style = "red" if is_err else "green"
+                    label = "error" if is_err else "result"
+                    out.write(_styled(out, f"[← {label}: {preview}]", style) + "\n")
         return
 
     if isinstance(message, ResultMessage):
@@ -449,9 +453,9 @@ def render_message(
         if getattr(message, "is_error", False):
             err = getattr(message, "result", None) or "unknown error"
             category = _classify_sdk_error("ResultMessage", str(err))
-            out.write(f"[error · {category}{suffix}] {err}\n")
+            out.write(_styled(out, f"[error · {category}{suffix}] {err}", "bold red") + "\n")
         else:
-            out.write(f"[done{suffix}]\n")
+            out.write(_styled(out, f"[done{suffix}]", "dim green") + "\n")
         return
 
 
@@ -967,6 +971,100 @@ def _flush(out: Any) -> None:
         flush()
 
 
+# --- Color / style ----------------------------------------------------------
+#
+# Visual hierarchy goal: the user's eye should land on the assistant's actual
+# answer first; everything bracketed is metadata and should recede. We use
+# Rich for styling because:
+#   1. It's the rendering layer Textual is built on, so the markup we write
+#      here translates 1:1 to RichLog content when we do the Textual rewrite
+#      (mission: docs/missions/agentwire-repl-textual.md).
+#   2. It handles TTY detection, NO_COLOR, color-system fallback, etc., so we
+#      don't have to.
+#
+# Style scheme (Rich style strings — translate to Textual identically):
+#   thinking      → dim                (secondary; reasoning noise)
+#   tool_progress → dim yellow         (in-flight; "byte counter ticking")
+#   tool_done     → cyan               (closed; "wrote N KB")
+#   tool_call     → bold cyan          ([→ Tool args] — the action)
+#   tool_result   → green              ([← result: ...])
+#   heartbeat     → dim                ([…still working · 5s])
+#   agent_meta    → dim cyan           ([agent started · ...])
+#   done          → dim green          ([done · tok · cost · time])
+#   error         → bold red           ([error · ...])
+#
+# Assistant text + thinking content stay uncolored — default fg is the
+# brightest, which is what we want for the actual reading material.
+
+from io import StringIO as _StyleStringIO
+
+try:
+    from rich.console import Console as _RichConsole
+
+    _STYLE_BUF = _StyleStringIO()
+    _STYLE_CONSOLE = _RichConsole(
+        file=_STYLE_BUF,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+        markup=True,
+        emoji=False,
+        soft_wrap=True,
+    )
+    _RICH_AVAILABLE = True
+except ImportError:  # pragma: no cover — rich is a required dep but stay safe
+    _RICH_AVAILABLE = False
+
+
+def _ansi_pair(style: str) -> tuple[str, str]:
+    """Return `(open, close)` ANSI sequences for a Rich style string.
+
+    Cached implicitly via the dict below — the renderer hits the same handful
+    of styles thousands of times per turn.
+    """
+    if not _RICH_AVAILABLE or not style:
+        return ("", "")
+    cached = _STYLE_CACHE.get(style)
+    if cached is not None:
+        return cached
+    _STYLE_BUF.seek(0)
+    _STYLE_BUF.truncate()
+    # Sentinel \x00 splits open codes from close codes in Rich's output.
+    _STYLE_CONSOLE.print(f"[{style}]\x00[/{style}]", end="")
+    raw = _STYLE_BUF.getvalue()
+    open_, _sep, close = raw.partition("\x00")
+    pair = (open_, close)
+    _STYLE_CACHE[style] = pair
+    return pair
+
+
+_STYLE_CACHE: dict[str, tuple[str, str]] = {}
+
+
+def _styled(out: Any, text: str, style: str) -> str:
+    """Wrap `text` in ANSI codes for `style` if `out` is a TTY, else plain."""
+    if not style:
+        return text
+    if not getattr(out, "isatty", lambda: False)():
+        return text
+    open_, close = _ansi_pair(style)
+    return f"{open_}{text}{close}"
+
+
+def _open(out: Any, style: str) -> str:
+    """Open ANSI for `style` if `out` is a TTY (used to span multiple writes)."""
+    if not style or not getattr(out, "isatty", lambda: False)():
+        return ""
+    return _ansi_pair(style)[0]
+
+
+def _close(out: Any, style: str) -> str:
+    """Close ANSI for `style` (matches `_open`)."""
+    if not style or not getattr(out, "isatty", lambda: False)():
+        return ""
+    return _ansi_pair(style)[1]
+
+
 def _format_bytes(n: int) -> str:
     """Human-readable byte count: `42 bytes`, `1.2 KB`, `3.4 MB`."""
     if n < 1024:
@@ -1013,12 +1111,16 @@ class _StreamRenderState:
             block = event.get("content_block") or {}
             btype = block.get("type")
             if btype == "thinking":
-                out.write("[thinking: ")
+                # Whole thinking block is dim — the bracket marker AND the
+                # streamed reasoning text inside. ANSI styling is sticky
+                # across writes until we emit the close on content_block_stop.
+                out.write(_open(out, "dim") + "[thinking: ")
                 self.open_block = "thinking"
                 self.streamed_thinking = True
             elif btype == "text":
                 # Newline before assistant text so it doesn't pile onto the
-                # previous line (often a tool result preview).
+                # previous line (often a tool result preview). No style — the
+                # answer is the brightest thing on screen by default.
                 out.write("\n")
                 self.open_block = "text"
                 self.streamed_text = True
@@ -1032,7 +1134,10 @@ class _StreamRenderState:
                 self._tool_use_name = name
                 self._tool_use_bytes = 0
                 self.open_block = "tool_use"
-                out.write(f"[writing {name} input · 0 bytes")
+                out.write(
+                    _open(out, "dim yellow")
+                    + f"[writing {name} input · 0 bytes"
+                )
                 _flush(out)
 
         elif etype == "content_block_delta":
@@ -1042,6 +1147,7 @@ class _StreamRenderState:
                 text = delta.get("thinking", "") or ""
                 if text:
                     # Collapse newlines inside thinking to keep the line flowing.
+                    # Style is already opened via _open — just write text.
                     out.write(text.replace("\n", " "))
                     _flush(out)
             elif dtype == "text_delta" and self.open_block == "text":
@@ -1051,22 +1157,33 @@ class _StreamRenderState:
                 partial = delta.get("partial_json") or ""
                 self._tool_use_bytes += len(partial)
                 # Refresh the line in place via CR+clear-to-EOL so the byte
-                # count ticks live without spamming new lines.
+                # count ticks live without spamming new lines. Re-open the
+                # style each time because \033[K clears any prior ANSI state.
                 out.write(
-                    f"\r\033[K[writing {self._tool_use_name} input · "
-                    f"{_format_bytes(self._tool_use_bytes)}"
+                    "\r\033[K"
+                    + _open(out, "dim yellow")
+                    + f"[writing {self._tool_use_name} input · "
+                    + _format_bytes(self._tool_use_bytes)
                 )
                 _flush(out)
 
         elif etype == "content_block_stop":
             if self.open_block == "thinking":
-                out.write("]\n")
+                out.write("]" + _close(out, "dim") + "\n")
             elif self.open_block == "text":
                 out.write("\n")
             elif self.open_block == "tool_use":
+                # Closed counter switches from dim-yellow (in-flight) to cyan
+                # (settled) — visual signal the write phase is done.
                 out.write(
-                    f"\r\033[K[wrote {self._tool_use_name} input · "
-                    f"{_format_bytes(self._tool_use_bytes)}]\n"
+                    "\r\033[K"
+                    + _styled(
+                        out,
+                        f"[wrote {self._tool_use_name} input · "
+                        f"{_format_bytes(self._tool_use_bytes)}]",
+                        "cyan",
+                    )
+                    + "\n"
                 )
                 self._tool_use_name = None
                 self._tool_use_bytes = 0
@@ -1075,13 +1192,19 @@ class _StreamRenderState:
     def close_open_block(self, out: Any) -> None:
         """Force-close any in-flight open block (e.g. before snapshot render)."""
         if self.open_block == "thinking":
-            out.write("]\n")
+            out.write("]" + _close(out, "dim") + "\n")
         elif self.open_block == "text":
             out.write("\n")
         elif self.open_block == "tool_use":
             out.write(
-                f"\r\033[K[wrote {self._tool_use_name} input · "
-                f"{_format_bytes(self._tool_use_bytes)}]\n"
+                "\r\033[K"
+                + _styled(
+                    out,
+                    f"[wrote {self._tool_use_name} input · "
+                    f"{_format_bytes(self._tool_use_bytes)}]",
+                    "cyan",
+                )
+                + "\n"
             )
             self._tool_use_name = None
             self._tool_use_bytes = 0
@@ -1113,7 +1236,9 @@ class _StreamRenderState:
             _flush(out)
             return
         if not self._heartbeat_started_inline:
-            out.write(f"[…still working · {elapsed}s")
+            # Open dim style; close on _consume_heartbeat when a real event
+            # arrives. Same dim treatment as thinking — both are "noise."
+            out.write(_open(out, "dim") + f"[…still working · {elapsed}s")
             self._heartbeat_started_inline = True
         else:
             out.write(f" · {elapsed}s")
@@ -1121,6 +1246,6 @@ class _StreamRenderState:
 
     def _consume_heartbeat(self, out: Any) -> None:
         if self._heartbeat_started_inline:
-            out.write("]\n")
+            out.write("]" + _close(out, "dim") + "\n")
             self._heartbeat_started_inline = False
             self._heartbeat_count = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "markdown>=3.5",
     "claude-agent-sdk>=0.1.0",
     "prompt_toolkit>=3.0.40",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -1145,6 +1145,59 @@ class TestStreamRenderState:
         assert s.open_block == "text"
         assert s.streamed_text is True
 
+    def test_no_ansi_codes_for_non_tty_output(self):
+        # Tests run with StringIO as `out` — isatty()==False — so no ANSI
+        # codes should ever leak into the captured output. Substring asserts
+        # in the rest of the suite depend on this.
+        s = self._state()
+        out = io.StringIO()
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "thinking"}},
+            out,
+        )
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "thinking_delta", "thinking": "plan"}},
+            out,
+        )
+        s.handle_partial({"type": "content_block_stop"}, out)
+        rendered = out.getvalue()
+        assert "\x1b[" not in rendered  # no ANSI escapes
+        assert "[thinking: plan]" in rendered
+
+    def test_ansi_codes_emitted_for_tty_output(self):
+        # When out.isatty() is True, dim-style ANSI codes wrap the thinking
+        # block. This is the visual hierarchy: thinking is secondary noise,
+        # dim makes it recede.
+        from agentwire.repl.app import _StreamRenderState
+
+        class _TTYBuffer:
+            def __init__(self):
+                self.buf = io.StringIO()
+
+            def write(self, s):
+                self.buf.write(s)
+
+            def flush(self):
+                pass
+
+            def isatty(self):
+                return True
+
+            def getvalue(self):
+                return self.buf.getvalue()
+
+        s = _StreamRenderState()
+        out = _TTYBuffer()
+        s.handle_partial(
+            {"type": "content_block_start", "content_block": {"type": "thinking"}},
+            out,
+        )
+        s.handle_partial({"type": "content_block_stop"}, out)
+        rendered = out.getvalue()
+        assert "\x1b[" in rendered  # ANSI present
+        assert "[thinking: " in rendered  # raw text still recoverable
+
     def test_heartbeat_silent_during_tool_use(self):
         # The byte counter IS the liveness signal during tool_use — adding
         # `·` dots would corrupt the in-place CR rewrite.

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "resend" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -77,6 +78,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "resend", specifier = ">=2.0.0" },
+    { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "runpod", marker = "extra == 'tts'", specifier = ">=1.6.0" },
     { name = "torch", marker = "extra == 'tts'", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

Color-codes the bracketed metadata in REPL output so the user's eye lands on the assistant's actual answer first and can skim past the noise. Uses **rich** because Textual (per `docs/missions/agentwire-repl-textual.md`) is built on Rich — the markup we write here translates 1:1 to `RichLog` content when we do the rewrite.

### Style scheme

| Marker | Style |
|---|---|
| `[thinking: ...]` | dim |
| `[…still working · 5s]` | dim |
| `[writing X input · 4.2 KB` (mid-stream) | dim yellow |
| `[wrote X input · 20.6 KB]` (settled) | cyan |
| `[→ Write file.html]` | bold cyan |
| `[← result: ...]` | green |
| `[← error: ...]` | red |
| `[agent started · ...]` | dim cyan |
| `[done · tok · cost · time]` | dim green |
| `[error · ...]` | bold red |
| assistant text | (uncolored — brightest) |

### TTY awareness

ANSI codes only emit when `out.isatty()` is True. Tests use `StringIO` (`isatty()==False`) and continue to assert substrings of the bracketed labels — those pass because text is unchanged when not a TTY.

### Implementation

- Added `rich>=13.0` to dependencies.
- `_ansi_pair(style)` renders Rich markup once into a buffer, splits open/close ANSI on a `\x00` sentinel, memoises the pair. Cached by style string.
- `_styled(out, text, style)` wraps a string when the target is a TTY.
- `_open(out, style)` / `_close(out, style)` let multi-write spans (thinking deltas, tool_use byte counter) keep the same style across many writes.

## Test plan

- [x] `uv run pytest` — 1095 passed, 4 skipped
- [x] new tests:
  - `test_no_ansi_codes_for_non_tty_output` — StringIO output never contains `\x1b[`
  - `test_ansi_codes_emitted_for_tty_output` — fake `isatty()==True` buffer gets ANSI codes wrapping bracketed text
- [x] live test in test-repl with a "colorful one-pager about prompt-injection defenses" prompt — verified all colors render correctly via `tmux capture-pane -e`: dim-cyan agent meta, dim thinking, dim-yellow byte counter ticking, cyan `[wrote 10.7 KB]`, bold-cyan `[→ Write ...]`, green `[← result: ...]`, dim-green `[done · 50.5s]`.

Built by [dotdev.dev](https://dotdev.dev)
