### PR TITLE
feat(repl): per-column overrides + per-column input for fanout view

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3446,6 +3446,9 @@ def cmd_repl(args) -> int:
         roles=getattr(args, "roles", None),
         view=getattr(args, "view", "chat"),
         cols=getattr(args, "cols", 3),
+        col_models=getattr(args, "col_models", None),
+        col_efforts=getattr(args, "col_efforts", None),
+        col_roles=getattr(args, "col_roles", None),
     )
 
 
@@ -10201,6 +10204,18 @@ def main() -> int:
     repl_parser.add_argument(
         "--cols", type=int, default=3, metavar="N",
         help="Column count for --view fanout (2-6, default 3).",
+    )
+    repl_parser.add_argument(
+        "--col-model", dest="col_models", action="append", metavar="N=MODEL",
+        help="Per-column model override for --view fanout (e.g. --col-model 0=claude-opus-4-7 --col-model 1=claude-sonnet-4-6). Repeatable.",
+    )
+    repl_parser.add_argument(
+        "--col-effort", dest="col_efforts", action="append", metavar="N=EFFORT",
+        help="Per-column effort override for --view fanout (e.g. --col-effort 0=max --col-effort 1=high). Repeatable.",
+    )
+    repl_parser.add_argument(
+        "--col-role", dest="col_roles", action="append", metavar="N=ROLE[,ROLE...]",
+        help="Per-column role override for --view fanout (e.g. --col-role 0=skeptic --col-role 1=optimist,explainer). Repeatable.",
     )
     repl_parser.set_defaults(func=cmd_repl)
 

--- a/agentwire/repl/app.py
+++ b/agentwire/repl/app.py
@@ -47,6 +47,9 @@ def run_repl(
     seed_message: str | None = None,
     view: str = "chat",
     cols: int = 3,
+    col_models: list[str] | None = None,
+    col_efforts: list[str] | None = None,
+    col_roles: list[str] | None = None,
 ) -> int:
     """Run the REPL. Returns exit code.
 
@@ -72,6 +75,9 @@ def run_repl(
         return asyncio.run(run_fanout_repl(
             mode=mode, model=model, cols=cols,
             system_prompt=system_prompt, roles=roles,
+            col_models_raw=col_models,
+            col_efforts_raw=col_efforts,
+            col_roles_raw=col_roles,
         ))
     from agentwire.repl.textual_app import run_textual_repl
     return asyncio.run(run_textual_repl(

--- a/agentwire/repl/views/fanout.py
+++ b/agentwire/repl/views/fanout.py
@@ -29,8 +29,9 @@ from textual.widgets import Footer, Header, Input, RichLog, Static
 
 from agentwire.repl.context import load_session_context
 from agentwire.sdk import (
-    HEARTBEAT,
+    DEFAULT_EFFORT,
     DEFAULT_MODEL,
+    HEARTBEAT,
     StreamRenderState,
     build_options,
     heartbeat_iter,
@@ -63,12 +64,26 @@ class FanoutColumn:
     Mirrors what `AgentwireREPL` keeps in fields, but scoped to one of N
     columns: independent SDK client, independent stream state, independent
     sinks bound to its own RichLog widgets, independent running totals.
+    Per-column overrides (model, effort, role list) are honored when set.
     """
 
-    def __init__(self, col: int, mode: str, model: str | None) -> None:
+    def __init__(
+        self,
+        col: int,
+        mode: str,
+        model: str | None,
+        effort: str | None = None,
+        roles: list[str] | None = None,
+    ) -> None:
         self.col = col
         self.mode = mode
         self.model = model or DEFAULT_MODEL
+        self.effort = effort or DEFAULT_EFFORT
+        # `roles=None` means "inherit app-level"; an explicit `[]` overrides
+        # to "no roles". Capture the distinction here.
+        self.roles_override: list[str] | None = (
+            list(roles) if roles is not None else None
+        )
         self.client: Any = None
         self.sdk_classes: dict[str, Any] | None = None
         self.chat_sink: RichLogSink | None = None
@@ -156,7 +171,14 @@ class FanoutREPL(App):
         color: $secondary;
     }
 
