### PR TITLE
fix(stt): surface the silent moonshine→WhisperKit fallback + document it (v1.29.4)

### DIFF
--- a/agentwire/__init__.py
+++ b/agentwire/__init__.py
@@ -1,3 +1,3 @@
 """AgentWire - Multi-session voice web interface for AI coding agents."""
 
-__version__ = "1.29.3"
+__version__ = "1.29.4"

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6182,6 +6182,23 @@ def cmd_doctor(args) -> int:
             else:
                 print(f"     -> Service is remote, start it on {service_config.machine}")
 
+    # 8b. Check STT server. STT isn't a `services.*` entry — it's configured via
+    # `stt.url`, so the loop above can't see it. Without this check, a crashed STT
+    # server is invisible and the portal silently falls back to a model-less
+    # WhisperKit (every push-to-talk then fails). Probe it explicitly.
+    stt_url = getattr(getattr(ctx.config, "stt", None), "url", None)
+    if stt_url:
+        from agentwire.stt.server_backend import STTServerBackend
+
+        if STTServerBackend.is_available(stt_url):
+            print(f"  [ok] Stt: responding on {stt_url}")
+        else:
+            print(f"  [!!] Stt: not responding on {stt_url}")
+            print("       Portal will fall back to WhisperKit (usually no model -> transcription FAILS).")
+            print("       Fix: agentwire stt start")
+            print("       If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'")
+            issues_found += 1
+
     # 9. Validate remote machines
     print("\nChecking remote machines...")
     remote_machines = {mid: m for mid, m in ctx.machines.items() if mid != ctx.local_machine_id}

--- a/agentwire/stt/__init__.py
+++ b/agentwire/stt/__init__.py
@@ -51,7 +51,18 @@ def get_stt_backend(config: Any) -> STTBackend:
             logger.info(f"Using STT server at {stt_url}")
             return STTServerBackend(url=stt_url, timeout=timeout)
         else:
-            logger.warning(f"STT server at {stt_url} not available, falling back to WhisperKit")
+            # Loud, actionable warning: this is the silent-failure trap. A
+            # configured-but-unreachable STT server means the moonshine server
+            # crashed or isn't started, and we're about to fall back to
+            # WhisperKit — which is usually NOT installed, so every transcription
+            # will then fail at request time with a confusing error. Say so here.
+            logger.warning(
+                "STT server configured at %s but not reachable — falling back to "
+                "WhisperKit (likely has no model installed; transcription will FAIL). "
+                "Start it with `agentwire stt start`; if it won't boot, install deps: "
+                "`uv pip install --python .venv/bin/python -e '.[stt]'`.",
+                stt_url,
+            )
 
     # Fall back to WhisperKit
     logger.info("Using local WhisperKitSTT")

--- a/docs/wiki/tts/stt-self-hosted.md
+++ b/docs/wiki/tts/stt-self-hosted.md
@@ -100,6 +100,60 @@ done
 
 Tried — load time 25.4 s → 3.2 s (real win), per-call inference ~457 ms → ~1342 ms (≈3× slower). Only 389 / 743 graph nodes are CoreML-compatible, so the autoregressive decoder bounces ANE↔CPU per token. Not worth pursuing until the upstream moonshine_onnx graph becomes more CoreML-friendly.
 
