### PR TITLE
feat(missions): core loop — dispatcher + feedback router (#195 PR 1/3)

### DIFF
--- a/agentwire/missions/__init__.py
+++ b/agentwire/missions/__init__.py
@@ -1,0 +1,30 @@
+"""Missions: first-class auto-dispatcher subsystem.
+
+Tick mission-dispatcher → spawn worker session for an eligible GitHub issue.
+Tick pr-feedback-router → inject new PR review comments into the worker.
+Tick worktree-janitor → tear down sessions + worktrees for merged/closed PRs.
+
+See docs/MISSIONS.md (Phase 8) and issue #195 for the full design.
+"""
+
+from agentwire.missions.config import MissionsConfig, RepoConfig, load_config
+from agentwire.missions.naming import (
+    branch_name,
+    is_mission_session,
+    parse_mission_session,
+    session_name,
+    slugify,
+    worktree_path,
+)
+
+__all__ = [
+    "MissionsConfig",
+    "RepoConfig",
+    "load_config",
+    "branch_name",
+    "is_mission_session",
+    "parse_mission_session",
+    "session_name",
+    "slugify",
+    "worktree_path",
+]

--- a/agentwire/missions/config.py
+++ b/agentwire/missions/config.py
@@ -1,0 +1,93 @@
+"""Missions config loader.
+
+Two sources, merged with per-repo override winning over the matching global entry:
+
+1. ``~/.agentwire/missions.yaml`` — global defaults + repo registry
+2. ``.agentwire.yml`` ``missions:`` block — per-repo override of select keys
+
+Repos are keyed by short name (e.g. ``agentwire-dev``); ``name`` holds the full
+``owner/repo`` form used by ``gh`` CLI commands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+GLOBAL_CONFIG_PATH = Path.home() / ".agentwire" / "missions.yaml"
+
+
+@dataclass
+class RepoConfig:
+    """A configured target repo for missions."""
+
+    short: str                # local key, e.g. "agentwire-dev"
+    name: str                 # GitHub full name, e.g. "dotdevdotdev/agentwire-dev"
+    projects_dir: Path        # parent dir; worktrees go in {projects_dir}/{short}-worktrees/
+    per_repo_concurrency: int = 1
+
+
+@dataclass
+class MissionsConfig:
+    """Top-level missions configuration."""
+
+    repos: dict[str, RepoConfig] = field(default_factory=dict)
+    global_concurrency: int = 3
+    work_hours_start: int = 9
+    work_hours_end: int = 18
+    default_max_iterations: int = 3
+
+    def get_repo(self, short: str) -> RepoConfig | None:
+        return self.repos.get(short)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+    except (yaml.YAMLError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_config(
+    global_path: Path = GLOBAL_CONFIG_PATH,
+    project_config_path: Path | None = None,
+) -> MissionsConfig:
+    """Load missions config.
+
+    Per-repo override only updates fields under a matched repo entry; the
+    repo must already exist in the global registry. Unknown repos in the
+    project override are silently ignored.
+    """
+    global_data = _load_yaml(global_path)
+    cfg = MissionsConfig(
+        global_concurrency=int(global_data.get("global_concurrency", 3)),
+        work_hours_start=int(global_data.get("work_hours_start", 9)),
+        work_hours_end=int(global_data.get("work_hours_end", 18)),
+        default_max_iterations=int(global_data.get("default_max_iterations", 3)),
+    )
+    for short, raw in (global_data.get("repos") or {}).items():
+        cfg.repos[short] = RepoConfig(
+            short=short,
+            name=raw["name"],
+            projects_dir=Path(raw["projects_dir"]).expanduser(),
+            per_repo_concurrency=int(raw.get("per_repo_concurrency", 1)),
+        )
+
+    if project_config_path is not None:
+        project_data = _load_yaml(project_config_path)
+        override = project_data.get("missions") or {}
+        repo_short = override.get("repo")
+        if repo_short and repo_short in cfg.repos:
+            if "per_repo_concurrency" in override:
+                cfg.repos[repo_short].per_repo_concurrency = int(
+                    override["per_repo_concurrency"]
+                )
+
+    return cfg

--- a/agentwire/missions/dispatcher.py
+++ b/agentwire/missions/dispatcher.py
@@ -1,0 +1,300 @@
+"""Mission dispatcher: pick eligible GitHub issues, spawn worker sessions.
+
+Stateless. Runs every 30 minutes from launchd during work hours, or on demand
+via ``agentwire mission tick``. Uses ``session_lock`` keyed on issue number to
+make concurrent runs safe.
+
+Side-effecting helpers (subprocess calls, github calls, tmux paste) live as
+module-level functions so tests can monkeypatch them. Pure logic stays in
+``eligibility`` and ``naming``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from agentwire.locking import LockConflict, session_lock
+from agentwire.missions import eligibility, github, naming, state
+from agentwire.missions.config import MissionsConfig, RepoConfig, load_config
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class DispatchReport:
+    """Result of one tick — useful for CLI/JSON output."""
+
+    started_at: str
+    dispatched: list[dict] = field(default_factory=list)
+    skipped: list[dict] = field(default_factory=list)
+    out_of_hours: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "started_at": self.started_at,
+            "out_of_hours": self.out_of_hours,
+            "dispatched": list(self.dispatched),
+            "skipped": list(self.skipped),
+        }
+
+
+# --- side-effecting helpers (monkeypatched in tests) --------------------------
+
+
+def list_mission_sessions() -> list[str]:
+    """Return names of running mission sessions (filtered through ``naming``)."""
+    result = subprocess.run(
+        ["agentwire", "list", "--sessions", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        log.warning("agentwire list failed: %s", result.stderr.strip())
+        return []
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    sessions = data.get("sessions", []) if isinstance(data, dict) else []
+    names = [s.get("name", "") for s in sessions if isinstance(s, dict)]
+    return [n for n in names if n and naming.is_mission_session(n)]
+
+
+def create_worker_session(session_full_name: str) -> None:
+    """Create a new mission worker session via ``agentwire new``.
+
+    Raises ``RuntimeError`` on failure.
+    """
+    result = subprocess.run(
+        [
+            "agentwire", "new",
+            "-s", session_full_name,
+            "--type", "claude-bypass",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"agentwire new failed (rc={result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def wait_for_session_ready(session_full_name: str, timeout: float = 30.0) -> bool:
+    """Poll the worker pane until its claude prompt shows up.
+
+    Looks for ``❯`` or ``Bypassing Permissions`` in the last ~20 lines of
+    output. Returns True on detection, False on timeout.
+    """
+    from agentwire import pane_manager
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            out = pane_manager.capture_pane(session_full_name, 0, lines=20)
+        except Exception:
+            time.sleep(0.5)
+            continue
+        if "❯" in out or "Bypassing Permissions" in out:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def send_prompt_to_worker(session_full_name: str, prompt: str) -> None:
+    """Inject the initial prompt into the worker session's pane 0."""
+    from agentwire import pane_manager
+
+    pane_manager.send_to_target(f"{session_full_name}.0", prompt, enter=True)
+
+
+def _within_work_hours(now: datetime, config: MissionsConfig) -> bool:
+    return config.work_hours_start <= now.hour < config.work_hours_end
+
+
+def _build_initial_prompt(
+    issue: github.Issue,
+    criteria: list[str],
+    branch: str,
+    repo: RepoConfig,
+) -> str:
+    """Assemble the initial worker prompt from issue body + criteria."""
+    crit = "\n".join(f"- {c}" for c in criteria)
+    return (
+        f"You are working on issue #{issue.number} in {repo.name}.\n"
+        f"\n"
+        f"## Issue title\n"
+        f"{issue.title}\n"
+        f"\n"
+        f"## Issue body\n"
+        f"{issue.body}\n"
+        f"\n"
+        f"## Acceptance criteria\n"
+        f"{crit}\n"
+        f"\n"
+        f"## Your task\n"
+        f"\n"
+        f"You are in an isolated git worktree on branch `{branch}`. Make the\n"
+        f"code changes to satisfy the acceptance criteria. Then:\n"
+        f"\n"
+        f"1. Commit your work with a clear message.\n"
+        f"2. Push the branch.\n"
+        f"3. Open a DRAFT pull request titled `mission #{issue.number}: <short summary>`\n"
+        f"   whose body references the issue (e.g. `Closes #{issue.number}`).\n"
+        f"4. Stop and wait for review.\n"
+        f"\n"
+        f"When you receive review feedback, you'll be sent `/clear` followed by\n"
+        f"a context-refresh prompt pointing at a summary file. Address the\n"
+        f"feedback, push, and wait again — the PR-feedback router handles each\n"
+        f"round. Begin.\n"
+    )
+
+
+# --- public entry point -------------------------------------------------------
+
+
+def tick(config: MissionsConfig | None = None, *, now: datetime | None = None) -> DispatchReport:
+    """One dispatcher tick.
+
+    Args:
+        config: Pre-loaded config; if None, loads from disk.
+        now: Override for "current time" (testing).
+    """
+    if config is None:
+        config = load_config()
+    if now is None:
+        now = datetime.now()
+
+    report = DispatchReport(started_at=now.isoformat())
+
+    if not _within_work_hours(now, config):
+        report.out_of_hours = True
+        state.record_tick("dispatcher")
+        return report
+
+    active_sessions = list_mission_sessions()
+    per_repo_active: dict[str, int] = {}
+    for s in active_sessions:
+        parsed = naming.parse_mission_session(s)
+        if parsed:
+            per_repo_active[parsed[0]] = per_repo_active.get(parsed[0], 0) + 1
+    global_active = len(active_sessions)
+
+    for repo_short, repo in config.repos.items():
+        if global_active >= config.global_concurrency:
+            report.skipped.append({"repo": repo_short, "reason": "global concurrency cap"})
+            break
+
+        repo_active = per_repo_active.get(repo_short, 0)
+        if repo_active >= repo.per_repo_concurrency:
+            report.skipped.append({"repo": repo_short, "reason": "per-repo concurrency cap"})
+            continue
+
+        try:
+            issues = github.list_issues(repo.name)
+        except github.GitHubError as e:
+            log.warning("github.list_issues(%s) failed: %s", repo.name, e)
+            report.skipped.append({"repo": repo_short, "reason": f"github error: {e}"})
+            continue
+
+        eligible_issues: list[github.Issue] = []
+        for issue in sorted(issues, key=lambda i: i.number):
+            ok, reason = eligibility.is_eligible(issue)
+            if ok:
+                eligible_issues.append(issue)
+            else:
+                report.skipped.append(
+                    {"repo": repo_short, "issue": issue.number, "reason": reason}
+                )
+
+        for issue in eligible_issues:
+            if (
+                repo_active >= repo.per_repo_concurrency
+                or global_active >= config.global_concurrency
+            ):
+                break
+            if _dispatch_one(repo_short, repo, issue, report):
+                repo_active += 1
+                global_active += 1
+
+    state.record_tick("dispatcher")
+    return report
+
+
+def _dispatch_one(
+    repo_short: str,
+    repo: RepoConfig,
+    issue: github.Issue,
+    report: DispatchReport,
+) -> bool:
+    """Try to dispatch one issue. Returns True on success."""
+    slug = naming.slugify(issue.title)
+    session_full = naming.session_name(repo_short, issue.number, slug)
+    branch = naming.branch_name(issue.number, slug)
+    lock_key = f"mission-{issue.number}"
+
+    try:
+        with session_lock(lock_key, wait=False):
+            try:
+                create_worker_session(session_full)
+            except RuntimeError as e:
+                report.skipped.append(
+                    {
+                        "repo": repo_short,
+                        "issue": issue.number,
+                        "reason": f"create_session failed: {e}",
+                    }
+                )
+                return False
+
+            if not wait_for_session_ready(session_full):
+                report.skipped.append(
+                    {
+                        "repo": repo_short,
+                        "issue": issue.number,
+                        "reason": "session not ready before timeout",
+                    }
+                )
+                return False
+
+            criteria = eligibility.extract_acceptance_criteria(issue.body) or []
+            prompt = _build_initial_prompt(issue, criteria, branch, repo)
+            send_prompt_to_worker(session_full, prompt)
+
+            try:
+                github.comment_issue(
+                    repo.name,
+                    issue.number,
+                    f"Dispatched to mission worker session `{session_full}` "
+                    f"on branch `{branch}`.\n\n— mission-dispatcher",
+                )
+            except github.GitHubError as e:
+                log.warning("comment_issue failed for #%d: %s", issue.number, e)
+
+            report.dispatched.append(
+                {
+                    "repo": repo_short,
+                    "issue": issue.number,
+                    "session": session_full,
+                    "branch": branch,
+                }
+            )
+            return True
+    except LockConflict:
+        report.skipped.append(
+            {
+                "repo": repo_short,
+                "issue": issue.number,
+                "reason": "locked (another dispatcher run in flight)",
+            }
+        )
+        return False

--- a/agentwire/missions/eligibility.py
+++ b/agentwire/missions/eligibility.py
@@ -1,0 +1,61 @@
+"""Eligibility gates for mission dispatch.
+
+Two gates AND'd:
+
+1. Issue carries the ``agent-ready`` label and is in state ``OPEN``.
+2. Issue body contains a case-insensitive ``## Acceptance criteria`` header,
+   followed (before the next ``##`` header) by at least one bullet
+   (``- ...``, ``* ...``, or ``+ ...``).
+
+Pure logic — no I/O.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agentwire.missions.github import Issue
+
+AGENT_READY_LABEL = "agent-ready"
+
+_HEADER_RE = re.compile(
+    r"^[ \t]*##[ \t]+acceptance[ \t]+criteria[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_NEXT_HEADER_RE = re.compile(r"^[ \t]*##[ \t]+\S+", re.MULTILINE)
+_BULLET_RE = re.compile(r"^[ \t]*[-*+][ \t]+(\S.*)$", re.MULTILINE)
+
+
+def has_agent_ready_label(issue: Issue) -> bool:
+    return AGENT_READY_LABEL in issue.labels
+
+
+def extract_acceptance_criteria(body: str) -> list[str] | None:
+    """Extract bullet text under the first ``## Acceptance criteria`` header.
+
+    Returns the list of bullet text (stripped, marker removed), or None if
+    the header is missing or no bullets follow it before the next ``##``.
+    """
+    if not body:
+        return None
+    header = _HEADER_RE.search(body)
+    if not header:
+        return None
+    start = header.end()
+    next_header = _NEXT_HEADER_RE.search(body, pos=start)
+    end = next_header.start() if next_header else len(body)
+    section = body[start:end]
+    bullets = [m.group(1).strip() for m in _BULLET_RE.finditer(section)]
+    return bullets or None
+
+
+def is_eligible(issue: Issue) -> tuple[bool, str]:
+    """Returns ``(eligible, reason_if_not_eligible)``."""
+    if issue.state != "OPEN":
+        return False, f"issue state is {issue.state or '<unknown>'}, not OPEN"
+    if not has_agent_ready_label(issue):
+        return False, f"missing label '{AGENT_READY_LABEL}'"
+    criteria = extract_acceptance_criteria(issue.body)
+    if not criteria:
+        return False, "no '## Acceptance criteria' section with bullets"
+    return True, ""

--- a/agentwire/missions/feedback_router.py
+++ b/agentwire/missions/feedback_router.py
@@ -1,0 +1,180 @@
+"""PR feedback router: inject new PR reviews into the worker session.
+
+Stateless. Runs every 15 minutes from launchd, or on demand via
+``agentwire mission route-feedback``.
+
+For each active mission session, find the associated PR by branch, list its
+reviews, route any not-yet-routed ones (state-tracked per PR) into the
+worker's session as a ``/clear`` + context-refresh prompt pair pointing at a
+per-mission summary file. The summary file (not Claude's in-context memory)
+is the durable record of what the worker should do next — keeps the worker's
+context bounded across many feedback rounds.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from agentwire.missions import dispatcher, eligibility, github, naming, state
+from agentwire.missions.config import MissionsConfig, load_config
+
+log = logging.getLogger(__name__)
+
+SUMMARIES_DIR = Path.home() / ".agentwire" / "missions" / "summaries"
+
+# Settle delay after sending /clear before the next prompt arrives.
+CLEAR_SETTLE_SECONDS = 1.0
+
+
+@dataclass
+class FeedbackReport:
+    """Result of one feedback-router tick — useful for CLI/JSON output."""
+
+    started_at: str
+    routed: list[dict] = field(default_factory=list)
+    skipped: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "started_at": self.started_at,
+            "routed": list(self.routed),
+            "skipped": list(self.skipped),
+        }
+
+
+def summary_path(repo_short: str, issue_number: int, slug: str) -> Path:
+    """Filesystem path for a mission's per-round summary file."""
+    return SUMMARIES_DIR / repo_short / f"{naming.branch_name(issue_number, slug)}.md"
+
+
+def build_summary(
+    issue: github.Issue,
+    pr: github.PullRequest,
+    new_reviews: list[github.Review],
+) -> str:
+    """Compose the markdown the worker reads on each refresh round."""
+    criteria = eligibility.extract_acceptance_criteria(issue.body) or []
+    crit_lines = "\n".join(f"- [ ] {c}" for c in criteria) or "- (no criteria parsed)"
+    review_blocks = []
+    for r in new_reviews:
+        body = r.body.strip() if r.body else "(no body)"
+        review_blocks.append(
+            f"### Review by @{r.user} ({r.state}) — {r.submitted_at}\n\n{body}\n"
+        )
+    reviews_section = "\n".join(review_blocks) if review_blocks else "(no reviewer comments)"
+    return (
+        f"# Mission #{issue.number}: {issue.title}\n"
+        f"\n"
+        f"PR: {pr.url}\n"
+        f"\n"
+        f"## Acceptance criteria\n"
+        f"{crit_lines}\n"
+        f"\n"
+        f"## New review feedback\n"
+        f"\n"
+        f"{reviews_section}\n"
+        f"\n"
+        f"## Next steps\n"
+        f"\n"
+        f"Address the feedback above. Commit and push. Stop and wait for the next review.\n"
+    )
+
+
+def _send_context_refresh(session_full: str, summary_file: Path) -> None:
+    """Send ``/clear`` and then a refresh prompt pointing at ``summary_file``.
+
+    Two paste operations with a small settle between so Claude has time to
+    process the ``/clear`` before the next prompt arrives.
+    """
+    dispatcher.send_prompt_to_worker(session_full, "/clear")
+    time.sleep(CLEAR_SETTLE_SECONDS)
+    refresh = (
+        f"New PR review feedback is in. Read this summary file and address "
+        f"each item, then commit and push:\n\n"
+        f"  {summary_file}\n\n"
+        f"When done, stop and wait for the next review round."
+    )
+    dispatcher.send_prompt_to_worker(session_full, refresh)
+
+
+def route_feedback(config: MissionsConfig | None = None) -> FeedbackReport:
+    """One router tick.
+
+    Walks active mission sessions, finds new PR reviews, writes summary files,
+    and pushes ``/clear`` + refresh prompts into each affected worker.
+    """
+    if config is None:
+        config = load_config()
+
+    report = FeedbackReport(started_at=datetime.now().isoformat())
+
+    for session_full in dispatcher.list_mission_sessions():
+        parsed = naming.parse_mission_session(session_full)
+        if not parsed:
+            continue
+        repo_short, issue_number, slug = parsed
+
+        repo = config.get_repo(repo_short)
+        if repo is None:
+            report.skipped.append({"session": session_full, "reason": "repo not in config"})
+            continue
+
+        branch = naming.branch_name(issue_number, slug)
+        try:
+            pr = github.get_pr_by_branch(repo.name, branch)
+        except github.GitHubError as e:
+            report.skipped.append({"session": session_full, "reason": f"get_pr_by_branch: {e}"})
+            continue
+        if pr is None:
+            report.skipped.append({"session": session_full, "reason": "no PR for branch yet"})
+            continue
+        if pr.state != "OPEN":
+            report.skipped.append({"session": session_full, "reason": f"PR is {pr.state}"})
+            continue
+
+        try:
+            reviews = github.list_pr_reviews(repo.name, pr.number)
+        except github.GitHubError as e:
+            report.skipped.append({"session": session_full, "reason": f"list_pr_reviews: {e}"})
+            continue
+
+        last_seen = state.last_routed_review(pr.number) or 0
+        new_reviews = [r for r in reviews if r.id > last_seen]
+        if not new_reviews:
+            report.skipped.append({"session": session_full, "reason": "no new reviews"})
+            continue
+
+        try:
+            issue = github.get_issue(repo.name, issue_number)
+        except github.GitHubError as e:
+            report.skipped.append({"session": session_full, "reason": f"get_issue: {e}"})
+            continue
+
+        summary = build_summary(issue, pr, new_reviews)
+        summary_file = summary_path(repo_short, issue_number, slug)
+        summary_file.parent.mkdir(parents=True, exist_ok=True)
+        summary_file.write_text(summary)
+
+        try:
+            _send_context_refresh(session_full, summary_file)
+        except Exception as e:
+            report.skipped.append({"session": session_full, "reason": f"send failed: {e}"})
+            continue
+
+        latest_id = max(r.id for r in new_reviews)
+        state.update_routed_review(pr.number, latest_id)
+        report.routed.append(
+            {
+                "session": session_full,
+                "pr": pr.number,
+                "reviews_routed": len(new_reviews),
+                "summary": str(summary_file),
+            }
+        )
+
+    state.record_tick("feedback_router")
+    return report

--- a/agentwire/missions/github.py
+++ b/agentwire/missions/github.py
@@ -1,0 +1,204 @@
+"""GitHub access for missions — thin wrappers around the ``gh`` CLI.
+
+Why ``gh`` (and not the REST API directly): the user already has ``gh``
+authenticated; building our own token plumbing duplicates that. ``gh ... --json``
+covers most of what we need; PR reviews are the one gap (no ``--json`` flag on
+``gh pr view``'s reviews field), so we fall through to ``gh api`` for that.
+
+All callers receive frozen dataclasses, never raw ``gh`` JSON, so swap-outs
+later (graphql, direct REST) stay invisible to ``eligibility`` / ``dispatcher``
+/ ``feedback_router``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+
+
+class GitHubError(RuntimeError):
+    """Raised when a ``gh`` call fails after retries."""
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    state: str  # "OPEN" | "CLOSED"
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    state: str  # "OPEN" | "MERGED" | "CLOSED"
+    head_ref: str
+    url: str
+    is_draft: bool
+
+
+@dataclass(frozen=True)
+class Review:
+    id: int
+    state: str  # "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING"
+    body: str
+    submitted_at: str  # ISO-8601 or ""
+    user: str
+
+
+_RETRYABLE_STDERR_FRAGMENTS = ("rate limit", "secondary rate limit", "abuse detection")
+
+
+def _run_gh(args: list[str], *, parse_json: bool = True, timeout: int = 30) -> object:
+    """Run ``gh <args>``. Parses stdout as JSON unless ``parse_json`` is False.
+
+    Retries up to 3 times on rate-limit hints (sleeping 2s between attempts).
+    """
+    last_err = ""
+    for attempt in range(3):
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            if not parse_json:
+                return result.stdout
+            stdout = result.stdout.strip()
+            if not stdout:
+                return None
+            try:
+                return json.loads(stdout)
+            except json.JSONDecodeError as e:
+                raise GitHubError(
+                    f"gh returned non-JSON for `gh {' '.join(args)}`: {e}\n{stdout[:200]}"
+                ) from e
+
+        stderr = (result.stderr or "").strip()
+        last_err = stderr or result.stdout.strip()
+        if attempt < 2 and any(frag in stderr.lower() for frag in _RETRYABLE_STDERR_FRAGMENTS):
+            time.sleep(2)
+            continue
+        break
+    raise GitHubError(f"gh {' '.join(args)} failed: {last_err}")
+
+
+def _parse_issue(d: dict) -> Issue:
+    labels = tuple(lbl.get("name", "") for lbl in (d.get("labels") or []))
+    return Issue(
+        number=int(d["number"]),
+        title=d.get("title") or "",
+        body=d.get("body") or "",
+        labels=labels,
+        state=(d.get("state") or "").upper(),
+    )
+
+
+def _parse_pr(d: dict) -> PullRequest:
+    return PullRequest(
+        number=int(d["number"]),
+        state=(d.get("state") or "").upper(),
+        head_ref=d.get("headRefName") or "",
+        url=d.get("url") or "",
+        is_draft=bool(d.get("isDraft", False)),
+    )
+
+
+def _parse_review(d: dict) -> Review:
+    user = (d.get("user") or {}).get("login") or ""
+    return Review(
+        id=int(d["id"]),
+        state=(d.get("state") or "").upper(),
+        body=d.get("body") or "",
+        submitted_at=d.get("submitted_at") or "",
+        user=user,
+    )
+
+
+def list_issues(repo: str, label: str = "agent-ready", limit: int = 50) -> list[Issue]:
+    """List open issues on ``repo`` carrying ``label``."""
+    data = _run_gh(
+        [
+            "issue", "list",
+            "--repo", repo,
+            "--label", label,
+            "--state", "open",
+            "--json", "number,title,body,labels,state",
+            "--limit", str(limit),
+        ]
+    )
+    return [_parse_issue(item) for item in (data or [])]
+
+
+def get_issue(repo: str, number: int) -> Issue:
+    """Fetch a single issue by number."""
+    data = _run_gh(
+        [
+            "issue", "view", str(number),
+            "--repo", repo,
+            "--json", "number,title,body,labels,state",
+        ]
+    )
+    return _parse_issue(data)
+
+
+def get_pr_by_branch(repo: str, branch: str) -> PullRequest | None:
+    """Return the PR whose head branch is ``branch`` (any state), or None."""
+    data = _run_gh(
+        [
+            "pr", "list",
+            "--repo", repo,
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,state,headRefName,url,isDraft",
+            "--limit", "1",
+        ]
+    )
+    if not data:
+        return None
+    return _parse_pr(data[0])
+
+
+def get_pr(repo: str, number: int) -> PullRequest | None:
+    """Fetch a single PR by number, or None if not found."""
+    try:
+        data = _run_gh(
+            [
+                "pr", "view", str(number),
+                "--repo", repo,
+                "--json", "number,state,headRefName,url,isDraft",
+            ]
+        )
+    except GitHubError:
+        return None
+    if not data:
+        return None
+    return _parse_pr(data)
+
+
+def list_pr_reviews(repo: str, pr_number: int) -> list[Review]:
+    """List review submissions on a PR.
+
+    Uses ``gh api repos/{repo}/pulls/{n}/reviews`` since ``gh pr view`` has no
+    ``--json reviews`` flag.
+    """
+    data = _run_gh(["api", f"repos/{repo}/pulls/{pr_number}/reviews"])
+    if not isinstance(data, list):
+        return []
+    return [_parse_review(item) for item in data]
+
+
+def comment_issue(repo: str, number: int, body: str) -> None:
+    """Post a comment on an issue."""
+    _run_gh(
+        [
+            "issue", "comment", str(number),
+            "--repo", repo,
+            "--body", body,
+        ],
+        parse_json=False,
+    )

--- a/agentwire/missions/naming.py
+++ b/agentwire/missions/naming.py
@@ -1,0 +1,83 @@
+"""Mission name derivations — pure functions, no I/O.
+
+Convention:
+- Session name:  {repo_short}/mission-{N}-{slug}
+- Git branch:    mission-{N}-{slug}
+- Worktree path: {projects_dir}/{repo_short}-worktrees/mission-{N}-{slug}
+
+The branch uses a dash (not `mission/N-slug` with a slash) because
+`agentwire/worktree.py:parse_session_name` splits a session name on its first
+`/` to derive (project, branch); a slashed branch would collide with that
+parser. The dash form preserves a 1:1 mapping between session, branch, and
+worktree.
+"""
+
+import re
+import unicodedata
+from pathlib import Path
+
+MAX_SLUG_LEN = 40
+
+
+def slugify(title: str) -> str:
+    """Convert a freeform issue title to an ASCII lower-kebab slug (≤40 chars).
+
+    Empty input or input that contains no alphanumerics returns "untitled".
+    """
+    normalized = unicodedata.normalize("NFKD", title)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only.lower()).strip("-")
+    if not slug:
+        return "untitled"
+    if len(slug) > MAX_SLUG_LEN:
+        slug = slug[:MAX_SLUG_LEN].rstrip("-")
+    return slug or "untitled"
+
+
+def branch_name(issue_number: int, slug: str) -> str:
+    """Git branch name for a mission. Format: ``mission-{N}-{slug}``."""
+    return f"mission-{issue_number}-{slug}"
+
+
+def session_name(repo_short: str, issue_number: int, slug: str) -> str:
+    """Tmux session name for a mission worker. Format: ``{repo}/mission-{N}-{slug}``.
+
+    Parses (via ``parse_session_name``) as project=``{repo_short}``,
+    branch=``mission-{N}-{slug}`` — matching the worktree path derivation.
+    """
+    return f"{repo_short}/{branch_name(issue_number, slug)}"
+
+
+def worktree_path(
+    projects_dir: Path,
+    repo_short: str,
+    issue_number: int,
+    slug: str,
+) -> Path:
+    """Filesystem path for the mission worker's git worktree.
+
+    Matches ``agentwire/worktree.py:get_session_path`` derivation:
+    ``{projects_dir}/{repo_short}-worktrees/{branch_name}``.
+    """
+    return projects_dir / f"{repo_short}-worktrees" / branch_name(issue_number, slug)
+
+
+_MISSION_BRANCH_RE = re.compile(r"^mission-(\d+)-(.+)$")
+
+
+def parse_mission_session(name: str) -> tuple[str, int, str] | None:
+    """Inverse of :func:`session_name`. Returns ``(repo_short, issue_number, slug)``
+    or ``None`` for foreign session names.
+    """
+    if "/" not in name:
+        return None
+    repo, branch = name.split("/", 1)
+    m = _MISSION_BRANCH_RE.match(branch)
+    if not m:
+        return None
+    return repo, int(m.group(1)), m.group(2)
+
+
+def is_mission_session(name: str) -> bool:
+    """True iff ``name`` is a well-formed mission session name."""
+    return parse_mission_session(name) is not None

--- a/agentwire/missions/state.py
+++ b/agentwire/missions/state.py
@@ -1,0 +1,102 @@
+"""Local state for the missions subsystem.
+
+State files live under ``~/.agentwire/missions/state/``. State is small JSON,
+written atomically via tempfile + ``os.replace`` so concurrent orchestrator
+runs don't tear each other's writes.
+
+- ``last_tick.json``: ``{component: iso_timestamp}`` heartbeats for
+  dispatcher / feedback_router / gc.
+- ``routed_reviews.json``: ``{pr_number_str: last_routed_review_id}`` —
+  feedback-router idempotency key per PR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".agentwire" / "missions" / "state"
+LAST_TICK_PATH = STATE_DIR / "last_tick.json"
+ROUTED_REVIEWS_PATH = STATE_DIR / "routed_reviews.json"
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write JSON atomically: temp file in same dir, then ``os.replace``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_last_tick() -> dict:
+    """Return the dict of ``{component: iso_timestamp}``."""
+    return _read_json(LAST_TICK_PATH)
+
+
+def record_tick(component: str) -> None:
+    """Stamp the current time for a component (``dispatcher`` / ``feedback_router`` / ``gc``)."""
+    data = read_last_tick()
+    data[component] = _now_iso()
+    _atomic_write(LAST_TICK_PATH, data)
+
+
+def read_routed_reviews() -> dict[str, int]:
+    """Return ``{pr_number_str: last_routed_review_id}``."""
+    raw = _read_json(ROUTED_REVIEWS_PATH)
+    out: dict[str, int] = {}
+    for k, v in raw.items():
+        try:
+            out[str(k)] = int(v)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def write_routed_reviews(data: dict[str, int]) -> None:
+    """Persist the full ``{pr_number_str: review_id}`` dict."""
+    _atomic_write(ROUTED_REVIEWS_PATH, {str(k): int(v) for k, v in data.items()})
+
+
+def update_routed_review(pr_number: int, review_id: int) -> None:
+    """Bump a single PR's last-routed-review-id."""
+    data = read_routed_reviews()
+    data[str(pr_number)] = int(review_id)
+    write_routed_reviews(data)
+
+
+def last_routed_review(pr_number: int) -> int | None:
+    """Return the last review id we routed for a PR, or ``None``."""
+    return read_routed_reviews().get(str(pr_number))
+
+
+def forget_pr(pr_number: int) -> None:
+    """Drop a PR's review-tracking entry (called by gc when PR is reaped)."""
+    data = read_routed_reviews()
+    data.pop(str(pr_number), None)
+    write_routed_reviews(data)

--- a/tests/unit/test_missions_config.py
+++ b/tests/unit/test_missions_config.py
@@ -1,0 +1,97 @@
+"""Tests for ``agentwire.missions.config`` — yaml loading + override merge."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agentwire.missions.config import MissionsConfig, load_config
+
+
+@pytest.fixture
+def missions_yaml(tmp_path):
+    """Write a minimal global ``missions.yaml`` and return its path."""
+    p = tmp_path / "missions.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "global_concurrency": 3,
+                "work_hours_start": 9,
+                "work_hours_end": 18,
+                "default_max_iterations": 3,
+                "repos": {
+                    "agentwire-dev": {
+                        "name": "dotdevdotdev/agentwire-dev",
+                        "projects_dir": "/Users/dotdev/projects",
+                        "per_repo_concurrency": 1,
+                    },
+                },
+            }
+        )
+    )
+    return p
+
+
+class TestLoadConfig:
+    def test_missing_file_returns_defaults(self, tmp_path):
+        cfg = load_config(global_path=tmp_path / "nope.yaml")
+        assert isinstance(cfg, MissionsConfig)
+        assert cfg.global_concurrency == 3
+        assert cfg.work_hours_start == 9
+        assert cfg.work_hours_end == 18
+        assert cfg.default_max_iterations == 3
+        assert cfg.repos == {}
+
+    def test_loads_global(self, missions_yaml):
+        cfg = load_config(global_path=missions_yaml)
+        assert cfg.global_concurrency == 3
+        assert "agentwire-dev" in cfg.repos
+        repo = cfg.repos["agentwire-dev"]
+        assert repo.name == "dotdevdotdev/agentwire-dev"
+        assert repo.projects_dir == Path("/Users/dotdev/projects")
+        assert repo.per_repo_concurrency == 1
+
+    def test_project_override_per_repo_concurrency(self, missions_yaml, tmp_path):
+        project_cfg = tmp_path / ".agentwire.yml"
+        project_cfg.write_text(
+            yaml.safe_dump({"missions": {"repo": "agentwire-dev", "per_repo_concurrency": 2}})
+        )
+        cfg = load_config(global_path=missions_yaml, project_config_path=project_cfg)
+        assert cfg.repos["agentwire-dev"].per_repo_concurrency == 2
+
+    def test_project_override_for_unknown_repo_is_ignored(self, missions_yaml, tmp_path):
+        project_cfg = tmp_path / ".agentwire.yml"
+        project_cfg.write_text(
+            yaml.safe_dump({"missions": {"repo": "ghost-repo", "per_repo_concurrency": 99}})
+        )
+        cfg = load_config(global_path=missions_yaml, project_config_path=project_cfg)
+        assert "ghost-repo" not in cfg.repos
+        assert cfg.repos["agentwire-dev"].per_repo_concurrency == 1
+
+    def test_malformed_yaml_falls_back_to_defaults(self, tmp_path):
+        p = tmp_path / "broken.yaml"
+        p.write_text("::not valid yaml: [")
+        cfg = load_config(global_path=p)
+        assert cfg.global_concurrency == 3
+        assert cfg.repos == {}
+
+    def test_get_repo(self, missions_yaml):
+        cfg = load_config(global_path=missions_yaml)
+        repo = cfg.get_repo("agentwire-dev")
+        assert repo is not None
+        assert repo.name == "dotdevdotdev/agentwire-dev"
+        assert cfg.get_repo("nope") is None
+
+    def test_tilde_in_projects_dir_expanded(self, tmp_path):
+        p = tmp_path / "missions.yaml"
+        p.write_text(
+            yaml.safe_dump(
+                {
+                    "repos": {
+                        "x": {"name": "owner/x", "projects_dir": "~/projects"},
+                    }
+                }
+            )
+        )
+        cfg = load_config(global_path=p)
+        assert str(cfg.repos["x"].projects_dir).startswith(str(Path.home()))

--- a/tests/unit/test_missions_dispatcher.py
+++ b/tests/unit/test_missions_dispatcher.py
@@ -1,0 +1,244 @@
+"""Tests for ``agentwire.missions.dispatcher.tick``.
+
+All side-effecting functions (subprocess, GitHub, tmux paste) are monkeypatched
+to no-op or to return canned data. The locking module is real (fcntl-based) but
+points at a tmp dir.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from agentwire import locking
+from agentwire.missions import dispatcher, github, state
+from agentwire.missions.config import MissionsConfig, RepoConfig
+from agentwire.missions.github import Issue
+
+# --- shared fixtures ----------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_locks(tmp_path, monkeypatch):
+    monkeypatch.setattr(locking, "LOCKS_DIR", tmp_path / "locks")
+    (tmp_path / "locks").mkdir()
+    return tmp_path / "locks"
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    state_dir = tmp_path / "missions-state"
+    monkeypatch.setattr(state, "STATE_DIR", state_dir)
+    monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
+    monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+
+
+@pytest.fixture
+def config():
+    return MissionsConfig(
+        repos={
+            "agentwire-dev": RepoConfig(
+                short="agentwire-dev",
+                name="owner/agentwire-dev",
+                projects_dir=Path("/tmp/projects"),
+                per_repo_concurrency=1,
+            ),
+        },
+        global_concurrency=3,
+        work_hours_start=9,
+        work_hours_end=18,
+    )
+
+
+def eligible_issue(number: int = 1, title: str = "Add a thing") -> Issue:
+    return Issue(
+        number=number,
+        title=title,
+        body="## Acceptance criteria\n- do the thing\n",
+        labels=("agent-ready",),
+        state="OPEN",
+    )
+
+
+@pytest.fixture
+def patch_world(monkeypatch):
+    """Patch all dispatcher side-effects to no-ops by default.
+
+    Tests override individual behaviors by reassigning attributes on the
+    returned ``World`` object, or by re-monkeypatching specific helpers.
+    """
+
+    class World:
+        # active session names returned by list_mission_sessions
+        active_sessions: list[str] = []
+        # list of issues returned by github.list_issues, per repo full name
+        issues_by_repo: dict[str, list[Issue]] = {}
+        # collect each invocation
+        created_sessions: list[str] = []
+        prompts_sent: list[tuple[str, str]] = []
+        comments_made: list[tuple[str, int, str]] = []
+        ready_response: bool = True
+        create_raises: bool = False
+
+    world = World()
+    world.issues_by_repo = {}
+    world.active_sessions = []
+    world.created_sessions = []
+    world.prompts_sent = []
+    world.comments_made = []
+
+    monkeypatch.setattr(dispatcher, "list_mission_sessions", lambda: list(world.active_sessions))
+
+    def _list_issues(repo, label="agent-ready", limit=50):
+        return list(world.issues_by_repo.get(repo, []))
+
+    monkeypatch.setattr(github, "list_issues", _list_issues)
+
+    def _create(session):
+        if world.create_raises:
+            raise RuntimeError("forced create failure")
+        world.created_sessions.append(session)
+
+    monkeypatch.setattr(dispatcher, "create_worker_session", _create)
+    monkeypatch.setattr(dispatcher, "wait_for_session_ready", lambda s, timeout=30.0: world.ready_response)
+    monkeypatch.setattr(
+        dispatcher,
+        "send_prompt_to_worker",
+        lambda s, p: world.prompts_sent.append((s, p)),
+    )
+    monkeypatch.setattr(
+        github,
+        "comment_issue",
+        lambda r, n, b: world.comments_made.append((r, n, b)),
+    )
+    return world
+
+
+# --- tests --------------------------------------------------------------------
+
+
+class TestWorkHours:
+    def test_out_of_hours_short_circuit(self, config, patch_world):
+        # 8am — before start (9)
+        now = datetime(2026, 5, 19, 8, 0)
+        report = dispatcher.tick(config, now=now)
+        assert report.out_of_hours is True
+        assert report.dispatched == []
+        # state still recorded
+        assert "dispatcher" in state.read_last_tick()
+
+    def test_after_hours(self, config, patch_world):
+        now = datetime(2026, 5, 19, 19, 0)
+        report = dispatcher.tick(config, now=now)
+        assert report.out_of_hours is True
+
+    def test_within_hours(self, config, patch_world):
+        now = datetime(2026, 5, 19, 12, 0)
+        report = dispatcher.tick(config, now=now)
+        assert report.out_of_hours is False
+
+
+class TestSingleDispatch:
+    def test_eligible_issue_dispatched(self, config, patch_world, isolated_locks):
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [eligible_issue(195, "Foo bar")]
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert len(report.dispatched) == 1
+        d = report.dispatched[0]
+        assert d["issue"] == 195
+        assert d["session"] == "agentwire-dev/mission-195-foo-bar"
+        assert d["branch"] == "mission-195-foo-bar"
+        assert patch_world.created_sessions == ["agentwire-dev/mission-195-foo-bar"]
+        assert len(patch_world.prompts_sent) == 1
+        session_arg, prompt = patch_world.prompts_sent[0]
+        assert session_arg == "agentwire-dev/mission-195-foo-bar"
+        assert "#195" in prompt
+        assert "## Acceptance criteria" in prompt
+        assert "mission-195-foo-bar" in prompt
+        assert len(patch_world.comments_made) == 1
+
+    def test_ineligible_issue_skipped(self, config, patch_world, isolated_locks):
+        bad = Issue(number=1, title="No criteria", body="prose only", labels=("agent-ready",), state="OPEN")
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [bad]
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert report.dispatched == []
+        assert any(s["issue"] == 1 and "Acceptance" in s["reason"] for s in report.skipped)
+
+    def test_create_failure_skipped(self, config, patch_world, isolated_locks):
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [eligible_issue(195)]
+        patch_world.create_raises = True
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert report.dispatched == []
+        assert any("create_session failed" in s.get("reason", "") for s in report.skipped)
+
+    def test_not_ready_skipped(self, config, patch_world, isolated_locks):
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [eligible_issue(195)]
+        patch_world.ready_response = False
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert report.dispatched == []
+        assert any("not ready" in s.get("reason", "") for s in report.skipped)
+        assert patch_world.prompts_sent == []
+
+
+class TestConcurrencyCaps:
+    def test_per_repo_cap_blocks(self, config, patch_world, isolated_locks):
+        # One active session already
+        patch_world.active_sessions = ["agentwire-dev/mission-100-existing"]
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [eligible_issue(195)]
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert report.dispatched == []
+        assert any(s.get("reason") == "per-repo concurrency cap" for s in report.skipped)
+
+    def test_dispatches_until_cap(self, patch_world, isolated_locks):
+        # Repo cap of 2; supply 3 eligible issues; expect 2 dispatched
+        cfg = MissionsConfig(
+            repos={
+                "agentwire-dev": RepoConfig(
+                    short="agentwire-dev",
+                    name="owner/agentwire-dev",
+                    projects_dir=Path("/tmp"),
+                    per_repo_concurrency=2,
+                )
+            },
+            global_concurrency=5,
+        )
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [
+            eligible_issue(1, "first"),
+            eligible_issue(2, "second"),
+            eligible_issue(3, "third"),
+        ]
+        report = dispatcher.tick(cfg, now=datetime(2026, 5, 19, 12, 0))
+        assert len(report.dispatched) == 2
+        # Sorted by issue number ASC, so 1 and 2 win
+        assert [d["issue"] for d in report.dispatched] == [1, 2]
+
+    def test_global_cap_blocks_across_repos(self, patch_world, isolated_locks):
+        cfg = MissionsConfig(
+            repos={
+                "a": RepoConfig("a", "o/a", Path("/tmp"), per_repo_concurrency=10),
+                "b": RepoConfig("b", "o/b", Path("/tmp"), per_repo_concurrency=10),
+            },
+            global_concurrency=1,
+        )
+        patch_world.issues_by_repo["o/a"] = [eligible_issue(1)]
+        patch_world.issues_by_repo["o/b"] = [eligible_issue(2)]
+        report = dispatcher.tick(cfg, now=datetime(2026, 5, 19, 12, 0))
+        assert len(report.dispatched) == 1
+
+
+class TestLocking:
+    def test_lock_held_prevents_dispatch(self, config, patch_world, isolated_locks):
+        patch_world.issues_by_repo["owner/agentwire-dev"] = [eligible_issue(195)]
+        with locking.session_lock("mission-195"):
+            report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert report.dispatched == []
+        assert any("locked" in s.get("reason", "") for s in report.skipped)
+
+
+class TestGithubError:
+    def test_list_issues_failure_skips_repo(self, config, patch_world, isolated_locks, monkeypatch):
+        def _raise(repo, **kw):
+            raise github.GitHubError("rate limit slowdown")
+
+        monkeypatch.setattr(github, "list_issues", _raise)
+        report = dispatcher.tick(config, now=datetime(2026, 5, 19, 12, 0))
+        assert any("github error" in s.get("reason", "") for s in report.skipped)

--- a/tests/unit/test_missions_eligibility.py
+++ b/tests/unit/test_missions_eligibility.py
@@ -1,0 +1,113 @@
+"""Tests for ``agentwire.missions.eligibility``."""
+
+from agentwire.missions.eligibility import (
+    AGENT_READY_LABEL,
+    extract_acceptance_criteria,
+    has_agent_ready_label,
+    is_eligible,
+)
+from agentwire.missions.github import Issue
+
+
+def make_issue(
+    *,
+    number: int = 1,
+    title: str = "T",
+    body: str = "",
+    labels: tuple[str, ...] = (),
+    state: str = "OPEN",
+) -> Issue:
+    return Issue(number=number, title=title, body=body, labels=labels, state=state)
+
+
+class TestHasAgentReadyLabel:
+    def test_present(self):
+        assert has_agent_ready_label(make_issue(labels=(AGENT_READY_LABEL,))) is True
+
+    def test_missing(self):
+        assert has_agent_ready_label(make_issue(labels=("other",))) is False
+
+    def test_among_others(self):
+        assert has_agent_ready_label(
+            make_issue(labels=("feature:foo", AGENT_READY_LABEL, "area:bug"))
+        ) is True
+
+
+class TestExtractAcceptanceCriteria:
+    def test_simple(self):
+        body = "## Acceptance criteria\n- one\n- two\n"
+        assert extract_acceptance_criteria(body) == ["one", "two"]
+
+    def test_lowercase_header(self):
+        body = "## acceptance criteria\n- one\n"
+        assert extract_acceptance_criteria(body) == ["one"]
+
+    def test_mixed_case_header(self):
+        body = "## Acceptance Criteria\n- one\n"
+        assert extract_acceptance_criteria(body) == ["one"]
+
+    def test_star_and_plus_bullets(self):
+        body = "## Acceptance criteria\n* star\n+ plus\n- dash\n"
+        assert extract_acceptance_criteria(body) == ["star", "plus", "dash"]
+
+    def test_stops_at_next_header(self):
+        body = "## Acceptance criteria\n- one\n\n## Notes\n- not a criterion\n"
+        assert extract_acceptance_criteria(body) == ["one"]
+
+    def test_continues_through_paragraphs(self):
+        body = "## Acceptance criteria\n\nSome preamble.\n\n- one\n- two\n"
+        assert extract_acceptance_criteria(body) == ["one", "two"]
+
+    def test_no_header_returns_none(self):
+        assert extract_acceptance_criteria("## Goals\n- not it\n") is None
+
+    def test_header_but_no_bullets_returns_none(self):
+        assert extract_acceptance_criteria("## Acceptance criteria\n\nNo bullets here.\n") is None
+
+    def test_empty_body(self):
+        assert extract_acceptance_criteria("") is None
+
+    def test_strips_bullet_marker(self):
+        body = "## Acceptance criteria\n-   spaced bullet\n"
+        assert extract_acceptance_criteria(body) == ["spaced bullet"]
+
+    def test_only_first_section_counts(self):
+        body = (
+            "## Acceptance criteria\n"
+            "- one\n"
+            "\n"
+            "## Acceptance criteria\n"
+            "- duplicate header ignored\n"
+        )
+        # First section wins; bullets in the second (same-name) section are
+        # consumed by the next-header stop.
+        assert extract_acceptance_criteria(body) == ["one"]
+
+
+class TestIsEligible:
+    def test_eligible(self):
+        issue = make_issue(
+            labels=(AGENT_READY_LABEL,),
+            body="## Acceptance criteria\n- do the thing\n",
+        )
+        ok, reason = is_eligible(issue)
+        assert ok is True and reason == ""
+
+    def test_not_eligible_missing_label(self):
+        issue = make_issue(body="## Acceptance criteria\n- x\n")
+        ok, reason = is_eligible(issue)
+        assert ok is False and "label" in reason
+
+    def test_not_eligible_no_criteria(self):
+        issue = make_issue(labels=(AGENT_READY_LABEL,), body="just prose")
+        ok, reason = is_eligible(issue)
+        assert ok is False and "Acceptance criteria" in reason
+
+    def test_not_eligible_closed(self):
+        issue = make_issue(
+            labels=(AGENT_READY_LABEL,),
+            body="## Acceptance criteria\n- x\n",
+            state="CLOSED",
+        )
+        ok, reason = is_eligible(issue)
+        assert ok is False and "CLOSED" in reason

--- a/tests/unit/test_missions_feedback_router.py
+++ b/tests/unit/test_missions_feedback_router.py
@@ -1,0 +1,225 @@
+"""Tests for ``agentwire.missions.feedback_router``."""
+
+from pathlib import Path
+
+import pytest
+
+from agentwire.missions import dispatcher, feedback_router, github, state
+from agentwire.missions.config import MissionsConfig, RepoConfig
+from agentwire.missions.github import Issue, PullRequest, Review
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    state_dir = tmp_path / "missions-state"
+    summaries_dir = tmp_path / "missions-summaries"
+    monkeypatch.setattr(state, "STATE_DIR", state_dir)
+    monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
+    monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(feedback_router, "SUMMARIES_DIR", summaries_dir)
+
+
+@pytest.fixture
+def cfg():
+    return MissionsConfig(
+        repos={
+            "agentwire-dev": RepoConfig(
+                short="agentwire-dev",
+                name="owner/agentwire-dev",
+                projects_dir=Path("/tmp"),
+            ),
+        },
+    )
+
+
+@pytest.fixture
+def patch_world(monkeypatch):
+    class World:
+        active_sessions: list[str] = []
+        pr_by_branch: dict = {}
+        reviews_by_pr: dict = {}
+        issue_by_n: dict = {}
+        prompts_sent: list = []
+
+    world = World()
+    world.active_sessions = []
+    world.pr_by_branch = {}
+    world.reviews_by_pr = {}
+    world.issue_by_n = {}
+    world.prompts_sent = []
+
+    monkeypatch.setattr(dispatcher, "list_mission_sessions", lambda: list(world.active_sessions))
+    monkeypatch.setattr(github, "get_pr_by_branch", lambda r, b: world.pr_by_branch.get((r, b)))
+    monkeypatch.setattr(
+        github, "list_pr_reviews", lambda r, n: list(world.reviews_by_pr.get((r, n), []))
+    )
+    monkeypatch.setattr(github, "get_issue", lambda r, n: world.issue_by_n[(r, n)])
+    monkeypatch.setattr(
+        dispatcher,
+        "send_prompt_to_worker",
+        lambda s, p: world.prompts_sent.append((s, p)),
+    )
+    monkeypatch.setattr(feedback_router.time, "sleep", lambda s: None)
+    return world
+
+
+# --- helpers ---
+
+
+def mk_issue(n=195, title="Foo bar"):
+    return Issue(
+        number=n,
+        title=title,
+        body="## Acceptance criteria\n- a\n- b\n",
+        labels=("agent-ready",),
+        state="OPEN",
+    )
+
+
+def mk_pr(n=42, branch="mission-195-foo-bar", state="OPEN"):
+    return PullRequest(
+        number=n,
+        state=state,
+        head_ref=branch,
+        url=f"https://github.com/o/r/pull/{n}",
+        is_draft=True,
+    )
+
+
+def mk_review(rid, state="CHANGES_REQUESTED", body="please fix x", user="rev"):
+    return Review(
+        id=rid,
+        state=state,
+        body=body,
+        submitted_at="2026-05-19T12:00:00Z",
+        user=user,
+    )
+
+
+# --- tests ---
+
+
+class TestNoActiveSessions:
+    def test_no_op(self, cfg, patch_world):
+        report = feedback_router.route_feedback(cfg)
+        assert report.routed == []
+        assert report.skipped == []
+
+
+class TestSkips:
+    def test_no_pr_yet(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        report = feedback_router.route_feedback(cfg)
+        assert report.routed == []
+        assert any("no PR" in s.get("reason", "") for s in report.skipped)
+        assert patch_world.prompts_sent == []
+
+    def test_pr_not_open(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="MERGED"),
+        }
+        report = feedback_router.route_feedback(cfg)
+        assert any("MERGED" in s.get("reason", "") for s in report.skipped)
+
+    def test_unknown_repo(self, cfg, patch_world):
+        patch_world.active_sessions = ["ghost/mission-1-x"]
+        report = feedback_router.route_feedback(cfg)
+        assert any("repo not in config" in s.get("reason", "") for s in report.skipped)
+
+    def test_no_new_reviews(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): []}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+        report = feedback_router.route_feedback(cfg)
+        assert report.routed == []
+        assert any("no new reviews" in s.get("reason", "") for s in report.skipped)
+
+    def test_non_mission_session_ignored(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/just-a-name"]
+        report = feedback_router.route_feedback(cfg)
+        assert report.routed == [] and report.skipped == []
+
+
+class TestRouting:
+    def test_routes_single_new_review(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        report = feedback_router.route_feedback(cfg)
+        assert len(report.routed) == 1
+        # Both /clear and the refresh prompt
+        assert len(patch_world.prompts_sent) == 2
+        assert patch_world.prompts_sent[0] == ("agentwire-dev/mission-195-foo-bar", "/clear")
+        assert "summary" in patch_world.prompts_sent[1][1].lower() or \
+               "address" in patch_world.prompts_sent[1][1].lower()
+        # Summary file written
+        summary = feedback_router.summary_path("agentwire-dev", 195, "foo-bar")
+        assert summary.exists()
+        text = summary.read_text()
+        assert "Mission #195" in text
+        assert "please fix x" in text
+        # State bumped
+        assert state.last_routed_review(42) == 1001
+
+    def test_filters_already_routed(self, cfg, patch_world):
+        state.update_routed_review(42, 1001)
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {
+            ("owner/agentwire-dev", 42): [
+                mk_review(1001, body="already routed"),
+                mk_review(1042, body="new one"),
+            ]
+        }
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        report = feedback_router.route_feedback(cfg)
+        assert len(report.routed) == 1
+        summary = feedback_router.summary_path("agentwire-dev", 195, "foo-bar")
+        text = summary.read_text()
+        assert "new one" in text
+        assert "already routed" not in text
+        assert state.last_routed_review(42) == 1042
+
+    def test_summary_includes_criteria(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+        feedback_router.route_feedback(cfg)
+        text = feedback_router.summary_path("agentwire-dev", 195, "foo-bar").read_text()
+        assert "- [ ] a" in text
+        assert "- [ ] b" in text
+
+
+class TestIdempotentReplay:
+    def test_second_run_with_no_new_reviews_is_quiet(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        feedback_router.route_feedback(cfg)
+        feedback_router.route_feedback(cfg)
+        # First run: /clear + refresh = 2 prompts. Second run: 0.
+        assert len(patch_world.prompts_sent) == 2
+
+
+class TestBuildSummary:
+    def test_no_criteria_marker(self):
+        issue = Issue(
+            number=1, title="t", body="no criteria header", labels=(), state="OPEN",
+        )
+        pr = mk_pr()
+        text = feedback_router.build_summary(issue, pr, [mk_review(1)])
+        assert "no criteria parsed" in text
+
+    def test_no_reviews(self):
+        issue = mk_issue()
+        pr = mk_pr()
+        text = feedback_router.build_summary(issue, pr, [])
+        assert "no reviewer comments" in text

--- a/tests/unit/test_missions_github.py
+++ b/tests/unit/test_missions_github.py
@@ -1,0 +1,174 @@
+"""Tests for ``agentwire.missions.github`` — gh CLI wrappers."""
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from agentwire.missions import github
+
+
+@dataclass
+class FakeResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@pytest.fixture
+def fake_gh(monkeypatch):
+    """Capture gh invocations and return preprogrammed responses.
+
+    Usage:
+        fake_gh.responses = [FakeResult(stdout=json.dumps([...]))]
+        out = github.list_issues(...)
+        assert fake_gh.calls == [["gh", "issue", "list", ...]]
+    """
+
+    class Fake:
+        responses: list = []
+        calls: list = []
+
+        def __call__(self, cmd, **kwargs):
+            self.calls.append(cmd)
+            if not self.responses:
+                return FakeResult(returncode=1, stderr="no response programmed")
+            return self.responses.pop(0)
+
+    fake = Fake()
+    monkeypatch.setattr(github.subprocess, "run", fake)
+    return fake
+
+
+class TestRunGh:
+    def test_parses_json_stdout(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout='[{"number": 1}]')]
+        out = github._run_gh(["issue", "list"])
+        assert out == [{"number": 1}]
+
+    def test_empty_stdout_returns_none(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="")]
+        assert github._run_gh(["foo"]) is None
+
+    def test_non_json_returns_text_when_parse_json_false(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="plain text")]
+        out = github._run_gh(["foo"], parse_json=False)
+        assert out == "plain text"
+
+    def test_raises_on_nonzero_returncode(self, fake_gh):
+        fake_gh.responses = [FakeResult(returncode=1, stderr="boom")]
+        with pytest.raises(github.GitHubError, match="boom"):
+            github._run_gh(["foo"])
+
+    def test_retries_on_rate_limit(self, fake_gh, monkeypatch):
+        slept = []
+        monkeypatch.setattr(github.time, "sleep", lambda s: slept.append(s))
+        fake_gh.responses = [
+            FakeResult(returncode=1, stderr="API rate limit exceeded"),
+            FakeResult(stdout='[]'),
+        ]
+        out = github._run_gh(["issue", "list"])
+        assert out == []
+        assert slept == [2]
+
+    def test_does_not_retry_on_normal_failure(self, fake_gh, monkeypatch):
+        slept = []
+        monkeypatch.setattr(github.time, "sleep", lambda s: slept.append(s))
+        fake_gh.responses = [FakeResult(returncode=1, stderr="not found")]
+        with pytest.raises(github.GitHubError):
+            github._run_gh(["foo"])
+        assert slept == []
+
+    def test_non_json_response_raises(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="{ not json")]
+        with pytest.raises(github.GitHubError, match="non-JSON"):
+            github._run_gh(["foo"])
+
+
+class TestListIssues:
+    def test_parses_labels(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout=json.dumps([
+            {
+                "number": 5,
+                "title": "Add a thing",
+                "body": "body text",
+                "labels": [{"name": "agent-ready"}, {"name": "feature:platform"}],
+                "state": "open",
+            },
+        ]))]
+        out = github.list_issues("owner/repo")
+        assert len(out) == 1
+        issue = out[0]
+        assert issue.number == 5
+        assert issue.labels == ("agent-ready", "feature:platform")
+        assert issue.state == "OPEN"
+
+    def test_passes_repo_and_label_args(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="[]")]
+        github.list_issues("owner/repo", label="feature:platform", limit=10)
+        cmd = fake_gh.calls[0]
+        assert "--repo" in cmd and "owner/repo" in cmd
+        assert "--label" in cmd and "feature:platform" in cmd
+        assert "--limit" in cmd and "10" in cmd
+        assert "--state" in cmd and "open" in cmd
+
+
+class TestGetIssue:
+    def test_single_issue(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout=json.dumps(
+            {"number": 7, "title": "T", "body": "B", "labels": [], "state": "open"}
+        ))]
+        issue = github.get_issue("o/r", 7)
+        assert issue.number == 7 and issue.title == "T"
+
+
+class TestPullRequests:
+    def test_get_pr_by_branch_found(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout=json.dumps([
+            {"number": 42, "state": "OPEN", "headRefName": "mission-7-x",
+             "url": "https://github.com/o/r/pull/42", "isDraft": True},
+        ]))]
+        pr = github.get_pr_by_branch("o/r", "mission-7-x")
+        assert pr is not None and pr.number == 42 and pr.is_draft
+
+    def test_get_pr_by_branch_none(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="[]")]
+        assert github.get_pr_by_branch("o/r", "no-such-branch") is None
+
+    def test_get_pr_returns_none_on_error(self, fake_gh):
+        fake_gh.responses = [FakeResult(returncode=1, stderr="not found")]
+        assert github.get_pr("o/r", 999) is None
+
+
+class TestPrReviews:
+    def test_parses_review_fields(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout=json.dumps([
+            {
+                "id": 1001,
+                "state": "CHANGES_REQUESTED",
+                "body": "Please fix X",
+                "submitted_at": "2026-05-19T00:00:00Z",
+                "user": {"login": "reviewer1"},
+            },
+        ]))]
+        reviews = github.list_pr_reviews("o/r", 42)
+        assert len(reviews) == 1
+        r = reviews[0]
+        assert r.id == 1001 and r.state == "CHANGES_REQUESTED"
+        assert r.user == "reviewer1"
+
+    def test_uses_api_endpoint(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="[]")]
+        github.list_pr_reviews("o/r", 42)
+        cmd = fake_gh.calls[0]
+        assert cmd[1] == "api"
+        assert "repos/o/r/pulls/42/reviews" in cmd
+
+
+class TestCommentIssue:
+    def test_passes_body(self, fake_gh):
+        fake_gh.responses = [FakeResult(stdout="https://github.com/o/r/issues/1#comment-...")]
+        github.comment_issue("o/r", 1, "hello")
+        cmd = fake_gh.calls[0]
+        assert "issue" in cmd and "comment" in cmd
+        assert "--body" in cmd and "hello" in cmd

