### PR TITLE
ui: clean up after SDK + inbound-channel guts

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -440,13 +440,6 @@ body {
     color: #c084fc;
 }
 
-/* SDK session types — distinct teal, called out as the agentwire-native
-   harness vs. claude-* (orange/green/blue). */
-.sidebar-tag.sidebar-tag-sdk {
-    background: rgba(45, 212, 191, 0.18);
-    color: #5eead4;
-}
-
 .sidebar-status-dot {
     width: 8px;
     height: 8px;

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -2,7 +2,15 @@ import { desktop } from '../desktop-manager.js';
 
 // Shared state across sessions and services sections
 export const activityStates = new Map();
-export function isService(name) { return name.startsWith('agentwire-'); }
+
+const SERVICE_SESSIONS = new Set([
+    'agentwire-portal',
+    'agentwire-tts',
+    'agentwire-stt',
+    'agentwire-scheduler',
+    'agentwire-notifications',
+]);
+export function isService(name) { return SERVICE_SESSIONS.has(name); }
 
 let allSessions = [];
 const listeners = new Set();
@@ -20,8 +28,7 @@ export function renderCard(s) {
     const dotClass = activity === 'idle' ? 'dot-idle' : activity === 'processing' ? 'dot-processing' : activity === 'generating' ? 'dot-generating' : 'dot-playing';
     const tags = [];
     if (s.type) {
-        const typeClass = String(s.type).startsWith('sdk-') ? 'sidebar-tag sidebar-tag-sdk' : 'sidebar-tag';
-        tags.push(`<span class="${typeClass}">${s.type}</span>`);
+        tags.push(`<span class="sidebar-tag">${s.type}</span>`);
     }
     if (machine) tags.push(`<span class="sidebar-tag">@${machine}</span>`);
     const roles = (s.roles || []).map(r => `<span class="sidebar-tag sidebar-tag-role">${r}</span>`).join('');


### PR DESCRIPTION
## Summary

Three small cleanups left behind by #185 (SDK gut) and #186 (inbound-channel gut):

- **Drop the unreachable `sdk-*` session-type tag branch** in `sessions-section.js`. `String(s.type).startsWith('sdk-')` can never match — the `sdk-bypass/prompted/restricted` session types were removed in #185.
- **Drop the `.sidebar-tag.sidebar-tag-sdk` CSS rule** in `desktop.css` that the unreachable JS would have set.
- **Tighten `isService()`** to an explicit allowlist of the five real service sessions (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`) instead of `name.startsWith('agentwire-')`. Worktree dev sessions like `agentwire-dev/test123` were getting caught by the prefix match and incorrectly landing in **Services**; they now correctly land in **Sessions**.

## Net

2 files, +10 / −10.

## Test plan

- [ ] Hard-refresh portal (Cmd+Shift+R)
- [ ] `agentwire-dev/test123` appears under **Sessions**, not Services
- [ ] `agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler` still appear under **Services**
- [ ] No console errors

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated session filtering logic in the sidebar to use a refined allowlist for improved accuracy.

* **Style**
  * Removed special visual styling previously applied to SDK session tags in the sidebar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->