### PR TITLE
feat(repl): Phase 2B — Header + StatusLine

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -57,7 +57,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.message import Message
-from textual.widgets import Footer, Header, Input, RichLog
+from textual.widgets import Footer, Header, Input, RichLog, Static
 
 from agentwire.repl import persistence
 from agentwire.repl.app import (
@@ -242,6 +242,50 @@ class TurnFinished(Message):
         super().__init__()
 
 
+# ----- StatusLine widget ----------------------------------------------------
+
+
+class StatusLine(Static):
+    """Single-line widget showing running totals + tunables.
+
+    Renders one of two formats depending on whether any turns have completed:
+    - pre-turn: `{mode} · {model} · effort={e} · thinking={t}`
+    - post-turn: `{N turns} · {tok} tok · ${cost:.4f} · effort={e} · thinking={t}`
+
+    `refresh_from_state(state)` is called by the App on every SdkEvent so
+    the line stays current with cost/token totals + slash-command tunable
+    changes (`/effort`, `/thinking`).
+    """
+
+    DEFAULT_CSS = """
+    StatusLine {
+        height: 1;
+        padding: 0 1;
+        color: $text 60%;
+        background: $surface;
+    }
+    """
+
+    def refresh_from_state(self, state: ReplState | None) -> None:
+        if state is None:
+            self.update("")
+            return
+        if state.turn_count == 0:
+            self.update(
+                f"{state.mode} · {state.model} · effort={state.effort} · "
+                f"thinking={state.thinking_mode}"
+            )
+            return
+        total = state.total_input_tokens + state.total_output_tokens
+        plural = "s" if state.turn_count != 1 else ""
+        self.update(
+            f"{state.turn_count} turn{plural} · "
+            f"{total} tok ({state.total_input_tokens} in / {state.total_output_tokens} out) · "
+            f"${state.total_cost_usd:.4f} · effort={state.effort} · "
+            f"thinking={state.thinking_mode}"
+        )
+
+
 # ----- the App --------------------------------------------------------------
 
 
@@ -333,6 +377,7 @@ class AgentwireREPL(App):
         yield Header(show_clock=False)
         yield RichLog(id="chat", markup=False, highlight=False, wrap=True, auto_scroll=True)
         yield RichLog(id="action", markup=False, highlight=False, wrap=True, auto_scroll=True)
+        yield StatusLine(id="status")
         yield Input(id="input", placeholder="> ")
         yield Footer()
 
@@ -345,12 +390,20 @@ class AgentwireREPL(App):
         self._sink = _RichLogSink(chat)
         self._action_sink = _ActionSink(action)
         self.query_one("#input", Input).focus()
+
+        # Header content — set after we know the mode/model.
+        self.title = "agentwire repl"
+        model_short = (self._cfg["model"] or DEFAULT_MODEL).replace("claude-", "")
+        self.sub_title = f"{self._cfg['mode']} · {model_short}"
         try:
             await self._open_session()
         except Exception as exc:
             self._sink.write(f"[startup error: {exc}]\n")
             self._sink.flush()
             return
+        # Initial status line after state is built.
+        self._refresh_status()
+
         if self._cfg["seed_message"]:
             self.run_worker(
                 self._run_turn(self._cfg["seed_message"]),
@@ -612,6 +665,8 @@ class AgentwireREPL(App):
         if text.startswith("/"):
             action = dispatch_command(text, self.state, self._sink)
             self._sink.flush()
+            # /effort and /thinking mutate state — reflect immediately.
+            self._refresh_status()
             if action == EXIT:
                 self.exit(self._exit_code)
                 return
@@ -727,9 +782,16 @@ class AgentwireREPL(App):
                 # Turn complete — clear the action pane so the next turn's
                 # partials start fresh.
                 self._action_sink.clear()
+            self._refresh_status()
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
             self._sink.flush()
+
+    def _refresh_status(self) -> None:
+        try:
+            self.query_one("#status", StatusLine).refresh_from_state(self.state)
+        except Exception:
+            pass
 
     def on_turn_finished(self, event: TurnFinished) -> None:
         assert self._sink is not None

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -456,7 +456,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 1C** — persistence, mentions, prompted mode, lifecycle (#129, 2026-04-25)
 - [x] **Phase 1D** — tests + manual smoke (#130, 2026-04-25; 17 textual tests; ready for soak before flag-flip in Phase 2D)
 - [x] **Phase 2A** — CurrentAction subpane + proportional weights (#131, 2026-04-25)
-- [ ] **Phase 2B** — Header + StatusLine
+- [x] **Phase 2B** — Header + StatusLine (#132, 2026-04-25)
 - [ ] **Phase 2C** — tool-call collapse + permission ModalScreen
 - [ ] **Phase 2D** — theming + `/layout` + flag default flip
 - [ ] **Phase 3A** — snapshot test infra

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -606,6 +606,106 @@ async def test_action_pane_cleared_on_result(patched_sdk, tmp_path, monkeypatch)
         assert app._action_sink._finalized == []
 
 
+class TestStatusLine:
+    """Phase 2B — running totals widget."""
+
+    def test_pre_turn_format(self):
+        from agentwire.repl.state import ReplState
+        from agentwire.repl.textual_app import StatusLine
+
+        line = StatusLine()
+        # Patch update() to capture instead of needing a mounted app.
+        captured: list = []
+        line.update = lambda content="": captured.append(content)
+
+        state = ReplState(mode="bypass", model="claude-opus-4-7", allowed_tools=[])
+        line.refresh_from_state(state)
+        assert captured
+        text = captured[-1]
+        assert "bypass" in text
+        assert "claude-opus-4-7" in text
+        assert "effort=high" in text
+        assert "thinking=adaptive" in text
+
+    def test_post_turn_format(self):
+        from agentwire.repl.state import ReplState
+        from agentwire.repl.textual_app import StatusLine
+
+        line = StatusLine()
+        captured: list = []
+        line.update = lambda content="": captured.append(content)
+
+        state = ReplState(mode="bypass", model="claude-opus-4-7", allowed_tools=[])
+        state.turn_count = 3
+        state.total_input_tokens = 100
+        state.total_output_tokens = 250
+        state.total_cost_usd = 0.0421
+        line.refresh_from_state(state)
+        text = captured[-1]
+        assert "3 turns" in text
+        assert "350 tok" in text
+        assert "$0.0421" in text
+        assert "100 in" in text and "250 out" in text
+
+    def test_singular_turn(self):
+        from agentwire.repl.state import ReplState
+        from agentwire.repl.textual_app import StatusLine
+
+        line = StatusLine()
+        captured: list = []
+        line.update = lambda content="": captured.append(content)
+
+        state = ReplState(mode="bypass", model="x", allowed_tools=[])
+        state.turn_count = 1
+        line.refresh_from_state(state)
+        assert "1 turn" in captured[-1]
+        assert "1 turns" not in captured[-1]
+
+
+@pytest.mark.asyncio
+async def test_status_line_refreshes_on_result(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, StatusLine
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass", model="claude-opus-4-7")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([
+            _FakeResultMessage(
+                total_cost_usd=0.05,
+                duration_ms=1000,
+                usage={"input_tokens": 10, "output_tokens": 20},
+            ),
+        ])
+        inp = app.query_one("#input", Input)
+        inp.value = "hi"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        status = app.query_one("#status", StatusLine)
+        # Static.update() stores content in private state; query via render().
+        rendered = status.render()
+        text = str(rendered) if rendered is not None else ""
+        assert "1 turn" in text
+        assert "$0.0500" in text
+
+
+@pytest.mark.asyncio
+async def test_header_title_set(patched_sdk):
+    from agentwire.repl.textual_app import AgentwireREPL
+
+    app = AgentwireREPL(mode="bypass", model="claude-opus-4-7")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app.title == "agentwire repl"
+        assert "bypass" in app.sub_title
+        assert "opus-4-7" in app.sub_title
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Phase 2B — Header + StatusLine.

### Header

Textual's built-in `Header` widget renders the App's title + sub_title at the top. Set in `on_mount`:
- `title = "agentwire repl"`
- `sub_title = f"{mode} · {model_short}"` (the `claude-` prefix is trimmed for compactness)

Header content reads: `agentwire repl — bypass · opus-4-7`

### StatusLine

Custom `Static` widget docked between Action and Input. Two render formats:

- **pre-turn**: `bypass · claude-opus-4-7 · effort=high · thinking=adaptive`
- **post-turn**: `1 turn · 12 tok (6 in / 6 out) · $0.1467 · effort=high · thinking=adaptive`

Refreshes on:
- Every `SdkEvent` (so cost/token totals update on `ResultMessage`)
- Every slash-command dispatch (so `/effort` and `/thinking` mutations show immediately)

## Test plan

- [x] `uv run pytest` — 1134 passed, 4 skipped
- [x] new tests (5):
  - `StatusLine.refresh_from_state` pre-turn / post-turn / singular formats
  - `test_status_line_refreshes_on_result` — full flow with mocked SDK produces `1 turn · ... · $0.0500` in rendered output
  - `test_header_title_set` — title and sub_title set correctly
- [x] live tmux smoke (130×45):
  - Header reads `agentwire repl — bypass · opus-4-7`
  - StatusLine pre-turn: `bypass · claude-opus-4-7 · effort=high · thinking=adaptive`
  - After one real turn: `1 turn · 12 tok (6 in / 6 out) · $0.1467 · effort=high · thinking=adaptive`

## Coming next

**Phase 2C**: tool-call collapse (merge `[→ Tool]` + `[← result]` into one-liner) + permission `ModalScreen` (replaces inline y/n/a placeholder).

Built by [dotdev.dev](https://dotdev.dev)
