### PR TITLE
feat(repl): Phase 3B — @-mention autocomplete

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -409,6 +409,7 @@ class AgentwireREPL(App):
     BINDINGS = [
         Binding("ctrl+d", "quit", "Exit"),
         Binding("ctrl+c", "cancel_turn", "Cancel turn"),
+        Binding("tab", "complete_mention", "Complete @mention", show=False),
     ]
 
     def __init__(
@@ -855,6 +856,120 @@ class AgentwireREPL(App):
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
             self._sink.flush()
+
+    # ------ @-mention autocomplete (Phase 3B) ------
+
+    _MENTION_PREVIEW_CAP = 8
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Update the action pane with @-mention candidates as the user types."""
+        if self._action_sink is None:
+            return
+        prefix = self._current_at_prefix(event.value, event.input.cursor_position)
+        if prefix is None:
+            # Not in an @-mention context — only clear if we previously
+            # populated candidates (avoid clobbering live SDK output).
+            if getattr(self, "_last_mention_prefix", None) is not None:
+                self._action_sink.clear()
+                self._last_mention_prefix = None
+            return
+
+        self._last_mention_prefix = prefix
+        matches = self._glob_mention_matches(prefix)
+        self._action_sink.clear()
+        if not matches:
+            self._action_sink.write(f"[mentions @{prefix}: no matches in {Path.cwd().name}/]\n")
+        else:
+            shown = matches[: self._MENTION_PREVIEW_CAP]
+            self._action_sink.write(
+                "[mentions: " + " · ".join(shown) + "]\n"
+            )
+            if len(matches) > self._MENTION_PREVIEW_CAP:
+                self._action_sink.write(
+                    f"[+{len(matches) - self._MENTION_PREVIEW_CAP} more — keep typing to filter, Tab to accept first]\n"
+                )
+            else:
+                self._action_sink.write("[Tab to accept first match]\n")
+
+    @staticmethod
+    def _current_at_prefix(text: str, cursor: int) -> str | None:
+        """Return the @-prefix the cursor is currently inside, or None."""
+        if not text:
+            return None
+        # Look at the text up to the cursor; find the last `@` after a
+        # whitespace boundary (or start).
+        head = text[:cursor]
+        if "@" not in head:
+            return None
+        at_idx = head.rfind("@")
+        # Must be preceded by whitespace or start-of-string (mirror mentions.py).
+        if at_idx > 0 and not head[at_idx - 1].isspace():
+            return None
+        # Path chars only (no spaces) — terminate at first whitespace.
+        rest = head[at_idx + 1:]
+        if any(c.isspace() for c in rest):
+            return None
+        return rest
+
+    def _glob_mention_matches(self, prefix: str) -> list[str]:
+        """Glob-match files under cwd whose path starts with `prefix`.
+
+        Empty prefix → top files in cwd by mtime. Caps at 50 results.
+        """
+        cwd = Path.cwd()
+        if not prefix:
+            try:
+                entries = sorted(
+                    [p for p in cwd.iterdir() if not p.name.startswith(".")],
+                    key=lambda p: -p.stat().st_mtime,
+                )[:50]
+                return [p.name + ("/" if p.is_dir() else "") for p in entries]
+            except Exception:
+                return []
+
+        # Match prefix against names + paths under cwd. Glob with `**` would
+        # be too broad; instead walk the prefix's parent.
+        pat_parent = Path(prefix).parent
+        pat_name = Path(prefix).name
+        search_dir = cwd / pat_parent
+        if not search_dir.exists():
+            return []
+        try:
+            candidates = []
+            for p in search_dir.iterdir():
+                if p.name.startswith("."):
+                    continue
+                if p.name.startswith(pat_name):
+                    rel = p.relative_to(cwd)
+                    candidates.append(str(rel) + ("/" if p.is_dir() else ""))
+            candidates.sort(key=lambda s: (0 if s.endswith("/") else 1, s.lower()))
+            return candidates[:50]
+        except Exception:
+            return []
+
+    def action_complete_mention(self) -> None:
+        """Tab in the input completes the current @prefix to the top match."""
+        try:
+            inp = self.query_one("#input", Input)
+        except Exception:
+            return
+        prefix = self._current_at_prefix(inp.value, inp.cursor_position)
+        if prefix is None:
+            return
+        matches = self._glob_mention_matches(prefix)
+        if not matches:
+            return
+        # Replace the @prefix with the top match.
+        head = inp.value[:inp.cursor_position]
+        tail = inp.value[inp.cursor_position:]
+        at_idx = head.rfind("@")
+        new_head = head[:at_idx + 1] + matches[0]
+        inp.value = new_head + tail
+        inp.cursor_position = len(new_head)
+        # Clear the action pane preview now that the mention is locked in.
+        if self._action_sink is not None:
+            self._action_sink.clear()
+            self._last_mention_prefix = None
 
     # ------ Textual-only slash commands (Phase 2D) ------
 

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -460,7 +460,7 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 2C** — tool-call collapse + permission ModalScreen (#133, 2026-04-25)
 - [x] **Phase 2D** — theming + `/layout` (#134, 2026-04-25). Flag default flip deferred to a follow-up after the 1-week daily-driver soak window completes.
 - [x] **Phase 3A** — snapshot test infra (#135, 2026-04-25; opt-in via `pytest -m snapshots` because the framework leaves asyncio state polluted across the rest of the suite)
-- [ ] **Phase 3B** — `@`-mention autocomplete
+- [x] **Phase 3B** — `@`-mention autocomplete (#136, 2026-04-25; live preview in action pane + Tab to complete to top match)
 - [ ] **Phase 3C** — slash command palette
 - [ ] **Phase 3D** — cost sparkline + transcript scrubber
 - [ ] **Phase 3E** — walkthrough doc

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -831,6 +831,97 @@ async def test_theme_switch(patched_sdk, tmp_path, monkeypatch):
         assert "theme set" in all_text or "theme error" in all_text
 
 
+class TestMentionPrefixDetect:
+    """Phase 3B — _current_at_prefix detects @-mention typing context."""
+
+    def test_detects_after_space(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        # Cursor at end of "summarize @notes"
+        text = "summarize @notes"
+        assert AgentwireREPL._current_at_prefix(text, len(text)) == "notes"
+
+    def test_detects_at_start(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        text = "@README"
+        assert AgentwireREPL._current_at_prefix(text, len(text)) == "README"
+
+    def test_skips_inside_email(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        # `foo@bar.com` shouldn't trigger — @ not preceded by whitespace.
+        text = "foo@bar.com"
+        assert AgentwireREPL._current_at_prefix(text, len(text)) is None
+
+    def test_returns_none_if_no_at(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        assert AgentwireREPL._current_at_prefix("just text", 9) is None
+
+    def test_terminates_at_whitespace_after_prefix(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        # "@notes hello" — cursor at end, the @prefix already terminated.
+        text = "@notes hello"
+        assert AgentwireREPL._current_at_prefix(text, len(text)) is None
+
+    def test_partial_prefix_at_cursor(self):
+        from agentwire.repl.textual_app import AgentwireREPL
+        # Cursor right after "REA" — text up to cursor is "look at @REA",
+        # which is 12 chars.
+        text = "look at @REA and stuff"
+        assert AgentwireREPL._current_at_prefix(text, 12) == "REA"
+
+
+@pytest.mark.asyncio
+async def test_at_mention_preview_shows_in_action_pane(
+    patched_sdk, tmp_path, monkeypatch
+):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alpha.txt").write_text("a")
+    (tmp_path / "alfred.md").write_text("b")
+    (tmp_path / "beta.txt").write_text("c")
+
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        # Simulate typing "@al" — the on_input_changed handler should
+        # populate the action pane with matches.
+        inp.value = "@al"
+        inp.cursor_position = len(inp.value)
+        # Force the changed-event callback to run.
+        app.on_input_changed(Input.Changed(inp, "@al"))
+        await pilot.pause()
+
+        # The action sink should now have entries containing alpha + alfred.
+        joined = "\n".join(app._action_sink._finalized + [app._action_sink._current])
+        assert "alpha" in joined or "alfred" in joined
+
+
+@pytest.mark.asyncio
+async def test_tab_completes_mention(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "README.md").write_text("readme")
+
+    from agentwire.repl.textual_app import AgentwireREPL
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.query_one("#input", Input)
+        inp.value = "look at @REA"
+        inp.cursor_position = len(inp.value)
+        app.action_complete_mention()
+        await pilot.pause()
+
+        assert "@README.md" in inp.value
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Phase 3B — `@`-mention autocomplete. As the user types `@` in the input, the action pane shows live mention candidates globbed from cwd. **Tab** in the input completes the `@`-prefix to the top match.

### Detection (`_current_at_prefix`)

- `@` must be at start-of-string or preceded by whitespace (matches `mentions.py` — emails like `foo@bar.com` don't trigger)
- Path chars only between `@` and cursor (no spaces)
- Returns `None` when cursor isn't inside an active `@`-mention context

### Glob (`_glob_mention_matches`)

- Walks the prefix's parent dir under cwd
- Returns matches starting with the prefix's basename, sorted by type (dirs first) + alphabetical, capped at 50

### Action pane preview

```
[mentions: foo.txt · bar.py · src/main.py]
[Tab to accept first match]
```

Cleared when the user moves out of the `@`-mention context or completes via Tab.

### Tab binding

`action_complete_mention` replaces `@<prefix>` with `@<top_match>` in the input value, preserving text after the cursor, and clears the action pane preview.

Submission still flows through `expand_mentions` in `on_input_submitted` unchanged — autocomplete is purely UI sugar.

## Test plan

- [x] `uv run pytest` — 1152 passed, 4 skipped
- [x] new tests:
  - `TestMentionPrefixDetect` (6 cases): whitespace boundary, start-of-line, embedded email rejection, no-match, terminated prefix, partial cursor
  - `test_at_mention_preview_shows_in_action_pane` — typing `@al` with `alpha.txt` + `alfred.md` in cwd populates the action sink
  - `test_tab_completes_mention` — `@REA` → `@README.md`

## Coming next

**Phase 3C**: slash command palette (Ctrl+P fuzzy picker).

Built by [dotdev.dev](https://dotdev.dev)
