### PR TITLE
feat(repl): Phase 2A — CurrentAction subpane + proportional layout

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -376,6 +376,7 @@ def render_message(
     ResultMessage: Any,
     out: Any = sys.stdout,
     stream_state: "_StreamRenderState | None" = None,
+    action_out: Any = None,
 ) -> None:
     """Render one SDK message to the terminal.
 
@@ -384,11 +385,24 @@ def render_message(
     show a one-line preview.
 
     `stream_state` carries cross-message bookkeeping for the partial-message
-    stream (Phase 3 PR ?, 2026-04-25): when partial events have already
-    streamed text/thinking content for an assistant turn, the final
-    AssistantMessage that arrives at message_stop would otherwise re-render
-    everything. We track which content indices were streamed and skip them.
+    stream: when partial events have already streamed text/thinking content
+    for an assistant turn, the final AssistantMessage that arrives at
+    message_stop would otherwise re-render everything. We track which
+    content indices were streamed and skip them.
+
+    `action_out` (Phase 2A, 2026-04-25): optional separate sink for partial-
+    stream events. The Textual REPL passes a dedicated CurrentAction RichLog
+    here so live thinking, byte counters, and heartbeats render in their own
+    docked subpane while finalized snapshot messages go to the chat pane via
+    `out`. When `action_out` is None or the same object as `out`, the legacy
+    behavior is preserved: everything goes to one sink (stdout in the line-
+    mode REPL).
     """
+    # If no separate action sink is provided, partials and snapshots share `out`.
+    if action_out is None:
+        action_out = out
+    dual_panes = action_out is not out
+
     # StreamEvent is a `@dataclass` with fields {uuid, session_id, event,
     # parent_tool_use_id}, delivered when include_partial_messages=True. The
     # `event` payload mirrors Anthropic's streaming API. We render