--- a/tests/unit/test_missions_naming.py
+++ b/tests/unit/test_missions_naming.py
@@ -1,0 +1,97 @@
+"""Tests for ``agentwire.missions.naming`` — pure derivations."""
+
+from pathlib import Path
+
+from agentwire.missions.naming import (
+    branch_name,
+    is_mission_session,
+    parse_mission_session,
+    session_name,
+    slugify,
+    worktree_path,
+)
+
+
+class TestSlugify:
+    def test_simple(self):
+        assert slugify("Add a logout button") == "add-a-logout-button"
+
+    def test_already_kebab(self):
+        assert slugify("add-thing-now") == "add-thing-now"
+
+    def test_unicode_normalized(self):
+        assert slugify("Café Olé") == "cafe-ole"
+
+    def test_emoji_stripped(self):
+        assert slugify("🚀 ship it!") == "ship-it"
+
+    def test_punctuation_collapsed(self):
+        assert slugify("Fix: bug #123, and-more!!!") == "fix-bug-123-and-more"
+
+    def test_leading_trailing_dashes_stripped(self):
+        assert slugify("---hello---") == "hello"
+
+    def test_truncated_to_40(self):
+        out = slugify("a" * 80)
+        assert len(out) <= 40
+        assert out == "a" * 40
+
+    def test_truncation_strips_trailing_dash(self):
+        out = slugify(("a" * 39) + "-" + ("b" * 80))
+        assert len(out) <= 40
+        assert not out.endswith("-")
+
+    def test_empty_returns_untitled(self):
+        assert slugify("") == "untitled"
+
+    def test_all_symbols_returns_untitled(self):
+        assert slugify("!!! @@@ ###") == "untitled"
+
+    def test_whitespace_only_returns_untitled(self):
+        assert slugify("   \t  \n  ") == "untitled"
+
+
+class TestNameDerivations:
+    def test_branch_name(self):
+        assert branch_name(195, "foo-bar") == "mission-195-foo-bar"
+
+    def test_session_name(self):
+        assert session_name("agentwire-dev", 195, "foo-bar") == "agentwire-dev/mission-195-foo-bar"
+
+    def test_worktree_path(self):
+        out = worktree_path(Path("/projects"), "agentwire-dev", 195, "foo-bar")
+        assert out == Path("/projects/agentwire-dev-worktrees/mission-195-foo-bar")
+
+
+class TestParseMissionSession:
+    def test_well_formed(self):
+        assert parse_mission_session("agentwire-dev/mission-195-foo-bar") == (
+            "agentwire-dev",
+            195,
+            "foo-bar",
+        )
+
+    def test_slug_with_internal_dashes(self):
+        assert parse_mission_session("repo/mission-7-a-b-c") == ("repo", 7, "a-b-c")
+
+    def test_no_slash(self):
+        assert parse_mission_session("just-a-name") is None
+
+    def test_wrong_prefix(self):
+        assert parse_mission_session("agentwire-dev/something-else") is None
+
+    def test_no_number(self):
+        assert parse_mission_session("agentwire-dev/mission-foo-bar") is None
+
+    def test_no_slug(self):
+        assert parse_mission_session("agentwire-dev/mission-195-") is None
+
+    def test_is_mission_session(self):
+        assert is_mission_session("agentwire-dev/mission-195-x") is True
+        assert is_mission_session("agentwire-dev/random") is False
+
+
+def test_roundtrip():
+    """session_name → parse_mission_session preserves all three components."""
+    sn = session_name("agentwire-dev", 195, "fix-the-thing")
+    assert parse_mission_session(sn) == ("agentwire-dev", 195, "fix-the-thing")

