### PR TITLE
ui: worktree button on each project row

### DIFF
--- a/agentwire/static/js/quicktask-modal.js
+++ b/agentwire/static/js/quicktask-modal.js
@@ -226,7 +226,7 @@ function attachListeners() {
     }
 }
 
-export async function openQuicktaskModal() {
+export async function openQuicktaskModal({ project: prefillProject } = {}) {
     if (modalEl) return;
     lastFocus = document.activeElement;
     const projects = await fetchProjects();
@@ -235,9 +235,17 @@ export async function openQuicktaskModal() {
     modalEl = wrapper.firstElementChild;
     document.body.appendChild(modalEl);
     attachListeners();
-    // Focus the first empty required field
     const projectInput = modalEl.querySelector('input[name="project"]');
+    const baseInput = modalEl.querySelector('input[name="base"]');
     const branchInput = modalEl.querySelector('input[name="branch"]');
+    // If launched from a project row, pre-fill project + base, skip straight to branch
+    if (prefillProject && projectInput) {
+        projectInput.value = prefillProject;
+        if (baseInput) {
+            const stored = localStorage.getItem(LS_BASE_PREFIX + prefillProject);
+            baseInput.value = stored || 'main';
+        }
+    }
     if (projectInput && !projectInput.value) projectInput.focus();
     else if (branchInput) branchInput.focus();
 }

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -30,8 +30,9 @@ export const projectsSection = {
                 }
                 for (const p of items) {
                     const name = p.name || p.path?.split('/').pop() || '?';
-                    html += `<div class="sidebar-list-item sidebar-project-item" data-path="${p.path || ''}" data-machine="${p.machine || ''}">
+                    html += `<div class="sidebar-list-item sidebar-project-item" data-path="${p.path || ''}" data-machine="${p.machine || ''}" data-name="${name}">
                         <span class="sidebar-list-item-title">${name}</span>
+                        <button class="sidebar-list-item-btn" data-action="worktree" title="New worktree session">⎇</button>
                         <button class="sidebar-list-item-btn" data-action="open" title="Open session">▸</button>
                     </div>`;
                 }
@@ -48,9 +49,18 @@ export const projectsSection = {
         if (!btn) return;
         const item = btn.closest('[data-path]');
         if (!item) return;
+        const action = btn.dataset.action;
         const path = item.dataset.path;
         const machine = item.dataset.machine || null;
-        if (btn.dataset.action === 'open' && path) {
+        const name = item.dataset.name || '';
+
+        if (action === 'worktree' && name) {
+            const { openQuicktaskModal } = await import('../quicktask-modal.js');
+            openQuicktaskModal({ project: name });
+            return;
+        }
+
+        if (action === 'open' && path) {
             try {
                 const res = await fetch('/api/create', {
                     method: 'POST',


### PR DESCRIPTION
## Summary

Add a **⎇** button next to the existing **▸** button on every project line in the Projects sidebar. Clicking it opens the Quicktask modal pre-filled with that project's name (and the last-used base branch), so you only need to type the new branch and hit submit.

Behavior matches the existing Cmd/Ctrl+K Quicktask flow:

- Pulls the base branch from origin (default: `main`)
- Creates a worktree under `~/projects/<name>-worktrees/<branch>/`
- Spawns the session and opens its terminal window

## Change shape

- `openQuicktaskModal()` now accepts an optional `{ project }` argument so a caller can launch it with the project name (and stored base) pre-filled
- `projects-section.js` adds a ⎇ button per row that calls `openQuicktaskModal({ project: name })`

2 files, +22 / −4.

## Test plan

- [ ] Hard-refresh portal (Cmd+Shift+R)
- [ ] Each project row shows two buttons: ⎇ (worktree) and ▸ (open)
- [ ] Click ▸ → opens session in repo dir (unchanged behavior)
- [ ] Click ⎇ → modal opens with project pre-filled and branch input focused
- [ ] Type a branch name → submit → worktree created at `~/projects/<name>-worktrees/<branch>/` and terminal opens
- [ ] Cmd/Ctrl+K still opens an empty modal (existing hotkey)

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick task modal now supports pre-filling project and branch information when creating tasks from the projects section, streamlining the workflow for users initiating tasks directly from project listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->