### PR TITLE
feat(safety): configurable damage control + escape hatch + portal review tool

### DIFF
--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -190,7 +190,10 @@ def query_audit_logs(
     if today:
         log_files = [LOGS_DIR / f"{datetime.now().strftime('%Y-%m-%d')}.jsonl"]
     else:
-        log_files = sorted(LOGS_DIR.glob("*.jsonl"), reverse=True)
+        # Sort chronologically (oldest first) so that within the merged list,
+        # entries are strictly in time order. Callers that want newest-first
+        # (e.g. the portal Safety section) reverse on their end after slicing.
+        log_files = sorted(LOGS_DIR.glob("*.jsonl"))
 
     for log_file in log_files:
         if not log_file.exists():

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -268,6 +268,14 @@ class OvernightConfig:
 
 
 @dataclass
+class SafetyConfig:
+    """Global damage-control safety knobs."""
+
+    enabled: bool = True
+    disabled_rules: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Config:
     """Root configuration for AgentWire."""
 
@@ -285,6 +293,7 @@ class Config:
     repl: ReplConfig = field(default_factory=ReplConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     overnight: OvernightConfig = field(default_factory=OvernightConfig)
+    safety: SafetyConfig = field(default_factory=SafetyConfig)
     channels: dict = field(default_factory=dict)
 
 
@@ -508,6 +517,18 @@ def _dict_to_config(data: dict) -> Config:
         theme_overrides = {}
     repl = ReplConfig(theme={str(k): str(v) for k, v in theme_overrides.items()})
 
+    # Safety (damage-control kill switch + disabled rules)
+    safety_data = data.get("safety", {}) or {}
+    if not isinstance(safety_data, dict):
+        safety_data = {}
+    disabled_rules_raw = safety_data.get("disabled_rules", []) or []
+    if not isinstance(disabled_rules_raw, list):
+        disabled_rules_raw = []
+    safety = SafetyConfig(
+        enabled=bool(safety_data.get("enabled", True)),
+        disabled_rules=[str(r) for r in disabled_rules_raw if r],
+    )
+
     return Config(
         server=server,
         projects=projects,
@@ -523,6 +544,7 @@ def _dict_to_config(data: dict) -> Config:
         overnight=overnight,
         channels=channel_configs,
         repl=repl,
+        safety=safety,
     )
 
 

--- a/agentwire/hooks/damage-control/audit_logger.py
+++ b/agentwire/hooks/damage-control/audit_logger.py
@@ -56,6 +56,9 @@ def log_entry(
     blocked_by: Optional[str] = None,
     user_approved: Optional[bool] = None,
     pattern_matched: Optional[str] = None,
+    rule_id: Optional[str] = None,
+    escape_reason: Optional[str] = None,
+    cwd: Optional[str] = None,
 ) -> None:
     """
     Write a log entry to the audit log.
@@ -63,11 +66,15 @@ def log_entry(
     Args:
         tool: Tool name (Bash, Edit, Write)
         command: Command or path that was checked
-        decision: "blocked", "asked", or "allowed"
+        decision: "blocked", "asked", "allowed", "allowed_by_escape", or "allowed_by_disabled"
         blocked_by: Reason/pattern that triggered block
         user_approved: Whether user approved (for ask patterns)
         pattern_matched: The regex pattern that matched
+        rule_id: Stable identifier of the matched rule (when applicable)
+        escape_reason: Reason supplied via "# allow:" escape hatch (when applicable)
+        cwd: Working directory where the command would have run
     """
+    import os
     context = get_session_context()
 
     entry = {
@@ -80,6 +87,9 @@ def log_entry(
         "blocked_by": blocked_by,
         "user_approved": user_approved,
         "pattern_matched": pattern_matched,
+        "rule_id": rule_id,
+        "escape_reason": escape_reason,
+        "cwd": cwd or os.environ.get("PWD") or os.getcwd(),
     }
 
     log_file = get_log_file()
@@ -94,6 +104,7 @@ def log_blocked(
     command: str,
     reason: str,
     pattern: Optional[str] = None,
+    rule_id: Optional[str] = None,
 ) -> None:
     """
     Log a blocked operation.
@@ -103,6 +114,7 @@ def log_blocked(
         command: Command or path that was blocked
         reason: Human-readable reason for block
         pattern: The regex pattern that matched
+        rule_id: Stable identifier of the matched rule
     """
     log_entry(
         tool=tool,
@@ -110,6 +122,39 @@ def log_blocked(
         decision="blocked",
         blocked_by=reason,
         pattern_matched=pattern,
+        rule_id=rule_id,
+    )
+
+
+def log_escape(
+    tool: str,
+    command: str,
+    escape_reason: str,
+) -> None:
+    """
+    Log a command that was allowed through the ``# allow: <reason>`` escape hatch.
+    """
+    log_entry(
+        tool=tool,
+        command=command,
+        decision="allowed_by_escape",
+        blocked_by=f"Escape hatch: {escape_reason}",
+        escape_reason=escape_reason,
+    )
+
+
+def log_disabled(
+    tool: str,
+    command: str,
+) -> None:
+    """
+    Log a command that was allowed because the safety system is disabled.
+    """
+    log_entry(
+        tool=tool,
+        command=command,
+        decision="allowed_by_disabled",
+        blocked_by="safety disabled",
     )
 
 

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -24,11 +24,13 @@ from pathlib import Path
 
 # audit_logger lives next to this script
 try:
-    from audit_logger import log_allowed, log_asked, log_blocked
+    from audit_logger import log_allowed, log_asked, log_blocked, log_disabled, log_escape
 except ImportError:
     def log_allowed(*args, **kwargs): pass
     def log_asked(*args, **kwargs): pass
     def log_blocked(*args, **kwargs): pass
+    def log_disabled(*args, **kwargs): pass
+    def log_escape(*args, **kwargs): pass
 
 
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
@@ -408,11 +410,42 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
     return patterns
 
 
+_RULE_ID_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug_for_rule(text: str, max_len: int = 60) -> str:
+    """Lowercase, ASCII, kebab-case slug suitable for rule IDs."""
+    s = _RULE_ID_SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return s[:max_len] or "rule"
+
+
+def _assign_rule_id(pattern_obj: Dict[str, Any], file_stem: str, taken: set) -> str:
+    """Generate (or honor) an ID for a bash pattern. Mutates pattern_obj in place."""
+    existing = pattern_obj.get("id")
+    if isinstance(existing, str) and existing.strip():
+        pattern_obj["id"] = existing.strip()
+        taken.add(pattern_obj["id"])
+        return pattern_obj["id"]
+    slug = _slug_for_rule(pattern_obj.get("reason", "rule"))
+    candidate = f"{file_stem}.{slug}"
+    n = 2
+    while candidate in taken:
+        candidate = f"{file_stem}.{slug}-{n}"
+        n += 1
+    pattern_obj["id"] = candidate
+    taken.add(candidate)
+    return candidate
+
+
 def load_config(
     rules_dir: Path,
     tooldefs_dir: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns."""
+    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns.
+
+    Bash patterns get a stable ``id`` field (``"<file>.<slug-of-reason>"``) so
+    they can be referenced by the ``safety.disabled_rules`` config.
+    """
     merged: Dict[str, Any] = {
         "bashToolPatterns": [],
         "zeroAccessPaths": [],
@@ -422,20 +455,108 @@ def load_config(
     }
     if not yaml or not rules_dir.exists():
         return merged
+    taken_ids: set = set()
     yaml_files = sorted(rules_dir.glob("*.yaml"))
     for rules_file in yaml_files:
         try:
             with open(rules_file, "r") as f:
                 data = yaml.safe_load(f) or {}
             for key in merged:
-                merged[key].extend(data.get(key, []))
+                items = data.get(key, []) or []
+                if key == "bashToolPatterns":
+                    for it in items:
+                        if isinstance(it, dict):
+                            _assign_rule_id(it, rules_file.stem, taken_ids)
+                            it.setdefault("source", rules_file.stem)
+                merged[key].extend(items)
         except Exception:
             continue
     if tooldefs_dir is not None:
-        merged["bashToolPatterns"].extend(
-            load_write_patterns_from_tooldefs(tooldefs_dir)
-        )
+        tooldef_patterns = load_write_patterns_from_tooldefs(tooldefs_dir)
+        for it in tooldef_patterns:
+            _assign_rule_id(it, "tooldef", taken_ids)
+            it.setdefault("source", "tooldef")
+        merged["bashToolPatterns"].extend(tooldef_patterns)
     return merged
+
+
+def load_safety_config(
+    global_config_path: Optional[Path] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve the effective ``safety`` block from global + nearest project config.
+
+    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
+    overrides global; ``disabled_rules`` are merged (set-union).
+    """
+    enabled = True
+    disabled_rules: List[str] = []
+    project_enabled: Optional[bool] = None
+    if not yaml:
+        return {"enabled": enabled, "disabled_rules": disabled_rules}
+
+    if global_config_path is None:
+        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+    try:
+        if global_config_path.exists():
+            with open(global_config_path, "r") as f:
+                data = yaml.safe_load(f) or {}
+            safety = data.get("safety", {})
+            if isinstance(safety, dict):
+                if "enabled" in safety:
+                    enabled = bool(safety["enabled"])
+                rules = safety.get("disabled_rules", [])
+                if isinstance(rules, list):
+                    disabled_rules.extend(str(r) for r in rules if r)
+    except Exception:
+        pass
+
+    if cwd is None:
+        cwd = os.environ.get("PWD", os.getcwd())
+    current = os.path.abspath(cwd)
+    while True:
+        candidate = os.path.join(current, ".agentwire.yml")
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, "r") as f:
+                    pdata = yaml.safe_load(f) or {}
+                psafety = pdata.get("safety", {})
+                if isinstance(psafety, dict):
+                    if "enabled" in psafety and psafety["enabled"] is not None:
+                        project_enabled = bool(psafety["enabled"])
+                    prules = psafety.get("disabled_rules", [])
+                    if isinstance(prules, list):
+                        disabled_rules.extend(str(r) for r in prules if r)
+            except Exception:
+                pass
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    if project_enabled is not None:
+        enabled = project_enabled
+
+    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+
+
+_ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
+
+
+def detect_escape_hatch(command: str) -> Optional[str]:
+    """Return the reason if ``command`` contains a ``# allow: <reason>`` marker.
+
+    Non-empty reason required; matches the rest of the comment line so the
+    marker works on multi-line / chained commands too.
+    """
+    if not command:
+        return None
+    m = _ESCAPE_HATCH_RE.search(command)
+    if not m:
+        return None
+    reason = m.group(1).strip()
+    return reason or None
 
 
 # ============================================================================
@@ -446,26 +567,56 @@ def load_config(
 def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     """Decide whether a bash command should be allowed/blocked/asked.
 
-    Returns ``{decision, reason, pattern, command}``.
+    Returns ``{decision, reason, pattern, command}`` plus optional ``id``,
+    ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      1. Hard-blocked bash patterns (no ``bypassable`` flag) → BLOCK
-      2. Ask patterns → ASK
-      3. Bypassable bash patterns → check allowlist for required operation
-      4. zeroAccessPaths → check allowlist with ``read`` permission
-      5. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      6. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      3. Ask patterns
+      4. Bypassable bash patterns → check allowlist for required operation
+      5. zeroAccessPaths → check allowlist with ``read`` permission
+      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
+    is_enabled = safety_cfg.get("enabled", True)
+
+    escape_reason = detect_escape_hatch(command)
+    if escape_reason:
+        return {
+            "decision": "allow",
+            "reason": f"Escape hatch: {escape_reason}",
+            "pattern": None,
+            "command": command,
+            "escape": True,
+            "escape_reason": escape_reason,
+        }
+
+    if is_enabled is False:
+        return {
+            "decision": "allow",
+            "reason": "safety disabled",
+            "pattern": None,
+            "command": command,
+            "disabled": True,
+        }
+
     bash_patterns = config.get("bashToolPatterns", [])
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
     allowed = load_allowed_paths(config)
 
-    bypassable_matches: List[Tuple[str, str]] = []
+    bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
     for pattern_obj in bash_patterns:
         if not isinstance(pattern_obj, dict):
+            continue
+        rule_id = pattern_obj.get("id")
+        if rule_id and rule_id in disabled_rules:
             continue
         pattern = pattern_obj.get("pattern", "")
         reason = pattern_obj.get("reason", "Matched pattern")
@@ -479,20 +630,22 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
                 elif bypassable:
-                    bypassable_matches.append((pattern, reason))
+                    bypassable_matches.append((pattern, reason, rule_id))
                 else:
                     return {
                         "decision": "block",
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
         except re.error:
             continue
 
-    for pattern, reason in bypassable_matches:
+    for pattern, reason, rule_id in bypassable_matches:
         operation = _infer_operation_from_reason(reason)
         if not is_command_path_allowed(command, allowed, operation):
             return {
@@ -500,6 +653,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                 "reason": reason,
                 "pattern": pattern,
                 "command": command,
+                "id": rule_id,
             }
 
     for path in zero_access:
@@ -548,6 +702,10 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
     """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    if safety_cfg.get("enabled", True) is False:
+        return False, ""
+
     allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
@@ -591,6 +749,7 @@ def _resolve_tooldefs_dir():
 
 def main() -> None:
     config = load_config(_resolve_rules_dir(), _resolve_tooldefs_dir())
+    config["safety"] = load_safety_config()
 
     try:
         input_data = json.load(sys.stdin)
@@ -623,7 +782,10 @@ def main() -> None:
     reason = result["reason"]
 
     if decision == "block":
-        log_blocked("Bash", command, reason)
+        try:
+            log_blocked("Bash", command, reason, pattern=result.get("pattern"), rule_id=result.get("id"))
+        except TypeError:
+            log_blocked("Bash", command, reason)
         print(f"SECURITY: Blocked: {reason}", file=sys.stderr)
         print(f"Command: {command[:100]}{'...' if len(command) > 100 else ''}", file=sys.stderr)
         sys.exit(2)
@@ -637,6 +799,12 @@ def main() -> None:
             }
         }
         print(json.dumps(output))
+        sys.exit(0)
+    elif result.get("escape"):
+        log_escape("Bash", command, result.get("escape_reason") or "")
+        sys.exit(0)
+    elif result.get("disabled"):
+        log_disabled("Bash", command)
         sys.exit(0)
     else:
         log_allowed("Bash", command, user_approved=False)

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -22,10 +22,11 @@ import sys
 from pathlib import Path
 
 try:
-    from audit_logger import log_allowed, log_blocked
+    from audit_logger import log_allowed, log_blocked, log_disabled
 except ImportError:
     def log_allowed(*args, **kwargs): pass
     def log_blocked(*args, **kwargs): pass
+    def log_disabled(*args, **kwargs): pass
 
 
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
@@ -405,11 +406,42 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
     return patterns
 
 
+_RULE_ID_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug_for_rule(text: str, max_len: int = 60) -> str:
+    """Lowercase, ASCII, kebab-case slug suitable for rule IDs."""
+    s = _RULE_ID_SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return s[:max_len] or "rule"
+
+
+def _assign_rule_id(pattern_obj: Dict[str, Any], file_stem: str, taken: set) -> str:
+    """Generate (or honor) an ID for a bash pattern. Mutates pattern_obj in place."""
+    existing = pattern_obj.get("id")
+    if isinstance(existing, str) and existing.strip():
+        pattern_obj["id"] = existing.strip()
+        taken.add(pattern_obj["id"])
+        return pattern_obj["id"]
+    slug = _slug_for_rule(pattern_obj.get("reason", "rule"))
+    candidate = f"{file_stem}.{slug}"
+    n = 2
+    while candidate in taken:
+        candidate = f"{file_stem}.{slug}-{n}"
+        n += 1
+    pattern_obj["id"] = candidate
+    taken.add(candidate)
+    return candidate
+
+
 def load_config(
     rules_dir: Path,
     tooldefs_dir: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns."""
+    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns.
+
+    Bash patterns get a stable ``id`` field (``"<file>.<slug-of-reason>"``) so
+    they can be referenced by the ``safety.disabled_rules`` config.
+    """
     merged: Dict[str, Any] = {
         "bashToolPatterns": [],
         "zeroAccessPaths": [],
@@ -419,20 +451,108 @@ def load_config(
     }
     if not yaml or not rules_dir.exists():
         return merged
+    taken_ids: set = set()
     yaml_files = sorted(rules_dir.glob("*.yaml"))
     for rules_file in yaml_files:
         try:
             with open(rules_file, "r") as f:
                 data = yaml.safe_load(f) or {}
             for key in merged:
-                merged[key].extend(data.get(key, []))
+                items = data.get(key, []) or []
+                if key == "bashToolPatterns":
+                    for it in items:
+                        if isinstance(it, dict):
+                            _assign_rule_id(it, rules_file.stem, taken_ids)
+                            it.setdefault("source", rules_file.stem)
+                merged[key].extend(items)
         except Exception:
             continue
     if tooldefs_dir is not None:
-        merged["bashToolPatterns"].extend(
-            load_write_patterns_from_tooldefs(tooldefs_dir)
-        )
+        tooldef_patterns = load_write_patterns_from_tooldefs(tooldefs_dir)
+        for it in tooldef_patterns:
+            _assign_rule_id(it, "tooldef", taken_ids)
+            it.setdefault("source", "tooldef")
+        merged["bashToolPatterns"].extend(tooldef_patterns)
     return merged
+
+
+def load_safety_config(
+    global_config_path: Optional[Path] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve the effective ``safety`` block from global + nearest project config.
+
+    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
+    overrides global; ``disabled_rules`` are merged (set-union).
+    """
+    enabled = True
+    disabled_rules: List[str] = []
+    project_enabled: Optional[bool] = None
+    if not yaml:
+        return {"enabled": enabled, "disabled_rules": disabled_rules}
+
+    if global_config_path is None:
+        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+    try:
+        if global_config_path.exists():
+            with open(global_config_path, "r") as f:
+                data = yaml.safe_load(f) or {}
+            safety = data.get("safety", {})
+            if isinstance(safety, dict):
+                if "enabled" in safety:
+                    enabled = bool(safety["enabled"])
+                rules = safety.get("disabled_rules", [])
+                if isinstance(rules, list):
+                    disabled_rules.extend(str(r) for r in rules if r)
+    except Exception:
+        pass
+
+    if cwd is None:
+        cwd = os.environ.get("PWD", os.getcwd())
+    current = os.path.abspath(cwd)
+    while True:
+        candidate = os.path.join(current, ".agentwire.yml")
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, "r") as f:
+                    pdata = yaml.safe_load(f) or {}
+                psafety = pdata.get("safety", {})
+                if isinstance(psafety, dict):
+                    if "enabled" in psafety and psafety["enabled"] is not None:
+                        project_enabled = bool(psafety["enabled"])
+                    prules = psafety.get("disabled_rules", [])
+                    if isinstance(prules, list):
+                        disabled_rules.extend(str(r) for r in prules if r)
+            except Exception:
+                pass
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    if project_enabled is not None:
+        enabled = project_enabled
+
+    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+
+
+_ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
+
+
+def detect_escape_hatch(command: str) -> Optional[str]:
+    """Return the reason if ``command`` contains a ``# allow: <reason>`` marker.
+
+    Non-empty reason required; matches the rest of the comment line so the
+    marker works on multi-line / chained commands too.
+    """
+    if not command:
+        return None
+    m = _ESCAPE_HATCH_RE.search(command)
+    if not m:
+        return None
+    reason = m.group(1).strip()
+    return reason or None
 
 
 # ============================================================================
@@ -443,26 +563,56 @@ def load_config(
 def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     """Decide whether a bash command should be allowed/blocked/asked.
 
-    Returns ``{decision, reason, pattern, command}``.
+    Returns ``{decision, reason, pattern, command}`` plus optional ``id``,
+    ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      1. Hard-blocked bash patterns (no ``bypassable`` flag) → BLOCK
-      2. Ask patterns → ASK
-      3. Bypassable bash patterns → check allowlist for required operation
-      4. zeroAccessPaths → check allowlist with ``read`` permission
-      5. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      6. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      3. Ask patterns
+      4. Bypassable bash patterns → check allowlist for required operation
+      5. zeroAccessPaths → check allowlist with ``read`` permission
+      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
+    is_enabled = safety_cfg.get("enabled", True)
+
+    escape_reason = detect_escape_hatch(command)
+    if escape_reason:
+        return {
+            "decision": "allow",
+            "reason": f"Escape hatch: {escape_reason}",
+            "pattern": None,
+            "command": command,
+            "escape": True,
+            "escape_reason": escape_reason,
+        }
+
+    if is_enabled is False:
+        return {
+            "decision": "allow",
+            "reason": "safety disabled",
+            "pattern": None,
+            "command": command,
+            "disabled": True,
+        }
+
     bash_patterns = config.get("bashToolPatterns", [])
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
     allowed = load_allowed_paths(config)
 
-    bypassable_matches: List[Tuple[str, str]] = []
+    bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
     for pattern_obj in bash_patterns:
         if not isinstance(pattern_obj, dict):
+            continue
+        rule_id = pattern_obj.get("id")
+        if rule_id and rule_id in disabled_rules:
             continue
         pattern = pattern_obj.get("pattern", "")
         reason = pattern_obj.get("reason", "Matched pattern")
@@ -476,20 +626,22 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
                 elif bypassable:
-                    bypassable_matches.append((pattern, reason))
+                    bypassable_matches.append((pattern, reason, rule_id))
                 else:
                     return {
                         "decision": "block",
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
         except re.error:
             continue
 
-    for pattern, reason in bypassable_matches:
+    for pattern, reason, rule_id in bypassable_matches:
         operation = _infer_operation_from_reason(reason)
         if not is_command_path_allowed(command, allowed, operation):
             return {
@@ -497,6 +649,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                 "reason": reason,
                 "pattern": pattern,
                 "command": command,
+                "id": rule_id,
             }
 
     for path in zero_access:
@@ -545,6 +698,10 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
     """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    if safety_cfg.get("enabled", True) is False:
+        return False, ""
+
     allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
@@ -577,6 +734,7 @@ def _resolve_rules_dir() -> Path:
 
 def main() -> None:
     config = load_config(_resolve_rules_dir())
+    config["safety"] = load_safety_config()
 
     try:
         input_data = json.load(sys.stdin)
@@ -592,6 +750,10 @@ def main() -> None:
 
     file_path = tool_input.get("file_path", "")
     if not file_path:
+        sys.exit(0)
+
+    if config["safety"].get("enabled", True) is False:
+        log_disabled("Edit", file_path)
         sys.exit(0)
 
     blocked, reason = check_path(file_path, config)

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -21,10 +21,11 @@ import sys
 from pathlib import Path
 
 try:
-    from audit_logger import log_allowed, log_blocked
+    from audit_logger import log_allowed, log_blocked, log_disabled
 except ImportError:
     def log_allowed(*args, **kwargs): pass
     def log_blocked(*args, **kwargs): pass
+    def log_disabled(*args, **kwargs): pass
 
 
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
@@ -404,11 +405,42 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
     return patterns
 
 
+_RULE_ID_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug_for_rule(text: str, max_len: int = 60) -> str:
+    """Lowercase, ASCII, kebab-case slug suitable for rule IDs."""
+    s = _RULE_ID_SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return s[:max_len] or "rule"
+
+
+def _assign_rule_id(pattern_obj: Dict[str, Any], file_stem: str, taken: set) -> str:
+    """Generate (or honor) an ID for a bash pattern. Mutates pattern_obj in place."""
+    existing = pattern_obj.get("id")
+    if isinstance(existing, str) and existing.strip():
+        pattern_obj["id"] = existing.strip()
+        taken.add(pattern_obj["id"])
+        return pattern_obj["id"]
+    slug = _slug_for_rule(pattern_obj.get("reason", "rule"))
+    candidate = f"{file_stem}.{slug}"
+    n = 2
+    while candidate in taken:
+        candidate = f"{file_stem}.{slug}-{n}"
+        n += 1
+    pattern_obj["id"] = candidate
+    taken.add(candidate)
+    return candidate
+
+
 def load_config(
     rules_dir: Path,
     tooldefs_dir: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns."""
+    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns.
+
+    Bash patterns get a stable ``id`` field (``"<file>.<slug-of-reason>"``) so
+    they can be referenced by the ``safety.disabled_rules`` config.
+    """
     merged: Dict[str, Any] = {
         "bashToolPatterns": [],
         "zeroAccessPaths": [],
@@ -418,20 +450,108 @@ def load_config(
     }
     if not yaml or not rules_dir.exists():
         return merged
+    taken_ids: set = set()
     yaml_files = sorted(rules_dir.glob("*.yaml"))
     for rules_file in yaml_files:
         try:
             with open(rules_file, "r") as f:
                 data = yaml.safe_load(f) or {}
             for key in merged:
-                merged[key].extend(data.get(key, []))
+                items = data.get(key, []) or []
+                if key == "bashToolPatterns":
+                    for it in items:
+                        if isinstance(it, dict):
+                            _assign_rule_id(it, rules_file.stem, taken_ids)
+                            it.setdefault("source", rules_file.stem)
+                merged[key].extend(items)
         except Exception:
             continue
     if tooldefs_dir is not None:
-        merged["bashToolPatterns"].extend(
-            load_write_patterns_from_tooldefs(tooldefs_dir)
-        )
+        tooldef_patterns = load_write_patterns_from_tooldefs(tooldefs_dir)
+        for it in tooldef_patterns:
+            _assign_rule_id(it, "tooldef", taken_ids)
+            it.setdefault("source", "tooldef")
+        merged["bashToolPatterns"].extend(tooldef_patterns)
     return merged
+
+
+def load_safety_config(
+    global_config_path: Optional[Path] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve the effective ``safety`` block from global + nearest project config.
+
+    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
+    overrides global; ``disabled_rules`` are merged (set-union).
+    """
+    enabled = True
+    disabled_rules: List[str] = []
+    project_enabled: Optional[bool] = None
+    if not yaml:
+        return {"enabled": enabled, "disabled_rules": disabled_rules}
+
+    if global_config_path is None:
+        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+    try:
+        if global_config_path.exists():
+            with open(global_config_path, "r") as f:
+                data = yaml.safe_load(f) or {}
+            safety = data.get("safety", {})
+            if isinstance(safety, dict):
+                if "enabled" in safety:
+                    enabled = bool(safety["enabled"])
+                rules = safety.get("disabled_rules", [])
+                if isinstance(rules, list):
+                    disabled_rules.extend(str(r) for r in rules if r)
+    except Exception:
+        pass
+
+    if cwd is None:
+        cwd = os.environ.get("PWD", os.getcwd())
+    current = os.path.abspath(cwd)
+    while True:
+        candidate = os.path.join(current, ".agentwire.yml")
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, "r") as f:
+                    pdata = yaml.safe_load(f) or {}
+                psafety = pdata.get("safety", {})
+                if isinstance(psafety, dict):
+                    if "enabled" in psafety and psafety["enabled"] is not None:
+                        project_enabled = bool(psafety["enabled"])
+                    prules = psafety.get("disabled_rules", [])
+                    if isinstance(prules, list):
+                        disabled_rules.extend(str(r) for r in prules if r)
+            except Exception:
+                pass
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    if project_enabled is not None:
+        enabled = project_enabled
+
+    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+
+
+_ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
+
+
+def detect_escape_hatch(command: str) -> Optional[str]:
+    """Return the reason if ``command`` contains a ``# allow: <reason>`` marker.
+
+    Non-empty reason required; matches the rest of the comment line so the
+    marker works on multi-line / chained commands too.
+    """
+    if not command:
+        return None
+    m = _ESCAPE_HATCH_RE.search(command)
+    if not m:
+        return None
+    reason = m.group(1).strip()
+    return reason or None
 
 
 # ============================================================================
@@ -442,26 +562,56 @@ def load_config(
 def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     """Decide whether a bash command should be allowed/blocked/asked.
 
-    Returns ``{decision, reason, pattern, command}``.
+    Returns ``{decision, reason, pattern, command}`` plus optional ``id``,
+    ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      1. Hard-blocked bash patterns (no ``bypassable`` flag) → BLOCK
-      2. Ask patterns → ASK
-      3. Bypassable bash patterns → check allowlist for required operation
-      4. zeroAccessPaths → check allowlist with ``read`` permission
-      5. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      6. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      3. Ask patterns
+      4. Bypassable bash patterns → check allowlist for required operation
+      5. zeroAccessPaths → check allowlist with ``read`` permission
+      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
+    is_enabled = safety_cfg.get("enabled", True)
+
+    escape_reason = detect_escape_hatch(command)
+    if escape_reason:
+        return {
+            "decision": "allow",
+            "reason": f"Escape hatch: {escape_reason}",
+            "pattern": None,
+            "command": command,
+            "escape": True,
+            "escape_reason": escape_reason,
+        }
+
+    if is_enabled is False:
+        return {
+            "decision": "allow",
+            "reason": "safety disabled",
+            "pattern": None,
+            "command": command,
+            "disabled": True,
+        }
+
     bash_patterns = config.get("bashToolPatterns", [])
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
     allowed = load_allowed_paths(config)
 
-    bypassable_matches: List[Tuple[str, str]] = []
+    bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
     for pattern_obj in bash_patterns:
         if not isinstance(pattern_obj, dict):
+            continue
+        rule_id = pattern_obj.get("id")
+        if rule_id and rule_id in disabled_rules:
             continue
         pattern = pattern_obj.get("pattern", "")
         reason = pattern_obj.get("reason", "Matched pattern")
@@ -475,20 +625,22 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
                 elif bypassable:
-                    bypassable_matches.append((pattern, reason))
+                    bypassable_matches.append((pattern, reason, rule_id))
                 else:
                     return {
                         "decision": "block",
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
         except re.error:
             continue
 
-    for pattern, reason in bypassable_matches:
+    for pattern, reason, rule_id in bypassable_matches:
         operation = _infer_operation_from_reason(reason)
         if not is_command_path_allowed(command, allowed, operation):
             return {
@@ -496,6 +648,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                 "reason": reason,
                 "pattern": pattern,
                 "command": command,
+                "id": rule_id,
             }
 
     for path in zero_access:
@@ -544,6 +697,10 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
     """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    if safety_cfg.get("enabled", True) is False:
+        return False, ""
+
     allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
@@ -576,6 +733,7 @@ def _resolve_rules_dir() -> Path:
 
 def main() -> None:
     config = load_config(_resolve_rules_dir())
+    config["safety"] = load_safety_config()
 
     try:
         input_data = json.load(sys.stdin)
@@ -591,6 +749,10 @@ def main() -> None:
 
     file_path = tool_input.get("file_path", "")
     if not file_path:
+        sys.exit(0)
+
+    if config["safety"].get("enabled", True) is False:
+        log_disabled("Write", file_path)
         sys.exit(0)
 
     blocked, reason = check_path(file_path, config)

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -109,11 +109,17 @@ def _normalize_allowed_entry(entry: dict) -> dict:
 class SafetyConfig:
     """Per-project safety overrides for damage control hooks."""
     allowed_paths: list[dict] = field(default_factory=list)
+    enabled: Optional[bool] = None  # None = inherit global
+    disabled_rules: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
-        d = {}
+        d: dict = {}
         if self.allowed_paths:
             d["allowed_paths"] = self.allowed_paths
+        if self.enabled is not None:
+            d["enabled"] = self.enabled
+        if self.disabled_rules:
+            d["disabled_rules"] = list(self.disabled_rules)
         return d
 
     @classmethod
@@ -122,7 +128,17 @@ class SafetyConfig:
         if not isinstance(raw, list):
             raw = []
         allowed_paths = [_normalize_allowed_entry(e) for e in raw if isinstance(e, dict)]
-        return cls(allowed_paths=allowed_paths)
+        enabled = data.get("enabled")
+        if enabled is not None:
+            enabled = bool(enabled)
+        rules = data.get("disabled_rules", [])
+        if not isinstance(rules, list):
+            rules = []
+        return cls(
+            allowed_paths=allowed_paths,
+            enabled=enabled,
+            disabled_rules=[str(r) for r in rules if r],
+        )
 
 
 @dataclass

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -374,11 +374,42 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
     return patterns
 
 
+_RULE_ID_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug_for_rule(text: str, max_len: int = 60) -> str:
+    """Lowercase, ASCII, kebab-case slug suitable for rule IDs."""
+    s = _RULE_ID_SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return s[:max_len] or "rule"
+
+
+def _assign_rule_id(pattern_obj: Dict[str, Any], file_stem: str, taken: set) -> str:
+    """Generate (or honor) an ID for a bash pattern. Mutates pattern_obj in place."""
+    existing = pattern_obj.get("id")
+    if isinstance(existing, str) and existing.strip():
+        pattern_obj["id"] = existing.strip()
+        taken.add(pattern_obj["id"])
+        return pattern_obj["id"]
+    slug = _slug_for_rule(pattern_obj.get("reason", "rule"))
+    candidate = f"{file_stem}.{slug}"
+    n = 2
+    while candidate in taken:
+        candidate = f"{file_stem}.{slug}-{n}"
+        n += 1
+    pattern_obj["id"] = candidate
+    taken.add(candidate)
+    return candidate
+
+
 def load_config(
     rules_dir: Path,
     tooldefs_dir: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns."""
+    """Load and merge all rule YAMLs in ``rules_dir`` plus tooldef ask-patterns.
+
+    Bash patterns get a stable ``id`` field (``"<file>.<slug-of-reason>"``) so
+    they can be referenced by the ``safety.disabled_rules`` config.
+    """
     merged: Dict[str, Any] = {
         "bashToolPatterns": [],
         "zeroAccessPaths": [],
@@ -388,20 +419,108 @@ def load_config(
     }
     if not yaml or not rules_dir.exists():
         return merged
+    taken_ids: set = set()
     yaml_files = sorted(rules_dir.glob("*.yaml"))
     for rules_file in yaml_files:
         try:
             with open(rules_file, "r") as f:
                 data = yaml.safe_load(f) or {}
             for key in merged:
-                merged[key].extend(data.get(key, []))
+                items = data.get(key, []) or []
+                if key == "bashToolPatterns":
+                    for it in items:
+                        if isinstance(it, dict):
+                            _assign_rule_id(it, rules_file.stem, taken_ids)
+                            it.setdefault("source", rules_file.stem)
+                merged[key].extend(items)
         except Exception:
             continue
     if tooldefs_dir is not None:
-        merged["bashToolPatterns"].extend(
-            load_write_patterns_from_tooldefs(tooldefs_dir)
-        )
+        tooldef_patterns = load_write_patterns_from_tooldefs(tooldefs_dir)
+        for it in tooldef_patterns:
+            _assign_rule_id(it, "tooldef", taken_ids)
+            it.setdefault("source", "tooldef")
+        merged["bashToolPatterns"].extend(tooldef_patterns)
     return merged
+
+
+def load_safety_config(
+    global_config_path: Optional[Path] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve the effective ``safety`` block from global + nearest project config.
+
+    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
+    overrides global; ``disabled_rules`` are merged (set-union).
+    """
+    enabled = True
+    disabled_rules: List[str] = []
+    project_enabled: Optional[bool] = None
+    if not yaml:
+        return {"enabled": enabled, "disabled_rules": disabled_rules}
+
+    if global_config_path is None:
+        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+    try:
+        if global_config_path.exists():
+            with open(global_config_path, "r") as f:
+                data = yaml.safe_load(f) or {}
+            safety = data.get("safety", {})
+            if isinstance(safety, dict):
+                if "enabled" in safety:
+                    enabled = bool(safety["enabled"])
+                rules = safety.get("disabled_rules", [])
+                if isinstance(rules, list):
+                    disabled_rules.extend(str(r) for r in rules if r)
+    except Exception:
+        pass
+
+    if cwd is None:
+        cwd = os.environ.get("PWD", os.getcwd())
+    current = os.path.abspath(cwd)
+    while True:
+        candidate = os.path.join(current, ".agentwire.yml")
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, "r") as f:
+                    pdata = yaml.safe_load(f) or {}
+                psafety = pdata.get("safety", {})
+                if isinstance(psafety, dict):
+                    if "enabled" in psafety and psafety["enabled"] is not None:
+                        project_enabled = bool(psafety["enabled"])
+                    prules = psafety.get("disabled_rules", [])
+                    if isinstance(prules, list):
+                        disabled_rules.extend(str(r) for r in prules if r)
+            except Exception:
+                pass
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    if project_enabled is not None:
+        enabled = project_enabled
+
+    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+
+
+_ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
+
+
+def detect_escape_hatch(command: str) -> Optional[str]:
+    """Return the reason if ``command`` contains a ``# allow: <reason>`` marker.
+
+    Non-empty reason required; matches the rest of the comment line so the
+    marker works on multi-line / chained commands too.
+    """
+    if not command:
+        return None
+    m = _ESCAPE_HATCH_RE.search(command)
+    if not m:
+        return None
+    reason = m.group(1).strip()
+    return reason or None
 
 
 # ============================================================================
@@ -412,26 +531,56 @@ def load_config(
 def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     """Decide whether a bash command should be allowed/blocked/asked.
 
-    Returns ``{decision, reason, pattern, command}``.
+    Returns ``{decision, reason, pattern, command}`` plus optional ``id``,
+    ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      1. Hard-blocked bash patterns (no ``bypassable`` flag) → BLOCK
-      2. Ask patterns → ASK
-      3. Bypassable bash patterns → check allowlist for required operation
-      4. zeroAccessPaths → check allowlist with ``read`` permission
-      5. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      6. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      3. Ask patterns
+      4. Bypassable bash patterns → check allowlist for required operation
+      5. zeroAccessPaths → check allowlist with ``read`` permission
+      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
+    is_enabled = safety_cfg.get("enabled", True)
+
+    escape_reason = detect_escape_hatch(command)
+    if escape_reason:
+        return {
+            "decision": "allow",
+            "reason": f"Escape hatch: {escape_reason}",
+            "pattern": None,
+            "command": command,
+            "escape": True,
+            "escape_reason": escape_reason,
+        }
+
+    if is_enabled is False:
+        return {
+            "decision": "allow",
+            "reason": "safety disabled",
+            "pattern": None,
+            "command": command,
+            "disabled": True,
+        }
+
     bash_patterns = config.get("bashToolPatterns", [])
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
     allowed = load_allowed_paths(config)
 
-    bypassable_matches: List[Tuple[str, str]] = []
+    bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
     for pattern_obj in bash_patterns:
         if not isinstance(pattern_obj, dict):
+            continue
+        rule_id = pattern_obj.get("id")
+        if rule_id and rule_id in disabled_rules:
             continue
         pattern = pattern_obj.get("pattern", "")
         reason = pattern_obj.get("reason", "Matched pattern")
@@ -445,20 +594,22 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
                 elif bypassable:
-                    bypassable_matches.append((pattern, reason))
+                    bypassable_matches.append((pattern, reason, rule_id))
                 else:
                     return {
                         "decision": "block",
                         "reason": reason,
                         "pattern": pattern,
                         "command": command,
+                        "id": rule_id,
                     }
         except re.error:
             continue
 
-    for pattern, reason in bypassable_matches:
+    for pattern, reason, rule_id in bypassable_matches:
         operation = _infer_operation_from_reason(reason)
         if not is_command_path_allowed(command, allowed, operation):
             return {
@@ -466,6 +617,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
                 "reason": reason,
                 "pattern": pattern,
                 "command": command,
+                "id": rule_id,
             }
 
     for path in zero_access:
@@ -514,6 +666,10 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
     """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    if safety_cfg.get("enabled", True) is False:
+        return False, ""
+
     allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -24,11 +24,14 @@ import termios
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict
 
 import aiohttp
 import aiohttp_jinja2
 import jinja2
+import yaml
 from aiohttp import web
 
 from .config import Config, load_config
@@ -196,6 +199,10 @@ class AgentWireServer:
         self.app.router.add_get("/api/config", self.api_get_config)
         self.app.router.add_post("/api/config", self.api_save_config)
         self.app.router.add_post("/api/config/reload", self.api_reload_config)
+        self.app.router.add_get("/api/safety/status", self.api_safety_status)
+        self.app.router.add_get("/api/safety/logs", self.api_safety_logs)
+        self.app.router.add_get("/api/safety/rules", self.api_safety_rules)
+        self.app.router.add_post("/api/safety/config", self.api_safety_config_post)
         self.app.router.add_post("/api/sessions/refresh", self.api_refresh_sessions)
         # Icon listing for dynamic icon picker
         self.app.router.add_get("/api/icons/{category}", self.api_icons)
@@ -3113,6 +3120,110 @@ projects:
             return web.json_response({"success": True})
         except Exception as e:
             return web.json_response({"error": str(e)})
+
+    async def api_safety_status(self, request: web.Request) -> web.Response:
+        """Damage-control current state: master enable, disabled rules, today's counts."""
+        try:
+            from .cli_safety import load_patterns, LOGS_DIR
+            patterns = load_patterns()
+            today = datetime.now().strftime("%Y-%m-%d")
+            log_file = LOGS_DIR / f"{today}.jsonl"
+            counts: Dict[str, int] = {}
+            if log_file.exists():
+                try:
+                    with open(log_file, "r") as f:
+                        for line in f:
+                            try:
+                                entry = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            d = entry.get("decision", "")
+                            counts[d] = counts.get(d, 0) + 1
+                except Exception:
+                    pass
+            safety_cfg = getattr(self.config, "safety", None)
+            return web.json_response({
+                "enabled": getattr(safety_cfg, "enabled", True) if safety_cfg else True,
+                "disabled_rules": list(getattr(safety_cfg, "disabled_rules", []) or []),
+                "rule_count": len(patterns.get("bashToolPatterns", [])),
+                "today_counts": counts,
+            })
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_safety_logs(self, request: web.Request) -> web.Response:
+        """Recent safety audit log entries with optional filters."""
+        try:
+            from .cli_safety import query_audit_logs
+            limit = int(request.query.get("limit", "200"))
+            decision = request.query.get("decision")
+            entries = query_audit_logs()  # all entries, newest-first by file
+            if decision:
+                wanted = {d.strip() for d in decision.split(",") if d.strip()}
+                entries = [e for e in entries if e.get("decision") in wanted]
+            if limit > 0:
+                entries = entries[-limit:]
+            return web.json_response({"entries": entries})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_safety_rules(self, request: web.Request) -> web.Response:
+        """Flat list of bash-rule IDs with their patterns/reasons."""
+        try:
+            from .cli_safety import load_patterns
+            patterns = load_patterns()
+            rules = []
+            for p in patterns.get("bashToolPatterns", []):
+                if not isinstance(p, dict):
+                    continue
+                rules.append({
+                    "id": p.get("id"),
+                    "pattern": p.get("pattern"),
+                    "reason": p.get("reason"),
+                    "ask": bool(p.get("ask", False)),
+                    "bypassable": bool(p.get("bypassable", False)),
+                    "source": p.get("source"),
+                })
+            return web.json_response({"rules": rules})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_safety_config_post(self, request: web.Request) -> web.Response:
+        """Update ~/.agentwire/config.yaml safety block (enabled, disabled_rules)."""
+        try:
+            data = await request.json()
+            cfg_path = Path.home() / ".agentwire" / "config.yaml"
+            raw: Dict[str, Any] = {}
+            if cfg_path.exists():
+                try:
+                    with open(cfg_path, "r") as f:
+                        raw = yaml.safe_load(f) or {}
+                except Exception:
+                    raw = {}
+            safety = raw.get("safety", {})
+            if not isinstance(safety, dict):
+                safety = {}
+            if "enabled" in data:
+                safety["enabled"] = bool(data["enabled"])
+            if "disabled_rules" in data and isinstance(data["disabled_rules"], list):
+                safety["disabled_rules"] = sorted({str(r) for r in data["disabled_rules"] if r})
+            raw["safety"] = safety
+            cfg_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(cfg_path, "w") as f:
+                yaml.safe_dump(raw, f, sort_keys=False)
+            # Reload runtime config so /api/safety/status sees the change immediately
+            try:
+                from .config import reload_config
+                self.config = reload_config()
+            except Exception:
+                pass
+            return web.json_response({
+                "success": True,
+                "enabled": safety.get("enabled", True),
+                "disabled_rules": safety.get("disabled_rules", []),
+            })
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
 
     async def api_refresh_sessions(self, request: web.Request) -> web.Response:
         """Refresh sessions and broadcast update to all dashboard clients.

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -1141,6 +1141,429 @@ body {
     color: var(--accent);
 }
 
+/* =========================================================================
+   Safety sidebar section
+   ========================================================================= */
+
+.safety-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 6px 4px 10px;
+    border-bottom: 1px solid var(--chrome-border);
+    margin-bottom: 8px;
+}
+
+.safety-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--text);
+}
+
+.safety-toggle input[type="checkbox"] {
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
+.safety-stats {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.safety-filters {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.safety-chip {
+    background: transparent;
+    border: 1px solid var(--chrome-border);
+    color: var(--text-muted);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.safety-chip:hover {
+    color: var(--text);
+    border-color: var(--accent);
+}
+
+.safety-chip.active {
+    background: var(--accent);
+    color: var(--background);
+    border-color: var(--accent);
+}
+
+.safety-decision {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 34px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.safety-decision.blocked {
+    background: rgba(220, 38, 38, 0.18);
+    color: #ef4444;
+    border: 1px solid #ef4444;
+}
+
+.safety-decision.escape {
+    background: rgba(249, 115, 22, 0.18);
+    color: #f97316;
+    border: 1px solid #f97316;
+}
+
+.safety-decision.asked {
+    background: rgba(234, 179, 8, 0.18);
+    color: #eab308;
+    border: 1px solid #eab308;
+}
+
+.safety-decision.allowed {
+    background: rgba(34, 197, 94, 0.12);
+    color: #22c55e;
+    border: 1px solid #22c55e44;
+}
+
+.safety-decision.disabled-mode {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--text-muted);
+    border: 1px solid var(--text-muted);
+}
+
+.safety-event {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    column-gap: 10px;
+    row-gap: 2px;
+    padding: 6px 4px;
+    border-radius: 4px;
+    cursor: pointer;
+    border-bottom: 1px solid transparent;
+}
+
+.safety-event:hover {
+    background: var(--hover);
+}
+
+.safety-event .safety-decision {
+    grid-row: 1 / span 2;
+    align-self: center;
+}
+
+.safety-event-cmd {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.safety-event-meta {
+    grid-column: 2;
+    grid-row: 2;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.safety-disabled-rules {
+    margin-bottom: 12px;
+    padding: 6px 4px 8px;
+    border-bottom: 1px solid var(--chrome-border);
+}
+
+.safety-disabled-rules-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+.safety-disabled-add {
+    background: transparent;
+    border: 1px solid var(--chrome-border);
+    color: var(--text-muted);
+    border-radius: 4px;
+    width: 24px;
+    height: 22px;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+}
+
+.safety-disabled-add:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.safety-disabled-rule {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 3px 0;
+    font-size: 12px;
+}
+
+.safety-disabled-rule code {
+    color: var(--accent);
+}
+
+.safety-rule-remove {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 4px;
+}
+
+.safety-rule-remove:hover {
+    color: var(--error);
+}
+
+.safety-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 12px;
+}
+
+/* Safety event detail modal */
+
+.safety-event-modal {
+    width: 560px;
+    max-width: 90vw;
+}
+
+.safety-event-detail-row {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 13px;
+}
+
+.safety-event-detail-row span {
+    color: var(--text-muted);
+}
+
+.safety-event-detail-row code {
+    color: var(--text);
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+}
+
+.safety-event-detail-cmd {
+    margin-top: 10px;
+}
+
+.safety-event-detail-cmd span {
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.safety-event-detail-cmd pre {
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    border-radius: 4px;
+    padding: 10px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin-top: 4px;
+}
+
+.safety-disable-from-event {
+    margin-top: 12px;
+    padding: 8px 12px;
+    background: rgba(249, 115, 22, 0.18);
+    border: 1px solid #f97316;
+    color: #f97316;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.safety-disable-from-event:hover {
+    background: rgba(249, 115, 22, 0.3);
+}
+
+/* Rule picker modal */
+
+.safety-rule-picker {
+    width: 600px;
+    max-width: 90vw;
+}
+
+.safety-rule-filter {
+    width: 100%;
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    color: var(--text);
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 13px;
+    margin-bottom: 10px;
+}
+
+.safety-rule-list {
+    max-height: 50vh;
+    overflow-y: auto;
+}
+
+.safety-rule-row {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 10px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--chrome-border);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.safety-rule-row:hover {
+    background: var(--hover);
+}
+
+.safety-rule-row code {
+    color: var(--accent);
+}
+
+/* "Show all" affordance in the sidebar */
+
+.safety-show-all {
+    width: 100%;
+    margin-top: 8px;
+    padding: 8px;
+    background: transparent;
+    border: 1px dashed var(--chrome-border);
+    color: var(--text-muted);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.safety-show-all:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    border-style: solid;
+}
+
+/* Safety review WinBox window */
+
+.safety-window-content {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    height: 100%;
+    background: var(--chrome);
+    color: var(--text);
+}
+
+.safety-window-sidebar {
+    border-right: 1px solid var(--chrome-border);
+    padding: 14px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.safety-window-stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}
+
+.safety-window-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px 4px;
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    border-radius: 4px;
+}
+
+.safety-window-stat label {
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.safety-window-section h4 {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 600;
+}
+
+.safety-project-select {
+    margin-top: 8px;
+    width: 100%;
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    color: var(--text);
+    padding: 6px 8px;
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.safety-refresh-btn {
+    margin-top: auto;
+    padding: 8px;
+    background: transparent;
+    border: 1px solid var(--chrome-border);
+    color: var(--text-muted);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.safety-refresh-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.safety-window-main {
+    overflow-y: auto;
+    padding: 14px 16px;
+    background: var(--background);
+}
+
+.safety-window-events .safety-event {
+    grid-template-columns: auto 1fr;
+    border-bottom: 1px solid var(--chrome-border);
+    padding: 8px 6px;
+}
+
+.safety-window .wb-body {
+    background: var(--chrome);
+}
+
 .btn-danger {
     background: var(--error);
     border-color: var(--error);

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -13,6 +13,7 @@ import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { sidebar } from './sidebar.js';
 import { configSection } from './sidebar/config-section.js';
+import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
 import { machinesSection } from './sidebar/machines-section.js';
 import { sessionsSection } from './sidebar/sessions-section.js';
@@ -69,6 +70,7 @@ async function init() {
     sidebar.addSection('artifacts', artifactsSection);
     sidebar.addSection('scheduler', schedulerSection);
     sidebar.addSection('workflows', workflowsSection);
+    sidebar.addSection('safety', safetySection);
     sidebar.addSection('config', configSection);
     setupClock();
     setupPageUnload();

--- a/agentwire/static/js/safety-shared.js
+++ b/agentwire/static/js/safety-shared.js
@@ -1,0 +1,164 @@
+/**
+ * Shared rendering + state helpers for the Safety sidebar section and
+ * the full Safety review WinBox window.
+ */
+
+export const DECISION_LABELS = {
+    blocked: 'BLOCKED',
+    asked: 'ASKED',
+    allowed: 'ALLOWED',
+    allowed_by_escape: 'ESCAPE',
+    allowed_by_disabled: 'DISABLED',
+};
+
+export const DECISION_CLASSES = {
+    blocked: 'blocked',
+    asked: 'asked',
+    allowed: 'allowed',
+    allowed_by_escape: 'escape',
+    allowed_by_disabled: 'disabled-mode',
+};
+
+export function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+}
+
+export function formatRel(iso) {
+    if (!iso) return '';
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) return '';
+    const secs = Math.max(0, Math.floor((Date.now() - t) / 1000));
+    if (secs < 60) return `${secs}s ago`;
+    if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+    if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+    return `${Math.floor(secs / 86400)}d ago`;
+}
+
+export function projectFromCwd(cwd) {
+    if (!cwd) return '—';
+    const parts = String(cwd).split('/').filter(Boolean);
+    const idx = parts.findIndex((p) => p === 'projects');
+    if (idx >= 0 && idx < parts.length - 1) return parts[idx + 1].split('-worktrees')[0];
+    return parts[parts.length - 1] || '—';
+}
+
+export function eventRow(e) {
+    const d = e.decision || 'allowed';
+    const klass = DECISION_CLASSES[d] || 'allowed';
+    const label = DECISION_LABELS[d] || d;
+    const cmd = (e.command || '').slice(0, 160);
+    const proj = projectFromCwd(e.cwd);
+    return `<div class="safety-event" data-event='${escapeHtml(JSON.stringify(e))}'>
+        <span class="safety-decision ${klass}">${label}</span>
+        <span class="safety-event-cmd">${escapeHtml(cmd)}</span>
+        <span class="safety-event-meta">${escapeHtml(proj)} · ${formatRel(e.timestamp)}</span>
+    </div>`;
+}
+
+export async function fetchSafetyStatus() {
+    try { return await fetch('/api/safety/status').then((r) => r.json()); } catch { return {}; }
+}
+
+export async function fetchSafetyLogs(decisionFilter = '', limit = 200) {
+    const qs = `?limit=${limit}${decisionFilter ? '&decision=' + encodeURIComponent(decisionFilter) : ''}`;
+    try {
+        const data = await fetch('/api/safety/logs' + qs).then((r) => r.json());
+        return data.entries || [];
+    } catch { return []; }
+}
+
+export async function fetchSafetyRules() {
+    try {
+        const data = await fetch('/api/safety/rules').then((r) => r.json());
+        return data.rules || [];
+    } catch { return []; }
+}
+
+export async function postSafetyConfig(payload) {
+    return fetch('/api/safety/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    }).then((r) => r.json());
+}
+
+export function showEventModal(e, onDisabledChange) {
+    const existing = document.getElementById('safetyEventOverlay');
+    if (existing) existing.remove();
+    const wrap = document.createElement('div');
+    wrap.id = 'safetyEventOverlay';
+    wrap.className = 'modal-overlay';
+    wrap.innerHTML = `<div class="modal safety-event-modal">
+        <div class="modal-header">
+            <h3>${escapeHtml(DECISION_LABELS[e.decision] || e.decision)}</h3>
+            <button class="modal-close" data-close>×</button>
+        </div>
+        <div class="modal-body">
+            <div class="safety-event-detail-row"><span>Timestamp</span><code>${escapeHtml(e.timestamp || '')}</code></div>
+            <div class="safety-event-detail-row"><span>Tool</span><code>${escapeHtml(e.tool || '')}</code></div>
+            <div class="safety-event-detail-row"><span>Session</span><code>${escapeHtml(e.session_id || 'unknown')}</code></div>
+            <div class="safety-event-detail-row"><span>cwd</span><code>${escapeHtml(e.cwd || '—')}</code></div>
+            ${e.rule_id ? `<div class="safety-event-detail-row"><span>Rule id</span><code>${escapeHtml(e.rule_id)}</code></div>` : ''}
+            ${e.blocked_by ? `<div class="safety-event-detail-row"><span>Reason</span>${escapeHtml(e.blocked_by)}</div>` : ''}
+            ${e.escape_reason ? `<div class="safety-event-detail-row"><span>Escape reason</span>${escapeHtml(e.escape_reason)}</div>` : ''}
+            ${e.pattern_matched ? `<div class="safety-event-detail-row"><span>Pattern</span><code>${escapeHtml(e.pattern_matched)}</code></div>` : ''}
+            <div class="safety-event-detail-cmd">
+                <span>Command</span>
+                <pre>${escapeHtml(e.command || '')}</pre>
+            </div>
+            ${e.rule_id ? `<button class="safety-disable-from-event" data-action="disable-rule" data-rule-id="${escapeHtml(e.rule_id)}">Disable rule "${escapeHtml(e.rule_id)}"</button>` : ''}
+        </div>
+    </div>`;
+    document.body.appendChild(wrap);
+    wrap.addEventListener('click', async (ev) => {
+        if (ev.target === wrap || ev.target.closest('[data-close]')) { wrap.remove(); return; }
+        const btn = ev.target.closest('[data-action="disable-rule"]');
+        if (btn) {
+            const status = await fetchSafetyStatus();
+            const id = btn.dataset.ruleId;
+            const next = [...(status.disabled_rules || []), id];
+            await postSafetyConfig({ disabled_rules: next });
+            wrap.remove();
+            if (onDisabledChange) onDisabledChange();
+        }
+    });
+}
+
+export async function openAddRulePicker(currentDisabled, onChange) {
+    const rules = await fetchSafetyRules();
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.innerHTML = `<div class="modal safety-rule-picker">
+        <div class="modal-header"><h3>Disable a rule</h3><button class="modal-close" data-close>×</button></div>
+        <div class="modal-body">
+            <input type="search" class="safety-rule-filter" placeholder="Filter rules…" autocomplete="off" />
+            <div class="safety-rule-list">
+                ${rules.map((r) => `
+                    <div class="safety-rule-row" data-rule-id="${escapeHtml(r.id)}">
+                        <code>${escapeHtml(r.id)}</code>
+                        <span>${escapeHtml(r.reason || '')}</span>
+                    </div>
+                `).join('')}
+            </div>
+        </div>
+    </div>`;
+    document.body.appendChild(overlay);
+    const filterInput = overlay.querySelector('.safety-rule-filter');
+    filterInput?.focus();
+    filterInput?.addEventListener('input', () => {
+        const q = filterInput.value.toLowerCase();
+        overlay.querySelectorAll('.safety-rule-row').forEach((row) => {
+            row.hidden = q && !row.textContent.toLowerCase().includes(q);
+        });
+    });
+    overlay.addEventListener('click', async (e) => {
+        if (e.target === overlay || e.target.closest('[data-close]')) { overlay.remove(); return; }
+        const row = e.target.closest('.safety-rule-row');
+        if (row) {
+            const id = row.dataset.ruleId;
+            await postSafetyConfig({ disabled_rules: [...currentDisabled, id] });
+            overlay.remove();
+            if (onChange) onChange();
+        }
+    });
+}

--- a/agentwire/static/js/safety-window.js
+++ b/agentwire/static/js/safety-window.js
@@ -1,0 +1,172 @@
+/**
+ * Safety review WinBox window — full admin view of damage-control history,
+ * disabled rules, and the master toggle. Opened from the sidebar's "Show all"
+ * button.
+ */
+
+import {
+    eventRow,
+    escapeHtml,
+    fetchSafetyStatus,
+    fetchSafetyLogs,
+    postSafetyConfig,
+    showEventModal,
+    openAddRulePicker,
+} from './safety-shared.js';
+
+let activeWindow = null;
+const state = {
+    decision: '',
+    project: '',
+    limit: 500,
+};
+
+function pageHtml(status, entries) {
+    const enabled = status?.enabled ?? true;
+    const counts = status?.today_counts || {};
+    const fmt = (k) => counts[k] || 0;
+    const disabled = status?.disabled_rules || [];
+    const projectOptions = Array.from(new Set(entries.map((e) => projectFromCwd(e.cwd)))).filter(Boolean);
+    return `
+        <div class="safety-window-content">
+            <aside class="safety-window-sidebar">
+                <label class="safety-toggle">
+                    <input type="checkbox" data-action="toggle-enabled" ${enabled ? 'checked' : ''} />
+                    <span>Damage control ${enabled ? 'enabled' : 'disabled'}</span>
+                </label>
+                <div class="safety-window-stats">
+                    <div class="safety-window-stat"><span class="safety-decision blocked">${fmt('blocked')}</span><label>blocked</label></div>
+                    <div class="safety-window-stat"><span class="safety-decision escape">${fmt('allowed_by_escape')}</span><label>escape</label></div>
+                    <div class="safety-window-stat"><span class="safety-decision asked">${fmt('asked')}</span><label>asked</label></div>
+                    <div class="safety-window-stat"><span class="safety-decision allowed">${fmt('allowed')}</span><label>allowed</label></div>
+                    <div class="safety-window-stat"><span class="safety-decision disabled-mode">${fmt('allowed_by_disabled')}</span><label>disabled</label></div>
+                </div>
+
+                <div class="safety-window-section">
+                    <h4>Filters</h4>
+                    <div class="safety-filters">
+                        <button class="safety-chip ${state.decision === '' ? 'active' : ''}" data-decision="">all</button>
+                        <button class="safety-chip ${state.decision === 'blocked' ? 'active' : ''}" data-decision="blocked">blocked</button>
+                        <button class="safety-chip ${state.decision === 'allowed_by_escape' ? 'active' : ''}" data-decision="allowed_by_escape">escape</button>
+                        <button class="safety-chip ${state.decision === 'asked' ? 'active' : ''}" data-decision="asked">asked</button>
+                        <button class="safety-chip ${state.decision === 'allowed_by_disabled' ? 'active' : ''}" data-decision="allowed_by_disabled">disabled</button>
+                    </div>
+                    <select class="safety-project-select" data-action="filter-project">
+                        <option value="">All projects</option>
+                        ${projectOptions.map((p) => `<option value="${escapeHtml(p)}" ${state.project === p ? 'selected' : ''}>${escapeHtml(p)}</option>`).join('')}
+                    </select>
+                </div>
+
+                <div class="safety-window-section">
+                    <div class="safety-disabled-rules-header">
+                        <h4>Disabled rules (${disabled.length})</h4>
+                        <button class="safety-disabled-add" data-action="add-rule">+</button>
+                    </div>
+                    <div class="safety-disabled-rules-list">
+                        ${disabled.length ? disabled.map((id) => `
+                            <div class="safety-disabled-rule" data-rule-id="${escapeHtml(id)}">
+                                <code>${escapeHtml(id)}</code>
+                                <button class="safety-rule-remove" data-action="remove-rule" data-rule-id="${escapeHtml(id)}" title="Re-enable rule">×</button>
+                            </div>
+                        `).join('') : '<div class="safety-empty">No rules disabled.</div>'}
+                    </div>
+                </div>
+
+                <button class="safety-refresh-btn" data-action="refresh">↻ Refresh</button>
+            </aside>
+
+            <main class="safety-window-main">
+                <div class="safety-window-events">
+                    ${entries.length
+                        ? entries.map(eventRow).join('')
+                        : '<div class="sidebar-empty">No events match the current filter.</div>'}
+                </div>
+            </main>
+        </div>
+    `;
+}
+
+function projectFromCwd(cwd) {
+    if (!cwd) return '';
+    const parts = String(cwd).split('/').filter(Boolean);
+    const idx = parts.findIndex((p) => p === 'projects');
+    if (idx >= 0 && idx < parts.length - 1) return parts[idx + 1].split('-worktrees')[0];
+    return parts[parts.length - 1] || '';
+}
+
+async function loadAndRender(container) {
+    container.innerHTML = '<div class="sidebar-empty">Loading…</div>';
+    const [status, allEntries] = await Promise.all([
+        fetchSafetyStatus(),
+        fetchSafetyLogs(state.decision, state.limit),
+    ]);
+    let entries = allEntries.slice().reverse();
+    if (state.project) {
+        entries = entries.filter((e) => projectFromCwd(e.cwd) === state.project);
+    }
+    container.innerHTML = pageHtml(status, entries);
+    bindControls(container, status);
+}
+
+function bindControls(container, status) {
+    container.querySelector('[data-action="toggle-enabled"]')?.addEventListener('change', async (e) => {
+        await postSafetyConfig({ enabled: e.target.checked });
+        loadAndRender(container);
+    });
+    container.querySelectorAll('.safety-chip').forEach((chip) => {
+        chip.addEventListener('click', () => {
+            state.decision = chip.dataset.decision || '';
+            loadAndRender(container);
+        });
+    });
+    container.querySelector('[data-action="filter-project"]')?.addEventListener('change', (e) => {
+        state.project = e.target.value || '';
+        loadAndRender(container);
+    });
+    container.querySelectorAll('[data-action="remove-rule"]').forEach((btn) => {
+        btn.addEventListener('click', async (e) => {
+            e.stopPropagation();
+            const id = btn.dataset.ruleId;
+            const next = (status.disabled_rules || []).filter((r) => r !== id);
+            await postSafetyConfig({ disabled_rules: next });
+            loadAndRender(container);
+        });
+    });
+    container.querySelector('[data-action="add-rule"]')?.addEventListener('click', () => {
+        openAddRulePicker(status.disabled_rules || [], () => loadAndRender(container));
+    });
+    container.querySelector('[data-action="refresh"]')?.addEventListener('click', () => loadAndRender(container));
+    container.querySelectorAll('.safety-event').forEach((row) => {
+        row.addEventListener('click', () => {
+            try {
+                showEventModal(JSON.parse(row.dataset.event), () => loadAndRender(container));
+            } catch (_) {}
+        });
+    });
+}
+
+export function openSafetyWindow() {
+    if (activeWindow && activeWindow.window) {
+        try { activeWindow.focus(); return; } catch (_) {}
+    }
+    const container = document.createElement('div');
+    container.className = 'safety-window-mount';
+    activeWindow = new WinBox({
+        title: 'Safety review',
+        icon: '<span style="font-size:14px">🛡️</span>',
+        mount: container,
+        width: '100%',
+        height: '100%',
+        x: 0,
+        y: 0,
+        minwidth: 640,
+        minheight: 420,
+        class: ['safety-window'],
+        onclose: () => {
+            activeWindow = null;
+            return false;
+        },
+    });
+    try { activeWindow.maximize(); } catch (_) {}
+    loadAndRender(container);
+}

--- a/agentwire/static/js/sidebar/safety-section.js
+++ b/agentwire/static/js/sidebar/safety-section.js
@@ -1,0 +1,131 @@
+/**
+ * Safety sidebar section — compact damage-control review.
+ *
+ * Caps the event list to SIDEBAR_LIMIT and offers a "Show all" button that
+ * opens a maximized WinBox window with the full review tool.
+ */
+
+import {
+    eventRow,
+    escapeHtml,
+    fetchSafetyStatus,
+    fetchSafetyLogs,
+    postSafetyConfig,
+    showEventModal,
+    openAddRulePicker,
+} from '../safety-shared.js';
+
+const SIDEBAR_LIMIT = 10;
+
+let currentFilter = { decision: '' };
+let cachedStatus = { disabled_rules: [] };
+
+function renderHeader(status) {
+    const enabled = status?.enabled ?? true;
+    const counts = status?.today_counts || {};
+    const fmt = (k) => counts[k] || 0;
+    return `<div class="safety-header">
+        <label class="safety-toggle">
+            <input type="checkbox" data-action="toggle-enabled" ${enabled ? 'checked' : ''} />
+            <span>Damage control ${enabled ? 'enabled' : 'disabled'}</span>
+        </label>
+        <div class="safety-stats">
+            <span class="safety-decision blocked">${fmt('blocked')}</span>
+            <span class="safety-decision escape">${fmt('allowed_by_escape')}</span>
+            <span class="safety-decision asked">${fmt('asked')}</span>
+            <span class="safety-decision disabled-mode">${fmt('allowed_by_disabled')}</span>
+        </div>
+        <div class="safety-filters">
+            <button class="safety-chip ${currentFilter.decision === '' ? 'active' : ''}" data-decision="">all</button>
+            <button class="safety-chip ${currentFilter.decision === 'blocked' ? 'active' : ''}" data-decision="blocked">blocked</button>
+            <button class="safety-chip ${currentFilter.decision === 'allowed_by_escape' ? 'active' : ''}" data-decision="allowed_by_escape">escape</button>
+            <button class="safety-chip ${currentFilter.decision === 'asked' ? 'active' : ''}" data-decision="asked">asked</button>
+        </div>
+    </div>`;
+}
+
+function renderDisabledRules(status) {
+    const disabled = status?.disabled_rules || [];
+    return `<div class="safety-disabled-rules">
+        <div class="safety-disabled-rules-header">
+            <span>Disabled rules (${disabled.length})</span>
+            <button class="safety-disabled-add" data-action="add-rule">+</button>
+        </div>
+        <div class="safety-disabled-rules-list">
+            ${disabled.length ? disabled.map((id) => `
+                <div class="safety-disabled-rule" data-rule-id="${escapeHtml(id)}">
+                    <code>${escapeHtml(id)}</code>
+                    <button class="safety-rule-remove" data-action="remove-rule" data-rule-id="${escapeHtml(id)}" title="Re-enable rule">×</button>
+                </div>
+            `).join('') : '<div class="safety-empty">No rules disabled.</div>'}
+        </div>
+    </div>`;
+}
+
+export const safetySection = {
+    title: 'Safety',
+    _body: null,
+    async mount(body) {
+        this._body = body;
+        await this.refresh(body);
+    },
+    async refresh(body) {
+        body.innerHTML = '<div class="sidebar-empty">Loading…</div>';
+        const [status, allEntries] = await Promise.all([
+            fetchSafetyStatus(),
+            fetchSafetyLogs(currentFilter.decision, 500),
+        ]);
+        cachedStatus = status || { disabled_rules: [] };
+
+        const newestFirst = allEntries.slice().reverse();
+        const shown = newestFirst.slice(0, SIDEBAR_LIMIT);
+        const remaining = newestFirst.length - shown.length;
+
+        body.innerHTML = renderHeader(status)
+            + renderDisabledRules(status)
+            + (shown.length
+                ? shown.map(eventRow).join('')
+                : '<div class="sidebar-empty">No safety events yet.</div>')
+            + (remaining > 0
+                ? `<button class="safety-show-all" data-action="open-window">Show all ${newestFirst.length} events →</button>`
+                : '');
+
+        body.querySelector('[data-action="toggle-enabled"]')?.addEventListener('change', async (e) => {
+            await postSafetyConfig({ enabled: e.target.checked });
+            this.refresh(body);
+        });
+        body.querySelectorAll('.safety-chip').forEach((chip) => {
+            chip.addEventListener('click', () => {
+                currentFilter.decision = chip.dataset.decision || '';
+                this.refresh(body);
+            });
+        });
+        body.querySelectorAll('[data-action="remove-rule"]').forEach((btn) => {
+            btn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const id = btn.dataset.ruleId;
+                const next = (cachedStatus.disabled_rules || []).filter((r) => r !== id);
+                await postSafetyConfig({ disabled_rules: next });
+                this.refresh(body);
+            });
+        });
+        body.querySelector('[data-action="add-rule"]')?.addEventListener('click', () => {
+            openAddRulePicker(cachedStatus.disabled_rules || [], () => this.refresh(body));
+        });
+        body.querySelectorAll('.safety-event').forEach((row) => {
+            row.addEventListener('click', () => {
+                try {
+                    showEventModal(JSON.parse(row.dataset.event), () => this.refresh(body));
+                } catch (_) {}
+            });
+        });
+        body.querySelector('[data-action="open-window"]')?.addEventListener('click', async () => {
+            const { openSafetyWindow } = await import('../safety-window.js');
+            const { sidebar } = await import('../sidebar.js');
+            // Close the sidebar so the maximized window has full screen real estate.
+            try { sidebar.unpin(); } catch (_) {}
+            try { sidebar.close(); } catch (_) {}
+            openSafetyWindow();
+        });
+    },
+};

--- a/tests/unit/test_safety_disabled_rules.py
+++ b/tests/unit/test_safety_disabled_rules.py
@@ -1,0 +1,36 @@
+"""Disabled rules in safety config skip the matching pattern."""
+
+from agentwire.cli_safety import load_patterns
+from agentwire.safety._core import check_command
+
+
+def test_rule_ids_are_populated():
+    cfg = load_patterns()
+    bash_patterns = cfg.get("bashToolPatterns", [])
+    assert bash_patterns, "expected at least one bash pattern"
+    for p in bash_patterns:
+        assert "id" in p, f"missing id on rule: {p.get('reason')}"
+        assert isinstance(p["id"], str) and "." in p["id"]
+
+
+def test_disabled_rule_skips_block():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True, "disabled_rules": ["core.filesystem-format-command"]}
+    result = check_command("mkfs.ext4 /dev/sda1", cfg)
+    assert result["decision"] == "allow"
+
+
+def test_non_disabled_rule_still_blocks():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True, "disabled_rules": ["nonexistent.rule"]}
+    result = check_command("mkfs.ext4 /dev/sda1", cfg)
+    assert result["decision"] == "block"
+    assert result.get("id") == "core.filesystem-format-command"
+
+
+def test_disabled_rule_only_affects_named_rule():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True, "disabled_rules": ["core.filesystem-format-command"]}
+    # A different blocking rule still fires
+    result = check_command("git filter-branch --tree-filter rm 'foo'", cfg)
+    assert result["decision"] == "block"

--- a/tests/unit/test_safety_escape_hatch.py
+++ b/tests/unit/test_safety_escape_hatch.py
@@ -1,0 +1,39 @@
+"""Escape hatch: `# allow: <reason>` makes the hook skip pattern checks and log it."""
+
+from agentwire.cli_safety import load_patterns
+from agentwire.safety._core import check_command, detect_escape_hatch
+
+
+def test_detect_escape_hatch_basic():
+    assert detect_escape_hatch("foo  # allow: cleanup") == "cleanup"
+
+
+def test_detect_escape_hatch_no_reason_returns_none():
+    assert detect_escape_hatch("foo  # allow:  ") is None
+
+
+def test_detect_escape_hatch_absent():
+    assert detect_escape_hatch("rm -rf /tmp") is None
+
+
+def test_check_command_escape_hatch_overrides_block():
+    cfg = load_patterns()
+    result = check_command("rm -rf /tmp  # allow: build cleanup", cfg)
+    assert result["decision"] == "allow"
+    assert result["escape"] is True
+    assert result["escape_reason"] == "build cleanup"
+    assert "Escape hatch" in result["reason"]
+
+
+def test_check_command_no_escape_still_blocks():
+    cfg = load_patterns()
+    result = check_command("rm -rf /tmp", cfg)
+    assert result["decision"] == "block"
+    assert "rm" in result["reason"].lower()
+
+
+def test_escape_hatch_inline_comment_at_end():
+    cfg = load_patterns()
+    result = check_command("git reset --hard origin/main  # allow: sync to remote", cfg)
+    assert result["decision"] == "allow"
+    assert result["escape_reason"] == "sync to remote"

--- a/tests/unit/test_safety_kill_switch.py
+++ b/tests/unit/test_safety_kill_switch.py
@@ -1,0 +1,34 @@
+"""Global kill switch (safety.enabled = false) short-circuits all blocks."""
+
+from agentwire.cli_safety import load_patterns
+from agentwire.safety._core import check_command, check_path
+
+
+def test_kill_switch_allows_dangerous_bash():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": False, "disabled_rules": []}
+    result = check_command("rm -rf /", cfg)
+    assert result["decision"] == "allow"
+    assert result.get("disabled") is True
+    assert result["reason"] == "safety disabled"
+
+
+def test_kill_switch_allows_protected_file():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": False, "disabled_rules": []}
+    blocked, _reason = check_path("/etc/passwd", cfg)
+    assert blocked is False
+
+
+def test_default_enabled_blocks():
+    cfg = load_patterns()
+    # No explicit safety key: defaults to enabled=True
+    result = check_command("rm -rf /", cfg)
+    assert result["decision"] == "block"
+
+
+def test_explicit_enabled_true_blocks():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True, "disabled_rules": []}
+    result = check_command("rm -rf /", cfg)
+    assert result["decision"] == "block"


### PR DESCRIPTION
## Summary

Damage control was firing too aggressively (blocking legit `git rm`, `rm -rf dist`, `git reset --hard`) with no relief valve. This PR keeps the patterns conservative but makes the system observable and dial-able:

- **Kill switch** — \`safety.enabled: false\` in \`~/.agentwire/config.yaml\` (global) or \`.agentwire.yml\` (project) bypasses everything.
- **Per-rule disable** — \`safety.disabled_rules: [id, …]\`. Every rule gets a stable auto-generated id (e.g. \`core.rm-with-recursive-or-force-flags\`).
- **Escape hatch** — \`# allow: <reason>\` anywhere in a bash command makes the hook skip pattern checks and log the reason. Stance from the issue: agents that want to bypass can bypass anyway — the audit log is the real safety net, not the patterns.
- **Portal review tool** — sidebar Safety section + maximized WinBox window. Master toggle, today's decision counts, filter chips, click-to-detail event modal, disabled-rules manager with rule-picker.

## What you can do now

- Re-enable / disable damage control from the sidebar toggle (writes \`~/.agentwire/config.yaml\` via \`POST /api/safety/config\`).
- See every blocked command, escape hatch use, and allowed action in chronological order.
- Click an event → see full command, cwd, session, rule id, pattern, escape reason; one-click \"Disable this rule\" if it's a chronic false positive.
- Run \`rm -rf dist  # allow: build cleanup\` and watch it pass through with a fully logged escape entry.

## Test plan

- [x] CLI: escape hatch (\`agentwire safety check 'git rm foo  # allow: legit'\` → ALLOW)
- [x] CLI: rule ids surface in check results
- [x] Hook: rm -rf disabled → blocked; enable kill switch → allowed (decision=allowed_by_disabled); add \`# allow:\` → allowed (decision=allowed_by_escape)
- [x] Hook: per-rule disable lets a specific command through, others still fire
- [x] Portal: toggle reflects on disk, persists across reloads
- [x] Portal: sidebar caps to 10 events with \"Show all N →\" footer
- [x] Portal: clicking \"Show all\" closes the sidebar and opens window maximized
- [x] Portal: multi-day log order is newest-first end-to-end
- [x] \`uv run pytest\` — 1419 passed, 4 skipped

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global safety kill switch to disable all safety checks.
  * Introduced ability to disable specific safety rules from configuration.
  * Added escape-hatch marker (`# allow: <reason>`) to bypass safety checks inline.
  * New Safety management UI with sidebar section and review dashboard.
  * Added safety API endpoints for status, logs, rules, and configuration updates.

* **Enhancements**
  * Improved audit logging with additional decision context and metadata.
  * Audit logs now sorted chronologically (oldest first).

* **Tests**
  * Added comprehensive safety configuration and escape-hatch unit tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->