### PR TITLE
fix(safety): close cli_safety mutation-operator gap (#162)

### DIFF
--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -425,13 +425,17 @@ def check_command_safety(command: str, verbose: bool = False) -> Dict[str, Any]:
                 "command": command
             }
 
+    mutation_ops = [
+        "rm ", "mv ", "sed -i", ">",
+        "cp ", "dd ", "tee ", "rsync ", "tar -c", "tar --create", "install ",
+    ]
     for path in read_only:
-        if matches_path_in_command(path, command) and any(op in command for op in ["rm", "mv", "sed -i", ">"]):
-            # Infer operation
+        if matches_path_in_command(path, command) and any(op in command for op in mutation_ops):
+            # Infer operation: rm/mv get specific verbs; everything else is "write"
             op = "write"
-            if "rm" in command:
+            if "rm " in command or command.startswith("rm "):
                 op = "delete"
-            elif "mv" in command:
+            elif "mv " in command or command.startswith("mv "):
                 op = "move"
             if is_command_path_allowed(command, allowed, op):
                 continue

--- a/tests/unit/test_cli_safety.py
+++ b/tests/unit/test_cli_safety.py
@@ -497,12 +497,11 @@ class TestExtractCommandPaths:
         assert any("scratch.txt" in p for p in paths)
 
 
-# --- Read-only path mutation operators: documents which slip through ---
+# --- Read-only path mutation operators ---
 #
-# Source line ~429 only catches `rm`, `mv`, `sed -i`, `>` for readOnlyPath
-# detection. Other mutating commands (cp, dd, tee, rsync, cat>, install) are
-# NOT caught — they fall through to "allow" unless covered by another rule.
-# These tests document that gap so we notice if it changes.
+# Source line ~429 catches rm/mv/sed -i/> plus cp/dd/tee/rsync/tar -c/install
+# for readOnlyPath detection. Each parametrized case writes (or deletes/moves)
+# to a path inside readOnlyPaths and must be blocked.
 
 class TestReadOnlyPathMutationOperators:
     def _rules(self, tmp_path, monkeypatch, patterns):
@@ -515,32 +514,31 @@ class TestReadOnlyPathMutationOperators:
         return rd
 
     @pytest.mark.parametrize("cmd", [
-        "rm /readonly/file",        # rm — caught
-        "mv src /readonly/file",    # mv — caught
-        "sed -i s/x/y/g /readonly/file",  # sed -i — caught
-        "echo data > /readonly/file",  # > redirect — caught
+        # Original four (regression fence)
+        "rm /readonly/file",
+        "mv src /readonly/file",
+        "sed -i s/x/y/g /readonly/file",
+        "echo data > /readonly/file",
+        # Newly closed gap (was test_uncaught_mutation_operators_currently_allowed)
+        "cp src /readonly/file",
+        "dd if=src of=/readonly/file",
+        "tee /readonly/file",
+        "rsync src /readonly/",
+        "tar -cf /readonly/x.tar src",
+        "tar --create -f /readonly/x.tar src",
+        "install -m 0644 src /readonly/dst",
     ])
     def test_caught_mutation_operators(self, cmd, tmp_path, monkeypatch):
         self._rules(tmp_path, monkeypatch, {"readOnlyPaths": ["/readonly/"]})
         assert check_command_safety(cmd)["decision"] == "block"
 
     @pytest.mark.parametrize("cmd", [
-        "cp src /readonly/file",
-        "dd if=src of=/readonly/file",
-        "tee /readonly/file",
-        "rsync src /readonly/",
-        "tar -cf /readonly/x.tar src",
-        "install -m 0644 src /readonly/dst",
+        # Pure reads — must NOT trigger the read-only block
+        "cat /readonly/file",
+        "tar -tf /readonly/x.tar",
+        "grep foo /readonly/file",
     ])