--- a/tests/unit/test_missions_state.py
+++ b/tests/unit/test_missions_state.py
@@ -1,0 +1,83 @@
+"""Tests for ``agentwire.missions.state`` — local state JSON files."""
+
+import json
+
+import pytest
+
+from agentwire.missions import state
+
+
+@pytest.fixture(autouse=True)
+def isolated_state_dir(tmp_path, monkeypatch):
+    """Redirect state paths at a tmp dir so tests don't touch real ``~/.agentwire/``."""
+    state_dir = tmp_path / "missions-state"
+    monkeypatch.setattr(state, "STATE_DIR", state_dir)
+    monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
+    monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    return state_dir
+
+
+class TestTick:
+    def test_record_creates_dir_and_file(self, isolated_state_dir):
+        state.record_tick("dispatcher")
+        assert isolated_state_dir.exists()
+        assert (isolated_state_dir / "last_tick.json").exists()
+        data = state.read_last_tick()
+        assert "dispatcher" in data
+
+    def test_record_does_not_overwrite_other_components(self):
+        state.record_tick("dispatcher")
+        state.record_tick("gc")
+        data = state.read_last_tick()
+        assert {"dispatcher", "gc"} <= set(data.keys())
+
+    def test_read_missing_returns_empty(self):
+        assert state.read_last_tick() == {}
+
+
+class TestRoutedReviews:
+    def test_initial_empty(self):
+        assert state.read_routed_reviews() == {}
+
+    def test_update_and_read(self):
+        state.update_routed_review(42, 1001)
+        assert state.last_routed_review(42) == 1001
+
+    def test_update_overwrites(self):
+        state.update_routed_review(42, 1001)
+        state.update_routed_review(42, 1042)
+        assert state.last_routed_review(42) == 1042
+
+    def test_multiple_prs(self):
+        state.update_routed_review(42, 1001)
+        state.update_routed_review(43, 2001)
+        assert state.last_routed_review(42) == 1001
+        assert state.last_routed_review(43) == 2001
+
+    def test_last_routed_for_unknown_pr(self):
+        state.update_routed_review(42, 1001)
+        assert state.last_routed_review(99) is None
+
+    def test_forget_pr(self):
+        state.update_routed_review(42, 1001)
+        state.update_routed_review(43, 2001)
+        state.forget_pr(42)
+        assert state.last_routed_review(42) is None
+        assert state.last_routed_review(43) == 2001
+
+    def test_atomicity_leaves_no_temp_files(self, isolated_state_dir):
+        state.update_routed_review(42, 1001)
+        leftover = list(isolated_state_dir.glob("routed_reviews.json.*"))
+        assert leftover == []
+
+    def test_corrupt_json_falls_back_to_empty(self, isolated_state_dir):
+        isolated_state_dir.mkdir(parents=True, exist_ok=True)
+        (isolated_state_dir / "routed_reviews.json").write_text("{ not json")
+        assert state.read_routed_reviews() == {}
+
+
+def test_routed_reviews_file_is_pretty_printed(isolated_state_dir):
+    state.update_routed_review(42, 1001)
+    text = (isolated_state_dir / "routed_reviews.json").read_text()
+    assert "\n" in text
+    assert json.loads(text) == {"42": 1001}