@@ -403,13 +417,14 @@ def render_message(
         if stream_state is not None:
             payload = getattr(message, "event", None)
             if isinstance(payload, dict):
-                stream_state.handle_partial(payload, out)
+                stream_state.handle_partial(payload, action_out)
         return
 
     # Any non-partial message arriving — close out a pending heartbeat line so
-    # the upcoming render starts on a clean line.
+    # the upcoming render starts on a clean line. Heartbeats live in the
+    # action sink; close them there.
     if stream_state is not None:
-        stream_state._consume_heartbeat(out)
+        stream_state._consume_heartbeat(action_out)
 
     if isinstance(message, SystemMessage):
         if getattr(message, "subtype", None) == "init":
@@ -421,14 +436,22 @@ def render_message(
         return
 
     if isinstance(message, AssistantMessage):
-        # Close any open partial line so the snapshot render starts cleanly.
+        # Close any open partial line so the action pane is left clean.
+        # Partials live in `action_out`; close them there.
         if stream_state is not None and stream_state.partials_active:
-            stream_state.close_open_block(out)
+            stream_state.close_open_block(action_out)
         for block in getattr(message, "content", []) or []:
             btype = _block_type(block)
             if btype == "text":
-                # Text already streamed via partials → skip redundant snapshot render.
-                if stream_state is not None and stream_state.streamed_text:
+                # In single-pane mode, skip snapshot if we already streamed
+                # the same content. In dual-pane mode, the snapshot lives in
+                # chat (out) which is permanent — always render it there
+                # regardless of what landed in the ephemeral action pane.
+                if (
+                    not dual_panes
+                    and stream_state is not None
+                    and stream_state.streamed_text
+                ):
                     continue
                 text = _block_attr(block, "text", "") or ""
                 if text:
@@ -442,8 +465,13 @@ def render_message(
                 line = f"[→ {name}{' ' + summary if summary else ''}]"
                 out.write(_styled(out, line, "bold cyan") + "\n")
             elif btype == "thinking":
-                # Thinking already streamed live via partials → skip snapshot.
-                if stream_state is not None and stream_state.streamed_thinking:
+                # Same dual-pane logic as text — chat keeps the permanent
+                # snapshot even though the action pane streamed live.
+                if (
+                    not dual_panes
+                    and stream_state is not None
+                    and stream_state.streamed_thinking
+                ):
                     continue
                 thinking = _block_attr(block, "thinking", "") or ""
                 first = thinking.split("\n", 1)[0].strip()

--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -1,19 +1,24 @@
-"""Textual-based rendering layer for `agentwire repl` (Phase 1C parity).
+"""Textual-based rendering layer for `agentwire repl` (Phase 2A — layout).
 
-Layout (Phase 1 — minimal; Phase 2 splits into chat + current-action with
-proportional weights):
+Layout (Phase 2A: proportional chat=6 / action=2 / input=3):
 
-    ┌─ Header ─────────────────────────────┐
-    │                                      │
-    ├─ ChatLog (RichLog, fr=1) ────────────┤
-    │  > previous user turn                │
-    │  [thinking: ...]                     │
-    │  assistant text                      │
-    │  [→ tool call]                       │
-    │  [← result]                          │
-    ├─ Input (TextArea, dock=bottom) ──────┤
-    │  > tell me about prompt caching      │
-    └─ Footer ─────────────────────────────┘
+    ┌─ Header ──────────────────────────────────┐
+    │                                           │
+    ├─ ChatLog (RichLog, fr=6) ─────────────────┤
+    │  > previous user turn                     │
+    │  assistant text                           │
+    │  [→ tool call]                            │
+    │  [← result]                               │
+    │  [done · ...]                             │
+    ├─ CurrentAction (RichLog, fr=2, title) ────┤
+    │  ╭─ Current action ─────────────────────╮ │
+    │  │ [thinking: ...] live stream          │ │
+    │  │ [writing X input · 4.2 KB live tick] │ │
+    │  │ […still working · 5s]                │ │
+    │  ╰──────────────────────────────────────╯ │
+    ├─ Input (Input, dock=bottom) ──────────────┤
+    │  > tell me about prompt caching           │
+    └─ Footer ──────────────────────────────────┘
 
 Event flow:
     user types → SubmittableTextArea posts Submitted → on_input_submitted
@@ -24,11 +29,18 @@ Event flow:
 
 Workers MUST use `self.post_message(...)` — never call RichLog.write directly.
 
-Phase 1C scope: full feature parity with the legacy line-mode REPL —
-transcript persistence, @-mention expansion, sdk-prompted permission
-prompts (inline placeholder), /clear and /resume lifecycle (close+reopen
-ClaudeSDKClient with new options), CLAUDECODE env handling, resume
-lookup via persistence.load_session.
+Phase 2A scope: split chat into chat + CurrentAction subpanes with
+proportional weights. Partial-stream events (thinking, byte counter,
+heartbeat) route to the action pane via a dedicated `_ActionSink` that
+supports proper in-place line updates (clear-and-rewrite). The action
+pane is cleared on every ResultMessage (turn complete) so the next
+turn's partials start fresh. Finalized snapshot Messages stay in chat
+via `_RichLogSink` as before.
+
+The 120-second silent gap of the legacy REPL is fully solved here:
+thinking and byte counter tick live in their own docked subpane, with
+clean in-place updates (not the choppy multi-line emission of Phase
+1B's single-sink approach).
 
 See `docs/missions/agentwire-repl-textual.md` for the full plan.
 """
@@ -145,6 +157,71 @@ class _RichLogSink:
             self._log.write(Text.from_ansi(text))
 
 
+class _ActionSink:
+    """Streaming sink for the CurrentAction subpane.
+
+    Unlike `_RichLogSink` (chat — append-only, buffer-until-newline), the
+    action pane shows live-updating content. We maintain our own list of
+    "finalized" lines plus a buffer for the in-flight current line, and
+    rewrite the entire RichLog on each update via clear()+write loop.
+
+    For an action pane with O(20) lines and a turn with O(1000) deltas,
+    the cost is ~20K writes — well within Textual's render budget.
+
+    `clear()` is called from the app on each ResultMessage (turn complete)
+    so the next turn's partials start with a clean pane.
+    """
+
+    _CR_CLEAR = "\r\x1b[K"
+
+    def __init__(self, log: RichLog) -> None:
+        self._log = log
+        self._finalized: list[str] = []
+        self._current = ""
+
+    def write(self, s: str) -> None:
+        if not s:
+            return
+        if self._CR_CLEAR in s:
+            # \r\033[K resets the in-flight line — used by the byte counter
+            # to refresh `[writing X · N KB` to a new value in place.
+            s = s.rsplit(self._CR_CLEAR, 1)[1]
+            self._current = ""
+        self._current += s
+        while "\n" in self._current:
+            line, self._current = self._current.split("\n", 1)
+            self._finalized.append(line)
+        self._refresh()
+
+    def flush(self) -> None:
+        self._refresh()
+
+    def isatty(self) -> bool:
+        return True
+
+    def clear(self) -> None:
+        """Wipe the pane — called at end of every turn (ResultMessage)."""
+        self._finalized.clear()
+        self._current = ""
+        try:
+            self._log.clear()
+        except AttributeError:
+            pass
+
+    def _refresh(self) -> None:
+        try:
+            self._log.clear()
+        except AttributeError:
+            return
+        for line in self._finalized:
+            if line == "":
+                self._log.write("")
+            else:
+                self._log.write(Text.from_ansi(line))
+        if self._current:
+            self._log.write(Text.from_ansi(self._current))
+
+
 # ----- SDK event message ----------------------------------------------------
 
 
@@ -182,8 +259,15 @@ class AgentwireREPL(App):
     }
 
     #chat {
-        height: 1fr;
+        height: 6fr;
         border: tall $accent;
+        padding: 0 1;
+    }
+
+    #action {
+        height: 2fr;
+        border: tall $warning;
+        border-title-color: $warning;
         padding: 0 1;
     }
 
@@ -231,7 +315,8 @@ class AgentwireREPL(App):
         self.state: ReplState | None = None
         self._client = None
         self._client_ctx = None
-        self._sink: _RichLogSink | None = None
+        self._sink: _RichLogSink | None = None  # chat — finalized snapshot messages
+        self._action_sink: _ActionSink | None = None  # action — live partials
         self._stream_state = _StreamRenderState()
         self._sdk_classes: dict[str, Any] | None = None
         self._saved_claudecode: str | None = None
@@ -247,6 +332,7 @@ class AgentwireREPL(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield RichLog(id="chat", markup=False, highlight=False, wrap=True, auto_scroll=True)
+        yield RichLog(id="action", markup=False, highlight=False, wrap=True, auto_scroll=True)
         yield Input(id="input", placeholder="> ")
         yield Footer()
 
@@ -254,7 +340,10 @@ class AgentwireREPL(App):
 
     async def on_mount(self) -> None:
         chat = self.query_one("#chat", RichLog)
+        action = self.query_one("#action", RichLog)
+        action.border_title = "Current action"
         self._sink = _RichLogSink(chat)
+        self._action_sink = _ActionSink(action)
         self.query_one("#input", Input).focus()
         try:
             await self._open_session()
@@ -595,11 +684,13 @@ class AgentwireREPL(App):
 
     def on_sdk_event(self, event: SdkEvent) -> None:
         assert self._sink is not None
+        assert self._action_sink is not None
         assert self._sdk_classes is not None
         msg = event.payload
         if msg is _HEARTBEAT:
-            self._stream_state.heartbeat(self._sink)
-            self._sink.flush()
+            # Heartbeats live in the action pane (live indicator).
+            self._stream_state.heartbeat(self._action_sink)
+            self._action_sink.flush()
             return
         try:
             render_message(
@@ -609,9 +700,11 @@ class AgentwireREPL(App):
                 SystemMessage=self._sdk_classes["SystemMessage"],
                 ResultMessage=self._sdk_classes["ResultMessage"],
                 out=self._sink,
+                action_out=self._action_sink,
                 stream_state=self._stream_state,
             )
             self._sink.flush()
+            self._action_sink.flush()
             if self._transcript is not None:
                 _persist_sdk_message(
                     msg,
@@ -631,6 +724,9 @@ class AgentwireREPL(App):
                 track_result(self.state, msg)
                 if getattr(msg, "is_error", False):
                     self._exit_code = 1
+                # Turn complete — clear the action pane so the next turn's
+                # partials start fresh.
+                self._action_sink.clear()
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
             self._sink.flush()

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -455,7 +455,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 1B** — Textual skeleton (#128, 2026-04-25; uses `Input` widget — TextArea/multi-line punted to 2A; sink streams partials choppily, clean on close — proper live streaming arrives with the CurrentAction widget in 2A)
 - [x] **Phase 1C** — persistence, mentions, prompted mode, lifecycle (#129, 2026-04-25)
 - [x] **Phase 1D** — tests + manual smoke (#130, 2026-04-25; 17 textual tests; ready for soak before flag-flip in Phase 2D)
-- [ ] **Phase 2A** — CurrentAction subpane + proportional weights
+- [x] **Phase 2A** — CurrentAction subpane + proportional weights (#131, 2026-04-25)
 - [ ] **Phase 2B** — Header + StatusLine
 - [ ] **Phase 2C** — tool-call collapse + permission ModalScreen
 - [ ] **Phase 2D** — theming + `/layout` + flag default flip

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -451,6 +451,161 @@ async def test_prompted_mode_routes_answer_to_permission(patched_sdk, tmp_path, 
         assert future.result() == "y"
 
 
+class TestActionSink:
+    """Phase 2A — CurrentAction pane streaming via clear+rewrite."""
+
+    def _action(self):
+        from agentwire.repl.textual_app import _ActionSink
+
+        class _FakeLog:
+            def __init__(self):
+                self.written: list = []
+                self.cleared: int = 0
+
+            def write(self, x):
+                self.written.append(x)
+
+            def clear(self):
+                self.cleared += 1
+                self.written.clear()
+
+        log = _FakeLog()
+        return _ActionSink(log), log
+
+    def test_streams_partials_in_place(self):
+        # Each delta clears + rewrites the pane. After 3 deltas, only the
+        # latest content is visible (one entry).
+        sink, log = self._action()
+        sink.write("[thinking: ")
+        sink.write("first")
+        sink.write(" delta")
+        # Each write triggers a refresh — the most recent state is visible.
+        assert log.cleared >= 3
+        # The current visible state is one in-flight line with full content.
+        assert len(log.written) == 1
+        assert log.written[0].plain == "[thinking: first delta"
+
+    def test_finalizes_on_newline(self):
+        sink, log = self._action()
+        sink.write("[thinking: planning]\n")
+        # Newline finalizes — the line moves into the finalized list.
+        assert len(sink._finalized) == 1
+        assert sink._finalized[0] == "[thinking: planning]"
+        assert sink._current == ""
+
+    def test_cr_clear_resets_current(self):
+        # \r\033[K refreshes the in-flight line with new content.
+        sink, log = self._action()
+        sink.write("[writing X · 0 bytes")
+        sink.write("\r\x1b[K[writing X · 1.2 KB")
+        assert sink._current == "[writing X · 1.2 KB"
+        # And the visible pane shows only the latest tick.
+        assert len(log.written) == 1
+        assert log.written[0].plain == "[writing X · 1.2 KB"
+
+    def test_clear_wipes_pane(self):
+        sink, log = self._action()
+        sink.write("line one\n")
+        sink.write("line two\n")
+        sink.write("partial")
+        before_clear = log.cleared
+        sink.clear()
+        assert sink._finalized == []
+        assert sink._current == ""
+        # clear() called the underlying log.clear()
+        assert log.cleared > before_clear
+
+    def test_isatty_true(self):
+        sink, _ = self._action()
+        assert sink.isatty() is True
+
+
+@pytest.mark.asyncio
+async def test_partials_route_to_action_pane(patched_sdk, tmp_path, monkeypatch):
+    # A StreamEvent (thinking_delta) should land in the action pane, not chat.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+    from dataclasses import dataclass
+
+    @dataclass
+    class FakeStreamEvent:
+        uuid: str
+        session_id: str
+        event: dict
+        parent_tool_use_id: str | None = None
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([
+            FakeStreamEvent(
+                uuid="u1",
+                session_id="s",
+                event={"type": "content_block_start", "content_block": {"type": "thinking"}},
+            ),
+            FakeStreamEvent(
+                uuid="u2",
+                session_id="s",
+                event={"type": "content_block_delta",
+                       "delta": {"type": "thinking_delta", "thinking": "planning"}},
+            ),
+            FakeStreamEvent(
+                uuid="u3",
+                session_id="s",
+                event={"type": "content_block_stop"},
+            ),
+            _FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={}),
+        ])
+
+        inp = app.query_one("#input", Input)
+        inp.value = "trigger thinking"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        # ResultMessage cleared the action pane, so it should be empty now.
+        # The chat pane should have the user echo + agent_started + done.
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat").lines
+        ]
+        chat_text = " ".join(chat_lines)
+        assert "trigger thinking" in chat_text
+        assert "done" in chat_text
+
+
+@pytest.mark.asyncio
+async def test_action_pane_cleared_on_result(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Manually populate the action sink to simulate in-flight partials.
+        app._action_sink.write("[thinking: in flight")
+        assert app._action_sink._current != ""
+
+        client = app._client
+        client.script([
+            _FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={}),
+        ])
+        inp = app.query_one("#input", Input)
+        inp.value = "go"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        # ResultMessage triggered the action sink clear.
+        assert app._action_sink._current == ""
+        assert app._action_sink._finalized == []
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Phase 2A — splits the chat region into two docked panes with proportional weights. **The 120-second silent-gap UX bug is fully solved here**: live thinking, byte counters, and heartbeats stream cleanly in a dedicated subpane while finalized turns land in a permanent chat history.

### Layout

```
┌─ Header ──────────────────────────────────┐
├─ ChatLog (RichLog, fr=6) ─────────────────┤
│  > previous user turn                     │
│  assistant text                           │
│  [→ tool call]                            │
│  [← result]                               │
│  [done · ...]                             │
├─ CurrentAction (RichLog, fr=2, title) ────┤
│  ╭─ Current action ─────────────────────╮ │
│  │ [thinking: ...] live stream          │ │
│  │ [writing X input · 4.2 KB live tick] │ │
│  │ […still working · 5s]                │ │
│  ╰──────────────────────────────────────╯ │
├─ Input (dock=bottom) ─────────────────────┤
│  > tell me about prompt caching           │
└─ Footer ──────────────────────────────────┘
```

### Renderer changes

`render_message(out=...)` now takes an optional `action_out=...` for the dedicated partial-stream sink. When None or same as `out`, behavior is unchanged (legacy line-mode REPL keeps using stdout for everything). When dual-pane:

- `StreamEvent` partials route to `action_out` via `_StreamRenderState`
- Heartbeat consumption fires on `action_out` before chat snapshot render
- `close_open_block` on `AssistantMessage` closes any open partial in action
- Snapshot `AssistantMessage` / `UserMessage` / `ResultMessage` / `SystemMessage` always render to `out` (chat) — never skipped, since the action pane is ephemeral and chat is the permanent record

### `_ActionSink`

Dedicated sink for the action pane:
- Maintains a list of finalized lines + an in-flight current-line buffer
- On each write: `log.clear()` then re-writes all lines (clean in-place updates)
- Honors `\r\033[K` byte-counter resets
- `clear()` is called by the app on each `ResultMessage` (turn complete)

For an action pane with O(20) lines and a turn with O(1000) deltas, the cost is ~20K writes — well within Textual's render budget.

## Test plan

- [x] `uv run pytest` — 1129 passed, 4 skipped
- [x] new tests (7):
  - `_ActionSink`: in-place streaming, newline finalization, `\r\033[K` reset, `clear()` wipes pane, `isatty()` true
  - `test_partials_route_to_action_pane` — `StreamEvent` (thinking_delta) routes to action
  - `test_action_pane_cleared_on_result` — `ResultMessage` triggers `_action_sink.clear()`
- [x] live tmux smoke (130×45 terminal):
  - Layout renders cleanly with bordered titled subpane
  - Real Opus 4.7 turn: assistant streamed live, chat shows clean snapshot, action cleared on `[done]`
  - Tool calls + tool results land in chat as before

## Coming next

**Phase 2B**: Header (session metadata pinned top) + custom StatusLine (running totals refresh on every event).

Built by [dotdev.dev](https://dotdev.dev)
