### PR TITLE
feat(repl): brand the Textual REPL with dotdev/agentwire palette + config overrides

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -183,6 +183,27 @@ class ServicesConfig:
 
 
 @dataclass
+class ReplConfig:
+    """Agentwire REPL (Textual TUI) configuration.
+
+    `theme` is a dict of color overrides keyed by Textual theme attribute
+    (primary, secondary, accent, foreground, background, surface, panel,
+    success, warning, error). Each value is any color string Textual
+    accepts (#RRGGBB, named colors, etc.). Empty/missing keys fall back
+    to the brand defaults defined in `agentwire/repl/textual_app.py`.
+
+    Example `~/.agentwire/config.yaml`:
+
+        repl:
+          theme:
+            primary: "#ff00aa"        # override neon-green primary
+            background: "#0d0d2a"     # tweak the flat-black background
+    """
+
+    theme: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
 class SessionConfig:
     """Default session configuration."""
 
@@ -261,6 +282,7 @@ class Config:
     portal: PortalConfig = field(default_factory=PortalConfig)
     services: ServicesConfig = field(default_factory=ServicesConfig)
     session: SessionConfig = field(default_factory=SessionConfig)
+    repl: ReplConfig = field(default_factory=ReplConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     overnight: OvernightConfig = field(default_factory=OvernightConfig)
     channels: dict = field(default_factory=dict)
@@ -479,6 +501,13 @@ def _dict_to_config(data: dict) -> Config:
         go_prompt=overnight_data.get("go_prompt", DEFAULT_GO_PROMPT),
     )
 
+    # REPL (Textual TUI) — theme overrides
+    repl_data = data.get("repl", {}) or {}
+    theme_overrides = repl_data.get("theme", {}) or {}
+    if not isinstance(theme_overrides, dict):
+        theme_overrides = {}
+    repl = ReplConfig(theme={str(k): str(v) for k, v in theme_overrides.items()})
+
     return Config(
         server=server,
         projects=projects,
@@ -493,6 +522,7 @@ def _dict_to_config(data: dict) -> Config:
         scheduler=scheduler,
         overnight=overnight,
         channels=channel_configs,
+        repl=repl,
     )
 
 

--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -59,6 +59,7 @@ from textual.binding import Binding
 from textual.containers import Center, Vertical
 from textual.message import Message
 from textual.screen import ModalScreen
+from textual.theme import Theme
 from textual.widgets import Button, Footer, Header, Input, Label, OptionList, RichLog, Static
 from textual.widgets.option_list import Option
 
@@ -93,6 +94,89 @@ from agentwire.repl.state import (
     track_result,
     track_system_init,
 )
+
+
+# ----- agentwire brand theme ------------------------------------------------
+#
+# Mirrors the dotdev/agentwire brand palette from agentwire-website's
+# `src/app/globals.css`:
+#   --background: #000000          flat black
+#   --foreground: #e2e8f0          near-white
+#   --primary:    #00ff88          neon green
+#   --secondary:  #00d4ff          neon cyan (accent)
+#   --muted/card: #0a0a0a          near-black surface
+#   --accent:     #1a1a1a          slightly elevated panel
+#   --border:     #27272a          subtle line
+#   --destructive: #dc2626         red
+#
+# Textual `Theme` keys map onto these:
+#   primary    → neon green   (main brand)
+#   secondary  → neon cyan    (accent)
+#   accent     → neon cyan    (titlebars, focus)
+#   background → #000000
+#   foreground → #e2e8f0
+#   surface    → #0a0a0a      (status line, modal interior)
+#   panel      → #1a1a1a      (button, elevated container)
+#   success    → neon green   (matches brand)
+#   warning    → amber        (in-progress markers)
+#   error      → red          (destructive / failures)
+
+AGENTWIRE_THEME_DEFAULTS: dict[str, str] = {
+    "primary": "#00ff88",
+    "secondary": "#00d4ff",
+    "accent": "#00d4ff",
+    "foreground": "#e2e8f0",
+    "background": "#000000",
+    "surface": "#0a0a0a",
+    "panel": "#1a1a1a",
+    "success": "#00ff88",
+    "warning": "#fbbf24",
+    "error": "#dc2626",
+}
+
+# Variables (theme-token level) that derive from the palette. The user can
+# override via `repl.theme.<key>` in `~/.agentwire/config.yaml` too.
+AGENTWIRE_THEME_VARIABLES: dict[str, str] = {
+    "header-foreground": "#00ff88",
+    "header-background": "#0a0a0a",
+    "footer-key-foreground": "#00d4ff",
+    "footer-foreground": "#e2e8f0",
+    "footer-background": "#000000",
+    "footer-description-foreground": "#b8b8b8",
+    "border-blurred": "#27272a",
+}
+
+
+def build_agentwire_theme(overrides: dict[str, str] | None = None) -> Theme:
+    """Construct the agentwire brand `Theme` with optional user overrides.
+
+    `overrides` is a flat dict from `~/.agentwire/config.yaml`'s
+    `repl.theme.*` entries. Keys map onto either Theme palette attributes
+    (primary, secondary, …) or Textual variable names (header-foreground,
+    footer-key-foreground, …). Unknown keys are ignored.
+    """
+    overrides = overrides or {}
+    palette = {**AGENTWIRE_THEME_DEFAULTS}
+    variables = {**AGENTWIRE_THEME_VARIABLES}
+    for key, value in overrides.items():
+        if not value:
+            continue
+        if key in palette:
+            palette[key] = value
+        else:
+            # Anything not in the palette is treated as a variable override
+            # (e.g. header-foreground, footer-key-foreground).
+            variables[key] = value
+    return Theme(
+        name="agentwire",
+        dark=True,
+        variables=variables,
+        **palette,
+    )
+
+
+# Stable instance for tests and code that doesn't need overrides.
+AGENTWIRE_THEME = build_agentwire_theme()
 
 
 # ----- adapters -------------------------------------------------------------