### PR DESCRIPTION
First of three PRs implementing the Missions subsystem from issue #195.

This PR ships **library-only**: the `agentwire/missions/` package plus 99 unit tests. CLI / MCP / portal / damage-control / launchd land in PRs 2 and 3.

## What's in this PR

Adds `agentwire/missions/`:

- **`naming.py`** — pure derivations (slugify, branch_name, session_name, worktree_path, parse_mission_session)
- **`config.py`** — load `~/.agentwire/missions.yaml` + per-repo override from `.agentwire.yml` `missions:` block
- **`state.py`** — atomic JSON state at `~/.agentwire/missions/state/` (tick heartbeats + per-PR last-routed-review-id for feedback-router idempotency)
- **`github.py`** — thin `gh` CLI wrappers returning frozen dataclasses (`Issue`, `PullRequest`, `Review`); rate-limit-aware retry; uses `gh api` REST for PR reviews (the no-`--json` gap)
- **`eligibility.py`** — two gates AND'd: `agent-ready` label present, body has `## Acceptance criteria` (case-insensitive) followed by ≥ 1 bullet
- **`dispatcher.py`** — `tick()` picks eligible issues sorted by number, locks per-issue via `session_lock(\"mission-{N}\")`, calls `agentwire new` (creates session + worktree + branch in one shot), waits for claude prompt, injects issue-body-derived initial prompt via `pane_manager.send_to_target`, comments on the issue
- **`feedback_router.py`** — `route_feedback()` finds the PR by branch, lists reviews, filters by last-routed-id, writes per-mission summary file at `~/.agentwire/missions/summaries/...`, sends `/clear` + refresh-prompt pointing at the summary. Worker context stays bounded across many feedback rounds — durable state lives on disk, not in Claude's conversation

