### PR TITLE
feat(repl): Phase 1A — flag + dispatcher fork for Textual rewrite

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -122,7 +122,40 @@ def run_repl(
     """
     if print_prompt is not None:
         return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt, roles))
+    if _should_use_textual():
+        from agentwire.repl.textual_app import run_textual_repl
+        return asyncio.run(run_textual_repl(
+            mode=mode, model=model, system_prompt=system_prompt,
+            session_name=session_name, resume=resume, roles=roles,
+            seed_message=seed_message,
+        ))
     return asyncio.run(_run_interactive(mode, model, system_prompt, session_name, resume, roles, seed_message))
+
+
+def _should_use_textual() -> bool:
+    """Decide whether to route to the Textual rewrite (Phase 1+).
+
+    Order matters:
+      1. `AGENTWIRE_REPL_TUI=textual` env flag — opt-in only during rollout.
+      2. Both stdin and stdout must be a TTY — non-TTY callers (scheduler,
+         workflow `human_gate`, piped stdin, captured stdout) keep the
+         existing line-mode path. This is load-bearing for headless work.
+      3. `import textual` must succeed — the textual dep is intentionally
+         optional during rollout; if missing, fall back rather than crash.
+    """
+    if os.environ.get("AGENTWIRE_REPL_TUI", "").lower() != "textual":
+        return False
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    try:
+        import textual  # noqa: F401
+    except ImportError:
+        sys.stderr.write(
+            "[repl: AGENTWIRE_REPL_TUI=textual but textual is not installed; "
+            "falling back to line-mode]\n"
+        )
+        return False
+    return True
 
 
 # -------- print mode (SDK-backed) --------

--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -1,0 +1,27 @@
+"""Textual-based rendering layer for `agentwire repl`.
+
+Phase 1A stub — the dispatcher in `app.py::run_repl` routes here when
+`AGENTWIRE_REPL_TUI=textual` is set on a TTY and `textual` is importable.
+
+Implementation arrives in Phase 1B (skeleton app), 1C (parity wiring),
+and 1D (tests). See `docs/missions/agentwire-repl-textual.md` for the
+phase-by-phase plan.
+"""
+
+from __future__ import annotations
+
+
+async def run_textual_repl(
+    *,
+    mode: str = "bypass",
+    model: str | None = None,
+    system_prompt: str | None = None,
+    session_name: str | None = None,
+    resume: str | None = None,
+    roles: list[str] | None = None,
+    seed_message: str | None = None,
+) -> int:
+    raise NotImplementedError(
+        "Textual REPL not yet implemented — Phase 1B (skeleton app) lands next. "
+        "Unset AGENTWIRE_REPL_TUI to use the existing line-mode REPL."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.0",
     "prompt_toolkit>=3.0.40",
     "rich>=13.0",
+    "textual>=0.80",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_repl_dispatch.py
+++ b/tests/unit/test_repl_dispatch.py
@@ -1,0 +1,148 @@
+"""Tests for `run_repl` dispatch — Phase 1A of the Textual rewrite.
+
+Decision tree:
+  1. `print_prompt is not None`         → `_run_print_mode`
+  2. AGENTWIRE_REPL_TUI=textual + TTY   → `run_textual_repl`
+  3. AGENTWIRE_REPL_TUI=textual + !TTY  → `_run_interactive`
+  4. flag unset                         → `_run_interactive`
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _stub_async(*args, **kwargs):
+    async def _coro():
+        return 0
+    return _coro()
+
+
+def _record(calls: list[str], name: str):
+    def _impl(*args, **kwargs):
+        calls.append(name)
+
+        async def _coro():
+            return 0
+        return _coro()
+    return _impl
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Wires recording stubs over each impl branch and returns the call log."""
+    log: list[str] = []
+    from agentwire.repl import app
+
+    monkeypatch.setattr(app, "_run_print_mode", _record(log, "print"))
+    monkeypatch.setattr(app, "_run_interactive", _record(log, "interactive"))
+
+    # textual_app is imported lazily inside run_repl, so patch the import target.
+    import agentwire.repl.textual_app as textual_app
+    monkeypatch.setattr(textual_app, "run_textual_repl", _record(log, "textual"))
+
+    return log
+
+
+class TestDispatch:
+    def test_print_mode_short_circuits(self, calls, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "textual")  # ignored in print mode
+        from agentwire.repl.app import run_repl
+
+        run_repl(print_prompt="hello")
+        assert calls == ["print"]
+
+    def test_flag_unset_routes_to_interactive(self, calls, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_REPL_TUI", raising=False)
+        from agentwire.repl.app import run_repl
+
+        run_repl()
+        assert calls == ["interactive"]
+
+    def test_flag_on_tty_routes_to_textual(self, calls, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "textual")
+        from agentwire.repl import app
+
+        # Both stdin and stdout must be a TTY.
+        monkeypatch.setattr(app.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(app.sys.stdout, "isatty", lambda: True, raising=False)
+
+        app.run_repl()
+        assert calls == ["textual"]
+
+    def test_flag_on_non_tty_falls_back_to_interactive(self, calls, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "textual")
+        from agentwire.repl import app
+
+        monkeypatch.setattr(app.sys.stdin, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(app.sys.stdout, "isatty", lambda: True, raising=False)
+
+        app.run_repl()
+        assert calls == ["interactive"]
+
+    def test_flag_on_stdout_only_falls_back(self, calls, monkeypatch):
+        # Both must be a TTY — stdout-only isn't enough.
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "textual")
+        from agentwire.repl import app
+
+        monkeypatch.setattr(app.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(app.sys.stdout, "isatty", lambda: False, raising=False)
+
+        app.run_repl()
+        assert calls == ["interactive"]
+
+    def test_flag_other_values_dont_route(self, calls, monkeypatch):
+        # Only "textual" enables the new path. Other values are ignored.
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "1")
+        from agentwire.repl.app import run_repl
+
+        run_repl()
+        assert calls == ["interactive"]
+
+    def test_flag_case_insensitive(self, calls, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "TEXTUAL")
+        from agentwire.repl import app
+
+        monkeypatch.setattr(app.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(app.sys.stdout, "isatty", lambda: True, raising=False)
+
+        app.run_repl()
+        assert calls == ["textual"]
+
+
+class TestStubRaises:
+    """Until Phase 1B lands, the stub raises NotImplementedError."""
+
+    def test_stub_raises(self):
+        import asyncio
+        from agentwire.repl.textual_app import run_textual_repl
+
+        with pytest.raises(NotImplementedError, match="Textual REPL not yet implemented"):
+            asyncio.run(run_textual_repl())
+
+
+class TestImportFallback:
+    """If textual import fails, dispatcher falls back to interactive."""
+
+    def test_missing_textual_falls_back(self, calls, monkeypatch, capsys):
+        monkeypatch.setenv("AGENTWIRE_REPL_TUI", "textual")
+        from agentwire.repl import app
+
+        monkeypatch.setattr(app.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(app.sys.stdout, "isatty", lambda: True, raising=False)
+
+        # Simulate textual not being importable.
+        import builtins
+        real_import = builtins.__import__
+
+        def _block_textual(name, *args, **kwargs):
+            if name == "textual":
+                raise ImportError("textual not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_textual)
+
+        app.run_repl()
+        assert calls == ["interactive"]
+        err = capsys.readouterr().err
+        assert "AGENTWIRE_REPL_TUI=textual but textual is not installed" in err

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ dependencies = [
     { name = "requests" },
     { name = "resend" },
     { name = "rich" },
+    { name = "textual" },
 ]
 
 [package.optional-dependencies]
@@ -81,6 +82,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "runpod", marker = "extra == 'tts'", specifier = ">=1.6.0" },
+    { name = "textual", specifier = ">=0.80" },
     { name = "torch", marker = "extra == 'tts'", specifier = ">=2.0.0" },
     { name = "torchaudio", marker = "extra == 'tts'", specifier = ">=2.0.0" },
     { name = "uvicorn", marker = "extra == 'stt'", specifier = ">=0.24.0" },
@@ -2021,6 +2023,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "llvmlite"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2076,6 +2090,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -2186,6 +2205,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -4715,6 +4746,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", size = 724390, upload-time = "2026-04-19T04:20:49.968Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5019,6 +5067,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 1A of the Textual REPL rewrite (per `docs/missions/agentwire-repl-textual.md`). Adds the opt-in feature flag and the dispatch fork; no Textual code yet.

- **Flag**: `AGENTWIRE_REPL_TUI=textual` (case-insensitive). Default off — every non-flagged call uses today's `_run_interactive` unchanged.
- **Dependency**: `textual>=0.80` added to `pyproject.toml`. Lazy import inside dispatcher — a missing install falls back with a stderr notice instead of crashing.
- **Stub**: `agentwire/repl/textual_app.run_textual_repl` raises `NotImplementedError` until Phase 1B.

### Decision tree

1. `print_prompt is not None` → existing `_run_print_mode` (print mode never moves to Textual — single-shot stdout pipe is the contract for `agentwire workflow run`, scheduler tasks, `human_gate` seeds).
2. `sys.stdin.isatty() and sys.stdout.isatty()` must both be true. Otherwise → existing `_run_interactive`. Protects scheduler, piped stdin, captured stdout, `human_gate` non-interactive callers.
3. `AGENTWIRE_REPL_TUI=textual` + `import textual` succeeds → `run_textual_repl`.
4. Else → existing `_run_interactive`.

## Test plan

- [x] `uv run pytest` — 1104 passed, 4 skipped
- [x] new `tests/unit/test_repl_dispatch.py` (9 tests):
  - print mode short-circuits even when flag is set
  - flag unset → interactive
  - flag on + TTY → textual
  - flag on + non-TTY (stdin or stdout) → interactive
  - non-"textual" flag values ignored
  - flag is case-insensitive
  - missing textual install → fallback + stderr warning
  - stub raises `NotImplementedError`
- [x] live smoke: `AGENTWIRE_REPL_TUI=textual` with TTY-faked stdin/stdout fires the stub raise as expected

Built by [dotdev.dev](https://dotdev.dev)
