### PR TITLE
fix(portal): prune dead session tabs from Open Windows after reboot

### DIFF
--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -776,6 +776,20 @@ class DesktopManager {
     }
 
     /**
+     * Subscribe to an event for a single emission, then auto-unsubscribe.
+     * @param {string} event - Event name
+     * @param {Function} callback - Callback function
+     * @returns {Function} Unsubscribe function
+     */
+    once(event, callback) {
+        const wrapper = (data) => {
+            this.off(event, wrapper);
+            callback(data);
+        };
+        return this.on(event, wrapper);
+    }
+
+    /**
      * Unsubscribe from an event.
      * @param {string} event - Event name
      * @param {Function} callback - Callback function

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -12,7 +12,7 @@ import { tileManager } from './tile-manager.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { sidebar } from './sidebar.js';
-import { buildSessionId, normalizeMachine } from './session-id.js';
+import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
 import { configSection } from './sidebar/config-section.js';
 import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
@@ -210,6 +210,12 @@ async function init() {
     // Do this BEFORE fetching sessions — restore is independent of the sessions list and
     // /api/sessions can take several seconds when remote machines need SSH probing.
     restoreTaskbarState();
+
+    // After a reboot/portal restart the persisted taskbar still references tmux sessions
+    // that no longer exist. Reconcile the restored tabs against the first live sessions
+    // list and drop the dead ones. One-shot so transient list hiccups can't kill an
+    // active window mid-session.
+    desktop.once('sessions', reconcileTaskbarWithSessions);
 
     // Fetch initial data in the background (will emit events to listeners above)
     desktop.fetchSessions();
@@ -578,6 +584,46 @@ export function restoreTaskbarState() {
     } finally {
         restoringTaskbar = false;
         saveTaskbarState();
+    }
+}
+
+/**
+ * Drop restored taskbar tabs whose underlying session no longer exists.
+ *
+ * After a reboot or portal restart, tmux sessions are gone but the persisted
+ * taskbar (localStorage) still references them — leaving dead "Open Windows"
+ * tabs that never self-correct. We reconcile against the live sessions list.
+ *
+ * Only local sessions are reconciled: /api/sessions/local is authoritative and
+ * arrives first, whereas remote sessions merge in asynchronously and must not be
+ * pruned on the local-only snapshot. Artifact tabs are file-backed, not
+ * session-backed, so they survive a reboot and are left alone.
+ *
+ * @param {Array<{name: string, machine?: string}>} sessions - Live sessions list
+ */
+function reconcileTaskbarWithSessions(sessions) {
+    const liveLocalIds = new Set(
+        (sessions || [])
+            .filter(s => isLocalMachine(s.machine))
+            .map(s => buildSessionId(s.name, null))
+    );
+    const buttons = Array.from(elements.taskbarWindows.querySelectorAll('.sidebar-open-item'));
+    for (const btn of buttons) {
+        const id = btn.dataset.session;
+        const rec = taskbarRecords.get(id);
+        if (!rec || rec.kind !== 'session') continue;
+        if (!isLocalMachine(rec.machine)) continue;  // remote: not authoritative yet
+        if (liveLocalIds.has(id)) continue;           // session still alive
+
+        // Stale tab. A materialized window cleans up its own button + record via
+        // onClose; a placeholder has no instance, so tear it down directly.
+        const inst = _lookupWindowInstance(id);
+        if (inst && typeof inst.close === 'function') {
+            try { inst.close(); } catch (e) {}
+        } else {
+            btn.remove();
+            unrecordTaskbarEntry(id);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

After a system reboot or portal restart, the **Open Windows** sidebar list keeps showing tabs for tmux sessions that no longer exist (e.g. `fragmentz`, `jordan`) and never self-corrects.

## Root cause

The taskbar is persisted in `localStorage` (`taskbar-state`) and `restoreTaskbarState()` deliberately runs **before** the sessions list is fetched (so restore isn't blocked by slow remote-SSH probing). Nothing ever reconciled the restored tabs against the live session list afterward.

## Fix

- Add `reconcileTaskbarWithSessions()` — on the **first** `sessions` emit after restore, drop any session tab whose local session no longer exists. Materialized windows clean up via their own `onClose`; placeholders are torn down directly.
- Add `once()` to the desktop event emitter (it only had `on`/`off`).

### Design choices (conservative)
- **One-shot**, not every update — a transient list hiccup can't kill an active window mid-session.
- **Local sessions only** — `/api/sessions/local` is authoritative and arrives first; remote sessions merge async, so pruning on the local-only snapshot would wrongly drop live remote tabs.
- **Artifact tabs untouched** — file-backed, survive reboot correctly.

## Verification

`node --check` passes on both files. Portal restarted in dev mode; hard-refresh clears the three stale tabs, leaving only the live `agentwire` session.

Built by [dotdev.dev](https://dotdev.dev)