### PR TITLE
feat(repl): bullet/indent renderer — drop CurrentAction pane, single-stream chat

### DIFF
--- a/agentwire/repl/textual_app.py
+++ b/agentwire/repl/textual_app.py
@@ -1,48 +1,34 @@
-"""Textual-based rendering layer for `agentwire repl` (Phase 2A — layout).
+"""Textual-based rendering layer for `agentwire repl` — bullet/indent format.
 
-Layout (Phase 2A: proportional chat=6 / action=2 / input=3):
+Layout: header, single ChatLog filling the body, status line, docked
+Input. The CurrentAction subpane was removed — every event renders into
+chat as either a top-level `- bullet` or a `  · child` indent.
 
     ┌─ Header ──────────────────────────────────┐
-    │                                           │
-    ├─ ChatLog (RichLog, fr=6) ─────────────────┤
-    │  > previous user turn                     │
-    │  assistant text                           │
-    │  [→ tool call]                            │
-    │  [← result]                               │
-    │  [done · ...]                             │
-    ├─ CurrentAction (RichLog, fr=2, title) ────┤
-    │  ╭─ Current action ─────────────────────╮ │
-    │  │ [thinking: ...] live stream          │ │
-    │  │ [writing X input · 4.2 KB live tick] │ │
-    │  │ […still working · 5s]                │ │
-    │  ╰──────────────────────────────────────╯ │
+    ├─ ChatLog (RichLog, fr=1) ─────────────────┤
+    │  - agent started · claude-opus-4-7        │
+    │  > user turn                              │
+    │  - thinking: planning the file structure  │
+    │    · deciding section ordering            │
+    │  - Write fanfic.html                      │
+    │    · result: <preview>                    │
+    │  assistant text continues here            │
+    │  - done · 7+9086 tok · $0.4499 · 106.7s   │
+    ├─ StatusLine ──────────────────────────────┤
     ├─ Input (Input, dock=bottom) ──────────────┤
     │  > tell me about prompt caching           │
     └─ Footer ──────────────────────────────────┘
 
 Event flow:
-    user types → SubmittableTextArea posts Submitted → on_input_submitted
-    → app.run_worker(_run_turn(text), exclusive=True)
-    → worker iterates client.receive_response() wrapped in _heartbeat_iter
-    → each message is post_message(SdkEvent(msg)) (thread-safe)
-    → on_sdk_event renders via render_message(out=_RichLogSink) on UI thread
+    user types → on_input_submitted → run_worker(_run_turn)
+    → worker iterates client.receive_response() wrapped in heartbeat_iter
+    → each message → post_message(SdkEvent(msg)) (thread-safe)
+    → on_sdk_event → render_message(out=RichLogSink) on UI thread
 
 Workers MUST use `self.post_message(...)` — never call RichLog.write directly.
 
