### PR TITLE
docs: update skills + wiki to reflect outbound-only channels

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-cli
-description: Full `agentwire` CLI command reference — session/pane management, portal, TTS/STT, voice, channels (email/sms/webhook/telegram/discord/slack), machine/tunnel/lock management, projects/history/roles, scheduler, overnight queue, web helpers (brave, fetch), safety/diagnostics. Use when running or composing `agentwire ...` shell commands, building automation scripts, or answering "how do I X from the CLI".
+description: Full `agentwire` CLI command reference — session/pane management, portal, TTS/STT, voice, channels (email + quo, outbound-only), machine/tunnel/lock management, projects/history/roles, scheduler, overnight queue, web helpers (brave, fetch), safety/diagnostics. Use when running or composing `agentwire ...` shell commands, building automation scripts, or answering "how do I X from the CLI".
 ---
 
 # AgentWire CLI Reference
@@ -61,7 +61,7 @@ agentwire voiceclone delete name # delete a voice clone
 agentwire open <url> --title "T"  # open URL or local file as artifact window
 agentwire open dashboard.html     # open from ~/.agentwire/artifacts/
 
-# Channels (communication integrations)
+# Channels (outbound notification integrations — email + quo)
 agentwire channels list         # list all registered channels
 agentwire channels list --json  # JSON output
 
@@ -72,24 +72,6 @@ agentwire email --attach file.pdf --body "See attached"
 
 # Quo SMS (send-only channel, no deps)
 agentwire quo --body "msg" --to "+1234567890"
-
-# SMS via Twilio (send-only channel, requires twilio)
-agentwire sms --body "msg" --to "+1234567890"
-
-# Webhook (send-only channel)
-agentwire webhook --body "msg" --url "https://hooks.example.com"
-
-# Telegram bridge (service channel)
-agentwire telegram start       # start bot in tmux
-agentwire telegram stop        # stop bot
-agentwire telegram serve       # run bot in foreground
-agentwire telegram status      # check bot status
-
-# Discord bridge (service channel, requires discord.py)
-agentwire discord start|serve|stop|status
-
-# Slack bridge (service channel, requires slack-bolt)
-agentwire slack start|serve|stop|status
 
 # Machine management
 agentwire machine list

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-config
-description: Reference for `~/.agentwire/config.yaml` — main config structure including server/portal/SSL, projects, TTS/STT, agent, dev, services, executables, pi (binary/system_prompt/extra_env/providers), uploads/artifacts/wiki, channels (email/telegram/quo/sms/webhook/discord/slack), scheduler, worktree, overnight, session defaults. Use when editing or debugging agentwire config, setting up TTS/STT backends, wiring up a new channel bridge, configuring pi providers, or explaining config fields to the user.
+description: Reference for `~/.agentwire/config.yaml` — main config structure including server/portal/SSL, projects, TTS/STT, agent, dev, services, executables, pi (binary/system_prompt/extra_env/providers), uploads/artifacts/wiki, channels (email + quo, outbound-only), scheduler, worktree, overnight, session defaults. Use when editing or debugging agentwire config, setting up TTS/STT backends, configuring pi providers, or explaining config fields to the user.
 ---
 
 # AgentWire Config (`~/.agentwire/config.yaml`)
@@ -79,9 +79,6 @@ services:  # Where services run (for multi-machine setups)
     session_name: "agentwire-tts"
   stt:
     session_name: "agentwire-stt"
-  telegram:
-    machine: null
-    session_name: "agentwire-telegram"
 
 executables:  # Override executable paths (optional, auto-detected by default)
   ffmpeg: "/opt/homebrew/bin/ffmpeg"
@@ -134,7 +131,7 @@ wiki:
 portal:
   url: "https://localhost:8765"
 
-channels:
+channels:  # Outbound-only notifications. Only email + quo ship.
   email:
     api_key: ""  # Resend API key (or set RESEND_API_KEY env var)
     from_address: "Echo <echo@yourdomain.com>"
@@ -143,84 +140,10 @@ channels:
     echo_image_url: "https://yourdomain.com/images/echo.png"
     echo_small_url: "https://yourdomain.com/images/echo-small.png"
     logo_image_url: "https://yourdomain.com/images/logo.png"
-  telegram:
-    bot_token: ""              # from @BotFather (or TELEGRAM_AGENTWIRE_BOT_TOKEN env var)
-    allowed_users: []          # Telegram user IDs (integers)
-    default_session: "main"    # fallback session for messages
-    voice_replies: true        # convert TTS to voice notes
-    forward_questions: true    # AskUserQuestion as inline keyboards
-    forward_alerts: true       # alerts to Telegram
-    session_name: "agentwire-telegram"
   quo:
     api_key: ""              # or QUO_API_KEY / OPENPHONE_API_KEY env var
     from_number: "+1234567890"  # E.164 or phone number ID (PNxxx)
     default_to: "+0987654321"
