### PR TITLE
feat(repl): Phase 2D — /layout + /theme slash commands

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -723,6 +723,14 @@ class AgentwireREPL(App):
             self._sink.write(f"> {line}\n")
         self._sink.flush()
 
+        # Textual-only slash commands intercepted before dispatch_command.
+        if text.startswith("/layout"):
+            self._handle_layout(text[len("/layout"):].strip())
+            return
+        if text.startswith("/theme"):
+            self._handle_theme(text[len("/theme"):].strip())
+            return
+
         if text.startswith("/"):
             action = dispatch_command(text, self.state, self._sink)
             self._sink.flush()
@@ -847,6 +855,96 @@ class AgentwireREPL(App):
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
             self._sink.flush()
+
+    # ------ Textual-only slash commands (Phase 2D) ------
+
+    def _handle_layout(self, args: str) -> None:
+        """`/layout` — adjust the chat / action proportional weights at runtime.
+
+        Usage:
+          /layout            # show current weights
+          /layout chat=8 action=1
+        """
+        assert self._sink is not None
+        if not args:
+            chat = self.query_one("#chat", RichLog)
+            action = self.query_one("#action", RichLog)
+            self._sink.write(
+                f"[layout: chat={chat.styles.height} action={action.styles.height}]\n"
+            )
+            self._sink.flush()
+            return
+
+        # Parse chat=N action=M tokens.
+        chat_n: int | None = None
+        action_n: int | None = None
+        for tok in args.split():
+            if "=" not in tok:
+                continue
+            key, _, val = tok.partition("=")
+            try:
+                n = int(val)
+            except ValueError:
+                continue
+            if key.lower() == "chat":
+                chat_n = n
+            elif key.lower() == "action":
+                action_n = n
+
+        if chat_n is None and action_n is None:
+            self._sink.write("[/layout: expected chat=N or action=N — nothing changed]\n")
+            self._sink.flush()
+            return
+
+        try:
+            if chat_n is not None and chat_n > 0:
+                self.query_one("#chat", RichLog).styles.height = f"{chat_n}fr"
+            if action_n is not None and action_n > 0:
+                self.query_one("#action", RichLog).styles.height = f"{action_n}fr"
+            self._sink.write(
+                f"[layout updated · "
+                f"chat={chat_n if chat_n is not None else 'unchanged'} · "
+                f"action={action_n if action_n is not None else 'unchanged'}]\n"
+            )
+        except Exception as exc:
+            self._sink.write(f"[/layout error: {exc}]\n")
+        self._sink.flush()
+
+    def _handle_theme(self, args: str) -> None:
+        """`/theme` — switch Textual themes at runtime.
+
+        Usage:
+          /theme               # show current theme + list available
+          /theme <name>        # set theme
+        """
+        assert self._sink is not None
+        if not args:
+            current = getattr(self, "theme", None) or "(default)"
+            available = self._available_themes()
+            self._sink.write(f"[theme: {current}]\n")
+            self._sink.write(f"[available: {', '.join(available)}]\n")
+            self._sink.flush()
+            return
+
+        try:
+            self.theme = args
+            self._sink.write(f"[theme set: {args}]\n")
+        except Exception as exc:
+            self._sink.write(f"[/theme error: {exc}]\n")
+        self._sink.flush()
+
+    def _available_themes(self) -> list[str]:
+        # Textual exposes `App.available_themes` as a property in 0.80+.
+        try:
+            return sorted(self.available_themes.keys())
+        except (AttributeError, TypeError):
+            # Fallback list of built-in themes for older Textual versions.
+            return [
+                "textual-dark", "textual-light",
+                "nord", "gruvbox", "catppuccin-mocha", "dracula",
+                "tokyo-night", "monokai", "flexoki",
+                "catppuccin-latte", "solarized-light",
+            ]
 
     def _refresh_status(self) -> None:
         try:

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -458,7 +458,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 2A** — CurrentAction subpane + proportional weights (#131, 2026-04-25)
 - [x] **Phase 2B** — Header + StatusLine (#132, 2026-04-25)
 - [x] **Phase 2C** — tool-call collapse + permission ModalScreen (#133, 2026-04-25)
-- [ ] **Phase 2D** — theming + `/layout` + flag default flip
+- [x] **Phase 2D** — theming + `/layout` (#134, 2026-04-25). Flag default flip deferred to a follow-up after the 1-week daily-driver soak window completes.
 - [ ] **Phase 3A** — snapshot test infra
 - [ ] **Phase 3B** — `@`-mention autocomplete
 - [ ] **Phase 3C** — slash command palette

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -733,6 +733,105 @@ async def test_header_title_set(patched_sdk):
 
 
 @pytest.mark.asyncio
+async def test_layout_slash_command_adjusts_weights(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input, RichLog
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "/layout chat=8 action=1"
+        await inp.action_submit()
+        await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat", RichLog).lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "layout updated" in all_text
+        assert "chat=8" in all_text
+        assert "action=1" in all_text
+
+
+@pytest.mark.asyncio
+async def test_layout_no_args_shows_current(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input, RichLog
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "/layout"
+        await inp.action_submit()
+        await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat", RichLog).lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "layout:" in all_text
+        assert "chat=" in all_text
+
+
+@pytest.mark.asyncio
+async def test_theme_no_args_shows_current_and_available(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input, RichLog
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "/theme"
+        await inp.action_submit()
+        await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat", RichLog).lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "theme:" in all_text
+        assert "available:" in all_text
+
+
+@pytest.mark.asyncio
+async def test_theme_switch(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input, RichLog
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Pick a theme that's likely available across textual versions.
+        themes = app._available_themes()
+        target = "textual-light" if "textual-light" in themes else themes[0]
+        inp = app.query_one("#input", Input)
+        inp.value = f"/theme {target}"
+        await inp.action_submit()
+        await pilot.pause()
+
+        chat_lines = [
+            line.text if hasattr(line, "text") else str(line)
+            for line in app.query_one("#chat", RichLog).lines
+        ]
+        all_text = " ".join(chat_lines)
+        assert "theme set" in all_text or "theme error" in all_text
+
+
+@pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL
     from textual.widgets import Input


### PR DESCRIPTION
## Summary

Phase 2D — two new Textual-only slash commands. The flag-default flip originally planned for 2D is deferred to a follow-up PR after the 1-week daily-driver soak window completes (destructive change; deserves its own timeline).

### `/layout` — runtime proportional-weight tweaks

```
/layout                       — show current weights
/layout chat=8 action=1       — set chat=8fr, action=1fr
/layout chat=10               — partial update; action unchanged
```

Updates `RichLog.styles.height = "Nfr"` directly so the change is immediate.

### `/theme` — Textual theme switching

```
/theme                        — show current + list available
/theme <name>                 — set self.theme = name
```

Built-ins: `textual-dark`, `textual-light`, `monokai`, `dracula`, `nord`, `gruvbox`, `catppuccin-mocha`, `tokyo-night`, `flexoki`, `solarized-light`, `catppuccin-latte`.

Both commands are intercepted in `on_input_submitted` before `dispatch_command`, so they don't appear in legacy line-mode `/help` listings.

## Test plan

- [x] `uv run pytest` — 1144 passed, 4 skipped
- [x] new tests (4):
  - `test_layout_slash_command_adjusts_weights` — `/layout chat=8 action=1` writes `[layout updated · chat=8 · action=1]`
  - `test_layout_no_args_shows_current` — bare `/layout` prints current weights
  - `test_theme_no_args_shows_current_and_available` — bare `/theme` lists themes
  - `test_theme_switch` — `/theme textual-light` confirms (or graceful error)
- [x] live tmux smoke: `/layout chat=10 action=1` shrunk the action pane visibly; `/theme` listed available themes

## Coming next

**Phase 3** (polish, trigger-driven order): `pytest-textual-snapshot` infra → `@`-mention autocomplete → slash command palette (Ctrl+P) → cost sparkline + transcript scrubber → walkthrough doc.

**Deferred follow-up**: flag-default flip after 1-week soak.

Built by [dotdev.dev](https://dotdev.dev)