-Phase 2A scope: split chat into chat + CurrentAction subpanes with
-proportional weights. Partial-stream events (thinking, byte counter,
-heartbeat) route to the action pane via a dedicated `_ActionSink` that
-supports proper in-place line updates (clear-and-rewrite). The action
-pane is cleared on every ResultMessage (turn complete) so the next
-turn's partials start fresh. Finalized snapshot Messages stay in chat
-via `_RichLogSink` as before.
-
-The 120-second silent gap of the legacy REPL is fully solved here:
-thinking and byte counter tick live in their own docked subpane, with
-clean in-place updates (not the choppy multi-line emission of Phase
-1B's single-sink approach).
-
-See `docs/missions/agentwire-repl-textual.md` for the full plan.
+See `docs/missions/agentwire-repl-textual.md` and
+`docs/missions/agentwire-sdk-primitives.md` (Phase 5: bullet redesign).
 """
 
 from __future__ import annotations
@@ -80,7 +66,7 @@ from agentwire.sdk import (
 )
 from agentwire.sdk.client import _mcp_enabled
 from agentwire.sdk.render import format_tool_input
-from agentwire.sdk.sinks.textual import ActionSink, RichLogSink
+from agentwire.sdk.sinks.textual import RichLogSink
 from agentwire.repl.commands import (
     COMMANDS,
     CONTINUE,
@@ -556,24 +542,15 @@ class AgentwireREPL(App):
         background: $background;
     }
 
-    /* Chat — main conversation area, wrapped in the brand neon green. */
+    /* Chat — main conversation area, wrapped in the brand neon green.
+       Streaming partials, snapshot turns, tool calls, and results all
+       land here as bullet/indent lines (`- top` + `  · child`). */
     #chat {
-        height: 6fr;
+        height: 1fr;
         border: tall $primary;
         padding: 0 1;
         background: $background;
         scrollbar-color: $primary $surface;
-    }
-
-    /* CurrentAction — live partial stream, wrapped in the brand cyan accent.
-       Flat-black background to match chat — no near-black surface. */
-    #action {
-        height: 2fr;
-        border: tall $secondary;
-        border-title-color: $secondary;
-        padding: 0 1;
-        background: $background;
-        scrollbar-color: $secondary $background;
     }
 
     /* Input — neon green border, flat-black inside.
@@ -647,8 +624,7 @@ class AgentwireREPL(App):
         self.state: ReplState | None = None
         self._client = None
         self._client_ctx = None
-        self._sink: RichLogSink | None = None  # chat — finalized snapshot messages
-        self._action_sink: ActionSink | None = None  # action — live partials
+        self._sink: RichLogSink | None = None  # chat — all rendered output
         self._stream_state = StreamRenderState()
         self._sdk_classes: dict[str, Any] | None = None
         self._saved_claudecode: str | None = None
@@ -659,7 +635,6 @@ class AgentwireREPL(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield RichLog(id="chat", markup=False, highlight=False, wrap=True, auto_scroll=True)
-        yield RichLog(id="action", markup=False, highlight=False, wrap=True, auto_scroll=True)
         yield StatusLine(id="status")
         yield Input(id="input", placeholder="> ")
         yield Footer()
@@ -688,10 +663,7 @@ class AgentwireREPL(App):
             pass
 
         chat = self.query_one("#chat", RichLog)
-        action = self.query_one("#action", RichLog)
-        action.border_title = "Current action"
         self._sink = RichLogSink(chat)
-        self._action_sink = ActionSink(action)
         self.query_one("#input", Input).focus()
 
         # Header content — set after we know the mode/model.
@@ -1043,13 +1015,11 @@ class AgentwireREPL(App):
 
     def on_sdk_event(self, event: SdkEvent) -> None:
         assert self._sink is not None
-        assert self._action_sink is not None
         assert self._sdk_classes is not None
         msg = event.payload
         if msg is HEARTBEAT:
-            # Heartbeats live in the action pane (live indicator).
-            self._stream_state.heartbeat(self._action_sink)
-            self._action_sink.flush()
+            self._stream_state.heartbeat(self._sink)
+            self._sink.flush()
             return
         try:
             render_message(
@@ -1059,11 +1029,9 @@ class AgentwireREPL(App):
                 SystemMessage=self._sdk_classes["SystemMessage"],
                 ResultMessage=self._sdk_classes["ResultMessage"],
                 out=self._sink,
-                action_out=self._action_sink,
                 stream_state=self._stream_state,
             )
             self._sink.flush()
-            self._action_sink.flush()
             if self._transcript is not None:
                 _persist_sdk_message(
                     msg,
@@ -1083,9 +1051,6 @@ class AgentwireREPL(App):
                 track_result(self.state, msg)
                 if getattr(msg, "is_error", False):
                     self._exit_code = 1
-                # Turn complete — clear the action pane so the next turn's
-                # partials start fresh.
-                self._action_sink.clear()
             self._refresh_status()
         except Exception as exc:
             self._sink.write(f"[render error: {exc}]\n")
@@ -1115,34 +1080,14 @@ class AgentwireREPL(App):
     _MENTION_PREVIEW_CAP = 8
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        """Update the action pane with @-mention candidates as the user types."""
-        if self._action_sink is None:
-            return
-        prefix = self._current_at_prefix(event.value, event.input.cursor_position)
-        if prefix is None:
-            # Not in an @-mention context — only clear if we previously
-            # populated candidates (avoid clobbering live SDK output).
-            if getattr(self, "_last_mention_prefix", None) is not None:
-                self._action_sink.clear()
-                self._last_mention_prefix = None
-            return
+        """Track the current @-prefix so Tab-complete works.
 
+        We used to render mention candidates into the CurrentAction pane,
+        but the pane is gone — the visual preview was the trade-off for
+        cleaner, single-stream chat. Tab still completes to the top match.
+        """
+        prefix = self._current_at_prefix(event.value, event.input.cursor_position)
         self._last_mention_prefix = prefix
-        matches = self._glob_mention_matches(prefix)
-        self._action_sink.clear()
-        if not matches:
-            self._action_sink.write(f"[mentions @{prefix}: no matches in {Path.cwd().name}/]\n")
-        else:
-            shown = matches[: self._MENTION_PREVIEW_CAP]
-            self._action_sink.write(
-                "[mentions: " + " · ".join(shown) + "]\n"
-            )
-            if len(matches) > self._MENTION_PREVIEW_CAP:
-                self._action_sink.write(
-                    f"[+{len(matches) - self._MENTION_PREVIEW_CAP} more — keep typing to filter, Tab to accept first]\n"
-                )
-            else:
-                self._action_sink.write("[Tab to accept first match]\n")
 
     @staticmethod
     def _current_at_prefix(text: str, cursor: int) -> str | None:
@@ -1219,10 +1164,7 @@ class AgentwireREPL(App):
         new_head = head[:at_idx + 1] + matches[0]
         inp.value = new_head + tail
         inp.cursor_position = len(new_head)
-        # Clear the action pane preview now that the mention is locked in.
-        if self._action_sink is not None:
-            self._action_sink.clear()
-            self._last_mention_prefix = None
+        self._last_mention_prefix = None
 
     # ------ Textual-only slash commands (Phase 2D + 3D) ------
 
@@ -1237,55 +1179,15 @@ class AgentwireREPL(App):
         self.push_screen(TranscriptScrubber(path))
 
     def _handle_layout(self, args: str) -> None:
-        """`/layout` — adjust the chat / action proportional weights at runtime.
+        """`/layout` — kept as a no-op slash command for now.
 
-        Usage:
-          /layout            # show current weights
-          /layout chat=8 action=1
+        Pre-redesign this resized the chat/action panes. The action pane
+        has been removed; chat fills the full vertical space available
+        between header and input. We keep the command registered so it
+        doesn't 404 in habits and tests, just reports the new layout.
         """
         assert self._sink is not None
-        if not args:
-            chat = self.query_one("#chat", RichLog)
-            action = self.query_one("#action", RichLog)
-            self._sink.write(
-                f"[layout: chat={chat.styles.height} action={action.styles.height}]\n"
-            )
-            self._sink.flush()
-            return
-
-        # Parse chat=N action=M tokens.
-        chat_n: int | None = None
-        action_n: int | None = None
-        for tok in args.split():
-            if "=" not in tok:
-                continue
-            key, _, val = tok.partition("=")
-            try:
-                n = int(val)
-            except ValueError:
-                continue
-            if key.lower() == "chat":
-                chat_n = n
-            elif key.lower() == "action":
-                action_n = n
-
-        if chat_n is None and action_n is None:
-            self._sink.write("[/layout: expected chat=N or action=N — nothing changed]\n")
-            self._sink.flush()
-            return
-
-        try:
-            if chat_n is not None and chat_n > 0:
-                self.query_one("#chat", RichLog).styles.height = f"{chat_n}fr"
-            if action_n is not None and action_n > 0:
-                self.query_one("#action", RichLog).styles.height = f"{action_n}fr"
-            self._sink.write(
-                f"[layout updated · "
-                f"chat={chat_n if chat_n is not None else 'unchanged'} · "
-                f"action={action_n if action_n is not None else 'unchanged'}]\n"
-            )
-        except Exception as exc:
-            self._sink.write(f"[/layout error: {exc}]\n")
+        self._sink.write("[/layout: chat-only layout — action pane removed in bullet redesign]\n")
         self._sink.flush()
 
     def _handle_theme(self, args: str) -> None:

--- a/agentwire/repl/views/fanout.py
+++ b/agentwire/repl/views/fanout.py
@@ -37,7 +37,7 @@ from agentwire.sdk import (
     heartbeat_iter,
     render_message,
 )
-from agentwire.sdk.sinks.textual import ActionSink, RichLogSink
+from agentwire.sdk.sinks.textual import RichLogSink
 
 
 class ColumnSdkEvent(Message):
@@ -87,7 +87,6 @@ class FanoutColumn:
         self.client: Any = None
         self.sdk_classes: dict[str, Any] | None = None
         self.chat_sink: RichLogSink | None = None
-        self.action_sink: ActionSink | None = None
         self.stream_state = StreamRenderState()
         self.input_tokens = 0
         self.output_tokens = 0
@@ -147,21 +146,12 @@ class FanoutREPL(App):
     }
 
     .col-chat {
-        height: 3fr;
+        height: 1fr;
         border: tall $primary;
         border-title-color: $primary;
         padding: 0 1;
         background: $background;
         scrollbar-color: $primary $background;
-    }
-
-    .col-action {
-        height: 1fr;
-        border: tall $secondary;
-        border-title-color: $secondary;
-        padding: 0 1;
-        background: $background;
-        scrollbar-color: $secondary $background;
     }
 
     .col-status {
@@ -248,9 +238,6 @@ class FanoutREPL(App):
                     chat = RichLog(id=f"chat-{col.col}", classes="col-chat", wrap=True, markup=False)
                     chat.border_title = self._chat_title(col)
                     yield chat
-                    action = RichLog(id=f"action-{col.col}", classes="col-action", wrap=True, markup=False)
-                    action.border_title = "current action"
-                    yield action
                     yield FanoutStatusLine(self._format_status(col), classes="col-status", id=f"status-{col.col}")
                     yield Input(
                         id=f"col-input-{col.col}",
@@ -261,12 +248,11 @@ class FanoutREPL(App):
         yield Footer()
 
     async def on_mount(self) -> None:
-        # Bind sinks to the just-mounted RichLogs.
+        # Bind chat sinks to the just-mounted RichLogs (single sink per column;
+        # streaming partials and snapshot turns share the same chat output).
         for col in self.columns:
             chat = self.query_one(f"#chat-{col.col}", RichLog)
-            action = self.query_one(f"#action-{col.col}", RichLog)
             col.chat_sink = RichLogSink(chat)
-            col.action_sink = ActionSink(action)
 
         try:
             from claude_agent_sdk import (
@@ -396,12 +382,12 @@ class FanoutREPL(App):
 
     def on_column_sdk_event(self, event: ColumnSdkEvent) -> None:
         col = self.columns[event.col]
-        if col.chat_sink is None or col.action_sink is None or col.sdk_classes is None:
+        if col.chat_sink is None or col.sdk_classes is None:
             return
         msg = event.payload
         if msg is HEARTBEAT:
-            col.stream_state.heartbeat(col.action_sink)
-            col.action_sink.flush()
+            col.stream_state.heartbeat(col.chat_sink)
+            col.chat_sink.flush()
             return
         try:
             render_message(
@@ -411,14 +397,11 @@ class FanoutREPL(App):
                 SystemMessage=col.sdk_classes["SystemMessage"],
                 ResultMessage=col.sdk_classes["ResultMessage"],
                 out=col.chat_sink,
-                action_out=col.action_sink,
                 stream_state=col.stream_state,
             )
             col.chat_sink.flush()
-            col.action_sink.flush()
             ResultMessage = col.sdk_classes["ResultMessage"]
             if isinstance(msg, ResultMessage):
-                col.action_sink.clear()
                 usage = getattr(msg, "usage", {}) or {}
                 if isinstance(usage, dict):
                     col.input_tokens += usage.get("input_tokens", 0) or 0

--- a/agentwire/sdk/render.py
+++ b/agentwire/sdk/render.py
@@ -225,42 +225,23 @@ def render_message(
     stream_state: Any = None,
     action_out: Any = None,
 ) -> None:
-    """Render one SDK message to the terminal.
+    """Render one SDK message to the terminal in bullet/indent format.
 
-    Compact, human-readable output matching the spirit of pi's JSONL but for
-    a terminal reader. Tools like `Read`/`Bash` show the target; tool results
-    show a one-line preview.
-
-    `stream_state` carries cross-message bookkeeping for the partial-message
-    stream: when partial events have already streamed text/thinking content
-    for an assistant turn, the final AssistantMessage that arrives at
-    message_stop would otherwise re-render everything. We track which
-    content indices were streamed and skip them.
-
-    `action_out`: optional separate sink for partial-stream events. The
-    Textual REPL passes a dedicated CurrentAction RichLog here so live
-    thinking, byte counters, and heartbeats render in their own docked
-    subpane while finalized snapshot messages go to the chat pane via `out`.
-    When `action_out` is None or the same object as `out`, the legacy
-    behavior is preserved: everything goes to one sink.
+    Top-level events render as `- bullet`; tool results indent under their
+    matching tool_use as `  · result: <preview>`. Streamed thinking and
+    text deltas come through `stream_state.handle_partial`. The
+    `action_out` param is accepted for backwards-compat with callers that
+    still pass it but is no longer used — everything goes to a single
+    sink (`out`).
     """
-    if action_out is None:
-        action_out = out
-    dual_panes = action_out is not out
-
-    # StreamEvent is a dataclass with `event`/`uuid`. Render thinking/text/
-    # tool-input deltas inline so users see real-time progress. Detection
-    # by duck-type to keep render_message decoupled from the SDK class.
+    # StreamEvent is a dataclass with `event`/`uuid`. Stream deltas via
+    # the state machine (single sink — action pane is gone).
     if hasattr(message, "event") and hasattr(message, "uuid") and not hasattr(message, "content"):
         if stream_state is not None:
             payload = getattr(message, "event", None)
             if isinstance(payload, dict):
-                stream_state.handle_partial(payload, action_out)
+                stream_state.handle_partial(payload, out)
         return
-
-    # Any non-partial message arriving — close out a pending heartbeat line.
-    if stream_state is not None:
-        stream_state._consume_heartbeat(action_out)
 
     if isinstance(message, SystemMessage):
         if getattr(message, "subtype", None) == "init":
@@ -268,20 +249,16 @@ def render_message(
             model = data.get("model", "") or ""
             sid = (data.get("session_id") or data.get("sessionId") or "")[:8]
             parts = [p for p in [model, f"session {sid}" if sid else ""] if p]
-            out.write(styled(out, f"[agent started · {' · '.join(parts)}]", "dim cyan") + "\n")
+            out.write(styled(out, f"- agent started · {' · '.join(parts)}", "dim cyan") + "\n")
         return
 
     if isinstance(message, AssistantMessage):
         if stream_state is not None and stream_state.partials_active:
-            stream_state.close_open_block(action_out)
+            stream_state.close_open_block(out)
         for block in getattr(message, "content", []) or []:
             btype = block_type(block)
             if btype == "text":
-                if (
-                    not dual_panes
-                    and stream_state is not None
-                    and stream_state.streamed_text
-                ):
+                if stream_state is not None and stream_state.streamed_text:
                     continue
                 text = block_attr(block, "text", "") or ""
                 if text:
@@ -293,26 +270,22 @@ def render_message(
                 tool_id = block_attr(block, "id", "") or ""
                 inp = block_attr(block, "input", {}) or {}
                 summary = format_tool_input(name, inp)
+                line = f"- {name}{' ' + summary if summary else ''}"
+                out.write(styled(out, line, "bold cyan") + "\n")
                 if stream_state is not None and tool_id:
+                    # Track so the matching tool_result indents under it.
                     stream_state.pending_tool_uses[tool_id] = {
                         "name": name,
                         "summary": summary,
                     }
-                else:
-                    line = f"[→ {name}{' ' + summary if summary else ''}]"
-                    out.write(styled(out, line, "bold cyan") + "\n")
             elif btype == "thinking":
-                if (
-                    not dual_panes
-                    and stream_state is not None
-                    and stream_state.streamed_thinking
-                ):
+                if stream_state is not None and stream_state.streamed_thinking:
                     continue
                 thinking = block_attr(block, "thinking", "") or ""
                 first = thinking.split("\n", 1)[0].strip()
                 if first:
                     preview = first if len(first) <= 80 else first[:77] + "..."
-                    out.write(styled(out, f"[thinking: {preview}]", "dim") + "\n")
+                    out.write(styled(out, f"- thinking: {preview}", "dim") + "\n")
         if stream_state is not None:
             stream_state.reset_for_next_assistant_turn()
         return
@@ -328,34 +301,15 @@ def render_message(
                     is_err = bool(block_attr(block, "is_error", False))
                     tool_use_id = block_attr(block, "tool_use_id", "") or ""
 
-                    pending = None
                     if stream_state is not None and tool_use_id:
-                        pending = stream_state.pending_tool_uses.pop(
-                            tool_use_id, None
-                        )
+                        # Pop so we don't double-emit if a future flush runs.
+                        stream_state.pending_tool_uses.pop(tool_use_id, None)
 
-                    if pending is not None and not is_err:
-                        name = pending["name"]
-                        summary = pending["summary"]
-                        parts = [name]
-                        if summary:
-                            parts.append(summary)
-                        if preview:
-                            parts.append(preview)
-                        line = f"[{' · '.join(parts)}]"
-                        out.write(styled(out, line, "cyan") + "\n")
-                    elif pending is not None and is_err:
-                        name = pending["name"]
-                        summary = pending["summary"]
-                        call = f"[→ {name}{' ' + summary if summary else ''}]"
-                        out.write(styled(out, call, "bold cyan") + "\n")
-                        out.write(styled(out, f"[← error: {preview}]", "red") + "\n")
-                    else:
-                        style = "red" if is_err else "green"
-                        label = "error" if is_err else "result"
-                        out.write(
-                            styled(out, f"[← {label}: {preview}]", style) + "\n"
-                        )
+                    label = "error" if is_err else "result"
+                    style = "red" if is_err else "green"
+                    out.write(
+                        styled(out, f"  · {label}: {preview}", style) + "\n"
+                    )
         return
 
     if isinstance(message, ResultMessage):
@@ -378,7 +332,8 @@ def render_message(
         if getattr(message, "is_error", False):
             err = getattr(message, "result", None) or "unknown error"
             category = _classify_sdk_error("ResultMessage", str(err))
-            out.write(styled(out, f"[error · {category}{suffix}] {err}", "bold red") + "\n")
+            out.write(styled(out, f"- error · {category}{suffix}", "bold red") + "\n")
+            out.write(styled(out, f"  · {err}", "red") + "\n")
         else:
-            out.write(styled(out, f"[done{suffix}]", "dim green") + "\n")
+            out.write(styled(out, f"- done{suffix}", "dim green") + "\n")
         return

--- a/agentwire/sdk/sinks/textual.py
+++ b/agentwire/sdk/sinks/textual.py
@@ -1,10 +1,10 @@
 """Textual-RichLog-backed sinks for SDK rendering.
 
 `RichLogSink` adapts `render_message`'s ANSI write stream into a Textual
-`RichLog` widget (append-only, line-at-a-time). `ActionSink` does the same
-but supports live in-place updates — re-paints the whole widget on every
-delta — used by the CurrentAction pane where the byte counter ticks live
-and thinking text streams character by character.
+`RichLog` widget (append-only, line-at-a-time). After the bullet/indent
+redesign, this is the only sink we need — the previous `ActionSink` for
+live in-place updates is gone (the CurrentAction pane it served was
+removed; everything streams into chat now).
 """
 
 from __future__ import annotations
@@ -18,14 +18,7 @@ class RichLogSink:
 
     The renderer writes ANSI-bearing strings; we buffer until newline, then
     emit each line as `Text.from_ansi(line)` so Rich parses styles faithfully.
-
-    `\\r\\033[K` in the input is the byte-counter "discard previous in-flight
-    line" signal — we honor it as "drop everything in the buffer up to and
-    including the last reset", which collapses repeated counter ticks to a
-    single visible line on close.
     """
-
-    _CR_CLEAR = "\r\x1b[K"
 
     def __init__(self, log: RichLog) -> None:
         self._log = log
@@ -34,11 +27,6 @@ class RichLogSink:
     def write(self, s: str) -> None:
         if not s:
             return
-        if self._CR_CLEAR in s:
-            # Discard any in-flight buffer content + everything in `s` before
-            # the last reset — the byte counter is announcing a fresh value.
-            self._buf = ""
-            s = s.rsplit(self._CR_CLEAR, 1)[1]
         self._buf += s
         while "\n" in self._buf:
             line, self._buf = self._buf.split("\n", 1)
@@ -57,66 +45,3 @@ class RichLogSink:
             self._log.write("")
         else:
             self._log.write(Text.from_ansi(text))
-
-
-class ActionSink:
-    """Streaming sink for the CurrentAction subpane.
-
-    Unlike `RichLogSink` (chat — append-only, buffer-until-newline), the
-    action pane shows live-updating content. We maintain our own list of
-    "finalized" lines plus a buffer for the in-flight current line, and
-    rewrite the entire RichLog on each update via clear()+write loop.
-
-    For an action pane with O(20) lines and a turn with O(1000) deltas,
-    the cost is ~20K writes — well within Textual's render budget.
-
-    `clear()` is called from the app on each ResultMessage (turn complete)
-    so the next turn's partials start with a clean pane.
-    """
-
-    _CR_CLEAR = "\r\x1b[K"
-
-    def __init__(self, log: RichLog) -> None:
-        self._log = log
-        self._finalized: list[str] = []
-        self._current = ""
-
-    def write(self, s: str) -> None:
-        if not s:
-            return
-        if self._CR_CLEAR in s:
-            s = s.rsplit(self._CR_CLEAR, 1)[1]
-            self._current = ""
-        self._current += s
-        while "\n" in self._current:
-            line, self._current = self._current.split("\n", 1)
-            self._finalized.append(line)
-        self._refresh()
-
-    def flush(self) -> None:
-        self._refresh()
-
-    def isatty(self) -> bool:
-        return True
-
-    def clear(self) -> None:
-        """Wipe the pane — called at end of every turn (ResultMessage)."""
-        self._finalized.clear()
-        self._current = ""
-        try:
-            self._log.clear()
-        except AttributeError:
-            pass
-
-    def _refresh(self) -> None:
-        try:
-            self._log.clear()
-        except AttributeError:
-            return
-        for line in self._finalized:
-            if line == "":
-                self._log.write("")
-            else:
-                self._log.write(Text.from_ansi(line))
-        if self._current:
-            self._log.write(Text.from_ansi(self._current))

--- a/agentwire/sdk/state.py
+++ b/agentwire/sdk/state.py
@@ -1,14 +1,14 @@
 """Per-turn streaming state for claude-agent-sdk partial messages.
 
 `StreamRenderState` walks the SDK's StreamEvent payloads (delivered when
-`include_partial_messages=True`) and routes each delta to the right place:
-thinking text streams inline (dim), tool_use byte counter ticks live, the
-final AssistantMessage snapshot then knows what's already been shown.
+`include_partial_messages=True`) and emits bullet-formatted output to a
+single chat sink. Each major chunk (thinking, text, tool_use+result) is
+its own top-level `- bullet`; continuation lines indent under it as
+`  · child` so the chat stays visually clean even with content streaming.
 
-The state machine itself is sink-agnostic: it calls `out.write()` and
-formatting helpers on whatever object is passed in. The Textual REPL
-gives it a RichLog-backed sink for the action pane; print mode gives it
-stdout.
+Tool-input live byte counters are intentionally not rendered — they were
+useful only with a dedicated action subpane, and we don't have one
+anymore. Tool calls render at snapshot time in `render.py` instead.
 """
 
 from __future__ import annotations
@@ -16,10 +16,7 @@ from __future__ import annotations
 from typing import Any
 
 from agentwire.sdk.render import (
-    close_style,
     flush,
-    format_bytes,
-    open_style,
     styled,
 )
 
@@ -29,22 +26,24 @@ class StreamRenderState:
 
     The SDK delivers StreamEvents (TypedDict with a `uuid` + `event` payload)
     when `include_partial_messages=True`. We render thinking_delta and
-    text_delta deltas inline so the user sees progress; the snapshot
-    AssistantMessage at message_stop then skips re-rendering anything we
-    already showed.
+    text_delta deltas in bullet/indent form so the user sees progress; the
+    snapshot AssistantMessage at message_stop then skips re-rendering
+    anything we already showed.
     """
 
     def __init__(self) -> None:
         self.streamed_text = False
         self.streamed_thinking = False
-        self.open_block: str | None = None  # "thinking" | "text" | "tool_use" | None
+        self.open_block: str | None = None  # "thinking" | "text" | None
         self._heartbeat_count = 0
-        self._heartbeat_started_inline = False
-        self._tool_use_name: str | None = None
-        self._tool_use_bytes: int = 0
-        # Tool-call collapse: deferred [→ Tool args] writes, keyed by
-        # tool_use_id. Folded into one line when the matching tool_result
-        # arrives. Unmatched at end of turn → flushed as-is.
+        # Buffer for the current logical line under the open block.
+        self._line_buf = ""
+        # First line of an open block goes on the same line as `- thinking:`;
+        # subsequent lines are emitted as `  · <line>` continuations.
+        self._first_line_emitted = False
+        # Tool-call collapse: tool_uses snapshotted in render_message keep
+        # an entry here so the matching tool_result emits as `  · result:`
+        # under the previously-rendered `- ToolName args` line.
         self.pending_tool_uses: dict[str, dict] = {}
 
     @property
@@ -52,7 +51,7 @@ class StreamRenderState:
         return self.streamed_text or self.streamed_thinking or self.open_block is not None
 
     def handle_partial(self, event: dict, out: Any) -> None:
-        """Render one StreamEvent.event payload."""
+        """Render one StreamEvent.event payload to bullet/indent format."""
         if not isinstance(event, dict):
             return
         etype = event.get("type")
@@ -63,23 +62,17 @@ class StreamRenderState:
             block = event.get("content_block") or {}
             btype = block.get("type")
             if btype == "thinking":
-                out.write(open_style(out, "dim") + "[thinking: ")
                 self.open_block = "thinking"
                 self.streamed_thinking = True
+                self._line_buf = ""
+                self._first_line_emitted = False
             elif btype == "text":
-                out.write("\n")
                 self.open_block = "text"
                 self.streamed_text = True
-            elif btype == "tool_use":
-                name = block.get("name") or "tool"
-                self._tool_use_name = name
-                self._tool_use_bytes = 0
-                self.open_block = "tool_use"
-                out.write(
-                    open_style(out, "dim yellow")
-                    + f"[writing {name} input · 0 bytes"
-                )
-                flush(out)
+                self._line_buf = ""
+                self._first_line_emitted = False
+            # tool_use: skip — we render the snapshot in render.py once the
+            # full args dict is available.
 
         elif etype == "content_block_delta":
             delta = event.get("delta") or {}
@@ -87,62 +80,55 @@ class StreamRenderState:
             if dtype == "thinking_delta" and self.open_block == "thinking":
                 text = delta.get("thinking", "") or ""
                 if text:
-                    out.write(text.replace("\n", " "))
-                    flush(out)
+                    self._buffer_and_emit_lines(out, text, kind="thinking")
             elif dtype == "text_delta" and self.open_block == "text":
-                out.write(delta.get("text", "") or "")
-                flush(out)
-            elif dtype == "input_json_delta" and self.open_block == "tool_use":
-                partial = delta.get("partial_json") or ""
-                self._tool_use_bytes += len(partial)
-                out.write(
-                    "\r\033[K"
-                    + open_style(out, "dim yellow")
-                    + f"[writing {self._tool_use_name} input · "
-                    + format_bytes(self._tool_use_bytes)
-                )
-                flush(out)
+                text = delta.get("text", "") or ""
+                if text:
+                    self._buffer_and_emit_lines(out, text, kind="text")
+            # input_json_delta: skip — no live byte counter without action pane.
 
         elif etype == "content_block_stop":
-            if self.open_block == "thinking":
-                out.write("]" + close_style(out, "dim") + "\n")
-            elif self.open_block == "text":
-                out.write("\n")
-            elif self.open_block == "tool_use":
-                out.write(
-                    "\r\033[K"
-                    + styled(
-                        out,
-                        f"[wrote {self._tool_use_name} input · "
-                        f"{format_bytes(self._tool_use_bytes)}]",
-                        "cyan",
-                    )
-                    + "\n"
-                )
-                self._tool_use_name = None
-                self._tool_use_bytes = 0
-            self.open_block = None
+            self._flush_open_block(out)
+
+    def _buffer_and_emit_lines(self, out: Any, text: str, *, kind: str) -> None:
+        """Append text to line buffer; emit complete lines on newlines."""
+        self._line_buf += text
+        while "\n" in self._line_buf:
+            line, self._line_buf = self._line_buf.split("\n", 1)
+            self._emit_line(out, line, kind=kind)
+
+    def _emit_line(self, out: Any, line: str, *, kind: str) -> None:
+        line = line.rstrip()
+        if not line and self._first_line_emitted:
+            return  # skip empty continuation lines
+        if kind == "thinking":
+            if not self._first_line_emitted:
+                out.write(styled(out, f"- thinking: {line}", "dim") + "\n")
+                self._first_line_emitted = True
+            else:
+                out.write(styled(out, f"  · {line}", "dim") + "\n")
+        elif kind == "text":
+            # Plain assistant text — no bullet, just the answer text.
+            out.write(line + "\n")
+            self._first_line_emitted = True
+        flush(out)
+
+    def _flush_open_block(self, out: Any) -> None:
+        """Emit any buffered remainder, then close the block."""
+        if self.open_block in ("thinking", "text") and self._line_buf:
+            self._emit_line(out, self._line_buf, kind=self.open_block)
+        elif self.open_block == "thinking" and not self._first_line_emitted:
+            # Empty thinking block — emit just the bullet so the user knows
+            # the model thought (briefly).
+            out.write(styled(out, "- thinking:", "dim") + "\n")
+            flush(out)
+        self._line_buf = ""
+        self._first_line_emitted = False
+        self.open_block = None
 
     def close_open_block(self, out: Any) -> None:
-        """Force-close any in-flight open block (e.g. before snapshot render)."""
-        if self.open_block == "thinking":
-            out.write("]" + close_style(out, "dim") + "\n")
-        elif self.open_block == "text":
-            out.write("\n")
-        elif self.open_block == "tool_use":
-            out.write(
-                "\r\033[K"
-                + styled(
-                    out,
-                    f"[wrote {self._tool_use_name} input · "
-                    f"{format_bytes(self._tool_use_bytes)}]",
-                    "cyan",
-                )
-                + "\n"
-            )
-            self._tool_use_name = None
-            self._tool_use_bytes = 0
-        self.open_block = None
+        """Force-close any in-flight open block (before snapshot render)."""
+        self._flush_open_block(out)
 
     def reset_for_next_assistant_turn(self) -> None:
         """Snapshot rendered → flags reset so the next assistant turn (within
@@ -151,38 +137,33 @@ class StreamRenderState:
         self.streamed_thinking = False
         self.open_block = None
         self._heartbeat_count = 0
-        self._heartbeat_started_inline = False
-        self._tool_use_name = None
-        self._tool_use_bytes = 0
+        self._line_buf = ""
+        self._first_line_emitted = False
 
     def flush_pending_tool_uses(self, out: Any) -> None:
-        """Emit any deferred tool_use lines whose tool_result never arrived."""
-        for pending in self.pending_tool_uses.values():
-            name = pending["name"]
-            summary = pending["summary"]
-            line = f"[→ {name}{' ' + summary if summary else ''}]"
-            out.write(styled(out, line, "bold cyan") + "\n")
+        """Emit indented placeholders for tool_uses whose result never arrived.
+
+        Each entry got its `- ToolName args` bullet at snapshot time; we
+        just clear the pending registry. The bullet remains in the chat
+        without a `  · result:` child — that itself is the signal that the
+        tool call didn't complete.
+        """
         self.pending_tool_uses.clear()
 
     def heartbeat(self, out: Any) -> None:
-        """Called when the SDK has been silent past `idle_timeout` seconds."""
+        """Called when the SDK has been silent past `idle_timeout` seconds.
+
+        Emits a single dim bullet per tick. Slightly noisy on long quiet
+        turns, but the alternative (silent gap) was the original 120s
+        bug we shipped streaming-visibility to fix.
+        """
         self._heartbeat_count += 1
         elapsed = self._heartbeat_count * 5
-        if self.open_block == "tool_use":
-            return
-        if self.open_block is not None:
-            out.write("·")
-            flush(out)
-            return
-        if not self._heartbeat_started_inline:
-            out.write(open_style(out, "dim") + f"[…still working · {elapsed}s")
-            self._heartbeat_started_inline = True
-        else:
-            out.write(f" · {elapsed}s")
+        out.write(styled(out, f"- still working · {elapsed}s", "dim") + "\n")
         flush(out)
 
     def _consume_heartbeat(self, out: Any) -> None:
-        if self._heartbeat_started_inline:
-            out.write("]" + close_style(out, "dim") + "\n")
-            self._heartbeat_started_inline = False
-            self._heartbeat_count = 0
+        # Heartbeats are now self-contained bullet lines, so a real event
+        # arriving doesn't need to "close" anything. Reset the counter so
+        # subsequent gaps start fresh.
+        self._heartbeat_count = 0

--- a/docs/repl-tui.md
+++ b/docs/repl-tui.md
@@ -17,18 +17,17 @@ TUI is for interactive sessions only.
 ```
 ┌─ Header ──────────────────────────────────────────────────┐
 │  agentwire repl — bypass · opus-4-7                       │
-├─ ChatLog (RichLog, fr=6) ─────────────────────────────────┤
+├─ ChatLog (RichLog, fr=1) ─────────────────────────────────┤
+│  - agent started · claude-opus-4-7 · session 0657172a     │
 │  > previous user turn                                     │
-│  [agent started · claude-opus-4-7 · session 0657172a]     │
-│  assistant text streamed live                             │
-│  [Bash · ls -la · 12 files (collapsed call+result)]       │
-│  [done · 7+9086 tok · $0.4499 · 106.7s]                   │
-├─ CurrentAction (RichLog, fr=2, titled) ───────────────────┤
-│  ╭─ Current action ─────────────────────────────────────╮ │
-│  │ [thinking: planning the file structure...]           │ │
-│  │ [writing Write input · 4.2 KB live tick]             │ │
-│  │ […still working · 5s]                                │ │
-│  ╰──────────────────────────────────────────────────────╯ │
+│  - thinking: planning the file structure                  │
+│    · deciding section ordering                            │
+│  - Write fanfic.html                                      │
+│    · result: file written (4.2 KB)                        │
+│  assistant text streamed live, line by line               │
+│  - Bash ls /tmp                                           │
+│    · result: 12 files in /tmp                             │
+│  - done · 7+9086 tok · $0.4499 · 106.7s                   │
 ├─ Input (dock=bottom) ─────────────────────────────────────┤
 │  > tell me about prompt caching                           │
 ├─ StatusLine ──────────────────────────────────────────────┤
@@ -36,10 +35,18 @@ TUI is for interactive sessions only.
 └─ Footer ──────────────────────────────────────────────────┘
 ```
 
-- **ChatLog** — finalized turns. Tool calls collapse to one-liners
-  (`[Bash · ls /tmp · 12 files]`).
-- **CurrentAction** — live partial-message stream. Cleared on every
-  ResultMessage so the next turn starts fresh.
+Everything streams into one ChatLog as a flat hierarchy of bullets:
+
+- `- top-level` lines mark major events: agent_started, thinking,
+  tool calls, assistant text, done.
+- `  · child` indents are details that hang off the bullet above:
+  thinking continuations, tool results.
+
+The previous CurrentAction subpane was removed in favour of this single
+chat with bullet hierarchy — partial-message streaming and snapshot
+turns share the same surface, and the indent gives visual structure
+even when content streams in fast.
+
 - **StatusLine** — running totals + sparkline of last-20-turn cost.
 - **Footer** — Textual binding hints (Ctrl+P, Ctrl+D, Ctrl+C).
 
@@ -86,14 +93,12 @@ Textual-only additions:
 
 ## `@`-mention autocomplete
 
-As you type `@`, the action pane shows live mention candidates globbed
-from cwd. **Tab** completes the prefix to the top match.
+As you type `@`, **Tab** completes the prefix to the top match. (The
+live candidate preview that lived in the now-removed CurrentAction
+pane went away with it; Tab still does the work.)
 
 ```
 > summarize @REA█
-
-[mentions: README.md · README-tutorial.md]
-[Tab to accept first match]
 ```
 
 After `Tab`:
@@ -205,18 +210,10 @@ textual-light, tokyo-night]
 
 ## Layout customization
 
-Resize the chat / action panes at runtime:
-
-```
-> /layout
-[layout: chat=6fr action=2fr]
-
-> /layout chat=10 action=1
-[layout updated · chat=10 · action=1]
-```
-
-Useful when running long sessions where you mostly want chat history,
-or when watching a tool-heavy turn where you want more action visibility.
+The CurrentAction subpane was removed in the bullet-format redesign, so
+there's only one pane to size now and it fills the body. `/layout`
+remains as a stub command that just announces this — kept for habit
+compatibility, not for tuning.
 
 ## Persistence
 

--- a/tests/unit/test_repl_fanout.py
+++ b/tests/unit/test_repl_fanout.py
@@ -166,10 +166,10 @@ class TestFanoutREPLBoot:
         async with app.run_test() as pilot:
             assert len(app.columns) == 3
             for i in range(3):
-                # Each column has its own RichLog widgets.
+                # Each column has its own widgets (chat + status + input).
                 assert app.query_one(f"#chat-{i}") is not None
-                assert app.query_one(f"#action-{i}") is not None
                 assert app.query_one(f"#status-{i}") is not None
+                assert app.query_one(f"#col-input-{i}") is not None
             # Master input present.
             assert app.query_one("#master-input") is not None
 

--- a/tests/unit/test_repl_sdk.py
+++ b/tests/unit/test_repl_sdk.py
@@ -205,7 +205,7 @@ class TestRenderAssistant:
             "type": "tool_use", "name": "Bash", "input": {"command": "ls -la"},
         }])
         out = _render(msg)
