### PR TITLE
cleanup: scrub remaining stale refs after inbound-channel gut

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -46,7 +46,6 @@ agentwire stt start|stop|status # STT server management
 # Voice
 agentwire say "text"            # speak (auto-routes to browser or local)
 agentwire say -s name "text"    # speak to specific session
-agentwire reply "text"           # reply to channel user (Discord/Slack/Telegram)
 agentwire notify-parent "text"   # notify parent session (worker→orchestrator)
 agentwire notify-parent --to name "text" # notify specific session
 agentwire listen start|stop|cancel  # voice recording

--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-desktop-ui
-description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Socials/Services, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
+description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
 ---
 
 # Portal Desktop UI Patterns

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -36,12 +36,11 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire jump --pane 1` | `pane_jump(pane=1)` |
 | `agentwire resize` | `pane_resize()` |
 
-## Voice & TTS (12 tools)
+## Voice & TTS (11 tools)
 
 | CLI Command | MCP Tool |
 |-------------|----------|
 | `agentwire say "text"` | `say(text="...")` |
-| `agentwire reply "text"` | `reply(text="...")` |
 | `agentwire notify-parent "text"` | `notify(text="...", to="...")` |
 | `agentwire listen start` | `listen_start()` |
 | `agentwire listen stop` | `listen_stop()` |
@@ -66,7 +65,7 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire lock clean` | `lock_clean()` |
 | `agentwire lock remove session` | `lock_remove(session="...")` |
 
-## Operations (10 tools)
+## Operations (12 tools)
 
 | CLI Command | MCP Tool |
 |-------------|----------|
@@ -82,14 +81,13 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire handoff init --title hint` | `handoff_init(title="...")` |
 | `agentwire handoff render <bundle-dir>` | `handoff_render(bundle_dir="...", story=True)` |
 | `agentwire handoff list` | `handoff_list()` |
-| `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."], plain_text=False)` |
 
 ## Channels (outbound-only)
 
 | CLI Command | MCP Tool |
 |-------------|----------|
 | `agentwire channels list` | `channels_list()` |
-| `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."])` |
+| `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."], plain_text=False)` |
 | `agentwire quo --body "..." --to "+1..."` | `quo_send(body="...", to="+1...")` |
 
 ## Notifications & Network (5 tools)
@@ -151,7 +149,7 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | Minimize all | `desktop_minimize_all()` |
 | Multi-window layout | `desktop_layout(windows=[{id: "...", zone: "left"}])` |
 
-**90 tools total.** When to use CLI vs MCP:
+**~85 tools total** (sessions, panes, voice, tasks, channels, scheduler, overnight queue, desktop UI, handoffs). When to use CLI vs MCP:
 - **MCP tools** — Agents in sessions (orchestrators, workers)
 - **CLI commands** — Humans, shell scripts, automation outside of agent sessions
 

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -73,7 +73,6 @@ tasks:
     output:
       capture: 50              # Lines to capture
       save: ~/logs/{{ task }}.log
-      notify: voice            # voice, alert, webhook ${URL}, command "..."
 
     # Branch management (for overnight/async agent workflows)
     starting_ref: main         # Git ref to checkout before task runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Full CLI command reference lives in the `agentwire-cli` skill.
 
 **Agents running in agentwire sessions should use MCP tools instead of CLI commands.**
 
-The `agentwire-mcp-tools` skill has the full reference (87 tools covering sessions, panes, voice, tasks, channels, scheduler, overnight queue, desktop UI). Rule of thumb: MCP for agents, CLI for humans/scripts.
+The `agentwire-mcp-tools` skill has the full reference (sessions, panes, voice, tasks, outbound channels, scheduler, overnight queue, desktop UI, handoffs). Rule of thumb: MCP for agents, CLI for humans/scripts.
 
 **Note:** MCP tools don't support git worktree creation. For isolated commits with worktrees, use the CLI `agentwire spawn --branch <name>` directly.
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ pip install agentwire-dev
 | **Worker Orchestration** | Spawn worker panes, coordinate tasks, voice commands |
 | **Safety Hooks** | 300+ dangerous commands blocked (rm -rf, force push, etc.) |
 | **TTS Responses** | Agents talk back via browser audio |
