### PR TITLE
fix(repl): wrap long lines with `|`-prefixed continuation markers

### DIFF
--- a/agentwire/sdk/sinks/textual.py
+++ b/agentwire/sdk/sinks/textual.py
@@ -1,23 +1,112 @@
 """Textual-RichLog-backed sinks for SDK rendering.
 
 `RichLogSink` adapts `render_message`'s ANSI write stream into a Textual
-`RichLog` widget (append-only, line-at-a-time). After the bullet/indent
-redesign, this is the only sink we need — the previous `ActionSink` for
-live in-place updates is gone (the CurrentAction pane it served was
-removed; everything streams into chat now).
+`RichLog` widget. Long lines are wrapped manually with continuation
+markers (`| ` for top-level bullets, `  | ` for indented children) so
+wrapped content stays visually connected to its parent bullet — RichLog's
+built-in wrap puts continuation lines flush-left with no indent, which
+made it impossible to tell where one bullet ended and the next began.
 """
 
 from __future__ import annotations
+
+import re
 
 from rich.text import Text
 from textual.widgets import RichLog
 
 
+# Match contiguous CSI/SGR ANSI sequences (e.g. "\x1b[2m", "\x1b[1;36m\x1b[0m").
+_ANSI_RUN_RE = re.compile(r"(?:\x1b\[[0-9;]*m)+")
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _split_ansi(text: str) -> tuple[str, str, str]:
+    """Peel off leading + trailing ANSI runs around the visible content.
+
+    Returns `(open_codes, plain_body, close_codes)`. Lines emitted by our
+    renderer are uniformly styled (open + content + close), so this
+    captures the styling we need to re-apply to each wrapped chunk.
+    """
+    open_match = _ANSI_RUN_RE.match(text)
+    open_codes = open_match.group(0) if open_match else ""
+
+    # Trailing ANSI: take the last run if it ends at the very end of `text`.
+    close_codes = ""
+    matches = list(_ANSI_RUN_RE.finditer(text))
+    if matches and matches[-1].end() == len(text):
+        close_codes = matches[-1].group(0)
+
+    body = text
+    if open_codes:
+        body = body[len(open_codes):]
+    if close_codes:
+        body = body[: len(body) - len(close_codes)]
+    return open_codes, body, close_codes
+
+
+def wrap_with_continuation(text: str, width: int) -> list[str]:
+    """Wrap `text` to `width` columns with bullet-aware continuation markers.
+
+    Top-level bullets (`- ...`) wrap to `| ...` continuations. Indented
+    children (`  · ...`) wrap to `  | ...`. Plain text wraps to a `  `
+    hang. ANSI styling on the source line is re-applied to each chunk.
+
+    `width` is the visible character cell count available; if zero or
+    too small to fit a continuation marker we return the line unchanged.
+    """
+    if width < 6:
+        return [text]
+    open_codes, body, close_codes = _split_ansi(text)
+    if len(body) <= width:
+        return [text]
+
+    if body.startswith("- "):
+        cont_prefix = "| "
+    elif body.startswith("  · "):
+        cont_prefix = "  | "
+    else:
+        cont_prefix = "  "
+
+    chunks: list[str] = []
+    remaining = body
+    first = True
+    while len(remaining) > width:
+        avail = width if first else width - len(cont_prefix)
+        if avail <= 0:
+            break
+        # Prefer a space break in the back half of the window so we don't
+        # split words mid-character on long URLs / paths. If no good break
+        # exists, hard-cut at `avail`.
+        space_idx = remaining.rfind(" ", 0, avail + 1)
+        if space_idx > avail // 2:
+            split_at = space_idx
+            consume_space = True
+        else:
+            split_at = avail
+            consume_space = False
+        chunk_body = remaining[:split_at].rstrip()
+        prefix = "" if first else cont_prefix
+        chunks.append(open_codes + prefix + chunk_body + close_codes)
+        remaining = remaining[split_at + (1 if consume_space else 0):]
+        first = False
+
+    if remaining:
+        prefix = "" if first else cont_prefix
+        chunks.append(open_codes + prefix + remaining + close_codes)
+
+    return chunks
+
+
 class RichLogSink:
     """Adapter so `render_message(out=...)` can target a `RichLog`.
 
-    The renderer writes ANSI-bearing strings; we buffer until newline, then
-    emit each line as `Text.from_ansi(line)` so Rich parses styles faithfully.
+    Buffers writes until newline, then emits each line — wrapping long
+    lines to the widget's content width with continuation markers.
     """
 
     def __init__(self, log: RichLog) -> None:
@@ -40,8 +129,19 @@ class RichLogSink:
     def isatty(self) -> bool:
         return True
 
+    def _content_width(self) -> int:
+        try:
+            return max(0, self._log.content_size.width)
+        except Exception:
+            return 0
+
     def _emit(self, text: str) -> None:
         if text == "":
             self._log.write("")
-        else:
+            return
+        width = self._content_width()
+        if not width:
             self._log.write(Text.from_ansi(text))
+            return
+        for chunk in wrap_with_continuation(text, width):
+            self._log.write(Text.from_ansi(chunk))