-        assert "→ Bash ls -la" in out
+        assert "- Bash ls -la" in out
 
     def test_tool_use_read_shows_file_path(self):
         msg = FakeAssistantMessage([{
@@ -218,7 +218,7 @@ class TestRenderAssistant:
         msg = FakeAssistantMessage([{
             "type": "tool_use", "name": "Grep", "input": {"pattern": "TODO"},
         }])
-        assert "→ Grep TODO" in _render(msg)
+        assert "- Grep TODO" in _render(msg)
 
     def test_tool_use_websearch(self):
         msg = FakeAssistantMessage([{
@@ -249,7 +249,7 @@ class TestRenderUser:
             "type": "tool_result", "tool_use_id": "tu_1", "content": "hello output",
         }])
         out = _render(msg)
-        assert "← result: hello output" in out
+        assert "· result: hello output" in out
 
     def test_tool_result_list_content(self):
         msg = FakeUserMessage([{
@@ -280,64 +280,62 @@ class TestRenderResult:
     def test_error_shows_error(self):
         msg = FakeResultMessage(is_error=True, result="rate limit hit")
         out = _render(msg)
-        assert "[error" in out
+        assert "- error" in out
         assert "rate limit hit" in out
 
     def test_minimal_result(self):
         msg = FakeResultMessage()
         out = _render(msg)
-        assert "[done" in out
+        assert "- done" in out
 
 
-class TestToolCallCollapse:
-    """Phase 2C — when stream_state is provided, tool_use + tool_result fold
-    into one `[Tool · args · preview]` line."""
+class TestToolCallHierarchy:
+    """Bullet-format renderer: tool_use renders as `- Tool args` immediately;
+    matching tool_result emits as `  · result: preview` indented under it."""
 
     def _state(self):
         from agentwire.sdk import StreamRenderState as _StreamRenderState
         return _StreamRenderState()
 
-    def test_tool_use_buffered_until_result(self):
+    def test_tool_use_renders_immediately(self):
         from agentwire.sdk import StreamRenderState as _StreamRenderState
         s = _StreamRenderState()
         out = io.StringIO()
 
-        # AssistantMessage with tool_use(id=tu_1) — should be buffered, NOT
-        # written to out yet.
         msg = FakeAssistantMessage([{
             "type": "tool_use", "id": "tu_1", "name": "Bash",
             "input": {"command": "ls -la"},
         }])
         render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
-        assert out.getvalue() == ""
+        rendered = out.getvalue()
+        # Top-level bullet is emitted right away.
+        assert "- Bash ls -la" in rendered
+        # And the id is tracked so a future tool_result can indent under it.
         assert "tu_1" in s.pending_tool_uses
 
-        # UserMessage with tool_result(tool_use_id=tu_1) → folds into one line.
+        # UserMessage with tool_result emits an indented child.
         result = FakeUserMessage([{
             "type": "tool_result", "tool_use_id": "tu_1", "content": "12 files",
         }])
         render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
         rendered = out.getvalue()
-        assert "Bash" in rendered
-        assert "ls -la" in rendered
-        assert "12 files" in rendered
-        # Folded format — no separate "→" or "← result:" markers
-        assert "→ Bash" not in rendered
-        assert "← result:" not in rendered
-        # Pending cleared.
+        assert "- Bash ls -la" in rendered
+        assert "  · result: 12 files" in rendered
+        # Pending cleared after the matching result lands.
         assert "tu_1" not in s.pending_tool_uses
 
-    def test_tool_use_no_stream_state_renders_inline(self):
-        # Without stream_state, tool_use renders as before (legacy path).
+    def test_tool_use_without_stream_state(self):
+        # Without stream_state, the bullet still emits — there's just no
+        # pending registry to track for the indent under it.
         msg = FakeAssistantMessage([{
             "type": "tool_use", "id": "tu_1", "name": "Bash",
             "input": {"command": "ls -la"},
         }])
         out = _render(msg)  # no stream_state
-        assert "[→ Bash ls -la]" in out
+        assert "- Bash ls -la" in out
 
-    def test_tool_use_no_id_renders_inline(self):
-        # Without an id, tool_use can't be matched to a result — render inline.
+    def test_tool_use_without_id(self):
+        # Even without an id, the bullet emits — just no pending registration.
         from agentwire.sdk import StreamRenderState as _StreamRenderState
         s = _StreamRenderState()
         out = io.StringIO()
@@ -346,12 +344,12 @@ class TestToolCallCollapse:
             "input": {"command": "ls -la"},
         }])
         render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
-        assert "[→ Bash ls -la]" in out.getvalue()
+        assert "- Bash ls -la" in out.getvalue()
         assert s.pending_tool_uses == {}
 
-    def test_unmatched_tool_use_flushed_on_result(self):
-        # Tool_use without matching tool_result should still appear in chat
-        # when the turn ends (via flush_pending_tool_uses).
+    def test_unmatched_tool_use_remains_visible(self):
+        # If a tool_use never gets a tool_result, the bullet stays in chat
+        # and the pending registry is just cleared on ResultMessage.
         from agentwire.sdk import StreamRenderState as _StreamRenderState
         s = _StreamRenderState()
         out = io.StringIO()
@@ -360,16 +358,16 @@ class TestToolCallCollapse:
             "input": {"command": "echo x"},
         }])
         render_message(msg, out=out, stream_state=s, **RENDER_KWARGS)