-| **SDK Sessions** | Structured Claude Agent SDK sessions with parent-child hierarchy |
-| **Telegram Bridge** | Control agents from Telegram with voice notes and inline keyboards |
+| **Outbound Channels** | Email (Resend) + SMS (Quo / OpenPhone) for cross-device notifications |
 | **Session Roles** | Leader/worker patterns for multi-agent workflows |
 
 ---

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2206,8 +2206,8 @@ def cmd_notify_parent(args) -> int:
     Sends a prefixed text message to the parent session via tmux.
     The parent is determined from .agentwire.yml or --to flag.
 
-    This is for session hierarchy communication. For replying to channel
-    users (Discord, Slack, etc.), use reply.
+    This is for session hierarchy communication. For outbound notifications
+    to the user across devices, use `agentwire email` or `agentwire quo`.
 
     Notification targets (in priority order):
     1. --to SESSION if specified

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -665,25 +665,6 @@ def say(text: str, session: str | None = None, voice: str | None = None) -> str:
 
 
 @mcp.tool()
-def reply(text: str) -> str:
-    """Reply to the channel user who messaged this session.
-
-    Use this to respond to Discord, Slack, or Telegram messages.
-    The message is delivered back to the originating platform.
-
-    Args:
-        text: Reply message text
-
-    Returns:
-        Success message or error description.
-    """
-    data = run_agentwire_cmd(["reply", text], json_output=False)
-    if data.get("success"):
-        return "Reply sent."
-    return f"Failed to send reply: {data.get('error', 'Unknown error')}"
-
-
-@mcp.tool()
 def notify(text: str, to: str | None = None) -> str:
     """Notify parent session (worker→orchestrator communication).
 

--- a/agentwire/overnight.py
+++ b/agentwire/overnight.py
@@ -87,9 +87,9 @@ def generate_id() -> str:
 def _inject_resume_flags(agent_cmd: str, session_type: str, resume_session_id: str) -> str:
     """Insert `--resume <id> --fork-session` after the `claude` binary token.
 
-    Phase 5: claude-* only. Other session types (sdk-*, pi-*) have their
-    own resume conventions and the claude-style UUID we record doesn't apply.
-    A no-op when there's nothing to resume or the type doesn't qualify.
+    claude-* only. Other session types (pi-*, bare) have their own resume
+    conventions and the claude-style UUID we record doesn't apply. A no-op
+    when there's nothing to resume or the type doesn't qualify.
 
     The previous form used `rfind("claude")` which was buggy for commands
     that also carry `--model claude-opus-4-7` — it would match inside the

--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -46,7 +46,7 @@ Workers auto-exit when idle. They write summary files before exiting, and you re
 
 ## Hierarchy
 
-Sessions can have parent sessions. When you go idle, your parent is notified. Use `notify(text, to=session)` to send text notifications up the chain. Use `reply(text)` to respond to channel users (Discord, Slack, Telegram).
+Sessions can have parent sessions. When you go idle, your parent is notified. Use `notify(text, to=session)` to send text notifications up the chain.
 
 ## Overnight Queue
 
@@ -80,6 +80,7 @@ When you discover something noteworthy during your work — a technology gotcha,
 
 | Tool | What it does |
 |------|-------------|
-| `reply(text)` | Reply to channel user (Discord, Slack, Telegram) |
 | `notify(text)` | Text notification to parent session |
 | `notify(text, to=name)` | Text notification to specific session |
+| `email_send(body, to)` | Send outbound email via Resend |
+| `quo_send(body, to)` | Send outbound SMS via Quo / OpenPhone |

--- a/agentwire/roles/orchestrator.md
+++ b/agentwire/roles/orchestrator.md
@@ -78,9 +78,9 @@ Make email better.
 
 ## Communication
 
-- **Report to the user** via `reply()` if they're on Discord/Slack/Telegram
 - **Speak updates** via `say()` if voice is enabled
 - **Notify parent** via `notify()` if you have a parent session
