### PR TITLE
chore: bump version to 1.24.0 + doc audit

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -23,6 +23,21 @@ agentwire worktree name --ref v2.0  # detached at tag/commit
 agentwire fork -s name          # fork session into new worktree
 agentwire fork -s name -t project/branch --commit abc123  # fork from specific commit
 
+# Textual REPL (claude-agent-sdk surface — see docs/repl-tui.md)
+agentwire repl                          # interactive Textual TUI (default)
+agentwire repl --mode bypass|prompted|restricted   # permission mode
+agentwire repl --model claude-sonnet-4-6           # override model
+agentwire repl --view fanout --cols 3              # multi-generation A/B
+agentwire repl --view fanout --cols 2 \\
+  --col-model 0=claude-opus-4-7 --col-model 1=claude-sonnet-4-6  # compare models
+agentwire repl --view fanout --cols 2 \\
+  --col-effort 0=max --col-effort 1=high           # compare effort
+agentwire repl -p "summarize foo.py"               # one-shot stdout pipe
+# Inside the REPL:  /help /clear /cost /tools /model /save /resume <name>
+#                   /effort <level> /thinking <mode> /say <text> /scrub
+#                   /theme <name> /run-workflow <name> /exit
+# Inside fanout: /exit, /quit, /cancel, /clear (also Ctrl+C, Ctrl+D)
+
 # Pane commands (for workers within same session)
 agentwire spawn --roles worker  # spawn worker pane
 agentwire send --pane 1 "task"  # send to pane

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -28,7 +28,7 @@ session:
 
 | Field | Values | Description |
 |-------|--------|-------------|
-| `type` | `claude-bypass`, `claude-auto`, `claude-prompted`, `claude-restricted`, `pi-zai`, `pi-zai-restricted`, `pi-zai-readonly` | Session permission level. **Use `claude-auto` for overnight/unattended work** — same capability as `claude-bypass` but with AI classifier blocking dangerous actions. Requires Team/Enterprise plan. |
+| `type` | `claude-bypass`, `claude-auto`, `claude-prompted`, `claude-restricted`, `pi-zai`, `pi-zai-restricted`, `pi-zai-readonly`, `sdk-bypass`, `sdk-prompted`, `sdk-restricted` | Session permission level. **Use `claude-auto` for overnight/unattended work** — same capability as `claude-bypass` but with AI classifier blocking dangerous actions. Requires Team/Enterprise plan. **`sdk-*` types** spawn the Textual `agentwire repl` (claude-agent-sdk via Anthropic subscription) — see `docs/repl-tui.md`. |
 | `roles` | List of role names | Roles to load (from bundled or `~/.agentwire/roles/`) |
 | `voice` | Voice name | TTS voice for this project |
 | `parent` | Session name | Parent session for hierarchical notifications |
