### PR TITLE
feat(handoff): shareable conversation bundles (closes #157)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,142 @@
+---
+description: Distill this conversation into a shareable handoff bundle (ai-handoff.md + show-the-story.html)
+---
+
+# /handoff
+
+You are about to compile this conversation into a **shareable handoff bundle**. The output is two artifacts:
+
+1. **`ai-handoff.md`** — XML-tagged markdown a teammate can paste into another LLM (Opus 4.7) to roughly continue the conversation.
+2. **`show-the-story.html`** — single-file presentation a human can open in a browser.
+
+You are uniquely positioned to do this well: you already have full conversation context. Don't ask the user clarifying questions unless something is genuinely ambiguous — distill what you know.
+
+## Workflow
+
+### 1. Initialize the bundle
+
+Call the MCP tool to create the bundle dir and pre-fill the template with git state and the CLAUDE.md/rules/memory chain:
+
+```
+mcp__agentwire__handoff_init(title="<short slug>")
+```
+
+The tool returns a `bundle_dir` and an `ai_handoff_path`. The pre-filled template at `ai_handoff_path` already has:
+- `<metadata>` populated with cwd, branch, commit, repo url
+- `<instructions>` populated with the full CLAUDE.md chain (verbatim)
+- `<project_state>` populated with `git status`, `git log`, and uncommitted diff
+
+You **must not touch** the `<instructions>` section unless redacting something sensitive — it's what makes the bundle portable across machines.
+
+### 2. Read the pre-filled template
+
+Use Read on `ai_handoff_path` to see exactly what got pre-filled.
+
+### 3. Fill in the rest
+
+Use Write (or Edit) on `ai_handoff_path` to replace every `{{ ... }}` placeholder with real content. Specifically:
+
+#### `<title>`
+One short line summarizing the session — what it was about, not what was decided. Roughly 4-8 words.
+
+#### `<metadata>` extras
+Fill `started_at` / `ended_at` if you can estimate them, `user_identity` (if mentioned), and `mcp_servers` (the ones actually used in this conversation).
+
+#### `<environment>`
+What the receiver can't see from `cwd` alone. Active panes, channels (Slack/Discord/email), scheduler state if relevant. If nothing notable, write a one-line "no special environment" note.
+
+#### `<conversation_summary>`
+This is the most load-bearing section. Be dense and structured.
+
+- `<goal>` — one sentence: what this session set out to do.
+- `<tldr>` — one paragraph the receiver reads first. Convey decisions made, current state, and what's next.
+- `<decisions>` — every meaningful decision. For each: `<title>` (short name), `<rationale>` (why), `<alternatives>` (what was considered and not picked). If a user message confirmed a choice, that's a decision.
+- `<dead_ends>` — things tried and rejected. Critical: this saves the receiver from retracing your steps.
+- `<open_threads>` — what's unresolved. Be specific. "tests/handoff/test_parser.py needs malformed-input cases" beats "tests pending".
+- `<stats>` — turns, files_touched, tools_used, duration_minutes. Estimates are fine.
+
+#### `<journey>`
+3-7 narrative beats — the *story* of the session, not the transcript. For each beat:
+- `<beat title="...">` — short headline.
+- `<quote>...</quote>` — optional verbatim line from the conversation that captured the turn (user or assistant).
+- `<what_happened>...</what_happened>` — what actually changed.
+
+This drives the visual presentation in show-the-story.html. Aim for memorable beats: turning points, surprises, decisions, blockers.
+
+#### `<recent_turns>`
+The last ~10-20 turns, **filtered**:
+- Drop tool noise (file reads, searches) unless the result drove a decision.
+- Keep all user turns verbatim — they're the signal of intent.
+- Keep assistant turns that made decisions, asked questions, or summarized.
+- Use markdown: `**user:**` / `**assistant:**` labels, blockquotes for quoted content.
+
+#### `<handoff>`
+Direct instructions to the next agent.
+- `<one_sentence>` — what they should do first.
+- `<resume_at>` — concrete file path / TODO id / step number.
+- `<caveats>` — permission boundaries ("don't push", "don't edit X without asking"), env-specific notes, anything the receiver could trip on.
+
+#### `<theme>`
+Pick a palette and vibe that matches the **emotional tone** of the session. A debugging crisis at 2am gets different colors than a clean greenfield design pass. Be honest in `mood`. The shape:
+
+```json
+{
+  "name": "short-slug",
+  "mood": "honest read of the session's emotional tone — 1 short sentence",
+  "palette": {
+    "bg": "#hex",
+    "surface": "#hex",
+    "fg": "#hex",
+    "muted": "#hex",
+    "accent": "#hex",
+    "accent_2": "#hex",
+    "border": "#hex"
+  },
+  "fonts": {
+    "heading": "css font-family stack",
+    "body": "css font-family stack"
+  },
+  "motion": "subtle"
+}
+```
+
+Tips:
+- Dark backgrounds work better in this template — `bg` should be deep.
+- `accent` is the dominant interactive color (tabs, headlines, highlights). Pick something that signals the mood.
+- `accent_2` is for warnings / dead-ends. Often a warm color.
+- Keep `fonts.heading` monospace-leaning, `fonts.body` sans-serif. Override only if the mood justifies it.
+- `motion`: `"subtle"` (default), `"playful"` (longer transitions), `"none"` (instant).
+
+### 4. Render the HTML
+
+After writing `ai-handoff.md`, render the HTML:
+
+```
+mcp__agentwire__handoff_render(bundle_dir="<from step 1>", story=true)
+```
+
+If render fails, the parser will tell you which tag is missing or malformed — fix and re-run.
+
+### 5. Report
+
+Give the user:
+- The bundle dir path
+- A one-sentence summary of what you produced
+- An explicit pointer to open `show-the-story.html` in a browser
+
+Don't paste the full ai-handoff.md back — it's long. Just confirm it's saved and mention the highlights you captured (number of decisions, dead ends, journey beats, theme name/mood).
+
+## Quality bar
+
+The receiver's first impression is everything. A great handoff:
+- Reads cold — the receiver doesn't need to be in this folder.
+- Is honest about dead ends. Hiding what didn't work wastes the receiver's tokens.
+- Names specific files and line numbers, not vague pointers.
+- Picks a theme that captures the session's actual feel. Don't pick "professional blue" for a chaotic debug session.
+
+## Don't
+
+- Don't ask the user "should I include X?" — make the call yourself.
+- Don't paste the entire conversation as `<recent_turns>` — filter aggressively.
+- Don't over-design the theme. The structure is fixed; you're picking colors and vibes, not a layout.
+- Don't edit `<instructions>` (the CLAUDE.md chain) unless redacting secrets.

--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -131,6 +131,14 @@ agentwire history list          # list conversation history
 agentwire history show <id>     # show session details
 agentwire history resume <id>   # resume session (always forks)
 
+# Shareable conversation handoffs (issue #157)
+agentwire handoff init [--title hint]      # create bundle dir + pre-filled ai-handoff.md template
+agentwire handoff render <bundle-dir>      # render show-the-story.html from ai-handoff.md
+agentwire handoff list                     # list past bundles
+# Inside a Claude Code session, prefer the /handoff slash command — it walks the
+# agent through filling the template using full conversation context (free, no
+# fresh LLM call). Outputs land in ~/.agentwire/artifacts/handoff-<slug>/.
+
 # Roles management
 agentwire roles list            # list available roles
 agentwire roles show <name>     # show role details

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-mcp-tools
-description: Reference for the 87 `mcp__agentwire__*` MCP tools — session/pane management, voice/TTS, tasks/locks, channels (email/sms/webhook/discord/slack), machines/tunnels/network, history/roles/projects, scheduler, overnight queue, desktop UI, notifications. Use when agents inside agentwire sessions need to pick the right MCP tool instead of shelling out to the `agentwire` CLI.
+description: Reference for the 90 `mcp__agentwire__*` MCP tools — session/pane management, voice/TTS, tasks/locks, channels (email/sms/webhook/discord/slack), machines/tunnels/network, history/roles/projects, scheduler, overnight queue, desktop UI, notifications. Use when agents inside agentwire sessions need to pick the right MCP tool instead of shelling out to the `agentwire` CLI.
 ---
 
 # AgentWire MCP Tools
@@ -79,6 +79,9 @@ description: Reference for the 87 `mcp__agentwire__*` MCP tools — session/pane
 | `agentwire history list` | `history_list()` |
 | `agentwire history show id` | `history_show(session_id="...")` |
 | `agentwire history resume id -p path` | `history_resume(session_id="...", project="...")` |
+| `agentwire handoff init --title hint` | `handoff_init(title="...")` |
+| `agentwire handoff render <bundle-dir>` | `handoff_render(bundle_dir="...", story=True)` |
+| `agentwire handoff list` | `handoff_list()` |
 | `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."], plain_text=False)` |
 
 ## Channels (7 tools)
@@ -152,7 +155,7 @@ description: Reference for the 87 `mcp__agentwire__*` MCP tools — session/pane
 | Minimize all | `desktop_minimize_all()` |
 | Multi-window layout | `desktop_layout(windows=[{id: "...", zone: "left"}])` |
 
-**87 tools total.** When to use CLI vs MCP:
+**90 tools total.** When to use CLI vs MCP:
 - **MCP tools** — Agents in sessions (orchestrators, workers)
 - **CLI commands** — Humans, shell scripts, automation outside of agent sessions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shareable conversation handoffs** — `agentwire handoff` produces two artifacts from one conversation: `ai-handoff.md` (XML-tagged markdown a teammate can paste into another LLM) and `show-the-story.html` (single-file presentation with tabs and scroll-slides) — issue [#157](https://github.com/dotdevdotdev/agentwire-dev/issues/157)
+  - In-conversation agent does the distillation (free — uses existing context, no fresh LLM call); CLI/MCP just renders deterministically via Jinja2
+  - `/handoff` slash command walks the agent through filling the template, picking a vibe-matched theme (palette, fonts, motion), and rendering
+  - Bundle is portable across machines: full CLAUDE.md / rules / memory chain inlined into `<instructions>` so the receiver doesn't need the original cwd
+  - Subcommands: `agentwire handoff init [--title]`, `agentwire handoff render <bundle-dir> [--story]`, `agentwire handoff list`
+  - MCP wrappers: `mcp__agentwire__handoff_init`, `mcp__agentwire__handoff_render`, `mcp__agentwire__handoff_list`
+  - Outputs land in `~/.agentwire/artifacts/handoff-<timestamp>-<slug>/`
+  - 42 new unit tests cover parser (valid/malformed/diff-pollution regressions), renderer (theme variations, tabs, self-containedness), git-state capture, and CLAUDE.md chain enumeration
 - **Anthropic workflow runner** — `runner: anthropic` alongside the existing pi runner (Phase 6, PRs 1–6)
   - Pluggable runner registry (`agentwire/workflows/runners/`) with a shared `NodeRunner` Protocol; pi kept byte-for-byte identical behind a thin shim
   - `AnthropicRunner` uses `claude-agent-sdk>=0.1.43` with subscription auth — no `ANTHROPIC_API_KEY` required, inherits `~/.claude/.credentials.json` (subscription-covered, no per-run billing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ tail -f /tmp/queue-processor-debug.log  # queue processor
 
 LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wiki pattern. Research and debugging knowledge compounds across sessions. Use `/wiki ingest`, `/wiki query <question>`, `/wiki lint` skills. **Before researching**: agents check the wiki first. After discovering: agents write it down.
 
+## Handoffs
+
+`/handoff` distills the current conversation into a shareable bundle: `ai-handoff.md` for another LLM and `show-the-story.html` for humans. The agent does the distillation in-context (free); the CLI/MCP renders deterministically. Outputs in `~/.agentwire/artifacts/handoff-<slug>/`. Full reference: [`docs/wiki/communication/handoff.md`](docs/wiki/communication/handoff.md).
+
 ## Reference Skills
 
 Reference detail lives in skills under `.claude/skills/` — invoke as needed:

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6802,6 +6802,324 @@ def cmd_mcp(args) -> int:
     return 0
 
 
+# =============================================================================
+# Handoff Commands (shareable conversation bundles — ai-handoff.md + show-the-story.html)
+# =============================================================================
+
+
+_HANDOFF_TEMPLATE = """\
+<session_bundle version="1">
+<title>{{ short title — what this session is about }}</title>
+
+<metadata>
+- cwd: __CWD__
+- repo_url: __REPO_URL__
+- branch: __BRANCH__
+- commit: __COMMIT__
+- session_type: claude-bypass
+- model: __MODEL__
+- started_at: {{ ISO timestamp }}
+- ended_at: {{ ISO timestamp }}
+- user_identity: {{ who }}
+- mcp_servers: {{ comma-separated list }}
+</metadata>
+
+<environment>
+{{ panes, channels, scheduler state, anything else the receiver can't see from cwd alone }}
+</environment>
+
+<instructions>
+{{ The CLI prefilled this section with collected CLAUDE.md / rules / memory.
+   Leave it alone unless you need to redact secrets. }}
+__INSTRUCTIONS_BLOCK__
+</instructions>
+
+<project_state>
+<git_status>
+__GIT_STATUS__
+</git_status>
+<git_log>
+__GIT_LOG__
+</git_log>
+<git_diff>
+__GIT_DIFF__
+</git_diff>
+{{ optionally <file path="..."> blocks for key files }}
+</project_state>
+
+<conversation_summary>
+<goal>{{ one sentence: what this session set out to do }}</goal>
+<tldr>{{ one paragraph the receiver reads first }}</tldr>
+<decisions>
+<decision>
+<title>{{ short name of decision }}</title>
+<rationale>{{ why it was made }}</rationale>
+<alternatives>
+- {{ alternative 1 }}
+- {{ alternative 2 }}
+</alternatives>
+</decision>
+</decisions>
+<dead_ends>
+<dead_end>
+<title>{{ thing tried }}</title>
+<why>{{ why rejected — saves the receiver from retracing }}</why>
+</dead_end>
+</dead_ends>
+<open_threads>
+<thread>
+<title>{{ unresolved item }}</title>
+<note>{{ where to pick up }}</note>
+</thread>
+</open_threads>
+<stats>
+- turns: {{ N }}
+- files_touched: {{ N }}
+- tools_used: {{ N }}
+- duration_minutes: {{ N }}
+</stats>
+</conversation_summary>
+
+<journey>
+<beat title="{{ short name }}">
+<quote>{{ optional verbatim line from the conversation }}</quote>
+<what_happened>{{ what changed at this beat }}</what_happened>
+</beat>
+</journey>
+
+<recent_turns>
+{{ Last ~10-20 turns, filtered: drop tool noise, keep user turns + decision-making
+   assistant turns. Use markdown blockquotes or simple labelled blocks. }}
+</recent_turns>
+
+<handoff>
+<one_sentence>{{ what the next agent should do first }}</one_sentence>
+<resume_at>{{ specific file path / TODO / step number }}</resume_at>
+<caveats>
+- {{ permission boundary, e.g. "do not push" }}
+- {{ env-specific note }}
+</caveats>
+</handoff>
+
+<theme>
+{
+  "name": "{{ short slug, e.g. evening-debug }}",
+  "mood": "{{ honest read of the session's emotional tone }}",
+  "palette": {
+    "bg": "#0e0f13",
+    "surface": "#1a1d24",
+    "fg": "#e2e8f0",
+    "muted": "#64748b",
+    "accent": "#5eead4",
+    "accent_2": "#fbbf24",
+    "border": "#2a2f3a"
+  },
+  "fonts": {
+    "heading": "ui-monospace, 'JetBrains Mono', monospace",
+    "body": "ui-sans-serif, system-ui, sans-serif"
+  },
+  "motion": "subtle"
+}
+</theme>
+</session_bundle>
+"""
+
+
+def _handoff_artifacts_dir() -> Path:
+    try:
+        from .config import load_config
+        cfg = load_config()
+        return Path(str(cfg.artifacts.dir)).expanduser()
+    except Exception:
+        return Path.home() / ".agentwire" / "artifacts"
+
+
+def _handoff_slug(title_hint: str | None = None) -> str:
+    import re as _re
+    ts = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    if title_hint:
+        clean = _re.sub(r"[^a-z0-9]+", "-", title_hint.lower()).strip("-")[:40]
+        if clean:
+            return f"handoff-{ts}-{clean}"
+    return f"handoff-{ts}"
+
+
+def _build_template(cwd: Path) -> str:
+    """Pre-fill template with collected git + instructions chain."""
+    from .handoff import git_state, instructions
+
+    snap = git_state.snapshot(cwd)
+    chain = instructions.collect(cwd)
+
+    instructions_block_parts = []
+    for instr in chain:
+        instructions_block_parts.append(
+            f'<file path="{instr.path}" kind="{instr.kind}">\n{instr.content}\n</file>'
+        )
+    instructions_block = "\n".join(instructions_block_parts) if instructions_block_parts else \
+        "{{ no CLAUDE.md or memory files found — this bundle is portable but light on instructions }}"
+
+    substitutions = {
+        "__CWD__": str(cwd),
+        "__REPO_URL__": snap.get("remote_url") or "{{ none }}",
+        "__BRANCH__": snap.get("branch") or "{{ unknown }}",
+        "__COMMIT__": snap.get("commit") or "{{ unknown }}",
+        "__MODEL__": "claude-opus-4-7",
+        "__INSTRUCTIONS_BLOCK__": instructions_block,
+        "__GIT_STATUS__": snap.get("status") or "(clean)",
+        "__GIT_LOG__": snap.get("log") or "(no commits)",
+        "__GIT_DIFF__": snap.get("diff") or "(no uncommitted diff)",
+    }
+    text = _HANDOFF_TEMPLATE
+    for key, value in substitutions.items():
+        text = text.replace(key, value)
+    return text
+
+
+def cmd_handoff_init(args) -> int:
+    """Create a handoff bundle directory and emit a pre-filled ai-handoff.md template.
+
+    The agent then edits ai-handoff.md to add the session-specific summary,
+    decisions, journey, and theme — the parts only the agent has context for.
+    """
+    json_mode = getattr(args, 'json', False)
+    title_hint = getattr(args, 'title', None)
+    output_dir = getattr(args, 'output_dir', None)
+
+    base = Path(output_dir).expanduser() if output_dir else _handoff_artifacts_dir()
+    bundle_dir = base / _handoff_slug(title_hint)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    cwd = Path.cwd()
+    template_text = _build_template(cwd)
+    handoff_path = bundle_dir / "ai-handoff.md"
+    handoff_path.write_text(template_text, encoding="utf-8")
+
+    manifest = {
+        "schema_version": 1,
+        "created_at": datetime.datetime.now().isoformat(timespec="seconds"),
+        "cwd": str(cwd),
+        "title_hint": title_hint or "",
+    }
+    (bundle_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+
+    if json_mode:
+        _output_json({
+            "success": True,
+            "bundle_dir": str(bundle_dir),
+            "ai_handoff_path": str(handoff_path),
+            "manifest_path": str(bundle_dir / "manifest.json"),
+            "instructions": (
+                "Edit ai-handoff.md to fill in the {{ ... }} placeholders. "
+                "Then run: agentwire handoff render <bundle_dir> --story"
+            ),
+        })
+    else:
+        print(f"Bundle dir: {bundle_dir}")
+        print(f"Edit:       {handoff_path}")
+        print()
+        print("Next: fill in the placeholders, then run:")
+        print(f"  agentwire handoff render {bundle_dir} --story")
+    return 0
+
+
+def cmd_handoff_render(args) -> int:
+    """Render show-the-story.html from an existing ai-handoff.md."""
+    from .handoff.parser import HandoffParseError, parse_file
+    from .handoff.renderer import render_to_file
+
+    json_mode = getattr(args, 'json', False)
+    target = Path(args.path).expanduser()
+
+    if target.is_dir():
+        md_path = target / "ai-handoff.md"
+        bundle_dir = target
+    else:
+        md_path = target
+        bundle_dir = target.parent
+
+    if not md_path.exists():
+        msg = f"ai-handoff.md not found at {md_path}"
+        if json_mode:
+            _output_json({"success": False, "error": msg})
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    try:
+        bundle = parse_file(md_path)
+    except HandoffParseError as e:
+        msg = f"Invalid ai-handoff.md: {e}"
+        if json_mode:
+            _output_json({"success": False, "error": msg, "path": str(md_path)})
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    outputs: dict[str, str] = {"ai_handoff_path": str(md_path)}
+
+    if getattr(args, 'story', True):
+        story_path = bundle_dir / "show-the-story.html"
+        render_to_file(bundle, story_path)
+        outputs["show_the_story_path"] = str(story_path)
+
+    if json_mode:
+        _output_json({"success": True, "bundle_dir": str(bundle_dir), **outputs})
+    else:
+        print(f"Bundle dir: {bundle_dir}")
+        for k, v in outputs.items():
+            print(f"  {k}: {v}")
+    return 0
+
+
+def cmd_handoff_list(args) -> int:
+    """List past handoff bundles in the artifacts directory."""
+    json_mode = getattr(args, 'json', False)
+    base = _handoff_artifacts_dir()
+
+    bundles = []
+    if base.exists():
+        for d in sorted(base.glob("handoff-*")):
+            if not d.is_dir():
+                continue
+            handoff_md = d / "ai-handoff.md"
+            story_html = d / "show-the-story.html"
+            manifest_path = d / "manifest.json"
+            manifest_data = {}
+            if manifest_path.exists():
+                try:
+                    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    pass
+            bundles.append({
+                "name": d.name,
+                "path": str(d),
+                "ai_handoff_exists": handoff_md.exists(),
+                "show_the_story_exists": story_html.exists(),
+                "created_at": manifest_data.get("created_at", ""),
+                "title_hint": manifest_data.get("title_hint", ""),
+                "cwd": manifest_data.get("cwd", ""),
+            })
+
+    if json_mode:
+        _output_json({"success": True, "bundles": bundles, "count": len(bundles)})
+    else:
+        if not bundles:
+            print(f"No handoff bundles in {base}")
+            return 0
+        print(f"Handoff bundles in {base}:")
+        for b in bundles:
+            badge = []
+            if b["ai_handoff_exists"]:
+                badge.append("md")
+            if b["show_the_story_exists"]:
+                badge.append("html")
+            print(f"  {b['name']:<60} [{','.join(badge) or '-'}] {b['title_hint']}")
+    return 0
+
+
 # === Hooks Commands ===
 
 CLAUDE_HOOKS_DIR = Path.home() / ".claude" / "hooks"
@@ -10530,6 +10848,56 @@ def main() -> int:
     history_resume.add_argument("--json", action="store_true", help="JSON output")
     history_resume.set_defaults(func=cmd_history_resume)
 
+    # === handoff command group ===
+    handoff_parser = subparsers.add_parser(
+        "handoff",
+        help="Shareable conversation bundles (ai-handoff.md + show-the-story.html)",
+    )
+    handoff_subparsers = handoff_parser.add_subparsers(dest="handoff_command")
+
+    handoff_init_parser = handoff_subparsers.add_parser(
+        "init",
+        help="Create a bundle dir + pre-filled ai-handoff.md template",
+    )
+    handoff_init_parser.add_argument(
+        "--title", help="Short title hint, used in the bundle slug"
+    )
+    handoff_init_parser.add_argument(
+        "--output-dir", help="Override artifacts dir (default: ~/.agentwire/artifacts)"
+    )
+    handoff_init_parser.add_argument(
+        "--json", action="store_true", help="JSON output"
+    )
+    handoff_init_parser.set_defaults(func=cmd_handoff_init)
+
+    handoff_render_parser = handoff_subparsers.add_parser(
+        "render",
+        help="Render show-the-story.html from an existing ai-handoff.md",
+    )
+    handoff_render_parser.add_argument(
+        "path", help="Bundle dir or path to ai-handoff.md"
+    )
+    handoff_render_parser.add_argument(
+        "--story", action="store_true", default=True,
+        help="Render show-the-story.html (default: on)",
+    )
+    handoff_render_parser.add_argument(
+        "--no-story", dest="story", action="store_false",
+        help="Skip HTML render (only validates the markdown)",
+    )
+    handoff_render_parser.add_argument(
+        "--json", action="store_true", help="JSON output"
+    )
+    handoff_render_parser.set_defaults(func=cmd_handoff_render)
+
+    handoff_list_parser = handoff_subparsers.add_parser(
+        "list", help="List past handoff bundles"
+    )
+    handoff_list_parser.add_argument(
+        "--json", action="store_true", help="JSON output"
+    )
+    handoff_list_parser.set_defaults(func=cmd_handoff_list)
+
     # === roles command group ===
     roles_parser = subparsers.add_parser(
         "roles", help="Manage composable roles"
@@ -10937,6 +11305,10 @@ def main() -> int:
 
     if args.command == "history" and getattr(args, "history_command", None) is None:
         history_parser.print_help()
+        return 0
+
+    if args.command == "handoff" and getattr(args, "handoff_command", None) is None:
+        handoff_parser.print_help()
         return 0
 
     if args.command == "hooks" and getattr(args, "hooks_command", None) is None:

--- a/agentwire/handoff/__init__.py
+++ b/agentwire/handoff/__init__.py
@@ -1,0 +1,34 @@
+"""
+Shareable conversation handoff bundles.
+
+Two artifacts produced from one source:
+- ai-handoff.md: XML-tagged markdown for pasting into another LLM
+- show-the-story.html: single-file human presentation with tabs and scroll-slides
+
+The in-conversation agent writes ai-handoff.md (it has full context for free).
+The CLI/MCP renders show-the-story.html from it via Jinja2 (deterministic).
+"""
+
+from .schema import (
+    BundleData,
+    Decision,
+    DeadEnd,
+    Instruction,
+    JourneyBeat,
+    Metadata,
+    OpenThread,
+    Stats,
+    Theme,
+)
+
+__all__ = [
+    "BundleData",
+    "Decision",
+    "DeadEnd",
+    "Instruction",
+    "JourneyBeat",
+    "Metadata",
+    "OpenThread",
+    "Stats",
+    "Theme",
+]

--- a/agentwire/handoff/git_state.py
+++ b/agentwire/handoff/git_state.py
@@ -1,0 +1,87 @@
+"""
+Git state capture for handoff bundles.
+
+No existing utility in the codebase wraps `git status/diff/log`; this is fresh.
+All functions tolerate non-git directories (return empty strings).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..utils.subprocess import run_command
+
+
+def _git(args: list[str], cwd: str | Path) -> str:
+    result = run_command(["git", *args], cwd=str(cwd), timeout=10)
+    if not result.success:
+        return ""
+    return result.stdout.strip()
+
+
+def is_git_repo(cwd: str | Path) -> bool:
+    return _git(["rev-parse", "--git-dir"], cwd) != ""
+
+
+def status(cwd: str | Path) -> str:
+    """Short porcelain status, or empty string if clean / not a repo."""
+    return _git(["status", "--short"], cwd)
+
+
+def diff(cwd: str | Path, staged: bool = False, max_lines: int = 2000) -> str:
+    """Unified diff. Truncates at max_lines to keep bundles bounded."""
+    args = ["diff", "--no-color"]
+    if staged:
+        args.append("--cached")
+    out = _git(args, cwd)
+    if not out:
+        return ""
+    lines = out.splitlines()
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines.append(f"[... diff truncated at {max_lines} lines ...]")
+    return "\n".join(lines)
+
+
+def log(cwd: str | Path, limit: int = 20) -> str:
+    return _git(["log", f"-{limit}", "--oneline", "--no-color"], cwd)
+
+
+def branch(cwd: str | Path) -> str | None:
+    out = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    return out or None
+
+
+def commit(cwd: str | Path) -> str | None:
+    out = _git(["rev-parse", "HEAD"], cwd)
+    return out or None
+
+
+def remote_url(cwd: str | Path) -> str | None:
+    out = _git(["config", "--get", "remote.origin.url"], cwd)
+    return out or None
+
+
+def snapshot(cwd: str | Path) -> dict[str, str | None]:
+    """One-shot capture of all relevant git state."""
+    if not is_git_repo(cwd):
+        return {
+            "is_repo": False,
+            "branch": None,
+            "commit": None,
+            "remote_url": None,
+            "status": "",
+            "diff": "",
+            "diff_staged": "",
+            "log": "",
+        }
+    return {
+        "is_repo": True,
+        "branch": branch(cwd),
+        "commit": commit(cwd),
+        "remote_url": remote_url(cwd),
+        "status": status(cwd),
+        "diff": diff(cwd),
+        "diff_staged": diff(cwd, staged=True),
+        "log": log(cwd),
+    }

--- a/agentwire/handoff/instructions.py
+++ b/agentwire/handoff/instructions.py
@@ -1,0 +1,147 @@
+"""
+Enumerate the CLAUDE.md instruction chain for inclusion in a handoff bundle.
+
+The bundle must be portable across machines and project folders, so the
+receiving agent doesn't need to recreate the sender's environment to act on
+the handoff. We inline:
+
+- ~/.claude/CLAUDE.md (user global)
+- ~/.claude/rules/*.md (rule files referenced by global)
+- ./CLAUDE.md (project root) and any nested CLAUDE.md walking up to the user home
+- ~/.claude/projects/<encoded>/memory/MEMORY.md + linked memory files
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..history import encode_project_path
+from .schema import Instruction
+
+
+HOME = Path.home()
+CLAUDE_DIR = HOME / ".claude"
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _user_global() -> Instruction | None:
+    p = CLAUDE_DIR / "CLAUDE.md"
+    content = _read(p)
+    if content is None:
+        return None
+    return Instruction(path=str(p), content=content, kind="claude_md")
+
+
+def _user_rules() -> list[Instruction]:
+    rules_dir = CLAUDE_DIR / "rules"
+    if not rules_dir.is_dir():
+        return []
+    out: list[Instruction] = []
+    for md in sorted(rules_dir.glob("*.md")):
+        content = _read(md)
+        if content is None:
+            continue
+        out.append(Instruction(path=str(md), content=content, kind="rule"))
+    return out
+
+
+def _project_chain(cwd: Path) -> list[Instruction]:
+    """Walk from cwd up toward home, collecting CLAUDE.md files.
+
+    Walking up matches Claude Code's recursive discovery, which loads parent
+    CLAUDE.md files for any project nested under another instructed dir.
+    """
+    out: list[Instruction] = []
+    seen: set[Path] = set()
+    cursor = cwd.resolve()
+    while True:
+        candidate = cursor / "CLAUDE.md"
+        if candidate.exists() and candidate.resolve() not in seen:
+            content = _read(candidate)
+            if content is not None:
+                out.append(
+                    Instruction(
+                        path=str(candidate),
+                        content=content,
+                        kind="project_claude_md",
+                    )
+                )
+                seen.add(candidate.resolve())
+        if cursor == cursor.parent or cursor == HOME:
+            break
+        cursor = cursor.parent
+    # Reverse so root-most CLAUDE.md comes first (loaded earliest by Claude Code).
+    return list(reversed(out))
+
+
+_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+\.md)\)")
+
+
+def _memory(cwd: Path) -> list[Instruction]:
+    """Read memory dir for the project. Index file is MEMORY.md.
+
+    Includes any sibling .md files that MEMORY.md links to.
+    """
+    encoded = encode_project_path(str(cwd.resolve()))
+    memory_dir = CLAUDE_DIR / "projects" / encoded / "memory"
+    if not memory_dir.is_dir():
+        return []
+
+    out: list[Instruction] = []
+    index = memory_dir / "MEMORY.md"
+    index_content = _read(index)
+    if index_content is None:
+        return []
+
+    out.append(Instruction(path=str(index), content=index_content, kind="memory"))
+
+    # Pull in linked .md files inside the memory dir.
+    referenced: set[str] = set()
+    for match in _LINK_RE.finditer(index_content):
+        target = match.group(1).strip()
+        if target.startswith(("http://", "https://", "/")):
+            continue
+        referenced.add(target)
+
+    for ref in sorted(referenced):
+        candidate = (memory_dir / ref).resolve()
+        # Stay within the memory dir.
+        try:
+            candidate.relative_to(memory_dir.resolve())
+        except ValueError:
+            continue
+        content = _read(candidate)
+        if content is None:
+            continue
+        out.append(Instruction(path=str(candidate), content=content, kind="memory"))
+
+    return out
+
+
+def collect(cwd: str | Path | None = None) -> list[Instruction]:
+    """Collect the full instruction chain for the given project directory.
+
+    Args:
+        cwd: Project directory. Defaults to current working directory.
+
+    Returns:
+        List of Instruction objects ordered roughly as Claude Code loads them:
+        global → rules → project (root-most → cwd) → memory.
+    """
+    cwd_path = Path(cwd) if cwd else Path.cwd()
+    out: list[Instruction] = []
+
+    if user := _user_global():
+        out.append(user)
+    out.extend(_user_rules())
+    out.extend(_project_chain(cwd_path))
+    out.extend(_memory(cwd_path))
+
+    return out

--- a/agentwire/handoff/parser.py
+++ b/agentwire/handoff/parser.py
@@ -1,0 +1,368 @@
+"""
+Parse ai-handoff.md into a BundleData.
+
+The agent writes ai-handoff.md as XML-tagged markdown. We extract sections by
+tag, parse JSON where required, and validate. Errors are loud — the agent
+needs clear feedback to self-correct on a re-run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .schema import (
+    REQUIRED_TAGS,
+    BundleData,
+    ConversationSummary,
+    Decision,
+    DeadEnd,
+    HandoffNote,
+    Instruction,
+    JourneyBeat,
+    Metadata,
+    OpenThread,
+    ProjectState,
+    Stats,
+    Theme,
+)
+
+
+class HandoffParseError(ValueError):
+    """Raised when ai-handoff.md is missing required tags or has malformed JSON."""
+
+
+@dataclass
+class _Section:
+    name: str
+    content: str
+    attrs: dict[str, str]
+
+
+_TAG_RE_TEMPLATE = (
+    r"<{tag}(?P<attrs>[^>]*)>(?P<body>.*?)</{tag}>"
+)
+
+
+def _extract_all(tag: str, text: str) -> list[_Section]:
+    pattern = re.compile(_TAG_RE_TEMPLATE.format(tag=re.escape(tag)), re.DOTALL)
+    sections: list[_Section] = []
+    for match in pattern.finditer(text):
+        attrs_raw = match.group("attrs") or ""
+        attrs = dict(re.findall(r'(\w+)="([^"]*)"', attrs_raw))
+        sections.append(
+            _Section(name=tag, content=match.group("body").strip(), attrs=attrs)
+        )
+    return sections
+
+
+def _extract_one(tag: str, text: str, required: bool = True) -> _Section | None:
+    sections = _extract_all(tag, text)
+    if not sections:
+        if required:
+            raise HandoffParseError(f"missing required <{tag}> section")
+        return None
+    return sections[0]
+
+
+def _kv_lines(content: str) -> dict[str, str]:
+    """Parse 'key: value' lines into a dict. Tolerates leading bullets / indentation."""
+    out: dict[str, str] = {}
+    for raw in content.splitlines():
+        line = raw.strip().lstrip("-").strip()
+        if not line or ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        out[k.strip().lower().replace(" ", "_")] = v.strip()
+    return out
+
+
+def _bullet_lines(content: str) -> list[str]:
+    """Extract bullet-list items as plain strings."""
+    out: list[str] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if line.startswith(("-", "*")):
+            out.append(line.lstrip("-* ").strip())
+    return out
+
+
+def _parse_metadata(section: _Section) -> Metadata:
+    fields = _kv_lines(section.content)
+    return Metadata(
+        cwd=fields.get("cwd", ""),
+        repo_url=fields.get("repo_url") or fields.get("repo") or None,
+        branch=fields.get("branch") or None,
+        commit=fields.get("commit") or None,
+        session_type=fields.get("session_type") or None,
+        model=fields.get("model") or None,
+        started_at=fields.get("started_at") or None,
+        ended_at=fields.get("ended_at") or None,
+        user_identity=fields.get("user") or fields.get("user_identity") or None,
+        mcp_servers=[s.strip() for s in fields.get("mcp_servers", "").split(",") if s.strip()],
+    )
+
+
+def _parse_instructions(section: _Section) -> list[Instruction]:
+    files = _extract_all("file", section.content)
+    if not files:
+        raise HandoffParseError(
+            "<instructions> must contain one or more <file path=\"...\">...</file> blocks"
+        )
+    out: list[Instruction] = []
+    for f in files:
+        path = f.attrs.get("path", "<unknown>")
+        kind = f.attrs.get("kind", "claude_md")
+        out.append(Instruction(path=path, content=f.content, kind=kind))
+    return out
+
+
+def _parse_project_state(section: _Section) -> ProjectState:
+    state = ProjectState()
+    if status_sec := _extract_one("git_status", section.content, required=False):
+        state.git_status = status_sec.content
+    if diff_sec := _extract_one("git_diff", section.content, required=False):
+        state.git_diff = diff_sec.content
+    if log_sec := _extract_one("git_log", section.content, required=False):
+        state.git_log = log_sec.content
+    for kf in _extract_all("file", section.content):
+        path = kf.attrs.get("path", "<unknown>")
+        state.key_files[path] = kf.content
+    return state
+
+
+def _parse_summary(section: _Section) -> ConversationSummary:
+    goal = _extract_one("goal", section.content, required=False)
+    tldr = _extract_one("tldr", section.content, required=False)
+    decisions_sec = _extract_one("decisions", section.content, required=False)
+    dead_ends_sec = _extract_one("dead_ends", section.content, required=False)
+    open_sec = _extract_one("open_threads", section.content, required=False)
+    stats_sec = _extract_one("stats", section.content, required=False)
+
+    decisions: list[Decision] = []
+    if decisions_sec:
+        for d in _extract_all("decision", decisions_sec.content):
+            title_m = _extract_one("title", d.content, required=False)
+            rationale_m = _extract_one("rationale", d.content, required=False)
+            decisions.append(
+                Decision(
+                    title=(title_m.content if title_m else d.attrs.get("title", "")),
+                    rationale=rationale_m.content if rationale_m else d.content,
+                    alternatives_considered=_bullet_lines(
+                        (_extract_one("alternatives", d.content, required=False) or _Section("alternatives", "", {})).content
+                    ),
+                )
+            )
+
+    dead_ends: list[DeadEnd] = []
+    if dead_ends_sec:
+        for d in _extract_all("dead_end", dead_ends_sec.content):
+            title_m = _extract_one("title", d.content, required=False)
+            why_m = _extract_one("why", d.content, required=False)
+            dead_ends.append(
+                DeadEnd(
+                    title=title_m.content if title_m else d.attrs.get("title", ""),
+                    why_rejected=why_m.content if why_m else d.content,
+                )
+            )
+
+    open_threads: list[OpenThread] = []
+    if open_sec:
+        for d in _extract_all("thread", open_sec.content):
+            title_m = _extract_one("title", d.content, required=False)
+            note_m = _extract_one("note", d.content, required=False)
+            open_threads.append(
+                OpenThread(
+                    title=title_m.content if title_m else d.attrs.get("title", ""),
+                    note=note_m.content if note_m else d.content,
+                )
+            )
+
+    stats = Stats()
+    if stats_sec:
+        kv = _kv_lines(stats_sec.content)
+        try:
+            stats.turns = int(kv.get("turns", "0"))
+            stats.files_touched = int(kv.get("files_touched", "0"))
+            stats.tools_used = int(kv.get("tools_used", "0"))
+            if "duration_minutes" in kv:
+                stats.duration_minutes = int(kv["duration_minutes"])
+        except ValueError:
+            pass  # leave defaults
+
+    return ConversationSummary(
+        goal=goal.content if goal else "",
+        tldr=tldr.content if tldr else "",
+        decisions=decisions,
+        dead_ends=dead_ends,
+        open_threads=open_threads,
+        stats=stats,
+    )
+
+
+def _parse_journey(section: _Section | None) -> list[JourneyBeat]:
+    if section is None:
+        return []
+    out: list[JourneyBeat] = []
+    for b in _extract_all("beat", section.content):
+        title = b.attrs.get("title", "")
+        what = _extract_one("what_happened", b.content, required=False)
+        quote = _extract_one("quote", b.content, required=False)
+        out.append(
+            JourneyBeat(
+                title=title,
+                what_happened=what.content if what else b.content,
+                quote=quote.content if quote else None,
+            )
+        )
+    return out
+
+
+def _parse_handoff(section: _Section) -> HandoffNote:
+    one = _extract_one("one_sentence", section.content, required=False)
+    resume = _extract_one("resume_at", section.content, required=False)
+    caveats_sec = _extract_one("caveats", section.content, required=False)
+    return HandoffNote(
+        one_sentence=one.content if one else "",
+        resume_at=resume.content if resume else "",
+        caveats=_bullet_lines(caveats_sec.content) if caveats_sec else [],
+    )
+
+
+def _parse_theme(section: _Section) -> Theme:
+    body = section.content.strip()
+    # Allow agents to wrap the JSON in a code fence.
+    body = re.sub(r"^```(?:json)?\n", "", body)
+    body = re.sub(r"\n```$", "", body)
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise HandoffParseError(f"<theme> contains invalid JSON: {e}") from e
+    theme = Theme()
+    if "name" in data:
+        theme.name = str(data["name"])
+    if "mood" in data:
+        theme.mood = str(data["mood"])
+    if isinstance(data.get("palette"), dict):
+        theme.palette.update({k: str(v) for k, v in data["palette"].items()})
+    if isinstance(data.get("fonts"), dict):
+        theme.fonts.update({k: str(v) for k, v in data["fonts"].items()})
+    if "motion" in data:
+        theme.motion = str(data["motion"])
+    return theme
+
+
+def _validate_required(text: str) -> None:
+    missing = [tag for tag in REQUIRED_TAGS if f"<{tag}" not in text]
+    if missing:
+        raise HandoffParseError(
+            f"missing required tags: {', '.join('<' + t + '>' for t in missing)}"
+        )
+
+
+_OPAQUE_TAGS = ("instructions", "project_state", "recent_turns")
+
+# Line-anchored variant: requires the opening tag at column 0 of a line.
+# Excludes diff lines like `+<instructions>` and indented quotes from matching.
+# The closing tag is unanchored (matches the first occurrence after the
+# opening). Use with re.MULTILINE | re.DOTALL.
+#
+# Why unanchored close: inline tags like `<title>foo</title>` have their close
+# on the same line. Block tags' first close-after-opening is always the
+# canonical one (since diff copies appear AFTER, never between, the canonical
+# pair).
+_ANCHORED_TAG_RE_TEMPLATE = r"^<{tag}(?P<attrs>[^>]*)>(?P<body>.*?)</{tag}>"
+
+
+def _extract_anchored(tag: str, text: str) -> _Section | None:
+    pattern = re.compile(
+        _ANCHORED_TAG_RE_TEMPLATE.format(tag=re.escape(tag)),
+        re.DOTALL | re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return None
+    attrs_raw = match.group("attrs") or ""
+    attrs = dict(re.findall(r'(\w+)="([^"]*)"', attrs_raw))
+    return _Section(name=tag, content=match.group("body").strip(), attrs=attrs)
+
+
+def _mask_opaque(text: str) -> tuple[str, dict[str, _Section]]:
+    """Replace opaque sections (instructions/project_state/recent_turns) with
+    placeholder tags before scanning for other top-level sections.
+
+    These sections may contain raw CLAUDE.md content, git diffs, or transcript
+    excerpts that quote handoff XML. Line-anchored matching restricts pairs to
+    tags at column 0, so diff-prefixed copies like `+<instructions>` are
+    ignored.
+    """
+    captured: dict[str, _Section] = {}
+    masked = text
+    for tag in _OPAQUE_TAGS:
+        section = _extract_anchored(tag, masked)
+        if section is None:
+            continue
+        captured[tag] = section
+        pattern = re.compile(
+            _ANCHORED_TAG_RE_TEMPLATE.format(tag=re.escape(tag)),
+            re.DOTALL | re.MULTILINE,
+        )
+        masked = pattern.sub(f"<{tag}></{tag}>", masked, count=1)
+    return masked, captured
+
+
+def parse(text: str) -> BundleData:
+    """Parse an ai-handoff.md string into a BundleData."""
+    _validate_required(text)
+
+    # Don't extract the <session_bundle> wrapper — its content may include the
+    # same wrapper as a literal (e.g. in a git diff that quotes this very
+    # template). Just operate on the full text; opaque-section masking handles
+    # the cross-contamination.
+    version_match = re.search(r'<session_bundle\b[^>]*\bversion="([^"]+)"', text)
+    version = version_match.group(1) if version_match else "1"
+    body = text
+
+    masked_body, opaque = _mask_opaque(body)
+
+    def _anchored_or_required(tag: str) -> _Section:
+        sec = _extract_anchored(tag, masked_body)
+        if sec is None:
+            raise HandoffParseError(f"missing required <{tag}> section at column 0")
+        return sec
+
+    metadata = _parse_metadata(_anchored_or_required("metadata"))
+    instructions = _parse_instructions(opaque["instructions"]) if "instructions" in opaque \
+        else _parse_instructions(_extract_one("instructions", body))
+    project_state = _parse_project_state(opaque["project_state"]) if "project_state" in opaque \
+        else _parse_project_state(_extract_one("project_state", body))
+    summary = _parse_summary(_anchored_or_required("conversation_summary"))
+    journey_sec = _extract_anchored("journey", masked_body)
+    journey = _parse_journey(journey_sec)
+    handoff = _parse_handoff(_anchored_or_required("handoff"))
+    theme = _parse_theme(_anchored_or_required("theme"))
+
+    recent_turns = opaque["recent_turns"].content if "recent_turns" in opaque else ""
+
+    title_sec = _extract_anchored("title", masked_body)
+    title = title_sec.content if title_sec else (summary.goal or "Session Handoff")
+
+    return BundleData(
+        version=version,
+        title=title,
+        metadata=metadata,
+        instructions=instructions,
+        project_state=project_state,
+        summary=summary,
+        journey=journey,
+        recent_turns=recent_turns,
+        handoff=handoff,
+        theme=theme,
+        raw_markdown=text,
+    )
+
+
+def parse_file(path: str | Path) -> BundleData:
+    return parse(Path(path).read_text(encoding="utf-8"))

--- a/agentwire/handoff/renderer.py
+++ b/agentwire/handoff/renderer.py
@@ -1,0 +1,56 @@
+"""
+Render a parsed BundleData into show-the-story.html.
+
+We use Jinja2 directly (not aiohttp-jinja2) because this runs offline as part
+of CLI/MCP, not inside the portal HTTP layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jinja2
+
+from .schema import BundleData
+
+
+_TABS = (
+    {"id": "overview", "label": "Overview"},
+    {"id": "goal", "label": "The Goal"},
+    {"id": "journey", "label": "Journey"},
+    {"id": "decisions", "label": "Decisions"},
+    {"id": "artifacts", "label": "Artifacts"},
+    {"id": "open", "label": "Open Threads"},
+    {"id": "cast", "label": "Cast & Context"},
+    {"id": "instructions", "label": "Instructions"},
+)
+
+
+def _templates_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "templates"
+
+
+def _env() -> jinja2.Environment:
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_templates_dir())),
+        autoescape=jinja2.select_autoescape(["html", "xml"]),
+        trim_blocks=False,
+        lstrip_blocks=False,
+    )
+
+
+def render_html(bundle: BundleData) -> str:
+    env = _env()
+    template = env.get_template("handoff/show-the-story.html.j2")
+    return template.render(
+        bundle=bundle,
+        theme=bundle.theme,
+        tabs=_TABS,
+    )
+
+
+def render_to_file(bundle: BundleData, output_path: str | Path) -> Path:
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(render_html(bundle), encoding="utf-8")
+    return out

--- a/agentwire/handoff/schema.py
+++ b/agentwire/handoff/schema.py
@@ -1,0 +1,158 @@
+"""
+Dataclasses for the handoff bundle.
+
+The in-conversation agent produces ai-handoff.md following the XML-tagged
+structure declared here. The parser materializes that into a BundleData,
+which the renderer consumes to produce show-the-story.html.
+
+Pydantic isn't a core dep, so we use stdlib dataclasses + light validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Instruction:
+    """A single CLAUDE.md / rules / memory file inlined into the bundle."""
+
+    path: str
+    content: str
+    kind: str = "claude_md"  # claude_md | rule | memory | project_claude_md
+
+
+@dataclass
+class Stats:
+    turns: int = 0
+    files_touched: int = 0
+    duration_minutes: int | None = None
+    tools_used: int = 0
+
+
+@dataclass
+class Decision:
+    title: str
+    rationale: str
+    alternatives_considered: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DeadEnd:
+    title: str
+    why_rejected: str
+
+
+@dataclass
+class OpenThread:
+    title: str
+    note: str
+
+
+@dataclass
+class JourneyBeat:
+    title: str
+    what_happened: str
+    quote: str | None = None
+
+
+@dataclass
+class Metadata:
+    cwd: str
+    repo_url: str | None
+    branch: str | None
+    commit: str | None
+    session_type: str | None
+    model: str | None
+    started_at: str | None
+    ended_at: str | None
+    user_identity: str | None
+    mcp_servers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ProjectState:
+    git_status: str = ""
+    git_diff: str = ""
+    git_log: str = ""
+    key_files: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ConversationSummary:
+    goal: str
+    tldr: str
+    decisions: list[Decision] = field(default_factory=list)
+    dead_ends: list[DeadEnd] = field(default_factory=list)
+    open_threads: list[OpenThread] = field(default_factory=list)
+    stats: Stats = field(default_factory=Stats)
+
+
+@dataclass
+class HandoffNote:
+    one_sentence: str
+    resume_at: str
+    caveats: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Theme:
+    """Theme JSON the agent picks based on session vibe.
+
+    Drops directly into theme.css.j2 to populate CSS variables.
+    """
+
+    name: str = "default"
+    mood: str = "neutral"
+    palette: dict[str, str] = field(
+        default_factory=lambda: {
+            "bg": "#0e0f13",
+            "surface": "#1a1d24",
+            "fg": "#e2e8f0",
+            "muted": "#64748b",
+            "accent": "#5eead4",
+            "accent_2": "#fbbf24",
+            "border": "#2a2f3a",
+        }
+    )
+    fonts: dict[str, str] = field(
+        default_factory=lambda: {
+            "heading": "ui-monospace, 'JetBrains Mono', monospace",
+            "body": "ui-sans-serif, system-ui, sans-serif",
+        }
+    )
+    motion: str = "subtle"  # subtle | none | playful
+
+
+@dataclass
+class BundleData:
+    """The full handoff bundle: parser output, renderer input."""
+
+    version: str
+    title: str
+    metadata: Metadata
+    instructions: list[Instruction]
+    project_state: ProjectState
+    summary: ConversationSummary
+    journey: list[JourneyBeat]
+    recent_turns: str  # raw markdown of last N turns, filtered
+    handoff: HandoffNote
+    theme: Theme
+    raw_markdown: str = ""  # original ai-handoff.md text, for embed-in-HTML
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flatten for Jinja2 — dataclasses.asdict-like but tolerates Path objects."""
+        from dataclasses import asdict
+
+        return asdict(self)
+
+
+REQUIRED_TAGS = (
+    "metadata",
+    "instructions",
+    "project_state",
+    "conversation_summary",
+    "handoff",
+    "theme",
+)

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -1406,6 +1406,100 @@ def history_resume(session_id: str, project: str) -> str:
 
 
 # =============================================================================
+# Handoff Tools (shareable conversation bundles)
+# =============================================================================
+
+
+@mcp.tool()
+def handoff_init(title: str = "") -> str:
+    """Create a handoff bundle dir + pre-filled ai-handoff.md template.
+
+    The agent must then edit ai-handoff.md to fill in summary, decisions,
+    journey, theme — everything the agent knows from the conversation.
+    After editing, call handoff_render to produce show-the-story.html.
+
+    Args:
+        title: Optional short title hint, used in the bundle slug.
+
+    Returns:
+        Bundle dir path and the path to the ai-handoff.md template to edit.
+    """
+    cmd = ["handoff", "init"]
+    if title:
+        cmd.extend(["--title", title])
+    data = run_agentwire_cmd(cmd)
+    if not data.get("success"):
+        return f"Failed to init handoff: {data.get('error', 'Unknown error')}"
+
+    return (
+        f"Handoff bundle initialized.\n\n"
+        f"  Bundle dir: {data.get('bundle_dir')}\n"
+        f"  Edit:       {data.get('ai_handoff_path')}\n\n"
+        f"Now: fill in the {{ ... }} placeholders in ai-handoff.md, then call "
+        f"handoff_render with bundle_dir."
+    )
+
+
+@mcp.tool()
+def handoff_render(bundle_dir: str, story: bool = True) -> str:
+    """Render show-the-story.html from an existing ai-handoff.md.
+
+    Call this after editing ai-handoff.md to produce the human-readable
+    one-pager presentation. The HTML is self-contained — opens offline,
+    can be emailed or pasted into another LLM.
+
+    Args:
+        bundle_dir: Path to the bundle dir (or directly to ai-handoff.md).
+        story: If True (default), render show-the-story.html. If False, just
+            validate the markdown without producing HTML.
+
+    Returns:
+        Paths to the rendered artifacts.
+    """
+    cmd = ["handoff", "render", bundle_dir]
+    if not story:
+        cmd.append("--no-story")
+    data = run_agentwire_cmd(cmd)
+    if not data.get("success"):
+        return f"Failed to render handoff: {data.get('error', 'Unknown error')}"
+
+    lines = ["Handoff rendered.", f"  Bundle: {data.get('bundle_dir')}"]
+    if path := data.get("show_the_story_path"):
+        lines.append(f"  HTML:   {path}")
+    if path := data.get("ai_handoff_path"):
+        lines.append(f"  MD:     {path}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def handoff_list() -> str:
+    """List past handoff bundles in ~/.agentwire/artifacts/.
+
+    Returns:
+        Bundle names with creation date and title hints, or a message
+        indicating none exist.
+    """
+    data = run_agentwire_cmd(["handoff", "list"])
+    if not data.get("success"):
+        return f"Failed to list handoffs: {data.get('error', 'Unknown error')}"
+
+    bundles = data.get("bundles", [])
+    if not bundles:
+        return "No handoff bundles found."
+
+    lines = [f"Handoff bundles ({len(bundles)}):"]
+    for b in bundles:
+        flags = []
+        if b.get("ai_handoff_exists"):
+            flags.append("md")
+        if b.get("show_the_story_exists"):
+            flags.append("html")
+        title = b.get("title_hint") or "(no title)"
+        lines.append(f"  - {b.get('name')} [{','.join(flags) or '-'}] {title}")
+    return "\n".join(lines)
+
+
+# =============================================================================
 # Lock Management Tools
 # =============================================================================
 

--- a/agentwire/templates/handoff/show-the-story.html.j2
+++ b/agentwire/templates/handoff/show-the-story.html.j2
@@ -1,0 +1,739 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <title>{{ bundle.title | e }}</title>
+  <style>
+    {% include "handoff/theme.css.j2" %}
+
+    * { box-sizing: border-box; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--fg);
+      font-family: var(--font-body);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); transition: color var(--motion-duration), border-color var(--motion-duration); }
+    a:hover { color: var(--accent-2); border-bottom-color: var(--accent-2); }
+
+    code { font-family: var(--font-heading); font-size: 0.875em; padding: 0.1em 0.35em; background: color-mix(in srgb, var(--surface) 60%, transparent); border: 1px solid var(--border); border-radius: 4px; }
+
+    pre {
+      font-family: var(--font-heading);
+      font-size: 0.82rem;
+      line-height: 1.55;
+      background: color-mix(in srgb, var(--surface) 80%, var(--bg));
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 1.1rem 1.25rem;
+      overflow-x: auto;
+      max-height: 65vh;
+      scrollbar-width: thin;
+      scrollbar-color: var(--border) transparent;
+    }
+    pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
+    pre::-webkit-scrollbar { height: 8px; width: 8px; }
+    pre::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+
+    h1, h2, h3, h4 {
+      font-family: var(--font-heading);
+      font-weight: 600;
+      letter-spacing: -0.015em;
+      line-height: 1.15;
+      margin: 0 0 0.5em;
+      color: var(--fg);
+    }
+
+    p { margin: 0 0 1rem; max-width: 72ch; }
+
+    ::selection { background: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--fg); }
+
+    /* ============================================================
+       App shell
+       ============================================================ */
+    .app {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      height: 100vh;
+      max-height: 100vh;
+    }
+
+    /* ============================================================
+       Tab bar
+       ============================================================ */
+    .tab-bar {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      padding: 0 clamp(1rem, 4vw, 3rem);
+      border-bottom: 1px solid var(--border);
+      background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 88%, var(--bg)));
+      overflow-x: auto;
+      scrollbar-width: none;
+      height: 56px;
+      flex-shrink: 0;
+    }
+    .tab-bar::-webkit-scrollbar { display: none; }
+
+    .tab-bar button {
+      position: relative;
+      background: transparent;
+      color: var(--muted);
+      border: 0;
+      padding: 0 0.95rem;
+      height: 100%;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: color var(--motion-duration);
+      white-space: nowrap;
+    }
+
+    .tab-bar button::after {
+      content: "";
+      position: absolute;
+      left: 0.95rem;
+      right: 0.95rem;
+      bottom: -1px;
+      height: 2px;
+      background: var(--accent);
+      transform: scaleX(0);
+      transform-origin: center;
+      transition: transform var(--motion-duration) ease;
+    }
+
+    .tab-bar button:hover { color: var(--fg); }
+    .tab-bar button.active { color: var(--accent); }
+    .tab-bar button.active::after { transform: scaleX(1); }
+
+    .tab-bar .meta {
+      margin-left: auto;
+      font-family: var(--font-heading);
+      font-size: 0.7rem;
+      color: var(--muted);
+      letter-spacing: 0.06em;
+      white-space: nowrap;
+      padding-left: 1.5rem;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .tab-bar .meta .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+    /* ============================================================
+       Panels & slides
+       ============================================================ */
+    .tab-content {
+      position: relative;
+      overflow: hidden;
+      background: var(--bg);
+      background-image: var(--bg-grid);
+    }
+
+    .panel {
+      display: none;
+      height: 100%;
+      overflow-y: auto;
+      scroll-snap-type: y mandatory;
+      scroll-behavior: smooth;
+      scrollbar-width: thin;
+      scrollbar-color: var(--border) transparent;
+    }
+    .panel::-webkit-scrollbar { width: 8px; }
+    .panel::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+
+    .panel.active { display: block; }
+
+    .slide {
+      min-height: 100vh;
+      scroll-snap-align: start;
+      padding: clamp(3rem, 8vh, 6rem) clamp(1.25rem, 5vw, 4rem);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      max-width: 1180px;
+      margin: 0 auto;
+      position: relative;
+    }
+
+    .slide.short { min-height: auto; padding-top: 4rem; padding-bottom: 4rem; }
+
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      color: var(--accent);
+      margin-bottom: 1.25rem;
+    }
+    .eyebrow::before {
+      content: "";
+      width: 28px;
+      height: 2px;
+      background: var(--accent);
+      opacity: 0.85;
+      flex-shrink: 0;
+    }
+
+    h1.title {
+      font-size: clamp(2.25rem, 6vw, 4.25rem);
+      font-weight: 700;
+      letter-spacing: -0.025em;
+      max-width: 18ch;
+      margin-bottom: 1.5rem;
+    }
+
+    h2 { font-size: clamp(1.6rem, 3.2vw, 2.6rem); margin-bottom: 1rem; }
+    h3 { font-size: 1.15rem; font-weight: 600; }
+
+    .lede {
+      font-size: clamp(1.05rem, 1.5vw, 1.3rem);
+      color: var(--muted);
+      max-width: 65ch;
+      line-height: 1.55;
+    }
+
+    .mood {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-family: var(--font-heading);
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      padding: 0.45rem 0.85rem;
+      background: color-mix(in srgb, var(--surface) 70%, transparent);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      margin-bottom: 1.25rem;
+    }
+    .mood::before {
+      content: "";
+      display: block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-2);
+      box-shadow: 0 0 8px var(--accent-2);
+    }
+
+    /* ============================================================
+       Stats strip
+       ============================================================ */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0;
+      margin-top: 2.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+      background: color-mix(in srgb, var(--surface) 60%, transparent);
+    }
+
+    .stat-card {
+      padding: 1.5rem 1.5rem;
+      border-right: 1px solid var(--border);
+    }
+    .stat-card:last-child { border-right: 0; }
+
+    .stat-card .label {
+      font-family: var(--font-heading);
+      font-size: 0.7rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+
+    .stat-card .value {
+      font-family: var(--font-heading);
+      font-size: 2.25rem;
+      font-weight: 700;
+      color: var(--fg);
+      letter-spacing: -0.02em;
+      line-height: 1;
+    }
+
+    .stat-card .value.text { font-size: 1rem; font-weight: 500; word-break: break-all; }
+
+    /* ============================================================
+       Key-value list (Cast & Context, etc.)
+       ============================================================ */
+    .kv {
+      display: grid;
+      grid-template-columns: minmax(120px, max-content) 1fr;
+      gap: 0.75rem 2rem;
+      margin: 2rem 0;
+      padding: 1.5rem 1.75rem;
+      background: color-mix(in srgb, var(--surface) 60%, transparent);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+    }
+    .kv dt {
+      font-family: var(--font-heading);
+      font-size: 0.72rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--muted);
+      align-self: center;
+    }
+    .kv dd {
+      margin: 0;
+      font-family: var(--font-heading);
+      font-size: 0.92rem;
+      color: var(--fg);
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }
+    .kv dd code { font-size: inherit; background: transparent; border: 0; padding: 0; color: inherit; }
+
+    /* ============================================================
+       Cards
+       ============================================================ */
+    .card {
+      position: relative;
+      background: color-mix(in srgb, var(--surface) 75%, transparent);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 1.4rem 1.5rem 1.5rem;
+      margin: 1rem 0;
+      box-shadow: var(--shadow-card);
+      transition: transform var(--motion-duration), box-shadow var(--motion-duration), border-color var(--motion-duration);
+    }
+    .card:hover {
+      box-shadow: var(--shadow-hover);
+      border-color: color-mix(in srgb, var(--border) 60%, var(--accent));
+    }
+
+    .card::before {
+      content: "";
+      position: absolute;
+      top: 1.4rem;
+      bottom: 1.5rem;
+      left: 0;
+      width: 3px;
+      background: var(--accent);
+      border-radius: 0 2px 2px 0;
+    }
+    .card.dead-end::before { background: #ef4444; }
+    .card.open::before { background: var(--accent-2); }
+
+    .card .tag {
+      display: inline-block;
+      font-family: var(--font-heading);
+      font-size: 0.68rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--accent);
+      margin-bottom: 0.5rem;
+    }
+    .card.dead-end .tag { color: #ef4444; }
+    .card.open .tag { color: var(--accent-2); }
+
+    .card h3 { margin-bottom: 0.4rem; }
+    .card p:last-child { margin-bottom: 0; }
+
+    /* ============================================================
+       Pull quotes
+       ============================================================ */
+    .pull-quote {
+      position: relative;
+      padding: 1rem 0 1rem 2.5rem;
+      margin: 1.25rem 0;
+      color: color-mix(in srgb, var(--fg) 85%, transparent);
+      font-family: var(--font-body);
+      font-style: italic;
+      font-size: clamp(1.1rem, 1.8vw, 1.4rem);
+      line-height: 1.5;
+      max-width: 60ch;
+    }
+    .pull-quote::before {
+      content: "\201C";
+      position: absolute;
+      left: 0;
+      top: -0.25rem;
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 3.5rem;
+      line-height: 1;
+      color: var(--accent);
+      opacity: 0.55;
+    }
+
+    /* ============================================================
+       Journey beats
+       ============================================================ */
+    .beat {
+      display: grid;
+      grid-template-columns: clamp(80px, 12vw, 130px) 1fr;
+      gap: clamp(1.5rem, 4vw, 3rem);
+      align-items: start;
+      max-width: 1000px;
+    }
+    .beat-index {
+      font-family: var(--font-heading);
+      font-size: clamp(2.75rem, 7vw, 4.75rem);
+      font-weight: 700;
+      color: color-mix(in srgb, var(--accent) 55%, var(--bg));
+      line-height: 0.95;
+      letter-spacing: -0.04em;
+      padding-top: 0.5rem;
+    }
+
+    /* ============================================================
+       Details (collapsibles)
+       ============================================================ */
+    details {
+      background: color-mix(in srgb, var(--surface) 65%, transparent);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      margin: 0.75rem 0;
+      overflow: hidden;
+    }
+
+    details summary {
+      cursor: pointer;
+      font-family: var(--font-heading);
+      font-size: 0.85rem;
+      color: var(--muted);
+      padding: 0.7rem 0.95rem;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: color var(--motion-duration), background var(--motion-duration);
+    }
+    details summary::-webkit-details-marker { display: none; }
+    details summary::before {
+      content: "";
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border: 4px solid transparent;
+      border-left-color: var(--muted);
+      transition: transform var(--motion-duration), border-color var(--motion-duration);
+      flex-shrink: 0;
+    }
+    details summary:hover { color: var(--fg); background: color-mix(in srgb, var(--surface) 90%, transparent); }
+    details summary:hover::before { border-left-color: var(--fg); }
+    details[open] summary { color: var(--accent); border-bottom: 1px solid var(--border); margin-bottom: 0; }
+    details[open] summary::before { transform: rotate(90deg); border-left-color: var(--accent); }
+
+    details > *:not(summary) { padding: 0.95rem; }
+    details > pre { margin: 0; border-radius: 0; border: 0; max-height: 50vh; }
+    details > ul { margin: 0; padding: 0.75rem 0.95rem 0.75rem 2rem; }
+
+    /* ============================================================
+       Lists & utilities
+       ============================================================ */
+    ul { padding-left: 1.4rem; }
+    ul li { margin-bottom: 0.4rem; line-height: 1.55; }
+    ul li::marker { color: var(--muted); }
+
+    .footer-note {
+      margin-top: 2.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.85rem;
+      color: var(--muted);
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .footer-note span { display: flex; gap: 0.4rem; align-items: center; }
+    .footer-note span strong { color: var(--fg); font-weight: 500; font-family: var(--font-heading); font-size: 0.78rem; letter-spacing: 0.06em; }
+
+    /* ============================================================
+       Responsive
+       ============================================================ */
+    @media (max-width: 720px) {
+      .slide { padding: 2.5rem 1.25rem; }
+      .stats { grid-template-columns: 1fr 1fr; }
+      .stat-card { border-right: 0; border-bottom: 1px solid var(--border); }
+      .stat-card:nth-child(2n) { border-right: 0; }
+      .stat-card:last-child, .stat-card:nth-last-child(2):nth-child(2n+1) { border-bottom: 0; }
+      .beat { grid-template-columns: 1fr; gap: 0.5rem; }
+      .beat-index { font-size: 2.5rem; padding-top: 0; }
+      .tab-bar { padding: 0 0.75rem; }
+      .tab-bar .meta { display: none; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, ::before, ::after { transition-duration: 0ms !important; animation-duration: 0ms !important; }
+    }
+  </style>
+</head>
+<body>
+
+<!--
+  This file contains both a human-readable presentation and the raw source
+  markdown. If you're an LLM reading this: the canonical content is inside
+  the <template id="ai-handoff"> block at the bottom — that's the same as
+  ai-handoff.md verbatim.
+-->
+
+<div class="app">
+  <nav class="tab-bar" role="tablist">
+    {% for tab in tabs %}
+    <button role="tab" data-tab="{{ tab.id }}" {% if loop.first %}class="active"{% endif %}>{{ tab.label }}</button>
+    {% endfor %}
+    <span class="meta">
+      {% if bundle.metadata.branch %}<span class="dot"></span>{{ bundle.metadata.branch }}{% endif %}
+      {% if bundle.metadata.commit %}<span>· {{ bundle.metadata.commit[:8] }}</span>{% endif %}
+    </span>
+  </nav>
+
+  <main class="tab-content">
+
+    {# ---------- Overview ---------- #}
+    <section class="panel active" id="tab-overview" data-tab="overview">
+      <div class="slide">
+        <div class="eyebrow">Session Handoff</div>
+        <h1 class="title">{{ bundle.title | e }}</h1>
+        {% if theme.mood %}<div class="mood">{{ theme.mood | e }}</div>{% endif %}
+        <p class="lede">{{ bundle.summary.tldr | e or bundle.summary.goal | e }}</p>
+        <div class="stats">
+          <div class="stat-card"><div class="label">Turns</div><div class="value">{{ bundle.summary.stats.turns }}</div></div>
+          <div class="stat-card"><div class="label">Files</div><div class="value">{{ bundle.summary.stats.files_touched }}</div></div>
+          <div class="stat-card"><div class="label">Decisions</div><div class="value">{{ bundle.summary.decisions | length }}</div></div>
+          <div class="stat-card"><div class="label">Dead Ends</div><div class="value">{{ bundle.summary.dead_ends | length }}</div></div>
+          {% if bundle.summary.stats.duration_minutes %}<div class="stat-card"><div class="label">Duration</div><div class="value">{{ bundle.summary.stats.duration_minutes }}<span style="font-size:0.55em;color:var(--muted);margin-left:2px">m</span></div></div>{% endif %}
+        </div>
+        <div class="footer-note">
+          <span><strong>cwd</strong> <code>{{ bundle.metadata.cwd | e }}</code></span>
+          {% if bundle.metadata.model %}<span><strong>model</strong> <code>{{ bundle.metadata.model | e }}</code></span>{% endif %}
+        </div>
+      </div>
+    </section>
+
+    {# ---------- Goal ---------- #}
+    <section class="panel" id="tab-goal" data-tab="goal">
+      <div class="slide">
+        <div class="eyebrow">The Goal</div>
+        <h2>{{ bundle.summary.goal | e or 'Continuing this session.' }}</h2>
+        {% if bundle.handoff.one_sentence %}
+          <p class="lede">{{ bundle.handoff.one_sentence | e }}</p>
+        {% endif %}
+        {% if bundle.handoff.resume_at %}
+          <div class="card">
+            <div class="tag">Resume at</div>
+            <p>{{ bundle.handoff.resume_at | e }}</p>
+          </div>
+        {% endif %}
+        {% if bundle.handoff.caveats %}
+          <h3 style="margin-top: 2rem">Caveats</h3>
+          <ul>
+            {% for c in bundle.handoff.caveats %}<li>{{ c | e }}</li>{% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </section>
+
+    {# ---------- Journey ---------- #}
+    <section class="panel" id="tab-journey" data-tab="journey">
+      {% if bundle.journey %}
+        {% for beat in bundle.journey %}
+        <div class="slide">
+          <div class="eyebrow">Beat {{ "%02d"|format(loop.index) }} / {{ "%02d"|format(bundle.journey | length) }}</div>
+          <div class="beat">
+            <div class="beat-index">{{ "%02d"|format(loop.index) }}</div>
+            <div>
+              <h2>{{ beat.title | e }}</h2>
+              {% if beat.quote %}<div class="pull-quote">{{ beat.quote | e }}</div>{% endif %}
+              <p>{{ beat.what_happened | e }}</p>
+            </div>
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="slide">
+          <div class="eyebrow">Journey</div>
+          <h2>No narrative beats captured</h2>
+          <p class="lede">The agent didn't include a journey section. The Decisions tab still has the substantive story.</p>
+        </div>
+      {% endif %}
+    </section>
+
+    {# ---------- Decisions ---------- #}
+    <section class="panel" id="tab-decisions" data-tab="decisions">
+      <div class="slide">
+        <div class="eyebrow">Decisions</div>
+        <h2>{{ bundle.summary.decisions | length }} key decision{{ '' if bundle.summary.decisions | length == 1 else 's' }}</h2>
+        {% for d in bundle.summary.decisions %}
+        <div class="card">
+          <div class="tag">Decision · {{ "%02d"|format(loop.index) }}</div>
+          <h3>{{ d.title | e }}</h3>
+          <p>{{ d.rationale | e }}</p>
+          {% if d.alternatives_considered %}
+            <details>
+              <summary>Alternatives considered ({{ d.alternatives_considered | length }})</summary>
+              <ul>
+                {% for a in d.alternatives_considered %}<li>{{ a | e }}</li>{% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+        </div>
+        {% endfor %}
+        {% if bundle.summary.dead_ends %}
+          <h3 style="margin-top: 3rem">Dead ends</h3>
+          <p style="color: var(--muted); max-width: 60ch">Things tried and rejected — reading these saves the next agent from retracing.</p>
+          {% for d in bundle.summary.dead_ends %}
+          <div class="card dead-end">
+            <div class="tag">Rejected</div>
+            <h3>{{ d.title | e }}</h3>
+            <p>{{ d.why_rejected | e }}</p>
+          </div>
+          {% endfor %}
+        {% endif %}
+      </div>
+    </section>
+
+    {# ---------- Artifacts ---------- #}
+    <section class="panel" id="tab-artifacts" data-tab="artifacts">
+      <div class="slide">
+        <div class="eyebrow">Project State</div>
+        <h2>What changed</h2>
+        {% if bundle.project_state.git_status %}
+          <h3 style="margin-top: 2rem">Working tree</h3>
+          <pre>{{ bundle.project_state.git_status | e }}</pre>
+        {% endif %}
+        {% if bundle.project_state.git_log %}
+          <h3 style="margin-top: 2rem">Recent commits</h3>
+          <pre>{{ bundle.project_state.git_log | e }}</pre>
+        {% endif %}
+        {% if bundle.project_state.git_diff %}
+          <details style="margin-top: 1rem">
+            <summary>Uncommitted diff</summary>
+            <pre>{{ bundle.project_state.git_diff | e }}</pre>
+          </details>
+        {% endif %}
+        {% for path, content in bundle.project_state.key_files.items() %}
+          <details>
+            <summary>{{ path | e }}</summary>
+            <pre>{{ content | e }}</pre>
+          </details>
+        {% endfor %}
+      </div>
+    </section>
+
+    {# ---------- Open Threads ---------- #}
+    <section class="panel" id="tab-open" data-tab="open">
+      <div class="slide">
+        <div class="eyebrow">Open Threads</div>
+        <h2>{{ bundle.summary.open_threads | length }} unresolved</h2>
+        {% for t in bundle.summary.open_threads %}
+        <div class="card open">
+          <div class="tag">Open</div>
+          <h3>{{ t.title | e }}</h3>
+          <p>{{ t.note | e }}</p>
+        </div>
+        {% else %}
+        <p class="lede">Nothing was left dangling.</p>
+        {% endfor %}
+      </div>
+    </section>
+
+    {# ---------- Cast & Context ---------- #}
+    <section class="panel" id="tab-cast" data-tab="cast">
+      <div class="slide">
+        <div class="eyebrow">Cast & Context</div>
+        <h2>{{ bundle.metadata.user_identity | e or 'Session participants' }}</h2>
+        <p class="lede">Where this session ran and what shaped it.</p>
+        <dl class="kv">
+          {% if bundle.metadata.repo_url %}<dt>Repo</dt><dd>{{ bundle.metadata.repo_url | e }}</dd>{% endif %}
+          {% if bundle.metadata.branch %}<dt>Branch</dt><dd>{{ bundle.metadata.branch | e }}</dd>{% endif %}
+          {% if bundle.metadata.commit %}<dt>Commit</dt><dd>{{ bundle.metadata.commit | e }}</dd>{% endif %}
+          {% if bundle.metadata.model %}<dt>Model</dt><dd>{{ bundle.metadata.model | e }}</dd>{% endif %}
+          {% if bundle.metadata.session_type %}<dt>Session</dt><dd>{{ bundle.metadata.session_type | e }}</dd>{% endif %}
+          {% if bundle.metadata.cwd %}<dt>Cwd</dt><dd>{{ bundle.metadata.cwd | e }}</dd>{% endif %}
+          {% if bundle.metadata.started_at %}<dt>Started</dt><dd>{{ bundle.metadata.started_at | e }}</dd>{% endif %}
+          {% if bundle.metadata.ended_at %}<dt>Ended</dt><dd>{{ bundle.metadata.ended_at | e }}</dd>{% endif %}
+        </dl>
+        {% if bundle.metadata.mcp_servers %}
+          <h3 style="margin-top: 2.5rem">MCP servers</h3>
+          <ul>
+            {% for s in bundle.metadata.mcp_servers %}<li><code>{{ s | e }}</code></li>{% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </section>
+
+    {# ---------- Instructions ---------- #}
+    <section class="panel" id="tab-instructions" data-tab="instructions">
+      <div class="slide">
+        <div class="eyebrow">Instructions Chain</div>
+        <h2>{{ bundle.instructions | length }} files inlined</h2>
+        <p class="lede">These shaped the agent's behavior. Inlined verbatim so the bundle is portable across machines.</p>
+        {% for instr in bundle.instructions %}
+        <details>
+          <summary><code style="background:transparent;border:0;padding:0;color:var(--muted)">{{ instr.path | e }}</code> <span style="color:var(--muted);font-size:0.65rem;letter-spacing:0.12em;text-transform:uppercase;margin-left:auto">{{ instr.kind }}</span></summary>
+          <pre>{{ instr.content | e }}</pre>
+        </details>
+        {% endfor %}
+      </div>
+    </section>
+
+  </main>
+</div>
+
+<!-- Source markdown for LLM ingestion. Pasting this whole HTML file into a
+     model gives it the human-readable structure AND the canonical handoff. -->
+<template id="ai-handoff">
+{{ bundle.raw_markdown }}
+</template>
+
+<script>
+  (function () {
+    const tabs = document.querySelectorAll('.tab-bar button[data-tab]');
+    const panels = document.querySelectorAll('.panel[data-tab]');
+    const tabIds = Array.from(tabs).map(b => b.dataset.tab);
+
+    function showTab(id) {
+      tabs.forEach(b => b.classList.toggle('active', b.dataset.tab === id));
+      panels.forEach(p => p.classList.toggle('active', p.dataset.tab === id));
+      try { history.replaceState(null, '', '#' + id); } catch (e) {}
+    }
+
+    tabs.forEach(b => b.addEventListener('click', () => showTab(b.dataset.tab)));
+
+    document.addEventListener('keydown', (e) => {
+      if (e.target.matches('input, textarea, [contenteditable]')) return;
+      const active = document.querySelector('.tab-bar button.active');
+      const idx = tabIds.indexOf(active.dataset.tab);
+      if (e.key === 'ArrowRight' && idx < tabIds.length - 1) {
+        showTab(tabIds[idx + 1]); e.preventDefault();
+      } else if (e.key === 'ArrowLeft' && idx > 0) {
+        showTab(tabIds[idx - 1]); e.preventDefault();
+      } else if (e.key >= '1' && e.key <= '9') {
+        const n = parseInt(e.key, 10) - 1;
+        if (n < tabIds.length) { showTab(tabIds[n]); e.preventDefault(); }
+      }
+    });
+
+    if (location.hash) {
+      const id = location.hash.slice(1);
+      if (tabIds.includes(id)) showTab(id);
+    }
+  })();
+</script>
+
+</body>
+</html>

--- a/agentwire/templates/handoff/theme.css.j2
+++ b/agentwire/templates/handoff/theme.css.j2
@@ -1,0 +1,19 @@
+:root {
+  --bg: {{ theme.palette.bg }};
+  --surface: {{ theme.palette.surface }};
+  --fg: {{ theme.palette.fg }};
+  --muted: {{ theme.palette.muted }};
+  --accent: {{ theme.palette.accent }};
+  --accent-2: {{ theme.palette.accent_2 }};
+  --border: {{ theme.palette.border }};
+  --font-heading: {{ theme.fonts.heading }};
+  --font-body: {{ theme.fonts.body }};
+  --motion-duration: {% if theme.motion == "playful" %}320ms{% elif theme.motion == "none" %}0ms{% else %}180ms{% endif %};
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --shadow-card: 0 1px 0 rgba(255,255,255,0.02) inset, 0 8px 24px -16px rgba(0,0,0,0.5);
+  --shadow-hover: 0 1px 0 rgba(255,255,255,0.04) inset, 0 12px 32px -12px rgba(0,0,0,0.6);
+  --bg-grid: linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.06) 100%);
+}

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -27,6 +27,7 @@ How sessions talk to humans and external platforms.
 
 - **[Channels](communication/channels.md)** — email, SMS, Discord, Slack, webhooks → sessions
 - **[Hammerspoon push-to-talk](communication/hammerspoon.md)** — global voice hotkeys on macOS
+- **[Conversation handoffs](communication/handoff.md)** — `/handoff` produces a portable bundle (LLM-targeted .md + human-targeted .html) for async teammate pickup
 
 ## Scheduling & Workflows
 

--- a/docs/wiki/communication/handoff.md
+++ b/docs/wiki/communication/handoff.md
@@ -1,0 +1,156 @@
+# Shareable Conversation Handoffs
+
+Distill a live agent conversation into a portable bundle a teammate can pick up async.
+
+> **Why:** GitHub issue [#157](https://github.com/dotdevdotdev/agentwire-dev/issues/157) — the Slack bot's "shared session" model forces everyone into one live thread. Handoffs let work continue across teammates without that.
+
+## What you get
+
+Two artifacts in one bundle dir:
+
+| File | Audience | Purpose |
+|------|----------|---------|
+| `ai-handoff.md` | Another LLM (Opus 4.7) | XML-tagged markdown, project-folder-independent. Paste as a single message to roughly continue the conversation. |
+| `show-the-story.html` | Human | Single-file presentation: tabs (Overview, Goal, Journey, Decisions, Artifacts, Open Threads, Cast & Context, Instructions), scroll-snap slides, LLM-picked theme. Opens offline. |
+
+The HTML also embeds the source `ai-handoff.md` in a `<template>` block, so dropping the HTML into an LLM works too.
+
+Bundles land in `~/.agentwire/artifacts/handoff-<timestamp>-<slug>/`.
+
+## Architecture
+
+```
+in-conversation agent
+        │
+        │ /handoff slash command  OR  mcp__agentwire__handoff_init
+        ▼
+agent fills ai-handoff.md (it has full context — no fresh LLM call needed)
+agent picks a vibe-matched <theme> JSON block
+        │
+        ▼
+agent calls: mcp__agentwire__handoff_render  OR  agentwire handoff render
+        │
+        ▼
+CLI parses ai-handoff.md → renders show-the-story.html via Jinja2
+```
+
+Key idea: the agent in the running conversation is the only thing with full context, so it does the distillation in-context. The CLI/MCP layer is purely deterministic rendering — no second LLM call, no token cost beyond what the conversation already paid.
+
+## Usage
+
+### From inside a Claude Code session
+
+```
+/handoff
+```
+
+The slash command (`.claude/commands/handoff.md`) walks the agent through:
+1. `mcp__agentwire__handoff_init` — creates the bundle dir and pre-fills `ai-handoff.md` with metadata, the full CLAUDE.md / rules / memory chain, and current git state
+2. Agent edits the template to fill goal, decisions, dead ends, journey beats, theme, etc.
+3. `mcp__agentwire__handoff_render` — produces `show-the-story.html`
+
+### Manual CLI
+
+```bash
+# Initialize bundle (run inside the project of interest)
+agentwire handoff init --title "fixing-auth-flow"
+
+# Edit the printed ai-handoff.md path. Replace every {{ ... }} placeholder.
+
+# Render the human presentation
+agentwire handoff render <bundle-dir>
+
+# List past bundles
+agentwire handoff list
+```
+
+### From an agent via MCP
+
+```
+mcp__agentwire__handoff_init(title="short-slug")        → bundle_dir, ai_handoff_path
+# (agent edits ai_handoff_path with Write tool)
+mcp__agentwire__handoff_render(bundle_dir=..., story=true)
+mcp__agentwire__handoff_list()
+```
+
+## Bundle structure
+
+`ai-handoff.md` is XML-tagged markdown:
+
+```
+<session_bundle version="1">
+  <title>...</title>
+  <metadata>cwd, repo, branch, commit, model, started_at, mcp_servers</metadata>
+  <environment>panes, channels, anything cwd alone can't reveal</environment>
+  <instructions>
+    <file path="~/.claude/CLAUDE.md" kind="claude_md">...</file>
+    <file path="~/.claude/rules/*.md" kind="rule">...</file>
+    <file path="./CLAUDE.md" kind="project_claude_md">...</file>
+    <file path=".../memory/MEMORY.md" kind="memory">...</file>
+  </instructions>
+  <project_state>git status, log, diff, key files</project_state>
+  <conversation_summary>
+    <goal>...</goal>
+    <tldr>...</tldr>
+    <decisions>...</decisions>
+    <dead_ends>...</dead_ends>
+    <open_threads>...</open_threads>
+    <stats>...</stats>
+  </conversation_summary>
+  <journey>
+    <beat title="...">narrative beat with quote + what_happened</beat>
+  </journey>
+  <recent_turns>filtered last 10–20 turns</recent_turns>
+  <handoff>one_sentence + resume_at + caveats</handoff>
+  <theme>{ "name": "...", "mood": "...", "palette": {...}, ... }</theme>
+</session_bundle>
+```
+
+The `<instructions>` block is what makes the bundle portable across machines — the receiver doesn't need to be in the original folder; the agent's behavioral context comes inlined.
+
+## Themes
+
+The agent picks a theme JSON block based on the session's emotional tone. The renderer translates the palette into CSS variables (`--bg`, `--fg`, `--accent`, etc.) and applies them to the static template. Same template, different vibes per bundle.
+
+```json
+{
+  "name": "ship-it-evening",
+  "mood": "focused build session, quiet satisfaction",
+  "palette": {
+    "bg": "#0c1014",
+    "surface": "#141a21",
+    "fg": "#d8e1ea",
+    "muted": "#5b6b7c",
+    "accent": "#7dd3fc",
+    "accent_2": "#fb923c",
+    "border": "#1f2933"
+  },
+  "fonts": {
+    "heading": "ui-monospace, 'JetBrains Mono', monospace",
+    "body": "ui-sans-serif, system-ui, sans-serif"
+  },
+  "motion": "subtle"
+}
+```
+
+`motion`: `subtle` (default, 180ms transitions), `playful` (320ms), or `none` (instant).
+
+## Implementation reference
+
+- Module: `agentwire/handoff/`
+  - `schema.py` — dataclasses (Bundle, Theme, Decision, JourneyBeat, Instruction, …)
+  - `git_state.py` — `git status` / `diff` / `log` / `branch` / `commit` capture
+  - `instructions.py` — enumerates `~/.claude/CLAUDE.md`, `~/.claude/rules/*.md`, project chain (walks up to `~`), `~/.claude/projects/<encoded>/memory/MEMORY.md` + linked files
+  - `parser.py` — line-anchored regex extraction (so diff-quoted tags like `+<theme>` don't confuse extraction)
+  - `renderer.py` — Jinja2 → single-file HTML
+- Templates: `agentwire/templates/handoff/{show-the-story.html.j2, theme.css.j2}`
+- CLI: `agentwire handoff {init,render,list}` in `agentwire/__main__.py`
+- MCP: `handoff_init`, `handoff_render`, `handoff_list` in `agentwire/mcp_server.py`
+- Slash command: `.claude/commands/handoff.md`
+
+## Out of scope (today)
+
+- Live regeneration / "living HTML presentation" session type — would watch the bundle dir and re-render as the source session adds turns. Future v2.
+- Bundle delivery via Slack / Discord / email — the channels module would extend cleanly to accept a bundle dir; not done yet.
+- Fork-from-bundle — receiver's edits stay separate, optional merge-back.
+- Multi-session bundles (orchestrator + workers).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ packages = ["agentwire"]
 include = [
     # Web assets and templates required at runtime
     "agentwire/templates/**/*.html",
+    "agentwire/templates/**/*.html.j2",
+    "agentwire/templates/**/*.css.j2",
     "agentwire/templates/**/*.txt",
     "agentwire/templates/**/*.conf",
     "agentwire/static/**/*",

--- a/tests/unit/test_handoff_git_state.py
+++ b/tests/unit/test_handoff_git_state.py
@@ -1,0 +1,83 @@
+"""Tests for agentwire/handoff/git_state.py."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentwire.handoff import git_state
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+@pytest.fixture
+def empty_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    _git(["config", "user.email", "test@test"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    _git(["commit", "--allow-empty", "-m", "initial"], repo)
+    return repo
+
+
+@pytest.fixture
+def dirty_repo(empty_repo: Path) -> Path:
+    (empty_repo / "tracked.txt").write_text("hello\n")
+    _git(["add", "tracked.txt"], empty_repo)
+    _git(["commit", "-m", "add tracked"], empty_repo)
+    # Now make it dirty
+    (empty_repo / "tracked.txt").write_text("hello\nworld\n")
+    (empty_repo / "untracked.txt").write_text("new\n")
+    return empty_repo
+
+
+class TestIsGitRepo:
+    def test_no_repo(self, tmp_path: Path):
+        assert git_state.is_git_repo(tmp_path) is False
+
+    def test_inside_repo(self, empty_repo: Path):
+        assert git_state.is_git_repo(empty_repo) is True
+
+
+class TestSnapshot:
+    def test_no_repo_returns_blank_state(self, tmp_path: Path):
+        snap = git_state.snapshot(tmp_path)
+        assert snap["is_repo"] is False
+        assert snap["branch"] is None
+        assert snap["status"] == ""
+        assert snap["diff"] == ""
+
+    def test_clean_repo(self, empty_repo: Path):
+        snap = git_state.snapshot(empty_repo)
+        assert snap["is_repo"] is True
+        assert snap["branch"] in ("main", "master")
+        assert snap["commit"] is not None
+        assert len(snap["commit"]) == 40
+        assert snap["status"] == ""
+
+    def test_dirty_repo_status_and_diff(self, dirty_repo: Path):
+        snap = git_state.snapshot(dirty_repo)
+        assert snap["is_repo"] is True
+        assert "tracked.txt" in snap["status"]
+        assert "untracked.txt" in snap["status"]
+        # The unstaged modification appears in diff
+        assert "world" in snap["diff"]
+
+    def test_log_present(self, dirty_repo: Path):
+        snap = git_state.snapshot(dirty_repo)
+        assert "add tracked" in snap["log"]
+
+
+class TestDiffTruncation:
+    def test_long_diff_gets_truncated(self, empty_repo: Path):
+        # Build a big modification
+        path = empty_repo / "big.txt"
+        _git(["commit", "--allow-empty", "-m", "marker"], empty_repo)
+        path.write_text("line\n" * 5000)
+        _git(["add", "big.txt"], empty_repo)
+        diff = git_state.diff(empty_repo, staged=True, max_lines=100)
+        assert "[... diff truncated at 100 lines ...]" in diff
+        assert diff.count("\n") <= 102  # 100 lines + truncation marker + slack

--- a/tests/unit/test_handoff_instructions.py
+++ b/tests/unit/test_handoff_instructions.py
@@ -1,0 +1,107 @@
+"""Tests for agentwire/handoff/instructions.py."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agentwire.handoff import instructions
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ~/.claude to a tmp dir so tests don't read real user files."""
+    fake_claude = tmp_path / ".claude"
+    fake_claude.mkdir()
+    monkeypatch.setattr(instructions, "HOME", tmp_path)
+    monkeypatch.setattr(instructions, "CLAUDE_DIR", fake_claude)
+    return tmp_path
+
+
+class TestGlobalCLAUDE:
+    def test_no_global_returns_empty_user(self, fake_home: Path, tmp_path: Path):
+        out = instructions.collect(cwd=tmp_path / "project")
+        # cwd doesn't exist; chain is empty
+        assert all(i.kind != "claude_md" for i in out)
+
+    def test_global_present(self, fake_home: Path, tmp_path: Path):
+        (fake_home / ".claude" / "CLAUDE.md").write_text("# global rules\n")
+        project = tmp_path / "project"
+        project.mkdir()
+        out = instructions.collect(cwd=project)
+        kinds = [i.kind for i in out]
+        assert "claude_md" in kinds
+        global_instr = next(i for i in out if i.kind == "claude_md")
+        assert "# global rules" in global_instr.content
+
+
+class TestRules:
+    def test_rules_directory_loaded(self, fake_home: Path, tmp_path: Path):
+        rules_dir = fake_home / ".claude" / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "a.md").write_text("rule A\n")
+        (rules_dir / "b.md").write_text("rule B\n")
+        project = tmp_path / "project"
+        project.mkdir()
+        out = instructions.collect(cwd=project)
+        rule_paths = [i.path for i in out if i.kind == "rule"]
+        assert any("a.md" in p for p in rule_paths)
+        assert any("b.md" in p for p in rule_paths)
+
+
+class TestProjectChain:
+    def test_project_claude_md_picked_up(self, fake_home: Path, tmp_path: Path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "CLAUDE.md").write_text("# project rules\n")
+        out = instructions.collect(cwd=project)
+        project_instr = [i for i in out if i.kind == "project_claude_md"]
+        assert len(project_instr) == 1
+        assert "# project rules" in project_instr[0].content
+
+    def test_nested_project_walks_up(self, fake_home: Path, tmp_path: Path):
+        project = tmp_path / "project"
+        nested = project / "sub"
+        nested.mkdir(parents=True)
+        (project / "CLAUDE.md").write_text("# parent\n")
+        (nested / "CLAUDE.md").write_text("# child\n")
+        out = instructions.collect(cwd=nested)
+        project_instr = [i for i in out if i.kind == "project_claude_md"]
+        # Should have both, ordered root-most first.
+        assert len(project_instr) == 2
+        assert "# parent" in project_instr[0].content
+        assert "# child" in project_instr[1].content
+
+
+class TestMemory:
+    def test_memory_dir_loaded(self, fake_home: Path, tmp_path: Path):
+        project = tmp_path / "project"
+        project.mkdir()
+        encoded = instructions.encode_project_path(str(project.resolve()))
+        memory_dir = fake_home / ".claude" / "projects" / encoded / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text(
+            "# memory\n\nSee [topic](topic.md) for details.\n"
+        )
+        (memory_dir / "topic.md").write_text("topic body\n")
+
+        out = instructions.collect(cwd=project)
+        memory_instr = [i for i in out if i.kind == "memory"]
+        assert len(memory_instr) == 2
+        memory_contents = "\n".join(i.content for i in memory_instr)
+        assert "topic body" in memory_contents
+
+    def test_memory_links_outside_dir_skipped(self, fake_home: Path, tmp_path: Path):
+        project = tmp_path / "project"
+        project.mkdir()
+        encoded = instructions.encode_project_path(str(project.resolve()))
+        memory_dir = fake_home / ".claude" / "projects" / encoded / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text(
+            "# memory\n\nSee [escape](../../../etc/passwd) — should be skipped.\n"
+        )
+
+        out = instructions.collect(cwd=project)
+        memory_instr = [i for i in out if i.kind == "memory"]
+        # Only MEMORY.md, no traversal.
+        assert len(memory_instr) == 1

--- a/tests/unit/test_handoff_parser.py
+++ b/tests/unit/test_handoff_parser.py
@@ -1,0 +1,228 @@
+"""Tests for agentwire/handoff/parser.py."""
+
+import pytest
+
+from agentwire.handoff.parser import HandoffParseError, parse
+
+
+def _minimal_valid() -> str:
+    return """\
+<session_bundle version="1">
+<title>Test Session</title>
+<metadata>
+- cwd: /tmp/foo
+- branch: main
+- model: claude-opus-4-7
+</metadata>
+<instructions>
+<file path="~/.claude/CLAUDE.md" kind="claude_md">
+hello
+</file>
+</instructions>
+<project_state>
+<git_status>(clean)</git_status>
+</project_state>
+<conversation_summary>
+<goal>Test the parser.</goal>
+<tldr>It works.</tldr>
+</conversation_summary>
+<handoff>
+<one_sentence>Continue the work.</one_sentence>
+<resume_at>tests/</resume_at>
+</handoff>
+<theme>
+{"name":"t","mood":"neutral","palette":{"bg":"#000","surface":"#111","fg":"#fff","muted":"#888","accent":"#0ff","accent_2":"#ff0","border":"#222"}}
+</theme>
+</session_bundle>
+"""
+
+
+class TestParseValid:
+    def test_minimal_valid_parses(self):
+        bundle = parse(_minimal_valid())
+        assert bundle.version == "1"
+        assert bundle.title == "Test Session"
+        assert bundle.metadata.cwd == "/tmp/foo"
+        assert bundle.metadata.branch == "main"
+        assert bundle.metadata.model == "claude-opus-4-7"
+        assert len(bundle.instructions) == 1
+        assert bundle.instructions[0].kind == "claude_md"
+        assert bundle.summary.goal == "Test the parser."
+        assert bundle.handoff.one_sentence == "Continue the work."
+        assert bundle.theme.name == "t"
+        assert bundle.theme.palette["accent"] == "#0ff"
+
+    def test_raw_markdown_preserved(self):
+        text = _minimal_valid()
+        bundle = parse(text)
+        assert bundle.raw_markdown == text
+
+    def test_decisions_with_alternatives(self):
+        text = _minimal_valid().replace(
+            "<tldr>It works.</tldr>",
+            """<tldr>It works.</tldr>
+<decisions>
+<decision>
+<title>Pick A</title>
+<rationale>Because</rationale>
+<alternatives>
+- option B
+- option C
+</alternatives>
+</decision>
+</decisions>""",
+        )
+        bundle = parse(text)
+        assert len(bundle.summary.decisions) == 1
+        d = bundle.summary.decisions[0]
+        assert d.title == "Pick A"
+        assert d.rationale == "Because"
+        assert d.alternatives_considered == ["option B", "option C"]
+
+    def test_journey_beats(self):
+        text = _minimal_valid().replace(
+            "</handoff>",
+            """</handoff>
+<journey>
+<beat title="Discovery">
+<quote>I think...</quote>
+<what_happened>Things changed.</what_happened>
+</beat>
+<beat title="Resolution">
+<what_happened>Done.</what_happened>
+</beat>
+</journey>""",
+        )
+        # journey is searched in body, position is fine
+        bundle = parse(text)
+        assert len(bundle.journey) == 2
+        assert bundle.journey[0].title == "Discovery"
+        assert bundle.journey[0].quote == "I think..."
+        assert bundle.journey[1].quote is None
+
+    def test_stats_parsing(self):
+        text = _minimal_valid().replace(
+            "<tldr>It works.</tldr>",
+            """<tldr>It works.</tldr>
+<stats>
+- turns: 42
+- files_touched: 7
+- tools_used: 100
+- duration_minutes: 134
+</stats>""",
+        )
+        bundle = parse(text)
+        assert bundle.summary.stats.turns == 42
+        assert bundle.summary.stats.files_touched == 7
+        assert bundle.summary.stats.tools_used == 100
+        assert bundle.summary.stats.duration_minutes == 134
+
+    def test_caveats_as_bullets(self):
+        text = _minimal_valid().replace(
+            "<resume_at>tests/</resume_at>",
+            """<resume_at>tests/</resume_at>
+<caveats>
+- don't push
+- ask before commits
+</caveats>""",
+        )
+        bundle = parse(text)
+        assert bundle.handoff.caveats == ["don't push", "ask before commits"]
+
+
+class TestParseInvalid:
+    def test_missing_metadata_tag(self):
+        text = _minimal_valid().replace("<metadata>", "<xxx>").replace("</metadata>", "</xxx>")
+        with pytest.raises(HandoffParseError, match="metadata"):
+            parse(text)
+
+    def test_missing_theme_tag(self):
+        text = _minimal_valid().split("<theme>")[0] + "</session_bundle>\n"
+        with pytest.raises(HandoffParseError, match="theme"):
+            parse(text)
+
+    def test_malformed_theme_json(self):
+        text = _minimal_valid().replace(
+            '{"name":"t","mood":"neutral","palette":{"bg":"#000","surface":"#111","fg":"#fff","muted":"#888","accent":"#0ff","accent_2":"#ff0","border":"#222"}}',
+            "{not valid json",
+        )
+        with pytest.raises(HandoffParseError, match="invalid JSON"):
+            parse(text)
+
+    def test_empty_instructions_block(self):
+        text = _minimal_valid().replace(
+            '<file path="~/.claude/CLAUDE.md" kind="claude_md">\nhello\n</file>',
+            "",
+        )
+        with pytest.raises(HandoffParseError, match="<file"):
+            parse(text)
+
+
+class TestOpaqueSections:
+    """When project_state contains a git diff that itself contains XML tags
+    (e.g. of this very file), the parser must NOT match those — only the
+    canonical top-level sections.
+    """
+
+    def test_diff_containing_theme_does_not_confuse_parser(self):
+        # Simulate a git diff that includes the template's own theme block.
+        polluted = _minimal_valid().replace(
+            "<git_status>(clean)</git_status>",
+            """<git_status>M file.py</git_status>
+<git_diff>
++<theme>
++{
++  "name": "{{ placeholder }}",
++  "mood": "{{ placeholder }}",
++  "palette": {"bg": "#000"}
++}
++</theme>
++<handoff>
++<one_sentence>{{ placeholder }}</one_sentence>
++</handoff>
+</git_diff>""",
+        )
+        bundle = parse(polluted)
+        # The REAL theme should win, not the diff one.
+        assert bundle.theme.name == "t"
+        assert bundle.theme.palette["accent"] == "#0ff"
+        # Real handoff should win, not the diff one.
+        assert bundle.handoff.one_sentence == "Continue the work."
+
+    def test_instructions_with_xml_in_content(self):
+        # CLAUDE.md content might quote XML examples.
+        polluted = _minimal_valid().replace(
+            "hello",
+            "see <theme>example</theme> for more",
+        )
+        bundle = parse(polluted)
+        assert bundle.theme.name == "t"  # real theme, not the inlined example
+        assert "<theme>example</theme>" in bundle.instructions[0].content
+
+    def test_diff_containing_literal_closing_project_state(self):
+        # Real-world hit: a git diff inside <project_state> contains the
+        # template's literal "</project_state>" string. Greedy match must take
+        # the canonical (last) closing tag, not the inner one.
+        polluted = _minimal_valid().replace(
+            "<git_status>(clean)</git_status>",
+            """<git_status>M file.py</git_status>
+<git_diff>
++<project_state>
++  hello
++</project_state>
++<theme>{"name":"fake"}</theme>
+</git_diff>""",
+        )
+        bundle = parse(polluted)
+        # Real theme wins (the JSON inside the fake one would parse but with name="fake")
+        assert bundle.theme.name == "t"
+
+
+class TestThemeFences:
+    def test_theme_in_code_fence(self):
+        text = _minimal_valid().replace(
+            '{"name":"t","mood":"neutral","palette":{"bg":"#000","surface":"#111","fg":"#fff","muted":"#888","accent":"#0ff","accent_2":"#ff0","border":"#222"}}',
+            '```json\n{"name":"fenced","mood":"calm","palette":{"bg":"#000","surface":"#111","fg":"#fff","muted":"#888","accent":"#0ff","accent_2":"#ff0","border":"#222"}}\n```',
+        )
+        bundle = parse(text)
+        assert bundle.theme.name == "fenced"

--- a/tests/unit/test_handoff_renderer.py
+++ b/tests/unit/test_handoff_renderer.py
@@ -1,0 +1,175 @@
+"""Tests for agentwire/handoff/renderer.py."""
+
+from agentwire.handoff.parser import parse
+from agentwire.handoff.renderer import render_html
+
+
+_BASE = """\
+<session_bundle version="1">
+<title>Render Test</title>
+<metadata>
+- cwd: /tmp/foo
+- branch: main
+- model: claude-opus-4-7
+- mcp_servers: agentwire, claude-in-chrome
+</metadata>
+<instructions>
+<file path="./CLAUDE.md" kind="project_claude_md">
+project rules
+</file>
+</instructions>
+<project_state>
+<git_status>M file.py</git_status>
+<git_log>abc1234 hello</git_log>
+<git_diff>
+diff --git a/file.py b/file.py
+@@ -1 +1 @@
+-old
++new
+</git_diff>
+</project_state>
+<conversation_summary>
+<goal>Make sure HTML renders.</goal>
+<tldr>If you can read this, it works.</tldr>
+<decisions>
+<decision>
+<title>Use Jinja2</title>
+<rationale>Already a dep.</rationale>
+</decision>
+</decisions>
+<dead_ends>
+<dead_end>
+<title>Tried raw f-strings</title>
+<why>Not maintainable.</why>
+</dead_end>
+</dead_ends>
+<open_threads>
+<thread>
+<title>More tests</title>
+<note>Coverage incomplete.</note>
+</thread>
+</open_threads>
+</conversation_summary>
+<journey>
+<beat title="Setup">
+<quote>Let's render this.</quote>
+<what_happened>Wrote the template.</what_happened>
+</beat>
+</journey>
+<handoff>
+<one_sentence>Verify HTML opens cleanly in a browser.</one_sentence>
+<resume_at>show-the-story.html</resume_at>
+<caveats>
+- inline only, no CDN
+</caveats>
+</handoff>
+<theme>
+{"name":"sunlit","mood":"calm","palette":{"bg":"#fafafa","surface":"#ffffff","fg":"#222","muted":"#888","accent":"#0066cc","accent_2":"#cc6600","border":"#ddd"}}
+</theme>
+</session_bundle>
+"""
+
+
+class TestRender:
+    def test_render_basic(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert html.startswith("<!DOCTYPE html>")
+        assert "<title>Render Test</title>" in html
+        assert "Make sure HTML renders." in html
+
+    def test_theme_palette_inlined(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        # Theme accent picks up in CSS variables
+        assert "#0066cc" in html
+        assert "#fafafa" in html
+
+    def test_decisions_visible(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert "Use Jinja2" in html
+        assert "Already a dep." in html
+
+    def test_dead_ends_visible(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert "Tried raw f-strings" in html
+
+    def test_journey_visible(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert "Setup" in html
+        assert "Let's render this." in html
+
+    def test_instructions_inlined_in_details(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert "./CLAUDE.md" in html
+        assert "project rules" in html
+
+    def test_raw_markdown_template_block(self):
+        """The HTML embeds the raw ai-handoff.md so it's LLM-droppable too."""
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert '<template id="ai-handoff">' in html
+        assert "<title>Render Test</title>" in html
+
+    def test_self_contained_no_external_assets(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        # No CDNs, external scripts, or imported stylesheets
+        assert "https://cdn." not in html
+        assert "<link rel=\"stylesheet\"" not in html
+        assert 'src="http' not in html
+
+    def test_tabs_present(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        for tab_label in (
+            "Overview",
+            "The Goal",
+            "Journey",
+            "Decisions",
+            "Artifacts",
+            "Open Threads",
+            "Cast & Context",
+            "Instructions",
+        ):
+            assert tab_label in html, f"missing tab: {tab_label}"
+
+    def test_keyboard_nav_script_present(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        assert "ArrowRight" in html
+        assert "ArrowLeft" in html
+
+
+class TestThemeVariations:
+    def test_dark_theme(self):
+        text = _BASE.replace(
+            '"bg":"#fafafa","surface":"#ffffff","fg":"#222"',
+            '"bg":"#0a0e14","surface":"#11161e","fg":"#e6e1cf"',
+        )
+        bundle = parse(text)
+        html = render_html(bundle)
+        assert "#0a0e14" in html
+        assert "#fafafa" not in html
+
+    def test_motion_subtle_default(self):
+        bundle = parse(_BASE)
+        html = render_html(bundle)
+        # subtle = 180ms transition duration
+        assert "180ms" in html
+
+    def test_motion_playful(self):
+        text = _BASE.replace('"#ddd"}}', '"#ddd"},"motion":"playful"}')
+        bundle = parse(text)
+        html = render_html(bundle)
+        assert "320ms" in html
+
+    def test_motion_none(self):
+        text = _BASE.replace('"#ddd"}}', '"#ddd"},"motion":"none"}')
+        bundle = parse(text)
+        html = render_html(bundle)
+        assert "0ms" in html


### PR DESCRIPTION
## Summary

Closes #157.

Adds `/handoff` — a way to distill a live agent conversation into a portable bundle a teammate can pick up async. Produces two artifacts from one source:

- **`ai-handoff.md`** — XML-tagged markdown a teammate can paste into another LLM to roughly continue the conversation. Project-folder-independent: full CLAUDE.md / rules / memory chain inlined.
- **`show-the-story.html`** — single-file presentation (tabs, scroll-snap slides, LLM-picked theme). Opens offline. Also embeds the source markdown so the HTML itself is LLM-droppable.

## Architecture

The in-conversation agent does the distillation in-context (free — no fresh LLM call); CLI/MCP renders deterministically via Jinja2.

```
in-conversation agent
        │
        │ /handoff slash command  OR  mcp__agentwire__handoff_init
        ▼
agent fills ai-handoff.md (it has full context)
agent picks a vibe-matched <theme> JSON block
        │
        ▼
agent calls: mcp__agentwire__handoff_render
        │
        ▼
CLI parses ai-handoff.md → renders show-the-story.html via Jinja2
```

## Surfaces

- CLI: `agentwire handoff {init, render, list}`
- MCP: `mcp__agentwire__{handoff_init, handoff_render, handoff_list}`
- Slash command: `/handoff` (project-scoped recipe in `.claude/commands/handoff.md`)
- Output: `~/.agentwire/artifacts/handoff-<timestamp>-<slug>/`

## Module layout

- `agentwire/handoff/` — schema (dataclasses), git_state, instructions chain enumeration, line-anchored parser, Jinja2 renderer
- `agentwire/templates/handoff/` — `show-the-story.html.j2`, `theme.css.j2`
- Single-file output: no CDN, no external CSS, no JS framework. Theme palette → CSS variables.

## What was dogfooded

This branch was its own first user. The `/handoff` slash command was invoked at the end of the design+build session, which surfaced two real parser bugs that would have hit anyone whose project's git diff or instructions chain quoted handoff XML literally:

1. Non-greedy regex grabbed inner `</project_state>` from a diff that quoted the template — fixed by line-anchoring opening tags (`^<tag>` with `re.MULTILINE`) so diff-prefixed copies like `+<tag>` don't match.
2. Outer `<session_bundle>` wrapper was getting truncated by diff-quoted wrappers — fixed by skipping the outer extraction entirely.

Both fixes have regression tests.

## Test plan

- [x] Unit tests: 42 new (parser, renderer, git_state, instructions). All 1269 unit tests pass; no regressions.
- [x] CLI smoke test: `agentwire handoff init` produces a valid template; `render` produces valid HTML.
- [x] End-to-end: invoked `/handoff` from a real Claude Code session in this very worktree; bundle generated, HTML opens cleanly with all 8 tabs, scroll-snap, keyboard nav, theme palette applied.
- [x] Visual design pass: typography, tab bar (sliding underline indicator), stat strip, journey beats with display indices, oversized pull quotes, leading-bar cards, custom chevron expanders, line-anchored eyebrow with accent rule.
- [x] Cross-folder portability: pasted `ai-handoff.md` into a fresh agent in a different folder — receiver had enough context to resume.

## Out of scope (future)

- Living regeneration — watch the bundle dir, re-distill incrementally as the source session adds turns
- Bundle delivery over channels (Slack/Discord/email)
- Fork-from-bundle workflow
- Multi-session bundles (orchestrator + workers)
- Pin-a-message (#156) is a lighter-weight cousin built on the same plumbing

Built by [dotdev.dev](https://dotdev.dev)