### PR TITLE
feat(missions): email when a draft PR opens for review

### DIFF
--- a/agentwire/missions/feedback_router.py
+++ b/agentwire/missions/feedback_router.py
@@ -84,6 +84,51 @@ def build_summary(
     )
 
 
+def _notify_pr_ready(repo_name: str, issue: github.Issue, pr: github.PullRequest) -> tuple[bool, str]:
+    """Send a 'draft PR ready for review' email. Returns (sent, error_or_message).
+
+    Best-effort: any email-config or send failure is non-fatal for the router.
+    The PR is still marked as notified so we don't retry on every tick — the
+    operator can resend manually if needed.
+    """
+    try:
+        from agentwire.channels.email import send_email, EmailConfigError
+    except ImportError as e:
+        return False, f"email channel unavailable: {e}"
+
+    criteria = eligibility.extract_acceptance_criteria(issue.body) or []
+    crit_lines = "\n".join(f"- {c}" for c in criteria) or "_(no acceptance criteria parsed)_"
+    subject = f"Mission #{issue.number}: draft PR ready for review"
+    body = (
+        f"A mission worker has opened a **draft PR** and is now waiting for your review.\n"
+        f"\n"
+        f"**Issue:** [#{issue.number} — {issue.title}](https://github.com/{repo_name}/issues/{issue.number})  \n"
+        f"**Draft PR:** [#{pr.number}]({pr.url})\n"
+        f"\n"
+        f"### Acceptance criteria\n"
+        f"\n"
+        f"{crit_lines}\n"
+        f"\n"
+        f"### What to do\n"
+        f"\n"
+        f"Review the PR. Leave comments / request changes / approve as usual — the\n"
+        f"feedback router will pick up new reviews on its next 15-minute tick and\n"
+        f"send them back into the worker session. Merge when satisfied; the janitor\n"
+        f"will reap the worker on its next pass.\n"
+    )
+
+    try:
+        result = send_email(subject=subject, body=body)
+    except EmailConfigError as e:
+        return False, f"email config error: {e}"
+    except Exception as e:
+        return False, f"send_email raised: {e}"
+
+    if not result.success:
+        return False, f"send_email returned error: {result.error}"
+    return True, result.message_id or "(no message_id)"
+
+
 def _send_context_refresh(session_full: str, summary_file: Path) -> None:
     """Send ``/clear`` and then a refresh prompt pointing at ``summary_file``.
 
@@ -135,6 +180,29 @@ def route_feedback(config: MissionsConfig | None = None) -> FeedbackReport:
         if pr.state != "OPEN":
             report.skipped.append({"session": session_full, "reason": f"PR is {pr.state}"})
             continue
+
+        # First-time-seen draft PR → send the operator an email and remember.
+        # Done before review processing so a brand-new PR gets noticed even on
+        # the same tick it first appears (PRs typically open with zero reviews).
+        if not state.is_pr_notified(pr.number):
+            try:
+                issue_for_notify = github.get_issue(repo.name, issue_number)
+            except github.GitHubError as e:
+                log.warning("notify: get_issue failed for #%d: %s", issue_number, e)
+                issue_for_notify = None
+            if issue_for_notify is not None:
+                sent, detail = _notify_pr_ready(repo.name, issue_for_notify, pr)
+                # Mark notified even on send failure so we don't retry every
+                # 15 minutes — operator can resend manually if needed.
+                state.mark_pr_notified(pr.number)
+                report.routed.append(
+                    {
+                        "session": session_full,
+                        "pr": pr.number,
+                        "event": "pr_opened_email" if sent else "pr_opened_email_failed",
+                        "detail": detail,
+                    }
+                )
 
         try:
             reviews = github.list_pr_reviews(repo.name, pr.number)

--- a/agentwire/missions/state.py
+++ b/agentwire/missions/state.py
@@ -21,6 +21,7 @@ from pathlib import Path
 STATE_DIR = Path.home() / ".agentwire" / "missions" / "state"
 LAST_TICK_PATH = STATE_DIR / "last_tick.json"
 ROUTED_REVIEWS_PATH = STATE_DIR / "routed_reviews.json"
+NOTIFIED_PRS_PATH = STATE_DIR / "notified_prs.json"
 
 
 def _atomic_write(path: Path, data: dict) -> None:
@@ -100,3 +101,36 @@ def forget_pr(pr_number: int) -> None:
     data = read_routed_reviews()
     data.pop(str(pr_number), None)
     write_routed_reviews(data)
+    forget_notified_pr(pr_number)
+
+
+def read_notified_prs() -> set[int]:
+    """Return the set of PR numbers we've already sent a 'draft ready' email for."""
+    raw = _read_json(NOTIFIED_PRS_PATH)
+    pr_numbers = raw.get("pr_numbers", []) if isinstance(raw, dict) else []
+    out: set[int] = set()
+    for n in pr_numbers:
+        try:
+            out.add(int(n))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def is_pr_notified(pr_number: int) -> bool:
+    """True iff a 'draft PR ready' email has already gone out for this PR."""
+    return int(pr_number) in read_notified_prs()
+
+
+def mark_pr_notified(pr_number: int) -> None:
+    """Record that a 'draft PR ready' email has been sent for this PR."""
+    current = read_notified_prs()
+    current.add(int(pr_number))
+    _atomic_write(NOTIFIED_PRS_PATH, {"pr_numbers": sorted(current)})
+
+
+def forget_notified_pr(pr_number: int) -> None:
+    """Drop a PR's notification tracking (called by gc when PR is reaped)."""
+    current = read_notified_prs()
+    current.discard(int(pr_number))
+    _atomic_write(NOTIFIED_PRS_PATH, {"pr_numbers": sorted(current)})

