### PR TITLE
feat(repl): Phase 3D — cost sparkline + transcript scrubber

### DIFF
--- a/agentwire/repl/state.py
+++ b/agentwire/repl/state.py
@@ -48,6 +48,9 @@ class ReplState:
     # prompt at SDK init; voice routes /say.
     role_names: list[str] = field(default_factory=list)
     voice: str | None = None
+    # Phase 3D — per-turn cost history for the StatusLine sparkline.
+    # Capped at 20 entries (rolling window). Reset on /clear.
+    turn_costs: list[float] = field(default_factory=list)
 
 
 def track_system_init(state: ReplState, message: Any) -> None:
@@ -67,7 +70,12 @@ def track_result(state: ReplState, message: Any) -> None:
     cost = getattr(message, "total_cost_usd", None)
     if cost is not None:
         try:
-            state.total_cost_usd += float(cost)
+            cost_f = float(cost)
+            state.total_cost_usd += cost_f
+            state.turn_costs.append(cost_f)
+            # Cap at 20 — rolling window for the sparkline.
+            if len(state.turn_costs) > 20:
+                state.turn_costs = state.turn_costs[-20:]
         except (TypeError, ValueError):
             pass
     state.turn_count += 1
@@ -85,3 +93,4 @@ def reset_for_restart(state: ReplState) -> None:
     state.session_id = None
     state.restart_count += 1
     state.always_allow_tools = set()
+    state.turn_costs = []

--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -438,7 +438,105 @@ class PermissionPrompt(ModalScreen[str]):
         self.dismiss(event.button.id or "deny")
 
 
