### PR TITLE
fix(missions): shakedown findings — env var, branch cleanup, stall label, dedup

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -101,6 +101,17 @@ def _build_tmux_env_flags_shell(env: dict[str, str]) -> str:
     return " ".join(parts) + " "
 
 
+def _set_session_name_env(agent: "AgentCommand", session_name: str) -> None:
+    """Stamp ``AGENTWIRE_SESSION_NAME`` onto an ``AgentCommand.env``.
+
+    Every session created via ``cmd_new`` / ``cmd_spawn`` / ``cmd_recreate``
+    / ``cmd_fork`` / scheduler-spawn paths gets this so downstream tooling
+    (notably the mission-worker damage-control rules in ``safety/_core.py``)
+    can identify which agentwire session the running tool is part of.
+    """
+    agent.env["AGENTWIRE_SESSION_NAME"] = session_name
+
+
 def inject_session_env(session: str, env: dict[str, str], remote_host: str | None = None) -> None:
     """Set env vars on an existing tmux session for FUTURE shells in that session.
 
@@ -3406,6 +3417,7 @@ def cmd_new(args) -> int:
     model_override = getattr(args, 'model', None)
     agent = build_agent_command(session_type, roles if roles else None, model=model_override)
     agent.env.update(parse_env_args(getattr(args, 'env', None)))
+    _set_session_name_env(agent, session_name)
 
     agent_cmd = agent.command
 

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -1857,9 +1857,19 @@ def mission_list() -> str:
         for repo_short, rows in active.items():
             for row in rows:
                 lines.append(f"    {repo_short} #{row['issue']}  → {row['session']}")
+    # Exclude already-active issues from the eligible queue so a dispatched
+    # issue doesn't show up twice.
+    active_by_repo = {
+        repo: {row["issue"] for row in rows}
+        for repo, rows in active.items()
+    }
     eligible = data.get("eligible", {}) or {}
     for repo_short, rows in eligible.items():
-        eligibles = [r for r in rows if r.get("eligible")]
+        active_set = active_by_repo.get(repo_short, set())
+        eligibles = [
+            r for r in rows
+            if r.get("eligible") and r["issue"] not in active_set
+        ]
         if eligibles:
             lines.append(f"  Eligible in {repo_short}:")
             for r in eligibles:

--- a/agentwire/missions/cli.py
+++ b/agentwire/missions/cli.py
@@ -481,7 +481,13 @@ def cmd_mission_route_feedback(args) -> int:
 
 
 def cmd_mission_init(args) -> int:
-    """Create the ``agent-ready`` label on a target repo (idempotent)."""
+    """Create the ``agent-ready`` and ``stalled`` labels on a target repo (idempotent).
+
+    Both labels are required for the mission lifecycle: ``agent-ready`` gates the
+    dispatcher, ``stalled`` is applied by ``mission stall``. Without ``stalled``
+    pre-created, ``mission stall`` would fail with "'stalled' not found" on a
+    fresh repo.
+    """
     config = load_config()
     # Allow either short name (looked up via config) or owner/repo form.
     short = args.repo
@@ -492,20 +498,24 @@ def cmd_mission_init(args) -> int:
             args,
             f"'{short}' is not a configured repo short name and not in 'owner/repo' form",
         )
-    try:
-        created = github.create_label(
-            repo_name,
-            "agent-ready",
-            color="0e8a16",
-            description="Eligible for mission-dispatcher to pick up.",
-        )
-    except github.GitHubError as e:
-        return _emit_error(args, f"create_label failed: {e}")
 
+    labels_spec = [
+        ("agent-ready", "0e8a16", "Eligible for mission-dispatcher to pick up."),
+        ("stalled", "d93f0b", "Paused by `agentwire mission stall` — not eligible."),
+    ]
+    results: list[dict] = []
+    for name, color, description in labels_spec:
+        try:
+            created = github.create_label(repo_name, name, color=color, description=description)
+        except github.GitHubError as e:
+            return _emit_error(args, f"create_label '{name}' failed: {e}")
+        results.append({"label": name, "created": created})
+
+    summary = ", ".join(
+        f"'{r['label']}' {'created' if r['created'] else 'exists'}" for r in results
+    )
     return _emit(
         args,
-        {"success": True, "repo": repo_name, "created": created},
-        human=(
-            f"Label 'agent-ready' {'created' if created else 'already exists'} on {repo_name}"
-        ),
+        {"success": True, "repo": repo_name, "labels": results},
+        human=f"{summary} on {repo_name}",
     )

--- a/agentwire/missions/gc.py
+++ b/agentwire/missions/gc.py
@@ -64,12 +64,18 @@ def kill_session(session_full_name: str) -> None:
 
 
 def remove_worktree(path: Path) -> None:
-    """Remove a git worktree at ``path`` via ``git worktree remove --force``.
+    """Remove a git worktree at ``path`` via ``git worktree remove --force``,
+    then delete the local branch it pointed at.
 
     ``--force`` because by the time gc runs the PR is merged/closed and any
     uncommitted work is moot. Runs from inside the worktree so git can resolve
     the main repo via the worktree's .git pointer. Raises ``RuntimeError`` on
     failure (e.g. broken worktree pointer, or path not registered with git).
+
+    After worktree removal, attempts ``git branch -D <branch>`` from the
+    canonical repo so killed missions don't leak local branches. Branch name
+    is derived from the worktree directory name (``mission-N-slug``). Branch
+    deletion failures are NOT fatal — the worktree is the load-bearing part.
     """
     cwd = str(path) if path.is_dir() else None
     result = subprocess.run(
@@ -83,6 +89,22 @@ def remove_worktree(path: Path) -> None:
         raise RuntimeError(
             f"git worktree remove failed (rc={result.returncode}): "
             f"{(result.stderr or result.stdout).strip()}"
+        )
+
+    # Best-effort branch cleanup. The worktree's parent is `{repo}-worktrees`;
+    # the canonical repo lives at `{projects_dir}/{repo}` (one level up + drop
+    # the `-worktrees` suffix). Run `git branch -D` from there.
+    branch = path.name
+    worktrees_parent = path.parent
+    canonical_repo = worktrees_parent.parent / worktrees_parent.name.removesuffix("-worktrees")
+    if canonical_repo.is_dir():
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(canonical_repo),
+            check=False,
         )
 
 

