### PR TITLE
feat(repl): Phase 3C — slash command palette (Ctrl+P)

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -59,7 +59,8 @@ from textual.binding import Binding
 from textual.containers import Center, Vertical
 from textual.message import Message
 from textual.screen import ModalScreen
-from textual.widgets import Button, Footer, Header, Input, Label, RichLog, Static
+from textual.widgets import Button, Footer, Header, Input, Label, OptionList, RichLog, Static
+from textual.widgets.option_list import Option
 
 from agentwire.repl import persistence
 from agentwire.repl.app import (
@@ -77,6 +78,7 @@ from agentwire.repl.app import (
     render_message,
 )
 from agentwire.repl.commands import (
+    COMMANDS,
     CONTINUE,
     EXIT,
     RESTART,
@@ -244,6 +246,124 @@ class TurnFinished(Message):
         super().__init__()
 
 
+# ----- Command palette ModalScreen (Phase 3C) ------------------------------
+
+
+class CommandPalette(ModalScreen[str | None]):
+    """Ctrl+P fuzzy picker for slash commands.
+
+    Reads from `agentwire.repl.commands.COMMANDS` (the existing registry)
+    so newly added slash commands appear here automatically. Returns the
+    selected command name (e.g. `/cost`) on dismiss, or None on Esc.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", priority=True),
+    ]
+
+    DEFAULT_CSS = """
+    CommandPalette {
+        align: center middle;
+    }
+    CommandPalette > Vertical {
+        background: $surface;
+        border: thick $accent;
+        width: 70;
+        height: 22;
+    }
+    CommandPalette Input {
+        margin: 1;
+        border: none;
+    }
+    CommandPalette OptionList {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Build a unique-by-Command list so aliases don't double-list.
+        seen: set[str] = set()
+        self._commands: list[tuple[str, str]] = []
+        for name, cmd in COMMANDS.items():
+            if cmd.name in seen:
+                continue
+            seen.add(cmd.name)
+            self._commands.append((cmd.name, cmd.summary))
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Input(id="palette-input", placeholder="Filter commands…")
+            yield OptionList(id="palette-list")
+
+    def on_mount(self) -> None:
+        self.query_one("#palette-input", Input).focus()
+        self._refilter("")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "palette-input":
+            self._refilter(event.value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "palette-input":
+            self._accept_highlighted()
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        # Mouse click on an option.
+        opt_id = event.option.id
+        if opt_id:
+            self.dismiss(opt_id)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _refilter(self, query: str) -> None:
+        olist = self.query_one("#palette-list", OptionList)
+        olist.clear_options()
+        q = query.lower().lstrip("/")
+        for name, summary in self._commands:
+            score = self._fuzzy_score(name, summary, q)
+            if score < 0:
+                continue
+            label = f"{name}  —  {summary}"
+            olist.add_option(Option(label, id=name))
+        # Highlight the first match by default.
+        if olist.option_count > 0:
+            olist.highlighted = 0
+
+    @staticmethod
+    def _fuzzy_score(name: str, summary: str, q: str) -> int:
+        """Return a score (>=0 = match, -1 = no match).
+
+        Matches are: empty query, substring of name (best), substring of
+        summary (lower priority). A leading `/` on the query is dropped so
+        users typing `/co` and `co` both match `/cost`.
+        """
+        q = q.lower().lstrip("/")
+        if not q:
+            return 0
+        n = name.lower().lstrip("/")
+        s = summary.lower()
+        if n.startswith(q):
+            return 0
+        if q in n:
+            return 1
+        if q in s:
+            return 2
+        return -1
+
+    def _accept_highlighted(self) -> None:
+        olist = self.query_one("#palette-list", OptionList)
+        idx = olist.highlighted
+        if idx is None or idx < 0 or idx >= olist.option_count:
+            self.dismiss(None)
+            return
+        opt = olist.get_option_at_index(idx)
+        self.dismiss(opt.id)
+
+
 # ----- Permission ModalScreen (Phase 2C) -----------------------------------
 
 
@@ -409,6 +529,7 @@ class AgentwireREPL(App):
     BINDINGS = [
         Binding("ctrl+d", "quit", "Exit"),
         Binding("ctrl+c", "cancel_turn", "Cancel turn"),
+        Binding("ctrl+p", "agentwire_palette", "Command palette"),
         Binding("tab", "complete_mention", "Complete @mention", show=False),
     ]
 
@@ -856,6 +977,25 @@ class AgentwireREPL(App):
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
             self._sink.flush()
+
+    # ------ Command palette (Phase 3C) ------
+
+    def action_agentwire_palette(self) -> None:
+        """Ctrl+P opens a fuzzy picker over the slash command registry."""
+        def _on_dismiss(selected: str | None) -> None:
+            if selected is None:
+                return
+            # Push the selected command name into the input so the user can
+            # add args (e.g. /resume <name>) before submitting.
+            try:
+                inp = self.query_one("#input", Input)
+            except Exception:
+                return
+            inp.value = selected + " "
+            inp.cursor_position = len(inp.value)
+            inp.focus()
+
+        self.push_screen(CommandPalette(), _on_dismiss)
 
     # ------ @-mention autocomplete (Phase 3B) ------
 

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -461,6 +461,6 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 2D** — theming + `/layout` (#134, 2026-04-25). Flag default flip deferred to a follow-up after the 1-week daily-driver soak window completes.
 - [x] **Phase 3A** — snapshot test infra (#135, 2026-04-25; opt-in via `pytest -m snapshots` because the framework leaves asyncio state polluted across the rest of the suite)
 - [x] **Phase 3B** — `@`-mention autocomplete (#136, 2026-04-25; live preview in action pane + Tab to complete to top match)
-- [ ] **Phase 3C** — slash command palette
+- [x] **Phase 3C** — slash command palette (#137, 2026-04-25; Ctrl+P opens fuzzy picker)
 - [ ] **Phase 3D** — cost sparkline + transcript scrubber
 - [ ] **Phase 3E** — walkthrough doc

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -922,6 +922,101 @@ async def test_tab_completes_mention(patched_sdk, tmp_path, monkeypatch):
         assert "@README.md" in inp.value
 
 
+class TestCommandPaletteFuzzy:
+    """Phase 3C — command palette fuzzy scoring."""
+
+    def test_empty_query_matches_all(self):
+        from agentwire.repl.textual_app import CommandPalette
+        assert CommandPalette._fuzzy_score("/help", "Show help", "") == 0
+
+    def test_prefix_match_best(self):
+        from agentwire.repl.textual_app import CommandPalette
+        assert CommandPalette._fuzzy_score("/cost", "Show cost", "co") == 0
+
+    def test_substring_in_name(self):
+        from agentwire.repl.textual_app import CommandPalette
+        # "lp" is a substring of "help" but not a prefix.
+        assert CommandPalette._fuzzy_score("/help", "Show help", "lp") == 1
+
+    def test_substring_in_summary(self):
+        from agentwire.repl.textual_app import CommandPalette
+        # "trans" doesn't appear in "/save" but does in "transcript".
+        assert CommandPalette._fuzzy_score("/save", "Show transcript path", "trans") == 2
+
+    def test_no_match(self):
+        from agentwire.repl.textual_app import CommandPalette
+        assert CommandPalette._fuzzy_score("/help", "Show help", "xyzzy") == -1
+
+    def test_query_with_slash_normalized(self):
+        from agentwire.repl.textual_app import CommandPalette
+        # User types "/co" — leading slash is normalized away.
+        assert CommandPalette._fuzzy_score("/cost", "Show cost", "/co") == 0
+
+
+@pytest.mark.asyncio
+async def test_command_palette_opens_and_filters(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, CommandPalette
+    from textual.widgets import Input, OptionList
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Open palette via the action.
+        app.action_agentwire_palette()
+        for _ in range(5):
+            await pilot.pause()
+
+        # Find the palette modal in the screen stack.
+        palette = next(
+            (s for s in app.screen_stack if isinstance(s, CommandPalette)),
+            None,
+        )
+        assert palette is not None
+
+        # Filter to commands containing "cost".
+        palette_input = palette.query_one("#palette-input", Input)
+        palette_input.value = "cost"
+        palette._refilter("cost")
+        await pilot.pause()
+
+        olist = palette.query_one("#palette-list", OptionList)
+        assert olist.option_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_command_palette_dismiss_writes_to_input(
+    patched_sdk, tmp_path, monkeypatch
+):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, CommandPalette
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        app.action_agentwire_palette()
+        for _ in range(5):
+            await pilot.pause()
+
+        palette = next(
+            (s for s in app.screen_stack if isinstance(s, CommandPalette)),
+            None,
+        )
+        assert palette is not None
+        # Dismiss with a known command name.
+        palette.dismiss("/help")
+        for _ in range(5):
+            await pilot.pause()
+
+        inp = app.query_one("#input", Input)
+        assert inp.value.startswith("/help")
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Phase 3C — slash command palette (Ctrl+P fuzzy picker).

`CommandPalette` ModalScreen launched by Ctrl+P. Reads from the existing `agentwire.repl.commands.COMMANDS` registry so any new slash command appears here automatically. Selecting an option populates the input with the command name + space, ready for the user to add args before hitting Enter.

### Fuzzy scoring

Lower is better:

| Score | Match |
|---|---|
| `0` | empty query, OR query is a prefix of the command name |
| `1` | query is a substring of the command name |
| `2` | query is a substring of the command summary |
| `-1` | no match (filtered out) |

Leading `/` on the query is normalized away — `/co` and `co` both match `/cost`.

### UX

- **Ctrl+P** opens the modal centered on screen
- Input at top filters live as the user types
- OptionList below shows ranked matches
- **Enter** selects highlighted option, **Esc** cancels, **mouse click** selects
- On dismiss, the App's `_on_dismiss` callback inserts the command into the input field (with trailing space) so args can follow

### Binding

`Binding("ctrl+p", "agentwire_palette", ...)` — the `agentwire_` prefix avoids collision with Textual's built-in `command_palette` action.

## Test plan

- [x] `uv run pytest` — 1160 passed, 4 skipped
- [x] new tests (8):
  - `TestCommandPaletteFuzzy` (6 cases): empty query, prefix match, name substring, summary substring, no match, leading-slash normalization
  - `test_command_palette_opens_and_filters` — palette pushes via `action_agentwire_palette`, OptionList populates
  - `test_command_palette_dismiss_writes_to_input` — `dismiss('/help')` → input.value starts with `/help`

## Coming next

**Phase 3D**: cost sparkline + transcript scrubber.

Built by [dotdev.dev](https://dotdev.dev)