+# ----- Transcript scrubber ModalScreen (Phase 3D) --------------------------
+
+
+class TranscriptScrubber(ModalScreen[None]):
+    """Read-only viewer for the current session's prior turns.
+
+    Triggered by `/scrub`. Lists each `user_input` event from the transcript
+    JSONL, with a 100-char preview. Esc / button to close. Selecting a turn
+    is a no-op for now (Phase 3D ships read-only; future scroll-to-turn is
+    separate).
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close", priority=True),
+        Binding("q", "close", "Close", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    TranscriptScrubber {
+        align: center middle;
+    }
+    TranscriptScrubber > Vertical {
+        background: $surface;
+        border: thick $accent;
+        width: 100;
+        height: 30;
+        padding: 0 1;
+    }
+    TranscriptScrubber Label {
+        margin: 1 0;
+        color: $text;
+    }
+    TranscriptScrubber OptionList {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, transcript_path: Path | None) -> None:
+        super().__init__()
+        self._path = transcript_path
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Transcript — prior turns this session (Esc to close)")
+            yield OptionList(id="scrub-list")
+
+    def on_mount(self) -> None:
+        olist = self.query_one("#scrub-list", OptionList)
+        if self._path is None or not Path(self._path).exists():
+            olist.add_option(Option("(no transcript)"))
+            return
+        import json
+        try:
+            lines = Path(self._path).read_text().splitlines()
+        except Exception as exc:
+            olist.add_option(Option(f"(read error: {exc})"))
+            return
+        n = 0
+        for line in lines:
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("type") == "user_input":
+                n += 1
+                text = (ev.get("text") or "").replace("\n", " ")
+                preview = text[:100] + ("..." if len(text) > 100 else "")
+                olist.add_option(Option(f"{n:>3}. {preview}"))
+        if n == 0:
+            olist.add_option(Option("(no user turns yet)"))
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
 # ----- StatusLine widget ----------------------------------------------------
+
+
+_SPARK_BARS = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[float]) -> str:
+    """Render a unicode-block sparkline from `values`.
+
+    Empty input → "". All zeros → flat baseline. Each value scales relative
+    to the peak in the series.
+    """
+    if not values:
+        return ""
+    peak = max(values)
+    if peak <= 0:
+        return _SPARK_BARS[0] * len(values)
+    out: list[str] = []
+    span = len(_SPARK_BARS) - 1
+    for v in values:
+        ratio = v / peak
+        idx = max(0, min(span, int(ratio * span)))
+        out.append(_SPARK_BARS[idx])
+    return "".join(out)
 
 
 class StatusLine(Static):
@@ -474,8 +572,10 @@ class StatusLine(Static):
             return
         total = state.total_input_tokens + state.total_output_tokens
         plural = "s" if state.turn_count != 1 else ""
+        spark = _sparkline(state.turn_costs)
+        spark_part = f" {spark}" if spark else ""
         self.update(
-            f"{state.turn_count} turn{plural} · "
+            f"{state.turn_count} turn{plural}{spark_part} · "
             f"{total} tok ({state.total_input_tokens} in / {state.total_output_tokens} out) · "
             f"${state.total_cost_usd:.4f} · effort={state.effort} · "
             f"thinking={state.thinking_mode}"
@@ -852,6 +952,9 @@ class AgentwireREPL(App):
         if text.startswith("/theme"):
             self._handle_theme(text[len("/theme"):].strip())
             return
+        if text == "/scrub" or text.startswith("/scrub "):
+            self._handle_scrub()
+            return
 
         if text.startswith("/"):
             action = dispatch_command(text, self.state, self._sink)
@@ -1111,7 +1214,17 @@ class AgentwireREPL(App):
             self._action_sink.clear()
             self._last_mention_prefix = None
 
-    # ------ Textual-only slash commands (Phase 2D) ------
+    # ------ Textual-only slash commands (Phase 2D + 3D) ------
+
+    def _handle_scrub(self) -> None:
+        """`/scrub` — open a read-only viewer of prior turns this session."""
+        path = None
+        if self._transcript is not None:
+            try:
+                path = Path(self._transcript.session_dir) / "transcript.jsonl"
+            except Exception:
+                path = None
+        self.push_screen(TranscriptScrubber(path))
 
     def _handle_layout(self, args: str) -> None:
         """`/layout` — adjust the chat / action proportional weights at runtime.

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -462,5 +462,5 @@ SDK `can_use_tool` callback `await self.push_screen_wait(PermissionPrompt(...))`
 - [x] **Phase 3A** — snapshot test infra (#135, 2026-04-25; opt-in via `pytest -m snapshots` because the framework leaves asyncio state polluted across the rest of the suite)
 - [x] **Phase 3B** — `@`-mention autocomplete (#136, 2026-04-25; live preview in action pane + Tab to complete to top match)
 - [x] **Phase 3C** — slash command palette (#137, 2026-04-25; Ctrl+P opens fuzzy picker)
-- [ ] **Phase 3D** — cost sparkline + transcript scrubber
+- [x] **Phase 3D** — cost sparkline + transcript scrubber (#138, 2026-04-25)
 - [ ] **Phase 3E** — walkthrough doc

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -1017,6 +1017,96 @@ async def test_command_palette_dismiss_writes_to_input(
         assert inp.value.startswith("/help")
 
 
+class TestSparkline:
+    """Phase 3D — unicode-block sparkline."""
+
+    def test_empty_returns_empty_string(self):
+        from agentwire.repl.textual_app import _sparkline
+        assert _sparkline([]) == ""
+
+    def test_all_zeros_baseline(self):
+        from agentwire.repl.textual_app import _sparkline
+        out = _sparkline([0, 0, 0])
+        assert len(out) == 3
+        # First bar is the baseline.
+        assert all(c == "▁" for c in out)
+
+    def test_increasing_series(self):
+        from agentwire.repl.textual_app import _sparkline
+        out = _sparkline([0.1, 0.5, 1.0])
+        # Last char is the peak block.
+        assert out[-1] == "█"
+        # All chars are members of the bar set.
+        assert all(c in "▁▂▃▄▅▆▇█" for c in out)
+
+
+@pytest.mark.asyncio
+async def test_status_line_shows_sparkline_after_turns(
+    patched_sdk, tmp_path, monkeypatch
+):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, StatusLine
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = app._client
+        client.script([
+            _FakeResultMessage(
+                total_cost_usd=0.05,
+                duration_ms=1000,
+                usage={"input_tokens": 10, "output_tokens": 20},
+            ),
+        ])
+        inp = app.query_one("#input", Input)
+        inp.value = "trigger"
+        await inp.action_submit()
+        for _ in range(20):
+            await pilot.pause()
+
+        status = app.query_one("#status", StatusLine)
+        text = str(status.render())
+        # After one turn, the sparkline (one bar) is in the status line.
+        assert any(b in text for b in "▁▂▃▄▅▆▇█")
+
+
+@pytest.mark.asyncio
+async def test_scrub_opens_modal(patched_sdk, tmp_path, monkeypatch):
+    from agentwire.repl import persistence
+    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
+    from agentwire.repl.textual_app import AgentwireREPL, TranscriptScrubber
+    from textual.widgets import Input
+
+    app = AgentwireREPL(mode="bypass")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Add a couple of fake events to the transcript file so the scrubber
+        # has something to show.
+        import json as _json
+        path = Path(app.state.session_dir) / "transcript.jsonl"
+        with path.open("a") as f:
+            f.write(_json.dumps({"type": "user_input", "text": "hello"}) + "\n")
+            f.write(_json.dumps({"type": "user_input", "text": "world"}) + "\n")
+
+        inp = app.query_one("#input", Input)
+        inp.value = "/scrub"
+        await inp.action_submit()
+        for _ in range(5):
+            await pilot.pause()
+
+        scrubber = next(
+            (s for s in app.screen_stack if isinstance(s, TranscriptScrubber)),
+            None,
+        )
+        assert scrubber is not None
+        # The OptionList should have at least 2 options (the two user_inputs).
+        from textual.widgets import OptionList
+        olist = scrubber.query_one("#scrub-list", OptionList)
+        assert olist.option_count >= 2
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Phase 3D — cost sparkline + transcript scrubber.

### Cost sparkline

- Per-turn cost history added to `ReplState.turn_costs` (capped at 20-turn rolling window; reset on `/clear`)
- `track_result` appends each turn's `total_cost_usd`
- New `_sparkline(values)` helper renders unicode-block bars `▁▂▃▄▅▆▇█` scaled to the peak in the series

StatusLine now embeds the sparkline next to the turn count:

```
Before: 3 turns · 350 tok · $0.0421 · effort=high · thinking=adaptive
After:  3 turns ▁▃█ · 350 tok · $0.0421 · effort=high · thinking=adaptive
```

### Transcript scrubber

New `/scrub` Textual-only slash command. Opens a `TranscriptScrubber` ModalScreen — read-only viewer listing every `user_input` event from the current session's `transcript.jsonl` with a 100-char preview. Esc / `q` to close.

Future PR can add scroll-to-turn behavior; this ships read-only.

## Test plan

- [x] `uv run pytest` — 1165 passed, 4 skipped
- [x] new tests (5):
  - `TestSparkline` (3): empty input, all-zeros baseline, increasing series hits peak block
  - `test_status_line_shows_sparkline_after_turns` — one turn produces a bar character in the rendered status line
  - `test_scrub_opens_modal` — `/scrub` pushes the scrubber, OptionList populates with `user_input` events

## Coming next

**Phase 3E**: `docs/repl-tui.md` walkthrough + screenshots.

Built by [dotdev.dev](https://dotdev.dev)