-        # ResultMessage finishes the turn → flush.
         result = FakeResultMessage()
         render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
         rendered = out.getvalue()
-        assert "[→ Bash" in rendered
-        assert "[done" in rendered
+        assert "- Bash echo x" in rendered
+        assert "- done" in rendered
+        # Pending cleared.
+        assert s.pending_tool_uses == {}
 
-    def test_error_result_emits_separate_lines(self):
-        # When the tool_result is an error, fold doesn't lose information —
-        # we emit both the call and the error explicitly.
+    def test_error_result_indents_as_error_child(self):
+        # An error result indents under its tool_use as `  · error: ...`.
         from agentwire.sdk import StreamRenderState as _StreamRenderState
         s = _StreamRenderState()
         out = io.StringIO()
@@ -384,8 +382,8 @@ class TestToolCallCollapse:
         }])
         render_message(result, out=out, stream_state=s, **RENDER_KWARGS)
         rendered = out.getvalue()
-        assert "[→ Bash" in rendered
-        assert "[← error:" in rendered
+        assert "- Bash false" in rendered
+        assert "  · error: exit 1" in rendered
 
 
 # --- format helpers ---
@@ -500,10 +498,10 @@ class TestPrintModeIntegration:
         assert captured_options["prompt"] == "summarize x.py"
         assert "agent started" in out
         assert "claude-opus-4-7" in out