## Design corrections vs the issue body

Two important deviations from issue #195's design that the implementation surfaced:

1. **Dispatcher is fire-and-forget, not blocking.** `scheduler.py:_dispatch_ensure_task` was named as the canonical pattern, but it blocks via `proc.communicate()` — wrong for missions because workers are persistent. The dispatcher instead calls `agentwire new` (returns once the worker is ready), injects the initial prompt, then exits. Worker outlives the dispatcher tick.

2. **Branch uses dash, not slash.** Issue body specifies `mission/{N}-{slug}` (slash). `agentwire/worktree.py:parse_session_name` splits the first `/` in a session name to derive (project, branch); a slashed branch would collide with that parser. Branch is `mission-{N}-{slug}` instead — round-trips cleanly through the existing convention.

(A third correction — MCP tools have no tier system today — applies to PR 2; flagged here for context. A fourth — damage-control hooks regenerate from `safety/_core.py` — applies to PR 3.)

## Tests

99 unit tests across 7 modules:
- `test_missions_naming.py` (slug edge cases, derivations, parse roundtrip)
- `test_missions_config.py` (yaml load + override + missing-file fallback)
- `test_missions_state.py` (atomic writes, idempotency, corrupt-json fallback)
- `test_missions_github.py` (subprocess mocked, rate-limit retry, parser shapes)
- `test_missions_eligibility.py` (header parsing, gate AND-ing)
- `test_missions_dispatcher.py` (work hours, eligibility, concurrency caps, locking, github errors)
- `test_missions_feedback_router.py` (no-PR / merged-PR skip, state-aware filtering, summary content, idempotent replay)

