### PR TITLE
feat(repl): fanout N-column view — multi-generation A/B prompting

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3444,6 +3444,8 @@ def cmd_repl(args) -> int:
         session_name=getattr(args, "session_name", None),
         resume=getattr(args, "resume", None),
         roles=getattr(args, "roles", None),
+        view=getattr(args, "view", "chat"),
+        cols=getattr(args, "cols", 3),
     )
 
 
@@ -10191,6 +10193,14 @@ def main() -> int:
     repl_parser.add_argument(
         "--role", dest="roles", action="append", metavar="NAME",
         help="Role name to compose into the system prompt (repeatable). Overrides .agentwire.yml roles.",
+    )
+    repl_parser.add_argument(
+        "--view", choices=["chat", "fanout"], default="chat",
+        help="UI view: 'chat' (default, single conversation) or 'fanout' (N parallel columns).",
+    )
+    repl_parser.add_argument(
+        "--cols", type=int, default=3, metavar="N",
+        help="Column count for --view fanout (2-6, default 3).",
     )
     repl_parser.set_defaults(func=cmd_repl)
 

--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -45,14 +45,18 @@ def run_repl(
     resume: str | None = None,
     roles: list[str] | None = None,
     seed_message: str | None = None,
+    view: str = "chat",
+    cols: int = 3,
 ) -> int:
     """Run the REPL. Returns exit code.
 
     - Print mode (`-p PROMPT`): single-shot stdout pipe — one SDK call,
       stream events, exit. Used by `agentwire workflow run`, scheduler
       tasks, and `human_gate` seeds where a TUI would interfere.
-    - Interactive: Textual TUI under `~/.agentwire/sessions/repl/<name>/`
-      with full transcript persistence.
+    - Interactive (default `--view chat`): Textual TUI under
+      `~/.agentwire/sessions/repl/<name>/` with full transcript persistence.
+    - `--view fanout --cols N`: composite view fanning the master input out
+      to N independent SDK clients side by side. Multi-generation A/B.
 
     `roles` overrides the role list from `.agentwire.yml` for this session;
     when None, project config wins.
@@ -63,6 +67,12 @@ def run_repl(
     """
     if print_prompt is not None:
         return asyncio.run(_run_print_mode(print_prompt, mode, model, system_prompt, roles))
