### PR TITLE
feat(portal): quicktask modal — Cmd/Ctrl+K launcher

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3650,6 +3650,34 @@ def cmd_new(args) -> int:
 
     # Local session
     # Resolve path
+    base_branch = getattr(args, 'base', 'main') or 'main'
+    pull_first = getattr(args, 'pull_first', True)
+
+    def _spawn_worktree(project_path: Path, session_path: Path) -> tuple[bool, str | None]:
+        """Fetch origin/<base> if requested, then create worktree starting at that ref."""
+        worktree_commit: str | None = None
+        if pull_first:
+            fetch = subprocess.run(
+                ["git", "fetch", "origin", base_branch],
+                cwd=project_path,
+                capture_output=True,
+                text=True,
+            )
+            if fetch.returncode != 0:
+                stderr = (fetch.stderr or fetch.stdout or "").strip()
+                return False, f"git fetch origin {base_branch} failed: {stderr}"
+            worktree_commit = f"origin/{base_branch}"
+        ok = ensure_worktree(
+            project_path,
+            branch,
+            session_path,
+            auto_create_branch=auto_create_branch,
+            commit=worktree_commit,
+        )
+        if not ok:
+            return False, f"Failed to create worktree for branch '{branch}' in {project_path}"
+        return True, None
+
     if path and branch and worktrees_enabled:
         # Path + branch: use provided path as main repo, create worktree from it
         project_path = Path(path).expanduser().resolve()
@@ -3659,15 +3687,9 @@ def cmd_new(args) -> int:
         if not session_path.exists():
             if not project_path.exists():
                 return _output_result(False, json_mode, f"Project path does not exist: {project_path}")
-
-            success = ensure_worktree(
-                project_path,
-                branch,
-                session_path,
-                auto_create_branch=auto_create_branch,
-            )
-            if not success:
-                return _output_result(False, json_mode, f"Failed to create worktree for branch '{branch}' in {project_path}")
+            ok, err = _spawn_worktree(project_path, session_path)
+            if not ok:
+                return _output_result(False, json_mode, err or "worktree creation failed")
     elif path:
         session_path = Path(path).expanduser().resolve()
     elif branch and worktrees_enabled:
@@ -3679,15 +3701,9 @@ def cmd_new(args) -> int:
         if not session_path.exists():
             if not project_path.exists():
                 return _output_result(False, json_mode, f"Project path does not exist: {project_path}")
-
-            success = ensure_worktree(
-                project_path,
-                branch,
-                session_path,
-                auto_create_branch=auto_create_branch,
-            )
-            if not success:
-                return _output_result(False, json_mode, f"Failed to create worktree for branch '{branch}' in {project_path}")
+            ok, err = _spawn_worktree(project_path, session_path)
+            if not ok:
+                return _output_result(False, json_mode, err or "worktree creation failed")
     else:
         # Simple session: ~/projects/project/
         session_path = projects_dir / project
@@ -10552,6 +10568,9 @@ def main() -> int:
     new_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
     new_parser.add_argument("--persist", action="store_true", help="Write --type/--roles to .agentwire.yml (default: session-level override only)")
     new_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable, keeps secrets out of `ps`)")
+    new_parser.add_argument("--base", default="main", help="For worktree sessions: base branch to fork the new branch from (default: main)")
+    new_parser.add_argument("--pull-first", dest="pull_first", action="store_true", default=True, help="For worktree sessions: fetch origin/<base> before branching (default)")
+    new_parser.add_argument("--no-pull-first", dest="pull_first", action="store_false", help="Skip the fetch — branch from the local copy of <base> as-is")
     new_parser.add_argument("--json", action="store_true", help="Output as JSON")
     new_parser.set_defaults(func=cmd_new)
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2567,6 +2567,8 @@ class AgentWireServer:
             machine = data.get("machine", "local")
             worktree = data.get("worktree", False)
             branch = data.get("branch", "").strip()
+            base = (data.get("base") or "main").strip() or "main"
+            pull_first = bool(data.get("pull_first", True))
 
             if not name:
                 return web.json_response({"error": "Session name is required"})