--- a/agentwire/static/js/sidebar/missions-section.js
+++ b/agentwire/static/js/sidebar/missions-section.js
@@ -88,11 +88,19 @@ export const missionsSection = {
             }
         }
 
-        // Eligible queue
+        // Eligible queue — exclude issues that are already running as active
+        // workers so a dispatched issue doesn't appear in both lists.
+        const activeIssueByRepo = {};
+        for (const repo of Object.keys(active)) {
+            activeIssueByRepo[repo] = new Set((active[repo] || []).map(r => r.issue));
+        }
         let eligibleTotal = 0;
         const eligibleRows = {};
         for (const repo of Object.keys(eligible)) {
-            const rows = (eligible[repo] || []).filter(r => r.eligible);
+            const activeSet = activeIssueByRepo[repo] || new Set();
+            const rows = (eligible[repo] || []).filter(
+                r => r.eligible && !activeSet.has(r.issue)
+            );
             eligibleRows[repo] = rows;
             eligibleTotal += rows.length;
         }

--- a/docs/wiki/missions.md
+++ b/docs/wiki/missions.md
@@ -171,6 +171,18 @@ launchctl unload ~/Library/LaunchAgents/dev.agentwire.mission-*.plist
 rm ~/Library/LaunchAgents/dev.agentwire.mission-*.plist
 ```
 
+## Keeping the installed CLI in sync
+
+`uv tool install` caches builds. After editing any file under `agentwire/missions/`, `agentwire/safety/_core.py`, or the launchd plists, the installed `agentwire` binary still runs the **previous** code until you rebuild. The orchestrator launchd jobs invoke that installed binary directly — they will keep running stale code indefinitely.
+
+```bash
+agentwire rebuild   # reinstall from source so the installed CLI picks up changes
+```
+
+A symptom of forgetting this: you push a fix (e.g. branch cleanup in `gc.remove_worktree`), the next `mission gc` looks like it ran successfully, but the bug persists. Run `agentwire rebuild` between code change and any live test against the dispatcher / feedback-router / janitor.
+
+The portal (Python web server) needs `agentwire portal restart --dev` for static-file changes; the launchd plists pick up the new binary on their next tick — no service restart needed.
+
 ## Your first mission
 
 1. **One-time setup:**
@@ -224,6 +236,7 @@ rm ~/Library/LaunchAgents/dev.agentwire.mission-*.plist
 | `mission gc` keeps complaining "no PR for branch yet" | Worker hasn't pushed/opened the PR. That's a skip, not a failure — gc only reaps when state is MERGED/CLOSED. |
 | Feedback router routes the same review twice | Shouldn't happen — `state/routed_reviews.json` keys on PR number. If it does, that file may be corrupted; delete it and the router will re-route everything once. |
 | Worker tried to edit a file outside its worktree | Damage-control blocked it. The block message points at which file. If the edit is legitimate (rare — usually it's not), use the `# allow:` escape hatch in a Bash command, or kill+respawn the worker with a wider config (don't disable safety system-wide). |
