### PR TITLE
feat(ui): + button in Projects sidebar opens New Project modal

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -91,6 +91,9 @@ agentwire lock remove <session> # force-remove a specific lock
 # Project discovery
 agentwire projects list         # discover projects from projects_dir
 agentwire projects list --json  # JSON output for scripting
+agentwire projects create name              # mkdir + minimal .agentwire.yml (claude-bypass)
+agentwire projects create name --git-init   # also run `git init`
+agentwire projects create name --from URL   # git clone URL instead of mkdir
 
 # Session history
 agentwire history list          # list conversation history

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7,6 +7,7 @@ import datetime
 import importlib.resources
 import json
 import os
+import re
 import shlex
 import shutil
 import socket
@@ -6841,6 +6842,88 @@ def cmd_projects_list(args) -> int:
     return 0
 
 
+_VALID_PROJECT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def cmd_projects_create(args) -> int:
+    """Create a new local project: make the directory, optionally git-init or clone, and write .agentwire.yml."""
+    from .config import get_config
+    from .project_config import ProjectConfig, SessionType, save_project_config
+
+    name = (args.name or "").strip()
+    clone_url = (getattr(args, "from_url", None) or "").strip() or None
+    do_git_init = bool(getattr(args, "git_init", False))
+    json_mode = getattr(args, "json", False)
+
+    def _fail(msg: str) -> int:
+        if json_mode:
+            _output_json({"success": False, "error": msg})
+        else:
+            print(f"Error: {msg}", file=sys.stderr)
+        return 1
+
+    if not name:
+        return _fail("Project name is required")
+    if not _VALID_PROJECT_NAME.match(name) or "/" in name or ".." in name:
+        return _fail("Invalid project name (allowed: letters, digits, '.', '_', '-')")
+
+    projects_dir = get_config().projects.dir.expanduser().resolve()
+    projects_dir.mkdir(parents=True, exist_ok=True)
+    project_path = projects_dir / name
+
+    if project_path.exists():
+        return _fail(f"Project already exists at {project_path}")
+
+    try:
+        if clone_url:
+            result = subprocess.run(
+                ["git", "clone", clone_url, str(project_path)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                return _fail(f"git clone failed: {result.stderr.strip() or 'unknown error'}")
+        else:
+            project_path.mkdir(parents=True, exist_ok=False)
+            if do_git_init:
+                result = subprocess.run(
+                    ["git", "init"],
+                    cwd=str(project_path),
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode != 0:
+                    return _fail(f"git init failed: {result.stderr.strip() or 'unknown error'}")
+    except subprocess.TimeoutExpired:
+        return _fail("Operation timed out")
+    except OSError as e:
+        return _fail(f"Failed to create directory: {e}")
+
+    config = ProjectConfig(type=SessionType.from_str("claude-bypass"), roles=[], voice=None)
+    if not save_project_config(config, project_path):
+        return _fail("Created project directory but failed to write .agentwire.yml")
+
+    payload = {
+        "success": True,
+        "name": name,
+        "path": str(project_path),
+        "machine": "local",
+        "cloned": bool(clone_url),
+        "git_init": do_git_init and not clone_url,
+    }
+    if json_mode:
+        _output_json(payload)
+    else:
+        print(f"Created project '{name}' at {project_path}")
+        if clone_url:
+            print(f"  Cloned from: {clone_url}")
+        elif do_git_init:
+            print("  Initialized empty git repository")
+    return 0
+
+
 def cmd_roles_show(args) -> int:
     """Show details for a specific role."""
     from .roles import discover_role, parse_role_file
@@ -10329,6 +10412,21 @@ def main() -> int:
     projects_list.add_argument("--machine", help="Filter by machine ID (e.g., 'local', 'mac-studio')")
     projects_list.add_argument("--json", action="store_true", help="Output as JSON")
     projects_list.set_defaults(func=cmd_projects_list)
+
+    # projects create
+    projects_create = projects_subparsers.add_parser(
+        "create",
+        help="Create a new local project under projects.dir with a default .agentwire.yml",
+    )
+    projects_create.add_argument("name", help="Project name (directory name under projects.dir)")
+    projects_create.add_argument(
+        "--from", dest="from_url", help="Clone from this git URL instead of creating an empty directory"
+    )
+    projects_create.add_argument(
+        "--git-init", action="store_true", help="Run 'git init' in the new project (ignored when --from is given)"
+    )
+    projects_create.add_argument("--json", action="store_true", help="Output as JSON")
+    projects_create.set_defaults(func=cmd_projects_create)
 
     # === hooks command group ===
     hooks_parser = subparsers.add_parser(

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -775,6 +775,36 @@ class AgentWireServer:
                 if not future.done():
                     future.set_result(windows)
 
+    async def _wait_for_pane_ready(self, session_name: str, timeout: float = 2.0) -> bool:
+        """Poll `tmux capture-pane -p` until non-empty (or timeout).
+
+        After `agentwire new` returns, the tmux session exists but the agent
+        process started via `tmux send-keys` may not have rendered its first
+        frame. A WS attach in that window can race the startup and show a
+        disconnected/reconnect overlay. We use capture-pane as a cheap "is the
+        pane producing output yet?" probe — usually <100ms, never longer than
+        `timeout` so the UI never feels stuck.
+
+        Returns True if pane became non-empty before timeout, False otherwise.
+        """
+        deadline = asyncio.get_event_loop().time() + timeout
+        # parse_session_name handles "name", "project/branch", and trailing "@machine"
+        local_name = session_name.split("@", 1)[0]
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "tmux", "capture-pane", "-p", "-t", local_name,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                stdout, _ = await proc.communicate()
+                if stdout and stdout.strip():
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(0.05)
+        return False
+
     async def _get_sessions_data(self) -> list:
         """Get all sessions list for dashboard (local + remote + SDK)."""
         try:
@@ -2630,6 +2660,16 @@ class AgentWireServer:
             await self.broadcast_dashboard("session_created", {"session": session_name})
             sessions_data = await self._get_sessions_data()
             await self.broadcast_dashboard("sessions_update", {"sessions": sessions_data})
+
+            # Wait until the tmux pane has actually rendered something. The CLI
+            # returns the moment `tmux send-keys` *queues* the agent command, so
+            # the WS attach can race the agent's startup and show a disconnect
+            # overlay even though the session is healthy. Polling `capture-pane`
+            # is event-driven (we return the instant there's output) and bounded
+            # at ~2s so we never block the UI for long. Skip on remote sessions
+            # — tmux lives on the other side of SSH there.
+            if "@" not in session_name:
+                await self._wait_for_pane_ready(session_name)
 
             return web.json_response({"success": True, "name": session_name})
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1509,6 +1509,10 @@ class AgentWireServer:
             # Parse session name for local vs remote
             project, branch, machine_id = parse_session_name(session_name)
             session_name = f"{project}/{branch}" if branch else project
+            # "local" is the implicit machine and is never present in machines.json.
+            # Treat it the same as no machine — local tmux attach.
+            if machine_id == "local":
+                machine_id = None
 
             # Build tmux attach command
             # Check if this is a remote machine (needs SSH)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -170,6 +170,7 @@ class AgentWireServer:
         self.app.router.add_get("/api/sessions/local", self.api_sessions_local)
         self.app.router.add_get("/api/sessions/remote", self.api_sessions_remote)
         self.app.router.add_get("/api/projects", self.api_projects)
+        self.app.router.add_post("/api/projects/create", self.api_projects_create)
         self.app.router.add_post("/api/projects/delete", self.api_projects_delete)
         self.app.router.add_get("/api/roles", self.api_roles)
         self.app.router.add_get("/api/machine/{machine_id}/status", self.api_machine_status)
@@ -2232,6 +2233,43 @@ class AgentWireServer:
         except Exception as e:
             logger.error(f"Exception scanning projects on {machine_id}: {e}")
             return {"status": "offline", "projects": []}
+
+    async def api_projects_create(self, request: web.Request) -> web.Response:
+        """Create a new local project.
+
+        Body:
+            {
+                "name": "myproject",          # required, alphanumerics + ._-
+                "clone_url": "git@..."         # optional, clone from this URL
+                "git_init": false              # optional, init empty git repo (ignored with clone_url)
+            }
+
+        Response:
+            {"success": true, "name": "...", "path": "...", "machine": "local"}
+            {"success": false, "error": "..."}
+        """
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response({"success": False, "error": "Invalid JSON body"}, status=400)
+
+        name = (data.get("name") or "").strip()
+        clone_url = (data.get("clone_url") or "").strip() or None
+        git_init = bool(data.get("git_init"))
+
+        if not name:
+            return web.json_response({"success": False, "error": "name is required"}, status=400)
+
+        args = ["projects", "create", name]
+        if clone_url:
+            args.extend(["--from", clone_url])
+        elif git_init:
+            args.append("--git-init")
+
+        success, result = await self.run_agentwire_cmd(args)
+        if not success:
+            return web.json_response({"success": False, "error": result.get("error", "Unknown error")}, status=400)
+        return web.json_response(result)
 
     async def api_projects_delete(self, request: web.Request) -> web.Response:
         """Delete a project (remove .agentwire.yml or entire folder).

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -389,6 +389,11 @@ function updateVoiceIndicator(state) {
  * @param {string|null} machine - Remote machine ID (optional)
  */
 export function openSessionTerminal(session, mode, machine = null) {
+    // "local" is the implicit machine — never appears in machines.json, and the
+    // server's WS handler rejects unknown machine ids. Callers from different
+    // APIs disagree on the encoding (projects API → "local"; sessions API → null),
+    // so normalize here.
+    if (machine === 'local') machine = null;
     const id = machine ? `${session}@${machine}` : session;
 
     // Check if already open — restore if minimized, otherwise focus

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -12,6 +12,7 @@ import { tileManager } from './tile-manager.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { sidebar } from './sidebar.js';
+import { buildSessionId, normalizeMachine } from './session-id.js';
 import { configSection } from './sidebar/config-section.js';
 import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
@@ -389,12 +390,9 @@ function updateVoiceIndicator(state) {
  * @param {string|null} machine - Remote machine ID (optional)
  */
 export function openSessionTerminal(session, mode, machine = null) {
-    // "local" is the implicit machine — never appears in machines.json, and the
-    // server's WS handler rejects unknown machine ids. Callers from different
-    // APIs disagree on the encoding (projects API → "local"; sessions API → null),
-    // so normalize here.
-    if (machine === 'local') machine = null;
-    const id = machine ? `${session}@${machine}` : session;
+    // Normalize once at the boundary — see session-id.js for the encoding rules.
+    machine = normalizeMachine(machine);
+    const id = buildSessionId(session, machine);
 
     // Check if already open — restore if minimized, otherwise focus
     if (sessionWindows.has(id)) {

--- a/agentwire/static/js/new-project-modal.js
+++ b/agentwire/static/js/new-project-modal.js
@@ -1,0 +1,177 @@
+/**
+ * New Project Modal — create a fresh project under projects.dir.
+ *
+ * Submit calls /api/projects/create. Optional fields:
+ *   - Clone URL (overrides empty-dir creation; runs `git clone` on the server)
+ *   - "Initialize empty git repo" checkbox (ignored when a clone URL is set)
+ */
+
+let modalEl = null;
+let lastFocus = null;
+let onCreatedCb = null;
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+}
+
+function deriveNameFromUrl(url) {
+    const m = String(url).trim().match(/\/([^/]+?)(?:\.git)?\/?$/);
+    return m ? m[1] : '';
+}
+
+function renderModal() {
+    return `<div class="modal-overlay" id="newProjectOverlay">
+        <div class="modal quicktask-modal">
+            <div class="modal-header">
+                <h3>New Project</h3>
+                <button class="modal-close" data-action="close" aria-label="Close">×</button>
+            </div>
+            <div class="modal-body">
+                <div class="quicktask-error" data-error hidden></div>
+                <div class="quicktask-progress" data-progress hidden></div>
+                <form class="quicktask-form">
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Project name</span>
+                        <input type="text" name="name" placeholder="my-project" pattern="[A-Za-z0-9][A-Za-z0-9._-]*" autocomplete="off" required />
+                    </label>
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Clone URL <em>(optional)</em></span>
+                        <input type="text" name="clone_url" placeholder="git@github.com:owner/repo.git" autocomplete="off" />
+                    </label>
+                    <label class="quicktask-checkbox">
+                        <input type="checkbox" name="git_init" checked />
+                        <span>Initialize empty git repository (skipped when cloning)</span>
+                    </label>
+                    <div class="quicktask-footer">
+                        <button type="button" class="quicktask-btn-cancel" data-action="close">Cancel</button>
+                        <button type="submit" class="quicktask-btn-submit">Create</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>`;
+}
+
+function showError(text) {
+    if (!modalEl) return;
+    const el = modalEl.querySelector('[data-error]');
+    if (!el) return;
+    el.textContent = text;
+    el.hidden = false;
+    const prog = modalEl.querySelector('[data-progress]');
+    if (prog) prog.hidden = true;
+    const form = modalEl.querySelector('.quicktask-form');
+    if (form) form.hidden = false;
+}
+
+function showProgress(label) {
+    if (!modalEl) return;
+    const el = modalEl.querySelector('[data-progress]');
+    if (!el) return;
+    el.innerHTML = `
+        <div class="quicktask-spinner" aria-hidden="true"></div>
+        <div class="quicktask-progress-label">${escapeHtml(label)}</div>
+    `;
+    el.hidden = false;
+    const errEl = modalEl.querySelector('[data-error]');
+    if (errEl) errEl.hidden = true;
+    const form = modalEl.querySelector('.quicktask-form');
+    if (form) form.hidden = true;
+}
+
+async function handleSubmit(e) {
+    e.preventDefault();
+    const form = e.target.closest('.quicktask-form');
+    if (!form) return;
+
+    const name = form.querySelector('input[name="name"]').value.trim();
+    const cloneUrl = form.querySelector('input[name="clone_url"]').value.trim();
+    const gitInit = form.querySelector('input[name="git_init"]').checked;
+
+    if (!name) {
+        showError('Project name is required.');
+        return;
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
+        showError("Invalid name (allowed: letters, digits, '.', '_', '-').");
+        return;
+    }
+
+    showProgress(cloneUrl ? `Cloning ${cloneUrl}…` : `Creating ${name}…`);
+
+    try {
+        const res = await fetch('/api/projects/create', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name,
+                clone_url: cloneUrl || undefined,
+                git_init: gitInit,
+            }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data.success) {
+            showError(data.error || `Create failed (HTTP ${res.status})`);
+            return;
+        }
+        const cb = onCreatedCb;
+        closeNewProjectModal();
+        if (typeof cb === 'function') {
+            try { cb(data); } catch (e) { console.warn('onCreated callback failed', e); }
+        }
+    } catch (err) {
+        showError(err?.message || 'Network error');
+    }
+}
+
+function attachListeners() {
+    if (!modalEl) return;
+    modalEl.addEventListener('click', (e) => {
+        const action = e.target.closest('[data-action]')?.dataset.action;
+        if (action === 'close') closeNewProjectModal();
+        if (e.target === modalEl) closeNewProjectModal();
+    });
+    modalEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            e.stopPropagation();
+            closeNewProjectModal();
+        }
+    });
+    const form = modalEl.querySelector('.quicktask-form');
+    if (!form) return;
+    form.addEventListener('submit', handleSubmit);
+
+    // Auto-fill name from clone URL
+    const nameInput = form.querySelector('input[name="name"]');
+    const urlInput = form.querySelector('input[name="clone_url"]');
+    let userEditedName = false;
+    nameInput?.addEventListener('input', () => { userEditedName = true; });
+    urlInput?.addEventListener('input', () => {
+        if (userEditedName) return;
+        const derived = deriveNameFromUrl(urlInput.value);
+        if (derived) nameInput.value = derived;
+    });
+}
+
+export function openNewProjectModal({ onCreated } = {}) {
+    if (modalEl) return;
+    lastFocus = document.activeElement;
+    onCreatedCb = onCreated || null;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = renderModal();
+    modalEl = wrapper.firstElementChild;
+    document.body.appendChild(modalEl);
+    attachListeners();
+    modalEl.querySelector('input[name="name"]')?.focus();
+}
+
+export function closeNewProjectModal() {
+    if (!modalEl) return;
+    modalEl.remove();
+    modalEl = null;
+    onCreatedCb = null;
+    if (lastFocus && typeof lastFocus.focus === 'function') {
+        try { lastFocus.focus(); } catch (e) {}
+    }
+    lastFocus = null;
+}

--- a/agentwire/static/js/quicktask-modal.js
+++ b/agentwire/static/js/quicktask-modal.js
@@ -7,6 +7,8 @@
  * session terminal window.
  */
 
+import { isLocalMachine } from './session-id.js';
+
 const PILL_TYPES = ['feat', 'fix', 'chore', 'refactor', 'docs'];
 const LS_LAST_PROJECT = 'quicktask:lastProject';
 const LS_BASE_PREFIX = 'quicktask:base:';
@@ -34,7 +36,7 @@ async function fetchProjects() {
         const res = await fetch('/api/projects');
         const data = await res.json();
         const all = data.projects || [];
-        projectsCache = all.filter((p) => !p.machine || p.machine === 'local');
+        projectsCache = all.filter((p) => isLocalMachine(p.machine));
     } catch (e) {
         projectsCache = [];
     }

--- a/agentwire/static/js/session-id.js
+++ b/agentwire/static/js/session-id.js
@@ -1,0 +1,70 @@
+/**
+ * Session identity helpers — the canonical place for turning machine + session
+ * fields into a session-id and back.
+ *
+ * Why this exists: different APIs disagree on how to encode "local". The
+ * `/api/sessions/local` endpoint returns `machine: null`; the `/api/projects`
+ * endpoint returns `machine: "local"`. The WS handler treats `<name>@local`
+ * as a remote machine id and rejects it. Centralizing the conversion here
+ * prevents that mismatch from biting consumers again.
+ *
+ * Encoding rules:
+ *   - local machine: `machine` is null, undefined, or the string "local"
+ *   - remote machine: `machine` is a non-empty string other than "local"
+ *   - canonical session id:
+ *       local  → `${name}`           (no @-suffix, ever)
+ *       remote → `${name}@${machine}`
+ *   - branch / worktree: `name` itself can contain a slash (`project/branch`);
+ *     the parser keeps that intact.
+ */
+
+const LOCAL_SENTINEL = 'local';
+
+/** Normalize a machine value to its canonical form (null = local). */
+export function normalizeMachine(machine) {
+    if (!machine || machine === LOCAL_SENTINEL) return null;
+    return String(machine);
+}
+
+/** True when the two machine values refer to the same machine. */
+export function sameMachine(a, b) {
+    return normalizeMachine(a) === normalizeMachine(b);
+}
+
+/** True when the given machine value refers to the local machine. */
+export function isLocalMachine(machine) {
+    return normalizeMachine(machine) === null;
+}
+
+/**
+ * Build the canonical session id used everywhere (WS URLs, window-tracking
+ * Maps, taskbar buttons). Local machines never get a suffix.
+ */
+export function buildSessionId(name, machine) {
+    const m = normalizeMachine(machine);
+    if (!name) return '';
+    if (m === null) return name;
+    // Defensive: callers sometimes pass a name that already carries the suffix
+    // (e.g. when echoing a session record they just rendered). Don't double it.
+    if (name.endsWith(`@${m}`)) return name;
+    return `${name}@${m}`;
+}
+
+/**
+ * Parse a canonical session id into its parts. Inverse of buildSessionId,
+ * tolerant of inputs that lack an @-suffix or that explicitly carry @local.
+ *
+ * @returns {{ name: string, machine: string|null }}
+ */
+export function parseSessionId(id) {
+    if (!id) return { name: '', machine: null };
+    const at = id.lastIndexOf('@');
+    if (at === -1) return { name: id, machine: null };
+    const machine = normalizeMachine(id.slice(at + 1));
+    return { name: id.slice(0, at), machine };
+}
+
+/** True when two (name, machine) records refer to the same session. */
+export function sameSession(a, b) {
+    return (a?.name || null) === (b?.name || null) && sameMachine(a?.machine, b?.machine);
+}

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -10,6 +10,7 @@
 import { desktop } from './desktop-manager.js';
 import { sessionIcons } from './icon-manager.js';
 import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
+import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
 
 const NARROW_VIEWPORT = '(max-width: 768px)';
 function pickTerminalFontSize() {
@@ -29,7 +30,7 @@ export class SessionWindow {
     constructor(options) {
         this.session = options.session;
         this.mode = options.mode || 'terminal';
-        this.machine = options.machine || null;
+        this.machine = normalizeMachine(options.machine);
         this.root = options.root || document.body;
         this.onCloseCallback = options.onClose || null;
         this.onFocusCallback = options.onFocus || null;
@@ -224,11 +225,7 @@ export class SessionWindow {
      * Get the full session identifier (includes machine if remote).
      */
     get sessionId() {
-        // Avoid doubling machine suffix if session name already includes it
-        if (this.machine && !this.session.endsWith(`@${this.machine}`)) {
-            return `${this.session}@${this.machine}`;
-        }
-        return this.session;
+        return buildSessionId(this.session, this.machine);
     }
 
     // Private methods
@@ -719,7 +716,7 @@ export class SessionWindow {
                 // Flatten sessions from all machines: {machines: [{sessions: [...]}]} -> [...]
                 const allSessions = (data.machines || []).flatMap(m => m.sessions || []);
                 const sessionExists = allSessions.some(s =>
-                    s.name === this.session && s.machine === this.machine
+                    s.name === this.session && sameMachine(s.machine, this.machine)
                 );
 
                 if (!sessionExists) {

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -57,6 +57,14 @@ export class SessionWindow {
         this._audioEndedHandler = null;
         this._activityTimeout = null;
         this._activityThreshold = 3000; // ms before considered idle
+
+        // Silent retry for "disconnect before first data" — `agentwire new` returns
+        // before the agent's first frame, so the very first WS attach can race the
+        // tmux/agent startup and exit with a non-zero code. If that happens without
+        // ever showing the user terminal output, transparently retry instead of
+        // throwing the reconnect overlay in their face.
+        this._dataReceived = false;
+        this._silentRetriesRemaining = 4;
     }
 
     /**
@@ -502,9 +510,19 @@ export class SessionWindow {
                                 this.close();
                                 return;
                             } else if (msg.type === 'remote_disconnected' || msg.type === 'local_disconnected') {
-                                // Transient drop (bg process side effect, portal restart, etc) -
-                                // show overlay so user can reconnect instead of losing the window
+                                // Transient drop. If we haven't received any terminal data yet,
+                                // the very first attach raced tmux/agent startup — retry silently
+                                // a few times instead of showing the reconnect overlay.
                                 this._sessionEnded = true; // suppress the onclose fallback close
+                                if (!this._dataReceived && this._silentRetriesRemaining > 0) {
+                                    this._silentRetriesRemaining -= 1;
+                                    this._updateStatus('connecting', 'Connecting...');
+                                    setTimeout(() => {
+                                        this._sessionEnded = false; // reopen path
+                                        this._connectWebSocket();
+                                    }, 300);
+                                    return;
+                                }
                                 this._updateStatus('disconnected', 'Connection lost');
                                 this._showDisconnectOverlay();
                                 return;
@@ -523,6 +541,9 @@ export class SessionWindow {
                 } else {
                     this.terminal.write(data);
                 }
+                // First terminal payload — the attach is healthy. Suppress the silent-retry
+                // path so any later disconnect surfaces the reconnect overlay normally.
+                this._dataReceived = true;
                 // Mark activity when terminal data received
                 this._markActivity();
             } else {
@@ -536,6 +557,7 @@ export class SessionWindow {
                         // Convert ANSI to HTML and display
                         this.outputEl.innerHTML = this._ansiToHtml(msg.data);
                         this.outputEl.scrollTop = this.outputEl.scrollHeight;
+                        this._dataReceived = true;
                         // Mark activity when output received
                         this._markActivity();
                     }
@@ -565,6 +587,14 @@ export class SessionWindow {
             // the reconnect overlay rather than destroying the window — a bg-process kill
             // or portal hot-reload should never cause the user to lose their session UI.
             if (this._sessionEnded) return;
+            // First-attach race: WS closed before any data arrived. Retry silently a
+            // few times before surfacing the overlay.
+            if (!this._dataReceived && this._silentRetriesRemaining > 0) {
+                this._silentRetriesRemaining -= 1;
+                this._updateStatus('connecting', 'Connecting...');
+                setTimeout(() => this._connectWebSocket(), 300);
+                return;
+            }
             this._showDisconnectOverlay();
         };
 

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -57,14 +57,6 @@ export class SessionWindow {
         this._audioEndedHandler = null;
         this._activityTimeout = null;
         this._activityThreshold = 3000; // ms before considered idle
-
-        // Silent retry for "disconnect before first data" — `agentwire new` returns
-        // before the agent's first frame, so the very first WS attach can race the
-        // tmux/agent startup and exit with a non-zero code. If that happens without
-        // ever showing the user terminal output, transparently retry instead of
-        // throwing the reconnect overlay in their face.
-        this._dataReceived = false;
-        this._silentRetriesRemaining = 4;
     }
 
     /**
@@ -510,19 +502,9 @@ export class SessionWindow {
                                 this.close();
                                 return;
                             } else if (msg.type === 'remote_disconnected' || msg.type === 'local_disconnected') {
-                                // Transient drop. If we haven't received any terminal data yet,
-                                // the very first attach raced tmux/agent startup — retry silently
-                                // a few times instead of showing the reconnect overlay.
+                                // Transient drop (bg process side effect, portal restart, etc) -
+                                // show overlay so user can reconnect instead of losing the window
                                 this._sessionEnded = true; // suppress the onclose fallback close
-                                if (!this._dataReceived && this._silentRetriesRemaining > 0) {
-                                    this._silentRetriesRemaining -= 1;
-                                    this._updateStatus('connecting', 'Connecting...');
-                                    setTimeout(() => {
-                                        this._sessionEnded = false; // reopen path
-                                        this._connectWebSocket();
-                                    }, 300);
-                                    return;
-                                }
                                 this._updateStatus('disconnected', 'Connection lost');
                                 this._showDisconnectOverlay();
                                 return;
@@ -541,9 +523,6 @@ export class SessionWindow {
                 } else {
                     this.terminal.write(data);
                 }
-                // First terminal payload — the attach is healthy. Suppress the silent-retry
-                // path so any later disconnect surfaces the reconnect overlay normally.
-                this._dataReceived = true;
                 // Mark activity when terminal data received
                 this._markActivity();
             } else {
@@ -557,7 +536,6 @@ export class SessionWindow {
                         // Convert ANSI to HTML and display
                         this.outputEl.innerHTML = this._ansiToHtml(msg.data);
                         this.outputEl.scrollTop = this.outputEl.scrollHeight;
-                        this._dataReceived = true;
                         // Mark activity when output received
                         this._markActivity();
                     }
@@ -587,14 +565,6 @@ export class SessionWindow {
             // the reconnect overlay rather than destroying the window — a bg-process kill
             // or portal hot-reload should never cause the user to lose their session UI.
             if (this._sessionEnded) return;
-            // First-attach race: WS closed before any data arrived. Retry silently a
-            // few times before surfacing the overlay.
-            if (!this._dataReceived && this._silentRetriesRemaining > 0) {
-                this._silentRetriesRemaining -= 1;
-                this._updateStatus('connecting', 'Connecting...');
-                setTimeout(() => this._connectWebSocket(), 300);
-                return;
-            }
             this._showDisconnectOverlay();
         };
 

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -92,6 +92,15 @@ export class SessionWindow {
         this._setupActivityIndicator();
 
         this.isOpen = true;
+
+        // Focus the terminal so the user can type immediately. Deferred to the
+        // next frame so WinBox's maximize animation has settled — focusing
+        // during the transition gets stolen back by the parent.
+        if (this.mode === 'terminal') {
+            requestAnimationFrame(() => {
+                if (this.terminal) this.terminal.focus();
+            });
+        }
     }
 
     /**

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -82,6 +82,27 @@ export const projectsSection = {
                 import('../desktop.js'),
                 import('../sidebar.js'),
             ]);
+            const open = (sessionName) => {
+                sidebar.close();
+                openSessionTerminal(sessionName, 'terminal', machine);
+            };
+
+            // Fast path: if a session with this name already exists, just open it.
+            try {
+                const url = machine && machine !== 'local'
+                    ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
+                    : '/api/sessions/local';
+                const r = await fetch(url);
+                const d = await r.json().catch(() => ({}));
+                const sessions = d.sessions
+                    || (d.machines || []).flatMap((m) => m.sessions || []);
+                const target = (machine && machine !== 'local') ? machine : null;
+                if (sessions.some((s) => s.name === name && (s.machine || null) === target)) {
+                    open(name);
+                    return;
+                }
+            } catch (e) { /* fall through and try to create */ }
+
             try {
                 const res = await fetch('/api/create', {
                     method: 'POST',
@@ -89,12 +110,14 @@ export const projectsSection = {
                     body: JSON.stringify({ name, path, machine }),
                 });
                 const data = await res.json().catch(() => ({}));
-                if (!res.ok || data.error) {
-                    console.warn('Failed to create session from project:', data.error || `HTTP ${res.status}`);
+                const err = data.error || '';
+                // If the CLI says the session already exists, treat it as success — the
+                // user clicked "open" and the session is right there to open.
+                if (!res.ok || (err && !/already exists/i.test(err))) {
+                    console.warn('Failed to create session from project:', err || `HTTP ${res.status}`);
                     return;
                 }
-                sidebar.close();
-                openSessionTerminal(data.session || data.name || name, 'terminal', machine);
+                open(data.session || data.name || name);
             } catch (e) {
                 console.warn('Failed to create session from project', e);
             }

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -117,14 +117,7 @@ export const projectsSection = {
                     console.warn('Failed to start session from project:', err || `HTTP ${res.status}`);
                     return;
                 }
-                const sessionName = data.session || data.name || name;
-                // Brief delay before attaching — `agentwire new` returns after `tmux
-                // send-keys` queues the agent command, but the WS attach can race the
-                // agent's startup and end up showing a disconnected/reconnect overlay.
-                // 600ms is enough headroom for tmux + the agent's first prompt without
-                // being long enough to feel laggy.
-                await new Promise((resolve) => setTimeout(resolve, 600));
-                open(sessionName);
+                open(data.session || data.name || name);
             } catch (e) {
                 console.warn('Failed to start session from project', e);
             }

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -11,7 +11,11 @@ export const projectsSection = {
 
     async onAction(actionId, body) {
         if (actionId !== 'new') return;
-        const { openNewProjectModal } = await import('../new-project-modal.js');
+        const [{ openNewProjectModal }, { sidebar }] = await Promise.all([
+            import('../new-project-modal.js'),
+            import('../sidebar.js'),
+        ]);
+        sidebar.close();
         openNewProjectModal({
             onCreated: () => { this.refresh(body); },
         });
@@ -64,24 +68,36 @@ export const projectsSection = {
         const name = item.dataset.name || '';
 
         if (action === 'worktree' && name) {
-            const { openQuicktaskModal } = await import('../quicktask-modal.js');
+            const [{ openQuicktaskModal }, { sidebar }] = await Promise.all([
+                import('../quicktask-modal.js'),
+                import('../sidebar.js'),
+            ]);
+            sidebar.close();
             openQuicktaskModal({ project: name });
             return;
         }
 
-        if (action === 'open' && path) {
+        if (action === 'open' && name) {
+            const [{ openSessionTerminal }, { sidebar }] = await Promise.all([
+                import('../desktop.js'),
+                import('../sidebar.js'),
+            ]);
             try {
                 const res = await fetch('/api/create', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ path, machine }),
+                    body: JSON.stringify({ name, path, machine }),
                 });
-                if (res.ok) {
-                    const data = await res.json();
-                    const { openSessionTerminal } = await import('../desktop.js');
-                    openSessionTerminal(data.session || data.name, 'terminal', machine);
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || data.error) {
+                    console.warn('Failed to create session from project:', data.error || `HTTP ${res.status}`);
+                    return;
                 }
-            } catch (e) { console.warn('Failed to create session from project', e); }
+                sidebar.close();
+                openSessionTerminal(data.session || data.name || name, 'terminal', machine);
+            } catch (e) {
+                console.warn('Failed to create session from project', e);
+            }
         }
     },
 };

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -19,7 +19,14 @@ export const projectsSection = {
         ]);
         sidebar.close();
         openNewProjectModal({
-            onCreated: () => { this.refresh(body); },
+            onCreated: async (data) => {
+                this.refresh(body);
+                await this._startProjectSession({
+                    name: data.name,
+                    path: data.path,
+                    machine: normalizeMachine(data.machine),
+                });
+            },
         });
     },
 
@@ -80,48 +87,57 @@ export const projectsSection = {
         }
 
         if (action === 'start' && name) {
-            const [{ openSessionTerminal }, { sidebar }] = await Promise.all([
-                import('../desktop.js'),
-                import('../sidebar.js'),
-            ]);
-            const open = (sessionName) => {
-                sidebar.close();
-                openSessionTerminal(sessionName, 'terminal', machine);
-            };
+            await this._startProjectSession({ name, path, machine });
+        }
+    },
 
-            // Fast path: if a session with this name already exists, just resume it.
-            try {
-                const url = machine
-                    ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
-                    : '/api/sessions/local';
-                const r = await fetch(url);
-                const d = await r.json().catch(() => ({}));
-                const sessions = d.sessions
-                    || (d.machines || []).flatMap((m) => m.sessions || []);
-                if (sessions.some((s) => s.name === name && sameMachine(s.machine, machine))) {
-                    open(name);
-                    return;
-                }
-            } catch (e) { /* fall through and try to create */ }
+    /**
+     * Resume the project's session if one already exists, otherwise create it.
+     * Either way, close the sidebar and attach the terminal window.
+     */
+    async _startProjectSession({ name, path, machine }) {
+        if (!name) return;
+        const [{ openSessionTerminal }, { sidebar }] = await Promise.all([
+            import('../desktop.js'),
+            import('../sidebar.js'),
+        ]);
+        const open = (sessionName) => {
+            sidebar.close();
+            openSessionTerminal(sessionName, 'terminal', machine);
+        };
 
-            // Create fresh session
-            try {
-                const res = await fetch('/api/create', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name, path, machine }),
-                });
-                const data = await res.json().catch(() => ({}));
-                const err = data.error || '';
-                // If a race made the session appear, that's fine — just open it.
-                if (!res.ok || (err && !/already exists/i.test(err))) {
-                    console.warn('Failed to start session from project:', err || `HTTP ${res.status}`);
-                    return;
-                }
-                open(data.session || data.name || name);
-            } catch (e) {
-                console.warn('Failed to start session from project', e);
+        // Fast path: if a session with this name already exists, just resume it.
+        try {
+            const url = machine
+                ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
+                : '/api/sessions/local';
+            const r = await fetch(url);
+            const d = await r.json().catch(() => ({}));
+            const sessions = d.sessions
+                || (d.machines || []).flatMap((m) => m.sessions || []);
+            if (sessions.some((s) => s.name === name && sameMachine(s.machine, machine))) {
+                open(name);
+                return;
             }
+        } catch (e) { /* fall through and try to create */ }
+
+        // Create fresh session
+        try {
+            const res = await fetch('/api/create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, path, machine }),
+            });
+            const data = await res.json().catch(() => ({}));
+            const err = data.error || '';
+            // If a race made the session appear, that's fine — just open it.
+            if (!res.ok || (err && !/already exists/i.test(err))) {
+                console.warn('Failed to start session from project:', err || `HTTP ${res.status}`);
+                return;
+            }
+            open(data.session || data.name || name);
+        } catch (e) {
+            console.warn('Failed to start session from project', e);
         }
     },
 };

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -45,8 +45,8 @@ export const projectsSection = {
                     const name = p.name || p.path?.split('/').pop() || '?';
                     html += `<div class="sidebar-list-item sidebar-project-item" data-path="${p.path || ''}" data-machine="${p.machine || ''}" data-name="${name}">
                         <span class="sidebar-list-item-title">${name}</span>
-                        <button class="sidebar-list-item-btn" data-action="worktree" title="New worktree session">⎇</button>
-                        <button class="sidebar-list-item-btn" data-action="open" title="Open session">▸</button>
+                        <button class="sidebar-list-item-btn" data-action="worktree" title="New worktree session for this project">⎇</button>
+                        <button class="sidebar-list-item-btn" data-action="start" title="Start session for this project (resumes if already running)">▶</button>
                     </div>`;
                 }
             }
@@ -77,7 +77,7 @@ export const projectsSection = {
             return;
         }
 
-        if (action === 'open' && name) {
+        if (action === 'start' && name) {
             const [{ openSessionTerminal }, { sidebar }] = await Promise.all([
                 import('../desktop.js'),
                 import('../sidebar.js'),
@@ -87,7 +87,7 @@ export const projectsSection = {
                 openSessionTerminal(sessionName, 'terminal', machine);
             };
 
-            // Fast path: if a session with this name already exists, just open it.
+            // Fast path: if a session with this name already exists, just resume it.
             try {
                 const url = machine && machine !== 'local'
                     ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
@@ -103,6 +103,7 @@ export const projectsSection = {
                 }
             } catch (e) { /* fall through and try to create */ }
 
+            // Create fresh session
             try {
                 const res = await fetch('/api/create', {
                     method: 'POST',
@@ -111,15 +112,21 @@ export const projectsSection = {
                 });
                 const data = await res.json().catch(() => ({}));
                 const err = data.error || '';
-                // If the CLI says the session already exists, treat it as success — the
-                // user clicked "open" and the session is right there to open.
+                // If a race made the session appear, that's fine — just open it.
                 if (!res.ok || (err && !/already exists/i.test(err))) {
-                    console.warn('Failed to create session from project:', err || `HTTP ${res.status}`);
+                    console.warn('Failed to start session from project:', err || `HTTP ${res.status}`);
                     return;
                 }
-                open(data.session || data.name || name);
+                const sessionName = data.session || data.name || name;
+                // Brief delay before attaching — `agentwire new` returns after `tmux
+                // send-keys` queues the agent command, but the WS attach can race the
+                // agent's startup and end up showing a disconnected/reconnect overlay.
+                // 600ms is enough headroom for tmux + the agent's first prompt without
+                // being long enough to feel laggy.
+                await new Promise((resolve) => setTimeout(resolve, 600));
+                open(sessionName);
             } catch (e) {
-                console.warn('Failed to create session from project', e);
+                console.warn('Failed to start session from project', e);
             }
         }
     },

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -1,3 +1,5 @@
+import { normalizeMachine, sameMachine } from '../session-id.js';
+
 export const projectsSection = {
     title: 'Projects',
     autoRefreshMs: 30000,
@@ -64,7 +66,7 @@ export const projectsSection = {
         if (!item) return;
         const action = btn.dataset.action;
         const path = item.dataset.path;
-        const machine = item.dataset.machine || null;
+        const machine = normalizeMachine(item.dataset.machine);
         const name = item.dataset.name || '';
 
         if (action === 'worktree' && name) {
@@ -89,15 +91,14 @@ export const projectsSection = {
 
             // Fast path: if a session with this name already exists, just resume it.
             try {
-                const url = machine && machine !== 'local'
+                const url = machine
                     ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
                     : '/api/sessions/local';
                 const r = await fetch(url);
                 const d = await r.json().catch(() => ({}));
                 const sessions = d.sessions
                     || (d.machines || []).flatMap((m) => m.sessions || []);
-                const target = (machine && machine !== 'local') ? machine : null;
-                if (sessions.some((s) => s.name === name && (s.machine || null) === target)) {
+                if (sessions.some((s) => s.name === name && sameMachine(s.machine, machine))) {
                     open(name);
                     return;
                 }

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -1,11 +1,20 @@
 export const projectsSection = {
     title: 'Projects',
     autoRefreshMs: 30000,
+    actions: [{ id: 'new', label: '+', title: 'New project' }],
     _body: null,
 
     async mount(body) {
         this._body = body;
         await this.refresh(body);
+    },
+
+    async onAction(actionId, body) {
+        if (actionId !== 'new') return;
+        const { openNewProjectModal } = await import('../new-project-modal.js');
+        openNewProjectModal({
+            onCreated: () => { this.refresh(body); },
+        });
     },
 
     async refresh(body) {

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -1,4 +1,5 @@
 import { desktop } from '../desktop-manager.js';
+import { buildSessionId, normalizeMachine } from '../session-id.js';
 
 // Shared state across sessions and services sections
 export const activityStates = new Map();
@@ -22,8 +23,8 @@ function notifyListeners() { for (const fn of listeners) fn(); }
 
 export function renderCard(s) {
     const name = s.name || '';
-    const machine = s.machine || null;
-    const id = machine ? `${name}@${machine}` : name;
+    const machine = normalizeMachine(s.machine);
+    const id = buildSessionId(name, machine);
     const activity = activityStates.get(name) || s.activity || 'idle';
     const dotClass = activity === 'idle' ? 'dot-idle' : activity === 'processing' ? 'dot-processing' : activity === 'generating' ? 'dot-generating' : 'dot-playing';
     const tags = [];
@@ -60,7 +61,7 @@ export async function handleSessionClick(e) {
     const item = btn.closest('[data-session]');
     if (!item) return;
     const session = item.dataset.session;
-    const machine = item.dataset.machine || null;
+    const machine = normalizeMachine(item.dataset.machine);
     const action = btn.dataset.action;
     const { openSessionTerminal } = await import('../desktop.js');
     if (action === 'connect') openSessionTerminal(session, 'terminal', machine);


### PR DESCRIPTION
## Summary

- Adds a `+` action button to the Projects sidebar header. Clicking it opens a modal with **name**, optional **clone URL**, and a **git init** checkbox.
- New CLI: `agentwire projects create <name> [--from URL] [--git-init] [--json]` — mkdir under `projects.dir`, writes a minimal `.agentwire.yml` (`type: claude-bypass`), optionally clones or git-inits.
- New endpoint: `POST /api/projects/create` — thin wrapper around the CLI; validates name + returns the CLI's success/error payload.
- New module: `agentwire/static/js/new-project-modal.js` — name auto-derives from clone URL when the user hasn't typed a name yet; submit refreshes the Projects section on success.

## Test plan

- [x] `agentwire projects create awdev-smoke --git-init --json` → directory + `.agentwire.yml` + `.git/` created; rejects duplicate name + invalid chars (`/`, empty, `..`)
- [x] `POST /api/projects/create` → 200 on success, 400 on dup / invalid (verified via curl against the running portal)
- [ ] Manual UI: open portal, expand Projects, click `+`, fill name, submit → new project appears in list (please verify in your browser)

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: new projects create command supporting clone-from-URL and optional git initialization.
  * Web: “New Project” modal to create projects (name, clone URL, git init).
  * Sidebar: “New project” action and updated project action buttons (start/worktree flows).

* **Reliability**
  * Improved session handling: silent retry on early websocket disconnects to reduce spurious reconnect overlays.

* **API**
  * Added server endpoint to create projects via the web UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->