-  sms:
-    account_sid: ""          # or TWILIO_ACCOUNT_SID env var
-    auth_token: ""           # or TWILIO_AUTH_TOKEN env var
-    from_number: "+1234567890"
-    default_to: "+0987654321"
-  webhook:
-    url: "https://hooks.example.com/agentwire"
-    method: "POST"
-    headers:
-      Authorization: "Bearer xxx"
-  discord:
-    bot_token: ""            # or DISCORD_BOT_TOKEN env var
-    allowed_user_ids: []     # Discord user IDs (integers)
-    default_session: "main"
-    voice_replies: true
-    session_name: "agentwire-discord"
-    # Composable session config hierarchy (platform → scope → specific):
-    default_type: claude-bypass
-    default_roles: [agentwire]
-    default_instructions: ""      # applies to all Discord sessions
-    dm_roles: [discord-dm]
-    dm_instructions: ""           # applies to all Discord DMs
-    channel_roles: [discord-dm]
-    channel_instructions: ""      # applies to all Discord channel sessions
-    channel_map:                  # per-channel overrides (append to scope)
-      "1234567890":
-        session: "backend"
-        project: "~/projects/api"
-        type: claude-auto         # override type
-        roles: [python-expert]    # appended + deduped
-        instructions: |
-          Backend team channel. Focus on Python.
-    user_map:                     # per-user DM overrides (DM scope only)
-      "252979000000000000":
-        roles: [admin]
-        instructions: |
-          Team lead — be direct and concise.
-    # Self-configuration tip: add channel-admin to dm_roles (or default_roles)
-    # so you can set up new channels by just DMing the bot. The agent will
-    # edit this config.yaml and restart the bridge for you.
-  slack:
-    bot_token: ""            # xoxb-... or SLACK_BOT_TOKEN env var
-    app_token: ""            # xapp-... or SLACK_APP_TOKEN env var
-    allowed_user_ids: []     # Slack user IDs (strings)
-    default_session: "main"
-    session_name: "agentwire-slack"
-    # Composable session config hierarchy (same as Discord):
-    default_type: claude-bypass
-    default_roles: [agentwire]
-    default_instructions: ""      # applies to all Slack sessions
-    dm_roles: [slack-dm]
-    dm_instructions: ""           # applies to all Slack DMs
-    channel_roles: [slack-dm]
-    channel_instructions: ""      # applies to all Slack channel sessions
-    channel_map:                  # per-channel overrides
-      "C12345":
-        session: "backend"
-        type: claude-auto
-        roles: [python-expert]
-        instructions: |
-          Backend team channel. Focus on Python.
-    user_map:                     # per-user DM overrides (DM scope only)
-      "U67890":
-        roles: [admin]
-        instructions: |
-          Team lead — be direct and concise.
 
 scheduler:
   dispatch_cooldown: 60  # Seconds between task dispatches (default: 60)

--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -13,15 +13,14 @@ The portal uses a left sidebar with a floating tab handle instead of hover hotzo
 - **Tab handle**: floating 20×40px button on left edge, rides sidebar when open, chevron flips direction
 - **Header**: connection status dot, session count, clock, pin toggle
 - **Open Windows section**: lists currently-open windows (drag to reorder, click to focus, × to close). Persisted in `localStorage['taskbar-state']` — restores on refresh.
-- **Accordion sections**: Sessions, Socials, Services, Machines, Projects, Artifacts, Scheduler, Config. Click header to expand/collapse. Data fetched on first expand.
+- **Accordion sections**: Sessions, Services, Machines, Projects, Artifacts, Scheduler, Workflows, Safety, Config. Click header to expand/collapse. Data fetched on first expand.
 - **Footer**: global PTT button, voice indicator
 
-**Session grouping:** Sessions are split into three accordion sections based on type:
-- **Sessions**: working sessions (excludes services and socials)
-- **Socials**: DM/channel sessions (`discord-dm-*`, `slack-dm-*`, `discord-ch-*`, `slack-ch-*`, or sessions with social roles)
-- **Services**: infrastructure sessions (`agentwire-*` prefix: portal, tts, stt, telegram, discord, slack)
+**Session grouping:** Sessions are split into two accordion sections based on the name:
+- **Services**: infrastructure sessions, matched against an explicit allowlist in `sessions-section.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`)
+- **Sessions**: everything else (working sessions, worktrees, remote sessions)
 