@@ -36,7 +36,10 @@ session:
 | `tasks` | Task definitions | Scheduled workload configurations |
 | `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist |
 
-For Z.AI sessions (`pi-zai*`), see the `agentwire-pi-zai` skill.
+For Z.AI sessions (`pi-zai*`), see the `agentwire-pi-zai` skill. For
+the Textual REPL surface (`sdk-*` types or `agentwire repl` directly),
+see `docs/repl-tui.md` — it covers slash commands, the `--view fanout`
+multi-generation A/B view, theming, and the portal watch-mode.
 
 ## Task Schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,8 @@ Reference detail lives in skills under `.claude/skills/` — invoke as needed:
 ## Docs
 
 - CLI: `agentwire --help` or `agentwire <cmd> --help`
-- `docs/repl-tui.md` - Textual REPL walkthrough (slash commands, shortcuts, theming, layout)
+- `docs/repl-tui.md` - Textual REPL walkthrough — single-stream bullet/indent format, slash commands, shortcuts, theming, `--view fanout` multi-generation A/B
+- `docs/missions/agentwire-sdk-primitives.md` - `agentwire/sdk/` package + composite views (fanout, portal watch-mode)
 - `docs/pi-zai.md` - Pi coding agent + Z.AI session types
 - `docs/workflows.md` - Pi workflow engine user guide (incl. scheduler integration)
 - `docs/scheduled-workloads.md` - Ensure vs workflow scheduled tasks, `.agentwire.yml` reference

--- a/agentwire/__init__.py
+++ b/agentwire/__init__.py
@@ -1,3 +1,3 @@
 """AgentWire - Multi-session voice web interface for AI coding agents."""
 
-__version__ = "1.23.0"
+__version__ = "1.24.0"

--- a/docs/missions/agentwire-repl-textual.md
+++ b/docs/missions/agentwire-repl-textual.md
@@ -139,7 +139,7 @@ Same posture as `agentwire-repl.md` Phase 6+. Don't pre-build:
 - `agentwire/repl/commands.py` — slash commands; reused unchanged.
 - `agentwire/repl/persistence.py` — transcript JSONL; reused unchanged.
 - `agentwire/repl/mentions.py` — @-mention expansion; reused unchanged.
-- `agentwire/repl/damage_control.py` — `make_pre_tool_hook`; reused unchanged.
+- `agentwire/sdk/damage_control.py` — `make_pre_tool_hook`; reused unchanged.
 - `agentwire/repl/context.py` — role/voice loading; reused unchanged.
 
 The rewrite is the rendering layer only. Everything below is intact.
@@ -302,7 +302,7 @@ These files are imported and reused as-is — no edits:
 - `agentwire/repl/commands.py` (slash handlers — `out: TextIO` signature already compatible with `_RichLogSink`)
 - `agentwire/repl/persistence.py` (transcript JSONL)
 - `agentwire/repl/mentions.py` (`@path` expansion)
-- `agentwire/repl/damage_control.py` (`make_pre_tool_hook`)
+- `agentwire/sdk/damage_control.py` (`make_pre_tool_hook`)
 - `agentwire/repl/context.py` (role/voice loading)
 - `agentwire/__main__.py::cmd_repl` and `repl_parser` (no CLI changes; flag is purely env)
 - `_run_print_mode`, `_run_interactive`, `build_options`, `render_message`, `_StreamRenderState`, `_heartbeat_iter` — remain in `app.py`, imported by both paths.

--- a/docs/missions/agentwire-repl.md
+++ b/docs/missions/agentwire-repl.md
@@ -201,8 +201,8 @@ Old code in git history is **reference only**, not a blueprint.
 ## Code references (study / possibly reuse — not copy blindly)
 
 - `agentwire/workflows/runners/anthropic.py` — SDK init, streaming pattern, options building
-- `agentwire/workflows/runners/anthropic_events.py` — SDK event → JSONL translation (reusable)
-- `agentwire/workflows/runners/anthropic_capabilities.py` — model / effort / thinking validation
+- `agentwire/sdk/events.py` — SDK event → JSONL translation (reusable; relocated from `workflows/runners/anthropic_events.py` in v1.24.0)
+- `agentwire/sdk/capabilities.py` — model / effort / thinking validation (relocated from `workflows/runners/anthropic_capabilities.py` in v1.24.0)
 - `agentwire/workflows/storage.py` — transcript JSONL + metadata pattern
 - `agentwire/workflows/cli.py` `_make_verbose_printer()` — event-to-terminal printer prototype
 - `agentwire/roles/__init__.py` — role parsing + merging (universal, works as-is)

--- a/docs/missions/agentwire-sdk-primitives.md
+++ b/docs/missions/agentwire-sdk-primitives.md
@@ -246,8 +246,8 @@ These stay open deliberately. Prototype first, decide from real usage.
 ## Code references (study / refactor — not copy blindly)
 
 - `agentwire/workflows/runners/anthropic.py` — current SDK init + streaming pattern
-- `agentwire/workflows/runners/anthropic_events.py` — current event classification
-- `agentwire/workflows/runners/anthropic_capabilities.py` — model/effort/thinking validation (stays as-is)
+- `agentwire/sdk/events.py` — event classification (was `workflows/runners/anthropic_events.py` pre-v1.24.0)
+- `agentwire/sdk/capabilities.py` — model/effort/thinking validation (was `workflows/runners/anthropic_capabilities.py`)
 - `agentwire/repl/textual_app.py` — current `_RichLogSink`, `_ActionSink`, `_StreamRenderState` integration
 - `agentwire/repl/app.py` — print mode + render helpers
 - `agentwire/workflows/storage.py` — transcript JSONL pattern (sink target)

--- a/docs/missions/completed/anthropic-sdk-runner.md
+++ b/docs/missions/completed/anthropic-sdk-runner.md
@@ -254,8 +254,8 @@ Zero changes to `scheduler.py`. Workflow tasks still just call `run_workflow(wf,
 | `agentwire/workflows/runners/__init__.py` | New — runner registry |
 | `agentwire/workflows/runners/pi.py` | New — thin wrapper around existing `pi_runner.py` (pi behaviour unchanged) |
 | `agentwire/workflows/runners/anthropic.py` | New — SDK-backed node executor using `claude-agent-sdk` |
-| `agentwire/workflows/runners/anthropic_events.py` | New — translate SDK `Message` objects → pi-shaped JSONL |
-| `agentwire/workflows/runners/anthropic_capabilities.py` | New — model → supported settings table; used by validator and runtime |
+| `agentwire/workflows/runners/anthropic_events.py` *(now `agentwire/sdk/events.py`, relocated v1.24.0)* | New — translate SDK `Message` objects → pi-shaped JSONL |
+| `agentwire/workflows/runners/anthropic_capabilities.py` *(now `agentwire/sdk/capabilities.py`, relocated v1.24.0)* | New — model → supported settings table; used by validator and runtime |
 | `agentwire/workflows/pi_runner.py` | Leave in place as a shim for one release cycle, then delete |
 | `agentwire/workflows/node.py` | Add `runner`, `effort`, `max_thinking_tokens`, `max_budget_usd`, `task_budget` fields on `ActionNode` |
 | `agentwire/workflows/definitions.py` | Parse top-level `runner:` + per-node `runner:` + new SDK settings; validate against registry |
@@ -334,7 +334,7 @@ Zero changes to `scheduler.py`. Workflow tasks still just call `run_workflow(wf,
       task_budget_tokens: 40000          # Opus 4.7 only, min 20000 (beta — passes through extra_args)
   ```
 
-  **Validation policy — strict, at parse time.** Bad combinations are caught at `agentwire workflow validate` and at `agentwire scheduler board` load, before a single node runs. No silent coercion, no "warn and continue" — errors surface with the exact setting that's wrong and why. A small capability table at `agentwire/workflows/runners/anthropic_capabilities.py` is consulted by both the validator and the runtime:
+  **Validation policy — strict, at parse time.** Bad combinations are caught at `agentwire workflow validate` and at `agentwire scheduler board` load, before a single node runs. No silent coercion, no "warn and continue" — errors surface with the exact setting that's wrong and why. A small capability table at `agentwire/sdk/capabilities.py` (was `agentwire/workflows/runners/anthropic_capabilities.py` pre-v1.24.0) is consulted by both the validator and the runtime:
 
   | Setting | Requires | Error if violated |
   |---|---|---|


### PR DESCRIPTION
## Summary

Release prep for v1.24.0. Doc/skills sweep + version bump in advance of PyPI publish + GitHub release.

## What landed in 1.24.0 (since 1.23.0)

- **PR #144** — refactor: extract \`agentwire/sdk/\` package (engine + sinks)
- **PR #145** — feat: fanout N-column view MVP
- **PR #146** — feat: portal SDK watch mode
- **PR #147** — feat: per-column overrides + per-column input
- **PR #148** — feat: bullet/indent renderer (drop CurrentAction pane)
- **PR #149** — fix: \`|\`-prefixed continuation markers on long lines
- **PR #150** — fix: fanout Ctrl+C / Ctrl+D / slash-command dispatch

## Doc/skills changes in this PR

- \`agentwire/__init__.py\` 1.23.0 → 1.24.0
- \`CLAUDE.md\`: cross-link to sdk-primitives mission
- \`.claude/skills/agentwire-cli/SKILL.md\`: new "Textual REPL" section
- \`.claude/skills/agentwire-project-config/SKILL.md\`: \`sdk-*\` types in the type table + repl-tui.md cross-link
- Mission docs: stale \`workflows/runners/anthropic_*\` and \`repl/damage_control.py\` paths point at the new \`agentwire/sdk/\` locations

## Test plan

- [x] \`uv run pytest tests/ -q\` — 1169 passed, 4 skipped
- [x] No code changes — pure doc/version

Built by [dotdev.dev](https://dotdev.dev)