+| Code change to `agentwire/missions/` doesn't take effect | The installed CLI is stale. Run `agentwire rebuild` — see [Keeping the installed CLI in sync](#keeping-the-installed-cli-in-sync). |
 
 ## Out of scope (v1)
 

--- a/tests/unit/test_missions_cli.py
+++ b/tests/unit/test_missions_cli.py
@@ -374,16 +374,21 @@ class TestRouteFeedback:
 
 
 class TestInit:
-    def test_creates_label_via_short_name(self, stub_world, capsys):
+    def test_creates_labels_via_short_name(self, stub_world, capsys):
         rc = cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["created"] is True
-        assert stub_world.labels_created[0]["repo"] == "owner/agentwire-dev"
+        assert {entry["label"] for entry in data["labels"]} == {"agent-ready", "stalled"}
+        assert all(entry["created"] is True for entry in data["labels"])
+        created_names = {row["name"] for row in stub_world.labels_created}
+        assert created_names == {"agent-ready", "stalled"}
+        assert all(row["repo"] == "owner/agentwire-dev" for row in stub_world.labels_created)
 
-    def test_creates_label_via_owner_repo_form(self, stub_world, capsys):
+    def test_creates_labels_via_owner_repo_form(self, stub_world, capsys):
         rc = cli.cmd_mission_init(_ns(repo="some-owner/some-repo", json=True))
         assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert {entry["label"] for entry in data["labels"]} == {"agent-ready", "stalled"}
 
     def test_idempotent_second_call(self, stub_world, capsys):
         cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
@@ -391,7 +396,7 @@ class TestInit:
         rc = cli.cmd_mission_init(_ns(repo="agentwire-dev", json=True))
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["created"] is False
+        assert all(entry["created"] is False for entry in data["labels"])
 
     def test_rejects_bare_short_with_no_config(self, stub_world, capsys):
         rc = cli.cmd_mission_init(_ns(repo="unknown-short-name", json=True))


### PR DESCRIPTION
## Summary