+    if view == "fanout":
+        from agentwire.repl.views.fanout import run_fanout_repl
+        return asyncio.run(run_fanout_repl(
+            mode=mode, model=model, cols=cols,
+            system_prompt=system_prompt, roles=roles,
+        ))
     from agentwire.repl.textual_app import run_textual_repl
     return asyncio.run(run_textual_repl(
         mode=mode, model=model, system_prompt=system_prompt,

--- a/agentwire/repl/views/__init__.py
+++ b/agentwire/repl/views/__init__.py
@@ -1,0 +1,7 @@
+"""Composite views for the Textual REPL.
+
+Each view is a separate `textual.App` subclass that composes the SDK
+primitives (`AgentwireSDKClient`, `StreamRenderState`, sinks) into a
+specific UI shape. Today: fan-out N-column. Future: diff, multi-tool-pane,
+conversation-tree.
+"""

--- a/agentwire/repl/views/fanout.py
+++ b/agentwire/repl/views/fanout.py
@@ -1,0 +1,407 @@
+"""Fan-out N-column view for the Textual REPL.
+
+Layout: master input docked at the bottom, N independent columns above.
+Each column is its own SDK conversation — own ClaudeSDKClient, own
+StreamRenderState, own RichLog widgets. When the user types in the master
+input, the same prompt fans out to all N clients in parallel; each column
+streams its own response independently.
+
+Use case: multi-generation A/B prompting. Run the same prompt across N
+columns with different models / different roles / different effort, then
+pick the best output. Per-column overrides land in a follow-on PR.
+
+This is the first composite view built on `agentwire.sdk.*` — it
+validates that the primitives are actually reusable. See
+docs/missions/agentwire-sdk-primitives.md Phase 2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.message import Message
+from textual.widgets import Footer, Header, Input, RichLog, Static
+
+from agentwire.repl.context import load_session_context
+from agentwire.sdk import (
+    HEARTBEAT,
+    DEFAULT_MODEL,
+    StreamRenderState,
+    build_options,
+    heartbeat_iter,
+    render_message,
+)
+from agentwire.sdk.sinks.textual import ActionSink, RichLogSink
+
+
+class ColumnSdkEvent(Message):
+    """One SDK message (or HEARTBEAT) tagged with the column it belongs to."""
+
+    def __init__(self, col: int, payload: Any) -> None:
+        self.col = col
+        self.payload = payload
+        super().__init__()
+
+
+class ColumnTurnFinished(Message):
+    """Worker for column N signals turn complete (or cancelled)."""
+
+    def __init__(self, col: int, error: str | None = None) -> None:
+        self.col = col
+        self.error = error
+        super().__init__()
+
+
+class FanoutColumn:
+    """One column's per-conversation state.
+
+    Mirrors what `AgentwireREPL` keeps in fields, but scoped to one of N
+    columns: independent SDK client, independent stream state, independent
+    sinks bound to its own RichLog widgets, independent running totals.
+    """
+
+    def __init__(self, col: int, mode: str, model: str | None) -> None:
+        self.col = col
+        self.mode = mode
+        self.model = model or DEFAULT_MODEL
+        self.client: Any = None
+        self.sdk_classes: dict[str, Any] | None = None
+        self.chat_sink: RichLogSink | None = None
+        self.action_sink: ActionSink | None = None
+        self.stream_state = StreamRenderState()
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cost_usd = 0.0
+        self.turn_count = 0
+
+
+class FanoutStatusLine(Static):
+    """Per-column running totals: cost / tokens / turn count."""
+
+    DEFAULT_CSS = """
+    FanoutStatusLine {
+        height: 1;
+        padding: 0 1;
+        background: $background;
+        color: $foreground;
+    }
+    """
+
+
+class FanoutREPL(App):
+    """Textual app: master input fans out to N independent SDK clients.
+
+    Each column has its own ChatLog (finalized turns), CurrentAction
+    (live partial-stream), and StatusLine. Typing in the master input
+    fires one `query()` per column in parallel — they stream concurrently,
+    and the user picks the winner by reading.
+    """
+
+    BINDINGS = [
+        Binding("ctrl+c", "cancel_all", "Cancel all turns", priority=True),
+        Binding("ctrl+d", "quit", "Exit"),
+    ]
+
+    DEFAULT_CSS = """
+    Screen {
+        background: $background;
+    }
+
+    Header {
+        dock: top;
+        background: $background;
+        color: $primary;
+    }
+    HeaderTitle { background: $background; color: $primary; }
+    HeaderIcon { background: $background; }
+
+    #columns {
+        height: 1fr;
+        background: $background;
+    }
+
+    .column {
+        width: 1fr;
+        height: 1fr;
+        background: $background;
+    }
+
+    .col-chat {
+        height: 3fr;
+        border: tall $primary;
+        border-title-color: $primary;
+        padding: 0 1;
+        background: $background;
+        scrollbar-color: $primary $background;
+    }
+
+    .col-action {
+        height: 1fr;
+        border: tall $secondary;
+        border-title-color: $secondary;
+        padding: 0 1;
+        background: $background;
+        scrollbar-color: $secondary $background;
+    }
+
+    .col-status {
+        height: 1;
+        padding: 0 1;
+        background: $background;
+        color: $secondary;
+    }
+
+    Input {
+        dock: bottom;
+        height: 3;
+        border: tall $primary;
+        border-title-color: $primary;
+        background: $background;
+        background-tint: $background;
+    }
+    Input:focus {
+        background: $background;
+        background-tint: $background;
+        border: tall $primary;
+    }
+
+    Footer { dock: bottom; background: $background; }
+    """
+
+    def __init__(self, *, mode: str, model: str | None, cols: int, system_prompt: str | None = None, roles: list[str] | None = None) -> None:
+        super().__init__()
+        self.mode = mode
+        self.system_prompt = system_prompt
+        self.roles = roles
+        self.title = f"agentwire repl — fanout · {cols} cols · {mode}"
+        self.columns: list[FanoutColumn] = [
+            FanoutColumn(col=i, mode=mode, model=model) for i in range(cols)
+        ]
+        self._ctx: Any = None
+
+    def compose(self) -> ComposeResult:
+        # Apply the agentwire brand theme — same one the chat view uses.
+        from agentwire.repl.textual_app import build_agentwire_theme
+        try:
+            from agentwire.config import load_config
+            cfg = load_config()
+            overrides = getattr(cfg, "repl", None)
+            theme_overrides = getattr(overrides, "theme", {}) if overrides else {}
+        except Exception:
+            theme_overrides = {}
+        self.register_theme(build_agentwire_theme(theme_overrides))
+        self.theme = "agentwire"
+
+        yield Header()
+        with Horizontal(id="columns"):
+            for col in self.columns:
+                with Vertical(classes="column", id=f"col-{col.col}"):
+                    chat = RichLog(id=f"chat-{col.col}", classes="col-chat", wrap=True, markup=False)
+                    chat.border_title = f"col {col.col + 1} · {col.model}"
+                    yield chat
+                    action = RichLog(id=f"action-{col.col}", classes="col-action", wrap=True, markup=False)
+                    action.border_title = "current action"
+                    yield action
+                    yield FanoutStatusLine(self._format_status(col), classes="col-status", id=f"status-{col.col}")
+        yield Input(id="master-input", placeholder="> fan-out to all columns")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        # Bind sinks to the just-mounted RichLogs.
+        for col in self.columns:
+            chat = self.query_one(f"#chat-{col.col}", RichLog)
+            action = self.query_one(f"#action-{col.col}", RichLog)
+            col.chat_sink = RichLogSink(chat)
+            col.action_sink = ActionSink(action)
+
+        try:
+            from claude_agent_sdk import (
+                AssistantMessage,
+                ClaudeAgentOptions,
+                ClaudeSDKClient,
+                ResultMessage,
+                SystemMessage,
+                UserMessage,
+            )
+        except ImportError as e:
+            self.exit(message=f"claude-agent-sdk not installed: {e}")
+            return
+
+        sdk_classes = {
+            "AssistantMessage": AssistantMessage,
+            "UserMessage": UserMessage,
+            "SystemMessage": SystemMessage,
+            "ResultMessage": ResultMessage,
+        }
+        self._ctx = load_session_context(Path.cwd(), role_overrides=self.roles)
+
+        # Open one SDK client per column.
+        for col in self.columns:
+            col.sdk_classes = sdk_classes
+            options = build_options(
+                ClaudeAgentOptions,
+                col.mode,
+                col.model,
+                self.system_prompt,
+                cwd=Path.cwd(),
+                session_context=self._ctx,
+            )
+            col.client = ClaudeSDKClient(options=options)
+            await col.client.__aenter__()
+
+        # Banner inside each column so the user sees what each column is.
+        for col in self.columns:
+            assert col.chat_sink is not None
+            col.chat_sink.write(
+                f"[col {col.col + 1} · {col.model} · {col.mode} · ready]\n"
+            )
+            col.chat_sink.flush()
+
+        self.query_one("#master-input", Input).focus()
+
+    async def on_unmount(self) -> None:
+        # Cleanly close every SDK client when the app exits.
+        for col in self.columns:
+            if col.client is not None:
+                try:
+                    await col.client.__aexit__(None, None, None)
+                except Exception:
+                    pass
+                col.client = None
+
+    # ------ master input → fan-out ------
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        text = event.value
+        if not text:
+            return
+        event.input.value = ""
+        # Echo the user turn into every column's chat (so each column has
+        # the same context visible).
+        for col in self.columns:
+            assert col.chat_sink is not None
+            col.chat_sink.write(f"\n> {text}\n")
+            col.chat_sink.flush()
+            col.turn_count += 1
+            self._refresh_status(col)
+        # Fire one worker per column.
+        for col in self.columns:
+            self.run_worker(
+                self._run_turn(col, text),
+                exclusive=False,
+                group=f"col-{col.col}",
+                name=f"col-{col.col}-turn",
+            )
+
+    async def _run_turn(self, col: FanoutColumn, text: str) -> None:
+        if col.client is None:
+            return
+        try:
+            await col.client.query(text)
+            async for message in heartbeat_iter(
+                col.client.receive_response(), idle_timeout=5.0
+            ):
+                self.post_message(ColumnSdkEvent(col.col, message))
+        except asyncio.CancelledError:
+            self.post_message(ColumnTurnFinished(col.col, error="cancelled"))
+            raise
+        except Exception as exc:
+            self.post_message(
+                ColumnTurnFinished(col.col, error=f"{type(exc).__name__}: {exc}")
+            )
+            return
+        self.post_message(ColumnTurnFinished(col.col))
+
+    # ------ rendering on UI thread ------
+
+    def on_column_sdk_event(self, event: ColumnSdkEvent) -> None:
+        col = self.columns[event.col]
+        if col.chat_sink is None or col.action_sink is None or col.sdk_classes is None:
+            return
+        msg = event.payload
+        if msg is HEARTBEAT:
+            col.stream_state.heartbeat(col.action_sink)
+            col.action_sink.flush()
+            return
+        try:
+            render_message(
+                msg,
+                AssistantMessage=col.sdk_classes["AssistantMessage"],
+                UserMessage=col.sdk_classes["UserMessage"],
+                SystemMessage=col.sdk_classes["SystemMessage"],
+                ResultMessage=col.sdk_classes["ResultMessage"],
+                out=col.chat_sink,
+                action_out=col.action_sink,
+                stream_state=col.stream_state,
+            )
+            col.chat_sink.flush()
+            col.action_sink.flush()
+            ResultMessage = col.sdk_classes["ResultMessage"]
+            if isinstance(msg, ResultMessage):
+                col.action_sink.clear()
+                usage = getattr(msg, "usage", {}) or {}
+                if isinstance(usage, dict):
+                    col.input_tokens += usage.get("input_tokens", 0) or 0
+                    col.output_tokens += usage.get("output_tokens", 0) or 0
+                cost = getattr(msg, "total_cost_usd", None)
+                if cost:
+                    col.cost_usd += float(cost)
+                self._refresh_status(col)
+        except Exception:
+            pass  # don't kill the whole app on render glitch
+
+    def on_column_turn_finished(self, event: ColumnTurnFinished) -> None:
+        col = self.columns[event.col]
+        if event.error and col.chat_sink is not None:
+            col.chat_sink.write(f"[col {col.col + 1} · {event.error}]\n")
+            col.chat_sink.flush()
+
+    # ------ cancellation ------
+
+    def action_cancel_all(self) -> None:
+        """Master Ctrl+C — cancel every running column turn."""
+        for w in self.workers:
+            if w.name and w.name.endswith("-turn") and w.is_running:
+                w.cancel()
+
+    # ------ status line ------
+
+    def _format_status(self, col: FanoutColumn) -> str:
+        return (
+            f"col {col.col + 1} · {col.turn_count} turns · "
+            f"{col.input_tokens + col.output_tokens} tok · "
+            f"${col.cost_usd:.4f}"
+        )
+
+    def _refresh_status(self, col: FanoutColumn) -> None:
+        try:
+            line = self.query_one(f"#status-{col.col}", FanoutStatusLine)
+            line.update(self._format_status(col))
+        except Exception:
+            pass
+
+
+async def run_fanout_repl(
+    *,
+    mode: str,
+    model: str | None,
+    cols: int,
+    system_prompt: str | None = None,
+    roles: list[str] | None = None,
+) -> int:
+    """Entry point invoked from `agentwire repl --view fanout --cols N`."""
+    if cols < 2:
+        raise ValueError("fanout requires --cols >= 2")
+    if cols > 6:
+        raise ValueError("fanout caps at 6 columns; pick fewer for usable widths")
+    app = FanoutREPL(
+        mode=mode, model=model, cols=cols,
+        system_prompt=system_prompt, roles=roles,
+    )
+    await app.run_async()
+    return 0

--- a/docs/missions/agentwire-sdk-primitives.md
+++ b/docs/missions/agentwire-sdk-primitives.md
@@ -4,7 +4,7 @@
 
 Extract the streaming SDK plumbing already proven in two surfaces (`runners/anthropic.py` headless + `repl/textual_app.py` interactive) into a reusable set of primitives, then compose those primitives into new views (fan-out, watch-mode, diff, conversation-tree). The Textual REPL and SDK workflow runner become the first two consumers of the same engine; everything else after that is `client + sink(s)`.
 
-**Status:** Phase 1 shipped (2026-04-26) — `agentwire/sdk/` package now hosts the shared streaming engine. Phase 2-4 pending.
+**Status:** Phase 1 + 2 shipped (2026-04-26) — `agentwire/sdk/` engine + fan-out N-column view live. Phase 3-4 pending.
 **Depends on:**
 - `agentwire-repl-textual.md` (complete) — Textual REPL ships with all the streaming logic this mission extracts
 - `pi-harness-overview.md` Phase 6 (complete) — `runners/anthropic.py` is the other proof point
@@ -128,9 +128,11 @@ Pure refactor. Zero behavior change. The Textual REPL, print mode, and SDK workf
 - New `agentwire/sdk/` is the only place these concerns live
 - Diffstat shows net code reduction (or close to neutral) once duplication is removed
 
-### Phase 2 — Fan-out N-column view (target: 1-2 weeks)
+### Phase 2 — Fan-out N-column view (shipped 2026-04-26, PR #145)
 
-The motivating composite view. Proves the primitives are actually reusable.
+The motivating composite view. Proved the primitives are actually reusable —
+`agentwire/repl/views/fanout.py` is ~340 LOC and consumes only `agentwire.sdk.*`
+plus Textual widgets. No SDK plumbing duplicated.
 
 - New view module: `agentwire/repl/views/fanout.py`
 - `/view fanout cols=3` slash command (default chat view is `/view chat`)

--- a/docs/repl-tui.md
+++ b/docs/repl-tui.md
@@ -229,10 +229,42 @@ contains:
 Both files are byte-identical to what the line-mode path produces, so
 `/resume` works across both implementations.
 
+## Fan-out view (multi-generation A/B)
+
+Run the same prompt across N independent SDK clients side by side:
+
+```bash
+agentwire repl --view fanout --cols 3
+```
+
+```
+┌─ col 1 · claude-opus-4-7 ─┬─ col 2 · claude-opus-4-7 ─┬─ col 3 · claude-opus-4-7 ─┐
+│ [chat history]            │ [chat history]            │ [chat history]            │
+│                           │                           │                           │
+├─ current action ──────────┼─ current action ──────────┼─ current action ──────────┤
+│ [thinking…]               │ [thinking…]               │ [thinking…]               │
+├─ status ──────────────────┼─ status ──────────────────┼─ status ──────────────────┤
+│ col 1 · 1 turn · 47 tok   │ col 2 · 1 turn · 51 tok   │ col 3 · 1 turn · 49 tok   │
+├───────────────────────────┴───────────────────────────┴───────────────────────────┤
+│ > master input — fans out to all columns                                          │
+└───────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Type into the master input — the prompt fans out to every column in
+parallel. Each column streams its own response independently with its
+own running totals (turns, tokens, cost). `Ctrl+C` cancels every
+in-flight column at once.
+
+Use case: when you want multiple Opus 4.7 attempts on the same prompt to
+pick the best one, or to compare model outputs (when per-column overrides
+ship). `--cols 2-6` is supported; 3 is a good default for most terminal
+widths.
+
 ## What's next
 
 Trigger-driven: snapshot tests for new visual changes (Phase 3A laid the
 infra; run via `pytest -m snapshots`).
 
 See `docs/missions/agentwire-repl-textual.md` for the living checklist
-and shipping log.
+and `docs/missions/agentwire-sdk-primitives.md` for the composite-views
+roadmap.

--- a/tests/unit/test_repl_fanout.py
+++ b/tests/unit/test_repl_fanout.py
@@ -1,0 +1,263 @@
+"""Tests for the fan-out N-column view (agentwire/repl/views/fanout.py).
+
+Covers boot, master-input fan-out semantics, per-column state isolation,
+cancellation, and arg validation. SDK client construction is patched to
+avoid hitting real auth — we substitute fake context-manager classes that
+record their construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentwire.repl.views.fanout import (
+    ColumnSdkEvent,
+    ColumnTurnFinished,
+    FanoutColumn,
+    FanoutREPL,
+    run_fanout_repl,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch, tmp_path):
+    """Don't let real config / damage-control / mcp interfere with tests."""
+    monkeypatch.setenv("AGENTWIRE_REPL_MCP", "0")
+    monkeypatch.setenv("AGENTWIRE_REPL_DAMAGE_CONTROL", "0")
+    monkeypatch.chdir(tmp_path)
+
+
+class FakeClient:
+    """Stand-in for ClaudeSDKClient.
+
+    Records every query() call. receive_response() yields a single
+    ResultMessage so a turn completes deterministically.
+    """
+
+    instances: list["FakeClient"] = []
+
+    def __init__(self, options=None):
+        self.options = options
+        self.queries: list[str] = []
+        self.entered = False
+        self.exited = False
+        FakeClient.instances.append(self)
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *args):
+        self.exited = True
+
+    async def query(self, text: str):
+        self.queries.append(text)
+
+    def receive_response(self):
+        async def gen():
+            yield SimpleNamespace(
+                __class__=FakeResultMessage,
+                usage={"input_tokens": 5, "output_tokens": 10},
+                total_cost_usd=0.0042,
+                duration_ms=100,
+                is_error=False,
+                result=None,
+            )
+        return gen()
+
+
+class FakeAssistantMessage:
+    pass
+
+
+class FakeUserMessage:
+    pass
+
+
+class FakeSystemMessage:
+    pass
+
+
+class FakeResultMessage:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class FakeOptions:
+    def __init__(self, **kw):
+        self.kwargs = kw
+        self.allowed_tools = kw.get("allowed_tools", [])
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Patch claude_agent_sdk so FanoutREPL.on_mount can construct clients
+    without real auth."""
+    FakeClient.instances = []
+    fake_module = SimpleNamespace(
+        ClaudeAgentOptions=FakeOptions,
+        ClaudeSDKClient=FakeClient,
+        AssistantMessage=FakeAssistantMessage,
+        UserMessage=FakeUserMessage,
+        SystemMessage=FakeSystemMessage,
+        ResultMessage=FakeResultMessage,
+    )
+    import sys
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_module)
+    return fake_module
+
+
+# ---- FanoutColumn ----------------------------------------------------------
+
+
+class TestFanoutColumn:
+    def test_init_defaults(self):
+        col = FanoutColumn(col=0, mode="bypass", model=None)
+        assert col.col == 0
+        assert col.mode == "bypass"
+        assert col.model  # filled with DEFAULT_MODEL when None
+        assert col.client is None
+        assert col.input_tokens == 0
+        assert col.output_tokens == 0
+        assert col.cost_usd == 0.0
+        assert col.turn_count == 0
+
+    def test_explicit_model(self):
+        col = FanoutColumn(col=2, mode="prompted", model="claude-sonnet-4-6")
+        assert col.col == 2
+        assert col.model == "claude-sonnet-4-6"
+        assert col.mode == "prompted"
+
+
+# ---- run_fanout_repl arg validation ---------------------------------------
+
+
+class TestArgValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_one_column(self):
+        with pytest.raises(ValueError, match=">= 2"):
+            await run_fanout_repl(mode="bypass", model=None, cols=1)
+
+    @pytest.mark.asyncio
+    async def test_rejects_zero_columns(self):
+        with pytest.raises(ValueError, match=">= 2"):
+            await run_fanout_repl(mode="bypass", model=None, cols=0)
+
+    @pytest.mark.asyncio
+    async def test_rejects_too_many_columns(self):
+        with pytest.raises(ValueError, match="caps at 6"):
+            await run_fanout_repl(mode="bypass", model=None, cols=7)
+
+
+# ---- FanoutREPL boot + fan-out --------------------------------------------
+
+
+class TestFanoutREPLBoot:
+    @pytest.mark.asyncio
+    async def test_compose_creates_n_columns(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model="claude-opus-4-7", cols=3)
+        async with app.run_test() as pilot:
+            assert len(app.columns) == 3
+            for i in range(3):
+                # Each column has its own RichLog widgets.
+                assert app.query_one(f"#chat-{i}") is not None
+                assert app.query_one(f"#action-{i}") is not None
+                assert app.query_one(f"#status-{i}") is not None
+            # Master input present.
+            assert app.query_one("#master-input") is not None
+
+    @pytest.mark.asyncio
+    async def test_each_column_gets_own_client(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model="claude-opus-4-7", cols=3)
+        async with app.run_test():
+            # Three independent FakeClient instances were constructed.
+            assert len(FakeClient.instances) == 3
+            for col in app.columns:
+                assert col.client is not None
+                # Each client got entered (async context manager).
+                assert col.client.entered is True
+
+    @pytest.mark.asyncio
+    async def test_columns_have_independent_stream_state(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=2)
+        async with app.run_test():
+            assert app.columns[0].stream_state is not app.columns[1].stream_state
+
+
+class TestFanoutFanOut:
+    @pytest.mark.asyncio
+    async def test_master_input_queries_all_columns(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=3)
+        async with app.run_test() as pilot:
+            inp = app.query_one("#master-input")
+            inp.value = "hello world"
+            await pilot.press("enter")
+            # Give workers a moment to pick up the queries.
+            for _ in range(20):
+                await pilot.pause()
+                if all(c.client.queries for c in app.columns):
+                    break
+            for col in app.columns:
+                assert col.client.queries == ["hello world"]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_does_not_fan_out(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=2)
+        async with app.run_test() as pilot:
+            inp = app.query_one("#master-input")
+            inp.value = ""
+            await pilot.press("enter")
+            await pilot.pause()
+            for col in app.columns:
+                assert col.client.queries == []
+
+    @pytest.mark.asyncio
+    async def test_turn_count_increments_per_column(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=2)
+        async with app.run_test() as pilot:
+            inp = app.query_one("#master-input")
+            inp.value = "first"
+            await pilot.press("enter")
+            await pilot.pause()
+            inp.value = "second"
+            await pilot.press("enter")
+            await pilot.pause()
+            for col in app.columns:
+                assert col.turn_count == 2
+
+
+class TestColumnSdkEvent:
+    def test_event_carries_column_index(self):
+        e = ColumnSdkEvent(col=2, payload="x")
+        assert e.col == 2
+        assert e.payload == "x"
+
+    def test_turn_finished_carries_error(self):
+        e = ColumnTurnFinished(col=1, error="boom")
+        assert e.col == 1
+        assert e.error == "boom"
+
+    def test_turn_finished_default_no_error(self):
+        e = ColumnTurnFinished(col=0)
+        assert e.error is None
+
+
+# ---- cleanup --------------------------------------------------------------
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_unmount_exits_all_clients(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=3)
+        async with app.run_test():
+            captured = list(FakeClient.instances)
+        # After the context manager exits, each client should have
+        # had __aexit__ called.
+        for client in captured:
+            assert client.exited is True


### PR DESCRIPTION
## Summary

Phase 2 of [docs/missions/agentwire-sdk-primitives.md](https://github.com/dotdevdotdev/agentwire-dev/blob/main/docs/missions/agentwire-sdk-primitives.md). New Textual view that fans the master input out to N independent SDK clients in parallel — multi-generation A/B prompting.

## What changed

- New module: \`agentwire/repl/views/fanout.py\` (\`FanoutREPL\` Textual app)
- New CLI flags: \`agentwire repl --view fanout --cols N\` (2-6, default 3)
- \`run_repl()\` dispatches to \`run_fanout_repl()\` when \`view=\"fanout\"\`
- 15 new tests (boot, fan-out semantics, per-column isolation, cleanup)

## Why this is the right shape

The entire fan-out view is **~340 LOC** and consumes only \`agentwire.sdk.*\` primitives — no SDK plumbing duplicated. That validates Phase 1's extraction was the right shape: each column gets its own \`ClaudeSDKClient\`, its own \`StreamRenderState\`, its own \`RichLogSink\` + \`ActionSink\`, and they multiplex through \`run_worker\` + \`post_message\`.

## Layout

\`\`\`
┌─ col 1 ─┬─ col 2 ─┬─ col 3 ─┐
│ chat    │ chat    │ chat    │
│ action  │ action  │ action  │
│ status  │ status  │ status  │
├─────────┴─────────┴─────────┤
│ > master input              │
└─────────────────────────────┘
\`\`\`

## Behavior

- **Master input** → fires one \`query()\` per column in parallel
- **Per-column streaming** — each column's events route to its own widgets via \`ColumnSdkEvent(col=N, payload=msg)\`
- **Per-column totals** — turns / tokens / cost tracked independently
- **Master Ctrl+C** — cancels every in-flight column at once
- **Cleanup** — each column's \`ClaudeSDKClient\` is \`__aexit__\`'d on app unmount

## Deferred to follow-on

- Per-column input (focus column N to type into just that branch)
- \`/col N model=X effort=max\` per-column overrides
- \`/promote N\` (pick a column as primary, archive others)
- Cost ceiling auto-cancel

These are polish; the architectural validation is the MVP shipped here.

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_fanout.py -q\` — 15 passed
- [x] \`uv run pytest tests/ -q\` — 1143 passed, 4 skipped
- [x] \`agentwire repl --help\` shows new \`--view\` and \`--cols\` flags
- [x] \`run_fanout_repl(cols=1)\` raises ValueError; \`cols=7\` raises ValueError

Built by [dotdev.dev](https://dotdev.dev)