### PR TITLE
fix(sidebar): wire scheduler section to the real API endpoints

### DIFF
--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -24,8 +24,17 @@ export const schedulerSection = {
 
     async refresh(body) {
         try {
-            const res = await fetch('/api/scheduler/state');
-            this._state = await res.json();
+            const [liveRes, boardRes] = await Promise.all([
+                fetch('/api/scheduler/live'),
+                fetch('/api/scheduler/board'),
+            ]);
+            const live = liveRes.ok ? await liveRes.json() : null;
+            const board = boardRes.ok ? await boardRes.json() : null;
+            if (live) {
+                this._state = { ...live, tasks: board?.tasks || [] };
+            } else {
+                this._state = null;
+            }
         } catch (e) {
             this._state = null;
         }
@@ -77,11 +86,11 @@ export const schedulerSection = {
         const action = btn.dataset.action;
         try {
             if (action === 'run') {
-                await fetch(`/api/scheduler/run/${encodeURIComponent(task)}`, { method: 'POST' });
+                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });
             } else if (action === 'enable') {
-                await fetch(`/api/scheduler/enable/${encodeURIComponent(task)}`, { method: 'POST' });
+                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/enable`, { method: 'POST' });
             } else if (action === 'disable') {
-                await fetch(`/api/scheduler/disable/${encodeURIComponent(task)}`, { method: 'POST' });
+                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/disable`, { method: 'POST' });
             }
             await this.refresh(body);
         } catch (e) { console.warn('Scheduler action failed', e); }


### PR DESCRIPTION
## Summary

The Scheduler sidebar section was calling URLs that don't exist on the server, so every refresh returned 404 and the section fell back to whatever stale WS state it had — showing **STOPPED** while the scheduler was actually running fine (CLI/launchd confirmed).

## URL fixes

| Was | Now |
|-----|-----|
| `/api/scheduler/state` | `/api/scheduler/live` (running state) + `/api/scheduler/board` (task list) |
| `/api/scheduler/run/{task}` | `/api/scheduler/tasks/{task}/run` |
| `/api/scheduler/enable/{task}` | `/api/scheduler/tasks/{task}/enable` |
| `/api/scheduler/disable/{task}` | `/api/scheduler/tasks/{task}/disable` |

`refresh()` now fetches `/live` and `/board` in parallel and merges them so the sidebar shows real status + the enabled/disabled task list, and the inline action buttons (run / enable / disable) actually hit existing routes.

## Test plan

- [ ] Hard-refresh portal
- [ ] Scheduler sidebar shows **Running** with green dot
- [ ] Task list populates from `/api/scheduler/board`
- [ ] ▶/⏸/⚡ buttons on each task no longer 404 in Network tab

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized scheduler data retrieval through concurrent API requests for improved performance
  * Restructured task action endpoints for streamlined command processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->