Two-pass live shakedown of the Missions subsystem (#195) against the real GitHub + tmux stack, against the real agentwire-dev repo, with a real worker that opened, addressed feedback on, and merged its own PR. Pass 1 ran the lifecycle end-to-end and uncovered two bugs; Pass 2 exercised the failure modes and uncovered three more. Five bugs total, all fixed and verified live.

### Pass 1 — full lifecycle

- ✅ Eligibility detection, dispatcher tick, worker spawn + worktree, initial prompt injection, draft PR open
- ✅ Feedback round: review captured, summary file written, `/clear` + refresh delivered, worker addressed feedback
- ✅ Idempotency: 2nd `route-feedback` is no-op
- ✅ Merge → issue auto-closed → gc reaped session + worktree
- **Bug 1:** `AGENTWIRE_SESSION_NAME` was never set anywhere — only the safety code read it, so mission-worker rules would never have fired in a real worker. Fixed in `__main__.py` via `_set_session_name_env` helper in `cmd_new`.
- **Bug 2:** `git worktree remove` left the local branch behind. Mission branches accumulated after gc. Fixed in `gc.remove_worktree` via best-effort `git branch -D` from the canonical repo.

### Pass 2 — failure modes + previously unexercised paths

- ✅ `mission spawn` bypasses eligibility (issue with no `agent-ready` label still dispatched)
- ✅ Worker damage-control: out-of-worktree write blocked; in-worktree allowed
- ✅ Worker damage-control: force-push to main blocked with mission-worker message; force-with-lease to mission branch passes the mission rule (global asks for confirmation, correct)
- ✅ `mission stall` removes `agent-ready`, adds `stalled`, posts comment, flips eligibility False
- ✅ `mission resume` restores eligibility
- ✅ Concurrency cap: two eligible, only one dispatched per tick; second skip reason `global concurrency cap`
- ✅ Portal `/api/missions/list` returns correct payload
- ✅ MCP `mission_list`, `mission_show`, `mission_status` all return correct shape from another process
- **Bug 3:** `mission init` only created `agent-ready`, leaving `stalled` undefined → `mission stall` failed on fresh repos with `'stalled' not found`. Init now creates both labels, idempotent.
- **Bug 4:** Sidebar + MCP `mission_list` rendered already-active issues a second time in the eligible queue. Both renderers now exclude active-issue numbers from the eligible filter.
- **Bug 5:** Wiki had no mention of the `agentwire rebuild` requirement after editing `agentwire/missions/`, `agentwire/safety/_core.py`, or the launchd plists. Added a section + troubleshooting row (Pass 1 burned an hour on this — installed CLI was stale while the fix sat unbuilt).

### Test coverage

- 147 mission unit + integration tests pass
- 26 mission-worker safety tests pass
- All `test_damage_control_sync.py` invariants hold

### Files

- `agentwire/__main__.py` — env var injection in `cmd_new`
- `agentwire/missions/gc.py` — branch deletion after worktree removal
- `agentwire/missions/cli.py` — `mission init` creates both labels
- `agentwire/mcp_server.py` — active-issue dedup in `mission_list`
- `agentwire/static/js/sidebar/missions-section.js` — active-issue dedup in sidebar
- `docs/wiki/missions.md` — rebuild workflow + troubleshooting
- `tests/unit/test_missions_cli.py` — updated init tests for two-label payload

## Test plan

- [x] Pass 1 full lifecycle dispatched → reviewed → merged → gc'd a real issue (#199 → PR #200) against the agentwire-dev repo
- [x] Pass 2 exercised spawn-bypass, damage-control (path + bash), stall/resume, concurrency cap, portal API, MCP tools (#201 / #203 / #204)
- [x] Synthetic test in `/tmp/fakerepo-clean` confirmed `gc.remove_worktree` deletes worktree + branch after `agentwire rebuild`
- [x] `mission kill 204` post-pass-2 verified single-command teardown removes session + worktree + branch
- [x] All test fixtures cleaned up — no leftover mission sessions, worktrees, or branches

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session names are now available to agents via environment variables.
  * Mission initialization creates both "agent-ready" and "stalled" labels on target repositories.

* **Bug Fixes**
  * Mission queue no longer displays issues already active in worker sessions.
  * Eligible queue sidebar properly filters out already-running issues per repository.

* **Documentation**
  * Added troubleshooting guide explaining when to run `agentwire rebuild` after code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotdevdotdev/agentwire-dev/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->