-        assert "→ Read x.py" in out
-        assert "← result: file contents here" in out
+        assert "- Read x.py" in out
+        assert "· result: file contents here" in out
         assert "Here's the summary." in out
-        assert "[done" in out
+        assert "- done" in out
         assert "100+50 tok" in out
 
     def test_error_result_returns_nonzero(self, monkeypatch, capsys):
@@ -534,7 +532,7 @@ class TestPrintModeIntegration:
         rc = run_repl(mode="bypass", print_prompt="x")
         out = capsys.readouterr().out
         assert rc == 1
-        assert "[error" in out
+        assert "- error" in out
 
     def test_missing_sdk_returns_one(self, monkeypatch, capsys):
         """If claude-agent-sdk isn't importable, print mode exits 1 with message."""
@@ -587,7 +585,9 @@ class TestStreamRenderState:
         assert s.streamed_text is True
         assert s.open_block is None
 
-    def test_thinking_delta_streams_inline(self):
+    def test_thinking_delta_streams_as_bullet_with_continuation(self):
+        # Thinking starts a `- thinking: ` bullet; subsequent newline-bounded
+        # chunks become `  · <continuation>` indented children.
         s = self._state()
         out = io.StringIO()
         s.handle_partial(
@@ -601,14 +601,14 @@ class TestStreamRenderState:
         )
         s.handle_partial({"type": "content_block_stop"}, out)
         rendered = out.getvalue()
