### PR TITLE
feat(repl): Phase 2C — tool-call collapse + permission ModalScreen

### DIFF
--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -460,10 +460,21 @@ def render_message(
                         out.write("\n")
             elif btype == "tool_use":
                 name = _block_attr(block, "name", "") or ""
+                tool_id = _block_attr(block, "id", "") or ""
                 inp = _block_attr(block, "input", {}) or {}
                 summary = _format_tool_input(name, inp)
-                line = f"[→ {name}{' ' + summary if summary else ''}]"
-                out.write(_styled(out, line, "bold cyan") + "\n")
+                # Tool-call collapse: when a stream_state is provided and we
+                # have a tool_id, defer writing this line — the matching
+                # tool_result will fold them into one `[Tool · args · preview]`.
+                # No id (or no stream_state) → render as before.
+                if stream_state is not None and tool_id:
+                    stream_state.pending_tool_uses[tool_id] = {
+                        "name": name,
+                        "summary": summary,
+                    }
+                else:
+                    line = f"[→ {name}{' ' + summary if summary else ''}]"
+                    out.write(_styled(out, line, "bold cyan") + "\n")
             elif btype == "thinking":
                 # Same dual-pane logic as text — chat keeps the permanent
                 # snapshot even though the action pane streamed live.
@@ -491,12 +502,48 @@ def render_message(
                     result_content = _block_attr(block, "content", None)
                     preview = _format_tool_result(result_content)
                     is_err = bool(_block_attr(block, "is_error", False))
-                    style = "red" if is_err else "green"
-                    label = "error" if is_err else "result"
-                    out.write(_styled(out, f"[← {label}: {preview}]", style) + "\n")
+                    tool_use_id = _block_attr(block, "tool_use_id", "") or ""
+
+                    # Tool-call collapse: if we deferred the matching
+                    # tool_use, fold it into this line.
+                    pending = None
+                    if stream_state is not None and tool_use_id:
+                        pending = stream_state.pending_tool_uses.pop(
+                            tool_use_id, None
+                        )
+
+                    if pending is not None and not is_err:
+                        # Merged: [Tool · args · preview]
+                        name = pending["name"]
+                        summary = pending["summary"]
+                        parts = [name]
+                        if summary:
+                            parts.append(summary)
+                        if preview:
+                            parts.append(preview)
+                        line = f"[{' · '.join(parts)}]"
+                        out.write(_styled(out, line, "cyan") + "\n")
+                    elif pending is not None and is_err:
+                        # Error result with deferred tool_use → emit both lines
+                        # so the user sees the call and the error clearly.
+                        name = pending["name"]
+                        summary = pending["summary"]
+                        call = f"[→ {name}{' ' + summary if summary else ''}]"
+                        out.write(_styled(out, call, "bold cyan") + "\n")
+                        out.write(_styled(out, f"[← error: {preview}]", "red") + "\n")
+                    else:
+                        # Standalone result (no matching deferred tool_use).
+                        style = "red" if is_err else "green"
+                        label = "error" if is_err else "result"
+                        out.write(
+                            _styled(out, f"[← {label}: {preview}]", style) + "\n"
+                        )
         return
 
     if isinstance(message, ResultMessage):
+        # Flush any tool_uses whose results never arrived this turn.
+        if stream_state is not None and stream_state.pending_tool_uses:
+            stream_state.flush_pending_tool_uses(out)
         usage = getattr(message, "usage", {}) or {}
         cost = getattr(message, "total_cost_usd", None)
         duration = getattr(message, "duration_ms", None)
@@ -1153,6 +1200,10 @@ class _StreamRenderState:
         self._heartbeat_started_inline = False
         self._tool_use_name: str | None = None
         self._tool_use_bytes: int = 0
+        # Tool-call collapse (Phase 2C): deferred [→ Tool args] writes,
+        # keyed by tool_use_id. Folded into one line when the matching
+        # tool_result arrives. Unmatched at end of turn → flushed as-is.
+        self.pending_tool_uses: dict[str, dict] = {}
 
     @property
     def partials_active(self) -> bool:
@@ -1281,6 +1332,19 @@ class _StreamRenderState:
         self._heartbeat_started_inline = False
         self._tool_use_name = None
         self._tool_use_bytes = 0
+
+    def flush_pending_tool_uses(self, out: Any) -> None:
+        """Emit any deferred tool_use lines whose tool_result never arrived.
+
+        Called on `ResultMessage` (turn complete) so unfinished tool calls
+        still appear in the chat history.
+        """
+        for pending in self.pending_tool_uses.values():
+            name = pending["name"]
+            summary = pending["summary"]
+            line = f"[→ {name}{' ' + summary if summary else ''}]"
+            out.write(_styled(out, line, "bold cyan") + "\n")
+        self.pending_tool_uses.clear()
 
     def heartbeat(self, out: Any) -> None:
         """Called when the SDK has been silent past `idle_timeout` seconds."""

--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -56,8 +56,10 @@ from typing import Any
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.containers import Center, Vertical
 from textual.message import Message
-from textual.widgets import Footer, Header, Input, RichLog, Static
+from textual.screen import ModalScreen
+from textual.widgets import Button, Footer, Header, Input, Label, RichLog, Static
 
 from agentwire.repl import persistence
 from agentwire.repl.app import (
@@ -242,6 +244,80 @@ class TurnFinished(Message):
         super().__init__()
 
 
+# ----- Permission ModalScreen (Phase 2C) -----------------------------------
+
+
+class PermissionPrompt(ModalScreen[str]):
+    """Centered modal for `sdk-prompted` mode tool-permission decisions.
+
+    Replaces Phase 1C's inline y/n/a placeholder. Returns one of:
+      'allow' | 'deny' | 'always'
+    via `push_screen_wait`.
+    """
+
+    BINDINGS = [
+        Binding("y", "decide('allow')", "Allow"),
+        Binding("n", "decide('deny')", "Deny"),
+        Binding("a", "decide('always')", "Always"),
+        Binding("escape", "decide('deny')", "Deny", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    PermissionPrompt {
+        align: center middle;
+    }
+    PermissionPrompt > Vertical {
+        background: $surface;
+        border: thick $accent;
+        padding: 1 2;
+        width: 80;
+        height: auto;
+    }
+    PermissionPrompt Label {
+        margin-bottom: 1;
+    }
+    PermissionPrompt Static.tool-line {
+        color: $text;
+        margin-bottom: 1;
+    }
+    PermissionPrompt Static.help-line {
+        color: $text 60%;
+    }
+    PermissionPrompt Center {
+        margin-top: 1;
+    }
+    PermissionPrompt Button {
+        margin: 0 1;
+    }
+    """
+
+    def __init__(self, tool_name: str, summary: str = "") -> None:
+        super().__init__()
+        self._tool_name = tool_name
+        self._summary = summary
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label(f"Allow {self._tool_name}?")
+            tool_line = self._tool_name + ((" " + self._summary) if self._summary else "")
+            yield Static(tool_line, classes="tool-line")
+            yield Static(
+                "y = allow once · n = deny · a = always allow this session · esc = deny",
+                classes="help-line",
+            )
+            with Center():
+                yield Button("Allow (y)", variant="success", id="allow")
+                yield Button("Deny (n)", variant="error", id="deny")
+                yield Button("Always (a)", variant="primary", id="always")
+
+    def action_decide(self, decision: str) -> None:
+        self.dismiss(decision)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        # Button id matches the decision string verbatim.
+        self.dismiss(event.button.id or "deny")
+
+
 # ----- StatusLine widget ----------------------------------------------------
 
 
@@ -367,11 +443,6 @@ class AgentwireREPL(App):
         self._exit_code = 0
         self._transcript = None
         self._ctx = None
-        # When sdk-prompted is asking for a tool decision, this holds the
-        # asyncio.Future the can_use_tool callback awaits. The input handler
-        # routes the next user submission as the answer instead of as a turn.
-        self._pending_permission: asyncio.Future | None = None
-        self._pending_tool_name: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -547,10 +618,10 @@ class AgentwireREPL(App):
     def _make_can_use_tool(self):
         """Permission callback for `sdk-prompted` mode.
 
-        Phase 1C placeholder — surfaces a `[? allow Tool args? (y/n/a)]`
-        line in the chat log, parks an asyncio.Future, and routes the next
-        user submission as the answer instead of as a turn. Phase 2C
-        replaces this with a centered `ModalScreen`.
+        Phase 2C: pushes a centered `PermissionPrompt` ModalScreen and
+        awaits the dismiss value ('allow' | 'deny' | 'always'). The modal
+        captures keyboard (y/n/a/esc) and clicks; the SDK loop is paused
+        on `push_screen_wait` until the user decides.
         """
         async def _can_use_tool(tool_name: str, tool_input: dict, ctx: Any):
             from claude_agent_sdk import (
@@ -562,31 +633,28 @@ class AgentwireREPL(App):
                 return PermissionResultAllow()
 
             summary = _format_tool_input(tool_name, tool_input or {})
-            line = f"[? allow {tool_name}{' ' + summary if summary else ''}? (y/n/a=always)]"
-            self._sink.write(line + "\n")
-            self._sink.flush()
-
-            loop = asyncio.get_event_loop()
-            future: asyncio.Future = loop.create_future()
-            self._pending_permission = future
-            self._pending_tool_name = tool_name
             try:
-                answer = await future
-            except asyncio.CancelledError:
-                return PermissionResultDeny(message="user denied (cancelled)")
-            finally:
-                self._pending_permission = None
-                self._pending_tool_name = None
+                decision = await self.push_screen_wait(
+                    PermissionPrompt(tool_name=tool_name, summary=summary)
+                )
+            except Exception as exc:
+                # If the modal can't be pushed (e.g. app shutting down),
+                # default to deny rather than allowing silently.
+                self._sink.write(f"[permission modal error: {exc}]\n")
+                self._sink.flush()
+                return PermissionResultDeny(message=f"modal error: {exc}")
 
-            answer = (answer or "").strip().lower()
-            if answer in ("a", "always"):
+            decision = (decision or "deny").lower()
+            if decision == "always":
                 self.state.always_allow_tools.add(tool_name)
                 self._sink.write(
                     f"[allow · {tool_name} now always allowed this session]\n"
                 )
                 self._sink.flush()
                 return PermissionResultAllow()
-            if answer in ("", "y", "yes"):
+            if decision == "allow":
+                self._sink.write(f"[allow · {tool_name}]\n")
+                self._sink.flush()
                 return PermissionResultAllow()
             self._sink.write(f"[deny · {tool_name}]\n")
             self._sink.flush()
@@ -645,13 +713,6 @@ class AgentwireREPL(App):
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         text = (event.value or "").strip()
         event.input.value = ""
-
-        # Permission-pending branch: if sdk-prompted is awaiting a y/n/a
-        # answer, the next submission is the answer (not a slash command,
-        # not a turn).
-        if self._pending_permission is not None and not self._pending_permission.done():
-            self._pending_permission.set_result(text)
-            return
 
         if not text:
             return

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -457,7 +457,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 1D** — tests + manual smoke (#130, 2026-04-25; 17 textual tests; ready for soak before flag-flip in Phase 2D)
 - [x] **Phase 2A** — CurrentAction subpane + proportional weights (#131, 2026-04-25)
 - [x] **Phase 2B** — Header + StatusLine (#132, 2026-04-25)
-- [ ] **Phase 2C** — tool-call collapse + permission ModalScreen
+- [x] **Phase 2C** — tool-call collapse + permission ModalScreen (#133, 2026-04-25)
 - [ ] **Phase 2D** — theming + `/layout` + flag default flip
 - [ ] **Phase 3A** — snapshot test infra
 - [ ] **Phase 3B** — `@`-mention autocomplete

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -287,6 +287,105 @@ class TestRenderResult:
         assert "[done" in out
 
 
+class TestToolCallCollapse:
+    """Phase 2C — when stream_state is provided, tool_use + tool_result fold
+    into one `[Tool · args · preview]` line."""
+
+    def _state(self):
+        from agentwire.repl.app import _StreamRenderState
+        return _StreamRenderState()
+
+    def test_tool_use_buffered_until_result(self):
+        from agentwire.repl.app import _StreamRenderState
+        s = _StreamRenderState()
+        out = io.StringIO()
+
+        # AssistantMessage with tool_use(id=tu_1) — should be buffered, NOT
+        # written to out yet.
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "id": "tu_1", "name": "Bash",
+            "input": {"command": "ls -la"},
+        }])
+        render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
+        assert out.getvalue() == ""
+        assert "tu_1" in s.pending_tool_uses
+
+        # UserMessage with tool_result(tool_use_id=tu_1) → folds into one line.
+        result = FakeUserMessage([{
+            "type": "tool_result", "tool_use_id": "tu_1", "content": "12 files",
+        }])
+        render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
+        rendered = out.getvalue()
+        assert "Bash" in rendered
+        assert "ls -la" in rendered
+        assert "12 files" in rendered
+        # Folded format — no separate "→" or "← result:" markers
+        assert "→ Bash" not in rendered
+        assert "← result:" not in rendered
+        # Pending cleared.
+        assert "tu_1" not in s.pending_tool_uses
+
+    def test_tool_use_no_stream_state_renders_inline(self):
+        # Without stream_state, tool_use renders as before (legacy path).
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "id": "tu_1", "name": "Bash",
+            "input": {"command": "ls -la"},
+        }])
+        out = _render(msg)  # no stream_state
+        assert "[→ Bash ls -la]" in out
+
+    def test_tool_use_no_id_renders_inline(self):
+        # Without an id, tool_use can't be matched to a result — render inline.
+        from agentwire.repl.app import _StreamRenderState
+        s = _StreamRenderState()
+        out = io.StringIO()
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "name": "Bash",  # no id
+            "input": {"command": "ls -la"},
+        }])
+        render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
+        assert "[→ Bash ls -la]" in out.getvalue()
+        assert s.pending_tool_uses == {}
+
+    def test_unmatched_tool_use_flushed_on_result(self):
+        # Tool_use without matching tool_result should still appear in chat
+        # when the turn ends (via flush_pending_tool_uses).
+        from agentwire.repl.app import _StreamRenderState
+        s = _StreamRenderState()
+        out = io.StringIO()
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "id": "tu_orphan", "name": "Bash",
+            "input": {"command": "echo x"},
+        }])
+        render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
+        # ResultMessage finishes the turn → flush.
+        result = FakeResultMessage()
+        render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
+        rendered = out.getvalue()
+        assert "[→ Bash" in rendered
+        assert "[done" in rendered
+
+    def test_error_result_emits_separate_lines(self):
+        # When the tool_result is an error, fold doesn't lose information —
+        # we emit both the call and the error explicitly.
+        from agentwire.repl.app import _StreamRenderState
+        s = _StreamRenderState()
+        out = io.StringIO()
+        msg = FakeAssistantMessage([{
+            "type": "tool_use", "id": "tu_err", "name": "Bash",
+            "input": {"command": "false"},
+        }])
+        render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
+        result = FakeUserMessage([{
+            "type": "tool_result", "tool_use_id": "tu_err",
+            "content": "exit 1", "is_error": True,
+        }])
+        render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
+        rendered = out.getvalue()
+        assert "[→ Bash" in rendered
+        assert "[← error:" in rendered
+
+
 # --- format helpers ---
 
 class TestFormatToolInput:

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -425,30 +425,56 @@ async def test_clear_writes_restart_event(patched_sdk, tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_prompted_mode_routes_answer_to_permission(patched_sdk, tmp_path, monkeypatch):
-    # The next user submission while a permission Future is pending
-    # answers the prompt instead of starting a new turn.
+async def test_permission_modal_dismisses_with_decision(patched_sdk, tmp_path, monkeypatch):
+    # Phase 2C — permission prompts pop a centered ModalScreen rather than
+    # parking an asyncio.Future on the app. Verify push_screen + dismiss
+    # cycle works with the y/n/a key bindings.
     from agentwire.repl import persistence
     monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
-    from agentwire.repl.textual_app import AgentwireREPL
-    from textual.widgets import Input
+    from agentwire.repl.textual_app import AgentwireREPL, PermissionPrompt
 
-    app = AgentwireREPL(mode="bypass")  # bypass so init doesn't need real SDK perms
+    app = AgentwireREPL(mode="bypass")
+    decisions: list = []
+
+    def _capture(decision):
+        decisions.append(decision)
+
     async with app.run_test() as pilot:
         await pilot.pause()
-        # Manually park a Future on the app — simulates can_use_tool awaiting.
-        loop = asyncio.get_event_loop()
-        future = loop.create_future()
-        app._pending_permission = future
-        app._pending_tool_name = "Bash"
+        modal = PermissionPrompt(tool_name="Bash", summary="ls -la")
+        app.push_screen(modal, _capture)
+        for _ in range(5):
+            await pilot.pause()
+        # The modal is up — pressing 'y' triggers action_decide('allow').
+        await pilot.press("y")
+        for _ in range(5):
+            await pilot.pause()
+        assert decisions == ["allow"]
 
-        inp = app.query_one("#input", Input)
-        inp.value = "y"
-        await inp.action_submit()
+
+@pytest.mark.asyncio
+async def test_permission_modal_buttons(patched_sdk, tmp_path, monkeypatch):
+    # Verify the three decision buttons each map to their decision string
+    # via the on_button_pressed handler.
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, PermissionPrompt
+
+    app = AgentwireREPL(mode="bypass")
+    decisions: list = []
+
+    async with app.run_test() as pilot:
         await pilot.pause()
-
-        assert future.done()
-        assert future.result() == "y"
+        for expected in ("allow", "deny", "always"):
+            modal = PermissionPrompt(tool_name="Bash", summary="ls -la")
+            app.push_screen(modal, decisions.append)
+            for _ in range(5):
+                await pilot.pause()
+            # Click the button by id.
+            await pilot.click(f"#{expected}")
+            for _ in range(5):
+                await pilot.pause()
+        assert decisions == ["allow", "deny", "always"]
 
 
 class TestActionSink:


### PR DESCRIPTION
## Summary

Phase 2C — two independent improvements that share the same PR.

### Tool-call collapse

When `stream_state` is provided to `render_message`, tool_use blocks with an `id` are deferred (not written immediately). When the matching tool_result arrives (matched by `tool_use_id`), both fold into one line:

```
Before:
  [→ Bash ls /tmp]
  [← result: file1 file2 file3 ...]

After:
  [Bash · ls /tmp · file1 file2 file3 ...]
```

- `_StreamRenderState.pending_tool_uses: dict[str, dict]` holds deferred entries
- `flush_pending_tool_uses(out)` is called on `ResultMessage` so unmatched tool_uses still appear
- Error results emit both lines (call + error) so failure modes stay obvious — collapse only happens on success
- `tool_use` without an id falls back to inline rendering (some providers/fakes don't always populate id)
- No `stream_state` → legacy two-line output (preserves test fixtures)

### Permission ModalScreen

Replaces Phase 1C's inline `[? allow Tool args? (y/n/a)]` placeholder with a centered `PermissionPrompt` ModalScreen:

- Buttons: **Allow (y)** / **Deny (n)** / **Always (a)**
- Bindings: `y` / `n` / `a` / `esc`
- Returns `'allow' | 'deny' | 'always'` via `push_screen_wait` / `dismiss`

Removes the `asyncio.Future`-on-app machinery — the modal pauses the SDK worker via `push_screen_wait` instead. `on_input_submitted` no longer has a permission-pending branch.

## Test plan

- [x] `uv run pytest` — 1140 passed, 4 skipped
- [x] new tests (5 in `test_repl_sdk.py`):
  - `test_tool_use_buffered_until_result` — fold into one line
  - `test_tool_use_no_stream_state_renders_inline` — legacy path preserved
  - `test_tool_use_no_id_renders_inline` — graceful fallback when id missing
  - `test_unmatched_tool_use_flushed_on_result` — orphan flush
  - `test_error_result_emits_separate_lines` — errors keep both lines visible
- [x] updated `test_repl_textual_app.py`: replaced Future-routing test with `PermissionPrompt` key-press + button-click cycle covering all three decisions
- [x] live tmux smoke: `[Bash · ls /tmp · ai-briefing.html ...]` rendered as a single line in chat after a real Opus 4.7 turn

## Coming next

**Phase 2D**: theming from `~/.agentwire/config.yaml` + `/layout` slash command + flag-default flip (after soak window).

Built by [dotdev.dev](https://dotdev.dev)