+- **Escalate to user** via `email_send()` / `quo_send()` for cross-device push when voice isn't enough
 - **Be concise** — status updates, not novels
 
 ## What NOT to do

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -12,7 +12,7 @@ tmux is the substrate. One agentwire session = one tmux session. Inside that ses
 
 ```
 tmux session "myproject"
-├── pane 0  → orchestrator   (Claude Code, claudeglm, pi, sdk-*)
+├── pane 0  → orchestrator   (Claude Code, claudeglm, pi)
 ├── pane 1  → worker          (spawned via pane_spawn, auto-kills on idle)
 ├── pane 2  → worker
 └── ...
@@ -20,7 +20,7 @@ tmux session "myproject"
 
 The orchestrator coordinates work and dispatches workers via the MCP `pane_spawn` tool. Workers fire an *idle notification* on completion (via `~/.claude/hooks/idle-handler.sh`); the hook routes the alert to pane 0 and kills the worker. Pane 0's own idle notifications route to whatever session is named in `parent:` (typically the human-facing session).
 
-For session types — claude-bypass, claude-auto, claudeglm-*, pi-*, sdk-*, bare — see [Sessions index](INDEX.md#sessions). For the worker-pane lifecycle in detail, see [CLAUDE.md](../../CLAUDE.md#worker-pane-lifecycle).
+For session types — claude-bypass, claude-auto, claudeglm-*, pi-*, bare — see [Sessions index](INDEX.md#sessions). For the worker-pane lifecycle in detail, see [CLAUDE.md](../../CLAUDE.md#worker-pane-lifecycle).
 
 ---
 
@@ -107,25 +107,25 @@ tasks:
 ## Communication Graph
 
 ```
-       External platforms (channels)             Voice / audio (primitives)
-       ───────────────────────────────           ──────────────────────────
-       Discord, Slack, Telegram (bridges)        TTS server (port 8100)
-       Email, SMS, Webhook, Quo (send-only)      STT server (whisperkit / faster-whisper)
-              │              ▲                          │            ▲
-              ▼              │                          ▼            │
+       Outbound channels (send-only)            Voice / audio (primitives)
+       ───────────────────────────────          ──────────────────────────
+       Email (Resend), Quo / OpenPhone SMS      TTS server (port 8100)
+                  ▲                              STT server (whisperkit / faster-whisper)
+                  │                                       │            ▲
+                  │ outbound notifications                ▼            │
        ┌─────────────────────────────────────────────────────────────────┐
        │                      AgentWire sessions                          │
        │                                                                  │
        │   parent: main ◄───── orchestrator ──── pane_spawn ──► worker   │
        │                            │                              │     │
        │                            └───── idle notifications ◄────┘     │
-       └──────────────────────────────────────────────────────────────────┘
+       └─────────────────────────────────────────────────────────────────┘
                                     ▲ ▼
-                          smart audio routing
-                          (browser if connected, else local speakers)
+                          smart audio routing                inbound input
+                  (browser if connected, else local)     ←── via portal WS
 ```
 
-- **Channels** are outbound-only notification integrations — a session calls `agentwire email` or `agentwire quo` to push a notification out. Inbound user input flows through the portal, not channels. → [Channels](communication/channels.md).
+- **Channels** are outbound-only notification integrations — a session calls `agentwire email` or `agentwire quo` to push a notification out. Inbound user input flows through the portal (web + tunnel), not channels. Inbound chat-platform bridges (Telegram, Discord, Slack) were removed; the portal is the single inbound surface. → [Channels](communication/channels.md).
 - **Voice and STT** live on the portal side as `say()` / `listen()` agent tools.
 - **Idle notifications** form a tree: workers → pane 0 of the same session → the `parent:` session (typically human-facing). This is what makes hierarchical multi-session orchestration tractable.
 

--- a/docs/wiki/communication/handoff.md
+++ b/docs/wiki/communication/handoff.md
@@ -151,6 +151,6 @@ The agent picks a theme JSON block based on the session's emotional tone. The re
 ## Out of scope (today)
 
 - Live regeneration / "living HTML presentation" session type — would watch the bundle dir and re-render as the source session adds turns. Future v2.
-- Bundle delivery via Slack / Discord / email — the channels module would extend cleanly to accept a bundle dir; not done yet.
+- Bundle delivery via email — the channels module would extend cleanly to accept a bundle dir; not done yet.
 - Fork-from-bundle — receiver's edits stay separate, optional merge-back.
 - Multi-session bundles (orchestrator + workers).

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -8,13 +8,9 @@ Terms that show up across the docs without a single source-of-truth definition. 
 
 An agent-generated HTML file written to `~/.agentwire/artifacts/` and served by the portal at `/artifacts/<filename>`. Used to share rich output (charts, dashboards, reports) across sessions and devices. → [Portal](internals/portal.md#artifacts).
 
-## B — Bridge
-
-A subtype of *channel* that runs as its own tmux service session and routes inbound messages from a platform (Discord, Slack, Telegram) to agentwire sessions. Bidirectional, long-lived, composable per channel/user. → [Channels](communication/channels.md).
-
 ## C — Channel
 
-An outbound notification integration — a session pushes a message to an external platform (email via Resend, SMS via Quo / OpenPhone). Stateless `SendOnlyChannel` subclasses; no inbound surface. → [Channels](communication/channels.md).
+An outbound notification integration — a session pushes a message to an external platform (email via Resend, SMS via Quo / OpenPhone). Stateless `SendOnlyChannel` subclasses; no inbound surface. Inbound user input flows through the portal, not channels. → [Channels](communication/channels.md).
 
 ## D — Damage Control
 

--- a/docs/wiki/scheduling/workflows.md
+++ b/docs/wiki/scheduling/workflows.md
@@ -114,7 +114,7 @@ nodes:
 
 ## History, persistence, and notifications
 
-Every run persists **independently of notifications**. Whether the workflow emails, posts to Slack, or does nothing at all, you always get:
+Every run persists **independently of notifications**. Whether the workflow emails the user, texts via Quo, or does nothing at all, you always get:
 
 ```
 ~/.agentwire/workflows/runs/<run-id>/

