### PR TITLE
feat(repl): Phase 1B — Textual skeleton app with SDK streaming

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -1,14 +1,465 @@
-"""Textual-based rendering layer for `agentwire repl`.
+"""Textual-based rendering layer for `agentwire repl` (Phase 1B skeleton).
 
-Phase 1A stub — the dispatcher in `app.py::run_repl` routes here when
-`AGENTWIRE_REPL_TUI=textual` is set on a TTY and `textual` is importable.
+Layout (Phase 1 — minimal; Phase 2 splits into chat + current-action with
+proportional weights):
 
-Implementation arrives in Phase 1B (skeleton app), 1C (parity wiring),
-and 1D (tests). See `docs/missions/agentwire-repl-textual.md` for the
-phase-by-phase plan.
+    ┌─ Header ─────────────────────────────┐
+    │                                      │
+    ├─ ChatLog (RichLog, fr=1) ────────────┤
+    │  > previous user turn                │
+    │  [thinking: ...]                     │
+    │  assistant text                      │
+    │  [→ tool call]                       │
+    │  [← result]                          │
+    ├─ Input (TextArea, dock=bottom) ──────┤
+    │  > tell me about prompt caching      │
+    └─ Footer ─────────────────────────────┘
+
+Event flow:
+    user types → SubmittableTextArea posts Submitted → on_input_submitted
+    → app.run_worker(_run_turn(text), exclusive=True)
+    → worker iterates client.receive_response() wrapped in _heartbeat_iter
+    → each message is post_message(SdkEvent(msg)) (thread-safe)
+    → on_sdk_event renders via render_message(out=_RichLogSink) on UI thread
+
+Workers MUST use `self.post_message(...)` — never call RichLog.write directly.
+
+Phase 1B scope: chat history + input + slash dispatch + SDK streaming. No
+persistence, no @-mentions, no permission prompts (those land in Phase 1C).
+
+See `docs/missions/agentwire-repl-textual.md` for the full plan.
 """
 
 from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.message import Message
+from textual.widgets import Footer, Header, Input, RichLog
+
+from agentwire.repl.app import (
+    BANNER,
+    DEFAULT_MODEL,
+    FULL_TOOLS,
+    RESTRICTED_TOOLS,
+    _HEARTBEAT,
+    _StreamRenderState,
+    _heartbeat_iter,
+    _mcp_enabled,
+    build_options,
+    render_message,
+)
+from agentwire.repl.commands import (
+    CONTINUE,
+    EXIT,
+    RESTART,
+    RESUME,
+    dispatch_command,
+)
+from agentwire.repl.context import load_session_context
+from agentwire.repl.state import ReplState, track_result, track_system_init
+
+
+# ----- adapters -------------------------------------------------------------
+
+
+class _RichLogSink:
+    """Adapter so `render_message(out=...)` can target a `RichLog`.
+
+    The renderer writes ANSI-bearing strings; we buffer until newline, then
+    emit each line as `Text.from_ansi(line)` so Rich parses styles faithfully.
+
+    Phase 1B trade-off — streaming partial messages (thinking, byte counter,
+    heartbeat) reach this sink as a sequence of writes terminated by a flush()
+    rather than a `\\n`. RichLog is append-only — there's no clean way to
+    update an in-flight line in place without bypassing its public API. So
+    each flush emits its current buffer as a discrete line, which means a
+    streaming thinking block shows as multiple lines (one per delta) rather
+    than one line growing in place.
+
+    Phase 2A introduces a dedicated CurrentAction widget that handles live
+    streaming properly. Until then, partial-stream output here is choppy but
+    correct; tool calls, results, agent meta, and finalized messages render
+    cleanly on their own lines.
+
+    `\\r\\033[K` in the input is the byte-counter "discard previous in-flight
+    line" signal — we honor it as "drop everything in the buffer up to and
+    including the last reset", which collapses repeated counter ticks to a
+    single visible line on close.
+    """
+
+    _CR_CLEAR = "\r\x1b[K"
+
+    def __init__(self, log: RichLog) -> None:
+        self._log = log
+        self._buf = ""
+
+    def write(self, s: str) -> None:
+        if not s:
+            return
+        if self._CR_CLEAR in s:
+            # Discard any in-flight buffer content + everything in `s` before
+            # the last reset — the byte counter is announcing a fresh value.
+            self._buf = ""
+            s = s.rsplit(self._CR_CLEAR, 1)[1]
+        self._buf += s
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            self._emit(line)
+
+    def flush(self) -> None:
+        # Emit any pending buffered content as a partial line. The choppy
+        # multi-line streaming this produces is intentional Phase 1B trade-off.
+        if self._buf:
+            self._emit(self._buf)
+            self._buf = ""
+
+    def isatty(self) -> bool:
+        # We want `_styled()` in app.py to emit ANSI; the sink renders it
+        # through Rich. Returning True here is what enables the styling.
+        return True
+
+    def _emit(self, text: str) -> None:
+        if text == "":
+            self._log.write("")
+        else:
+            self._log.write(Text.from_ansi(text))
+
+
+# ----- SDK event message ----------------------------------------------------
+
+
+class SdkEvent(Message):
+    """One SDK message (or _HEARTBEAT sentinel) handed off from the worker
+    thread to the UI thread for rendering."""
+
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+        super().__init__()
+
+
+class TurnFinished(Message):
+    """Worker signals turn complete (or cancelled). UI re-enables input."""
+
+    def __init__(self, error: str | None = None) -> None:
+        self.error = error
+        super().__init__()
+
+
+# ----- the App --------------------------------------------------------------
+
+
+class AgentwireREPL(App):
+    """Textual REPL skeleton — Phase 1B.
+
+    Phase 1B carries chat rendering + slash dispatch + SDK streaming.
+    Phase 1C wires persistence, @-mentions, permission prompts, /clear+/resume
+    lifecycle. Phase 2 splits the chat region into chat+CurrentAction.
+    """
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #chat {
+        height: 1fr;
+        border: tall $accent;
+        padding: 0 1;
+    }
+
+    #input {
+        dock: bottom;
+        height: 3;
+        border: tall $accent-lighten-1;
+    }
+
+    Header {
+        dock: top;
+    }
+
+    Footer {
+        dock: bottom;
+    }
+    """
+
+    BINDINGS = [
+        Binding("ctrl+d", "quit", "Exit"),
+        Binding("ctrl+c", "cancel_turn", "Cancel turn"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        mode: str = "bypass",
+        model: str | None = None,
+        system_prompt: str | None = None,
+        session_name: str | None = None,
+        resume: str | None = None,
+        roles: list[str] | None = None,
+        seed_message: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._cfg = dict(
+            mode=mode,
+            model=model,
+            system_prompt=system_prompt,
+            session_name=session_name,
+            resume=resume,
+            roles=roles,
+            seed_message=seed_message,
+        )
+        self.state: ReplState | None = None
+        self._client = None
+        self._client_ctx = None
+        self._sink: _RichLogSink | None = None
+        self._stream_state = _StreamRenderState()
+        self._sdk_classes: dict[str, Any] | None = None
+        self._saved_claudecode: str | None = None
+        self._exit_code = 0
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield RichLog(id="chat", markup=False, highlight=False, wrap=True, auto_scroll=True)
+        yield Input(id="input", placeholder="> ")
+        yield Footer()
+
+    # ------ lifecycle ------
+
+    async def on_mount(self) -> None:
+        chat = self.query_one("#chat", RichLog)
+        self._sink = _RichLogSink(chat)
+        self.query_one("#input", Input).focus()
+        try:
+            await self._open_session()
+        except Exception as exc:
+            self._sink.write(f"[startup error: {exc}]\n")
+            self._sink.flush()
+            return
+        if self._cfg["seed_message"]:
+            self.run_worker(
+                self._run_turn(self._cfg["seed_message"]),
+                exclusive=True,
+                name="sdk-turn",
+            )
+
+    async def on_unmount(self) -> None:
+        try:
+            if self._client_ctx is not None:
+                await self._client_ctx.__aexit__(None, None, None)
+        except Exception:
+            # Never raise during shutdown.
+            pass
+        if self._saved_claudecode is not None:
+            os.environ["CLAUDECODE"] = self._saved_claudecode
+
+    async def _open_session(self) -> None:
+        try:
+            from claude_agent_sdk import (
+                AssistantMessage,
+                ClaudeAgentOptions,
+                ClaudeSDKClient,
+                ResultMessage,
+                SystemMessage,
+                UserMessage,
+            )
+        except ImportError as exc:
+            raise RuntimeError(f"claude-agent-sdk not installed: {exc}")
+
+        self._sdk_classes = {
+            "ClaudeAgentOptions": ClaudeAgentOptions,
+            "ClaudeSDKClient": ClaudeSDKClient,
+            "AssistantMessage": AssistantMessage,
+            "UserMessage": UserMessage,
+            "SystemMessage": SystemMessage,
+            "ResultMessage": ResultMessage,
+        }
+
+        # Build state.
+        mode = self._cfg["mode"]
+        placeholder = (RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS).copy()
+        self.state = ReplState(
+            mode=mode,
+            model=self._cfg["model"] or DEFAULT_MODEL,
+            allowed_tools=placeholder,
+        )
+
+        # Roles + voice.
+        ctx = load_session_context(Path.cwd(), role_overrides=self._cfg["roles"])
+        self.state.role_names = list(ctx.role_names)
+        self.state.voice = ctx.voice
+
+        # Build options + open client. No can_use_tool yet (Phase 1C).
+        options = build_options(
+            ClaudeAgentOptions,
+            mode,
+            self._cfg["model"],
+            self._cfg["system_prompt"],
+            cwd=Path.cwd(),
+            resume_sdk_session_id=None,
+            effort=self.state.effort,
+            thinking_mode=self.state.thinking_mode,
+            can_use_tool=None,
+            session_context=ctx,
+        )
+        self.state.allowed_tools = (
+            list(options.allowed_tools)
+            if hasattr(options, "allowed_tools")
+            else list(getattr(options, "kwargs", {}).get("allowed_tools", []))
+        )
+
+        # Banner into chat.
+        self._render_banner()
+
+        # CLAUDECODE env nesting fix (mirrors _run_interactive).
+        self._saved_claudecode = os.environ.pop("CLAUDECODE", None)
+
+        # Open the SDK client.
+        self._client_ctx = ClaudeSDKClient(options=options)
+        self._client = await self._client_ctx.__aenter__()
+
+    def _render_banner(self) -> None:
+        assert self._sink is not None
+        assert self.state is not None
+        model_display = self._cfg["model"] or f"{DEFAULT_MODEL} (default)"
+        self._sink.write(BANNER.format(mode=self._cfg["mode"], model=model_display))
+        self._sink.write(
+            "Interactive mode (Textual). Enter to send · Alt+Enter for newline · "
+            "Ctrl+D to exit · Ctrl+C to cancel.\n"
+            "Type /help for commands.\n"
+        )
+        if _mcp_enabled():
+            self._sink.write(
+                "agentwire MCP server attached — /tools to see what's wired in.\n"
+            )
+        if self.state.role_names:
+            self._sink.write(f"Roles: {', '.join(self.state.role_names)}\n")
+        if self.state.voice:
+            self._sink.write(f"Voice: {self.state.voice}\n")
+        self._sink.write("\n")
+        self._sink.flush()
+
+    # ------ input handling ------
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        text = (event.value or "").strip()
+        # Clear input field for next turn.
+        event.input.value = ""
+        if not text:
+            return
+        assert self._sink is not None
+
+        # Echo the user turn into chat for readability.
+        for line in text.splitlines():
+            self._sink.write(f"> {line}\n")
+        self._sink.flush()
+
+        if text.startswith("/"):
+            action = dispatch_command(text, self.state, self._sink)
+            self._sink.flush()
+            if action == EXIT:
+                self.exit(self._exit_code)
+                return
+            if action in (RESTART, RESUME):
+                # Phase 1C wires the actual restart lifecycle. For now flag
+                # that this isn't yet implemented so users aren't surprised.
+                self._sink.write(
+                    "[/clear and /resume restart the SDK session — wired in Phase 1C]\n"
+                )
+                self._sink.flush()
+            return
+
+        # Plain user turn — fire SDK in a worker.
+        self.run_worker(
+            self._run_turn(text),
+            exclusive=True,
+            name="sdk-turn",
+        )
+
+    def action_cancel_turn(self) -> None:
+        # Cancel any in-flight worker. exclusive=True on the next run also
+        # cancels, but Ctrl+C should be eager.
+        worker = next(
+            (w for w in self.workers if w.name == "sdk-turn" and w.is_running),
+            None,
+        )
+        if worker is not None:
+            worker.cancel()
+
+    # ------ SDK turn worker ------
+
+    async def _run_turn(self, text: str) -> None:
+        assert self._client is not None
+        assert self._sink is not None
+        assert self._sdk_classes is not None
+        try:
+            await self._client.query(text)
+            async for message in _heartbeat_iter(
+                self._client.receive_response(), idle_timeout=5.0
+            ):
+                self.post_message(SdkEvent(message))
+        except asyncio.CancelledError:
+            self.post_message(TurnFinished(error="cancelled"))
+            raise
+        except Exception as exc:
+            self.post_message(TurnFinished(error=f"{type(exc).__name__}: {exc}"))
+            return
+        self.post_message(TurnFinished())
+
+    # ------ rendering on the UI thread ------
+
+    def on_sdk_event(self, event: SdkEvent) -> None:
+        assert self._sink is not None
+        assert self._sdk_classes is not None
+        msg = event.payload
+        if msg is _HEARTBEAT:
+            self._stream_state.heartbeat(self._sink)
+            self._sink.flush()
+            return
+        try:
+            render_message(
+                msg,
+                AssistantMessage=self._sdk_classes["AssistantMessage"],
+                UserMessage=self._sdk_classes["UserMessage"],
+                SystemMessage=self._sdk_classes["SystemMessage"],
+                ResultMessage=self._sdk_classes["ResultMessage"],
+                out=self._sink,
+                stream_state=self._stream_state,
+            )
+            self._sink.flush()
+            if isinstance(msg, self._sdk_classes["SystemMessage"]):
+                track_system_init(self.state, msg)
+            elif isinstance(msg, self._sdk_classes["ResultMessage"]):
+                track_result(self.state, msg)
+                if getattr(msg, "is_error", False):
+                    self._exit_code = 1
+        except Exception as exc:
+            self._sink.write(f"[render error: {exc}]\n")
+            self._sink.flush()
+
+    def on_turn_finished(self, event: TurnFinished) -> None:
+        assert self._sink is not None
+        if event.error == "cancelled":
+            self._sink.write("[turn cancelled]\n")
+            self._sink.flush()
+        elif event.error:
+            self._sink.write(f"[turn error: {event.error}]\n")
+            self._sink.flush()
+        # Refocus the input so the next turn can start typing right away.
+        try:
+            self.query_one("#input", Input).focus()
+        except Exception:
+            pass
+
+
+# ----- entry point ----------------------------------------------------------
 
 
 async def run_textual_repl(
@@ -21,7 +472,14 @@ async def run_textual_repl(
     roles: list[str] | None = None,
     seed_message: str | None = None,
 ) -> int:
-    raise NotImplementedError(
-        "Textual REPL not yet implemented — Phase 1B (skeleton app) lands next. "
-        "Unset AGENTWIRE_REPL_TUI to use the existing line-mode REPL."
+    app = AgentwireREPL(
+        mode=mode,
+        model=model,
+        system_prompt=system_prompt,
+        session_name=session_name,
+        resume=resume,
+        roles=roles,
+        seed_message=seed_message,
     )
+    await app.run_async()
+    return app._exit_code

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -439,8 +439,8 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 
 # Living checklist (update as we ship)
 
-- [ ] **Phase 1A** — flag + dispatcher
-- [ ] **Phase 1B** — Textual skeleton
+- [x] **Phase 1A** — flag + dispatcher (#127, 2026-04-25)
+- [x] **Phase 1B** — Textual skeleton (#128, 2026-04-25; uses `Input` widget — TextArea/multi-line punted to 2A; sink streams partials choppily, clean on close — proper live streaming arrives with the CurrentAction widget in 2A)
 - [ ] **Phase 1C** — persistence, mentions, prompted mode, lifecycle
 - [ ] **Phase 1D** — tests + manual smoke
 - [ ] **Phase 2A** — CurrentAction subpane + proportional weights

--- a/tests/unit/test_repl_dispatch.py
+++ b/tests/unit/test_repl_dispatch.py
@@ -110,15 +110,23 @@ class TestDispatch:
         assert calls == ["textual"]
 
 
-class TestStubRaises:
-    """Until Phase 1B lands, the stub raises NotImplementedError."""
+class TestTextualEntryPoint:
+    """Phase 1B replaces the stub with an AgentwireREPL App. Verify the
+    entry point exists and is async (without booting the actual TUI here —
+    that lives in test_repl_textual_app.py)."""
 
-    def test_stub_raises(self):
-        import asyncio
+    def test_run_textual_repl_exists(self):
+        import inspect
         from agentwire.repl.textual_app import run_textual_repl
 
-        with pytest.raises(NotImplementedError, match="Textual REPL not yet implemented"):
-            asyncio.run(run_textual_repl())
+        assert inspect.iscoroutinefunction(run_textual_repl)
+
+    def test_app_class_exposed(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+
+        # Just verify the class is importable; full lifecycle tests are in
+        # test_repl_textual_app.py.
+        assert AgentwireREPL.__name__ == "AgentwireREPL"
 
 
 class TestImportFallback:

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -1,0 +1,338 @@
+"""Phase 1B tests — Textual REPL skeleton.
+
+Covers:
+- _RichLogSink ANSI parsing
+- App boots with mocked SDK
+- TextArea submission routes through to /help
+- Plain user turn fires the worker, sink renders SDK events
+
+Phase 1C tests for persistence, mentions, prompted-mode, /clear lifecycle
+arrive in the next PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+# ---- _RichLogSink ANSI parsing --------------------------------------------
+
+
+class TestRichLogSink:
+    def test_writes_plain_text(self):
+        from agentwire.repl.textual_app import _RichLogSink
+
+        captured: list[Any] = []
+
+        class _FakeLog:
+            lines: list = []
+
+            def write(self, x):
+                captured.append(x)
+
+            def refresh(self):
+                pass
+
+        sink = _RichLogSink(_FakeLog())
+        sink.write("hello world\n")
+        assert len(captured) == 1
+        # Text.from_ansi returns a Rich Text instance; its .plain matches.
+        assert captured[0].plain == "hello world"
+
+    def test_buffers_until_newline(self):
+        # No in-place line updates in Phase 1B — the sink buffers until \n,
+        # then emits one complete line. Phase 2A's CurrentAction widget will
+        # handle live in-place streaming.
+        from agentwire.repl.textual_app import _RichLogSink
+
+        captured: list[Any] = []
+
+        class _FakeLog:
+            lines: list = []
+
+            def write(self, x):
+                captured.append(x)
+
+        sink = _RichLogSink(_FakeLog())
+        sink.write("hello ")
+        assert captured == []  # no newline yet, no emit
+        sink.write("world\n")
+        assert len(captured) == 1
+        assert captured[0].plain == "hello world"
+
+    def test_flush_emits_partial_buffer(self):
+        # The renderer calls flush() after each delta to make streaming
+        # progress visible. In Phase 1B that emits the buffered content as
+        # a line, leading to choppy multi-line streaming for partials —
+        # an intentional trade-off until Phase 2A's CurrentAction widget.
+        from agentwire.repl.textual_app import _RichLogSink
+
+        captured: list[Any] = []
+
+        class _FakeLog:
+            lines: list = []
+
+            def write(self, x):
+                captured.append(x)
+
+        sink = _RichLogSink(_FakeLog())
+        sink.write("[thinking: ")
+        sink.flush()
+        assert len(captured) == 1
+        sink.write("first delta")
+        sink.flush()
+        assert len(captured) == 2
+
+    def test_parses_ansi_escapes(self):
+        from agentwire.repl.textual_app import _RichLogSink
+
+        captured: list[Any] = []
+
+        class _FakeLog:
+            lines: list = []
+
+            def write(self, x):
+                captured.append(x)
+
+            def refresh(self):
+                pass
+
+        sink = _RichLogSink(_FakeLog())
+        sink.write("\x1b[1mbold\x1b[0m text\n")
+        assert len(captured) == 1
+        text = captured[0]
+        assert text.plain == "bold text"
+        # Rich Text spans: first 4 chars styled bold.
+        spans = text.spans
+        assert any("bold" in str(span.style).lower() for span in spans)
+
+    def test_cr_clear_collapses_buffer(self):
+        # \r\033[K means "discard everything before this point on the current
+        # line". With buffered emission, that translates to: drop whatever
+        # is in the buffer, take only the content after the last reset.
+        # The byte counter sequence ends with `]\n` which finalizes one
+        # clean [wrote X · N KB] line.
+        from agentwire.repl.textual_app import _RichLogSink
+
+        captured: list[Any] = []
+
+        class _FakeLog:
+            lines: list = []
+
+            def write(self, x):
+                captured.append(x)
+
+        sink = _RichLogSink(_FakeLog())
+        # Simulate: "[writing X · 0 bytes" → "\r\033[K[writing X · 1.2 KB"
+        # → "\r\033[K[wrote X · 1.2 KB]\n"
+        sink.write("[writing X · 0 bytes")
+        sink.write("\r\x1b[K[writing X · 1.2 KB")
+        sink.write("\r\x1b[K[wrote X · 1.2 KB]\n")
+        # Only the final closed line emits.
+        assert len(captured) == 1
+        assert captured[0].plain == "[wrote X · 1.2 KB]"
+
+    def test_isatty_returns_true(self):
+        # Required so _styled() in app.py emits ANSI codes that the sink parses.
+        from agentwire.repl.textual_app import _RichLogSink
+
+        class _FakeLog:
+            lines: list = []
+
+        sink = _RichLogSink(_FakeLog())
+        assert sink.isatty() is True
+
+
+# ---- Mock SDK ---------------------------------------------------------------
+
+
+@dataclass
+class _FakeOptions:
+    """Mirrors the bits build_options inspects."""
+    allowed_tools: list = field(default_factory=list)
+    permission_mode: str = "bypassPermissions"
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeUserMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeSystemMessage:
+    def __init__(self, subtype="init", data=None):
+        self.subtype = subtype
+        self.data = data or {}
+
+
+class _FakeResultMessage:
+    def __init__(self, *, total_cost_usd=0.0, duration_ms=0, usage=None, is_error=False, result=None):
+        self.total_cost_usd = total_cost_usd
+        self.duration_ms = duration_ms
+        self.usage = usage or {}
+        self.is_error = is_error
+        self.result = result
+
+
+class _FakeClient:
+    """Mocks ClaudeSDKClient — async context manager + query/receive_response."""
+
+    def __init__(self, options=None, **kwargs):
+        self.options = options
+        self._scripted: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def query(self, text: str) -> None:
+        self._last_query = text
+
+    def script(self, messages: list) -> None:
+        self._scripted = list(messages)
+
+    def receive_response(self):
+        scripted = self._scripted
+        self._scripted = []
+
+        async def _gen():
+            for msg in scripted:
+                await asyncio.sleep(0)  # let other tasks see it
+                yield msg
+
+        return _gen()
+
+
+@pytest.fixture
+def patched_sdk(monkeypatch):
+    """Patches `claude_agent_sdk` imports inside textual_app._open_session."""
+    fakes = {
+        "ClaudeAgentOptions": _FakeOptions,
+        "ClaudeSDKClient": _FakeClient,
+        "AssistantMessage": _FakeAssistantMessage,
+        "UserMessage": _FakeUserMessage,
+        "SystemMessage": _FakeSystemMessage,
+        "ResultMessage": _FakeResultMessage,
+    }
+
+    # Build a fake module to satisfy `from claude_agent_sdk import ...`.
+    import types
+    fake_module = types.ModuleType("claude_agent_sdk")
+    for name, cls in fakes.items():
+        setattr(fake_module, name, cls)
+
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_module)
+
+    # Also stub build_options since it imports from claude_agent_sdk and may
+    # call methods on the real classes. We just need it to return an
+    # object with an allowed_tools attribute.
+    from agentwire.repl import textual_app
+
+    def _fake_build_options(ClaudeAgentOptions, mode, model, system_prompt, **kwargs):
+        return _FakeOptions(allowed_tools=["Read", "Bash", "Edit"])
+
+    monkeypatch.setattr(textual_app, "build_options", _fake_build_options)
+    return fakes
+
+
+# ---- App boots --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_boots_and_renders_banner(patched_sdk):
+    from agentwire.repl.textual_app import AgentwireREPL
+
+    app = AgentwireREPL(mode="bypass", model="claude-opus-4-7")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat").lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "agentwire repl" in all_text
+        assert "claude-opus-4-7" in all_text
+
+
+@pytest.mark.asyncio
+async def test_help_command_writes_to_chat(patched_sdk):
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "/help"
+        await inp.action_submit()
+        await pilot.pause()
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat").lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "Available commands" in all_text or "help" in all_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_user_turn_fires_worker_and_renders_sdk_events(patched_sdk):
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Script the fake client to emit a SystemMessage(init) + ResultMessage.
+        # Need to grab the actual instance the app opened.
+        client = app._client
+        assert isinstance(client, _FakeClient)
+        client.script([
+            _FakeSystemMessage(subtype="init", data={"model": "claude-opus-4-7", "session_id": "abc12345"}),
+            _FakeResultMessage(total_cost_usd=0.0042, duration_ms=1500,
+                               usage={"input_tokens": 10, "output_tokens": 5}),
+        ])
+
+        inp = app.query_one("#input", Input)
+        inp.value = "hello"
+        await inp.action_submit()
+
+        # Let the worker run + post events back.
+        for _ in range(20):
+            await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat").lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "agent started" in all_text
+        assert "claude-opus-4-7" in all_text
+        # ResultMessage produces "[done · ...]"
+        assert "done" in all_text
+
+
+@pytest.mark.asyncio
+async def test_exit_command_quits_app(patched_sdk):
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "/exit"
+        await inp.action_submit()
+        await pilot.pause()
+        # After /exit, the app exits — return_code is set.
+        assert app.return_code == 0 or not app.is_running


### PR DESCRIPTION
## Summary

Phase 1B of the Textual REPL rewrite (per `docs/missions/agentwire-repl-textual.md`). Implements the `AgentwireREPL` Textual App, replacing the Phase 1A stub. Still behind `AGENTWIRE_REPL_TUI=textual`.

### Architecture

```
TextArea Input.Submitted → app.on_input_submitted → app.run_worker(_run_turn(text), exclusive=True)
                                                       ↓
                                                  client.query(text)
                                                  async for msg in _heartbeat_iter(client.receive_response()):
                                                      self.post_message(SdkEvent(msg))    # thread-safe

App.on_sdk_event(SdkEvent) → render_message(msg, ..., out=_RichLogSink) on UI thread
```

- Layout: `Header` / `RichLog` (id=#chat) / `Input` (id=#input, dock=bottom) / `Footer`
- Workers MUST use `self.post_message(...)` — never call `RichLog.write` from a worker (documented in module header)
- `exclusive=True` cancels any in-flight turn (matches today's Ctrl+C semantics)
- Slash commands dispatch through the existing `commands.py` via a `RichLog`-shaped sink — no changes to `commands.py`

### Phase 1B trade-offs

These are documented in `textual_app.py`:

- **Input widget instead of TextArea**: original plan was `TextArea` with Enter=submit / Alt+Enter=newline, but Textual `TextArea` key bindings don't preempt the widget's default newline insert in smoke tests. `Input` has built-in `Submitted` semantics and works out of the box. Multi-line input punted to **Phase 2A** when we redesign the input region.
- **Choppy partial-stream display**: `_RichLogSink` buffers writes until newline and emits one `Text.from_ansi(line)` to `RichLog` on each flush. Streaming partials (thinking, byte counter ticks) get one RichLog entry per delta — live but multi-line. **Phase 2A's CurrentAction widget handles proper in-place streaming.** Tool calls, results, agent meta, and finalized messages all render cleanly.
- **`\r\033[K` byte-counter resets** are honored by collapsing the buffer, so the close `[wrote X · N KB]` lands as a single clean line.
- **/clear and /resume** show a "Phase 1C wires this" hint — actual restart lifecycle (close+reopen `ClaudeSDKClient`) is the next PR.

### Verified live in tmux

- Agent boot + banner with mode/model/roles/voice
- `/help` dispatch (full command list rendered)
- Real SDK turn against Opus 4.7 with MCP tools (`mcp__agentwire__say`, `Bash`)
- Byte counter close (`[wrote Bash input · 149 bytes]` as one line via `\r\033[K` collapse)
- Tool calls, tool results, turn-finished cleanup
- `/exit` cleanly returns 0

## Test plan

- [x] `uv run pytest` — 1115 passed, 4 skipped
- [x] new `tests/unit/test_repl_textual_app.py` (10 tests):
  - `_RichLogSink`: plain text, ANSI parse, buffering until newline, flush emits partial buffer, `\r\033[K` collapse, `isatty()` returns True
  - App boots and renders banner with mocked SDK
  - `/help` dispatch writes commands to chat
  - Full turn fires worker, scripts a `SystemMessage(init) + ResultMessage`, asserts `[agent started]` and `[done]` render
  - `/exit` quits app
- [x] updated `test_repl_dispatch.py` to verify the new entry point shape (no longer a stub)
- [x] live tmux smoke

## Coming next

**Phase 1C**: persistence, `@`-mention expansion, `sdk-prompted` permission prompt placeholder, `/clear`/`/resume` lifecycle, banner parity polish.

Built by [dotdev.dev](https://dotdev.dev)