-        assert "[thinking: let me plan this]" in rendered
+        assert "- thinking: let me" in rendered
+        assert "  · plan this" in rendered
         assert s.streamed_thinking is True
 
-    def test_input_json_delta_shows_byte_counter(self):
-        # Tool input streaming via input_json_delta would dump raw JSON bytes
-        # into the chat. Instead we show a live byte counter — the snapshot
-        # AssistantMessage that follows gives the formatted [→ Write file.html]
-        # summary with parsed args.
+    def test_input_json_delta_skipped(self):
+        # No live byte counter post-redesign — tool input only renders at
+        # snapshot time when full args are known. Partial input_json_delta
+        # events do not emit anything.
         s = self._state()
         out = io.StringIO()
         s.handle_partial(
@@ -621,38 +621,9 @@ class TestStreamRenderState:
              "delta": {"type": "input_json_delta", "partial_json": '{"file_path": "x"}'}},
             out,
         )
-        rendered = out.getvalue()
-        # Counter line is written, raw JSON is not.
-        assert "writing Write input" in rendered
-        assert '"file_path"' not in rendered
-        assert s.open_block == "tool_use"
-        assert s._tool_use_bytes == len('{"file_path": "x"}')
-
-    def test_tool_use_close_finalizes_byte_counter(self):
-        s = self._state()
-        out = io.StringIO()
-        s.handle_partial(
-            {"type": "content_block_start",
-             "content_block": {"type": "tool_use", "name": "Write"}},
-            out,
-        )
-        # 2 KB of fake JSON across two deltas
-        s.handle_partial(
-            {"type": "content_block_delta",
-             "delta": {"type": "input_json_delta", "partial_json": "x" * 1024}},
-            out,
-        )
-        s.handle_partial(
-            {"type": "content_block_delta",
-             "delta": {"type": "input_json_delta", "partial_json": "x" * 1024}},
-            out,
-        )
         s.handle_partial({"type": "content_block_stop"}, out)
-        rendered = out.getvalue()
-        assert "wrote Write input" in rendered
-        assert "2.0 KB" in rendered
-        assert s.open_block is None
-        assert s._tool_use_bytes == 0  # reset after close
+        # No output — snapshot AssistantMessage will render the bullet.
+        assert out.getvalue() == ""
 
     def test_streamevent_dataclass_detected_by_render_message(self, monkeypatch):
         # StreamEvent is a @dataclass, not a dict. Earlier code did