--- a/tests/unit/test_missions_feedback_router.py
+++ b/tests/unit/test_missions_feedback_router.py
@@ -16,6 +16,7 @@ def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setattr(state, "STATE_DIR", state_dir)
     monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
     monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(state, "NOTIFIED_PRS_PATH", state_dir / "notified_prs.json")
     monkeypatch.setattr(feedback_router, "SUMMARIES_DIR", summaries_dir)
 
 
@@ -40,6 +41,8 @@ def patch_world(monkeypatch):
         reviews_by_pr: dict = {}
         issue_by_n: dict = {}
         prompts_sent: list = []
+        notifications_sent: list = []
+        notify_result: tuple[bool, str] = (True, "stub-message-id")
 
     world = World()
     world.active_sessions = []
@@ -47,6 +50,8 @@ def patch_world(monkeypatch):
     world.reviews_by_pr = {}
     world.issue_by_n = {}
     world.prompts_sent = []
+    world.notifications_sent = []
+    world.notify_result = (True, "stub-message-id")
 
     monkeypatch.setattr(dispatcher, "list_mission_sessions", lambda: list(world.active_sessions))
     monkeypatch.setattr(github, "get_pr_by_branch", lambda r, b: world.pr_by_branch.get((r, b)))
@@ -60,6 +65,12 @@ def patch_world(monkeypatch):
         lambda s, p: world.prompts_sent.append((s, p)),
     )
     monkeypatch.setattr(feedback_router.time, "sleep", lambda s: None)
+
+    def _stub_notify(repo_name, issue, pr):
+        world.notifications_sent.append({"repo": repo_name, "issue": issue.number, "pr": pr.number})
+        return world.notify_result
+
+    monkeypatch.setattr(feedback_router, "_notify_pr_ready", _stub_notify)
     return world
 
 
@@ -128,12 +139,15 @@ class TestSkips:
         assert any("repo not in config" in s.get("reason", "") for s in report.skipped)
 
     def test_no_new_reviews(self, cfg, patch_world):
+        # PR opened previously and already notified → router skips quietly.
+        state.mark_pr_notified(42)
         patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
         patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): []}
         patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
         report = feedback_router.route_feedback(cfg)
         assert report.routed == []
+        assert patch_world.notifications_sent == []
         assert any("no new reviews" in s.get("reason", "") for s in report.skipped)
 
     def test_non_mission_session_ignored(self, cfg, patch_world):
@@ -144,6 +158,7 @@ class TestSkips:
 
 class TestRouting:
     def test_routes_single_new_review(self, cfg, patch_world):
+        state.mark_pr_notified(42)  # pretend PR already announced
         patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
         patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}
@@ -166,6 +181,7 @@ class TestRouting:
         assert state.last_routed_review(42) == 1001
 
     def test_filters_already_routed(self, cfg, patch_world):
+        state.mark_pr_notified(42)
         state.update_routed_review(42, 1001)
         patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
@@ -186,6 +202,7 @@ class TestRouting:
         assert state.last_routed_review(42) == 1042
 
     def test_summary_includes_criteria(self, cfg, patch_world):
+        state.mark_pr_notified(42)
         patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
         patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}
@@ -196,8 +213,49 @@ class TestRouting:
         assert "- [ ] b" in text
 
 
+class TestPrOpenedNotification:
+    def test_first_seen_pr_triggers_email(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): []}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        report = feedback_router.route_feedback(cfg)
+
+        assert patch_world.notifications_sent == [
+            {"repo": "owner/agentwire-dev", "issue": 195, "pr": 42}
+        ]
+        assert state.is_pr_notified(42)
+        assert any(r.get("event") == "pr_opened_email" for r in report.routed)
+
+    def test_second_tick_does_not_resend(self, cfg, patch_world):
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): []}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        feedback_router.route_feedback(cfg)
+        feedback_router.route_feedback(cfg)
+
+        # First tick sends the email; second is a no-op.
+        assert len(patch_world.notifications_sent) == 1
+
+    def test_send_failure_still_marks_notified(self, cfg, patch_world):
+        # Don't retry on every tick when SMTP / config breaks.
+        patch_world.notify_result = (False, "stub failure")
+        patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
+        patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
+        patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): []}
+        patch_world.issue_by_n = {("owner/agentwire-dev", 195): mk_issue()}
+
+        report = feedback_router.route_feedback(cfg)
+        assert state.is_pr_notified(42)
+        assert any(r.get("event") == "pr_opened_email_failed" for r in report.routed)
+
+
 class TestIdempotentReplay:
     def test_second_run_with_no_new_reviews_is_quiet(self, cfg, patch_world):
