### PR TITLE
feat(portal): sidebar polish + titlebar PTT fix

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5,7 +5,7 @@
     --menu-height: 0px;  /* Menu bar removed — kept at 0 for WinBox max sizing calc */
     --taskbar-height: 0px;  /* Phase 2 removed the bottom bar; kept at 0 for WinBox max sizing calc */
     --spacing-base: 8px;
-    --sidebar-width: 280px;
+    --sidebar-width: 400px;
     --sidebar-tab-width: 20px;
     --sidebar-tab-height: 40px;
     --sidebar-transition: 180ms ease;
@@ -634,6 +634,14 @@ body {
     gap: 4px;
     margin-top: 4px;
     padding-left: 14px;
+}
+
+.sidebar-session-row3 {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+    padding-left: 14px;
     flex-wrap: wrap;
 }
 
@@ -643,6 +651,8 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1;
+    min-width: 0;
 }
 
 .sidebar-empty {

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -865,33 +865,30 @@ export class SessionWindow {
         this.pttButton.className = 'wb-title-ptt';
         this.pttButton.title = 'Hold to record voice input';
         this.pttButton.innerHTML = '<span class="ptt-icon">🎤</span>';
-        // Stop the click/mousedown from triggering WinBox drag/focus behavior.
-        this.pttButton.addEventListener('mousedown', (e) => e.stopPropagation());
         titleEl.insertBefore(this.pttButton, titleEl.firstChild);
 
-        // Mouse events
-        this.pttButton.addEventListener('mousedown', (e) => {
+        // WinBox attaches capture-phase mousedown on .wb-drag for window dragging,
+        // which swallows our mousedown. Use pointer events with capture phase to beat
+        // WinBox to the punch, and setPointerCapture so tiny cursor movements within
+        // the small 22px button don't fire pointerleave mid-hold.
+        const onDown = (e) => {
             e.preventDefault();
+            e.stopPropagation();
+            this.pttButton.setPointerCapture?.(e.pointerId);
             this._startRecording();
-        });
-        this.pttButton.addEventListener('mouseup', () => this._stopRecording());
-        this.pttButton.addEventListener('mouseleave', () => {
-            if (this.pttState === 'recording') {
-                this._stopRecording();
-            }
-        });
-
-        // Touch events for mobile
-        this.pttButton.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            this._startRecording();
-        });
-        this.pttButton.addEventListener('touchend', () => this._stopRecording());
-        this.pttButton.addEventListener('touchcancel', () => {
-            if (this.pttState === 'recording') {
-                this._cancelRecording();
-            }
-        });
+        };
+        const onUp = (e) => {
+            e.stopPropagation();
+            this.pttButton.releasePointerCapture?.(e.pointerId);
+            if (this.pttState === 'recording') this._stopRecording();
+        };
+        const onCancel = (e) => {
+            this.pttButton.releasePointerCapture?.(e.pointerId);
+            if (this.pttState === 'recording') this._cancelRecording();
+        };
+        this.pttButton.addEventListener('pointerdown', onDown, true);
+        this.pttButton.addEventListener('pointerup', onUp, true);
+        this.pttButton.addEventListener('pointercancel', onCancel);
 
         // Keyboard shortcut: Ctrl+Space to toggle recording (when window focused)
         this._pttKeyHandler = (e) => {

--- a/agentwire/static/js/sidebar.js
+++ b/agentwire/static/js/sidebar.js
@@ -33,10 +33,15 @@ export const sidebar = {
             this.close();
         });
 
-        // ESC closes (unless pinned)
+        // ESC closes (unless pinned). Cmd/Ctrl + ` toggles.
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && this.isOpen() && !this.isPinned()) {
                 this.close();
+                return;
+            }
+            if ((e.metaKey || e.ctrlKey) && (e.key === '`' || e.code === 'Backquote')) {
+                e.preventDefault();
+                this.toggle();
             }
         });
 

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -39,6 +39,7 @@ export function renderCard(s) {
     if (machine) tags.push(`<span class="sidebar-tag">@${machine}</span>`);
     const roles = (s.roles || []).map(r => `<span class="sidebar-tag sidebar-tag-role">${r}</span>`).join('');
     const path = s.path ? s.path.replace(/^\/Users\/[^/]+\//, '~/') : '';
+    const tagsHtml = `${tags.join('')}${roles}`;
     return `<div class="sidebar-session-card" data-session="${name}" data-machine="${machine || ''}" data-id="${id}">
         <div class="sidebar-session-row1">
             <span class="sidebar-activity-dot ${dotClass}" data-session-dot="${name}"></span>
@@ -46,10 +47,8 @@ export function renderCard(s) {
             <button class="sidebar-list-item-btn" data-action="connect" title="Connect">▸</button>
             <button class="sidebar-list-item-btn" data-action="monitor" title="Monitor">👁</button>
         </div>
-        <div class="sidebar-session-row2">
-            ${tags.join('')}${roles}
-            ${path ? `<span class="sidebar-session-path">${path}</span>` : ''}
-        </div>
+        ${path ? `<div class="sidebar-session-row2"><span class="sidebar-session-path">${path}</span></div>` : ''}
+        ${tagsHtml ? `<div class="sidebar-session-row3">${tagsHtml}</div>` : ''}
     </div>`;
 }
 


### PR DESCRIPTION
## Summary

- Widen left sidebar (280px → 400px) so longer session names fit (closes #176).
- Add Cmd/Ctrl + \` keybind to toggle the sidebar.
- Restructure session cards into 3 rows: Name | Path | Tags.
- Fix per-session titlebar PTT button — clicks now reliably start recording.

## PTT bug detail

WinBox attaches a capture-phase \`mousedown\` listener to \`.wb-drag\` (the parent of \`.wb-title\`) for window dragging. Our PTT button — prepended into \`.wb-title\` — never received \`mousedown\` because WinBox swallowed it. Switching to \`pointerdown\`/\`pointerup\` with capture phase gets the event through. Pairing with \`setPointerCapture\` keeps tiny cursor movements inside the 22px button from firing \`pointerleave\` and cancelling the recording mid-hold.

Bonus: rediscovered that the local \`.venv\` for the STT server lost its \`moonshine_onnx\` install at some point, so STT was returning silent 500s — reinstalling moonshine_onnx + fastapi/uvicorn/python-multipart and restarting \`agentwire stt\` restored it. No code change needed for that.

## Test plan

- [x] \`Cmd/Ctrl + \`\` toggles the sidebar
- [x] Session cards render Name / Path / Tags on 3 rows
- [x] Per-session titlebar PTT button records, transcribes (Moonshine), and posts to the session
- [x] STT round-trip confirmed end-to-end via TTS reply

Built by [dotdev.dev](https://dotdev.dev)