@@ -701,17 +672,17 @@ class TestStreamRenderState:
         )
         s.handle_partial(
             {"type": "content_block_delta",
-             "delta": {"type": "thinking_delta", "thinking": "plan"}},
+             "delta": {"type": "thinking_delta", "thinking": "plan\n"}},
             out,
         )
         s.handle_partial({"type": "content_block_stop"}, out)
         rendered = out.getvalue()
         assert "\x1b[" not in rendered  # no ANSI escapes
-        assert "[thinking: plan]" in rendered
+        assert "- thinking: plan" in rendered
 
     def test_ansi_codes_emitted_for_tty_output(self):
         # When out.isatty() is True, dim-style ANSI codes wrap the thinking
-        # block. This is the visual hierarchy: thinking is secondary noise,
+        # bullet. This is the visual hierarchy: thinking is secondary noise,
         # dim makes it recede.
         from agentwire.sdk import StreamRenderState as _StreamRenderState
 
@@ -737,27 +708,15 @@ class TestStreamRenderState:
             {"type": "content_block_start", "content_block": {"type": "thinking"}},
             out,
         )
+        s.handle_partial(
+            {"type": "content_block_delta",
+             "delta": {"type": "thinking_delta", "thinking": "plan\n"}},
+            out,
+        )
         s.handle_partial({"type": "content_block_stop"}, out)
         rendered = out.getvalue()
         assert "\x1b[" in rendered  # ANSI present
-        assert "[thinking: " in rendered  # raw text still recoverable
-
-    def test_heartbeat_silent_during_tool_use(self):
-        # The byte counter IS the liveness signal during tool_use — adding
-        # `·` dots would corrupt the in-place CR rewrite.
-        s = self._state()
-        out = io.StringIO()
-        s.handle_partial(
-            {"type": "content_block_start",
-             "content_block": {"type": "tool_use", "name": "Write"}},
-            out,
-        )
-        before = out.getvalue()
-        s.heartbeat(out)
-        s.heartbeat(out)
-        after = out.getvalue()
-        # Heartbeat is a no-op during tool_use.
-        assert before == after
+        assert "- thinking: plan" in rendered  # raw text still recoverable
 
     def test_assistant_skips_streamed_text(self, monkeypatch):
         # When partials already streamed text, the snapshot AssistantMessage
@@ -797,43 +756,37 @@ class TestStreamRenderState:
         )
         assert "full reply" in out.getvalue()
 
-    def test_heartbeat_inline_when_open_block(self):
+    def test_heartbeat_emits_bullet_per_tick(self):
+        # Each idle tick emits its own `- still working · Ns` bullet —
+        # slightly noisy on long quiet turns but each line is self-contained
+        # in the bullet format.
         s = self._state()
         out = io.StringIO()
-        s.handle_partial(
-            {"type": "content_block_start", "content_block": {"type": "thinking"}},
-            out,
-        )
         s.heartbeat(out)
         s.heartbeat(out)
-        # Two dots appended to the open thinking line.
         rendered = out.getvalue()
-        assert rendered.count("·") == 2
+        assert "- still working · 5s" in rendered
+        assert "- still working · 10s" in rendered
 
-    def test_heartbeat_standalone_when_idle(self):
+    def test_heartbeat_resets_on_real_event(self):
+        # When a real event arrives, the heartbeat counter resets so the
+        # next gap starts fresh. The previously-emitted bullets stay in the
+        # chat (they're history) — there's no in-place mutation.
         s = self._state()
         out = io.StringIO()
         s.heartbeat(out)
         s.heartbeat(out)
-        # Forms a single status line: "[…still working · 5s · 10s"
-        # (no trailing ] until a real event consumes it)
-        rendered = out.getvalue()
-        assert "still working" in rendered
-        assert "5s" in rendered and "10s" in rendered
-
-    def test_heartbeat_consumed_by_real_event(self):
-        s = self._state()
-        out = io.StringIO()
-        s.heartbeat(out)
-        # Real event arrives → consumes the open heartbeat line
+        assert s._heartbeat_count == 2
         s.handle_partial(
             {"type": "content_block_start", "content_block": {"type": "text"}},
             out,
         )
+        # Counter zeroed.
+        assert s._heartbeat_count == 0
+        # Subsequent heartbeats start at 5s again.
+        s.heartbeat(out)
         rendered = out.getvalue()
-        # Heartbeat line was closed (saw "]\n" before any content).
-        assert "still working" in rendered
-        assert rendered.index("]") < rendered.rindex("\n")
+        assert rendered.count("- still working · 5s") == 2
 
 
 class TestHeartbeatIter:

--- a/tests/unit/test_repl_textual_app.py
+++ b/tests/unit/test_repl_textual_app.py
@@ -67,10 +67,9 @@ class TestRichLogSink:
         assert captured[0].plain == "hello world"
 
     def test_flush_emits_partial_buffer(self):
-        # The renderer calls flush() after each delta to make streaming
-        # progress visible. In Phase 1B that emits the buffered content as
-        # a line, leading to choppy multi-line streaming for partials —
-        # an intentional trade-off until Phase 2A's CurrentAction widget.
+        # flush() emits whatever is in the buffer as a partial line — used
+        # by the bullet-format renderer when a stream block hasn't seen a
+        # newline yet but needs to land in the chat.
         from agentwire.sdk.sinks.textual import RichLogSink as _RichLogSink
 
         captured: list[Any] = []
@@ -82,7 +81,7 @@ class TestRichLogSink:
                 captured.append(x)
 
         sink = _RichLogSink(_FakeLog())
-        sink.write("[thinking: ")
+        sink.write("- thinking: ")
         sink.flush()
         assert len(captured) == 1
         sink.write("first delta")
@@ -111,32 +110,6 @@ class TestRichLogSink:
         # Rich Text spans: first 4 chars styled bold.
         spans = text.spans
         assert any("bold" in str(span.style).lower() for span in spans)
-
-    def test_cr_clear_collapses_buffer(self):
-        # \r\033[K means "discard everything before this point on the current
-        # line". With buffered emission, that translates to: drop whatever
-        # is in the buffer, take only the content after the last reset.
-        # The byte counter sequence ends with `]\n` which finalizes one
-        # clean [wrote X · N KB] line.
-        from agentwire.sdk.sinks.textual import RichLogSink as _RichLogSink
-
-        captured: list[Any] = []
-
-        class _FakeLog:
-            lines: list = []
-
-            def write(self, x):
-                captured.append(x)
-
-        sink = _RichLogSink(_FakeLog())
-        # Simulate: "[writing X · 0 bytes" → "\r\033[K[writing X · 1.2 KB"
-        # → "\r\033[K[wrote X · 1.2 KB]\n"
-        sink.write("[writing X · 0 bytes")
-        sink.write("\r\x1b[K[writing X · 1.2 KB")
-        sink.write("\r\x1b[K[wrote X · 1.2 KB]\n")
-        # Only the final closed line emits.
-        assert len(captured) == 1
-        assert captured[0].plain == "[wrote X · 1.2 KB]"
 
     def test_isatty_returns_true(self):
         # Required so _styled() in app.py emits ANSI codes that the sink parses.
@@ -477,159 +450,10 @@ async def test_permission_modal_buttons(patched_sdk, tmp_path, monkeypatch):
         assert decisions == ["allow", "deny", "always"]
 
 