+        state.mark_pr_notified(42)  # PR-opened email already sent
         patch_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         patch_world.pr_by_branch = {("owner/agentwire-dev", "mission-195-foo-bar"): mk_pr()}
         patch_world.reviews_by_pr = {("owner/agentwire-dev", 42): [mk_review(1001)]}

--- a/tests/unit/test_missions_gc.py
+++ b/tests/unit/test_missions_gc.py
@@ -15,6 +15,7 @@ def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setattr(state, "STATE_DIR", state_dir)
     monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
     monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(state, "NOTIFIED_PRS_PATH", state_dir / "notified_prs.json")
 
 
 @pytest.fixture

--- a/tests/unit/test_missions_state.py
+++ b/tests/unit/test_missions_state.py
@@ -14,6 +14,7 @@ def isolated_state_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(state, "STATE_DIR", state_dir)
     monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
     monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(state, "NOTIFIED_PRS_PATH", state_dir / "notified_prs.json")
     return state_dir
 
 
@@ -81,3 +82,39 @@ def test_routed_reviews_file_is_pretty_printed(isolated_state_dir):
     text = (isolated_state_dir / "routed_reviews.json").read_text()
     assert "\n" in text
     assert json.loads(text) == {"42": 1001}
+
+
+class TestNotifiedPrs:
+    def test_unmarked_pr_is_not_notified(self):
+        assert state.is_pr_notified(42) is False
+        assert state.read_notified_prs() == set()
+
+    def test_mark_then_check(self):
+        state.mark_pr_notified(42)
+        assert state.is_pr_notified(42) is True
+        assert state.read_notified_prs() == {42}
+
+    def test_mark_is_idempotent(self):
+        state.mark_pr_notified(42)
+        state.mark_pr_notified(42)
+        assert state.read_notified_prs() == {42}
+
+    def test_forget_drops_one_pr(self):
+        state.mark_pr_notified(42)
+        state.mark_pr_notified(43)
+        state.forget_notified_pr(42)
+        assert state.read_notified_prs() == {43}
+
+    def test_forget_pr_clears_both_tracking_stores(self):
+        # forget_pr is what gc calls on reap — should clear both reviews
+        # and notification stores for the same PR.
+        state.update_routed_review(42, 1001)
+        state.mark_pr_notified(42)
+        state.forget_pr(42)
+        assert state.last_routed_review(42) is None
+        assert state.is_pr_notified(42) is False
+
+    def test_corrupt_notified_file_falls_back_to_empty(self, isolated_state_dir):
+        isolated_state_dir.mkdir(parents=True, exist_ok=True)
+        (isolated_state_dir / "notified_prs.json").write_text("{ not json")
+        assert state.read_notified_prs() == set()


### PR DESCRIPTION
## Summary

Hooks the existing agentwire email channel (Resend, configured in \`channels.email\`) into the feedback router so the operator gets a single branded email the first time a mission worker opens its draft PR.

## What lands

- New state file \`~/.agentwire/missions/state/notified_prs.json\` — list of PR numbers already announced
- New state helpers in \`agentwire/missions/state.py\`: \`is_pr_notified\`, \`mark_pr_notified\`, \`forget_notified_pr\`, \`read_notified_prs\`
- \`forget_pr\` (called by gc on reap) now also clears the notification stamp so a re-opened PR can notify fresh
- New private helper \`feedback_router._notify_pr_ready\` — composes the email body (PR link, issue title, parsed acceptance criteria) and calls \`agentwire.channels.email.send_email\`
- Notification gate runs once per PR per its lifetime; failures still mark notified so the router doesn't spam retries every 15 minutes

## What stays the same

- Workers still create **draft** PRs and stop. No auto-merge.
- Reviewer is in charge of every merge.
- Janitor only reaps sessions whose PR is \`MERGED\` or \`CLOSED\`.

## Test plan

- [x] 54 tests pass across feedback_router / state / gc / integration suites
- [x] Three new state tests for notified_prs (mark / idempotent / forget / corrupt fallback)
- [x] Three new feedback_router tests for the notify gate (first-seen fires, second tick is no-op, send-failure still marks)
- [x] All existing routing tests pre-mark the PR notified so they isolate review routing from the new notify path
- [ ] Live verification: next feedback-router tick (within 15 minutes of merge + rebuild) will email the operator once per active worker's PR

Built by [dotdev.dev](https://dotdev.dev)