--- a/scripts/queue-processor.sh
+++ b/scripts/queue-processor.sh
@@ -59,14 +59,6 @@ while true; do
         else
             log "Alert failed with exit code $?"
         fi
-        # Also send to Telegram if configured
-        if [[ -n "${TELEGRAM_AGENTWIRE_BOT_TOKEN:-}" && -n "${TELEGRAM_USER_ID:-}" ]]; then
-            TELEGRAM_MSG="[${SESSION}] ${MESSAGE}"
-            curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_AGENTWIRE_BOT_TOKEN}/sendMessage" \
-                -H "Content-Type: application/json" \
-                -d "{\"chat_id\":${TELEGRAM_USER_ID},\"text\":$(printf '%s' "$TELEGRAM_MSG" | jq -Rs .)}" \
-                >>"$DEBUG_LOG" 2>&1 && log "Telegram alert sent" || log "Telegram alert failed"
-        fi
     else
         log "Empty message, skipping"
     fi


### PR DESCRIPTION
## Summary

Final sweep of CLI logic, help text, comments, docs, skills, and CLAUDE.md to remove references to surfaces removed in #186 (inbound channels), prior SDK gut, and prior socials sidebar cleanup. No code paths remain that call non-existent CLI commands or describe removed features.

- **README**: drop "SDK Sessions" + "Telegram Bridge" feature rows, replace with "Outbound Channels"
- **roles/{agentwire,orchestrator}.md**: remove `reply()` tool refs; point at `email_send`/`quo_send` for cross-device escalation
- **mcp_server.py**: delete dead `reply()` MCP tool (shelled out to removed `agentwire reply` CLI)
- **__main__.py**: scrub `cmd_notify_parent` docstring's reply cross-reference
- **overnight.py**: drop `sdk-*` from a comment (SDK gone since 2026-04-12)
- **skills**: agentwire-cli (drop reply line), agentwire-mcp-tools (drop reply row + dedupe email_send), agentwire-desktop-ui (Sessions/Socials → Sessions/Services), agentwire-project-config (drop removed `notify:` task field)
- **CLAUDE.md**: drop hard MCP tool count
- **docs/wiki**: glossary (remove Bridge term, expand Channel), architecture (redraw communication graph, drop `sdk-*`), handoff (Slack/Discord/email → email), workflows (Slack → Quo)
- **scripts/queue-processor.sh**: drop Telegram bot bridge — queue processor now just sends in-tmux alerts; outbound goes via channels

## Test plan

- [x] `agentwire rebuild` succeeds
- [x] `agentwire notify-parent --help` clean (no reply/Discord/Slack/Telegram refs)
- [x] `rg telegram|discord|slack|webhook|sdk-bypass|reply.*Discord` across `agentwire/ docs/ .claude/ README.md` returns only intentional historical mentions in CHANGELOG and the "removed" note in channels.md/architecture.md

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outbound notification channels (Email and SMS) for user alerts and workflow completions.
  * Added session-aware `notify()` tool for inter-session communication.
  * Added session-targeting `say` command variant.

* **Feature Changes**
  * Replaced `reply` command with `say` command for voice interactions.
  * Removed Telegram bridge integration.
  * Updated notification routing to prioritize outbound channels over platform bridges.

* **Documentation**
  * Updated architecture and communication flow documentation to reflect outbound-only channel model.
  * Clarified session hierarchy and parent-notification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->