+## Troubleshooting: "STT does nothing" (the silent double-fallback)
+
+This bit us once and is worth recognizing fast, because it fails **silently in two
+places**. Symptom: push-to-talk produces no transcription and no visible error
+(often first noticed on a tablet/phone, which red-herrings you toward the client).
+
+**The failure chain:**
+
+1. The STT server (`agentwire-stt` tmux session on `:8101`) **crashes on startup** —
+   most commonly `ModuleNotFoundError: No module named 'fastapi'` (or `moonshine_onnx`)
+   because the project `.venv` is missing the STT deps. The crash is only visible in
+   the tmux pane; the session stays alive at a shell prompt, so it *looks* started.
+2. The portal builds `self.stt` once at startup via `get_stt_backend()`. With `:8101`
+   unreachable, `STTServerBackend.is_available()` is `False`, so it **falls back to
+   `WhisperKitSTT`** — which usually has no model installed.
+3. Every `/transcribe` then returns `{"error": ...}` with HTTP **200**, so the browser
+   shows nothing. The only trace is `ERROR agentwire.stt.whisperkit: WhisperKit model
+   not found` in the portal log.
+
+**Diagnose (in order):**
+
+```bash
+agentwire doctor                                   # now prints [!!] Stt if :8101 is down
+curl -s http://localhost:8101/health               # {"status":"ok","model":{"backend":"moonshine",...}}
+tmux capture-pane -pt agentwire-stt -S -50         # shows the real crash (missing import)
+tmux capture-pane -pt agentwire-portal -S -200 | grep -i stt   # "Using STT server" vs "falling back to WhisperKit"
+```
+
+The portal log line at startup is the tell:
+- `Using STT server at http://localhost:8101` + `STT backend: STTServerBackend` → good.
+- `STT server ... not reachable — falling back to WhisperKit` → the server is down.
+
+**Fix:** install the STT deps into the venv the server actually launches with
+(`.venv/bin/python`), restart the server, then **restart the portal** (it only picks
+the backend at startup):
+
+```bash
+uv pip install --python .venv/bin/python -e '.[stt]'   # declares moonshine + soundfile + fastapi
+agentwire stt stop && agentwire stt start              # wait for "Moonshine ONNX loaded"
+agentwire portal restart --dev                         # re-runs get_stt_backend()
+```
+
+**Why it stayed hidden:** `stt.url` is configured but the server was down, and the
+WhisperKit fallback only errors at *request* time, not at startup. As of this writing
+the fallback now logs a loud, actionable warning and `agentwire doctor` health-checks
+`:8101` — so next time it surfaces immediately instead of silently degrading.
+
+**Tablet note:** if the mic does nothing on a phone/tablet *before* audio ever reaches
+`/transcribe`, that's a different problem — a non-secure browser context. Reaching the
+portal at `https://<LAN-IP>:8765` with a click-through self-signed cert is **not** a
+secure context, so `navigator.mediaDevices` is `undefined` and recording silently
+no-ops. Give the tablet a trusted origin (tunnel/valid cert) or, to test, allow the
+origin via `chrome://flags/#unsafely-treat-insecure-origin-as-secure`.
+
 ## Reference
 
 - Portal endpoint: `POST /transcribe` — multipart `file=@audio.webm`. Returns `{"text": "..."}`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,16 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.1.0",
 ]
-# STT server dependencies (faster-whisper for speech-to-text)
+# STT server dependencies. Moonshine ONNX is the default backend on Mac
+# (small, fast, CPU-only, no torch) — it MUST be declared here or a fresh venv
+# silently loses the default backend and the portal falls back to a model-less
+# WhisperKit. faster-whisper is the higher-accuracy fallback for `STT_BACKEND=whisper`.
 stt = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "python-multipart>=0.0.6",
+    "useful-moonshine-onnx>=20250101",
+    "soundfile>=0.12.0",
     "faster-whisper>=1.0.0",
 ]
 # TTS server dependencies (for GPU machines running the TTS backend)


### PR DESCRIPTION
## What happened (the bug we just hit)
Push-to-talk produced no transcription and **no visible error**. Root cause was a silent double-fallback:

1. The moonshine STT server (`:8101`) crashed on startup — the project `.venv` was missing its deps (`fastapi`, `moonshine_onnx`). The tmux session stayed at a shell prompt so it *looked* up.
2. The portal builds its STT backend once at startup; with `:8101` unreachable it fell back to **WhisperKit**, which had no model installed.
3. `/transcribe` then returned `{"error": ...}` with HTTP 200, so the browser showed nothing. Only trace was a `WhisperKit model not found` line in the portal log.

Nothing surfaced it: `doctor` never checked STT, and the fallback logged a bland warning.

## Changes
- **pyproject** — declare moonshine in the `stt` extra (`useful-moonshine-onnx` + `soundfile`). The default backend is now actually installed by `-e '.[stt]'` instead of being a manual step the wiki had to warn about.
- **`get_stt_backend`** — the configured-but-unreachable fallback now logs a loud, actionable warning (names the consequence + the exact fix commands).
- **`doctor`** — health-checks the STT server at `stt.url`. It isn't a `services.*` entry, so the existing services loop couldn't see it; added a dedicated probe via `STTServerBackend.is_available()`. Prints `[ok] Stt: responding on …` / `[!!] Stt: not responding …`.
- **wiki** (`docs/wiki/tts/stt-self-hosted.md`) — new Troubleshooting section: full failure chain, diagnosis order, fix, and the tablet secure-context red herring.

## Verification
- `[ok] Stt: responding on http://localhost:8101` now appears in `agentwire doctor`.
- End-to-end confirmed: tablet push-to-talk transcribes via moonshine (~0.6 s).
- Python compiles; doctor runs clean.

Built by [dotdev.dev](https://dotdev.dev)