### PR TITLE
chore: security audit + identity cleanup (closes #182)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,3 +44,16 @@ AgentWire includes built-in security features:
 - **Audit Logging:** All blocked operations are logged
 
 See `docs/wiki/internals/damage-control.md` for details.
+
+## Trust Model
+
+The portal (HTTPS server bound to `0.0.0.0:8765` by default) **has no built-in authentication or authorization on its API endpoints**. This is by design — agentwire is built for a local-network trust perimeter, typically running on the same machine as the operator's browser or behind a Cloudflare Tunnel + Zero Trust gate (see `docs/wiki/deployment/remote-access.md`).
+
+What this means in practice:
+
+- **Anyone who can reach the portal port can drive it.** All `/api/*` endpoints (scheduler control, missions dispatch, project deletion, artifact upload, desktop window control) execute without auth.
+- **Do not expose the portal directly to the public internet.** Use either firewall rules limiting access to trusted IPs, or front it with an auth gateway. Cloudflare Tunnel + Zero Trust is the recommended pattern; details in the deployment docs.
+- **Project deletion via `/api/projects/delete`** validates the path is absolute, contains no `..`, contains no shell metacharacters, and is not in a protected list. Local execution uses argv form (no shell); SSH execution uses `shlex.quote` per argument. These mitigations don't substitute for perimeter security — they reduce blast radius if the perimeter fails.
+- **CSRF / Origin checks are not enforced** on state-changing POSTs. A browser inside the trust perimeter that loads attacker-controlled content could be coerced into making requests to the portal. If your portal is reachable from a browser on a less-trusted network, add an origin check or fence it behind an auth proxy.
+
+If you need authentication, the recommended path is **Cloudflare Tunnel + Zero Trust** rather than adding auth in-process: identity, MFA, audit, and revocation are all handled upstream and survive process restarts.

--- a/agentwire/__init__.py
+++ b/agentwire/__init__.py
@@ -1,3 +1,3 @@
 """AgentWire - Multi-session voice web interface for AI coding agents."""
 
-__version__ = "1.29.0"
+__version__ = "1.29.1"

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2343,39 +2343,49 @@ class AgentWireServer:
             machine = data.get("machine")
             delete_type = data.get("deleteType")
 
-            if not path:
+            if not path or not isinstance(path, str):
                 return web.json_response({"success": False, "error": "Missing path"})
             if delete_type not in ("config", "folder"):
                 return web.json_response({"success": False, "error": "Invalid deleteType"})
 
-            # Build the delete command
-            if delete_type == "config":
-                cmd = f"rm -f '{path}/.agentwire.yml'"
-            else:
-                # Safety check: don't allow deleting root or home
-                if path in ("/", "/root", "/home") or path.rstrip("/") in ("~", "$HOME"):
-                    return web.json_response({"success": False, "error": "Cannot delete protected paths"})
-                cmd = f"rm -rf '{path}'"
+            # Path validation: absolute, no traversal, no shell metacharacters.
+            # The endpoint has no auth (local-trust model — see SECURITY.md), so
+            # treat the input as untrusted regardless and reject anything that
+            # could escape argv quoting on either local or remote (SSH) execution.
+            if not path.startswith("/"):
+                return web.json_response({"success": False, "error": "path must be absolute"})
+            if ".." in Path(path).parts:
+                return web.json_response({"success": False, "error": "path may not contain '..'"})
+            if re.search(r"[\s;&|`$<>(){}\[\]\\\"'*?#]", path):
+                return web.json_response({"success": False, "error": "path contains disallowed characters"})
+            if path.rstrip("/") in ("", "/root", "/home", "/Users", "/tmp", "/etc") or path.rstrip("/") in ("~", "$HOME"):
+                return web.json_response({"success": False, "error": "Cannot delete protected paths"})
 
-            # Execute locally or remotely
+            # Build argv. For SSH we still need to cross a remote shell, so
+            # quote with shlex; locally we use array form with shell=False.
+            if delete_type == "config":
+                target = f"{path.rstrip('/')}/.agentwire.yml"
+                local_argv = ["rm", "-f", target]
+            else:
+                local_argv = ["rm", "-rf", path]
+
             if machine and machine != "local":
-                # Remote machine
+                # Remote shell — quote each argv element through shlex.
+                remote_cmd = " ".join(shlex.quote(a) for a in local_argv)
                 result = await asyncio.to_thread(
                     subprocess.run,
-                    ["ssh", machine, cmd],
+                    ["ssh", machine, remote_cmd],
                     capture_output=True,
                     text=True,
-                    timeout=30
+                    timeout=30,
                 )
             else:
-                # Local
                 result = await asyncio.to_thread(
                     subprocess.run,
-                    cmd,
-                    shell=True,
+                    local_argv,
                     capture_output=True,
                     text=True,
-                    timeout=30
+                    timeout=30,
                 )
 
             if result.returncode != 0:

--- a/docs/wiki/deployment/remote-machines.md
+++ b/docs/wiki/deployment/remote-machines.md
@@ -186,13 +186,13 @@ Each machine should have a `~/.agentwire/machine/CLAUDE.md` — a living documen
 When an AI agent needs to do ops work on a remote machine (manage services, install packages, debug the box itself), spawn a Claude Code session in `~/.agentwire/machine/` rather than SSHing and running ad-hoc commands. The agent picks up both `~/.claude/CLAUDE.md` (user preferences) and `~/.agentwire/machine/CLAUDE.md` (machine context) automatically, giving it full situational awareness without needing to rediscover everything.
 
 ```bash
-# Spawn an ops session on a remote machine
-ssh dotdev-pc
+# Spawn an ops session on a remote machine (replace `my-server` with your hostname)
+ssh my-server
 cd ~/.agentwire/machine
 claude  # gets both global prefs and machine context
 
 # Or spawn via agentwire from the Mac
-agentwire new -s dotdev-pc-ops --machine dotdev-pc -p ~/.agentwire/machine
+agentwire new -s my-server-ops --machine my-server -p ~/.agentwire/machine
 ```
 
 ### What to Put in `~/.agentwire/machine/CLAUDE.md`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def project_config_file(project_dir):
     data = {
         "type": "claude-bypass",
         "roles": ["agentwire", "voice"],
-        "voice": "dotdev",
+        "voice": "default",
         "parent": "main",
     }
     with open(config_path, "w") as f:

--- a/tests/unit/test_cli_safety.py
+++ b/tests/unit/test_cli_safety.py
@@ -105,12 +105,16 @@ class TestIsPathAllowedForOp:
         assert is_path_allowed_for_op("/home/user/project/dist/file.whl", allowed, "delete") is True
 
     def test_limited_permissions_allow(self):
+        import os
+        env_path = os.path.expanduser("~/.env")
         allowed = [{"path": "~/.env", "allow": {"read", "write"}}]
-        assert is_path_allowed_for_op("/Users/dotdev/.env", allowed, "write") is True
+        assert is_path_allowed_for_op(env_path, allowed, "write") is True
 
     def test_limited_permissions_deny(self):
+        import os
+        env_path = os.path.expanduser("~/.env")
         allowed = [{"path": "~/.env", "allow": {"read", "write"}}]
-        assert is_path_allowed_for_op("/Users/dotdev/.env", allowed, "delete") is False
+        assert is_path_allowed_for_op(env_path, allowed, "delete") is False
 
 
 # --- check_command_safety ---

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -19,9 +19,9 @@ class TestPathEncoding:
 
     def test_round_trip_lossy_with_hyphens(self):
         """Paths with hyphens lose information (known Claude Code limitation)."""
-        original = "/Users/dotdev/projects/agentwire-dev"
+        original = "/home/user/projects/my-app"
         encoded = encode_project_path(original)
-        assert encoded == "-Users-dotdev-projects-agentwire-dev"
+        assert encoded == "-home-user-projects-my-app"
         # decode converts ALL dashes to slashes — can't distinguish original hyphens
         decoded = decode_project_path(encoded)
         assert decoded != original  # Lossy

--- a/tests/unit/test_missions_config.py
+++ b/tests/unit/test_missions_config.py
@@ -21,8 +21,8 @@ def missions_yaml(tmp_path):
                 "default_max_iterations": 3,
                 "repos": {
                     "agentwire-dev": {
-                        "name": "dotdevdotdev/agentwire-dev",
-                        "projects_dir": "/Users/dotdev/projects",
+                        "name": "acme/example-repo",
+                        "projects_dir": "/home/user/projects",
                         "per_repo_concurrency": 1,
                     },
                 },
@@ -47,8 +47,8 @@ class TestLoadConfig:
         assert cfg.global_concurrency == 3
         assert "agentwire-dev" in cfg.repos
         repo = cfg.repos["agentwire-dev"]
-        assert repo.name == "dotdevdotdev/agentwire-dev"
-        assert repo.projects_dir == Path("/Users/dotdev/projects")
+        assert repo.name == "acme/example-repo"
+        assert repo.projects_dir == Path("/home/user/projects")
         assert repo.per_repo_concurrency == 1
 
     def test_project_override_per_repo_concurrency(self, missions_yaml, tmp_path):
@@ -79,7 +79,7 @@ class TestLoadConfig:
         cfg = load_config(global_path=missions_yaml)
         repo = cfg.get_repo("agentwire-dev")
         assert repo is not None
-        assert repo.name == "dotdevdotdev/agentwire-dev"
+        assert repo.name == "acme/example-repo"
         assert cfg.get_repo("nope") is None
 
     def test_tilde_in_projects_dir_expanded(self, tmp_path):

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -94,7 +94,7 @@ class TestProjectConfig:
         data = {
             "type": "claude-bypass",
             "roles": ["agentwire", "voice"],
-            "voice": "dotdev",
+            "voice": "default",
             "parent": "main",
             "shell": "/bin/bash",
             "tasks": {"t1": {"prompt": "hello"}},
@@ -102,7 +102,7 @@ class TestProjectConfig:
         config = ProjectConfig.from_dict(data)
         assert config.type == SessionType.CLAUDE_BYPASS
         assert config.roles == ["agentwire", "voice"]
-        assert config.voice == "dotdev"
+        assert config.voice == "default"
         assert config.parent == "main"
         assert config.shell == "/bin/bash"
         assert "t1" in config.tasks
@@ -133,11 +133,11 @@ class TestProjectConfig:
         full = ProjectConfig(
             type=SessionType.WORKER,
             roles=["agentwire"],
-            voice="dotdev",
+            voice="default",
         ).to_dict()
         assert full["type"] == "worker"
         assert full["roles"] == ["agentwire"]
-        assert full["voice"] == "dotdev"
+        assert full["voice"] == "default"
 
     def test_round_trip(self):
         original = ProjectConfig(


### PR DESCRIPTION
## Summary

Pre-contributor sweep — close #182 by removing hardcoded `dotdev` username from tests, plus a broader audit of identifiable info and a real shell-injection fix found along the way.

## Identity cleanup

| File | Change |
|---|---|
| `tests/unit/test_history.py` | `/Users/dotdev/projects/agentwire-dev` → `/home/user/projects/my-app` (the test that prompted #182) |
| `tests/unit/test_cli_safety.py` | Use `os.path.expanduser("~/.env")` so the test passes for any contributor |
| `tests/unit/test_missions_config.py` | `dotdevdotdev/agentwire-dev` → `acme/example-repo`; `/Users/dotdev/projects` → `/home/user/projects` |
| `tests/conftest.py` + `tests/unit/test_project_config.py` | `voice="dotdev"` → `voice="default"` |
| `docs/wiki/deployment/remote-machines.md` | `dotdev-pc` hostname → `my-server` placeholder |

Intentional attribution (NOT changed): `pyproject.toml` Repository/Homepage URLs, README contact, "Built by dotdev.dev" footers, CHANGELOG release links.

## Security

**Shell injection in `/api/projects/delete` (real bug, fixed).** Previously built a shell command via f-string with the user-supplied `path` interpolated inside single quotes. A path containing an embedded single quote followed by a destructive command could escape the quoting. Local exec went through `shell=True`; remote exec went over SSH (which executes the string on the remote shell). Both vectors closed:

- Validate path: must be absolute, no `..`, no shell metacharacters, not in a protected set (root, home, /Users, /tmp, /etc, $HOME)
- Local exec: argv form, `shell=False`
- Remote exec: `shlex.quote` per argv element before joining for SSH

**SECURITY.md — Trust Model section added.** Explicitly documents that the portal has no built-in auth on `/api/*` endpoints by design (local-network trust perimeter), names the assumption, and points at Cloudflare Tunnel + Zero Trust as the recommended pattern for any deployment that needs auth.

## Out of scope

- No CSRF / Origin checks on POSTs — portal-wide change; documented in SECURITY.md
- Other `shell=True` callsites read trusted local config (`~/.agentwire/scheduler.yaml`, project `.agentwire.yml`) — different threat model

## Test plan

- [x] `pytest tests/unit/` → 874/875 (1 unrelated pre-existing failure: MCP `session_send` cross-session assertion)
- [x] `pytest tests/unit/test_history.py tests/unit/test_cli_safety.py tests/unit/test_missions_config.py tests/unit/test_project_config.py tests/unit/test_scheduler.py` → 200/200
- [x] `agentwire rebuild` — clean install
- [ ] Manual: hit `/api/projects/delete` with a path containing shell metacharacters → rejected with "path contains disallowed characters"

Built by [dotdev.dev](https://dotdev.dev)