@@ -2592,6 +2594,10 @@ class AgentWireServer:
                 args.extend(["-p", custom_path])
             # Set session type via --type flag
             args.extend(["--type", session_type])
+            # Worktree-only flags: base branch + pull-first behaviour
+            if worktree and branch:
+                args.extend(["--base", base])
+                args.append("--pull-first" if pull_first else "--no-pull-first")
             # Set roles if provided (handle both array and string formats)
             if roles:
                 # Validate roles exist before passing to CLI

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -961,6 +961,186 @@ body {
     font-weight: 500;
 }
 
+/* =========================================================================
+   Quicktask modal
+   ========================================================================= */
+
+.quicktask-modal {
+    width: 480px;
+}
+
+.quicktask-modal .modal-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--chrome-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.quicktask-modal .modal-body {
+    padding: 16px;
+}
+
+.quicktask-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.quicktask-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.quicktask-label {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.quicktask-label em {
+    font-style: normal;
+    font-size: 12px;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.quicktask-form input[type="text"] {
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 8px 10px;
+    font-size: 14px;
+    font-family: inherit;
+}
+
+.quicktask-form input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.quicktask-pills {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.quicktask-pill {
+    background: transparent;
+    border: 1px solid var(--chrome-border);
+    border-radius: 999px;
+    color: var(--text-muted);
+    padding: 3px 10px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.quicktask-pill:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.quicktask-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: var(--text);
+    cursor: pointer;
+}
+
+.quicktask-checkbox input[type="checkbox"] {
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
+.quicktask-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.quicktask-btn-cancel,
+.quicktask-btn-submit {
+    padding: 7px 14px;
+    border-radius: 4px;
+    border: 1px solid var(--chrome-border);
+    background: transparent;
+    color: var(--text);
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.quicktask-btn-submit {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--background);
+    font-weight: 600;
+}
+
+.quicktask-btn-submit:hover {
+    filter: brightness(1.1);
+}
+
+.quicktask-btn-cancel:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.quicktask-error {
+    background: rgba(220, 38, 38, 0.15);
+    border: 1px solid var(--error);
+    color: var(--error);
+    border-radius: 4px;
+    padding: 8px 12px;
+    font-size: 13px;
+    margin-bottom: 12px;
+}
+
+.quicktask-progress {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 28px 0 22px;
+}
+
+.quicktask-spinner {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 3px solid var(--chrome-border);
+    border-top-color: var(--accent);
+    animation: quicktask-spin 700ms linear infinite;
+}
+
+@keyframes quicktask-spin {
+    to { transform: rotate(360deg); }
+}
+
+.quicktask-progress-label {
+    color: var(--text);
+    font-size: 14px;
+    text-align: center;
+}
+
+.sidebar-quicktask {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px 6px;
+    line-height: 1;
+}
+
+.sidebar-quicktask:hover {
+    color: var(--accent);
+}
+
 .btn-danger {
     background: var(--error);
     border-color: var(--error);

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -24,6 +24,7 @@ import { workflowsSection } from './sidebar/workflows-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { socialsSection } from './sidebar/socials-section.js';
 import { notificationsPanel } from './notifications-panel.js';
+import { openQuicktaskModal, isQuicktaskOpen } from './quicktask-modal.js';
 
 // State - track open windows
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
@@ -55,6 +56,10 @@ document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
     sidebar.init();
+    document.getElementById('sidebarQuicktask')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openQuicktaskModal();
+    });
     sidebar.addSection('sessions', sessionsSection);
     sidebar.addSection('sdk-sessions', sdkSessionsSection);
     sidebar.addSection('socials', socialsSection);
@@ -800,6 +805,12 @@ function setupGlobalPtt() {
         if ((e.ctrlKey || e.metaKey) && e.code === 'Space' && globalPttState === 'idle') {
             e.preventDefault();
             startGlobalRecording();
+        }
+        // Cmd/Ctrl + K opens the Quicktask modal. xterm.js uses a hidden textarea
+        // for terminal input, so we don't skip on tag — Cmd+K is always intercepted.
+        if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
+            e.preventDefault();
+            if (!isQuicktaskOpen()) openQuicktaskModal();
         }
     });
     document.addEventListener('keyup', (e) => {

--- a/agentwire/static/js/quicktask-modal.js
+++ b/agentwire/static/js/quicktask-modal.js
@@ -1,0 +1,257 @@
+/**
+ * Quicktask Modal — fast launcher for "pull-base, branch-off, worktree, session".
+ *
+ * Hotkey: Cmd/Ctrl+K. Opens a modal that takes a project (autocompleted from
+ * /api/projects), a base branch (default main), and a new branch, then calls
+ * /api/create with worktree:true, base, pull_first. On success, opens the new
+ * session terminal window.
+ */
+
+const PILL_TYPES = ['feat', 'fix', 'chore', 'refactor', 'docs'];
+const LS_LAST_PROJECT = 'quicktask:lastProject';
+const LS_BASE_PREFIX = 'quicktask:base:';
+
+let modalEl = null;
+let lastFocus = null;
+let projectsCache = null;
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+}
+
+function slugify(text) {
+    return String(text)
+        .toLowerCase()
+        .normalize('NFKD').replace(/[̀-ͯ]/g, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 64);
+}
+
+async function fetchProjects() {
+    if (projectsCache) return projectsCache;
+    try {
+        const res = await fetch('/api/projects');
+        const data = await res.json();
+        const all = data.projects || [];
+        projectsCache = all.filter((p) => !p.machine || p.machine === 'local');
+    } catch (e) {
+        projectsCache = [];
+    }
+    return projectsCache;
+}
+
+function renderModal(projects) {
+    const lastProject = localStorage.getItem(LS_LAST_PROJECT) || '';
+    const baseFor = (proj) => localStorage.getItem(LS_BASE_PREFIX + proj) || 'main';
+    const optionsHtml = projects.map((p) => `<option value="${escapeHtml(p.name)}">`).join('');
+    const pillsHtml = PILL_TYPES.map((t) => `<button type="button" class="quicktask-pill" data-prefix="${t}">${t}</button>`).join('');
+
+    return `<div class="modal-overlay" id="quicktaskOverlay">
+        <div class="modal quicktask-modal">
+            <div class="modal-header">
+                <h3>Quicktask</h3>
+                <button class="modal-close" data-action="close" aria-label="Close">×</button>
+            </div>
+            <div class="modal-body">
+                <div class="quicktask-error" data-error hidden></div>
+                <div class="quicktask-progress" data-progress hidden></div>
+                <form class="quicktask-form">
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Project</span>
+                        <input type="text" name="project" list="quicktaskProjects" value="${escapeHtml(lastProject)}" autocomplete="off" required />
+                        <datalist id="quicktaskProjects">${optionsHtml}</datalist>
+                    </label>
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Base branch</span>
+                        <input type="text" name="base" value="${escapeHtml(baseFor(lastProject))}" autocomplete="off" required />
+                    </label>
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Task title <em>(optional)</em></span>
+                        <input type="text" name="title" placeholder="Voice fix bug" autocomplete="off" />
+                    </label>
+                    <div class="quicktask-field">
+                        <span class="quicktask-label">New branch</span>
+                        <div class="quicktask-pills">${pillsHtml}</div>
+                        <input type="text" name="branch" placeholder="feat/voice-fix-bug" autocomplete="off" required />
+                    </div>
+                    <label class="quicktask-checkbox">
+                        <input type="checkbox" name="pull_first" checked />
+                        <span>Pull base from origin first</span>
+                    </label>
+                    <div class="quicktask-footer">
+                        <button type="button" class="quicktask-btn-cancel" data-action="close">Cancel</button>
+                        <button type="submit" class="quicktask-btn-submit">Create + Open</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>`;
+}
+
+function bind(form) {
+    const titleInput = form.querySelector('input[name="title"]');
+    const branchInput = form.querySelector('input[name="branch"]');
+    const projectInput = form.querySelector('input[name="project"]');
+    const baseInput = form.querySelector('input[name="base"]');
+    const pillButtons = form.querySelectorAll('.quicktask-pill');
+
+    let userEditedBranch = false;
+    branchInput.addEventListener('input', () => { userEditedBranch = true; });
+
+    titleInput?.addEventListener('input', () => {
+        if (userEditedBranch) return;
+        const slug = slugify(titleInput.value);
+        const current = branchInput.value;
+        // Preserve a leading `<type>/` prefix the user clicked
+        const prefixMatch = current.match(/^([a-z]+)\//);
+        branchInput.value = prefixMatch ? `${prefixMatch[1]}/${slug}` : slug;
+    });
+
+    pillButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const prefix = btn.dataset.prefix;
+            const stripped = branchInput.value.replace(/^[a-z]+\//, '');
+            branchInput.value = `${prefix}/${stripped}`;
+            branchInput.focus();
+        });
+    });
+
+    projectInput?.addEventListener('change', () => {
+        const proj = projectInput.value.trim();
+        if (proj) {
+            const stored = localStorage.getItem(LS_BASE_PREFIX + proj);
+            if (stored) baseInput.value = stored;
+        }
+    });
+}
+
+function showError(text) {
+    if (!modalEl) return;
+    const el = modalEl.querySelector('[data-error]');
+    if (!el) return;
+    el.textContent = text;
+    el.hidden = false;
+    const prog = modalEl.querySelector('[data-progress]');
+    if (prog) prog.hidden = true;
+}
+
+function showProgress(label) {
+    if (!modalEl) return;
+    const el = modalEl.querySelector('[data-progress]');
+    if (!el) return;
+    el.innerHTML = `
+        <div class="quicktask-spinner" aria-hidden="true"></div>
+        <div class="quicktask-progress-label">${escapeHtml(label)}</div>
+    `;
+    el.hidden = false;
+    const errEl = modalEl.querySelector('[data-error]');
+    if (errEl) errEl.hidden = true;
+    const form = modalEl.querySelector('.quicktask-form');
+    if (form) form.hidden = true;
+}
+
+async function handleSubmit(e) {
+    e.preventDefault();
+    const form = e.target.closest('.quicktask-form');
+    if (!form) return;
+
+    const project = form.querySelector('input[name="project"]').value.trim();
+    const base = form.querySelector('input[name="base"]').value.trim() || 'main';
+    const branch = form.querySelector('input[name="branch"]').value.trim();
+    const pullFirst = form.querySelector('input[name="pull_first"]').checked;
+
+    if (!project || !branch) {
+        showError('Project and new branch are required.');
+        return;
+    }
+
+    localStorage.setItem(LS_LAST_PROJECT, project);
+    localStorage.setItem(LS_BASE_PREFIX + project, base);
+
+    showProgress(pullFirst ? `Pulling ${base} and starting ${branch}…` : `Starting ${branch}…`);
+
+    try {
+        const res = await fetch('/api/create', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: project,
+                worktree: true,
+                branch,
+                base,
+                pull_first: pullFirst,
+            }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+            const formEl = modalEl.querySelector('.quicktask-form');
+            if (formEl) formEl.hidden = false;
+            const prog = modalEl.querySelector('[data-progress]');
+            if (prog) prog.hidden = true;
+            showError(data.error || `Create failed (HTTP ${res.status})`);
+            return;
+        }
+        const sessionName = data.session || data.name || `${project}/${branch}`;
+        closeQuicktaskModal();
+        const { openSessionTerminal } = await import('./desktop.js');
+        openSessionTerminal(sessionName, 'terminal');
+    } catch (err) {
+        const formEl = modalEl.querySelector('.quicktask-form');
+        if (formEl) formEl.hidden = false;
+        const prog = modalEl.querySelector('[data-progress]');
+        if (prog) prog.hidden = true;
+        showError(err?.message || 'Network error');
+    }
+}
+
+function attachListeners() {
+    if (!modalEl) return;
+    modalEl.addEventListener('click', (e) => {
+        const action = e.target.closest('[data-action]')?.dataset.action;
+        if (action === 'close') closeQuicktaskModal();
+        // Click outside the .modal closes it
+        if (e.target === modalEl) closeQuicktaskModal();
+    });
+    modalEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            e.stopPropagation();
+            closeQuicktaskModal();
+        }
+    });
+    const form = modalEl.querySelector('.quicktask-form');
+    if (form) {
+        form.addEventListener('submit', handleSubmit);
+        bind(form);
+    }
+}
+
+export async function openQuicktaskModal() {
+    if (modalEl) return;
+    lastFocus = document.activeElement;
+    const projects = await fetchProjects();
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = renderModal(projects);
+    modalEl = wrapper.firstElementChild;
+    document.body.appendChild(modalEl);
+    attachListeners();
+    // Focus the first empty required field
+    const projectInput = modalEl.querySelector('input[name="project"]');
+    const branchInput = modalEl.querySelector('input[name="branch"]');
+    if (projectInput && !projectInput.value) projectInput.focus();
+    else if (branchInput) branchInput.focus();
+}
+
+export function closeQuicktaskModal() {
+    if (!modalEl) return;
+    modalEl.remove();
+    modalEl = null;
+    if (lastFocus && typeof lastFocus.focus === 'function') {
+        try { lastFocus.focus(); } catch (e) {}
+    }
+    lastFocus = null;
+}
+
+export function isQuicktaskOpen() {
+    return modalEl !== null;
+}