@@ -267,7 +351,7 @@ class CommandPalette(ModalScreen[str | None]):
     }
     CommandPalette > Vertical {
         background: $surface;
-        border: thick $accent;
+        border: thick $secondary;
         width: 70;
         height: 22;
     }
@@ -388,20 +472,21 @@ class PermissionPrompt(ModalScreen[str]):
     }
     PermissionPrompt > Vertical {
         background: $surface;
-        border: thick $accent;
+        border: thick $primary;
         padding: 1 2;
         width: 80;
         height: auto;
     }
     PermissionPrompt Label {
         margin-bottom: 1;
+        color: $primary;
     }
     PermissionPrompt Static.tool-line {
-        color: $text;
+        color: $foreground;
         margin-bottom: 1;
     }
     PermissionPrompt Static.help-line {
-        color: $text 60%;
+        color: $foreground 60%;
     }
     PermissionPrompt Center {
         margin-top: 1;
@@ -461,14 +546,14 @@ class TranscriptScrubber(ModalScreen[None]):
     }
     TranscriptScrubber > Vertical {
         background: $surface;
-        border: thick $accent;
+        border: thick $secondary;
         width: 100;
         height: 30;
         padding: 0 1;
     }
     TranscriptScrubber Label {
         margin: 1 0;
-        color: $text;
+        color: $primary;
     }
     TranscriptScrubber OptionList {
         height: 1fr;
@@ -555,7 +640,7 @@ class StatusLine(Static):
     StatusLine {
         height: 1;
         padding: 0 1;
-        color: $text 60%;
+        color: $secondary;
         background: $surface;
     }
     """
@@ -596,25 +681,35 @@ class AgentwireREPL(App):
     CSS = """
     Screen {
         layout: vertical;
+        background: $background;
     }
 
+    /* Chat — main conversation area, wrapped in the brand neon green. */
     #chat {
         height: 6fr;
-        border: tall $accent;
+        border: tall $primary;
         padding: 0 1;
+        background: $background;
+        scrollbar-color: $primary $surface;
     }
 
+    /* CurrentAction — live partial stream, wrapped in the brand cyan accent. */
     #action {
         height: 2fr;
-        border: tall $warning;
-        border-title-color: $warning;
+        border: tall $secondary;
+        border-title-color: $secondary;
         padding: 0 1;
+        background: $surface;
+        scrollbar-color: $secondary $surface;
     }
 
+    /* Input — neon green border to match chat (the input is part of the
+       primary conversation flow). */
     #input {
         dock: bottom;
         height: 3;
