### PR TITLE
feat(missions): operations layer — gc + CLI + MCP tools (#195 PR 2/3)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2,7 +2,6 @@
 
 import argparse
 import base64
-from dataclasses import dataclass, field
 import datetime
 import importlib.resources
 import json
@@ -17,6 +16,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -1386,8 +1386,9 @@ def cmd_tts_restart(args) -> int:
     Used by CLI when venv_mismatch occurs during TTS request.
     Supports both local and remote TTS servers.
     """
-    from .network import NetworkContext
     import time
+
+    from .network import NetworkContext
 
     ctx = NetworkContext.from_config()
     session_name = get_tts_session_name()
@@ -6265,8 +6266,9 @@ def cmd_voiceclone_list(args) -> int:
     """List available voices."""
     json_mode = getattr(args, 'json', False)
 
-    from .voiceclone import is_runpod_backend, list_voices_runpod, get_tts_url
     import requests
+
+    from .voiceclone import get_tts_url, is_runpod_backend, list_voices_runpod
 
     if is_runpod_backend():
         success, result = list_voices_runpod()
@@ -7728,22 +7730,16 @@ def cmd_ensure(args) -> int:
     10. Handle retries on failure
     """
     from .completion import (
-        CompletionTimeout,
-        generate_summary_filename,
         get_summary_prompt,
-        status_to_exit_code,
     )
     from .locking import LockConflict, LockTimeout, session_lock
     from .tasks import (
-        PreCommandError,
         TaskNotFound,
         TaskValidationError,
         load_task,
-        run_post_command,
-        run_pre_command,
         validate_task,
     )
-    from .templating import TemplateContext, TemplateError, expand_all, preview_template
+    from .templating import TemplateContext, preview_template
 
     session_name = args.session
     task_name = args.task
@@ -8083,7 +8079,7 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
                         capture_output=True, text=True,
                     )
                     if fork_result.returncode != 0 and not json_mode:
-                        print(f"Warning: context fork failed, starting fresh session")
+                        print("Warning: context fork failed, starting fresh session")
                 elif not json_mode:
                     print(f"Warning: starting_session '{task.starting_session}' not found, starting fresh")
 
@@ -8946,8 +8942,8 @@ def cmd_scheduler_history(args) -> int:
 
 def cmd_scheduler_report(args) -> int:
     """Generate a morning report HTML artifact of recent task runs."""
-    import re as _re
     from html import escape as html_escape
+
     from .scheduler import _parse_duration, format_interval, load_board, read_events
 
     json_mode = getattr(args, 'json', False)
@@ -9510,7 +9506,7 @@ def cmd_overnight_prepare(args) -> int:
             "status": item.status,
         })
     else:
-        print(f"Queued for overnight execution:")
+        print("Queued for overnight execution:")
         print(f"  ID: {item.id}")
         print(f"  Session: {item.session}")
         print(f"  Branch: {item.work_branch}")
@@ -9522,7 +9518,7 @@ def cmd_overnight_prepare(args) -> int:
 
 def cmd_overnight_list(args) -> int:
     """List overnight queue items."""
-    from .overnight import load_queue, load_done
+    from .overnight import load_done, load_queue
 
     json_mode = getattr(args, "json", False)
     show_all = getattr(args, "all", False)
@@ -9561,7 +9557,7 @@ def cmd_overnight_list(args) -> int:
 
 def cmd_overnight_status(args) -> int:
     """Show overnight orchestrator state and queue summary."""
-    from .overnight import load_queue, read_live_state, in_overnight_window
+    from .overnight import in_overnight_window, load_queue, read_live_state
 
     json_mode = getattr(args, "json", False)
 
@@ -9607,7 +9603,7 @@ def cmd_overnight_status(args) -> int:
 
 def cmd_overnight_cancel(args) -> int:
     """Cancel a queued overnight item."""
-    from .overnight import load_item, save_item, delete_item
+    from .overnight import delete_item, load_item
 
     item_id = args.id
     json_mode = getattr(args, "json", False)
@@ -10756,6 +10752,95 @@ def main() -> int:
     sched_report.add_argument("--json", action="store_true", help="Output JSON")
     sched_report.set_defaults(func=cmd_scheduler_report)
 