-All three share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).
+Both share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).
 
 **Keyboard:** Tab cycles forward through open windows, Shift+Tab cycles backward. Works inside terminals (captured on `window` in capture phase before xterm).
 

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-mcp-tools
-description: Reference for the 90 `mcp__agentwire__*` MCP tools — session/pane management, voice/TTS, tasks/locks, channels (email/sms/webhook/discord/slack), machines/tunnels/network, history/roles/projects, scheduler, overnight queue, desktop UI, notifications. Use when agents inside agentwire sessions need to pick the right MCP tool instead of shelling out to the `agentwire` CLI.
+description: Reference for the `mcp__agentwire__*` MCP tools — session/pane management, voice/TTS, tasks/locks, channels (email + quo, outbound-only), machines/tunnels/network, history/roles/projects, scheduler, overnight queue, desktop UI, notifications. Use when agents inside agentwire sessions need to pick the right MCP tool instead of shelling out to the `agentwire` CLI.
 ---
 
 # AgentWire MCP Tools
@@ -84,17 +84,13 @@ description: Reference for the 90 `mcp__agentwire__*` MCP tools — session/pane
 | `agentwire handoff list` | `handoff_list()` |
 | `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."], plain_text=False)` |
 
-## Channels (7 tools)
+## Channels (outbound-only)
 
 | CLI Command | MCP Tool |
 |-------------|----------|
 | `agentwire channels list` | `channels_list()` |
-| `agentwire quo --body "..." --to "+1..."` | `quo_send(body="...", to="+1...")` |
-| `agentwire sms --body "..." --to "+1..."` | `sms_send(body="...", to="+1...")` |
-| `agentwire webhook --body "..." --url "..."` | `webhook_send(text="...", url="...")` |
-| `agentwire discord status` | `discord_status()` |
-| `agentwire slack status` | `slack_status()` |
 | `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."])` |
+| `agentwire quo --body "..." --to "+1..."` | `quo_send(body="...", to="+1...")` |
 
 ## Notifications & Network (5 tools)
 

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -162,8 +162,5 @@ Roles define agent behavior and are composable. Mix and match roles in `.agentwi
 | `task-runner` | Scheduled task execution |
 | `chatbot` | Conversational personality |
 | `init` | Setup wizard behavior |
-| `slack-dm` | Slack bot — reply()-based conversation with Slack users |
-| `discord-dm` | Discord bot — reply()-based conversation with Discord users |
-| `channel-admin` | Self-configure channel setup via chat (edit config.yaml, restart bridges) |
 
 Use `agentwire roles list` to see available roles. Roles are bundled in `agentwire/roles/` and can be composed freely in `.agentwire.yml`.

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -125,8 +125,8 @@ tasks:
                           (browser if connected, else local speakers)
 ```
 
-- **Channels** route inbound messages from external platforms into specific sessions, and forward outbound events (alerts, AskUserQuestion, voice) back out. → [Channels](communication/channels.md).
-- **Voice and STT** are *primitives*, not channels: any channel can call `self.tts(...)` and `self.stt(...)` from the base class.
+- **Channels** are outbound-only notification integrations — a session calls `agentwire email` or `agentwire quo` to push a notification out. Inbound user input flows through the portal, not channels. → [Channels](communication/channels.md).
+- **Voice and STT** live on the portal side as `say()` / `listen()` agent tools.
 - **Idle notifications** form a tree: workers → pane 0 of the same session → the `parent:` session (typically human-facing). This is what makes hierarchical multi-session orchestration tractable.
 
 ---


### PR DESCRIPTION
## Summary

Catches up the documentation surface to the inbound-channel gut (#186) and post-gut UI cleanups (#187).

## Changes

- **agentwire-cli skill** — drop telegram / discord / slack / sms / webhook CLI sections; description now mentions email + quo only
- **agentwire-mcp-tools skill** — drop `sms_send` / `webhook_send` / `discord_status` / `slack_status` MCP tools from the channels table; description updated
- **agentwire-config skill** — drop telegram / discord / slack / sms / webhook channel config blocks and the telegram service stanza; description reflects email + quo
- **agentwire-desktop-ui skill** — drop the Socials sidebar section reference; Services description now mentions the explicit allowlist (from #187) instead of the old `startsWith('agentwire-')` match
- **agentwire-project-config skill** — drop `slack-dm` / `discord-dm` / `channel-admin` roles from the role table (those role files were deleted in #186)
- **docs/wiki/architecture.md** — channels paragraph now describes the outbound-only posture; voice/STT pointers updated since the channel base class no longer carries TTS/STT primitives

6 files, +14 / −117.

## Test plan

- [ ] `grep -rE "telegram|discord|slack" .claude/skills/agentwire-* docs/wiki/` returns no hits
- [ ] Eyeball channels skill descriptions render correctly when the agent searches for "send email" or "send SMS"

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified supported messaging channels to email and quo only (outbound notifications).
  * Reorganized desktop UI sidebar: added Workflows and Safety sections; removed Socials accordion.
  * Expanded available system roles with new role types (worker, task-runner, chatbot, init).
  * Clarified architecture documentation on channel capabilities and voice/STT functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->