-        border: tall $accent-lighten-1;
+        border: tall $primary;
+        background: $background;
     }
 
     Header {
@@ -677,6 +772,26 @@ class AgentwireREPL(App):
     # ------ lifecycle ------
 
     async def on_mount(self) -> None:
+        # Build + apply the agentwire brand theme, merging any per-user
+        # overrides from `~/.agentwire/config.yaml` (`repl.theme.*`). Other
+        # built-in themes remain available via `/theme <name>`.
+        try:
+            overrides: dict[str, str] = {}
+            try:
+                from agentwire.config import get_config
+                cfg = get_config()
+                overrides = dict(getattr(cfg.repl, "theme", {}) or {})
+            except Exception:
+                # Config load is best-effort — fall back to defaults silently.
+                pass
+            theme = build_agentwire_theme(overrides)
+            self.register_theme(theme)
+            self.theme = "agentwire"
+        except Exception:
+            # Older Textual versions or theme-system changes shouldn't crash
+            # the app — fall back to the default theme.
+            pass
+
         chat = self.query_one("#chat", RichLog)
         action = self.query_one("#action", RichLog)
         action.border_title = "Current action"

--- a/docs/repl-tui.md
+++ b/docs/repl-tui.md
@@ -157,14 +157,47 @@ Esc / `q` to close.
 
 ## Theming
 
-Built-in Textual themes work out of the box:
+The default `agentwire` theme matches the dotdev/agentwire brand:
+
+| Token | Color | Role |
+|---|---|---|
+| `primary` | `#00ff88` neon green | chat border, input border, modal labels |
+| `secondary` / `accent` | `#00d4ff` neon cyan | action-pane border, status text, modal borders |
+| `background` | `#000000` flat black | screen + chat |
+| `surface` | `#0a0a0a` near-black | status line, modal interior, action pane |
+| `foreground` | `#e2e8f0` near-white | main text |
+| `success` | `#00ff88` | matches primary |
+| `warning` | `#fbbf24` amber | in-progress markers |
+| `error` | `#dc2626` red | destructive |
+
+### Per-user overrides
+
+Drop a `repl.theme` block into `~/.agentwire/config.yaml`:
+
+```yaml
+repl:
+  theme:
+    primary: "#ff00aa"        # override neon-green primary
+    background: "#0d0d2a"     # tweak the flat-black background
+    header-foreground: "#ffffff"  # variable-level override
+```
+
+Any palette key (`primary`, `secondary`, `accent`, `foreground`,
+`background`, `surface`, `panel`, `success`, `warning`, `error`) and
+any Textual variable (e.g. `header-foreground`, `footer-key-foreground`,
+`border-blurred`) can be overridden independently. Missing keys keep
+the brand defaults.
+
+### Switching at runtime
+
+Other Textual built-ins remain available:
 
 ```
 > /theme
-[theme: textual-dark]
-[available: catppuccin-latte, catppuccin-mocha, dracula, flexoki,
-gruvbox, monokai, nord, solarized-light, textual-dark, textual-light,
-tokyo-night]
+[theme: agentwire]
+[available: agentwire, catppuccin-latte, catppuccin-mocha, dracula,
+flexoki, gruvbox, monokai, nord, solarized-light, textual-dark,
+textual-light, tokyo-night]
 
 > /theme dracula
 [theme set: dracula]

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -1107,6 +1107,81 @@ async def test_scrub_opens_modal(patched_sdk, tmp_path, monkeypatch):
         assert olist.option_count >= 2
 
 
+class TestAgentwireBrandTheme:
+    """Phase: brand theme — neon green primary + neon cyan accent on flat black."""
+
+    def test_default_palette_matches_brand(self):
+        from agentwire.repl.textual_app import build_agentwire_theme
+
+        theme = build_agentwire_theme()
+        assert theme.name == "agentwire"
+        assert theme.dark is True
+        assert theme.primary == "#00ff88"
+        assert theme.secondary == "#00d4ff"
+        assert theme.accent == "#00d4ff"
+        assert theme.foreground == "#e2e8f0"
+        assert theme.background == "#000000"
+        assert theme.surface == "#0a0a0a"
+        assert theme.success == "#00ff88"
+        assert theme.warning == "#fbbf24"
+        assert theme.error == "#dc2626"
+
+    def test_palette_overrides_apply(self):
+        from agentwire.repl.textual_app import build_agentwire_theme
+
+        theme = build_agentwire_theme({
+            "primary": "#ff00aa",
+            "background": "#0d0d2a",
+        })
+        assert theme.primary == "#ff00aa"
+        assert theme.background == "#0d0d2a"
+        # Other palette keys keep their brand defaults.
+        assert theme.secondary == "#00d4ff"
+        assert theme.foreground == "#e2e8f0"
+
+    def test_variable_overrides_apply(self):
+        # Keys outside the palette (e.g. header-foreground) go to variables.
+        from agentwire.repl.textual_app import build_agentwire_theme
+
+        theme = build_agentwire_theme({
+            "header-foreground": "#ff00ff",
+        })
+        assert theme.variables["header-foreground"] == "#ff00ff"
+
+    def test_empty_overrides_keep_defaults(self):
+        from agentwire.repl.textual_app import build_agentwire_theme
+
+        theme = build_agentwire_theme({"primary": ""})
+        # Empty string treated as no-op — brand default preserved.
+        assert theme.primary == "#00ff88"
+
+
+def test_repl_config_loads_theme_overrides(tmp_path, monkeypatch):
+    """Config plumbing: repl.theme.* in YAML round-trips into Config.repl.theme."""
+    from agentwire import config as cfg_mod
+
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text(
+        "repl:\n"
+        "  theme:\n"
+        '    primary: "#ff00aa"\n'
+        '    background: "#0d0d2a"\n'
+    )
+    cfg = cfg_mod.load_config(yaml_path)
+    assert cfg.repl.theme["primary"] == "#ff00aa"
+    assert cfg.repl.theme["background"] == "#0d0d2a"
+
+
+def test_repl_config_default_theme_is_empty(tmp_path):
+    """No `repl.theme` in YAML → empty dict, app falls back to brand defaults."""
+    from agentwire import config as cfg_mod
+
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("server:\n  port: 8765\n")
+    cfg = cfg_mod.load_config(yaml_path)
+    assert cfg.repl.theme == {}
+
+
 @pytest.mark.asyncio
 async def test_exit_command_quits_app(patched_sdk):
     from agentwire.repl.textual_app import AgentwireREPL


### PR DESCRIPTION
## Summary

Brands the Textual REPL with the dotdev/agentwire palette (lifted from `agentwire-website/src/app/globals.css`) **and** lets users override any color via `~/.agentwire/config.yaml`.

### Brand palette

| Token | Color | Role |
|---|---|---|
| `primary` | `#00ff88` neon green | chat border, input border, modal labels |
| `secondary` / `accent` | `#00d4ff` neon cyan | action-pane border, status text, modal borders |
| `background` | `#000000` flat black | screen + chat |
| `surface` | `#0a0a0a` near-black | status line, modal interior, action pane |
| `foreground` | `#e2e8f0` near-white | main text |
| `success` | `#00ff88` | matches primary |
| `warning` | `#fbbf24` amber | in-progress markers |
| `error` | `#dc2626` red | destructive |

### User overrides

```yaml
# ~/.agentwire/config.yaml
repl:
  theme:
    primary: "#ff00aa"        # palette key
    background: "#0d0d2a"
    header-foreground: "#ffffff"  # variable key
```

Any palette key (`primary`, `secondary`, `accent`, `foreground`, `background`, `surface`, `panel`, `success`, `warning`, `error`) and any Textual variable (`header-foreground`, `footer-key-foreground`, `border-blurred`, …) can be overridden independently. Missing keys keep brand defaults.

### Implementation

- `AGENTWIRE_THEME_DEFAULTS` + `AGENTWIRE_THEME_VARIABLES` at module scope
- `build_agentwire_theme(overrides)` constructs a Textual `Theme`, merging palette + variable overrides
- `on_mount` registers the theme + `self.theme = "agentwire"`
- App CSS + modal CSS rewritten to use `$primary` / `$secondary` / `$surface` consistently
- New `ReplConfig` dataclass; root `Config` gains a `repl` field; `_dict_to_config` parses `repl.theme.*` from yaml
- Other Textual built-ins remain selectable via `/theme <name>` at runtime

## Test plan

- [x] `uv run pytest` — 1128 passed, 4 skipped
- [x] new tests (6):
  - `TestAgentwireBrandTheme` (4): default palette matches brand; palette overrides apply; variable overrides go to variables; empty-string overrides ignored
  - `test_repl_config_loads_theme_overrides` — yaml round-trip
  - `test_repl_config_default_theme_is_empty` — no `repl.theme` key → empty dict, app falls back to defaults
- [x] live tmux smoke: chat border renders `#00ff88` neon green, action border + title render `#00d4ff` neon cyan, status line + modals all branded
- [x] end-to-end override path verified via temp `config.yaml`

Built by [dotdev.dev](https://dotdev.dev)