+    # === mission command group ===
+    from .missions import cli as mission_cli
+
+    mission_parser = subparsers.add_parser(
+        "mission",
+        help="Manage agent-driven missions (issue→branch→draft PR cycles)",
+        description=(
+            "First-class auto-dispatcher: stateless orchestrators tick the GitHub "
+            "issue board, spawn worker sessions in isolated worktrees, route PR "
+            "feedback back, and gc when the PR closes. See docs/MISSIONS.md."
+        ),
+    )
+    mission_subparsers = mission_parser.add_subparsers(dest="mission_command")
+
+    # mission list
+    m_list = mission_subparsers.add_parser("list", help="List active workers + eligible issues")
+    m_list.add_argument("--json", action="store_true", help="Output JSON")
+    m_list.set_defaults(func=mission_cli.cmd_mission_list)
+
+    # mission show <N>
+    m_show = mission_subparsers.add_parser("show", help="Show one issue + dispatch + PR state")
+    m_show.add_argument("number", type=int, help="GitHub issue number")
+    m_show.add_argument("--repo", required=True, help="Repo short name (from missions config)")
+    m_show.add_argument("--json", action="store_true", help="Output JSON")
+    m_show.set_defaults(func=mission_cli.cmd_mission_show)
+
+    # mission status
+    m_status = mission_subparsers.add_parser("status", help="Per-repo summary of active + eligible")
+    m_status.add_argument("--json", action="store_true", help="Output JSON")
+    m_status.set_defaults(func=mission_cli.cmd_mission_status)
+
+    # mission spawn <N>
+    m_spawn = mission_subparsers.add_parser(
+        "spawn", help="Force-dispatch an issue, bypassing eligibility"
+    )
+    m_spawn.add_argument("number", type=int, help="GitHub issue number")
+    m_spawn.add_argument("--repo", required=True, help="Repo short name")
+    m_spawn.add_argument("--json", action="store_true", help="Output JSON")
+    m_spawn.set_defaults(func=mission_cli.cmd_mission_spawn)
+
+    # mission stall <N>
+    m_stall = mission_subparsers.add_parser("stall", help="Stop dispatch for an issue with a reason")
+    m_stall.add_argument("number", type=int, help="GitHub issue number")
+    m_stall.add_argument("--repo", required=True, help="Repo short name")
+    m_stall.add_argument("--reason", required=True, help="Reason (posted as comment)")
+    m_stall.add_argument("--json", action="store_true", help="Output JSON")
+    m_stall.set_defaults(func=mission_cli.cmd_mission_stall)
+
+    # mission resume <N>
+    m_resume = mission_subparsers.add_parser("resume", help="Re-enable an issue for dispatch")
+    m_resume.add_argument("number", type=int, help="GitHub issue number")
+    m_resume.add_argument("--repo", required=True, help="Repo short name")
+    m_resume.add_argument("--json", action="store_true", help="Output JSON")
+    m_resume.set_defaults(func=mission_cli.cmd_mission_resume)
+
+    # mission kill <N>
+    m_kill = mission_subparsers.add_parser(
+        "kill", help="Kill worker session + worktree (does NOT close the PR)"
+    )
+    m_kill.add_argument("number", type=int, help="GitHub issue number")
+    m_kill.add_argument("--repo", required=True, help="Repo short name")
+    m_kill.add_argument("--json", action="store_true", help="Output JSON")
+    m_kill.set_defaults(func=mission_cli.cmd_mission_kill)
+
+    # mission gc
+    m_gc = mission_subparsers.add_parser("gc", help="Reap sessions whose PR is merged/closed")
+    m_gc.add_argument("--json", action="store_true", help="Output JSON")
+    m_gc.set_defaults(func=mission_cli.cmd_mission_gc)
+
+    # mission tick
+    m_tick = mission_subparsers.add_parser("tick", help="Run one dispatcher tick now")
+    m_tick.add_argument("--json", action="store_true", help="Output JSON")
+    m_tick.set_defaults(func=mission_cli.cmd_mission_tick)
+
+    # mission route-feedback
+    m_route = mission_subparsers.add_parser(
+        "route-feedback", help="Run one PR-feedback router tick now"
+    )
+    m_route.add_argument("--json", action="store_true", help="Output JSON")
+    m_route.set_defaults(func=mission_cli.cmd_mission_route_feedback)
+
+    # mission init <repo>
+    m_init = mission_subparsers.add_parser(
+        "init", help="Create the agent-ready label on a repo (idempotent)"
+    )
+    m_init.add_argument("repo", help="Repo short name (from config) or owner/repo form")
+    m_init.add_argument("--json", action="store_true", help="Output JSON")
+    m_init.set_defaults(func=mission_cli.cmd_mission_init)
+
     # === overnight command group ===
     overnight_parser = subparsers.add_parser(
         "overnight",
@@ -10890,6 +10975,10 @@ def main() -> int:
 
     if args.command == "scheduler" and getattr(args, "scheduler_command", None) is None:
         scheduler_parser.print_help()
+        return 0
+
+    if args.command == "mission" and getattr(args, "mission_command", None) is None:
+        mission_parser.print_help()
         return 0
 
     if args.command == "overnight" and getattr(args, "overnight_command", None) is None:

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -637,9 +637,10 @@ def say(text: str, session: str | None = None, voice: str | None = None) -> str:
     """
     # Quick TTS health check — fail fast if server is unreachable
     try:
+        import urllib.request
+
         from .config import load_config as load_typed_config
         from .network import NetworkContext
-        import urllib.request
 
         cfg = load_typed_config()
         if cfg.tts.backend not in ("runpod", "none"):
@@ -1825,6 +1826,246 @@ def scheduler_report(since: str = "8h", artifact: bool = False) -> str:
         f"Morning report generated: {path}\n"
         f"Tasks: {total} total — {complete} complete, {failed} failed, {incomplete} incomplete"
     )
+
+
+# =============================================================================
+# Mission Tools (first-class auto-dispatcher subsystem)
+# =============================================================================
+
+
+@mcp.tool()
+def mission_list() -> str:
+    """List active mission worker sessions and eligible-but-unstarted issues.
+
+    A mission is a GitHub issue labeled ``agent-ready`` with an
+    ``## Acceptance criteria`` section. The dispatcher spawns one worker
+    session per active mission in an isolated git worktree.
+
+    Returns:
+        Per-repo summary of active workers and eligible issue queue.
+    """
+    data = run_agentwire_cmd(["mission", "list"])
+    if not data.get("success"):
+        return f"Failed to list missions: {data.get('error', 'Unknown error')}"
+
+    lines: list[str] = ["Missions:"]
+    active = data.get("active", {}) or {}
+    if not active:
+        lines.append("  Active: (none)")
+    else:
+        lines.append("  Active:")
+        for repo_short, rows in active.items():
+            for row in rows:
+                lines.append(f"    {repo_short} #{row['issue']}  → {row['session']}")
+    eligible = data.get("eligible", {}) or {}
+    for repo_short, rows in eligible.items():
+        eligibles = [r for r in rows if r.get("eligible")]
+        if eligibles:
+            lines.append(f"  Eligible in {repo_short}:")
+            for r in eligibles:
+                lines.append(f"    #{r['issue']}  {r['title']}")
+    for err in data.get("errors") or []:
+        lines.append(f"  ! {err['repo']}: {err['error']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def mission_show(number: int, repo: str) -> str:
+    """Show one mission issue with criteria, dispatch state, and PR link.
+
+    Args:
+        number: GitHub issue number.
+        repo: Repo short name from missions config (e.g. ``agentwire-dev``).
+
+    Returns:
+        Issue summary, acceptance criteria, worker session and PR status.
+    """
+    data = run_agentwire_cmd(["mission", "show", str(number), "--repo", repo])
+    if not data.get("success"):
+        return f"Failed to show mission: {data.get('error', 'Unknown error')}"
+
+    issue = data.get("issue", {}) or {}
+    lines = [f"#{issue.get('number')} {issue.get('title','')}  [{issue.get('state','?')}]"]
+    labels = issue.get("labels") or []
+    lines.append(f"labels: {', '.join(labels) or '(none)'}")
+    lines.append(f"eligible: {data.get('eligible')}")
+    if not data.get("eligible"):
+        lines.append(f"  reason: {data.get('eligibility_reason','')}")
+    lines.append("acceptance criteria:")
+    for c in data.get("acceptance_criteria") or []:
+        lines.append(f"  - {c}")
+    session = data.get("session")
+    if session:
+        lines.append(f"worker: {session['session']}  (branch {session['branch']})")
+    else:
+        lines.append("worker: not active")
+    pr = data.get("pr")
+    if pr and "number" in pr:
+        lines.append(f"PR: #{pr['number']} [{pr['state']}]  {pr['url']}")
+    elif pr and "error" in pr:
+        lines.append(f"PR lookup error: {pr['error']}")
+    elif session:
+        lines.append("PR: not yet opened")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def mission_status() -> str:
+    """Summarize mission orchestrator state: active workers vs caps, queue depth.
+
+    Returns:
+        Global active/cap counts, per-repo breakdown, last-tick heartbeats.
+    """
+    data = run_agentwire_cmd(["mission", "status"])
+    if not data.get("success"):
+        return f"Failed to get status: {data.get('error', 'Unknown error')}"
+
+    global_active = data.get("global_active", 0)
+    global_cap = data.get("global_cap", 0)
+    wh = data.get("work_hours") or [9, 18]
+    lines = [
+        f"Missions: {global_active}/{global_cap} active  (work hours {wh[0]:02d}–{wh[1]:02d})"
+    ]
+    for r in data.get("repos") or []:
+        err = f"  ! {r['error']}" if r.get("error") else ""
+        lines.append(
+            f"  {r['repo']}: {r['active']}/{r['cap']} active, {r['eligible']} eligible{err}"
+        )
+    last = data.get("last_tick") or {}
+    if last:
+        lines.append("last tick:")
+        for component, ts in last.items():
+            lines.append(f"  {component}: {ts}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def mission_spawn(number: int, repo: str) -> str:
+    """Force-dispatch a specific issue, bypassing eligibility checks.
+
+    Use this for manual override (e.g., kicking off a mission on an issue
+    that doesn't have ``agent-ready`` yet, or after editing the criteria).
+    Honors the per-issue lock — concurrent runs are safe.
+
+    Args:
+        number: GitHub issue number.
+        repo: Repo short name.
+
+    Returns:
+        Dispatch result with session name and branch.
+    """
+    data = run_agentwire_cmd(
+        ["mission", "spawn", str(number), "--repo", repo],
+        timeout=120,
+    )
+    if not data.get("success"):
+        return f"Failed to spawn mission: {data.get('error', 'Unknown error')}"
+    dispatched = data.get("dispatched") or []
+    if not dispatched:
+        skipped = data.get("skipped") or []
+        if skipped:
+            return f"Spawn skipped: {skipped[0].get('reason','?')}"
+        return "Spawn returned no result."
+    d = dispatched[0]
+    return f"Dispatched #{d['issue']} → {d['session']}  (branch {d['branch']})"
+
+
+@mcp.tool()
+def mission_stall(number: int, repo: str, reason: str) -> str:
+    """Stop dispatching an issue with a public reason.
+
+    Removes ``agent-ready``, adds ``stalled``, posts ``reason`` as a comment
+    so the issue's audit trail captures why.
+
+    Args:
+        number: GitHub issue number.
+        repo: Repo short name.
+        reason: One-line explanation (becomes the issue comment body).
+
+    Returns:
+        Confirmation message.
+    """
+    data = run_agentwire_cmd(
+        ["mission", "stall", str(number), "--repo", repo, "--reason", reason]
+    )
+    if not data.get("success"):
+        return f"Failed to stall mission: {data.get('error', 'Unknown error')}"
+    return f"Stalled #{number}: {reason}"
+
+
+@mcp.tool()
+def mission_resume(number: int, repo: str) -> str:
+    """Re-enable a stalled issue for the next dispatcher tick.
+
+    Restores ``agent-ready`` and removes ``stalled``. Does not spawn — the
+    dispatcher will pick it up on its next scheduled run, or call
+    ``mission_spawn`` to start immediately.
+
+    Args:
+        number: GitHub issue number.
+        repo: Repo short name.
+
+    Returns:
+        Confirmation message.
+    """
+    data = run_agentwire_cmd(["mission", "resume", str(number), "--repo", repo])
+    if not data.get("success"):
+        return f"Failed to resume mission: {data.get('error', 'Unknown error')}"
+    return f"Resumed #{number} — eligible at next dispatcher tick."
+
+
+@mcp.tool()
+def mission_kill(number: int, repo: str) -> str:
+    """Kill an active mission worker session + worktree (does NOT close the PR).
+
+    Use this when you want operator-side teardown without changing GitHub
+    state. For PR-driven teardown (PR merged/closed), use ``mission_gc``.
+
+    Args:
+        number: GitHub issue number.
+        repo: Repo short name.
+
+    Returns:
+        Outcome including whether the worktree was removed.
+    """
+    data = run_agentwire_cmd(["mission", "kill", str(number), "--repo", repo])
+    if not data.get("success"):
+        return f"Failed to kill mission: {data.get('error', 'Unknown error')}"
+    msg = f"Killed {data.get('session','?')}"
+    if data.get("worktree_removed"):
+        msg += f"; removed worktree {data.get('worktree','')}"
+    elif data.get("worktree_error"):
+        msg += f"; worktree remove failed: {data['worktree_error']}"
+    return msg
+
+
+@mcp.tool()
+def mission_gc() -> str:
+    """Run the worktree-janitor immediately: reap sessions whose PR closed.
+
+    Walks active mission sessions, checks each PR's state, and tears down
+    workers whose PR is MERGED or CLOSED (kills session, removes worktree,
+    clears state). Also sweeps for orphan worktree directories with no
+    matching session.
+
+    Returns:
+        Summary of reaped sessions and removed orphans.
+    """
+    data = run_agentwire_cmd(["mission", "gc"], timeout=120)
+    if not data.get("success"):
+        return f"Failed to run gc: {data.get('error', 'Unknown error')}"
+    reaped = data.get("reaped") or []
+    orphans = data.get("orphans_removed") or []
+    skipped = data.get("skipped") or []
+    lines = [f"Reaped: {len(reaped)}, orphans removed: {len(orphans)}, skipped: {len(skipped)}"]
+    for r in reaped:
+        lines.append(f"  reap   {r['session']}  (PR #{r['pr']} {r['pr_state']})")
+    for o in orphans:
+        lines.append(f"  orphan {o['path']}")
+    for s in skipped:
+        tag = s.get("session") or s.get("orphan") or "?"
+        lines.append(f"  skip   {tag}: {s.get('reason','?')}")
+    return "\n".join(lines)
 
 
 # =============================================================================

--- a/agentwire/missions/cli.py
+++ b/agentwire/missions/cli.py
@@ -1,0 +1,511 @@
+"""CLI handlers for ``agentwire mission ...``.
+
+Thin wrappers over ``dispatcher`` / ``feedback_router`` / ``gc`` / ``github``.
+Argparse wiring lives in ``agentwire/__main__.py``; the handlers receive an
+``argparse.Namespace`` and return an exit code.
+
+Each handler supports ``--json`` so the portal / MCP layer can shell out and
+parse structured output.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from agentwire.missions import (
+    dispatcher,
+    eligibility,
+    feedback_router,
+    gc,
+    github,
+    naming,
+    state,
+)
+from agentwire.missions.config import MissionsConfig, load_config
+
+# --- output helpers -----------------------------------------------------------
+
+
+def _emit(args, payload: dict[str, Any], human: str = "", exit_code: int = 0) -> int:
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, default=str))
+    elif human:
+        print(human)
+    return exit_code
+
+
+def _emit_error(args, message: str, exit_code: int = 1) -> int:
+    if getattr(args, "json", False):
+        print(json.dumps({"success": False, "error": message}, indent=2))
+    else:
+        print(f"error: {message}", file=sys.stderr)
+    return exit_code
+
+
+# --- shared lookups -----------------------------------------------------------
+
+
+@dataclass
+class _RepoLookup:
+    config: MissionsConfig
+    repo_short: str
+    repo_name: str
+
+
+def _resolve_repo(args, config: MissionsConfig) -> _RepoLookup | None:
+    """Map ``--repo`` (short name) to a full ``owner/repo`` via config.
+
+    Returns ``None`` and prints an error if the short name isn't registered.
+    """
+    short = getattr(args, "repo", None)
+    if not short:
+        return None
+    repo = config.get_repo(short)
+    if repo is None:
+        _emit_error(args, f"repo '{short}' not in missions config")
+        return None
+    return _RepoLookup(config=config, repo_short=short, repo_name=repo.name)
+
+
+def _find_active_session_for_issue(
+    repo_short: str, issue_number: int
+) -> tuple[str, str] | None:
+    """Return ``(session_full, slug)`` for the running mission session that
+    matches ``repo_short`` + ``issue_number``, or ``None`` if no session is
+    active.
+    """
+    for s in dispatcher.list_mission_sessions():
+        parsed = naming.parse_mission_session(s)
+        if parsed and parsed[0] == repo_short and parsed[1] == issue_number:
+            return s, parsed[2]
+    return None
+
+
+# --- handlers -----------------------------------------------------------------
+
+
+def cmd_mission_list(args) -> int:
+    """List eligible-but-unstarted issues + active mission sessions per repo."""
+    config = load_config()
+    active = dispatcher.list_mission_sessions()
+    active_by_repo: dict[str, list[dict]] = {}
+    for s in active:
+        parsed = naming.parse_mission_session(s)
+        if not parsed:
+            continue
+        repo_short, n, slug = parsed
+        active_by_repo.setdefault(repo_short, []).append(
+            {"issue": n, "slug": slug, "session": s}
+        )
+
+    eligible_by_repo: dict[str, list[dict]] = {}
+    errors: list[dict] = []
+    for repo_short, repo in config.repos.items():
+        try:
+            issues = github.list_issues(repo.name)
+        except github.GitHubError as e:
+            errors.append({"repo": repo_short, "error": str(e)})
+            continue
+        bucket = []
+        for issue in sorted(issues, key=lambda i: i.number):
+            ok, reason = eligibility.is_eligible(issue)
+            bucket.append(
+                {
+                    "issue": issue.number,
+                    "title": issue.title,
+                    "eligible": ok,
+                    "reason": reason if not ok else "",
+                }
+            )
+        eligible_by_repo[repo_short] = bucket
+
+    payload = {
+        "active": active_by_repo,
+        "eligible": eligible_by_repo,
+        "errors": errors,
+    }
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print("Active mission sessions:")
+    if not active_by_repo:
+        print("  (none)")
+    for repo_short, rows in active_by_repo.items():
+        print(f"  {repo_short}:")
+        for row in rows:
+            print(f"    #{row['issue']:<5} {row['session']}")
+    print()
+    print("Eligible issues (agent-ready + acceptance criteria):")
+    if not eligible_by_repo:
+        print("  (no repos configured)")
+    for repo_short, rows in eligible_by_repo.items():
+        eligibles = [r for r in rows if r["eligible"]]
+        print(f"  {repo_short}: {len(eligibles)} eligible")
+        for row in eligibles:
+            print(f"    #{row['issue']:<5} {row['title']}")
+    if errors:
+        print()
+        print("Errors:")
+        for e in errors:
+            print(f"  {e['repo']}: {e['error']}")
+    return 0
+
+
+def cmd_mission_show(args) -> int:
+    """Show a single issue: body, criteria, dispatch status, PR link."""
+    config = load_config()
+    lookup = _resolve_repo(args, config)
+    if lookup is None:
+        return 2
+
+    try:
+        issue = github.get_issue(lookup.repo_name, args.number)
+    except github.GitHubError as e:
+        return _emit_error(args, f"get_issue failed: {e}")
+
+    criteria = eligibility.extract_acceptance_criteria(issue.body) or []
+    ok, reason = eligibility.is_eligible(issue)
+
+    active = _find_active_session_for_issue(lookup.repo_short, issue.number)
+    session_info = None
+    pr_info: dict | None = None
+    if active:
+        session_full, slug = active
+        branch = naming.branch_name(issue.number, slug)
+        session_info = {"session": session_full, "branch": branch, "slug": slug}
+        try:
+            pr = github.get_pr_by_branch(lookup.repo_name, branch)
+        except github.GitHubError as e:
+            pr_info = {"error": str(e)}
+        else:
+            if pr is not None:
+                pr_info = {
+                    "number": pr.number,
+                    "state": pr.state,
+                    "url": pr.url,
+                    "is_draft": pr.is_draft,
+                }
+
+    payload = {
+        "issue": {
+            "number": issue.number,
+            "title": issue.title,
+            "state": issue.state,
+            "labels": list(issue.labels),
+            "body": issue.body,
+        },
+        "acceptance_criteria": criteria,
+        "eligible": ok,
+        "eligibility_reason": reason,
+        "session": session_info,
+        "pr": pr_info,
+    }
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print(f"#{issue.number} {issue.title}  [{issue.state}]")
+    print(f"labels: {', '.join(issue.labels) or '(none)'}")
+    print(f"eligible: {ok}{f'  ({reason})' if not ok else ''}")
+    print()
+    print("Acceptance criteria:")
+    if not criteria:
+        print("  (none parsed)")
+    for c in criteria:
+        print(f"  - {c}")
+    print()
+    if session_info:
+        print(f"Active worker: {session_info['session']}")
+        if pr_info:
+            if "error" in pr_info:
+                print(f"PR lookup error: {pr_info['error']}")
+            else:
+                print(
+                    f"PR: #{pr_info['number']} [{pr_info['state']}]"
+                    f"  {pr_info['url']}"
+                )
+        else:
+            print("PR: not yet opened")
+    else:
+        print("Worker: not active")
+    return 0
+
+
+def cmd_mission_status(args) -> int:
+    """Summarized per-repo counts: active workers + eligible queue depth."""
+    config = load_config()
+    active = dispatcher.list_mission_sessions()
+    active_by_repo: dict[str, int] = {}
+    for s in active:
+        parsed = naming.parse_mission_session(s)
+        if parsed:
+            active_by_repo[parsed[0]] = active_by_repo.get(parsed[0], 0) + 1
+
+    rows: list[dict] = []
+    for repo_short, repo in config.repos.items():
+        try:
+            issues = github.list_issues(repo.name)
+            eligible_count = sum(1 for i in issues if eligibility.is_eligible(i)[0])
+            err = None
+        except github.GitHubError as e:
+            eligible_count = 0
+            err = str(e)
+        rows.append(
+            {
+                "repo": repo_short,
+                "active": active_by_repo.get(repo_short, 0),
+                "cap": repo.per_repo_concurrency,
+                "eligible": eligible_count,
+                "error": err,
+            }
+        )
+
+    payload = {
+        "global_active": len(active),
+        "global_cap": config.global_concurrency,
+        "work_hours": [config.work_hours_start, config.work_hours_end],
+        "repos": rows,
+        "last_tick": state.read_last_tick(),
+    }
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print(
+        f"Mission orchestrator status   (global: {len(active)}/{config.global_concurrency},"
+        f" work hours {config.work_hours_start:02d}–{config.work_hours_end:02d})"
+    )
+    print(f"{'repo':<24} {'active/cap':<12} {'eligible':<10} error")
+    for r in rows:
+        ac = f"{r['active']}/{r['cap']}"
+        err = r["error"] or ""
+        print(f"{r['repo']:<24} {ac:<12} {r['eligible']:<10} {err}")
+    last = payload["last_tick"]
+    if last:
+        print()
+        for component, ts in last.items():
+            print(f"  {component} last ran: {ts}")
+    return 0
+
+
+def cmd_mission_spawn(args) -> int:
+    """Force-dispatch a specific issue, bypassing eligibility checks."""
+    config = load_config()
+    lookup = _resolve_repo(args, config)
+    if lookup is None:
+        return 2
+
+    try:
+        issue = github.get_issue(lookup.repo_name, args.number)
+    except github.GitHubError as e:
+        return _emit_error(args, f"get_issue failed: {e}")
+
+    repo = config.get_repo(lookup.repo_short)
+    report = dispatcher.DispatchReport(started_at=datetime.now().isoformat())
+    ok = dispatcher._dispatch_one(lookup.repo_short, repo, issue, report)
+    if ok and getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+        return 0
+    if ok:
+        d = report.dispatched[0]
+        print(f"Dispatched #{d['issue']} → {d['session']}  (branch {d['branch']})")
+        return 0
+
+    return _emit_error(
+        args,
+        "dispatch failed: " + "; ".join(s.get("reason", "?") for s in report.skipped),
+    )
+
+
+def cmd_mission_stall(args) -> int:
+    """Remove ``agent-ready``, add ``stalled``, comment the reason."""
+    config = load_config()
+    lookup = _resolve_repo(args, config)
+    if lookup is None:
+        return 2
+
+    try:
+        github.edit_issue_labels(
+            lookup.repo_name,
+            args.number,
+            add=["stalled"],
+            remove=["agent-ready"],
+        )
+        github.comment_issue(
+            lookup.repo_name,
+            args.number,
+            f"Mission stalled: {args.reason}\n\n— `agentwire mission stall`",
+        )
+    except github.GitHubError as e:
+        return _emit_error(args, f"stall failed: {e}")
+
+    return _emit(
+        args,
+        {"success": True, "issue": args.number, "action": "stalled"},
+        human=f"Stalled #{args.number}: {args.reason}",
+    )
+
+
+def cmd_mission_resume(args) -> int:
+    """Restore ``agent-ready``, remove ``stalled``."""
+    config = load_config()
+    lookup = _resolve_repo(args, config)
+    if lookup is None:
+        return 2
+
+    try:
+        github.edit_issue_labels(
+            lookup.repo_name,
+            args.number,
+            add=["agent-ready"],
+            remove=["stalled"],
+        )
+    except github.GitHubError as e:
+        return _emit_error(args, f"resume failed: {e}")
+
+    return _emit(
+        args,
+        {"success": True, "issue": args.number, "action": "resumed"},
+        human=f"Resumed #{args.number} — eligible for next dispatcher tick",
+    )
+
+
+def cmd_mission_kill(args) -> int:
+    """Manual override: kill the worker + worktree without closing the PR.
+
+    Distinct from ``gc``, which is PR-driven (only tears down sessions whose
+    PR is MERGED/CLOSED). Use ``kill`` when you want the operator-side
+    teardown without changing GitHub state.
+    """
+    config = load_config()
+    lookup = _resolve_repo(args, config)
+    if lookup is None:
+        return 2
+
+    active = _find_active_session_for_issue(lookup.repo_short, args.number)
+    if active is None:
+        return _emit_error(args, f"no active mission session for #{args.number}")
+
+    session_full, slug = active
+    repo = config.get_repo(lookup.repo_short)
+    wt = naming.worktree_path(repo.projects_dir, repo.short, args.number, slug)
+
+    try:
+        gc.kill_session(session_full)
+    except RuntimeError as e:
+        return _emit_error(args, f"kill_session failed: {e}")
+
+    worktree_removed = False
+    worktree_error: str | None = None
+    if wt.exists():
+        try:
+            gc.remove_worktree(wt)
+            worktree_removed = True
+        except RuntimeError as e:
+            worktree_error = str(e)
+
+    payload = {
+        "success": True,
+        "issue": args.number,
+        "session": session_full,
+        "worktree": str(wt),
+        "worktree_removed": worktree_removed,
+        "worktree_error": worktree_error,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Killed {session_full}")
+        if worktree_removed:
+            print(f"Removed worktree {wt}")
+        elif worktree_error:
+            print(f"Worktree remove failed: {worktree_error}", file=sys.stderr)
+    return 0
+
+
+def cmd_mission_gc(args) -> int:
+    """Run the worktree-janitor synchronously."""
+    report = gc.gc()
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(f"Reaped: {len(report.reaped)}, orphans removed: {len(report.orphans_removed)}, "
+              f"skipped: {len(report.skipped)}")
+        for r in report.reaped:
+            print(f"  reap   {r['session']}  (PR #{r['pr']} {r['pr_state']})")
+        for o in report.orphans_removed:
+            print(f"  orphan {o['path']}")
+        for s in report.skipped:
+            tag = s.get("session") or s.get("orphan") or "?"
+            print(f"  skip   {tag}: {s.get('reason', '?')}")
+    return 0
+
+
+def cmd_mission_tick(args) -> int:
+    """Run the dispatcher synchronously."""
+    report = dispatcher.tick()
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        if report.out_of_hours:
+            print("Out of work hours — no dispatch.")
+        print(f"Dispatched: {len(report.dispatched)}, skipped: {len(report.skipped)}")
+        for d in report.dispatched:
+            print(f"  spawn  #{d['issue']} → {d['session']}")
+        for s in report.skipped:
+            tag = f"#{s['issue']}" if "issue" in s else s.get("repo", "?")
+            print(f"  skip   {tag}: {s.get('reason', '?')}")
+    return 0
+
+
+def cmd_mission_route_feedback(args) -> int:
+    """Run the PR-feedback router synchronously."""
+    report = feedback_router.route_feedback()
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(f"Routed: {len(report.routed)}, skipped: {len(report.skipped)}")
+        for r in report.routed:
+            print(f"  route  PR #{r['pr']} → {r['session']}  ({r['reviews_routed']} review(s))")
+        for s in report.skipped:
+            print(f"  skip   {s.get('session', '?')}: {s.get('reason', '?')}")
+    return 0
+
+
+def cmd_mission_init(args) -> int:
+    """Create the ``agent-ready`` label on a target repo (idempotent)."""
+    config = load_config()
+    # Allow either short name (looked up via config) or owner/repo form.
+    short = args.repo
+    repo = config.get_repo(short)
+    repo_name = repo.name if repo is not None else short
+    if "/" not in repo_name:
+        return _emit_error(
+            args,
+            f"'{short}' is not a configured repo short name and not in 'owner/repo' form",
+        )
+    try:
+        created = github.create_label(
+            repo_name,
+            "agent-ready",
+            color="0e8a16",
+            description="Eligible for mission-dispatcher to pick up.",
+        )
+    except github.GitHubError as e:
+        return _emit_error(args, f"create_label failed: {e}")
+
+    return _emit(
+        args,
+        {"success": True, "repo": repo_name, "created": created},
+        human=(
+            f"Label 'agent-ready' {'created' if created else 'already exists'} on {repo_name}"
+        ),
+    )

--- a/agentwire/missions/gc.py
+++ b/agentwire/missions/gc.py
@@ -1,0 +1,206 @@
+"""Mission worktree-janitor: reap sessions + worktrees whose PR is closed.
+
+Stateless. Runs every 6 hours from launchd, or on demand via
+``agentwire mission gc``. Walks active mission sessions, looks up the
+associated PR by branch, and tears down sessions whose PR is ``MERGED`` or
+``CLOSED``. Also sweeps the worktrees parent dir for orphan worktrees
+(directories with no matching tmux session).
+
+Side-effecting shell-outs (``agentwire kill``, ``git worktree remove``) live
+as module-level functions so tests can monkeypatch them.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from agentwire.missions import dispatcher, github, naming, state
+from agentwire.missions.config import MissionsConfig, RepoConfig, load_config
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class GcReport:
+    """Result of one gc tick — useful for CLI/JSON output."""
+
+    started_at: str
+    reaped: list[dict] = field(default_factory=list)
+    skipped: list[dict] = field(default_factory=list)
+    orphans_removed: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "started_at": self.started_at,
+            "reaped": list(self.reaped),
+            "skipped": list(self.skipped),
+            "orphans_removed": list(self.orphans_removed),
+        }
+
+
+# --- side-effecting helpers (monkeypatched in tests) --------------------------
+
+
+def kill_session(session_full_name: str) -> None:
+    """Kill a tmux session via ``agentwire kill``.
+
+    Raises ``RuntimeError`` on failure.
+    """
+    result = subprocess.run(
+        ["agentwire", "kill", "-s", session_full_name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"agentwire kill failed (rc={result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def remove_worktree(path: Path) -> None:
+    """Remove a git worktree at ``path`` via ``git worktree remove --force``.
+
+    ``--force`` because by the time gc runs the PR is merged/closed and any
+    uncommitted work is moot. Runs from inside the worktree so git can resolve
+    the main repo via the worktree's .git pointer. Raises ``RuntimeError`` on
+    failure (e.g. broken worktree pointer, or path not registered with git).
+    """
+    cwd = str(path) if path.is_dir() else None
+    result = subprocess.run(
+        ["git", "worktree", "remove", "--force", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git worktree remove failed (rc={result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def list_worktree_dirs(parent_dir: Path) -> list[Path]:
+    """List mission-* subdirectories under a ``{repo}-worktrees`` parent."""
+    if not parent_dir.is_dir():
+        return []
+    return [p for p in parent_dir.iterdir() if p.is_dir() and p.name.startswith("mission-")]
+
+
+# --- public entry point -------------------------------------------------------
+
+
+def gc(config: MissionsConfig | None = None) -> GcReport:
+    """One janitor tick.
+
+    For each active mission session, reap it if its PR is MERGED/CLOSED.
+    Then sweep each configured repo's worktree parent for orphans.
+    """
+    if config is None:
+        config = load_config()
+
+    report = GcReport(started_at=datetime.now().isoformat())
+
+    active_sessions = dispatcher.list_mission_sessions()
+    live_session_names: set[str] = set(active_sessions)
+    # Worktree paths gc has already touched this tick — avoid the orphan
+    # sweep re-attempting (or re-reporting) a path the session-reap loop
+    # already removed (or failed on).
+    handled_worktree_paths: set[Path] = set()
+
+    for session_full in active_sessions:
+        parsed = naming.parse_mission_session(session_full)
+        if not parsed:
+            continue
+        repo_short, issue_number, slug = parsed
+
+        repo = config.get_repo(repo_short)
+        if repo is None:
+            report.skipped.append({"session": session_full, "reason": "repo not in config"})
+            continue
+
+        branch = naming.branch_name(issue_number, slug)
+        try:
+            pr = github.get_pr_by_branch(repo.name, branch)
+        except github.GitHubError as e:
+            report.skipped.append({"session": session_full, "reason": f"get_pr_by_branch: {e}"})
+            continue
+
+        if pr is None:
+            report.skipped.append({"session": session_full, "reason": "no PR for branch yet"})
+            continue
+        if pr.state == "OPEN":
+            report.skipped.append({"session": session_full, "reason": "PR still OPEN"})
+            continue
+
+        wt = naming.worktree_path(repo.projects_dir, repo.short, issue_number, slug)
+        handled_worktree_paths.add(wt)
+        _reap_session(session_full, repo, issue_number, slug, pr, wt, report)
+        live_session_names.discard(session_full)
+
+    for repo_short, repo in config.repos.items():
+        parent = repo.projects_dir / f"{repo_short}-worktrees"
+        for wt_dir in list_worktree_dirs(parent):
+            if wt_dir in handled_worktree_paths:
+                continue
+            session_for_dir = f"{repo_short}/{wt_dir.name}"
+            if session_for_dir in live_session_names:
+                continue
+            try:
+                remove_worktree(wt_dir)
+                report.orphans_removed.append({"repo": repo_short, "path": str(wt_dir)})
+            except RuntimeError as e:
+                report.skipped.append(
+                    {"orphan": str(wt_dir), "reason": f"worktree remove failed: {e}"}
+                )
+
+    state.record_tick("gc")
+    return report
+
+
+def _reap_session(
+    session_full: str,
+    repo: RepoConfig,
+    issue_number: int,
+    slug: str,
+    pr: github.PullRequest,
+    wt: Path,
+    report: GcReport,
+) -> None:
+    """Tear down one mission worker: kill session, remove worktree, clear state."""
+    try:
+        kill_session(session_full)
+    except RuntimeError as e:
+        report.skipped.append(
+            {"session": session_full, "reason": f"kill failed: {e}"}
+        )
+        return
+
+    worktree_removed = False
+    if wt.exists():
+        try:
+            remove_worktree(wt)
+            worktree_removed = True
+        except RuntimeError as e:
+            report.skipped.append(
+                {"session": session_full, "reason": f"worktree remove failed: {e}"}
+            )
+
+    state.forget_pr(pr.number)
+
+    report.reaped.append(
+        {
+            "session": session_full,
+            "issue": issue_number,
+            "pr": pr.number,
+            "pr_state": pr.state,
+            "worktree_removed": worktree_removed,
+            "worktree_path": str(wt),
+        }
+    )

--- a/agentwire/missions/github.py
+++ b/agentwire/missions/github.py
@@ -202,3 +202,51 @@ def comment_issue(repo: str, number: int, body: str) -> None:
         ],
         parse_json=False,
     )
+
+
+def edit_issue_labels(
+    repo: str,
+    number: int,
+    add: list[str] | None = None,
+    remove: list[str] | None = None,
+) -> None:
+    """Add and/or remove labels on an issue via ``gh issue edit``."""
+    args = ["issue", "edit", str(number), "--repo", repo]
+    for label in add or []:
+        args.extend(["--add-label", label])
+    for label in remove or []:
+        args.extend(["--remove-label", label])
+    if len(args) == 5:
+        return  # no labels to change
+    _run_gh(args, parse_json=False)
+
+
+_ALREADY_EXISTS_FRAGMENTS = ("already exists", "label already exists")
+
+
+def create_label(
+    repo: str,
+    name: str,
+    color: str = "0e8a16",
+    description: str = "",
+) -> bool:
+    """Create a label on a repo. Idempotent — returns False if it already existed.
+
+    ``color`` is a 6-char hex without ``#``. Default is green (0e8a16) for
+    the ``agent-ready`` semantic.
+    """
+    args = ["label", "create", name, "--repo", repo, "--color", color]
+    if description:
+        args.extend(["--description", description])
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode == 0:
+        return True
+    stderr = (result.stderr or "").lower()
+    if any(frag in stderr for frag in _ALREADY_EXISTS_FRAGMENTS):
+        return False
+    raise GitHubError(f"gh label create failed: {(result.stderr or result.stdout).strip()}")

--- a/tests/unit/test_missions_cli.py
+++ b/tests/unit/test_missions_cli.py
@@ -1,0 +1,398 @@
+"""Tests for ``agentwire.missions.cli`` handlers.
+
+Tests use argparse Namespace fakes (no shell invocation) and monkeypatch all
+downstream side-effects (gh, dispatcher.list_mission_sessions, gc helpers).
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from agentwire.missions import cli, dispatcher, feedback_router, gc, github, state
+from agentwire.missions.config import MissionsConfig, RepoConfig
+from agentwire.missions.github import Issue, PullRequest, Review
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    state_dir = tmp_path / "missions-state"
+    summaries_dir = tmp_path / "missions-summaries"
+    monkeypatch.setattr(state, "STATE_DIR", state_dir)
+    monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
+    monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(feedback_router, "SUMMARIES_DIR", summaries_dir)
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return MissionsConfig(
+        repos={
+            "agentwire-dev": RepoConfig(
+                short="agentwire-dev",
+                name="owner/agentwire-dev",
+                projects_dir=tmp_path / "projects",
+                per_repo_concurrency=2,
+            ),
+        },
+        global_concurrency=3,
+    )
+
+
+@pytest.fixture
+def stub_world(monkeypatch, cfg):
+    """Fake all CLI side-effects.
+
+    Tests pre-set fields on the returned World to control fixture behavior.
+    """
+
+    class World:
+        active_sessions: list[str] = []
+        issues_by_repo: dict = {}
+        issue_by_number: dict = {}
+        prs_by_branch: dict = {}
+        reviews_by_pr: dict = {}
+        comments_made: list = []
+        labels_edited: list = []
+        labels_created: list = []
+        labels_create_raises: bool = False
+        comment_raises: bool = False
+        label_edit_raises: bool = False
+        # dispatcher side-effects
+        created_sessions: list = []
+        prompts_sent: list = []
+        wait_ready_response: bool = True
+        # gc side-effects
+        kill_calls: list = []
+        remove_calls: list = []
+        kill_raises: bool = False
+        remove_raises: bool = False
+
+    w = World()
+    w.active_sessions = []
+    w.issues_by_repo = {}
+    w.issue_by_number = {}
+    w.prs_by_branch = {}
+    w.reviews_by_pr = {}
+    w.comments_made = []
+    w.labels_edited = []
+    w.labels_created = []
+    w.created_sessions = []
+    w.prompts_sent = []
+    w.kill_calls = []
+    w.remove_calls = []
+
+    # CLI and every downstream component each import load_config — patch all so
+    # the in-memory ``cfg`` fixture is honored end-to-end.
+    monkeypatch.setattr(cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(dispatcher, "load_config", lambda: cfg)
+    monkeypatch.setattr(feedback_router, "load_config", lambda: cfg)
+    monkeypatch.setattr(gc, "load_config", lambda: cfg)
+    # feedback_router uses time.sleep between /clear and refresh; skip it
+    monkeypatch.setattr(feedback_router.time, "sleep", lambda s: None)
+
+    monkeypatch.setattr(dispatcher, "list_mission_sessions", lambda: list(w.active_sessions))
+    monkeypatch.setattr(github, "list_issues", lambda repo, **kw: list(w.issues_by_repo.get(repo, [])))
+    monkeypatch.setattr(github, "get_issue", lambda repo, n: w.issue_by_number[(repo, n)])
+    monkeypatch.setattr(github, "get_pr_by_branch", lambda repo, b: w.prs_by_branch.get((repo, b)))
+    monkeypatch.setattr(github, "list_pr_reviews", lambda repo, n: list(w.reviews_by_pr.get((repo, n), [])))
+
+    def _edit(repo, n, add=None, remove=None):
+        if w.label_edit_raises:
+            raise github.GitHubError("api error")
+        w.labels_edited.append({"repo": repo, "n": n, "add": add or [], "remove": remove or []})
+
+    monkeypatch.setattr(github, "edit_issue_labels", _edit)
+
+    def _comment(repo, n, body):
+        if w.comment_raises:
+            raise github.GitHubError("api error")
+        w.comments_made.append({"repo": repo, "n": n, "body": body})
+
+    monkeypatch.setattr(github, "comment_issue", _comment)
+
+    def _create_label(repo, name, color="0e8a16", description=""):
+        if w.labels_create_raises:
+            raise github.GitHubError("api error")
+        # Mimic idempotent contract: first call returns True, repeat returns False
+        already = any(le["repo"] == repo and le["name"] == name for le in w.labels_created)
+        w.labels_created.append({"repo": repo, "name": name, "color": color, "description": description})
+        return not already
+
+    monkeypatch.setattr(github, "create_label", _create_label)
+
+    # dispatcher internals used by `mission spawn`
+    def _new(session):
+        w.created_sessions.append(session)
+
+    monkeypatch.setattr(dispatcher, "create_worker_session", _new)
+    monkeypatch.setattr(dispatcher, "wait_for_session_ready", lambda s, timeout=30.0: w.wait_ready_response)
+    monkeypatch.setattr(dispatcher, "send_prompt_to_worker", lambda s, p: w.prompts_sent.append((s, p)))
+
+    # gc helpers used by `mission kill`
+    def _kill(session):
+        if w.kill_raises:
+            raise RuntimeError("kill failed")
+        w.kill_calls.append(session)
+
+    monkeypatch.setattr(gc, "kill_session", _kill)
+
+    def _remove(path):
+        if w.remove_raises:
+            raise RuntimeError("remove failed")
+        w.remove_calls.append(path)
+
+    monkeypatch.setattr(gc, "remove_worktree", _remove)
+
+    return w
+
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def _make_issue(n=195, title="Foo bar", labels=("agent-ready",), state="OPEN",
+                body="## Acceptance criteria\n- thing\n"):
+    return Issue(number=n, title=title, body=body, labels=labels, state=state)
+
+
+# --- tests ---
+
+
+class TestList:
+    def test_human_output_with_active_and_eligible(self, stub_world, capsys):
+        stub_world.active_sessions = ["agentwire-dev/mission-100-existing"]
+        stub_world.issues_by_repo = {
+            "owner/agentwire-dev": [_make_issue(195, "Foo bar"), _make_issue(196, "Bar baz")]
+        }
+        rc = cli.cmd_mission_list(_ns(json=False))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "mission-100-existing" in out
+        assert "#195" in out and "Foo bar" in out
+
+    def test_json_output(self, stub_world, capsys):
+        stub_world.active_sessions = ["agentwire-dev/mission-100-existing"]
+        stub_world.issues_by_repo = {
+            "owner/agentwire-dev": [_make_issue(195, "Foo bar")]
+        }
+        rc = cli.cmd_mission_list(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "active" in data and "eligible" in data
+        assert data["active"]["agentwire-dev"][0]["issue"] == 100
+        assert data["eligible"]["agentwire-dev"][0]["issue"] == 195
+
+    def test_github_error_recorded(self, stub_world, capsys, monkeypatch):
+        def _boom(repo, **kw):
+            raise github.GitHubError("rate limit")
+
+        monkeypatch.setattr(github, "list_issues", _boom)
+        rc = cli.cmd_mission_list(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert any("rate limit" in e["error"] for e in data["errors"])
+
+
+class TestShow:
+    def test_no_active_session(self, stub_world, capsys):
+        stub_world.issue_by_number[("owner/agentwire-dev", 195)] = _make_issue(195)
+        rc = cli.cmd_mission_show(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["session"] is None
+        assert data["pr"] is None
+        assert data["acceptance_criteria"] == ["thing"]
+        assert data["eligible"] is True
+
+    def test_with_active_session_and_pr(self, stub_world, capsys):
+        stub_world.issue_by_number[("owner/agentwire-dev", 195)] = _make_issue(195)
+        stub_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        stub_world.prs_by_branch[("owner/agentwire-dev", "mission-195-foo-bar")] = PullRequest(
+            number=42, state="OPEN", head_ref="mission-195-foo-bar",
+            url="https://github.com/o/r/pull/42", is_draft=True,
+        )
+        rc = cli.cmd_mission_show(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["session"]["session"] == "agentwire-dev/mission-195-foo-bar"
+        assert data["pr"]["number"] == 42 and data["pr"]["state"] == "OPEN"
+
+    def test_unknown_repo(self, stub_world, capsys):
+        rc = cli.cmd_mission_show(_ns(number=1, repo="ghost", json=True))
+        assert rc == 2
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is False
+
+
+class TestStatus:
+    def test_summary(self, stub_world, capsys):
+        stub_world.active_sessions = ["agentwire-dev/mission-100-x", "agentwire-dev/mission-200-y"]
+        stub_world.issues_by_repo = {
+            "owner/agentwire-dev": [_make_issue(195), _make_issue(196)]
+        }
+        rc = cli.cmd_mission_status(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["global_active"] == 2
+        assert data["repos"][0]["active"] == 2
+        assert data["repos"][0]["eligible"] == 2
+
+
+class TestSpawn:
+    def test_force_dispatches_ineligible(self, stub_world, capsys, monkeypatch):
+        # locking — bypass real flock
+        from agentwire import locking
+        monkeypatch.setattr(locking, "LOCKS_DIR", Path("/tmp/agentwire-cli-test-locks"))
+        Path("/tmp/agentwire-cli-test-locks").mkdir(exist_ok=True)
+
+        # Issue lacking the agent-ready label — normally ineligible
+        ineligible = _make_issue(195, labels=("feature:platform",))
+        stub_world.issue_by_number[("owner/agentwire-dev", 195)] = ineligible
+
+        rc = cli.cmd_mission_spawn(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["dispatched"][0]["issue"] == 195
+
+    def test_get_issue_failure(self, stub_world, capsys, monkeypatch):
+        def _boom(repo, n):
+            raise github.GitHubError("not found")
+
+        monkeypatch.setattr(github, "get_issue", _boom)
+        rc = cli.cmd_mission_spawn(_ns(number=999, repo="agentwire-dev", json=True))
+        assert rc == 1
+
+
+class TestStallResume:
+    def test_stall(self, stub_world, capsys):
+        rc = cli.cmd_mission_stall(_ns(number=195, repo="agentwire-dev",
+                                       reason="needs more info", json=True))
+        assert rc == 0
+        assert stub_world.labels_edited == [
+            {"repo": "owner/agentwire-dev", "n": 195,
+             "add": ["stalled"], "remove": ["agent-ready"]}
+        ]
+        assert stub_world.comments_made[0]["body"].startswith("Mission stalled: needs more info")
+
+    def test_resume(self, stub_world, capsys):
+        rc = cli.cmd_mission_resume(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        assert stub_world.labels_edited == [
+            {"repo": "owner/agentwire-dev", "n": 195,
+             "add": ["agent-ready"], "remove": ["stalled"]}
+        ]
+        # resume should NOT post a comment
+        assert stub_world.comments_made == []
+
+    def test_stall_label_failure(self, stub_world, capsys):
+        stub_world.label_edit_raises = True
+        rc = cli.cmd_mission_stall(_ns(number=195, repo="agentwire-dev",
+                                       reason="x", json=True))
+        assert rc == 1
+
+
+class TestKill:
+    def test_kill_active_session(self, stub_world, capsys, tmp_path):
+        session = "agentwire-dev/mission-195-foo-bar"
+        stub_world.active_sessions = [session]
+        # Make the worktree dir exist so remove_worktree gets called
+        wt = tmp_path / "projects" / "agentwire-dev-worktrees" / "mission-195-foo-bar"
+        wt.mkdir(parents=True)
+
+        rc = cli.cmd_mission_kill(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["session"] == session
+        assert data["worktree_removed"] is True
+        assert stub_world.kill_calls == [session]
+        assert stub_world.remove_calls == [wt]
+
+    def test_kill_with_no_active_session(self, stub_world, capsys):
+        rc = cli.cmd_mission_kill(_ns(number=999, repo="agentwire-dev", json=True))
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert "no active mission session" in out["error"]
+
+    def test_kill_worktree_missing_no_error(self, stub_world, capsys):
+        session = "agentwire-dev/mission-195-foo-bar"
+        stub_world.active_sessions = [session]
+        # No worktree on disk
+        rc = cli.cmd_mission_kill(_ns(number=195, repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["worktree_removed"] is False
+        assert stub_world.remove_calls == []
+
+
+class TestGc:
+    def test_runs_gc(self, stub_world, capsys, monkeypatch):
+        # gc is a separate module; call it through cli with no active sessions
+        rc = cli.cmd_mission_gc(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["reaped"] == [] and data["orphans_removed"] == []
+
+
+class TestTick:
+    def test_runs_dispatcher(self, stub_world, capsys, monkeypatch):
+        # Out-of-hours fast path: should not raise; return tick-report shape
+        from datetime import datetime
+        monkeypatch.setattr(
+            "agentwire.missions.dispatcher.datetime",
+            type("D", (), {"now": classmethod(lambda cls: datetime(2026, 5, 19, 3, 0))}),
+        )
+        rc = cli.cmd_mission_tick(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["out_of_hours"] is True
+
+
+class TestRouteFeedback:
+    def test_runs_router_no_sessions(self, stub_world, capsys):
+        rc = cli.cmd_mission_route_feedback(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["routed"] == [] and data["skipped"] == []
+
+    def test_router_with_new_review(self, stub_world, capsys):
+        stub_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        stub_world.prs_by_branch[("owner/agentwire-dev", "mission-195-foo-bar")] = PullRequest(
+            number=42, state="OPEN", head_ref="mission-195-foo-bar",
+            url="https://github.com/o/r/pull/42", is_draft=True,
+        )
+        stub_world.reviews_by_pr[("owner/agentwire-dev", 42)] = [Review(
+            id=1001, state="CHANGES_REQUESTED", body="fix x",
+            submitted_at="2026-05-19T12:00:00Z", user="rev",
+        )]
+        stub_world.issue_by_number[("owner/agentwire-dev", 195)] = _make_issue(195)
+        rc = cli.cmd_mission_route_feedback(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data["routed"]) == 1
+
+
+class TestInit:
+    def test_creates_label_via_short_name(self, stub_world, capsys):
+        rc = cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["created"] is True
+        assert stub_world.labels_created[0]["repo"] == "owner/agentwire-dev"
+
+    def test_creates_label_via_owner_repo_form(self, stub_world, capsys):
+        rc = cli.cmd_mission_init(_ns(repo="some-owner/some-repo", json=True))
+        assert rc == 0
+
+    def test_idempotent_second_call(self, stub_world, capsys):
+        cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
+        capsys.readouterr()  # drain first output
+        rc = cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["created"] is False
+
+    def test_rejects_bare_short_with_no_config(self, stub_world, capsys):
+        rc = cli.cmd_mission_init(_ns(repo="unknown-short-name", json=True))
+        assert rc == 1

--- a/tests/unit/test_missions_gc.py
+++ b/tests/unit/test_missions_gc.py
@@ -1,0 +1,275 @@
+"""Tests for ``agentwire.missions.gc``."""
+
+from pathlib import Path
+
+import pytest
+
+from agentwire.missions import dispatcher, gc, github, state
+from agentwire.missions.config import MissionsConfig, RepoConfig
+from agentwire.missions.github import PullRequest
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    state_dir = tmp_path / "missions-state"
+    monkeypatch.setattr(state, "STATE_DIR", state_dir)
+    monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
+    monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+
+
+@pytest.fixture
+def projects_dir(tmp_path):
+    """Build a fake projects/<repo>-worktrees/ layout that gc can scan."""
+    pd = tmp_path / "projects"
+    pd.mkdir()
+    return pd
+
+
+@pytest.fixture
+def cfg(projects_dir):
+    return MissionsConfig(
+        repos={
+            "agentwire-dev": RepoConfig(
+                short="agentwire-dev",
+                name="owner/agentwire-dev",
+                projects_dir=projects_dir,
+            ),
+        },
+    )
+
+
+@pytest.fixture
+def patch_world(monkeypatch):
+    """Fake all side-effects: session list, gh, kill, worktree remove."""
+
+    class World:
+        active_sessions: list[str] = []
+        prs_by_branch: dict = {}
+        killed: list[str] = []
+        removed: list[Path] = []
+        kill_raises: bool = False
+        remove_raises: bool = False
+        list_pr_raises: bool = False
+
+    w = World()
+    w.active_sessions = []
+    w.prs_by_branch = {}
+    w.killed = []
+    w.removed = []
+
+    monkeypatch.setattr(dispatcher, "list_mission_sessions", lambda: list(w.active_sessions))
+
+    def _get_pr_by_branch(repo, branch):
+        if w.list_pr_raises:
+            raise github.GitHubError("rate limit")
+        return w.prs_by_branch.get((repo, branch))
+
+    monkeypatch.setattr(github, "get_pr_by_branch", _get_pr_by_branch)
+
+    def _kill(session):
+        if w.kill_raises:
+            raise RuntimeError("kill failed")
+        w.killed.append(session)
+
+    monkeypatch.setattr(gc, "kill_session", _kill)
+
+    def _remove(path):
+        if w.remove_raises:
+            raise RuntimeError("worktree remove failed")
+        w.removed.append(path)
+
+    monkeypatch.setattr(gc, "remove_worktree", _remove)
+    return w
+
+
+def mk_pr(n=42, state="MERGED", branch="mission-195-foo-bar"):
+    return PullRequest(
+        number=n,
+        state=state,
+        head_ref=branch,
+        url=f"https://github.com/o/r/pull/{n}",
+        is_draft=False,
+    )
+
+
+def _make_worktree_dir(projects_dir: Path, repo_short: str, branch: str) -> Path:
+    """Create a fake worktree directory at the canonical location."""
+    p = projects_dir / f"{repo_short}-worktrees" / branch
+    p.mkdir(parents=True)
+    return p
+
+
+# --- tests ---
+
+
+class TestNoSessions:
+    def test_no_op(self, cfg, patch_world):
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        assert report.skipped == []
+        # gc still records its heartbeat
+        assert "gc" in state.read_last_tick()
+
+
+class TestReapMerged:
+    def test_merged_pr_session_reaped(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-195-foo-bar"
+        wt = _make_worktree_dir(projects_dir, "agentwire-dev", "mission-195-foo-bar")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="MERGED"),
+        }
+        state.update_routed_review(42, 1001)  # gc should clear this
+
+        report = gc.gc(cfg)
+        assert len(report.reaped) == 1
+        r = report.reaped[0]
+        assert r["session"] == session
+        assert r["pr"] == 42
+        assert r["pr_state"] == "MERGED"
+        assert r["worktree_removed"] is True
+        assert patch_world.killed == [session]
+        assert patch_world.removed == [wt]
+        # state cleared for the reaped PR
+        assert state.last_routed_review(42) is None
+
+    def test_closed_pr_session_reaped(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-7-thing"
+        _make_worktree_dir(projects_dir, "agentwire-dev", "mission-7-thing")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-7-thing"): mk_pr(n=8, state="CLOSED"),
+        }
+        report = gc.gc(cfg)
+        assert len(report.reaped) == 1
+        assert report.reaped[0]["pr_state"] == "CLOSED"
+
+
+class TestSkips:
+    def test_open_pr_untouched(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-195-foo-bar"
+        _make_worktree_dir(projects_dir, "agentwire-dev", "mission-195-foo-bar")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="OPEN"),
+        }
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        assert any("PR still OPEN" in s.get("reason", "") for s in report.skipped)
+        assert patch_world.killed == []
+
+    def test_no_pr_yet_untouched(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        assert any("no PR for branch" in s.get("reason", "") for s in report.skipped)
+
+    def test_unknown_repo_skipped(self, cfg, patch_world):
+        patch_world.active_sessions = ["ghost/mission-1-x"]
+        report = gc.gc(cfg)
+        assert any("repo not in config" in s.get("reason", "") for s in report.skipped)
+
+    def test_github_error_skips(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.list_pr_raises = True
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        assert any("get_pr_by_branch" in s.get("reason", "") for s in report.skipped)
+
+    def test_non_mission_session_ignored(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/regular-feature-branch"]
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        # No skip recorded — it's not a mission session
+        assert not any(s.get("session") == "agentwire-dev/regular-feature-branch" for s in report.skipped)
+
+
+class TestKillFailure:
+    def test_kill_failure_skips_session(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-195-foo-bar"
+        _make_worktree_dir(projects_dir, "agentwire-dev", "mission-195-foo-bar")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="MERGED"),
+        }
+        patch_world.kill_raises = True
+        report = gc.gc(cfg)
+        assert report.reaped == []
+        assert any("kill failed" in s.get("reason", "") for s in report.skipped)
+        # worktree should not be removed if kill failed
+        assert patch_world.removed == []
+
+
+class TestWorktreeRemoveFailure:
+    def test_remove_failure_still_reaps_session(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-195-foo-bar"
+        _make_worktree_dir(projects_dir, "agentwire-dev", "mission-195-foo-bar")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="MERGED"),
+        }
+        patch_world.remove_raises = True
+        report = gc.gc(cfg)
+        # session was killed (kill succeeded)
+        assert patch_world.killed == [session]
+        # but worktree removal failed; it's recorded as a skip
+        assert any("worktree remove failed" in s.get("reason", "") for s in report.skipped)
+        # session is not counted as reaped because we want operator attention
+        # (the session is killed but disk state needs manual cleanup)
+        # Behavior: we DO add a `reaped` entry but mark worktree_removed=False.
+        # This makes the kill visible in the report.
+        assert len(report.reaped) == 1
+        assert report.reaped[0]["worktree_removed"] is False
+
+
+class TestOrphanCleanup:
+    def test_orphan_worktree_removed(self, cfg, patch_world, projects_dir):
+        # Worktree on disk with no matching session → orphan
+        orphan = _make_worktree_dir(projects_dir, "agentwire-dev", "mission-999-orphan")
+        # No active sessions
+        report = gc.gc(cfg)
+        assert any(o["path"] == str(orphan) for o in report.orphans_removed)
+        assert orphan in patch_world.removed
+
+    def test_live_session_dir_not_orphan(self, cfg, patch_world, projects_dir):
+        session = "agentwire-dev/mission-100-live"
+        wt = _make_worktree_dir(projects_dir, "agentwire-dev", "mission-100-live")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-100-live"): mk_pr(state="OPEN"),
+        }
+        report = gc.gc(cfg)
+        # Live session's worktree must NOT be treated as orphan
+        assert wt not in patch_world.removed
+        assert report.orphans_removed == []
+
+    def test_reaped_session_dir_not_double_removed(self, cfg, patch_world, projects_dir):
+        """After a session reap, the same dir must not also appear as orphan.
+
+        Stub ``remove_worktree`` records the call but doesn't actually delete
+        the dir — gc must dedup via its in-memory ``handled_worktree_paths``
+        set, so ``remove`` is called exactly once across reap + orphan sweep.
+        """
+        session = "agentwire-dev/mission-195-foo-bar"
+        wt = _make_worktree_dir(projects_dir, "agentwire-dev", "mission-195-foo-bar")
+        patch_world.active_sessions = [session]
+        patch_world.prs_by_branch = {
+            ("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr(state="MERGED"),
+        }
+        report = gc.gc(cfg)
+        assert len(report.reaped) == 1
+        assert patch_world.removed == [wt]  # exactly once
+        assert report.orphans_removed == []
+
+    def test_orphan_remove_failure_reported(self, cfg, patch_world, projects_dir):
+        _make_worktree_dir(projects_dir, "agentwire-dev", "mission-999-orphan")
+        patch_world.remove_raises = True
+        report = gc.gc(cfg)
+        assert report.orphans_removed == []
+        assert any("worktree remove failed" in s.get("reason", "") for s in report.skipped)
+
+    def test_missing_worktrees_parent_no_error(self, cfg, patch_world, projects_dir):
+        # No {repo}-worktrees dir exists at all
+        report = gc.gc(cfg)
+        assert report.orphans_removed == []
+        assert report.skipped == []


### PR DESCRIPTION
## Summary

Phase 3+4+5 of mission #195. Library-only core landed in PR 1 (#196); this PR makes it operator-driven.

**Phase 3** — `agentwire/missions/gc.py`: walks active `*/mission-*` sessions, tears down workers whose PR is MERGED/CLOSED, sweeps for orphan worktree dirs.

**Phase 4** — `agentwire/missions/cli.py` + argparse wiring: 11 handlers behind `agentwire mission ...` (`list`, `show`, `status`, `spawn`, `stall`, `resume`, `kill`, `gc`, `tick`, `route-feedback`, `init`). All `--json`-aware.

**Phase 5** — `agentwire/mcp_server.py`: 8 `mission_*` MCP tools wrapping the CLI via `run_agentwire_cmd`. Pattern matches `scheduler_*`.

## Design notes (carried from plan)

- `kill` (CLI/MCP) and `gc` are intentionally distinct: `kill` is operator-side teardown that does NOT close the PR; `gc` is PR-driven teardown (only tears down when the PR is already MERGED/CLOSED). This means an operator can yank a runaway worker without losing the in-flight PR.
- `gc` defensively dedups via `handled_worktree_paths` so partial-failure cases (kill OK, worktree-remove fails) don't double-attempt in the orphan-sweep loop.
- `spawn` bypasses eligibility checks but honors the same per-issue `session_lock("mission-N")` — concurrent spawns on the same issue are safe.
- Drop the MCP tier distinction (issue body said "read-only for any agent; write for orchestrator-tier") — no such system exists in the codebase, so all 8 mission tools are equally available at v1.
- `agentwire mission init` is idempotent — `create_label` returns `True` on first create, `False` if the label already exists.

## What was reused (anchors in `main`)

| Reused | Why |
|---|---|
| `agentwire/locking.py:53` `session_lock` | Per-issue lock for `mission spawn` (via `_dispatch_one`) |
| `agentwire/missions/dispatcher.py` `_dispatch_one` | `mission spawn` is "bypass eligibility, run dispatch" |
| `agentwire/mcp_server.py:102` `run_agentwire_cmd` | All 8 MCP tools are thin shellouts over CLI |
| `agentwire/__main__.py` scheduler subparser pattern | argparse group + help-fallback wired the same way |

## Test plan

- [x] `uv run pytest tests/unit/test_missions_*.py` — 137 pass (15 new gc + 23 new cli + 99 pre-existing from PR 1)
- [x] `uv run ruff check agentwire/missions/ tests/unit/test_missions_*.py agentwire/mcp_server.py` — clean
- [x] Full unit suite (`tests/unit/`) — 966 pass, 1 unrelated pre-existing failure (`test_session_send_cross_session`, present on `main` too)
- [ ] Manual smoke: `agentwire mission --help`, `agentwire mission list`, `agentwire mission status` (after rebuild)
- [ ] Manual smoke: invoke `mission_list` MCP tool from an agent session

## What's next

PR 3 — `mission/195-safety-portal-integration` (Phases 6+7+8):
- `safety/_core.py` mission-worker rules + regen damage-control hooks
- portal sidebar `missions-section.js` + `/api/missions/list` + `mission_changed` WS event
- launchd plist templates + `docs/MISSIONS.md` + integration tests + CLAUDE.md pointer

Refs #195.

Built by [dotdev.dev](https://dotdev.dev)