### PR TITLE
feat(tests): coverage for cli_safety, pi_runner, damage-control hooks, scheduler gates, channel errors

### DIFF
--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -1028,6 +1028,78 @@ class TestInjectInstructions:
         assert not claude.exists()
 
 
+class TestChannelErrorPaths:
+    """Network and HTTP error handling in send_* functions.
+
+    Covers the HTTPError/Exception fall-through branches in webhook and
+    quo. These were 0% covered — only happy-path send tests existed.
+    """
+
+    @pytest.fixture
+    def _set_config(self, tmp_path):
+        """Set agentwire config from a dict; restore on teardown."""
+        import agentwire.config as config_mod
+        from agentwire.config import load_config
+        original = config_mod._config
+
+        def _set(data):
+            (tmp_path / "config.yaml").write_text(yaml.safe_dump(data))
+            config_mod._config = load_config(tmp_path / "config.yaml")
+        yield _set
+        config_mod._config = original
+
+    def test_webhook_http_error(self, _set_config):
+        import urllib.error
+        _set_config({"channels": {"webhook": {"url": "https://h.example.com/x"}}})
+        from agentwire.channels.webhook import send_webhook
+
+        err = urllib.error.HTTPError(
+            url="https://h.example.com/x", code=503,
+            msg="Service Unavailable", hdrs=None, fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = send_webhook(text="msg")
+        assert result.success is False
+        assert "503" in result.error
+
+    def test_webhook_network_exception(self, _set_config):
+        _set_config({"channels": {"webhook": {"url": "https://h.example.com/x"}}})
+        from agentwire.channels.webhook import send_webhook
+
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("DNS fail")):
+            result = send_webhook(text="msg")
+        assert result.success is False
+        assert "DNS fail" in result.error
+
+    def test_quo_http_error(self, _set_config, monkeypatch, tmp_path):
+        import urllib.error
+        monkeypatch.setenv("HOME", str(tmp_path))  # block dotenv loading real keys
+        _set_config({"channels": {"quo": {
+            "api_key": "k", "from_number": "+15551112222", "default_to": "+15553334444",
+        }}})
+        from agentwire.channels.quo import send_quo_sms
+
+        err = urllib.error.HTTPError(
+            url="https://api.openphone.com/v1/messages", code=401,
+            msg="Unauthorized", hdrs=None, fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = send_quo_sms(body="hi")
+        assert result.success is False
+
+    def test_quo_generic_exception(self, _set_config, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_config({"channels": {"quo": {
+            "api_key": "k", "from_number": "+15551112222", "default_to": "+15553334444",
+        }}})
+        from agentwire.channels.quo import send_quo_sms
+
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("read timeout")):
+            result = send_quo_sms(body="hi")
+        assert result.success is False
+        assert "timeout" in result.error.lower()
+
+
 class TestSlackComposeHierarchy:
     """Tests for SlackBridge.compose_dm_config and compose_channel_config."""
 

--- a/tests/unit/test_cli_safety.py
+++ b/tests/unit/test_cli_safety.py
@@ -335,3 +335,212 @@ class TestCheckCommandSafetyAllowlist:
 
         result = check_command_safety("mv something dist/file")
         assert result["decision"] == "block"
+
+
+# --- check_command_safety: pattern types & decision-order edge cases ---
+
+class TestCheckCommandSafetyDecisionPaths:
+    """Cover branches that drive evaluation order: ask, hard-block, regex error,
+    zero-access bypass, no-delete bypass."""
+
+    def _rules(self, tmp_path, monkeypatch, patterns):
+        import yaml
+        import agentwire.cli_safety as mod
+        rd = tmp_path / "rules"
+        rd.mkdir(exist_ok=True)
+        (rd / "patterns.yaml").write_text(yaml.safe_dump(patterns))
+        monkeypatch.setattr(mod, "RULES_DIR", rd)
+        return rd
+
+    def test_ask_pattern_returns_ask(self, tmp_path, monkeypatch):
+        self._rules(tmp_path, monkeypatch, {
+            "bashToolPatterns": [
+                {"pattern": r"\bgit\s+push\b", "reason": "git push", "ask": True},
+            ],
+        })
+        result = check_command_safety("git push origin main")
+        assert result["decision"] == "ask"
+        assert result["reason"] == "git push"
+
+    def test_invalid_regex_skipped_not_crashed(self, tmp_path, monkeypatch):
+        """A malformed pattern must not crash safety evaluation."""
+        self._rules(tmp_path, monkeypatch, {
+            "bashToolPatterns": [
+                {"pattern": r"[unclosed", "reason": "bad pattern"},
+                {"pattern": r"\bdanger\b", "reason": "real danger"},
+            ],
+        })
+        # Bad regex skipped; real one still works.
+        bad = check_command_safety("danger ahead")
+        assert bad["decision"] == "block"
+        assert bad["reason"] == "real danger"
+        # And a benign command still allowed.
+        good = check_command_safety("echo hi")
+        assert good["decision"] == "allow"
+
+    def test_non_dict_pattern_entry_skipped(self, tmp_path, monkeypatch):
+        """Stray non-dict entries in bashToolPatterns must be tolerated."""
+        self._rules(tmp_path, monkeypatch, {
+            "bashToolPatterns": [
+                "not a dict",  # bogus entry
+                {"pattern": r"\bbadcmd\b", "reason": "bad"},
+            ],
+        })
+        result = check_command_safety("badcmd run")
+        assert result["decision"] == "block"
+
+    def test_zero_access_path_blocks(self, tmp_path, monkeypatch):
+        """A zero-access path (e.g. /etc/secret) blocks even read-only access."""
+        self._rules(tmp_path, monkeypatch, {
+            "zeroAccessPaths": ["/etc/secret"],
+        })
+        result = check_command_safety("cat /etc/secret")
+        assert result["decision"] == "block"
+        assert "Zero-access" in result["reason"]
+
+    def test_zero_access_bypassed_by_allowlist_with_read(self, tmp_path, monkeypatch):
+        """zeroAccessPaths can be bypassed if the path is allowlisted with read."""
+        self._rules(tmp_path, monkeypatch, {
+            "zeroAccessPaths": ["/etc/secret"],
+            "allowedPaths": [{"path": "/etc/secret", "allow": ["read"]}],
+        })
+        result = check_command_safety("cat /etc/secret")
+        assert result["decision"] == "allow"
+
+    def test_no_delete_path_blocks_rm_only(self, tmp_path, monkeypatch):
+        """noDeletePaths only flags rm — cat is fine."""
+        self._rules(tmp_path, monkeypatch, {"noDeletePaths": ["README.md"]})
+        # rm blocks
+        assert check_command_safety("rm README.md")["decision"] == "block"
+        # cat is fine
+        assert check_command_safety("cat README.md")["decision"] == "allow"
+
+    def test_no_delete_bypassed_by_allowlist_with_delete(self, tmp_path, monkeypatch):
+        self._rules(tmp_path, monkeypatch, {
+            "noDeletePaths": ["dist/"],
+            "allowedPaths": [{"path": "*/dist/*", "allow": ["delete"]}],
+        })
+        result = check_command_safety("rm /tmp/proj/dist/old.whl")
+        assert result["decision"] == "allow"
+
+    def test_decision_order_ask_beats_block(self, tmp_path, monkeypatch):
+        """ask wins when both ask and bypassable patterns match a command."""
+        self._rules(tmp_path, monkeypatch, {
+            "bashToolPatterns": [
+                {"pattern": r"\brm\b", "reason": "rm anything", "ask": True},
+                {"pattern": r"\brm\s+[^-]", "reason": "rm bypassable", "bypassable": True},
+            ],
+        })
+        # Both match — ask wins because it's evaluated first.
+        result = check_command_safety("rm foo.txt")
+        assert result["decision"] == "ask"
+
+    def test_no_match_allows(self, tmp_path, monkeypatch):
+        self._rules(tmp_path, monkeypatch, {
+            "bashToolPatterns": [
+                {"pattern": r"\brm\b", "reason": "rm"},
+            ],
+        })
+        result = check_command_safety("ls -la")
+        assert result["decision"] == "allow"
+        assert result["pattern"] is None
+
+
+# --- _infer_operation_from_reason: dispatch by reason text ---
+
+@pytest.mark.parametrize("reason,expected_op", [
+    ("rm file deletion", "delete"),
+    ("trash everything", "delete"),
+    ("rmdir empty", "delete"),
+    ("delete entry", "delete"),
+    # Note: substring matching means "permission" -> contains "rm" -> "delete".
+    # The branch order is delete-first, so chmod-only reasons must avoid "rm".
+    ("chmod -x", "chmod"),
+    ("chown user", "chmod"),
+    ("chgrp group", "chmod"),
+    ("mv operation", "move"),
+    ("apply move", "move"),
+    ("write to file", "write"),  # default fallback
+    ("", "write"),  # empty reason → write
+])
+def test_infer_operation_from_reason(reason, expected_op):
+    from agentwire.cli_safety import _infer_operation_from_reason
+    assert _infer_operation_from_reason(reason) == expected_op
+
+
+# --- _extract_command_paths: path extraction from command strings ---
+
+class TestExtractCommandPaths:
+    def _extract(self, cmd):
+        from agentwire.cli_safety import _extract_command_paths
+        return _extract_command_paths(cmd)
+
+    def test_absolute_path(self):
+        assert "/etc/passwd" in self._extract("cat /etc/passwd")
+
+    def test_home_path_expanded(self):
+        # ~ paths are expanded to absolute
+        paths = self._extract("rm ~/.ssh/id_rsa")
+        assert any(p.endswith("/.ssh/id_rsa") for p in paths)
+
+    def test_quoted_path(self):
+        paths = self._extract('cat "/etc/secret file"')
+        assert "/etc/secret file" in paths
+
+    def test_flag_excluded(self):
+        # -rf is a flag, not a path
+        paths = self._extract("rm -rf /tmp/x")
+        assert not any(p == "-rf" or p.startswith("-") for p in paths)
+
+    def test_relative_path(self):
+        paths = self._extract("rm ./scratch.txt")
+        assert any("scratch.txt" in p for p in paths)
+
+
+# --- Read-only path mutation operators: documents which slip through ---
+#
+# Source line ~429 only catches `rm`, `mv`, `sed -i`, `>` for readOnlyPath
+# detection. Other mutating commands (cp, dd, tee, rsync, cat>, install) are
+# NOT caught — they fall through to "allow" unless covered by another rule.
+# These tests document that gap so we notice if it changes.
+
+class TestReadOnlyPathMutationOperators:
+    def _rules(self, tmp_path, monkeypatch, patterns):
+        import yaml
+        import agentwire.cli_safety as mod
+        rd = tmp_path / "rules"
+        rd.mkdir(exist_ok=True)
+        (rd / "patterns.yaml").write_text(yaml.safe_dump(patterns))
+        monkeypatch.setattr(mod, "RULES_DIR", rd)
+        return rd
+
+    @pytest.mark.parametrize("cmd", [
+        "rm /readonly/file",        # rm — caught
+        "mv src /readonly/file",    # mv — caught
+        "sed -i s/x/y/g /readonly/file",  # sed -i — caught
+        "echo data > /readonly/file",  # > redirect — caught
+    ])
+    def test_caught_mutation_operators(self, cmd, tmp_path, monkeypatch):
+        self._rules(tmp_path, monkeypatch, {"readOnlyPaths": ["/readonly/"]})
+        assert check_command_safety(cmd)["decision"] == "block"
+
+    @pytest.mark.parametrize("cmd", [
+        "cp src /readonly/file",
+        "dd if=src of=/readonly/file",
+        "tee /readonly/file",
+        "rsync src /readonly/",
+        "tar -cf /readonly/x.tar src",
+        "install -m 0644 src /readonly/dst",
+    ])
+    def test_uncaught_mutation_operators_currently_allowed(self, cmd, tmp_path, monkeypatch):
+        """Documents the security gap: these operators write to read-only paths
+        but are not detected by the current readOnlyPaths rule.
+
+        If this test starts failing (decision becomes 'block'), the gap was
+        closed in source — flip the assertion and update.
+        """
+        self._rules(tmp_path, monkeypatch, {"readOnlyPaths": ["/readonly/"]})
+        result = check_command_safety(cmd)
+        assert result["decision"] == "allow", (
+            f"Gap closed for {cmd!r} — update this test to assert 'block'"
+        )

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -1,0 +1,380 @@
+"""Tests for agentwire/hooks/damage-control/ — Bash/Edit/Write tool hooks.
+
+These hooks are PEP 723 inline-deps scripts invoked by Claude Code. They live
+under hyphenated filenames (`bash-tool-damage-control.py`), so they're loaded
+via importlib instead of normal imports. Each hook exposes a top-level
+`check_command` (bash) or `check_path` (edit/write) function plus a `main()`
+that reads JSON from stdin.
+
+We test the pure decision functions directly (fast, deterministic) and a
+representative subprocess flow per hook (covers the stdin/exit-code surface).
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "agentwire" / "hooks" / "damage-control"
+
+
+def _load_hook(filename: str):
+    """Load a hyphenated hook script as an importable module.
+
+    The script's `audit_logger` import resolves via sys.path injection so the
+    fallback no-op log_* functions are not needed.
+    """
+    sys.path.insert(0, str(HOOKS_DIR))
+    try:
+        path = HOOKS_DIR / filename
+        spec = importlib.util.spec_from_file_location(
+            filename.replace(".py", "").replace("-", "_"), path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def bash_hook():
+    return _load_hook("bash-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def edit_hook():
+    return _load_hook("edit-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def write_hook():
+    return _load_hook("write-tool-damage-control.py")
+
+
+# ---------------------------------------------------------------------------
+# bash-tool-damage-control.py: check_command decision matrix
+# ---------------------------------------------------------------------------
+
+
+class TestBashHookCheckCommand:
+    @staticmethod
+    def _config(**overrides):
+        """Minimal config; tests override the relevant key."""
+        return {
+            "bashToolPatterns": [],
+            "zeroAccessPaths": [],
+            "readOnlyPaths": [],
+            "noDeletePaths": [],
+            "allowedPaths": [],
+            **overrides,
+        }
+
+    def test_no_patterns_allows(self, bash_hook):
+        blocked, ask, reason = bash_hook.check_command("echo hello", self._config())
+        assert (blocked, ask) == (False, False)
+
+    def test_hard_block_pattern(self, bash_hook):
+        cfg = self._config(bashToolPatterns=[
+            {"pattern": r"\brm\s+-rf\s+/", "reason": "rm -rf /"},
+        ])
+        blocked, ask, reason = bash_hook.check_command("rm -rf /", cfg)
+        assert blocked is True
+        assert ask is False
+        assert "rm -rf /" in reason
+
+    def test_ask_pattern(self, bash_hook):
+        cfg = self._config(bashToolPatterns=[
+            {"pattern": r"\bgit\s+push\b", "reason": "git push", "ask": True},
+        ])
+        blocked, ask, reason = bash_hook.check_command("git push origin main", cfg)
+        assert (blocked, ask) == (False, True)
+        assert reason == "git push"
+
+    def test_bypassable_pattern_blocks_without_allowlist(self, bash_hook):
+        cfg = self._config(bashToolPatterns=[
+            {"pattern": r"\brm\s+", "reason": "rm deletion", "bypassable": True},
+        ])
+        blocked, ask, _ = bash_hook.check_command("rm /etc/passwd", cfg)
+        assert (blocked, ask) == (True, False)
+
+    def test_bypassable_pattern_allowed_via_allowlist(self, bash_hook):
+        cfg = self._config(
+            bashToolPatterns=[
+                {"pattern": r"\brm\s+", "reason": "rm deletion", "bypassable": True},
+            ],
+            allowedPaths=[{"path": "*/dist/*", "allow": "all"}],
+        )
+        blocked, ask, _ = bash_hook.check_command(
+            "rm /home/user/proj/dist/old.whl", cfg
+        )
+        assert (blocked, ask) == (False, False)
+
+    def test_zero_access_path_blocks(self, bash_hook):
+        cfg = self._config(zeroAccessPaths=["/etc/secret"])
+        blocked, _, reason = bash_hook.check_command("cat /etc/secret", cfg)
+        assert blocked is True
+        assert "zero-access" in reason
+
+    def test_zero_access_method_call_skipped(self, bash_hook):
+        """`module.py(...)` should not match `*.py` zero-access pattern."""
+        cfg = self._config(zeroAccessPaths=["*.py"])
+        blocked, _, _ = bash_hook.check_command(
+            "python -c 'import module.py()'", cfg
+        )
+        assert blocked is False
+
+    def test_invalid_regex_skipped_not_crashed(self, bash_hook):
+        cfg = self._config(bashToolPatterns=[
+            {"pattern": r"[unclosed", "reason": "bad pattern"},
+            {"pattern": r"\bdanger\b", "reason": "real danger"},
+        ])
+        # Bad regex skipped; real one fires.
+        blocked, _, reason = bash_hook.check_command("danger ahead", cfg)
+        assert blocked is True
+        assert reason == "Blocked: real danger"
+
+    def test_read_only_path_caught_via_redirect(self, bash_hook):
+        cfg = self._config(readOnlyPaths=["/etc/"])
+        blocked, _, _ = bash_hook.check_command("echo data > /etc/foo", cfg)
+        assert blocked is True
+
+    def test_no_delete_path_blocks_rm(self, bash_hook):
+        cfg = self._config(noDeletePaths=[".git/"])
+        blocked, _, _ = bash_hook.check_command("rm .git/HEAD", cfg)
+        assert blocked is True
+
+    def test_no_delete_path_allows_cat(self, bash_hook):
+        """no-delete only blocks deletes, not reads."""
+        cfg = self._config(noDeletePaths=[".git/"])
+        blocked, ask, _ = bash_hook.check_command("cat .git/HEAD", cfg)
+        assert (blocked, ask) == (False, False)
+
+
+# ---------------------------------------------------------------------------
+# bash-tool-damage-control.py: helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestBashHookHelpers:
+    def test_glob_to_regex_extension(self, bash_hook):
+        regex = bash_hook.glob_to_regex("*.py")
+        # Should match "rm test.py" but not "module.python"
+        import re
+        assert re.search(regex, "rm test.py")
+        assert not re.search(regex, "module.python")
+
+    def test_is_glob_pattern_detection(self, bash_hook):
+        assert bash_hook.is_glob_pattern("*.py") is True
+        assert bash_hook.is_glob_pattern("file?.txt") is True
+        assert bash_hook.is_glob_pattern("[abc]") is True
+        assert bash_hook.is_glob_pattern("plain.txt") is False
+
+    @pytest.mark.parametrize("reason,expected", [
+        ("rm anything", "delete"),
+        ("trash this", "delete"),
+        ("rmdir empty", "delete"),
+        ("chmod -x", "chmod"),
+        ("chown user", "chmod"),
+        ("mv operation", "move"),
+        ("write to disk", "write"),
+        ("", "write"),
+    ])
+    def test_infer_operation_from_reason(self, bash_hook, reason, expected):
+        assert bash_hook._infer_operation_from_reason(reason) == expected
+
+    def test_extract_paths_from_command(self, bash_hook):
+        paths = bash_hook._extract_paths_from_command("cat /etc/passwd /tmp/foo")
+        assert "/etc/passwd" in paths
+        assert "/tmp/foo" in paths
+
+
+# ---------------------------------------------------------------------------
+# bash hook: subprocess end-to-end (stdin → exit code → stderr)
+# ---------------------------------------------------------------------------
+
+
+class TestBashHookSubprocess:
+    """Test the full main() flow: read JSON from stdin, exit 0/1/2."""
+
+    HOOK = HOOKS_DIR / "bash-tool-damage-control.py"
+
+    def _run(self, payload, env_extra=None):
+        env = {
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": "/tmp",
+            **(env_extra or {}),
+        }
+        # Use system python directly (skip uv-run startup) — the script's
+        # imports (yaml, audit_logger) are present in the venv
+        proc = subprocess.run(
+            [sys.executable, str(self.HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        return proc
+
+    def test_non_bash_tool_passes(self):
+        # Edit tool input must be ignored (this hook only checks Bash)
+        proc = self._run({"tool_name": "Edit", "tool_input": {"file_path": "/x"}})
+        assert proc.returncode == 0
+
+    def test_empty_command_passes(self):
+        proc = self._run({"tool_name": "Bash", "tool_input": {"command": ""}})
+        assert proc.returncode == 0
+
+    def test_invalid_json_exits_1(self):
+        proc = subprocess.run(
+            [sys.executable, str(self.HOOK)],
+            input="not json {{{",
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin"},
+            timeout=10,
+        )
+        assert proc.returncode == 1
+        assert "Invalid JSON" in proc.stderr or "Error" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# edit-tool-damage-control.py & write-tool-damage-control.py
+# ---------------------------------------------------------------------------
+
+
+class TestEditWriteHookStructure:
+    """Sanity checks: hooks are loadable and expose the expected entry points."""
+
+    def test_edit_hook_loads(self, edit_hook):
+        # Should expose the same helper API as bash hook
+        assert hasattr(edit_hook, "main")
+
+    def test_write_hook_loads(self, write_hook):
+        assert hasattr(write_hook, "main")
+
+
+class TestEditHookSubprocess:
+    HOOK = HOOKS_DIR / "edit-tool-damage-control.py"
+
+    def _run(self, payload):
+        proc = subprocess.run(
+            [sys.executable, str(self.HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", "HOME": "/tmp"},
+            timeout=10,
+        )
+        return proc
+
+    def test_non_edit_tool_passes(self):
+        # Bash tool input must be ignored (this hook only checks Edit/MultiEdit)
+        proc = self._run({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+        assert proc.returncode == 0
+
+    def test_missing_file_path_passes(self):
+        proc = self._run({"tool_name": "Edit", "tool_input": {}})
+        assert proc.returncode == 0
+
+
+class TestWriteHookSubprocess:
+    HOOK = HOOKS_DIR / "write-tool-damage-control.py"
+
+    def _run(self, payload):
+        proc = subprocess.run(
+            [sys.executable, str(self.HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", "HOME": "/tmp"},
+            timeout=10,
+        )
+        return proc
+
+    def test_non_write_tool_passes(self):
+        proc = self._run({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+        assert proc.returncode == 0
+
+    def test_missing_file_path_passes(self):
+        proc = self._run({"tool_name": "Write", "tool_input": {}})
+        assert proc.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# audit_logger.py
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogger:
+    @pytest.fixture
+    def audit_module(self, tmp_path, monkeypatch):
+        """Load audit_logger with AGENTWIRE_DIR pointing at tmp_path."""
+        monkeypatch.setenv("AGENTWIRE_DIR", str(tmp_path / ".agentwire"))
+        spec = importlib.util.spec_from_file_location(
+            "audit_logger_test", HOOKS_DIR / "audit_logger.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_log_blocked_writes_jsonl(self, audit_module):
+        audit_module.log_blocked("Bash", "rm -rf /", "rm -rf root")
+        log_file = audit_module.get_log_file()
+        assert log_file.exists()
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["decision"] == "blocked"
+        assert entry["tool"] == "Bash"
+        assert entry["blocked_by"] == "rm -rf root"
+        assert entry["command"] == "rm -rf /"
+
+    def test_log_asked_writes_jsonl(self, audit_module):
+        audit_module.log_asked("Bash", "git push", "destructive op")
+        entry = json.loads(audit_module.get_log_file().read_text().strip())
+        assert entry["decision"] == "asked"
+        assert entry["blocked_by"] == "destructive op"
+
+    def test_log_allowed_user_approved_flag(self, audit_module):
+        audit_module.log_allowed("Bash", "git commit", user_approved=True)
+        entry = json.loads(audit_module.get_log_file().read_text().strip())
+        assert entry["decision"] == "allowed"
+        assert entry["user_approved"] is True
+
+    def test_log_allowed_no_user_approval_omits_flag(self, audit_module):
+        """user_approved=False stores None to keep entries lean."""
+        audit_module.log_allowed("Bash", "ls", user_approved=False)
+        entry = json.loads(audit_module.get_log_file().read_text().strip())
+        assert entry["user_approved"] is None
+
+    def test_session_context_from_env(self, audit_module, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_SESSION_ID", "sess-123")
+        monkeypatch.setenv("AGENTWIRE_AGENT_ID", "worker-1")
+        ctx = audit_module.get_session_context()
+        assert ctx == {"session_id": "sess-123", "agent_id": "worker-1"}
+
+    def test_session_context_defaults(self, audit_module, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_SESSION_ID", raising=False)
+        monkeypatch.delenv("AGENTWIRE_AGENT_ID", raising=False)
+        ctx = audit_module.get_session_context()
+        assert ctx == {"session_id": "unknown", "agent_id": "main"}
+
+    def test_log_dir_creates_path(self, audit_module, tmp_path):
+        log_dir = audit_module.get_log_dir()
+        assert log_dir.exists()
+        assert log_dir.is_dir()
+        # AGENTWIRE_DIR fixture pointed it at tmp_path/.agentwire
+        assert str(tmp_path) in str(log_dir)
+
+    def test_multiple_entries_append(self, audit_module):
+        audit_module.log_blocked("Bash", "cmd1", "r1")
+        audit_module.log_asked("Bash", "cmd2", "r2")
+        audit_module.log_allowed("Bash", "cmd3")
+        lines = audit_module.get_log_file().read_text().strip().split("\n")
+        assert len(lines) == 3
+        decisions = [json.loads(line)["decision"] for line in lines]
+        assert decisions == ["blocked", "asked", "allowed"]

--- a/tests/unit/test_pi_runner.py
+++ b/tests/unit/test_pi_runner.py
@@ -1,0 +1,427 @@
+"""Tests for agentwire/workflows/pi_runner.py — pi subprocess + JSONL parsing."""
+
+import json
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentwire.workflows import pi_runner
+from agentwire.workflows.node import ActionNode
+
+
+# ---------------------------------------------------------------------------
+# build_pi_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPiCommand:
+    def test_minimal_node(self):
+        node = ActionNode(id="t", prompt="hello")
+        cmd = pi_runner.build_pi_command(node)
+        assert cmd[0] == "pi"
+        assert "-p" in cmd and cmd[cmd.index("-p") + 1] == "hello"
+        assert "--provider" in cmd and cmd[cmd.index("--provider") + 1] == "zai"
+        assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "glm-5.1"
+        assert "--mode" in cmd and cmd[cmd.index("--mode") + 1] == "json"
+        assert "--no-session" in cmd
+        # Empty tools list → DEFAULT_TOOLS injected, not --no-tools
+        assert "--tools" in cmd
+        tools_arg = cmd[cmd.index("--tools") + 1]
+        assert tools_arg  # non-empty
+
+    def test_explicit_provider_and_model(self):
+        node = ActionNode(id="t", prompt="x", provider="deepseek", model="deepseek-chat")
+        cmd = pi_runner.build_pi_command(node)
+        assert cmd[cmd.index("--provider") + 1] == "deepseek"
+        assert cmd[cmd.index("--model") + 1] == "deepseek-chat"
+
+    def test_custom_binary(self):
+        node = ActionNode(id="t", prompt="x")
+        cmd = pi_runner.build_pi_command(node, pi_binary="/opt/pi/bin/pi")
+        assert cmd[0] == "/opt/pi/bin/pi"
+
+    def test_thinking_flag(self):
+        node = ActionNode(id="t", prompt="x", thinking="high")
+        cmd = pi_runner.build_pi_command(node)
+        assert cmd[cmd.index("--thinking") + 1] == "high"
+
+    def test_explicit_tools_used_verbatim(self):
+        node = ActionNode(id="t", prompt="x", tools=["read", "bash"])
+        cmd = pi_runner.build_pi_command(node)
+        assert cmd[cmd.index("--tools") + 1] == "read,bash"
+
+
+# ---------------------------------------------------------------------------
+# _get_pi_api_key — config first, env fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGetPiApiKey:
+    def test_config_takes_precedence(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "pi:\n  providers:\n    zai:\n      api_key: from-config\n"
+        )
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", config_path)
+        monkeypatch.setenv("ZAI_API_KEY", "from-env")
+        assert pi_runner._get_pi_api_key("zai") == "from-config"
+
+    def test_env_fallback_when_config_missing(self, tmp_path, monkeypatch):
+        # Point at non-existent config
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", tmp_path / "missing.yaml")
+        monkeypatch.setenv("ZAI_API_KEY", "from-env")
+        assert pi_runner._get_pi_api_key("zai") == "from-env"
+
+    def test_env_fallback_when_config_empty_for_provider(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("pi:\n  providers:\n    zai:\n      api_key: ''\n")
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", config_path)
+        monkeypatch.setenv("ZAI_API_KEY", "from-env")
+        assert pi_runner._get_pi_api_key("zai") == "from-env"
+
+    def test_env_var_name_normalizes_hyphens(self, tmp_path, monkeypatch):
+        """Provider 'foo-bar' should map to env var FOO_BAR_API_KEY."""
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", tmp_path / "missing.yaml")
+        monkeypatch.setenv("FOO_BAR_API_KEY", "ok")
+        assert pi_runner._get_pi_api_key("foo-bar") == "ok"
+
+    def test_neither_present_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", tmp_path / "missing.yaml")
+        monkeypatch.delenv("ZAI_API_KEY", raising=False)
+        assert pi_runner._get_pi_api_key("zai") == ""
+
+    def test_malformed_config_does_not_crash(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yaml"
+        # Top-level YAML scalar (not a dict) — code path checks isinstance(data, dict)
+        config_path.write_text("just-a-string")
+        monkeypatch.setattr(pi_runner, "CONFIG_PATH", config_path)
+        monkeypatch.setenv("ZAI_API_KEY", "from-env")
+        assert pi_runner._get_pi_api_key("zai") == "from-env"
+
+
+# ---------------------------------------------------------------------------
+# _extract_final_assistant_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFinalAssistantText:
+    def test_empty_events(self):
+        assert pi_runner._extract_final_assistant_text([]) == ""
+
+    def test_single_assistant_message(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hello world"}],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "hello world"
+
+    def test_returns_last_assistant_message(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "first"}],
+            }},
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "final"}],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "final"
+
+    def test_skips_user_messages(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "ignored"}],
+            }},
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "answer"}],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "answer"
+
+    def test_concatenates_text_blocks(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "part 1 "},
+                    {"type": "text", "text": "part 2"},
+                ],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "part 1 part 2"
+
+    def test_skips_non_text_blocks(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "read", "input": {}},
+                    {"type": "text", "text": "answer"},
+                ],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "answer"
+
+    def test_skips_other_event_types(self):
+        events = [
+            {"type": "agent_start"},
+            {"type": "turn_start"},
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+            }},
+        ]
+        assert pi_runner._extract_final_assistant_text(events) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_calls
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToolCalls:
+    def test_empty(self):
+        assert pi_runner._extract_tool_calls([]) == []
+
+    def test_single_tool_call(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "read", "input": {"path": "x"}},
+                ],
+            }},
+        ]
+        calls = pi_runner._extract_tool_calls(events)
+        assert calls == [{"id": "t1", "name": "read", "input": {"path": "x"}}]
+
+    def test_dedupe_by_id(self):
+        block = {"type": "tool_use", "id": "t1", "name": "read", "input": {"path": "x"}}
+        events = [
+            {"type": "message_end", "message": {"role": "assistant", "content": [block]}},
+            {"type": "turn_end", "message": {"role": "assistant", "content": [block]}},
+        ]
+        calls = pi_runner._extract_tool_calls(events)
+        assert len(calls) == 1
+
+    def test_skips_user_messages(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "user",
+                "content": [{"type": "tool_use", "id": "x", "name": "read"}],
+            }},
+        ]
+        assert pi_runner._extract_tool_calls(events) == []
+
+    def test_skips_non_tooluse_blocks(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thinking..."},
+                    {"type": "tool_use", "id": "t1", "name": "read"},
+                ],
+            }},
+        ]
+        calls = pi_runner._extract_tool_calls(events)
+        assert len(calls) == 1 and calls[0]["id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# _extract_token_usage
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTokenUsage:
+    def test_empty(self):
+        usage = pi_runner._extract_token_usage([])
+        assert usage == {
+            "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0,
+            "totalTokens": 0, "cost": 0.0,
+        }
+
+    def test_single_message(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "usage": {"input": 100, "output": 50, "totalTokens": 150,
+                          "cost": {"total": 0.0025}},
+            }},
+        ]
+        usage = pi_runner._extract_token_usage(events)
+        assert usage["input"] == 100
+        assert usage["output"] == 50
+        assert usage["totalTokens"] == 150
+        assert usage["cost"] == 0.0025
+
+    def test_aggregates_across_messages(self):
+        events = [
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "usage": {"input": 100, "output": 50, "cost": {"total": 0.01}},
+            }},
+            {"type": "message_end", "message": {
+                "role": "assistant",
+                "usage": {"input": 200, "output": 75, "cost": {"total": 0.02}},
+            }},
+        ]
+        usage = pi_runner._extract_token_usage(events)
+        assert usage["input"] == 300
+        assert usage["output"] == 125
+        assert usage["cost"] == pytest.approx(0.03)
+
+    def test_missing_usage_skipped(self):
+        events = [
+            {"type": "message_end", "message": {"role": "assistant"}},
+        ]
+        usage = pi_runner._extract_token_usage(events)
+        assert usage["input"] == 0
+
+
+# ---------------------------------------------------------------------------
+# run_node — subprocess paths via Popen mock
+# ---------------------------------------------------------------------------
+
+
+class TestRunNode:
+    @pytest.fixture
+    def fake_pi(self, monkeypatch):
+        """shutil.which('pi') returns a non-None path."""
+        monkeypatch.setattr(pi_runner.shutil, "which", lambda _: "/usr/local/bin/pi")
+        monkeypatch.setattr(pi_runner, "_get_pi_api_key", lambda _: "test-key")
+
+    def _popen_returning(self, stdout="", stderr="", returncode=0, timeout_first=False):
+        """Build a Popen mock with the requested communicate() result."""
+        proc = MagicMock()
+        if timeout_first:
+            proc.communicate.side_effect = [
+                subprocess.TimeoutExpired(cmd="pi", timeout=1),
+                ("", ""),  # second call after kill
+            ]
+        else:
+            proc.communicate.return_value = (stdout, stderr)
+        proc.returncode = returncode
+        proc.kill = MagicMock()
+        return proc
+
+    def test_validation_failure_returns_failure_no_subprocess(self, fake_pi, monkeypatch):
+        node = ActionNode(id="", prompt="")  # invalid: missing id and prompt
+        with patch.object(pi_runner.subprocess, "Popen") as mock_popen:
+            result = pi_runner.run_node(node)
+        assert result.status == "failure"
+        assert "id is required" in result.error or "prompt is required" in result.error
+        mock_popen.assert_not_called()
+
+    def test_pi_binary_missing(self, monkeypatch):
+        monkeypatch.setattr(pi_runner.shutil, "which", lambda _: None)
+        node = ActionNode(id="t", prompt="hello")
+        result = pi_runner.run_node(node)
+        assert result.status == "failure"
+        assert "pi binary not found" in result.error
+
+    def test_success_path(self, fake_pi):
+        events_jsonl = "\n".join([
+            json.dumps({"type": "agent_start"}),
+            json.dumps({"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "all done"}],
+                "usage": {"input": 10, "output": 5, "totalTokens": 15},
+            }}),
+        ])
+        proc = self._popen_returning(stdout=events_jsonl, stderr="", returncode=0)
+        node = ActionNode(id="t", prompt="hello")
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            result = pi_runner.run_node(node)
+        assert result.status == "success"
+        assert result.final_text == "all done"
+        assert result.exit_code == 0
+        assert result.tokens_used["input"] == 10
+
+    def test_nonzero_exit_records_error(self, fake_pi):
+        proc = self._popen_returning(stdout="", stderr="boom", returncode=1)
+        node = ActionNode(id="t", prompt="hello")
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            result = pi_runner.run_node(node)
+        assert result.status == "failure"
+        assert result.exit_code == 1
+        assert "boom" in result.error
+
+    def test_timeout(self, fake_pi):
+        proc = self._popen_returning(timeout_first=True)
+        node = ActionNode(id="t", prompt="hello", timeout=1)
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            result = pi_runner.run_node(node)
+        assert result.status == "timeout"
+        assert result.exit_code == -1
+        assert "timeout" in result.error.lower()
+        proc.kill.assert_called_once()
+
+    def test_malformed_jsonl_lines_skipped(self, fake_pi):
+        events_jsonl = "\n".join([
+            "not valid json",
+            json.dumps({"type": "message_end", "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+            }}),
+        ])
+        proc = self._popen_returning(stdout=events_jsonl, returncode=0)
+        node = ActionNode(id="t", prompt="hello")
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            result = pi_runner.run_node(node)
+        # Bad line skipped; valid line parsed
+        assert result.status == "success"
+        assert result.final_text == "ok"
+        # The malformed line is NOT in events (skipped on JSONDecodeError)
+        types = [e.get("type") for e in result.events]
+        assert "message_end" in types
+
+    def test_api_error_in_event_surfaces_as_failure(self, fake_pi):
+        events_jsonl = json.dumps({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "error",
+                "errorMessage": "rate limit hit",
+                "content": [],
+            },
+        })
+        # exit 0, but stopReason=error → should still be marked failure
+        proc = self._popen_returning(stdout=events_jsonl, returncode=0)
+        node = ActionNode(id="t", prompt="hello")
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            result = pi_runner.run_node(node)
+        assert result.status == "failure"
+        assert "rate limit" in result.error
+
+    def test_writes_event_log_when_path_given(self, fake_pi, tmp_path):
+        events_jsonl = json.dumps({"type": "agent_start"})
+        proc = self._popen_returning(stdout=events_jsonl, returncode=0)
+        node = ActionNode(id="t", prompt="hello")
+        log_path = tmp_path / "subdir" / "events.jsonl"
+        with patch.object(pi_runner.subprocess, "Popen", return_value=proc):
+            pi_runner.run_node(node, event_log_path=log_path)
+        assert log_path.exists()
+        # Subdir was created
+        assert log_path.parent.is_dir()
+        assert "agent_start" in log_path.read_text()
+
+    def test_api_key_injected_into_env(self, fake_pi):
+        captured_env = {}
+        def capture_popen(*args, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            proc = MagicMock()
+            proc.communicate.return_value = ("", "")
+            proc.returncode = 0
+            return proc
+        node = ActionNode(id="t", prompt="hello", provider="deepseek")
+        with patch.object(pi_runner, "_get_pi_api_key", lambda p: f"key-for-{p}"):
+            with patch.object(pi_runner.subprocess, "Popen", side_effect=capture_popen):
+                pi_runner.run_node(node)
+        assert captured_env.get("DEEPSEEK_API_KEY") == "key-for-deepseek"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -52,6 +52,125 @@ class TestFormatOverdue:
         assert format_overdue(seconds) == expected
 
 
+# --- _check_gate: precondition gates (git_commit, git_diff, command) ---
+
+class TestCheckGate:
+    """End-to-end tests against a real git repo fixture in tmp_path.
+
+    Gates are AND'd: all must pass for _check_gate to return True. Failure
+    in subprocess (git not found, malformed cmd) fails OPEN — gate returns
+    True so the task can run.
+    """
+
+    @pytest.fixture
+    def git_project(self, tmp_path):
+        """Initialize a git repo with one commit; return the path."""
+        import subprocess as sp
+        sp.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        sp.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+        sp.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+        (tmp_path / "README.md").write_text("hello\n")
+        sp.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        sp.run(["git", "commit", "-qm", "initial"], cwd=tmp_path, check=True)
+        return tmp_path
+
+    @pytest.fixture
+    def board(self, git_project):
+        from agentwire.scheduler import Board, SchedulerTask, TaskState
+        task = SchedulerTask(name="t", project=str(git_project))
+        return Board(tasks={"t": task}, state={"t": TaskState()})
+
+    def _head(self, project):
+        import subprocess as sp
+        return sp.run(
+            ["git", "-C", str(project), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    def _new_commit(self, project, file="other.txt", content="x"):
+        import subprocess as sp
+        (project / file).write_text(content)
+        sp.run(["git", "-C", str(project), "add", "-A"], check=True)
+        sp.run(["git", "-C", str(project), "commit", "-qm", "next"], check=True)
+
+    def test_no_gate_passes(self, board):
+        from agentwire.scheduler import _check_gate
+        assert _check_gate(board, "t") is True
+
+    def test_git_commit_no_baseline_passes(self, board):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"git_commit": True}
+        assert _check_gate(board, "t") is True
+
+    def test_git_commit_unchanged_blocks(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"git_commit": True}
+        board.state["t"].last_gate_commit = self._head(git_project)
+        assert _check_gate(board, "t") is False
+
+    def test_git_commit_advanced_passes(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"git_commit": True}
+        old_head = self._head(git_project)
+        board.state["t"].last_gate_commit = old_head
+        self._new_commit(git_project)
+        assert _check_gate(board, "t") is True
+
+    def test_git_commit_invalid_project_fails_open(self, board, tmp_path):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"git_commit": True}
+        board.tasks["t"].project = str(tmp_path / "not-a-repo")
+        board.state["t"].last_gate_commit = "deadbeef"
+        assert _check_gate(board, "t") is True  # fail open
+
+    def test_git_diff_no_changes_in_paths_blocks(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        old_head = self._head(git_project)
+        self._new_commit(git_project, file="other.txt")
+        board.tasks["t"].gate = {"git_diff": ["src/"]}
+        board.state["t"].last_gate_commit = old_head
+        assert _check_gate(board, "t") is False
+
+    def test_git_diff_changes_in_paths_passes(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        import subprocess as sp
+        old_head = self._head(git_project)
+        (git_project / "watched.txt").write_text("changed")
+        sp.run(["git", "-C", str(git_project), "add", "-A"], check=True)
+        sp.run(["git", "-C", str(git_project), "commit", "-qm", "watched"], check=True)
+        board.tasks["t"].gate = {"git_diff": ["watched.txt"]}
+        board.state["t"].last_gate_commit = old_head
+        assert _check_gate(board, "t") is True
+
+    def test_git_diff_no_baseline_passes(self, board):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"git_diff": ["src/"]}
+        assert _check_gate(board, "t") is True
+
+    def test_command_zero_exit_passes(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "true"}
+        assert _check_gate(board, "t") is True
+
+    def test_command_nonzero_exit_blocks(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "false"}
+        assert _check_gate(board, "t") is False
+
+    def test_command_with_pipe_runs_via_shell(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "echo ok | grep -q ok"}
+        assert _check_gate(board, "t") is True
+
+    def test_multiple_gates_all_required(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        old = self._head(git_project)
+        board.state["t"].last_gate_commit = old
+        self._new_commit(git_project)
+        board.tasks["t"].gate = {"git_commit": True, "command": "false"}
+        assert _check_gate(board, "t") is False
+
+
 # --- _EXIT_TO_STATUS mapping ---
 
 class TestExitCodeMapping:


### PR DESCRIPTION
## Summary

PR 3 of 3 in the test suite cleanup. Drives coverage on safety-critical paths from <50% to >60% on average, with several modules going over 90%. **126 new tests across 5 commits**, all exercising real behavior — no mock-of-mock tests.

## Coverage delta per module

| Module | Before | After | Note |
|---|---:|---:|---|
| \`workflows/pi_runner.py\` | 12% | **98%** | Recently shipped pi-\<provider\> core |
| \`scheduler.py\` | 35% | **61%** | Gate evaluation (\`git_commit\`, \`git_diff\`, \`command\`) |
| \`channels/webhook.py\` | (low) | **69%** | HTTP error paths |
| \`channels/quo.py\` | (low) | **66%** | HTTP/network error paths |
| \`cli_safety.py\` | 39% | **43%** | Decision-order, regex tolerance, mutation-detection gap |
| \`hooks/damage-control/*.py\` | **0%** | covered* | importlib loads — pytest-cov can't track |
| **TOTAL** | 29% | **32%** | |

\* Hyphenated filenames (\`bash-tool-damage-control.py\`) load via \`importlib.spec_from_file_location\`, which pytest-cov doesn't instrument. Tests do exercise real source — verified by injecting bad regex and asserting error tolerance.

## Phase breakdown (one commit each)

### 3a — \`cli_safety.py\` (+33 tests)
- ASK pattern returns \`'ask'\` (not \`'block'\`)
- Invalid regex skipped, not crashed (line 397-399)
- Non-dict pattern entries tolerated (line 372)
- Zero-access path blocking + allowlist bypass with read perm
- No-delete path blocking + allowlist bypass with delete perm
- Decision order: ask wins over bypassable when both match
- \`_infer_operation_from_reason\` for delete/chmod/move/write branches
- \`_extract_command_paths\` for absolute, ~, quoted, relative paths
- **Read-only path mutation operators**: documents which slip through (\`cp\`, \`dd\`, \`tee\`, \`rsync\`, \`tar\`, \`install\` — currently allowed because the source-side check only handles \`rm\`/\`mv\`/\`sed -i\`/\`>\`). Test asserts current behavior so we notice if it changes.

### 3b — Damage-control hooks (+39 tests)
- \`bash-tool-damage-control.py\`: 12 tests on \`check_command\` (hard-block, ask, bypassable + allowlist, zero-access, read-only, no-delete, regex tolerance, method-call false-positive avoidance) plus helpers
- bash hook subprocess: non-Bash tool input, empty command, malformed JSON → exit 1
- edit/write hooks: load + entry-point sanity checks
- \`audit_logger.py\`: \`log_blocked\`/\`log_asked\`/\`log_allowed\` JSONL writes, \`user_approved\` flag handling, session context from env, multiple-entry append

### 3c — \`pi_runner.py\` (+36 tests)
- \`build_pi_command\`: minimal, custom binary, provider/model overrides, thinking, explicit-tools-verbatim
- \`_get_pi_api_key\`: config-precedence, env-fallback, missing-config, hyphen-in-provider env name, malformed YAML
- \`_extract_final_assistant_text\`: empty, last-wins, skips user/non-text/other events
- \`_extract_tool_calls\`: empty, single, dedupe-by-id, skips user/non-tooluse
- \`_extract_token_usage\`: aggregation across messages
- \`run_node\`: validation-failure-no-subprocess, missing pi binary, success path, non-zero exit, timeout (Popen.kill), malformed JSONL skipped, \`stopReason=error\` → failure, event_log_path writes (auto-mkdir parent), API key env injection

### 3d — Scheduler gates (+12 tests)
Real git repo fixture in \`tmp_path\` — gates run real subprocess against real git, no mocks.
- \`git_commit\`: no baseline → pass; HEAD unchanged → block; HEAD advanced → pass; invalid project → fail open
- \`git_diff\`: no changes in scoped paths → block; changes in scoped path → pass
- \`command\`: exit 0 → pass; non-zero → block; shell pipes work
- Multiple gates AND'd: any one failing blocks

### 3f — Channel error paths (+4 tests)
- \`webhook\`: 503 \`HTTPError\` → \`ChannelResult(success=False, error contains '503')\`
- \`webhook\`: \`ConnectionError\` → error preserved
- \`quo\`: 401 \`HTTPError\` and \`TimeoutError\` → both surfaced as failure

## Out of scope (deferred)

- **Phase 3e (server WebSockets)**: 3 of 4 endpoints untested. The aiohttp test setup is more involved and there's already partial coverage in \`test_server_sdk_watch.py\`. Worth a follow-up PR.
- **Discord/Slack channels**: bridge-style channels with bot loops; needs more invasive mocking. Webhook + quo cover the urllib send-pattern.

## Test plan

- [x] \`uv run pytest --tb=no -q\` — green (1288 passed, 4 skipped, +126 new)
- [x] Per-module coverage table above measured via \`uv run pytest --cov=agentwire --cov-report=term\`
- [x] All new tests exercise real behavior (no mock-of-mock); hooks and gates run real subprocess

Built by [dotdev.dev](https://dotdev.dev)