--- a/agentwire/templates/desktop.html
+++ b/agentwire/templates/desktop.html
@@ -18,6 +18,9 @@
                 <span class="status-dot disconnected"></span>
             </div>
             <div class="sidebar-clock" id="sidebarClock"></div>
+            <button class="sidebar-quicktask" id="sidebarQuicktask" title="New quicktask (Cmd/Ctrl+K)" aria-label="New quicktask">
+                <span class="sidebar-quicktask-icon">⚡</span>
+            </button>
             <button class="sidebar-pin" id="sidebarPin" title="Pin sidebar open" aria-label="Pin sidebar">
                 <span class="sidebar-pin-icon">📌</span>
             </button>


### PR DESCRIPTION
## Summary

A fast modal launcher for the "pull main, branch off, create worktree, start tmux session" loop — Cmd/Ctrl+K from anywhere, or click the ⚡ button in the sidebar header.

## What's new

- **CLI** — `agentwire new` accepts `--base <branch>` (default \`main\`) and `--pull-first` / \`--no-pull-first\`. When pull-first is on, runs \`git fetch origin <base>\` (fetch only, never touches the main repo's working tree) and passes \`commit=origin/<base>\` to the existing \`ensure_worktree\` so the new branch starts at the freshly-fetched tip.
- **API** — \`/api/create\` reads \`base\` + \`pull_first\` and threads them to the CLI.
- **UI** — \`agentwire/static/js/quicktask-modal.js\` (NEW). Modal with:
  - Project autocomplete (datalist from \`/api/projects\`, local machines for v1)
  - Base branch input (defaults to \`main\`, persisted per-project in localStorage)
  - Optional task-title field that auto-slugifies into the new-branch field
  - Pill row above the new-branch input: \`feat / fix / chore / refactor / docs\` — click to prepend the prefix
  - Pull-first checkbox (default on)
  - Single spinner during creation, surfaces backend errors inline

## Test plan

- [x] CLI: \`agentwire new -s test/feat-x --base main --pull-first\` runs fetch + creates worktree at \`origin/main\` HEAD
- [x] API: POST /api/create with \`{worktree, branch, base, pull_first}\` round-trips through to the CLI
- [x] UI: Cmd/Ctrl+K opens modal, ⚡ button opens modal, Esc closes, click outside closes
- [x] UI: project autocompletes, branch pills prepend correctly, slugify ignores after manual edit
- [x] UI: spinner displays during request; errors surface back to the form

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Quicktask" modal to create new worktree sessions via sidebar button or Ctrl/Cmd+K shortcut, with project and branch selection.
  * Added CLI flags (`--base`, `--pull-first`, `--no-pull-first`) for enhanced worktree creation control.
  * Server API now supports configurable base branch and fetch options for session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->