--- a/tests/unit/test_repl_sink_wrap.py
+++ b/tests/unit/test_repl_sink_wrap.py
@@ -1,0 +1,94 @@
+"""Tests for `wrap_with_continuation` — the bullet-aware wrap helper.
+
+Long lines wrap to the widget's content width; continuation chunks get
+a `|` marker that matches their parent bullet's indent so the visual
+connection survives the wrap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentwire.sdk.sinks.textual import wrap_with_continuation
+
+
+class TestWrapTopLevelBullet:
+    def test_short_line_returns_as_is(self):
+        out = wrap_with_continuation("- short", width=80)
+        assert out == ["- short"]
+
+    def test_wraps_top_level_bullet_with_pipe_continuation(self):
+        text = "- thinking: hello world this is a long line"
+        out = wrap_with_continuation(text, width=20)
+        assert out[0].startswith("- ")
+        for chunk in out[1:]:
+            assert chunk.startswith("| ")
+        # Concatenated chunks (minus prefixes + spaces lost on break) should
+        # cover the whole input.
+        joined = " ".join(c.removeprefix("- ").removeprefix("| ") for c in out)
+        assert "thinking" in joined and "long line" in joined
+
+    def test_wrap_breaks_on_space_when_possible(self):
+        text = "- Bash echo alpha beta gamma delta epsilon"
+        out = wrap_with_continuation(text, width=20)
+        for chunk in out:
+            # No mid-word breaks: each chunk's body is whitespace-clean
+            body = chunk.removeprefix("- ").removeprefix("| ")
+            assert not body.endswith(" ")
+            assert not body.startswith(" ")
+
+
+class TestWrapIndentedChild:
+    def test_wraps_indented_child_with_double_pipe_continuation(self):
+        text = "  · result: file written to /Users/dotdev/projects/long/path"
+        out = wrap_with_continuation(text, width=24)
+        assert out[0].startswith("  · ")
+        for chunk in out[1:]:
+            assert chunk.startswith("  | ")
+
+
+class TestWrapPlainText:
+    def test_plain_text_wraps_with_hang(self):
+        text = "assistant text response that exceeds the column width"
+        out = wrap_with_continuation(text, width=20)
+        assert out[0].startswith("assistant")
+        for chunk in out[1:]:
+            assert chunk.startswith("  ")
+            # Plain text continuations don't have a pipe — just a hang.
+            assert not chunk.startswith("| ")
+            assert not chunk.startswith("  | ")
+
+
+class TestWrapAnsi:
+    def test_preserves_ansi_open_close_per_chunk(self):
+        text = "\x1b[2m- thinking: hello world this is dim text\x1b[0m"
+        out = wrap_with_continuation(text, width=20)
+        for chunk in out:
+            assert chunk.startswith("\x1b[2m")
+            assert chunk.endswith("\x1b[0m")
+
+    def test_strips_correctly_when_no_ansi(self):
+        text = "- plain bullet that wraps because it is long"
+        out = wrap_with_continuation(text, width=20)
+        for chunk in out:
+            assert "\x1b[" not in chunk
+
+
+class TestWrapEdges:
+    def test_zero_width_returns_unchanged(self):
+        out = wrap_with_continuation("- some line", width=0)
+        assert out == ["- some line"]
+
+    def test_too_small_width_returns_unchanged(self):
+        out = wrap_with_continuation("- some line", width=3)
+        assert out == ["- some line"]
+
+    def test_long_unbreakable_word_hard_cuts(self):
+        # No spaces — wrap has to hard-cut.
+        text = "- " + "a" * 100
+        out = wrap_with_continuation(text, width=20)
+        assert len(out) > 1
+        # No spaces in any chunk's body.
+        for chunk in out:
+            body = chunk.removeprefix("- ").removeprefix("| ")
+            assert " " not in body


### PR DESCRIPTION
## Summary

User screenshot showed the middle column's tool-call line cut off mid-path while wrapped lines elsewhere went flush-left, severing the visual connection to the parent bullet. The bullet/indent format only works if wrapped continuations clearly belong to their bullet.

## Implementation

\`RichLogSink._emit\` now queries the RichLog's \`content_size.width\` and runs each line through \`wrap_with_continuation\` before writing.

| Line kind | Wrap continuation marker |
|---|---|
| \`- top-level bullet\` | \`\| \` |
| \`  · indented child\` | \`  \| \` |
| plain assistant text | \`  \` (hang) |

Example:

\`\`\`
- Write /Users/dotdev/projects/agentwire-
| dev/bunnies.html
  · result: file written to /Users/dotdev
  |   /projects/agentwire-dev/bunnies.html
\`\`\`

ANSI styling on the source line is split into leading/trailing runs and re-applied around each chunk's body, so per-chunk colours don't break.

Falls back to the unwrapped line when width is zero (e.g. before mount, or test environments with stub logs), or when width is too small to fit a continuation prefix.

## Test plan

- [x] \`uv run pytest tests/unit/test_repl_sink_wrap.py -q\` — 10 passed (top-level, indented, plain, ANSI, edges)
- [x] \`uv run pytest tests/ -q\` — 1164 passed, 4 skipped

Built by [dotdev.dev](https://dotdev.dev)