-    def test_uncaught_mutation_operators_currently_allowed(self, cmd, tmp_path, monkeypatch):
-        """Documents the security gap: these operators write to read-only paths
-        but are not detected by the current readOnlyPaths rule.
-
-        If this test starts failing (decision becomes 'block'), the gap was
-        closed in source — flip the assertion and update.
-        """
+    def test_read_only_commands_allowed(self, cmd, tmp_path, monkeypatch):
+        """Reading from a read-only path is fine — only mutation operators block."""
         self._rules(tmp_path, monkeypatch, {"readOnlyPaths": ["/readonly/"]})
-        result = check_command_safety(cmd)
-        assert result["decision"] == "allow", (
-            f"Gap closed for {cmd!r} — update this test to assert 'block'"
-        )
+        assert check_command_safety(cmd)["decision"] == "allow"


### PR DESCRIPTION
## Summary

Closes #162.

\`agentwire/cli_safety.py:429\` only recognized 4 mutation operators when checking writes to a \`readOnlyPath\`. PR #160 documented the gap with passing-on-purpose tests; this PR closes it.

**Now blocked** (previously slipped through to "allow"):

| Command | Before | After |
|---|---|---|
| \`cp src /readonly/file\` | ALLOW | BLOCK |
| \`dd if=src of=/readonly/file\` | ALLOW | BLOCK |
| \`tee /readonly/file\` | ALLOW | BLOCK |
| \`rsync src /readonly/\` | ALLOW | BLOCK |
| \`tar -cf /readonly/x.tar src\` | ALLOW | BLOCK |
| \`tar --create -f /readonly/x.tar src\` | ALLOW | BLOCK |
| \`install -m 0644 src /readonly/dst\` | ALLOW | BLOCK |

The 4 originally-caught operators (\`rm\`, \`mv\`, \`sed -i\`, \`>\`) still block. Reads (\`cat\`, \`tar -tf\`, \`grep\`) still allow.

## Implementation

- Extended the inline operator list at \`cli_safety.py:429\` to include the 7 missing operators with trailing-space disambiguation (\`cp \`, \`dd \`, \`tee \`, \`rsync \`, \`install \` — prevents matching \`cpus\`/\`installer\`/etc).
- \`tar -c\` + \`tar --create\` covers both flag forms; \`tar -tf\`/\`tar -xf\` (read paths) stay unmatched.
- Operation inference (\`delete\` for \`rm\`, \`move\` for \`mv\`, \`write\` for the rest) maps cleanly to the allowlist's operation enum.

## Tests

- \`TestReadOnlyPathMutationOperators::test_uncaught_mutation_operators_currently_allowed\` deleted — its 6 cases moved into \`test_caught_mutation_operators\` and assertions flipped from \`'allow'\` to \`'block'\`. Added a 7th case (\`tar --create\` long-form). Total: 11 cases, all expected to block.
- New \`test_read_only_commands_allowed\` (3 cases) confirms reads still flow through to allow — a regression fence that the substring check stays scoped to mutations.
- Suite: 1288 → 1292 (4 net-new cases).

## Out of scope

The bash hook (\`bash-tool-damage-control.py\`) also misses \`dd\`/\`rsync\`/\`tar -c\`/\`install\` in its \`READ_ONLY_BLOCKED\` regex list. Fixing that drift, plus extracting a shared pattern module, is tracked by issue #164. Keeping this PR scoped to \`cli_safety\` only.

## Test plan

- [x] \`uv run pytest tests/unit/test_cli_safety.py::TestReadOnlyPathMutationOperators -v\` → 14 passed
- [x] \`uv run pytest --tb=short -q\` → 1292 passed, 4 skipped
- [x] In-process smoke test against the explicit issue commands → all match expected decision
- [x] Coverage on \`agentwire/cli_safety.py\` holds at 43%
- [x] Gap-documenting comment block removed (lines 500-505 of \`test_cli_safety.py\`)

Built by [dotdev.dev](https://dotdev.dev)