### PR TITLE
fix(scheduler): WS scheduler_state event was missing running flag

### DIFF
--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -750,7 +750,7 @@ def _notify_portal_state() -> None:
 
         requests.post(
             f"{portal_url}/api/notify",
-            json={"event": "scheduler_state", **state},
+            json={"event": "scheduler_state", "running": True, **state},
             verify=False,
             timeout=timeout,
         )

--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -46,7 +46,10 @@ export const schedulerSection = {
             body.innerHTML = '<div class="sidebar-empty">Scheduler not running</div>';
             return;
         }
-        const { running, current_task, tasks, uptime } = this._state;
+        const { current_task, tasks, uptime } = this._state;
+        // Tolerate both shapes: HTTP /live sends `running: true`; older WS
+        // events only had `status: "running"`.
+        const running = this._state.running ?? (this._state.status === 'running');
         const statusDot = running ? 'dot-online' : 'dot-offline';
         const statusText = running ? 'Running' : 'Stopped';
 


### PR DESCRIPTION
## Summary

After #189, the Scheduler sidebar still showed **STOPPED** even though `/api/scheduler/live` returns `running: true`. Root cause:

- `scheduler-live.json` does **not** include a `running` field
- `/api/scheduler/live` synthesizes `running: true` from a tmux-session check
- `_notify_portal_state()` in scheduler.py just spreads the file contents into the WS broadcast — so the WS `scheduler_state` event has no `running` field
- After mount, the initial /live fetch correctly set the sidebar to **Running**, then a heartbeat-driven WS event overwrote `_state` with a payload missing `running` → sidebar read `undefined` → falsy → **Stopped**

## Two-sided fix

- **scheduler.py** — add `running: True` to the WS notification body (the scheduler is by definition running when it's emitting state)
- **sidebar JS** — read `state.running ?? state.status === 'running'` so it tolerates both shapes (and any older WS clients between the sidebar restart and the next scheduler restart)

2 files, +5 / −2.

## Test plan

- [ ] Hard-refresh portal
- [ ] Scheduler sidebar shows **Running** with green dot
- [ ] Status doesn't flip back to Stopped on heartbeat
- [ ] Restart the scheduler daemon to make sure the new WS payload includes `running: true` (`agentwire scheduler stop && agentwire scheduler start`)

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced scheduler state tracking with improved compatibility for state notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->