### PR TITLE
feat(repl): Phase 1C — persistence, mentions, prompted mode, lifecycle

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -1,4 +1,4 @@
-"""Textual-based rendering layer for `agentwire repl` (Phase 1B skeleton).
+"""Textual-based rendering layer for `agentwire repl` (Phase 1C parity).
 
 Layout (Phase 1 — minimal; Phase 2 splits into chat + current-action with
 proportional weights):
@@ -24,8 +24,11 @@ Event flow:
 
 Workers MUST use `self.post_message(...)` — never call RichLog.write directly.
 
-Phase 1B scope: chat history + input + slash dispatch + SDK streaming. No
-persistence, no @-mentions, no permission prompts (those land in Phase 1C).
+Phase 1C scope: full feature parity with the legacy line-mode REPL —
+transcript persistence, @-mention expansion, sdk-prompted permission
+prompts (inline placeholder), /clear and /resume lifecycle (close+reopen
+ClaudeSDKClient with new options), CLAUDECODE env handling, resume
+lookup via persistence.load_session.
 
 See `docs/missions/agentwire-repl-textual.md` for the full plan.
 """
@@ -44,6 +47,7 @@ from textual.binding import Binding
 from textual.message import Message
 from textual.widgets import Footer, Header, Input, RichLog
 
+from agentwire.repl import persistence
 from agentwire.repl.app import (
     BANNER,
     DEFAULT_MODEL,
@@ -51,8 +55,10 @@ from agentwire.repl.app import (
     RESTRICTED_TOOLS,
     _HEARTBEAT,
     _StreamRenderState,
+    _format_tool_input,
     _heartbeat_iter,
     _mcp_enabled,
+    _persist_sdk_message,
     build_options,
     render_message,
 )
@@ -64,7 +70,13 @@ from agentwire.repl.commands import (
     dispatch_command,
 )
 from agentwire.repl.context import load_session_context
-from agentwire.repl.state import ReplState, track_result, track_system_init
+from agentwire.repl.mentions import expand_mentions
+from agentwire.repl.state import (
+    ReplState,
+    reset_for_restart,
+    track_result,
+    track_system_init,
+)
 
 
 # ----- adapters -------------------------------------------------------------
@@ -224,6 +236,13 @@ class AgentwireREPL(App):
         self._sdk_classes: dict[str, Any] | None = None
         self._saved_claudecode: str | None = None
         self._exit_code = 0
+        self._transcript = None
+        self._ctx = None
+        # When sdk-prompted is asking for a tool decision, this holds the
+        # asyncio.Future the can_use_tool callback awaits. The input handler
+        # routes the next user submission as the answer instead of as a turn.
+        self._pending_permission: asyncio.Future | None = None
+        self._pending_tool_name: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -257,6 +276,12 @@ class AgentwireREPL(App):
         except Exception:
             # Never raise during shutdown.
             pass
+        if self._transcript is not None and self.state is not None:
+            try:
+                persistence.finalize(self._transcript, self.state)
+                self._transcript.close()
+            except Exception:
+                pass
         if self._saved_claudecode is not None:
             os.environ["CLAUDECODE"] = self._saved_claudecode
 
@@ -282,6 +307,19 @@ class AgentwireREPL(App):
             "ResultMessage": ResultMessage,
         }
 
+        # Resume lookup — find the prior session's last sdk_session_id.
+        resume_sdk_session_id: str | None = None
+        if self._cfg["resume"]:
+            prior = persistence.load_session(self._cfg["resume"])
+            if prior is None:
+                raise RuntimeError(
+                    f"no session named {self._cfg['resume']!r} under "
+                    f"{persistence.DEFAULT_REPL_HOME}"
+                )
+            ids = prior.get("sdk_session_ids") or []
+            if ids:
+                resume_sdk_session_id = ids[-1]
+
         # Build state.
         mode = self._cfg["mode"]
         placeholder = (RESTRICTED_TOOLS if mode == "restricted" else FULL_TOOLS).copy()
@@ -292,22 +330,23 @@ class AgentwireREPL(App):
         )
 
         # Roles + voice.
-        ctx = load_session_context(Path.cwd(), role_overrides=self._cfg["roles"])
-        self.state.role_names = list(ctx.role_names)
-        self.state.voice = ctx.voice
+        self._ctx = load_session_context(Path.cwd(), role_overrides=self._cfg["roles"])
+        self.state.role_names = list(self._ctx.role_names)
+        self.state.voice = self._ctx.voice
 
-        # Build options + open client. No can_use_tool yet (Phase 1C).
+        # Build options + open client. can_use_tool only in sdk-prompted.
+        can_use_tool = self._make_can_use_tool() if mode == "prompted" else None
         options = build_options(
             ClaudeAgentOptions,
             mode,
             self._cfg["model"],
             self._cfg["system_prompt"],
             cwd=Path.cwd(),
-            resume_sdk_session_id=None,
+            resume_sdk_session_id=resume_sdk_session_id,
             effort=self.state.effort,
             thinking_mode=self.state.thinking_mode,
-            can_use_tool=None,
-            session_context=ctx,
+            can_use_tool=can_use_tool,
+            session_context=self._ctx,
         )
         self.state.allowed_tools = (
             list(options.allowed_tools)
@@ -315,8 +354,25 @@ class AgentwireREPL(App):
             else list(getattr(options, "kwargs", {}).get("allowed_tools", []))
         )
 
+        # Transcript persistence (mirrors legacy REPL).
+        self._transcript = persistence.create_session(
+            mode=mode,
+            model=self._cfg["model"] or DEFAULT_MODEL,
+            allowed_tools=self.state.allowed_tools,
+            name=self._cfg["session_name"],
+        )
+        self.state.session_dir = str(self._transcript.session_dir)
+        self.state.transcript_name = self._transcript.name
+
         # Banner into chat.
         self._render_banner()
+        if resume_sdk_session_id:
+            self._sink.write(
+                f"Resuming {self._cfg['resume']!r} "
+                f"(sdk session {resume_sdk_session_id[:8]}…)\n"
+            )
+        self._sink.write(f"[transcript → {self._transcript.session_dir}]\n\n")
+        self._sink.flush()
 
         # CLAUDECODE env nesting fix (mirrors _run_interactive).
         self._saved_claudecode = os.environ.pop("CLAUDECODE", None)
@@ -346,12 +402,115 @@ class AgentwireREPL(App):
         self._sink.write("\n")
         self._sink.flush()
 
+    def _make_can_use_tool(self):
+        """Permission callback for `sdk-prompted` mode.
+
+        Phase 1C placeholder — surfaces a `[? allow Tool args? (y/n/a)]`
+        line in the chat log, parks an asyncio.Future, and routes the next
+        user submission as the answer instead of as a turn. Phase 2C
+        replaces this with a centered `ModalScreen`.
+        """
+        async def _can_use_tool(tool_name: str, tool_input: dict, ctx: Any):
+            from claude_agent_sdk import (
+                PermissionResultAllow,
+                PermissionResultDeny,
+            )
+
+            if tool_name in self.state.always_allow_tools:
+                return PermissionResultAllow()
+
+            summary = _format_tool_input(tool_name, tool_input or {})
+            line = f"[? allow {tool_name}{' ' + summary if summary else ''}? (y/n/a=always)]"
+            self._sink.write(line + "\n")
+            self._sink.flush()
+
+            loop = asyncio.get_event_loop()
+            future: asyncio.Future = loop.create_future()
+            self._pending_permission = future
+            self._pending_tool_name = tool_name
+            try:
+                answer = await future
+            except asyncio.CancelledError:
+                return PermissionResultDeny(message="user denied (cancelled)")
+            finally:
+                self._pending_permission = None
+                self._pending_tool_name = None
+
+            answer = (answer or "").strip().lower()
+            if answer in ("a", "always"):
+                self.state.always_allow_tools.add(tool_name)
+                self._sink.write(
+                    f"[allow · {tool_name} now always allowed this session]\n"
+                )
+                self._sink.flush()
+                return PermissionResultAllow()
+            if answer in ("", "y", "yes"):
+                return PermissionResultAllow()
+            self._sink.write(f"[deny · {tool_name}]\n")
+            self._sink.flush()
+            return PermissionResultDeny(message="user denied")
+
+        return _can_use_tool
+
+    async def _restart_session(self) -> None:
+        """Close+reopen the SDK client for /clear, /resume, /effort, /thinking."""
+        assert self.state is not None
+        assert self._sdk_classes is not None
+
+        next_resume_id = self.state.pending_resume_sdk_session_id
+        self.state.pending_resume_sdk_session_id = None
+
+        # Close current client first.
+        try:
+            if self._client_ctx is not None:
+                await self._client_ctx.__aexit__(None, None, None)
+        except Exception:
+            pass
+        self._client = None
+        self._client_ctx = None
+
+        # Rebuild options with possibly-new effort/thinking/resume.
+        can_use_tool = (
+            self._make_can_use_tool() if self._cfg["mode"] == "prompted" else None
+        )
+        options = build_options(
+            self._sdk_classes["ClaudeAgentOptions"],
+            self._cfg["mode"],
+            self._cfg["model"],
+            self._cfg["system_prompt"],
+            cwd=Path.cwd(),
+            resume_sdk_session_id=next_resume_id,
+            effort=self.state.effort,
+            thinking_mode=self.state.thinking_mode,
+            can_use_tool=can_use_tool,
+            session_context=self._ctx,
+        )
+
+        # Record the restart.
+        if self._transcript is not None:
+            self._transcript.write_event({
+                "type": "restart",
+                "resume_sdk_session_id": next_resume_id,
+            })
+        reset_for_restart(self.state)
+
+        # Reopen.
+        self._client_ctx = self._sdk_classes["ClaudeSDKClient"](options=options)
+        self._client = await self._client_ctx.__aenter__()
+
     # ------ input handling ------
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         text = (event.value or "").strip()
-        # Clear input field for next turn.
         event.input.value = ""
+
+        # Permission-pending branch: if sdk-prompted is awaiting a y/n/a
+        # answer, the next submission is the answer (not a slash command,
+        # not a turn).
+        if self._pending_permission is not None and not self._pending_permission.done():
+            self._pending_permission.set_result(text)
+            return
+
         if not text:
             return
         assert self._sink is not None
@@ -368,17 +527,36 @@ class AgentwireREPL(App):
                 self.exit(self._exit_code)
                 return
             if action in (RESTART, RESUME):
-                # Phase 1C wires the actual restart lifecycle. For now flag
-                # that this isn't yet implemented so users aren't surprised.
-                self._sink.write(
-                    "[/clear and /resume restart the SDK session — wired in Phase 1C]\n"
+                self.run_worker(
+                    self._restart_session(),
+                    exclusive=True,
+                    name="sdk-restart",
                 )
-                self._sink.flush()
             return
 
-        # Plain user turn — fire SDK in a worker.
+        # Expand @path mentions before sending (mirrors legacy REPL).
+        expanded_text, expansions = expand_mentions(text, cwd=Path.cwd())
+        if expansions:
+            count = len(expansions)
+            self._sink.write(
+                f"[expanded {count} mention"
+                f"{'s' if count != 1 else ''}: "
+                f"{', '.join(e.raw for e in expansions)}]\n"
+            )
+            self._sink.flush()
+
+        # Persist the user turn before firing the SDK.
+        if self._transcript is not None:
+            event_data: dict = {"type": "user_input", "text": text}
+            if expansions:
+                event_data["expanded_text"] = expanded_text
+                event_data["mentions"] = [
+                    {"raw": e.raw, "target": e.target} for e in expansions
+                ]
+            self._transcript.write_event(event_data)
+
         self.run_worker(
-            self._run_turn(text),
+            self._run_turn(expanded_text),
             exclusive=True,
             name="sdk-turn",
         )
@@ -434,8 +612,21 @@ class AgentwireREPL(App):
                 stream_state=self._stream_state,
             )
             self._sink.flush()
+            if self._transcript is not None:
+                _persist_sdk_message(
+                    msg,
+                    self._transcript,
+                    self._sdk_classes["AssistantMessage"],
+                    self._sdk_classes["UserMessage"],
+                    self._sdk_classes["SystemMessage"],
+                    self._sdk_classes["ResultMessage"],
+                )
             if isinstance(msg, self._sdk_classes["SystemMessage"]):
                 track_system_init(self.state, msg)
+                if self.state.session_id and self._transcript is not None:
+                    persistence.record_session_id(
+                        self._transcript, self.state.session_id
+                    )
             elif isinstance(msg, self._sdk_classes["ResultMessage"]):
                 track_result(self.state, msg)
                 if getattr(msg, "is_error", False):

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -441,7 +441,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 
 - [x] **Phase 1A** — flag + dispatcher (#127, 2026-04-25)
 - [x] **Phase 1B** — Textual skeleton (#128, 2026-04-25; uses `Input` widget — TextArea/multi-line punted to 2A; sink streams partials choppily, clean on close — proper live streaming arrives with the CurrentAction widget in 2A)
-- [ ] **Phase 1C** — persistence, mentions, prompted mode, lifecycle
+- [x] **Phase 1C** — persistence, mentions, prompted mode, lifecycle (#129, 2026-04-25)
 - [ ] **Phase 1D** — tests + manual smoke
 - [ ] **Phase 2A** — CurrentAction subpane + proportional weights
 - [ ] **Phase 2B** — Header + StatusLine

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -13,7 +13,9 @@ arrive in the next PR.
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -320,6 +322,133 @@ async def test_user_turn_fires_worker_and_renders_sdk_events(patched_sdk):
         assert "claude-opus-4-7" in all_text
         # ResultMessage produces "[done · ...]"
         assert "done" in all_text
+
+
+@pytest.mark.asyncio
+async def test_user_turn_writes_transcript_event(patched_sdk, tmp_path, monkeypatch):
+    # Persistence parity: each user turn writes a `user_input` event,
+    # finalize() runs on unmount, and metadata.json/transcript.jsonl exist.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        assert isinstance(client, _FakeClient)
+        client.script([
+            _FakeSystemMessage(subtype="init", data={"model": "claude-opus-4-7", "session_id": "deadbeef"}),
+            _FakeResultMessage(total_cost_usd=0.01, duration_ms=500,
+                               usage={"input_tokens": 5, "output_tokens": 3}),
+        ])
+
+        inp = app.query_one("#input", Input)
+        inp.value = "hello world"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        session_dir = app.state.session_dir
+        events_path = Path(session_dir) / "transcript.jsonl"
+        assert events_path.exists()
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        kinds = [e.get("type") for e in events]
+        assert "user_input" in kinds
+        # Finalize happens on unmount — verify metadata.json exists after.
+    metadata = Path(session_dir) / "metadata.json"
+    assert metadata.exists()
+
+
+@pytest.mark.asyncio
+async def test_at_mention_expands_and_records(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "notes.txt").write_text("hello mention\n")
+
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([_FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={})])
+
+        inp = app.query_one("#input", Input)
+        inp.value = "summarize @notes.txt"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat").lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "expanded 1 mention" in all_text or "@notes.txt" in all_text
+
+        events_path = Path(app.state.session_dir) / "transcript.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        user_events = [e for e in events if e.get("type") == "user_input"]
+        assert len(user_events) == 1
+        assert "mentions" in user_events[0]
+        assert user_events[0]["mentions"][0]["raw"] == "@notes.txt"
+
+
+@pytest.mark.asyncio
+async def test_clear_writes_restart_event(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        starting_restart_count = app.state.restart_count
+
+        inp = app.query_one("#input", Input)
+        inp.value = "/clear"
+        await inp.action_submit()
+        # Let the restart worker run.
+        for _ in range(10):
+            await pilot.pause()
+
+        assert app.state.restart_count == starting_restart_count + 1
+        events_path = Path(app.state.session_dir) / "transcript.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        kinds = [e.get("type") for e in events]
+        assert "restart" in kinds
+
+
+@pytest.mark.asyncio
+async def test_prompted_mode_routes_answer_to_permission(patched_sdk, tmp_path, monkeypatch):
+    # The next user submission while a permission Future is pending
+    # answers the prompt instead of starting a new turn.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")  # bypass so init doesn't need real SDK perms
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Manually park a Future on the app — simulates can_use_tool awaiting.
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+        app._pending_permission = future
+        app._pending_tool_name = "Bash"
+
+        inp = app.query_one("#input", Input)
+        inp.value = "y"
+        await inp.action_submit()
+        await pilot.pause()
+
+        assert future.done()
+        assert future.result() == "y"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Phase 1C of the Textual REPL rewrite. Brings the new path to full feature parity with the legacy line-mode REPL — every behavior in `_run_sdk_session` is now wired in `textual_app.py`. Still behind `AGENTWIRE_REPL_TUI=textual`.

### What's new

- **Transcript persistence**: `persistence.create_session` in `on_mount`; every rendered SDK message goes through `_persist_sdk_message`; user turns write a `user_input` event before `client.query`; `on_unmount` runs `persistence.finalize` + `transcript.close`. Records the SDK `session_id` on `track_system_init`.
- **`@`-mention expansion**: `expand_mentions(text, cwd=Path.cwd())` before `client.query`; expansion notice prints to chat; the `user_input` transcript event records both raw text and the resolved `mentions[]`.
- **`/clear`, `/resume`, `/effort`, `/thinking` lifecycle**: `dispatch_command` returning `RESTART`/`RESUME` triggers a `_restart_session` worker that closes the current `ClaudeSDKClient`, rebuilds options with possibly-new `effort`/`thinking`/`resume`, writes a `restart` event, calls `reset_for_restart(state)`, reopens the client.
- **Resume lookup**: `persistence.load_session(name)` reads the prior session's last `sdk_session_id` and threads it through `build_options`.
- **`sdk-prompted` permission prompt placeholder**: `_make_can_use_tool` surfaces `[? allow Tool args? (y/n/a=always)]` in chat, parks an `asyncio.Future`, routes the next user submission as the answer instead of as a turn (or slash). Phase 2C replaces this with a centered `ModalScreen`.
- **CLAUDECODE env nesting fix** preserved (pop on mount, restore on unmount).

### Verified live

- `/clear` renders the restart message and writes a `restart` event
- Real SDK turn after `/clear` streams correctly
- `transcript.jsonl` contains: `restart → user_input → session → agent_start → message_end → turn_end → agent_end`
- `metadata.json` writes on unmount

## Test plan

- [x] `uv run pytest` — 1119 passed, 4 skipped
- [x] new tests (4 in `test_repl_textual_app.py`):
  - `test_user_turn_writes_transcript_event` — `user_input` event + finalize persists metadata
  - `test_at_mention_expands_and_records` — expansion notice in chat, `mentions[]` in transcript event
  - `test_clear_writes_restart_event` — `/clear` increments `state.restart_count` and writes `restart` event
  - `test_prompted_mode_routes_answer_to_permission` — pending permission Future resolved by next user submission
- [x] live tmux smoke

## Coming next

**Phase 1D**: round out tests, manual smoke, mark Phase 1 shipped (and surface the parity caveats to a default-flip plan).

Built by [dotdev.dev](https://dotdev.dev)
