### PR TITLE
chore: hide missions + disable orchestrators (v1.29.2)

### DIFF
--- a/agentwire/__init__.py
+++ b/agentwire/__init__.py
@@ -1,3 +1,3 @@
 """AgentWire - Multi-session voice web interface for AI coding agents."""
 
-__version__ = "1.29.1"
+__version__ = "1.29.2"

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -20,7 +20,9 @@ import { machinesSection } from './sidebar/machines-section.js';
 import { sessionsSection } from './sidebar/sessions-section.js';
 import { projectsSection } from './sidebar/projects-section.js';
 import { schedulerSection } from './sidebar/scheduler-section.js';
-import { missionsSection } from './sidebar/missions-section.js';
+// Missions hidden for now — auto-spawn/state model under rethink. Re-enable by
+// uncommenting this import + the addSection('missions', …) call below.
+// import { missionsSection } from './sidebar/missions-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { notificationsPanel } from './notifications-panel.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
@@ -64,7 +66,7 @@ async function init() {
     sidebar.addSection('projects', projectsSection);
     sidebar.addSection('artifacts', artifactsSection);
     sidebar.addSection('scheduler', schedulerSection);
-    sidebar.addSection('missions', missionsSection);
+    // sidebar.addSection('missions', missionsSection);  // hidden for now — see import note above
     sidebar.addSection('safety', safetySection);
     sidebar.addSection('config', configSection);
     setupClock();


### PR DESCRIPTION
Hides the Missions feature for now — the auto-spawn / live-board-vs-file-state model needs a rethink before it earns its place.

## Changes
- **Portal sidebar:** comment out the Missions section (import + `addSection`). Reversible by uncommenting.
- **launchd orchestrators:** stopped and moved `dev.agentwire.mission-{dispatcher,feedback-router,janitor}.plist` to `~/Library/LaunchAgents/disabled-missions/` so they no longer tick / auto-spawn worktrees and won't reload at login. (Local machine action — not in repo.)
- **Version:** bump to 1.29.2.

## Why
The dispatcher refills `per_repo_concurrency` slots every tick from `agent-ready` issues and holds the worktrees until each draft PR merges — so the board self-refills faster than PRs drain, and the "board" itself isn't persisted (it's re-derived from GitHub + tmux each request). Pausing until the design is reworked.

## Re-enable
1. Uncomment the import + `addSection('missions', …)` in `desktop.js`.
2. `mv ~/Library/LaunchAgents/disabled-missions/*.plist ~/Library/LaunchAgents/ && launchctl load` each.

Built by [dotdev.dev](https://dotdev.dev)