All side-effects monkeypatched; locking exercises the real `fcntl` path against a tmp dir.

```bash
uv run pytest tests/unit/test_missions_*.py -q
# 99 passed in 0.10s
```

## Verification

Library is importable and tested. The dispatcher and feedback router functions are callable from a Python REPL after this PR merges, but they have no CLI entry point yet (that comes in PR 2). End-to-end verification (with `agentwire mission tick`, real GitHub issue, real worker session) lands with PR 3.

## Test plan

- [x] `uv run pytest tests/unit/test_missions_*.py` — 99 pass
- [x] `uv run ruff check agentwire/missions/ tests/unit/test_missions_*.py` — clean
- [x] No regression on existing tests (`tests/unit/test_locking.py`, `test_handoff_renderer.py` sampled)

## What's NOT in this PR

Tracked as PR 2 (`mission/195-operations`):
- `gc.py` — worktree janitor
- `cli.py` + argparse wiring in `__main__.py`
- 8 MCP tool wrappers in `mcp_server.py`

Tracked as PR 3 (`mission/195-safety-portal-integration`):
- Damage-control hook rules in `safety/_core.py` + regen
- Portal `/api/missions/list` endpoint + `missions-section.js` sidebar + WS event
- launchd plist templates + `agentwire mission install-launchd`
- `docs/MISSIONS.md` + CLAUDE.md pointer
- End-to-end integration tests

Refs #195

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added missions subsystem for automating AI agent worker sessions on GitHub issues
  * Configuration-based issue discovery with eligibility checks and worker session management
  * Automated PR feedback routing with work-hours enforcement and concurrency controls
  * GitHub integration for issue tracking and feedback coordination

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->