### PR TITLE
feat(portal): defs-first workflows sidebar

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3358,6 +3358,40 @@ def cmd_new(args) -> int:
         # Simple session: ~/projects/project/
         session_path = projects_dir / project
 
+    # Safety: refuse to attach a new session to a path that is already the working
+    # directory of another active session. Two agents sharing the same working tree
+    # is the dangerous footgun (one's dirty state visible to the other, branches
+    # mixing). Worktree sessions (project/branch) get unique paths and won't trip
+    # this. --force overrides.
+    if not args.force:
+        target = str(session_path.resolve()) if session_path.exists() else str(session_path)
+        panes_result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}"],
+            capture_output=True, text=True,
+        )
+        if panes_result.returncode == 0:
+            conflicting: set[str] = set()
+            for line in panes_result.stdout.splitlines():
+                if "\t" not in line:
+                    continue
+                sess, p = line.split("\t", 1)
+                if sess == session_name:
+                    continue
+                try:
+                    if str(Path(p).resolve()) == target:
+                        conflicting.add(sess)
+                except (OSError, RuntimeError):
+                    continue
+            if conflicting:
+                others = ", ".join(sorted(conflicting))
+                hint = (
+                    f"Refusing to attach session '{session_name}' to {session_path}: "
+                    f"already the working directory of active session(s): {others}. "
+                    "Use a 'project/branch' name to create an isolated worktree, "
+                    "pick a different path, or pass --force to override."
+                )
+                return _output_result(False, json_mode, hint)
+
     if not session_path.exists():
         if args.force or path:
             # Auto-create directory with -f flag or when custom path explicitly provided

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -294,14 +294,31 @@ def session_create(
     project_dir: str | None = None,
     roles: str | None = None,
     session_type: str | None = None,
+    base: str | None = None,
+    pull_first: bool = True,
 ) -> str:
     """Create a new AgentWire session.
 
+    Worktree mode: use 'project/branch' as the name (e.g. 'fragmentz/nav-dropdown-185')
+    to fork an isolated git worktree off `base` (default 'main') at
+    `<project_dir>-worktrees/<branch>/`. This is the safe way to spin up parallel
+    agents on the same repo — each gets its own working tree and branch.
+
+    Flat names (no slash) attach a session directly to `project_dir` as-is. If
+    that path is already the working directory of another active session, the
+    call is refused — two agents on the same dirty tree is unsafe.
+
     Args:
-        name: Session name (required)
-        project_dir: Project directory path (optional)
-        roles: Comma-separated list of roles to apply (optional)
-        session_type: Session type like 'claude-bypass', 'claude-bypass' (optional)
+        name: Session name. Use 'project/branch' for an isolated worktree;
+            a flat name attaches to project_dir directly.
+        project_dir: Project directory path. For worktree mode, this is the main
+            repo (the worktree is created alongside it). Optional.
+        roles: Comma-separated list of roles to apply. Optional.
+        session_type: Session type like 'claude-bypass'. Optional.
+        base: Base branch to fork the worktree from (worktree mode only,
+            default 'main'). Ignored for flat names.
+        pull_first: Fetch origin/<base> before branching (worktree mode only,
+            default True). Set False to branch off the local <base> as-is.
 
     Returns:
         Success message or error description.
@@ -314,6 +331,10 @@ def session_create(
         args.extend(["--roles", roles])
     if session_type:
         args.extend(["--type", session_type])
+    if base:
+        args.extend(["--base", base])
+    if not pull_first:
+        args.append("--no-pull-first")
 
     data = run_agentwire_cmd(args)
     if data.get("success"):

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -244,6 +244,7 @@ class AgentWireServer:
         self.app.router.add_post("/api/missions/tick", self.api_missions_tick)
         self.app.router.add_post("/api/missions/gc", self.api_missions_gc)
         # Workflow history endpoints
+        self.app.router.add_get("/api/workflows/list", self.api_workflows_list)
         self.app.router.add_get("/api/workflows/runs", self.api_workflows_runs_list)
         self.app.router.add_get("/api/workflows/runs/{run_id}", self.api_workflows_run_detail)
         # Artifact windows: upload and serve agent-generated HTML
@@ -4423,6 +4424,118 @@ projects:
             tail = int(request.query.get("tail", "100"))
             events = read_events(tail=tail, task_filter=name)
             return web.json_response({"events": events})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_workflows_list(self, request: web.Request) -> web.Response:
+        """GET /api/workflows/list - All workflow defs joined with scheduler state.
+
+        Returns one entry per WorkflowDef found by discover_workflows(), marked
+        as scheduled/enabled by cross-referencing scheduler.yaml tasks. Scheduler
+        tasks that reference a workflow with no matching def are returned in
+        `orphans` so the UI can surface broken config.
+        """
+        try:
+            from .workflows.cli import RUNS_DIR
+            from .workflows.definitions import discover_workflows
+            from .workflows.storage import list_runs
+            from .scheduler import load_board
+
+            def _summarize_schedule(sched) -> str:
+                if sched is None:
+                    return ""
+                if sched.after:
+                    base = f"after {sched.after}"
+                    if sched.delay:
+                        mins, secs = divmod(int(sched.delay), 60)
+                        suffix = f"{mins}m" if mins and not secs else (
+                            f"{mins}m{secs}s" if mins else f"{secs}s"
+                        )
+                        base = f"{base} +{suffix}"
+                    return base
+                every = (sched.every or "").strip().lower()
+                at = sched.at
+                weekdays = {
+                    "monday", "tuesday", "wednesday", "thursday",
+                    "friday", "saturday", "sunday",
+                }
+                if every in weekdays and at:
+                    return f"{every.capitalize()} {at}"
+                if every == "day" and at:
+                    return f"daily {at}"
+                if every == "week" and at:
+                    return f"weekly {at}"
+                if every == "weekday" and at:
+                    return f"weekdays {at}"
+                if not every:
+                    return f"at {at}" if at else ""
+                if at:
+                    return f"every {every} at {at}"
+                return f"every {every}"
+
+            def _collect() -> dict:
+                defs = discover_workflows()
+                board = load_board()
+                # name -> SchedulerTask, picking the first task per workflow name
+                tasks_by_workflow: dict[str, object] = {}
+                for task in board.tasks.values():
+                    if task.workflow and task.workflow not in tasks_by_workflow:
+                        tasks_by_workflow[task.workflow] = task
+
+                workflows: list[dict] = []
+                claimed_tasks: set[str] = set()
+                for wf in defs:
+                    task = tasks_by_workflow.get(wf.name)
+                    scheduled = task is not None
+                    enabled = bool(task.enabled) if task else False
+                    schedule_summary = _summarize_schedule(task.schedule) if task else ""
+                    last_run_at: float | None = None
+                    last_status: str = ""
+                    if task is not None:
+                        state = board.state.get(task.name)
+                        if state and state.last_run:
+                            last_run_at = state.last_run.timestamp()
+                            last_status = state.last_status
+                            claimed_tasks.add(task.name)
+                    if last_run_at is None:
+                        # Fall back to the most recent run dir for this workflow
+                        runs = list_runs(RUNS_DIR, workflow=wf.name, limit=1)
+                        if runs:
+                            last_run_at = runs[0].get("started_at")
+                            last_status = runs[0].get("status", "")
+                    workflows.append({
+                        "name": wf.name,
+                        "description": wf.description,
+                        "node_count": len(wf.nodes),
+                        "scheduled": scheduled,
+                        "enabled": enabled,
+                        "task_name": task.name if task else "",
+                        "schedule_summary": schedule_summary,
+                        "last_run_at": last_run_at,
+                        "last_status": last_status,
+                    })
+
+                # Orphans: scheduler tasks pointing at workflows that have no def.
+                def_names = {wf.name for wf in defs}
+                orphans: list[dict] = []
+                for wf_name, task in tasks_by_workflow.items():
+                    if wf_name in def_names:
+                        continue
+                    state = board.state.get(task.name)
+                    orphans.append({
+                        "name": wf_name,
+                        "task_name": task.name,
+                        "enabled": bool(task.enabled),
+                        "schedule_summary": _summarize_schedule(task.schedule),
+                        "last_run_at": state.last_run.timestamp() if state and state.last_run else None,
+                        "last_status": state.last_status if state else "",
+                    })
+
+                return {"workflows": workflows, "orphans": orphans}
+
+            loop = asyncio.get_event_loop()
+            data = await loop.run_in_executor(None, _collect)
+            return web.json_response(data)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -4459,13 +4459,13 @@ body.sidebar-pinned .sidebar-tab {
 
 .notification-panel {
     position: fixed;
-    bottom: 16px;
+    bottom: 150px;
     right: 16px;
     z-index: 1500;
     display: flex;
     flex-direction: column-reverse;
     gap: 8px;
-    max-height: calc(100vh - 32px);
+    max-height: calc(100vh - 166px);
     overflow-y: auto;
     pointer-events: none;
     scrollbar-width: none;

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -4587,6 +4587,33 @@ body.sidebar-pinned .sidebar-tab {
     color: #a994d4;
 }
 
+.sidebar-workflow-def {
+    cursor: pointer;
+}
+.sidebar-workflow-def .sidebar-chevron {
+    flex-shrink: 0;
+    opacity: 0.5;
+    font-size: 11px;
+    transition: transform 0.15s ease;
+    width: 10px;
+    text-align: center;
+}
+.sidebar-workflow-def[data-expanded="true"] .sidebar-chevron {
+    transform: rotate(90deg);
+}
+.sidebar-workflow-runs {
+    padding-left: 14px;
+    margin: 2px 0 4px 11px;
+    border-left: 1px solid var(--chrome-border);
+}
+.sidebar-tag-warn {
+    background: rgba(220, 38, 38, 0.18);
+    color: #f87171;
+}
+.sidebar-workflow-orphan .sidebar-list-item-title {
+    color: #f87171;
+}
+
 .workflow-window-content {
     padding: 16px 20px;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/agentwire/static/js/sidebar/workflows-section.js
+++ b/agentwire/static/js/sidebar/workflows-section.js
@@ -1,11 +1,38 @@
 /**
- * Workflows sidebar section — lists recent workflow runs.
+ * Workflows sidebar section — defs-first list with inline run drill-down.
  *
- * Clicking a run opens the WorkflowWindow detail view. Independent of the
- * Scheduler section (scheduler shows *what will fire*, this shows *what ran*).
+ * Top level is a list of workflow definitions (from /api/workflows/list).
+ * Each row carries a status dot (enabled/disabled/never-scheduled), a
+ * schedule cadence pill, and a chevron. Click expands the row inline and
+ * lazy-fetches that workflow's recent runs from /api/workflows/runs?workflow=X.
+ * Click a run row → opens the WorkflowWindow detail view.
+ *
+ * Orphan scheduler tasks (workflow: refs without a matching def) render as
+ * red warning rows above the def list so broken config is visible.
  */
 
 import { openWorkflowWindow } from '../windows/workflow-window.js';
+
+const EXPANDED_KEY = 'workflows-section-expanded';
+
+function _loadExpanded() {
+    try {
+        const raw = localStorage.getItem(EXPANDED_KEY);
+        if (!raw) return new Set();
+        const arr = JSON.parse(raw);
+        return new Set(Array.isArray(arr) ? arr : []);
+    } catch {
+        return new Set();
+    }
+}
+
+function _saveExpanded(set) {
+    try {
+        localStorage.setItem(EXPANDED_KEY, JSON.stringify([...set]));
+    } catch {
+        // localStorage may be unavailable; expansions stay session-scoped
+    }
+}
 
 function _fmtTime(ts) {
     if (!ts) return '';
@@ -28,18 +55,47 @@ function _fmtDuration(ms) {
     return rem ? `${m}m${rem}s` : `${m}m`;
 }
 
-function _statusDot(status) {
+function _runStatusDot(status) {
     if (status === 'success') return 'dot-online';
     if (status === 'failed' || status === 'error') return 'dot-offline';
     if (status === 'running') return 'dot-processing';
     return 'dot-idle';
 }
 
+function _defStatusDot(wf) {
+    if (!wf.scheduled) return 'dot-checking';
+    return wf.enabled ? 'dot-online' : 'dot-idle';
+}
+
+function _escape(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+}
+
+function _sortWorkflows(workflows) {
+    // Active first (scheduled && enabled), then scheduled-but-disabled, then
+    // unscheduled defs. Alpha within each group.
+    const rank = wf => {
+        if (wf.scheduled && wf.enabled) return 0;
+        if (wf.scheduled) return 1;
+        return 2;
+    };
+    return [...workflows].sort((a, b) => {
+        const ra = rank(a), rb = rank(b);
+        if (ra !== rb) return ra - rb;
+        return a.name.localeCompare(b.name);
+    });
+}
+
 export const workflowsSection = {
     title: 'Workflows',
-    autoRefreshMs: 10000,  // poll every 10s while expanded
+    autoRefreshMs: 10000,
     _body: null,
-    _runs: null,
+    _workflows: [],
+    _orphans: [],
+    _expanded: null,         // Set<string> hydrated lazily on mount
+    _runsCache: new Map(),   // workflow_name -> runs[] (most recent fetch)
 
     actions: [
         { id: 'refresh', label: '↻', title: 'Refresh' },
@@ -51,64 +107,154 @@ export const workflowsSection = {
 
     async mount(body) {
         this._body = body;
+        if (this._expanded === null) this._expanded = _loadExpanded();
         await this.refresh(body);
     },
 
     async refresh(body) {
+        this._body = body;
+        if (this._expanded === null) this._expanded = _loadExpanded();
         try {
-            const res = await fetch('/api/workflows/runs?limit=30');
+            const res = await fetch('/api/workflows/list');
             const data = await res.json();
-            this._runs = Array.isArray(data.runs) ? data.runs : [];
-        } catch (e) {
-            this._runs = null;
+            if (data.error) throw new Error(data.error);
+            this._workflows = Array.isArray(data.workflows) ? data.workflows : [];
+            this._orphans = Array.isArray(data.orphans) ? data.orphans : [];
+        } catch {
+            this._workflows = null;
+            this._orphans = [];
         }
+
+        // Refresh run lists for any expanded workflows in parallel.
+        if (this._workflows) {
+            const known = new Set(this._workflows.map(w => w.name));
+            // Drop expansions whose def no longer exists.
+            for (const name of [...this._expanded]) {
+                if (!known.has(name)) this._expanded.delete(name);
+            }
+            _saveExpanded(this._expanded);
+            await Promise.all([...this._expanded].map(name => this._fetchRuns(name)));
+        }
+
         this._render(body);
     },
 
+    async _fetchRuns(workflowName) {
+        try {
+            const res = await fetch(`/api/workflows/runs?workflow=${encodeURIComponent(workflowName)}&limit=30`);
+            const data = await res.json();
+            this._runsCache.set(workflowName, Array.isArray(data.runs) ? data.runs : []);
+        } catch {
+            this._runsCache.set(workflowName, []);
+        }
+    },
+
     _render(body) {
-        if (this._runs === null) {
-            body.innerHTML = '<div class="sidebar-empty">Failed to load runs</div>';
+        if (this._workflows === null) {
+            body.innerHTML = '<div class="sidebar-empty">Failed to load workflows</div>';
             return;
         }
-        if (this._runs.length === 0) {
-            body.innerHTML = '<div class="sidebar-empty">No runs yet</div>';
+        if (this._workflows.length === 0 && this._orphans.length === 0) {
+            body.innerHTML = '<div class="sidebar-empty">No workflows defined</div>';
             return;
         }
 
-        // Group by workflow name — scannable with multiple runs per workflow
-        const byWorkflow = new Map();
-        for (const r of this._runs) {
-            const wf = r.workflow || '(unknown)';
-            if (!byWorkflow.has(wf)) byWorkflow.set(wf, []);
-            byWorkflow.get(wf).push(r);
+        const parts = [];
+
+        // Orphans first — scheduler tasks pointing at deleted defs.
+        for (const orph of this._orphans) {
+            const cadence = orph.schedule_summary
+                ? `<span class="sidebar-tag">${_escape(orph.schedule_summary)}</span>`
+                : '';
+            parts.push(`<div class="sidebar-list-item sidebar-workflow-orphan" data-orphan="${_escape(orph.name)}" title="Scheduler task '${_escape(orph.task_name)}' references missing workflow def">
+                <span class="sidebar-status-dot dot-offline"></span>
+                <span class="sidebar-list-item-title">${_escape(orph.name)}</span>
+                ${cadence}
+                <span class="sidebar-tag sidebar-tag-warn">missing def</span>
+            </div>`);
         }
 
-        let html = '';
-        for (const [wf, runs] of byWorkflow) {
-            html += `<div class="sidebar-section-subheader">${wf}</div>`;
-            for (const r of runs) {
-                const dot = _statusDot(r.status);
-                const when = _fmtTime(r.started_at);
-                const dur = _fmtDuration(r.duration_ms);
-                const runner = r.runner || '';
-                const runnerBadge = runner
-                    ? `<span class="sidebar-workflow-runner" data-runner="${runner}">${runner}</span>`
-                    : '';
-                html += `<div class="sidebar-list-item sidebar-workflow-run" data-run-id="${r.run_id}" title="${r.run_id}">
-                    <span class="sidebar-status-dot ${dot}"></span>
-                    <span class="sidebar-list-item-title">${when} · ${dur}</span>
-                    ${runnerBadge}
-                </div>`;
+        // Workflow defs, sorted active-first then alphabetical.
+        const sorted = _sortWorkflows(this._workflows);
+        for (const wf of sorted) {
+            const expanded = this._expanded.has(wf.name);
+            const dot = _defStatusDot(wf);
+            const cadence = wf.schedule_summary
+                ? `<span class="sidebar-tag">${_escape(wf.schedule_summary)}</span>`
+                : (wf.scheduled ? '' : '<span class="sidebar-tag">unscheduled</span>');
+            parts.push(`<div class="sidebar-list-item sidebar-workflow-def" data-workflow="${_escape(wf.name)}" data-expanded="${expanded}" title="${_escape(wf.description || wf.name)}">
+                <span class="sidebar-status-dot ${dot}"></span>
+                <span class="sidebar-list-item-title">${_escape(wf.name)}</span>
+                ${cadence}
+                <span class="sidebar-chevron">▸</span>
+            </div>`);
+
+            if (expanded) {
+                parts.push(this._renderRuns(wf.name));
             }
         }
 
-        body.innerHTML = html;
+        body.innerHTML = parts.join('');
         body.onclick = (e) => this._handleClick(e);
     },
 
+    _renderRuns(workflowName) {
+        const runs = this._runsCache.get(workflowName);
+        if (runs === undefined) {
+            return `<div class="sidebar-workflow-runs" data-parent="${_escape(workflowName)}">
+                <div class="sidebar-empty">Loading…</div>
+            </div>`;
+        }
+        if (runs.length === 0) {
+            return `<div class="sidebar-workflow-runs" data-parent="${_escape(workflowName)}">
+                <div class="sidebar-empty">No runs yet</div>
+            </div>`;
+        }
+        const rows = runs.map(r => {
+            const dot = _runStatusDot(r.status);
+            const when = _fmtTime(r.started_at);
+            const dur = _fmtDuration(r.duration_ms);
+            const runner = r.runner || '';
+            const runnerBadge = runner
+                ? `<span class="sidebar-workflow-runner" data-runner="${_escape(runner)}">${_escape(runner)}</span>`
+                : '';
+            return `<div class="sidebar-list-item sidebar-workflow-run" data-run-id="${_escape(r.run_id)}" title="${_escape(r.run_id)}">
+                <span class="sidebar-status-dot ${dot}"></span>
+                <span class="sidebar-list-item-title">${_escape(when)} · ${_escape(dur)}</span>
+                ${runnerBadge}
+            </div>`;
+        }).join('');
+        return `<div class="sidebar-workflow-runs" data-parent="${_escape(workflowName)}">${rows}</div>`;
+    },
+
     _handleClick(e) {
-        const item = e.target.closest('[data-run-id]');
-        if (!item) return;
-        openWorkflowWindow(item.dataset.runId);
+        const runItem = e.target.closest('[data-run-id]');
+        if (runItem) {
+            openWorkflowWindow(runItem.dataset.runId);
+            return;
+        }
+        const defItem = e.target.closest('[data-workflow]');
+        if (defItem) {
+            this._toggleExpand(defItem.dataset.workflow);
+            return;
+        }
+        // Orphan rows are non-interactive for now.
+    },
+
+    async _toggleExpand(workflowName) {
+        if (this._expanded.has(workflowName)) {
+            this._expanded.delete(workflowName);
+            _saveExpanded(this._expanded);
+            this._render(this._body);
+            return;
+        }
+        this._expanded.add(workflowName);
+        _saveExpanded(this._expanded);
+        // Render immediately with the loading placeholder, then patch in runs.
+        this._render(this._body);
+        if (!this._runsCache.has(workflowName)) {
+            await this._fetchRuns(workflowName);
+            this._render(this._body);
+        }
     },
 };


### PR DESCRIPTION
## Summary

- Flip the Workflows sidebar from a flat run-history dump to a list of workflow definitions, cross-referenced with `scheduler.yaml`.
- Each row carries a status dot (enabled / disabled / never-scheduled) and a schedule cadence pill (`daily 08:05`, `every 1h`, `Monday 09:00`); clicking expands inline to lazy-load that workflow's recent runs.
- Scheduler tasks pointing at a deleted def render as orphan warnings at the top — surfaces real config drift (e.g. a `workflow:` ref whose YAML was retired).
- New backend endpoint `GET /api/workflows/list` composes `discover_workflows()` + `load_board()` and emits `{workflows, orphans}`. Expand state persists across reloads via `localStorage`.

## Files

- `agentwire/server.py` — register `/api/workflows/list` route + handler with `schedule_summary` helper and orphan detection.
- `agentwire/static/js/sidebar/workflows-section.js` — full rewrite as defs-first accordion with lazy per-workflow run fetch.
- `agentwire/static/css/desktop.css` — chevron rotation, indented run sublist, warn-tag pill, orphan row coloring.

## Test plan

- [x] Smoke-tested `curl -k https://localhost:8765/api/workflows/list` — returns `{workflows: [...], orphans: [...]}` with `daily 08:05` / `every 1h` etc. cadence strings.
- [x] Verified orphan detection by enabling a scheduler task whose def lives in `_retired/` — endpoint correctly surfaced it as an orphan with `last_status: failed`.
- [ ] Visual check in browser: status dots reflect enabled/disabled state, click expands chevron + runs, click run row opens `WorkflowWindow`, reload preserves expansion.
- [ ] Confirm orphan rows render with red dot + "missing def" tag.

Built by [dotdev.dev](https://dotdev.dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows section now displays workflow definitions with expandable details and lazy-loaded run history.
  * MCP session creation supports worktree-specific options for flexible project branching.

* **Bug Fixes**
  * Local session creation now prevents attaching to directories already in use by other running sessions (overridable with `--force`).
  * Added detection and warnings for orphaned scheduler tasks.

* **Style**
  * Improved toast notification positioning and workflow sidebar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->