-class TestActionSink:
-    """Phase 2A — CurrentAction pane streaming via clear+rewrite."""
-
-    def _action(self):
-        from agentwire.sdk.sinks.textual import ActionSink as _ActionSink
-
-        class _FakeLog:
-            def __init__(self):
-                self.written: list = []
-                self.cleared: int = 0
-
-            def write(self, x):
-                self.written.append(x)
-
-            def clear(self):
-                self.cleared += 1
-                self.written.clear()
-
-        log = _FakeLog()
-        return _ActionSink(log), log
-
-    def test_streams_partials_in_place(self):
-        # Each delta clears + rewrites the pane. After 3 deltas, only the
-        # latest content is visible (one entry).
-        sink, log = self._action()
-        sink.write("[thinking: ")
-        sink.write("first")
-        sink.write(" delta")
-        # Each write triggers a refresh — the most recent state is visible.
-        assert log.cleared >= 3
-        # The current visible state is one in-flight line with full content.
-        assert len(log.written) == 1
-        assert log.written[0].plain == "[thinking: first delta"
-
-    def test_finalizes_on_newline(self):
-        sink, log = self._action()
-        sink.write("[thinking: planning]\n")
-        # Newline finalizes — the line moves into the finalized list.
-        assert len(sink._finalized) == 1
-        assert sink._finalized[0] == "[thinking: planning]"
-        assert sink._current == ""
-
-    def test_cr_clear_resets_current(self):
-        # \r\033[K refreshes the in-flight line with new content.
-        sink, log = self._action()
-        sink.write("[writing X · 0 bytes")
-        sink.write("\r\x1b[K[writing X · 1.2 KB")
-        assert sink._current == "[writing X · 1.2 KB"
-        # And the visible pane shows only the latest tick.
-        assert len(log.written) == 1
-        assert log.written[0].plain == "[writing X · 1.2 KB"
-
-    def test_clear_wipes_pane(self):
-        sink, log = self._action()
-        sink.write("line one\n")
-        sink.write("line two\n")
-        sink.write("partial")
-        before_clear = log.cleared
-        sink.clear()
-        assert sink._finalized == []
-        assert sink._current == ""
-        # clear() called the underlying log.clear()
-        assert log.cleared > before_clear
-
-    def test_isatty_true(self):
-        sink, _ = self._action()
-        assert sink.isatty() is True
-
-
-@pytest.mark.asyncio
-async def test_partials_route_to_action_pane(patched_sdk, tmp_path, monkeypatch):
-    # A StreamEvent (thinking_delta) should land in the action pane, not chat.
-    from agentwire.repl import persistence
-    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
-    from agentwire.repl.textual_app import AgentwireREPL
-    from textual.widgets import Input
-    from dataclasses import dataclass
-
-    @dataclass
-    class FakeStreamEvent:
-        uuid: str
-        session_id: str
-        event: dict
-        parent_tool_use_id: str | None = None
-
-    app = AgentwireREPL(mode="bypass")
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        client = app._client
-        client.script([
-            FakeStreamEvent(
-                uuid="u1",
-                session_id="s",
-                event={"type": "content_block_start", "content_block": {"type": "thinking"}},
-            ),
-            FakeStreamEvent(
-                uuid="u2",
-                session_id="s",
-                event={"type": "content_block_delta",
-                       "delta": {"type": "thinking_delta", "thinking": "planning"}},
-            ),
-            FakeStreamEvent(
-                uuid="u3",
-                session_id="s",
-                event={"type": "content_block_stop"},
-            ),
-            _FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={}),
-        ])
-
-        inp = app.query_one("#input", Input)
-        inp.value = "trigger thinking"
-        await inp.action_submit()
-        for _ in range(20):
-            await pilot.pause()
-
-        # ResultMessage cleared the action pane, so it should be empty now.
-        # The chat pane should have the user echo + agent_started + done.
-        chat_lines = [
-            line.text if hasattr(line, "text") else str(line)
-            for line in app.query_one("#chat").lines
-        ]
-        chat_text = " ".join(chat_lines)
-        assert "trigger thinking" in chat_text
-        assert "done" in chat_text
-
-
-@pytest.mark.asyncio
-async def test_action_pane_cleared_on_result(patched_sdk, tmp_path, monkeypatch):
-    from agentwire.repl import persistence
-    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
-    from agentwire.repl.textual_app import AgentwireREPL
-    from textual.widgets import Input
-
-    app = AgentwireREPL(mode="bypass")
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        # Manually populate the action sink to simulate in-flight partials.
-        app._action_sink.write("[thinking: in flight")
-        assert app._action_sink._current != ""
-
-        client = app._client
-        client.script([
-            _FakeResultMessage(total_cost_usd=0.0, duration_ms=10, usage={}),
-        ])
-        inp = app.query_one("#input", Input)
-        inp.value = "go"
-        await inp.action_submit()
-        for _ in range(20):
-            await pilot.pause()
-
-        # ResultMessage triggered the action sink clear.
-        assert app._action_sink._current == ""
-        assert app._action_sink._finalized == []
+# TestActionSink + test_partials_route_to_action_pane +
+# test_action_pane_cleared_on_result were removed when the CurrentAction
+# pane was removed in the bullet/indent redesign — everything streams
+# into the single chat sink now.
 
 
 class TestStatusLine:
@@ -733,32 +557,8 @@ async def test_header_title_set(patched_sdk):
 
 
 @pytest.mark.asyncio
-async def test_layout_slash_command_adjusts_weights(patched_sdk, tmp_path, monkeypatch):
-    from agentwire.repl import persistence
-    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
-    from agentwire.repl.textual_app import AgentwireREPL
-    from textual.widgets import Input, RichLog
-
-    app = AgentwireREPL(mode="bypass")
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        inp = app.query_one("#input", Input)
-        inp.value = "/layout chat=8 action=1"
-        await inp.action_submit()
-        await pilot.pause()
-
-        chat_lines = [
-            line.text if hasattr(line, "text") else str(line)
-            for line in app.query_one("#chat", RichLog).lines
-        ]
-        all_text = " ".join(chat_lines)
-        assert "layout updated" in all_text
-        assert "chat=8" in all_text
-        assert "action=1" in all_text
-
-
-@pytest.mark.asyncio
-async def test_layout_no_args_shows_current(patched_sdk, tmp_path, monkeypatch):
+async def test_layout_command_announces_chat_only(patched_sdk, tmp_path, monkeypatch):
+    """`/layout` is a no-op stub now — there's only one pane to size."""
     from agentwire.repl import persistence
     monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
     from agentwire.repl.textual_app import AgentwireREPL
@@ -777,8 +577,7 @@ async def test_layout_no_args_shows_current(patched_sdk, tmp_path, monkeypatch):
             for line in app.query_one("#chat", RichLog).lines
         ]
         all_text = " ".join(chat_lines)
-        assert "layout:" in all_text
-        assert "chat=" in all_text
+        assert "chat-only layout" in all_text
 
 
 @pytest.mark.asyncio
@@ -869,35 +668,9 @@ class TestMentionPrefixDetect:
         assert AgentwireREPL._current_at_prefix(text, 12) == "REA"
 
 
-@pytest.mark.asyncio
-async def test_at_mention_preview_shows_in_action_pane(
-    patched_sdk, tmp_path, monkeypatch
-):
-    from agentwire.repl import persistence
-    monkeypatch.setattr(persistence, "DEFAULT_REPL_HOME", tmp_path / "repl")
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "alpha.txt").write_text("a")
-    (tmp_path / "alfred.md").write_text("b")
-    (tmp_path / "beta.txt").write_text("c")
-
-    from agentwire.repl.textual_app import AgentwireREPL
-    from textual.widgets import Input
-
-    app = AgentwireREPL(mode="bypass")
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        inp = app.query_one("#input", Input)
-        # Simulate typing "@al" — the on_input_changed handler should
-        # populate the action pane with matches.
-        inp.value = "@al"
-        inp.cursor_position = len(inp.value)
-        # Force the changed-event callback to run.
-        app.on_input_changed(Input.Changed(inp, "@al"))
-        await pilot.pause()
-
-        # The action sink should now have entries containing alpha + alfred.
-        joined = "\n".join(app._action_sink._finalized + [app._action_sink._current])
-        assert "alpha" in joined or "alfred" in joined
+# test_at_mention_preview_shows_in_action_pane removed: the live mention
+# preview lived in the CurrentAction pane, which is gone post-redesign.
+# Tab completion (test_tab_completes_mention below) still works.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

User feedback: the dual-pane chat + CurrentAction layout wasn't pulling its weight, and \`[bracket]\` log lines didn't make it easy to see which content belonged to what. This PR replaces both with a single ChatLog that streams everything in bullet/indent format.

## Format change

| before                                | after                                       |
|---                                     |---                                          |
| \`[agent started · X]\`                | \`- agent started · X\`                     |
| \`[thinking: X]\`                      | \`- thinking: X\` + \`  · <continuations>\` |
| \`[→ Tool args]\`                      | \`- Tool args\`                             |
| \`[Tool · args · preview]\` (collapsed) | \`- Tool args\` + \`  · result: preview\`   |
| \`[← error: X]\`                       | \`  · error: X\` (indented)                 |
| \`[done · ...]\`                       | \`- done · ...\`                            |
| \`[error · cat] msg\`                  | \`- error · cat\` + \`  · msg\`             |

## Layout change

- Removed \`#action\` RichLog from \`AgentwireREPL\` and from each fan-out column
- Removed \`ActionSink\` class — single chat sink everywhere
- Dropped dual-pane branching from \`render_message\`
- @-mention live preview removed (it lived in the action pane); Tab still completes
- \`/layout\` is a stub no-op now (only one pane to size)
- Live byte counter for tool input streaming dropped — without a dedicated pane it'd just spam chat. Tool calls render at snapshot time once full args are decided.

## StreamRenderState rewrite

- **thinking_delta**: line-buffered. First line continues the \`- thinking: \` bullet; subsequent lines emit as \`  · <line>\` indented children.
- **text_delta**: line-buffered, emits each complete line as it arrives.
- **input_json_delta**: skipped (no live tick).
- **heartbeat**: one self-contained \`- still working · Ns\` bullet per tick; counter resets when a real event arrives.

## Test plan

- [x] \`uv run pytest tests/ -q\` — 1154 passed, 4 skipped
- [x] All affected files (\`test_repl_sdk.py\`, \`test_repl_textual_app.py\`, \`test_repl_fanout.py\`) updated for bullet format
- [x] \`TestActionSink\` deleted; \`TestToolCallCollapse\` renamed/rewritten as \`TestToolCallHierarchy\`
- [x] StreamRenderState tests rewritten for bullet output

Built by [dotdev.dev](https://dotdev.dev)