-    Input {
+    .col-input {
+        height: 3;
+        border: tall $secondary;
+        background: $background;
+        background-tint: $background;
+    }
+
+    Input#master-input {
         dock: bottom;
         height: 3;
         border: tall $primary;
@@ -164,7 +186,7 @@ class FanoutREPL(App):
         background: $background;
         background-tint: $background;
     }
-    Input:focus {
+    Input#master-input:focus {
         background: $background;
         background-tint: $background;
         border: tall $primary;
@@ -173,16 +195,38 @@ class FanoutREPL(App):
     Footer { dock: bottom; background: $background; }
     """
 
-    def __init__(self, *, mode: str, model: str | None, cols: int, system_prompt: str | None = None, roles: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        mode: str,
+        model: str | None,
+        cols: int,
+        system_prompt: str | None = None,
+        roles: list[str] | None = None,
+        col_models: dict[int, str] | None = None,
+        col_efforts: dict[int, str] | None = None,
+        col_roles: dict[int, list[str]] | None = None,
+    ) -> None:
         super().__init__()
         self.mode = mode
         self.system_prompt = system_prompt
         self.roles = roles
         self.title = f"agentwire repl — fanout · {cols} cols · {mode}"
+        col_models = col_models or {}
+        col_efforts = col_efforts or {}
+        col_roles = col_roles or {}
         self.columns: list[FanoutColumn] = [
-            FanoutColumn(col=i, mode=mode, model=model) for i in range(cols)
+            FanoutColumn(
+                col=i,
+                mode=mode,
+                model=col_models.get(i, model),
+                effort=col_efforts.get(i),
+                roles=col_roles.get(i),
+            )
+            for i in range(cols)
         ]
         self._ctx: Any = None
+        self._col_ctxs: dict[int, Any] = {}
 
     def compose(self) -> ComposeResult:
         # Apply the agentwire brand theme — same one the chat view uses.
@@ -202,12 +246,17 @@ class FanoutREPL(App):
             for col in self.columns:
                 with Vertical(classes="column", id=f"col-{col.col}"):
                     chat = RichLog(id=f"chat-{col.col}", classes="col-chat", wrap=True, markup=False)
-                    chat.border_title = f"col {col.col + 1} · {col.model}"
+                    chat.border_title = self._chat_title(col)
                     yield chat
                     action = RichLog(id=f"action-{col.col}", classes="col-action", wrap=True, markup=False)
                     action.border_title = "current action"
                     yield action
                     yield FanoutStatusLine(self._format_status(col), classes="col-status", id=f"status-{col.col}")
+                    yield Input(
+                        id=f"col-input-{col.col}",
+                        placeholder=f"> col {col.col + 1} only",
+                        classes="col-input",
+                    )
         yield Input(id="master-input", placeholder="> fan-out to all columns")
         yield Footer()
 
@@ -240,16 +289,26 @@ class FanoutREPL(App):
         }
         self._ctx = load_session_context(Path.cwd(), role_overrides=self.roles)
 
-        # Open one SDK client per column.
+        # Open one SDK client per column. Per-column role overrides need
+        # their own session context so the system prompt picks up the
+        # right role layering.
         for col in self.columns:
             col.sdk_classes = sdk_classes
+            if col.roles_override is not None:
+                col_ctx = load_session_context(
+                    Path.cwd(), role_overrides=col.roles_override
+                )
+            else:
+                col_ctx = self._ctx
+            self._col_ctxs[col.col] = col_ctx
             options = build_options(
                 ClaudeAgentOptions,
                 col.mode,
                 col.model,
                 self.system_prompt,
                 cwd=Path.cwd(),
-                session_context=self._ctx,
+                effort=col.effort,
+                session_context=col_ctx,
             )
             col.client = ClaudeSDKClient(options=options)
             await col.client.__aenter__()
@@ -257,8 +316,11 @@ class FanoutREPL(App):
         # Banner inside each column so the user sees what each column is.
         for col in self.columns:
             assert col.chat_sink is not None
+            roles_part = ""
+            if col.roles_override:
+                roles_part = f" · roles={','.join(col.roles_override)}"
             col.chat_sink.write(
-                f"[col {col.col + 1} · {col.model} · {col.mode} · ready]\n"
+                f"[col {col.col + 1} · {col.model} · effort={col.effort} · {col.mode}{roles_part} · ready]\n"
             )
             col.chat_sink.flush()
 
@@ -274,23 +336,36 @@ class FanoutREPL(App):
                     pass
                 col.client = None
 
-    # ------ master input → fan-out ------
+    # ------ inputs (master + per-column) ------
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         text = event.value
         if not text:
             return
         event.input.value = ""
-        # Echo the user turn into every column's chat (so each column has
-        # the same context visible).
-        for col in self.columns:
+        input_id = getattr(event.input, "id", "") or ""
+        if input_id == "master-input":
+            target_cols = list(self.columns)
+        elif input_id.startswith("col-input-"):
+            try:
+                idx = int(input_id.removeprefix("col-input-"))
+            except ValueError:
+                return
+            if not 0 <= idx < len(self.columns):
+                return
+            target_cols = [self.columns[idx]]
+        else:
+            return
+
+        # Echo the user turn into each target column's chat.
+        for col in target_cols:
             assert col.chat_sink is not None
             col.chat_sink.write(f"\n> {text}\n")
             col.chat_sink.flush()
             col.turn_count += 1
             self._refresh_status(col)
-        # Fire one worker per column.
-        for col in self.columns:
+        # Fire one worker per target column.
+        for col in target_cols:
             self.run_worker(
                 self._run_turn(col, text),
                 exclusive=False,
@@ -371,6 +446,12 @@ class FanoutREPL(App):
 
     # ------ status line ------
 
+    def _chat_title(self, col: FanoutColumn) -> str:
+        roles = ""
+        if col.roles_override:
+            roles = f" · {','.join(col.roles_override)}"
+        return f"col {col.col + 1} · {col.model} · {col.effort}{roles}"
+
     def _format_status(self, col: FanoutColumn) -> str:
         return (
             f"col {col.col + 1} · {col.turn_count} turns · "
@@ -386,6 +467,40 @@ class FanoutREPL(App):
             pass
 
 
+def parse_col_overrides(
+    raw: list[str] | None, *, max_col: int, value_split: bool = False
+) -> dict[int, Any]:
+    """Parse `N=value` repeated args into `{col_index: value}`.
+
+    `--col-model 0=claude-opus-4-7 --col-model 2=claude-sonnet-4-6` →
+    `{0: "claude-opus-4-7", 2: "claude-sonnet-4-6"}`. Indices are
+    user-facing 0-based. When `value_split=True`, comma-splits the value
+    into a list (used for roles, which can be multi-valued).
+    """
+    out: dict[int, Any] = {}
+    for entry in raw or []:
+        if "=" not in entry:
+            raise ValueError(
+                f"invalid column override {entry!r}: expected 'INDEX=VALUE'"
+            )
+        idx_str, _, value = entry.partition("=")
+        try:
+            idx = int(idx_str)
+        except ValueError as e:
+            raise ValueError(
+                f"invalid column index {idx_str!r} in {entry!r}: not an integer"
+            ) from e
+        if idx < 0 or idx >= max_col:
+            raise ValueError(
+                f"column index {idx} in {entry!r} out of range [0,{max_col})"
+            )
+        if value_split:
+            out[idx] = [v.strip() for v in value.split(",") if v.strip()]
+        else:
+            out[idx] = value
+    return out
+
+
 async def run_fanout_repl(
     *,
     mode: str,
@@ -393,15 +508,24 @@ async def run_fanout_repl(
     cols: int,
     system_prompt: str | None = None,
     roles: list[str] | None = None,
+    col_models_raw: list[str] | None = None,
+    col_efforts_raw: list[str] | None = None,
+    col_roles_raw: list[str] | None = None,
 ) -> int:
     """Entry point invoked from `agentwire repl --view fanout --cols N`."""
     if cols < 2:
         raise ValueError("fanout requires --cols >= 2")
     if cols > 6:
         raise ValueError("fanout caps at 6 columns; pick fewer for usable widths")
+    col_models = parse_col_overrides(col_models_raw, max_col=cols)
+    col_efforts = parse_col_overrides(col_efforts_raw, max_col=cols)
+    col_roles = parse_col_overrides(col_roles_raw, max_col=cols, value_split=True)
     app = FanoutREPL(
         mode=mode, model=model, cols=cols,
         system_prompt=system_prompt, roles=roles,
+        col_models=col_models,
+        col_efforts=col_efforts,
+        col_roles=col_roles,
     )
     await app.run_async()
     return 0

--- a/docs/missions/agentwire-sdk-primitives.md
+++ b/docs/missions/agentwire-sdk-primitives.md
@@ -4,7 +4,7 @@
 
 Extract the streaming SDK plumbing already proven in two surfaces (`runners/anthropic.py` headless + `repl/textual_app.py` interactive) into a reusable set of primitives, then compose those primitives into new views (fan-out, watch-mode, diff, conversation-tree). The Textual REPL and SDK workflow runner become the first two consumers of the same engine; everything else after that is `client + sink(s)`.
 
-**Status:** Phases 1-3 shipped (2026-04-26) — `agentwire/sdk/` engine + fan-out N-column view + portal watch-mode (transcript-tail SSE-equivalent over WS). Phase 4 trigger-driven.
+**Status:** Phases 1-4 shipped (2026-04-26) — `agentwire/sdk/` engine + fan-out N-column view (with per-column model/effort/role overrides + per-column input) + portal watch-mode (transcript-tail SSE-equivalent over WS). Further composite views (diff, multi-tool-pane, conv-tree, voice/channel sinks) remain trigger-driven.
 **Depends on:**
 - `agentwire-repl-textual.md` (complete) — Textual REPL ships with all the streaming logic this mission extracts
 - `pi-harness-overview.md` Phase 6 (complete) — `runners/anthropic.py` is the other proof point
@@ -177,13 +177,29 @@ plus Textual widgets. No SDK plumbing duplicated.
 - Tail-and-stream works across pane death (transcript file is the SSOT).
 - Watch window renders text, thinking, tool_use, tool_result, turn_end without crashes on novel block types.
 
-### Phase 4+ — Additional views (trigger-driven)
+### Phase 4 — Fan-out per-column overrides + per-column input (shipped 2026-04-26, PR #147)
 
-Each is its own sub-PR. Ship the highest-value one first based on real usage from Phases 2-3.
+Promoted from Phase 2's deferred polish to Phase 4. Per-column model / effort / role overrides + a per-column input field land here — they're what makes fan-out actually useful for *comparing* (different models / efforts / roles), not just multi-generation with one config.
+
+CLI:
+
+```bash
+agentwire repl --view fanout --cols 3 \
+  --col-model 0=claude-opus-4-7 \
+  --col-model 1=claude-sonnet-4-6 \
+  --col-effort 0=max --col-effort 1=high \
+  --col-role 0=skeptic --col-role 1=optimist
+```
+
+Per-column input: each column has its own Input below the StatusLine; submitting to a column-input fires only that column's worker. Master input (docked at the bottom) still fans out to all columns.
+
+### Phase 5+ — Additional views (trigger-driven)
+
+Each is its own sub-PR. Ship the highest-value one first based on real usage from Phases 2-4.
 
 | View | What it does | Trigger to build |
 |---|---|---|
-| Diff view | Two columns, same prompt, different model/role/effort, side-by-side comparison with shared StatusLine | We notice we use fan-out=2 for this exact pattern repeatedly |
+| Diff view | (subsumed by Phase 4 — `agentwire repl --view fanout --cols 2 --col-model 0=A --col-model 1=B` already does this) | n/a |
 | Multi-tool-pane | Main chat + filtered sinks per tool type ("currently running Bash" pane, "thinking trace" pane) | Long tool-heavy turns where chat scrollback hides what's running |
 | Conversation-tree | Branch a turn N ways, explore alternatives without losing parent (parent-child with promote/discard) | We find ourselves wanting to try-and-revert mid-session |
 | Workflow visualizer | Each workflow node = one column; live node states + outputs as DAG executes | Workflows grow complex enough that JSONL tail isn't enough |

--- a/docs/repl-tui.md
+++ b/docs/repl-tui.md
@@ -234,7 +234,22 @@ Both files are byte-identical to what the line-mode path produces, so
 Run the same prompt across N independent SDK clients side by side:
 
 ```bash
+# Fan-out 3 ways with the same model
 agentwire repl --view fanout --cols 3
+
+# Compare models side by side
+agentwire repl --view fanout --cols 3 \
+  --col-model 0=claude-opus-4-7 \
+  --col-model 1=claude-sonnet-4-6 \
+  --col-model 2=claude-haiku-4-5
+
+# Compare effort levels
+agentwire repl --view fanout --cols 2 \
+  --col-effort 0=max --col-effort 1=high
+
+# Compare roles (e.g. skeptic vs optimist)
+agentwire repl --view fanout --cols 2 \
+  --col-role 0=skeptic --col-role 1=optimist
 ```
 
 ```
@@ -254,6 +269,10 @@ Type into the master input — the prompt fans out to every column in
 parallel. Each column streams its own response independently with its
 own running totals (turns, tokens, cost). `Ctrl+C` cancels every
 in-flight column at once.
+
+Each column also has its own input field — type into one and the
+prompt only goes to that column. Useful for redirecting a single
+branch ("col 2 — try again with X") without affecting the others.
 
 Use case: when you want multiple Opus 4.7 attempts on the same prompt to
 pick the best one, or to compare model outputs (when per-column overrides

--- a/tests/unit/test_repl_fanout.py
+++ b/tests/unit/test_repl_fanout.py
@@ -20,6 +20,7 @@ from agentwire.repl.views.fanout import (
     ColumnTurnFinished,
     FanoutColumn,
     FanoutREPL,
+    parse_col_overrides,
     run_fanout_repl,
 )
 
@@ -261,3 +262,138 @@ class TestCleanup:
         # had __aexit__ called.
         for client in captured:
             assert client.exited is True
+
+
+# ---- Phase 4: per-column overrides + per-column input ---------------------
+
+
+class TestParseColOverrides:
+    def test_simple_string_value(self):
+        out = parse_col_overrides(["0=opus", "2=sonnet"], max_col=3)
+        assert out == {0: "opus", 2: "sonnet"}
+
+    def test_split_value_returns_list(self):
+        out = parse_col_overrides(["0=skeptic,explainer"], max_col=2, value_split=True)
+        assert out == {0: ["skeptic", "explainer"]}
+
+    def test_split_strips_whitespace_and_drops_empty(self):
+        out = parse_col_overrides(["0= a , b , "], max_col=1, value_split=True)
+        assert out == {0: ["a", "b"]}
+
+    def test_missing_equals_raises(self):
+        with pytest.raises(ValueError, match="expected 'INDEX=VALUE'"):
+            parse_col_overrides(["broken"], max_col=2)
+
+    def test_non_integer_index_raises(self):
+        with pytest.raises(ValueError, match="not an integer"):
+            parse_col_overrides(["x=opus"], max_col=2)
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="out of range"):
+            parse_col_overrides(["5=opus"], max_col=3)
+
+    def test_negative_index_raises(self):
+        with pytest.raises(ValueError, match="out of range"):
+            parse_col_overrides(["-1=opus"], max_col=3)
+
+    def test_none_input_returns_empty(self):
+        assert parse_col_overrides(None, max_col=3) == {}
+
+
+class TestPerColumnOverrides:
+    @pytest.mark.asyncio
+    async def test_col_models_apply_per_column(self, fake_sdk):
+        app = FanoutREPL(
+            mode="bypass", model="claude-opus-4-7", cols=3,
+            col_models={0: "claude-sonnet-4-6"},
+        )
+        async with app.run_test():
+            assert app.columns[0].model == "claude-sonnet-4-6"
+            assert app.columns[1].model == "claude-opus-4-7"
+            assert app.columns[2].model == "claude-opus-4-7"
+
+    @pytest.mark.asyncio
+    async def test_col_efforts_apply_per_column(self, fake_sdk):
+        app = FanoutREPL(
+            mode="bypass", model=None, cols=2,
+            col_efforts={0: "max", 1: "low"},
+        )
+        async with app.run_test():
+            assert app.columns[0].effort == "max"
+            assert app.columns[1].effort == "low"
+
+    @pytest.mark.asyncio
+    async def test_col_roles_apply_per_column(self, fake_sdk):
+        app = FanoutREPL(
+            mode="bypass", model=None, cols=2,
+            col_roles={0: ["skeptic"], 1: ["optimist", "explainer"]},
+        )
+        async with app.run_test():
+            assert app.columns[0].roles_override == ["skeptic"]
+            assert app.columns[1].roles_override == ["optimist", "explainer"]
+
+    @pytest.mark.asyncio
+    async def test_no_override_uses_default(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model="claude-opus-4-7", cols=2)
+        async with app.run_test():
+            for col in app.columns:
+                assert col.effort == "high"  # DEFAULT_EFFORT
+                assert col.roles_override is None
+
+
+class TestPerColumnInput:
+    @pytest.mark.asyncio
+    async def test_per_column_input_widgets_present(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=3)
+        async with app.run_test():
+            for i in range(3):
+                assert app.query_one(f"#col-input-{i}") is not None
+
+    @pytest.mark.asyncio
+    async def test_per_column_input_only_queries_that_column(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=3)
+        async with app.run_test() as pilot:
+            inp = app.query_one("#col-input-1")
+            inp.focus()
+            inp.value = "only col 2"
+            await pilot.press("enter")
+            for _ in range(20):
+                await pilot.pause()
+                if app.columns[1].client.queries:
+                    break
+            assert app.columns[0].client.queries == []
+            assert app.columns[1].client.queries == ["only col 2"]
+            assert app.columns[2].client.queries == []
+
+    @pytest.mark.asyncio
+    async def test_master_input_still_fans_to_all(self, fake_sdk):
+        app = FanoutREPL(mode="bypass", model=None, cols=2)
+        async with app.run_test() as pilot:
+            inp = app.query_one("#master-input")
+            inp.focus()
+            inp.value = "to all"
+            await pilot.press("enter")
+            for _ in range(20):
+                await pilot.pause()
+                if all(c.client.queries for c in app.columns):
+                    break
+            for col in app.columns:
+                assert col.client.queries == ["to all"]
+
+
+class TestRunFanoutReplOverridesValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_col_model_format_raises(self, fake_sdk):
+        with pytest.raises(ValueError, match="expected 'INDEX=VALUE'"):
+            await run_fanout_repl(
+                mode="bypass", model=None, cols=2,
+                col_models_raw=["broken"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_col_model_index_out_of_range_raises(self, fake_sdk):
+        with pytest.raises(ValueError, match="out of range"):
+            await run_fanout_repl(
+                mode="bypass", model=None, cols=2,
+                col_models_raw=["5=opus"],
+            )


### PR DESCRIPTION
## Summary

Phase 4 of [docs/missions/agentwire-sdk-primitives.md](https://github.com/dotdevdotdev/agentwire-dev/blob/main/docs/missions/agentwire-sdk-primitives.md). Promoted from Phase 2's deferred polish — these are what make fan-out actually useful for *comparing* (different models / efforts / roles), not just multi-generation with one config.

## CLI

\`\`\`bash
agentwire repl --view fanout --cols 3 \\
  --col-model 0=claude-opus-4-7 \\
  --col-model 1=claude-sonnet-4-6 \\
  --col-effort 0=max --col-effort 1=high \\
  --col-role 0=skeptic --col-role 1=optimist
\`\`\`

## What changed

- \`FanoutColumn\` now carries its own model, effort, and role-override list. \`build_options\` is called with per-column effort + per-column session context (which respects the per-column role override).
- Each column gets its own \`Input\` widget below the StatusLine; submitting there only fires that column's worker. Master input still fans out.
- Column border title shows model + effort + roles so config is readable at a glance: \`col 1 · claude-opus-4-7 · max · skeptic\`.
- New \`parse_col_overrides()\` helper validates \`N=VALUE\` syntax and index range; errors propagate cleanly from the CLI.

## Mission scope revision

This PR **subsumes** the original "diff view" Phase 4 candidate. The mission's Phase 4+ table previously listed a separate diff view; in practice \`fanout cols=2 --col-model 0=A --col-model 1=B\` *is* the diff view, no separate code needed. Mission doc updated to reflect this.

Remaining Phase 5+ candidates (multi-tool-pane, conv-tree, voice/channel sinks) stay trigger-driven.

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_fanout.py -q\` — 32 passed (15 prior + 17 new)
- [x] \`uv run pytest tests/ -q\` — 1167 passed, 4 skipped
- [x] \`agentwire repl --help\` shows the new \`--col-model\` / \`--col-effort\` / \`--col-role\` flags

Built by [dotdev.dev](https://dotdev.dev)