### PR TITLE
feat(repl): Phase 1D — test pass + flag-flip readiness

### DIFF
--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -5,7 +5,7 @@
 A from-scratch rendering layer for `agentwire repl` built on [Textual](https://github.com/textualize/textual). The current `prompt_toolkit` line-oriented loop hit its ceiling: there's no way to keep streaming partial output visible without flooding the chat history, no proportional layout, no borders/titles, no docked status line, no scrollable subregion for "what claude is doing right now". Textual gives all of that out of the box.
 
 **Phase of:** own mission (sibling of `agentwire-repl.md`)
-**Status:** **plans fleshed out (2026-04-25). Ready to execute Phase 1A.** Phase 1-3 implementation plans live in this doc; living checklist at bottom tracks shipping.
+**Status:** **Phase 1 shipped (parity, 2026-04-25). Phase 2A next.** The Textual REPL is feature-complete behind `AGENTWIRE_REPL_TUI=textual` — chat history, slash commands, persistence, mentions, prompted-mode, /clear+/resume lifecycle all parity with the legacy line-mode path. Live partial streaming is intentionally choppy in Phase 1 (one RichLog entry per delta on flush); Phase 2A's CurrentAction subpane fixes that with proper in-place streaming.
 **Depends on:** `agentwire-repl.md` Phases 1-5 (complete) + streaming-visibility quick fixes (#123-#125 shipped 2026-04-25)
 **Blocks:** future REPL feature work that needs richer layout (mode badges, modal permission prompts, inline waveform for /say, etc.)
 
@@ -282,6 +282,18 @@ Mock `claude_agent_sdk.ClaudeSDKClient` with a fake whose `receive_response()` y
 
 **Don't add `pytest-textual-snapshot` here** — that's Phase 3. Snapshot maintenance overhead before parity is shipped is premature.
 
+## Phase 1 ship status (2026-04-25)
+
+Phase 1 is feature-complete behind the flag. To flip the default in Phase 2D, the soak window must validate:
+
+- [ ] No regressions vs legacy REPL across a 1-week daily-driver window
+- [ ] `transcript.jsonl` shape matches legacy (verified via `diff` of golden runs)
+- [ ] `human_gate` non-TTY callers stay on the line-mode path (test_repl_dispatch covers this)
+- [ ] Multi-line input (Alt+Enter) works — currently `Input` is single-line only; Phase 2A swaps to `TextArea` when redesigning the input region
+- [ ] Live partial streaming reads cleanly — currently choppy; Phase 2A's CurrentAction subpane fixes this
+
+When all green: Phase 2D removes the `AGENTWIRE_REPL_TUI` env check, makes `textual` a hard dep, deletes `_run_interactive` (keeping `_run_print_mode` since print mode never moves to Textual).
+
 ## What stays unchanged across all of Phase 1
 
 These files are imported and reused as-is — no edits:
@@ -442,7 +454,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 1A** — flag + dispatcher (#127, 2026-04-25)
 - [x] **Phase 1B** — Textual skeleton (#128, 2026-04-25; uses `Input` widget — TextArea/multi-line punted to 2A; sink streams partials choppily, clean on close — proper live streaming arrives with the CurrentAction widget in 2A)
 - [x] **Phase 1C** — persistence, mentions, prompted mode, lifecycle (#129, 2026-04-25)
-- [ ] **Phase 1D** — tests + manual smoke
+- [x] **Phase 1D** — tests + manual smoke (#130, 2026-04-25; 17 textual tests; ready for soak before flag-flip in Phase 2D)
 - [ ] **Phase 2A** — CurrentAction subpane + proportional weights
 - [ ] **Phase 2B** — Header + StatusLine
 - [ ] **Phase 2C** — tool-call collapse + permission ModalScreen

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -465,3 +465,84 @@ async def test_exit_command_quits_app(patched_sdk):
         await pilot.pause()
         # After /exit, the app exits — return_code is set.
         assert app.return_code == 0 or not app.is_running
+
+
+@pytest.mark.asyncio
+async def test_result_with_error_sets_exit_code(patched_sdk, tmp_path, monkeypatch):
+    # Parity with legacy REPL: a ResultMessage carrying is_error=True should
+    # set exit_code=1 so the process returns non-zero.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([
+            _FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={},
+                               is_error=True, result="boom"),
+        ])
+        inp = app.query_one("#input", Input)
+        inp.value = "trigger error"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+        assert app._exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_message_fires_first_turn(patched_sdk, tmp_path, monkeypatch):
+    # Workflow human_gate runners pass seed_message — it should fire as the
+    # first turn after on_mount instead of waiting for user input.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+
+    app = AgentwireREPL(mode="bypass", seed_message="hello from seed")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        # Worker fires immediately on mount because seed_message is set.
+        # The worker calls client.query — verify it received the seed text.
+        for _ in range(10):
+            await pilot.pause()
+            if getattr(client, "_last_query", None) == "hello from seed":
+                break
+        assert client._last_query == "hello from seed"
+
+
+@pytest.mark.asyncio
+async def test_unmount_finalizes_transcript_with_running_totals(
+    patched_sdk, tmp_path, monkeypatch
+):
+    # metadata.json on unmount should reflect cost/token totals from any
+    # ResultMessages tracked during the session.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([
+            _FakeResultMessage(
+                total_cost_usd=0.5,
+                duration_ms=2000,
+                usage={"input_tokens": 100, "output_tokens": 200},
+            ),
+        ])
+        inp = app.query_one("#input", Input)
+        inp.value = "go"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+        session_dir = app.state.session_dir
+
+    # After context exit (on_unmount fired): metadata reflects totals.
+    metadata = json.loads((Path(session_dir) / "metadata.json").read_text())
+    assert metadata["turn_count"] >= 1
+    assert metadata["total_cost_usd"] >= 0.5


### PR DESCRIPTION
## Summary

Phase 1D — test pass + flag-flip readiness. Closes Phase 1.

### New tests (3)

- `test_result_with_error_sets_exit_code` — `ResultMessage(is_error=True)` sets `app._exit_code=1`, parity with legacy REPL's nonzero exit
- `test_seed_message_fires_first_turn` — workflow `human_gate` runners pass `seed_message`; the worker fires it as the first turn from `on_mount` instead of waiting for user input
- `test_unmount_finalizes_transcript_with_running_totals` — `metadata.json` on unmount reflects cost/token totals from tracked `ResultMessage`s

### Mission doc

- Marks Phase 1 status as **shipped (parity)** at the top
- Adds a "Phase 1 ship status" section enumerating the soak gates that unblock the default flip in Phase 2D:
  - 1-week daily-driver soak with no regressions
  - `transcript.jsonl` shape matches legacy (golden diff)
  - `human_gate` non-TTY callers stay on line-mode (covered by `test_repl_dispatch`)
  - Multi-line input via TextArea (Phase 2A swaps Input → TextArea)
  - Live partial streaming reads cleanly (Phase 2A's CurrentAction subpane)

When all green, Phase 2D removes the env-flag gate, makes `textual` a hard dep, and deletes `_run_interactive`.

## Test plan

- [x] `uv run pytest` — 1122 passed, 4 skipped
- [x] All 17 textual app tests cover: sink ANSI/buffering/flush/CR-clear/isatty, app boot, /help dispatch, full turn with mocked SDK, /exit, persistence, mentions, /clear lifecycle, prompted-mode permission, error exit code, seed_message, finalize totals
- [x] No regressions in legacy REPL tests (`test_repl_sdk.py`, `test_repl_commands.py`, etc.)

## Coming next

**Phase 2A**: layout split — CurrentAction subpane (`fr=2`), chat pane (`fr=6`), input (`3` lines). Partials route to CurrentAction; finalized turns route to chat. Where this rewrite earns its keep.

Built by [dotdev.dev](https://dotdev.dev)
