### PR TITLE
Scheduler UI toggle/board + `agentwire up` + custom services

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -33,6 +33,12 @@ agentwire split -s name         # add terminal pane(s)
 agentwire detach -s name        # move pane to its own session
 agentwire resize -s name        # resize window to fit largest client
 
+# Boot everything
+agentwire up                    # boot all services (portal, TTS, STT, scheduler,
+                                #   custom) then start/attach the dev session
+agentwire up --no-tts --no-stt  # skip optional voice services
+agentwire up --dev              # run portal from source (uv run)
+
 # Portal management
 agentwire portal start          # start in tmux
 agentwire portal stop           # stop portal
@@ -165,10 +171,17 @@ agentwire overnight report                  # morning report
 # Setup & Development
 agentwire init                  # interactive setup wizard
 agentwire generate-certs        # generate SSL certificates
-agentwire dev                   # start/attach to dev session
+agentwire up                    # boot all services + dev session (see "Boot everything")
+agentwire dev                   # start/attach to dev session ONLY (no services)
 agentwire rebuild               # clear uv cache and reinstall
 agentwire uninstall             # uninstall the tool
 ```
+
+`agentwire dev` only spawns the `agentwire` agent session — it does NOT start
+the portal or any service. Use `agentwire up` after a reboot to bring up the
+full stack. `up` brings up portal → TTS → STT → autostart custom services, then
+runs `dev`; the scheduler rides along via the portal's `scheduler.autostart`.
+TTS is skipped for `none`/`runpod` backends; STT is skipped without `stt.url`.
 
 Session formats: `name`, `project/branch` (worktree), `name@machine` (remote)
 Pane targeting: `--pane N` auto-detects session from `$TMUX_PANE`

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -79,6 +79,14 @@ services:  # Where services run (for multi-machine setups)
     session_name: "agentwire-tts"
   stt:
     session_name: "agentwire-stt"
+  custom:  # User-defined service sessions — boot with `agentwire up`,
+           #   shown in the portal's Services column
+    - name: "agent-brain"          # tmux session name (required)
+      project: "~/projects/brain"  # project dir; defaults to dev source dir
+      autostart: true              # boot with `agentwire up` (default true)
+      roles: "brain"               # optional; overrides project .agentwire.yml
+      type: "claude-bypass"        # optional; session type override
+    - "simple-service"             # string shorthand = name only, autostart on
 
 executables:  # Override executable paths (optional, auto-detected by default)
   ffmpeg: "/opt/homebrew/bin/ffmpeg"
@@ -146,6 +154,7 @@ channels:  # Outbound-only notifications. Only email + quo ship.
     default_to: "+0987654321"
 
 scheduler:
+  autostart: true        # Start the scheduler daemon when the portal boots (default: true)
   dispatch_cooldown: 60  # Seconds between task dispatches (default: 60)
 
 worktree:

--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -17,7 +17,7 @@ The portal uses a left sidebar with a floating tab handle instead of hover hotzo
 - **Footer**: global PTT button, voice indicator
 
 **Session grouping:** Sessions are split into two accordion sections based on the name:
-- **Services**: infrastructure sessions, matched against an explicit allowlist in `sessions-section.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`)
+- **Services**: infrastructure sessions. The built-in allowlist in `sessions-section.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`) is merged at load time with config-defined custom services fetched from `/api/services/custom` (driven by `services.custom` in `config.yaml`). When the fetch resolves, `notifyListeners()` re-renders so flagged sessions hop into this column.
 - **Sessions**: everything else (working sessions, worktrees, remote sessions)
 
 Both share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -761,8 +761,12 @@ def _notify_portal_sessions_changed():
 # === Portal Commands ===
 
 
-def _start_portal_local(args) -> int:
-    """Start portal locally in tmux."""
+def _start_portal_local(args, attach: bool = True) -> int:
+    """Start portal locally in tmux.
+
+    When attach is False (used by `agentwire up`), the portal is started
+    detached and we return without attaching.
+    """
     from .network import NetworkContext
     from .tunnels import TunnelManager
 
@@ -770,8 +774,9 @@ def _start_portal_local(args) -> int:
 
     if tmux_session_exists(session_name):
         print(f"Portal already running in tmux session '{session_name}'")
-        print("Attaching... (Ctrl+B D to detach)")
-        subprocess.run(["tmux", "attach-session", "-t", session_name])
+        if attach:
+            print("Attaching... (Ctrl+B D to detach)")
+            subprocess.run(["tmux", "attach-session", "-t", session_name])
         return 0
 
     # Ensure required tunnels are up before starting portal
@@ -835,8 +840,11 @@ def _start_portal_local(args) -> int:
 
     _ensure_notifications_session()
 
-    print("Portal started. Attaching... (Ctrl+B D to detach)")
-    subprocess.run(["tmux", "attach-session", "-t", session_name])
+    if attach:
+        print("Portal started. Attaching... (Ctrl+B D to detach)")
+        subprocess.run(["tmux", "attach-session", "-t", session_name])
+    else:
+        print("Portal started.")
     return 0
 
 
@@ -1147,19 +1155,21 @@ def _get_venv_for_backend(backend: str) -> str:
     return "qwen"
 
 
-def _start_tts_local(args, venv_override: str | None = None) -> int:
+def _start_tts_local(args, venv_override: str | None = None, attach: bool = True) -> int:
     """Start TTS server locally in tmux.
 
     Args:
         args: Parsed CLI arguments
         venv_override: Force specific venv (used for restart after venv_mismatch)
+        attach: When False (used by `agentwire up`), start detached and return.
     """
     session_name = get_tts_session_name()
 
     if tmux_session_exists(session_name):
         print(f"TTS server already running in tmux session '{session_name}'")
-        print("Attaching... (Ctrl+B D to detach)")
-        subprocess.run(["tmux", "attach-session", "-t", session_name])
+        if attach:
+            print("Attaching... (Ctrl+B D to detach)")
+            subprocess.run(["tmux", "attach-session", "-t", session_name])
         return 0
 
     # Get TTS config
@@ -1204,8 +1214,11 @@ def _start_tts_local(args, venv_override: str | None = None) -> int:
 
     _ensure_notifications_session()
 
-    print("TTS server started. Attaching... (Ctrl+B D to detach)")
-    subprocess.run(["tmux", "attach-session", "-t", session_name])
+    if attach:
+        print("TTS server started. Attaching... (Ctrl+B D to detach)")
+        subprocess.run(["tmux", "attach-session", "-t", session_name])
+    else:
+        print("TTS server started.")
     return 0
 
 
@@ -5623,6 +5636,98 @@ def cmd_dev(args) -> int:
     print("Attaching... (Ctrl+B D to detach)")
     subprocess.run(["tmux", "attach-session", "-t", session_name])
     return 0
+
+
+def _start_custom_service(svc) -> None:
+    """Start a custom service session (detached) if not already running."""
+    if tmux_session_exists(svc.name):
+        print(f"  [ok] {svc.name} (already running)")
+        return
+
+    project = svc.project or str(get_source_dir())
+    cmd = [sys.executable, "-m", "agentwire", "new", "-s", svc.name, "-p", project, "--json"]
+    if svc.roles:
+        cmd.extend(["--roles", svc.roles])
+    if svc.type:
+        cmd.extend(["--type", svc.type])
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=60)
+        print(f"  [ok] {svc.name} (started)")
+    except Exception as e:
+        print(f"  [!!] {svc.name}: {e}", file=sys.stderr)
+
+
+def cmd_up(args) -> int:
+    """Boot all AgentWire services, then start/attach the dev session.
+
+    Brings up (detached): portal, TTS, STT, and any autostart custom
+    services from config. The scheduler is auto-started by the portal
+    (services.scheduler.autostart). Then runs `agentwire dev` to
+    create + attach the main session.
+
+    Per-service start is best-effort — a failure to start one service
+    doesn't block the rest or the dev session.
+    """
+    from argparse import Namespace
+    from .config import load_config as load_config_typed
+    from .network import NetworkContext
+
+    cfg_dict = load_config()
+    cfg = load_config_typed()
+    ctx = NetworkContext.from_config()
+
+    def _is_local(name: str) -> bool:
+        try:
+            return ctx.is_local(name)
+        except Exception:
+            return True
+
+    print("Bringing up AgentWire services...")
+
+    # Portal (autostarts the scheduler on boot)
+    if _is_local("portal"):
+        portal_args = Namespace(
+            dev=getattr(args, "dev", False),
+            no_tts=getattr(args, "no_tts", False),
+            no_stt=getattr(args, "no_stt", False),
+            port=None, host=None,
+            config=getattr(args, "config", None),
+        )
+        _start_portal_local(portal_args, attach=False)
+    else:
+        print("  Portal configured for a remote machine — skipping (start it there).")
+
+    # TTS — skip if disabled or using a cloud backend
+    tts_backend = cfg_dict.get("tts", {}).get("backend", "chatterbox")
+    if getattr(args, "no_tts", False):
+        print("  TTS skipped (--no-tts).")
+    elif tts_backend in ("none", "runpod"):
+        print(f"  TTS skipped (backend: {tts_backend}).")
+    elif _is_local("tts"):
+        tts_args = Namespace(port=None, host=None, backend=None)
+        _start_tts_local(tts_args, attach=False)
+    else:
+        print("  TTS configured for a remote machine — skipping (start it there).")
+
+    # STT — start when configured (uses a local source venv)
+    if getattr(args, "no_stt", False):
+        print("  STT skipped (--no-stt).")
+    elif cfg_dict.get("stt", {}).get("url"):
+        stt_args = Namespace(port=None, host=None, model=None, backend=None)
+        cmd_stt_start(stt_args)
+    else:
+        print("  STT skipped (no stt.url configured).")
+
+    # Custom services
+    custom = [s for s in cfg.services.custom if s.autostart]
+    if custom:
+        print("Starting custom services...")
+        for svc in custom:
+            _start_custom_service(svc)
+
+    print()
+    # Finally, the dev session (creates + attaches the agentwire session)
+    return cmd_dev(args)
 
 
 # === Init Command ===
@@ -10178,6 +10283,15 @@ def main() -> int:
         "dev", help="Start/attach to dev agentwire session"
     )
     dev_parser.set_defaults(func=cmd_dev)
+
+    up_parser = subparsers.add_parser(
+        "up", help="Boot all services (portal, TTS, STT, scheduler, custom) then the dev session"
+    )
+    up_parser.add_argument("--dev", action="store_true", help="Run portal from source (uv run)")
+    up_parser.add_argument("--no-tts", action="store_true", help="Skip starting the TTS server")
+    up_parser.add_argument("--no-stt", action="store_true", help="Skip starting the STT server")
+    up_parser.add_argument("--config", type=Path, default=None, help="Path to config file")
+    up_parser.set_defaults(func=cmd_up)
 
     # === listen command group ===
     listen_parser = subparsers.add_parser("listen", help="Voice input recording")

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -179,11 +179,33 @@ class ServiceConfig:
 
 
 @dataclass
+class CustomServiceConfig:
+    """A user-defined session that behaves like a service.
+
+    Custom services show up in the portal's Services column and are booted
+    by `agentwire up`. A service is just an agentwire session created in a
+    project directory; `roles`/`type` override the project's .agentwire.yml
+    when set.
+    """
+
+    name: str
+    project: Optional[str] = None
+    autostart: bool = True
+    roles: Optional[str] = None  # comma-separated; overrides project .agentwire.yml
+    type: Optional[str] = None   # session type override (e.g. claude-bypass)
+
+    def __post_init__(self):
+        if self.project:
+            self.project = str(_expand_path(self.project) or self.project)
+
+
+@dataclass
 class ServicesConfig:
     """Where each service runs in the network."""
 
     portal: ServiceConfig = field(default_factory=lambda: ServiceConfig(port=8765, scheme="https"))
     tts: ServiceConfig = field(default_factory=lambda: ServiceConfig(port=8100, scheme="http"))
+    custom: list = field(default_factory=list)  # list[CustomServiceConfig]
 
 
 @dataclass
@@ -218,6 +240,7 @@ class SessionConfig:
 class SchedulerConfig:
     """Scheduler daemon configuration."""
 
+    autostart: bool = True         # start the daemon when the portal boots
     board_file: Path = field(default_factory=lambda: Path.home() / ".agentwire" / "scheduler.yaml")
     events_file: Path = field(default_factory=lambda: Path.home() / ".agentwire" / "scheduler-events.jsonl")
     live_state_file: Path = field(default_factory=lambda: Path.home() / ".agentwire" / "scheduler-live.json")
@@ -462,9 +485,22 @@ def _dict_to_config(data: dict) -> Config:
         health_endpoint=tts_service_data.get("health_endpoint", "/health"),
         scheme=tts_service_data.get("scheme", "http"),  # TTS defaults to HTTP
     )
+    custom_services = []
+    for entry in services_data.get("custom", []) or []:
+        if isinstance(entry, str):
+            custom_services.append(CustomServiceConfig(name=entry))
+        elif isinstance(entry, dict) and entry.get("name"):
+            custom_services.append(CustomServiceConfig(
+                name=entry["name"],
+                project=entry.get("project"),
+                autostart=entry.get("autostart", True),
+                roles=entry.get("roles"),
+                type=entry.get("type"),
+            ))
     services = ServicesConfig(
         portal=portal_service,
         tts=tts_service,
+        custom=custom_services,
     )
 
     # Channel configs (registry-driven)
@@ -485,6 +521,7 @@ def _dict_to_config(data: dict) -> Config:
     # Scheduler
     scheduler_data = data.get("scheduler", {})
     scheduler = SchedulerConfig(
+        autostart=scheduler_data.get("autostart", True),
         board_file=scheduler_data.get("board_file", "~/.agentwire/scheduler.yaml"),
         events_file=scheduler_data.get("events_file", "~/.agentwire/scheduler-events.jsonl"),
         live_state_file=scheduler_data.get("live_state_file", "~/.agentwire/scheduler-live.json"),

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -227,6 +227,8 @@ class AgentWireServer:
         self.app.router.add_post("/api/desktop/notification", self.api_desktop_notification)
         self.app.router.add_post("/api/desktop/notification/dismiss", self.api_desktop_notification_dismiss)
         self.app.router.add_get("/api/desktop/notifications", self.api_desktop_notifications_list)
+        # Services registry (custom service sessions from config)
+        self.app.router.add_get("/api/services/custom", self.api_services_custom)
         # Scheduler monitoring endpoints
         self.app.router.add_get("/api/scheduler/live", self.api_scheduler_live)
         self.app.router.add_get("/api/scheduler/events", self.api_scheduler_events)
@@ -4348,6 +4350,18 @@ projects:
             logger.error(f"History resume API failed: {e}")
             return web.json_response({"error": str(e)}, status=500)
 
+    async def api_services_custom(self, request: web.Request) -> web.Response:
+        """GET /api/services/custom - Names of config-defined custom services.
+
+        The sidebar merges these into its Services column so user-flagged
+        sessions group as services rather than regular sessions.
+        """
+        try:
+            names = [s.name for s in self.config.services.custom]
+            return web.json_response({"names": names})
+        except Exception as e:
+            return web.json_response({"error": str(e), "names": []}, status=500)
+
     async def api_scheduler_live(self, request: web.Request) -> web.Response:
         """GET /api/scheduler/live - Live scheduler state.
 
@@ -4435,26 +4449,36 @@ projects:
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
+    async def _start_scheduler_daemon(self) -> bool:
+        """Launch the scheduler daemon in a detached tmux session.
+
+        No-op if it's already running. Returns True if it was started.
+        """
+        if await self._is_scheduler_running():
+            return False
+        # Create tmux session and launch scheduler serve (same as CLI but detached)
+        proc = await asyncio.create_subprocess_exec(
+            "tmux", "new-session", "-d", "-s", "agentwire-scheduler",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+        proc2 = await asyncio.create_subprocess_exec(
+            "tmux", "send-keys", "-t", "agentwire-scheduler",
+            "agentwire scheduler serve", "Enter",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc2.wait()
+        return True
+
     async def api_scheduler_start(self, request: web.Request) -> web.Response:
         """POST /api/scheduler/start - Start the scheduler daemon in tmux."""
         try:
-            if await self._is_scheduler_running():
-                return web.json_response({"success": True, "status": "already_running"})
-            # Create tmux session and launch scheduler serve (same as CLI but detached)
-            proc = await asyncio.create_subprocess_exec(
-                "tmux", "new-session", "-d", "-s", "agentwire-scheduler",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
+            started = await self._start_scheduler_daemon()
+            return web.json_response(
+                {"success": True, "status": "started" if started else "already_running"}
             )
-            await proc.wait()
-            proc2 = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", "agentwire-scheduler",
-                "agentwire scheduler serve", "Enter",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await proc2.wait()
-            return web.json_response({"success": True, "status": "started"})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
@@ -4785,6 +4809,14 @@ async def run_server(config: Config):
 
     # Cleanup old uploads on startup
     await server.cleanup_old_uploads()
+
+    # Auto-start the scheduler daemon alongside the portal (configurable).
+    if config.scheduler.autostart:
+        try:
+            if await server._start_scheduler_daemon():
+                logger.info("Auto-started scheduler daemon")
+        except Exception as e:
+            logger.warning(f"Scheduler autostart failed: {e}")
 
     # Start session monitor for all-sessions dashboard indicators
     monitor_task = asyncio.create_task(server.monitor_all_sessions())

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -404,6 +404,10 @@ body {
     flex-shrink: 0;
 }
 
+.sidebar-list-item-meta.overdue {
+    color: var(--error);
+}
+
 .sidebar-list-item-btn {
     flex-shrink: 0;
     background: transparent;

--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -65,9 +65,13 @@ export const schedulerSection = {
             ]);
             const live = liveRes.ok ? await liveRes.json() : null;
             const board = boardRes.ok ? await boardRes.json() : null;
-            if (live) {
-                this._state = { ...live, tasks: board?.tasks || [] };
+            // The board (tasks, overdue, last status) is available whether or not
+            // the daemon is running. Render it regardless so a stopped scheduler
+            // still shows what's queued + how overdue it is, plus a start toggle.
+            if (board) {
+                this._state = { running: !!live, ...(live || {}), tasks: board.tasks || [] };
             } else {
+                // No board at all — API unreachable, not just a stopped daemon.
                 this._state = null;
             }
         } catch (e) {
@@ -77,13 +81,35 @@ export const schedulerSection = {
     },
 
     _renderTaskRow(t, current_task) {
-        const name = typeof t === 'string' ? t : (t.name || t.task || '?');
-        const enabled = typeof t === 'object' ? t.enabled !== false : true;
-        const statusClass = !enabled ? 'dot-offline' : (name === current_task ? 'dot-processing' : 'dot-idle');
+        const obj = typeof t === 'object' ? t : {};
+        const name = typeof t === 'string' ? t : (obj.name || obj.task || '?');
+        const enabled = obj.enabled !== false;
+        const inFlight = !!obj.in_flight;
+        const lastStatus = obj.last_status;
+        const isCurrent = inFlight || name === current_task;
+
+        // Status dot reflects task health, not just enabled/disabled.
+        let dotClass = 'sidebar-activity-dot dot-idle';
+        if (!enabled) dotClass = 'sidebar-activity-dot dot-idle';
+        else if (isCurrent) dotClass = 'sidebar-activity-dot dot-processing';
+        else if (lastStatus === 'failed') dotClass = 'sidebar-status-dot dot-offline';
+        else if (lastStatus === 'complete') dotClass = 'sidebar-status-dot dot-online';
+
+        // Overdue meta: real "+13h12m" string once it's run before; a plain
+        // "due" badge for never-run tasks (their overdue_str is epoch garbage).
+        let meta = '';
+        if (enabled && !isCurrent && obj.overdue_by > 0) {
+            meta = obj.last_run_iso
+                ? `<span class="sidebar-list-item-meta overdue">${_escape(obj.overdue_str || 'overdue')}</span>`
+                : `<span class="sidebar-list-item-meta">due</span>`;
+        }
+
         const safeName = _escape(name);
-        return `<div class="sidebar-list-item sidebar-scheduler-task" data-task="${safeName}">
-            <span class="sidebar-status-dot ${statusClass}"></span>
+        const title = _escape(`${name} — ${obj.schedule_str || ''}${obj.last_run ? ` · last: ${obj.last_run} (${lastStatus || '?'})` : ''}`);
+        return `<div class="sidebar-list-item sidebar-scheduler-task" data-task="${safeName}" title="${title}">
+            <span class="${dotClass}"></span>
             <span class="sidebar-list-item-title">${safeName}</span>
+            ${meta}
             <button class="sidebar-list-item-btn" data-action="${enabled ? 'disable' : 'enable'}" title="${enabled ? 'Disable' : 'Enable'}">${enabled ? '⏸' : '▶'}</button>
             <button class="sidebar-list-item-btn" data-action="run" title="Run now">⚡</button>
         </div>`;
@@ -101,15 +127,24 @@ export const schedulerSection = {
 
     _render(body) {
         if (!this._state) {
-            body.innerHTML = '<div class="sidebar-empty">Scheduler not running</div>';
+            // Null only when the board API itself is unreachable (portal down).
+            body.innerHTML = '<div class="sidebar-empty">Scheduler unavailable</div>';
+            this._lastHtml = '';
             return;
         }
         const { current_task, tasks } = this._state;
         const running = this._state.running ?? (this._state.status === 'running');
         const statusDot = running ? 'dot-online' : 'dot-offline';
         const statusText = running ? 'Running' : 'Stopped';
+        const toggleAction = running ? 'scheduler-stop' : 'scheduler-start';
+        const toggleIcon = running ? '⏸' : '▶';
+        const toggleTitle = running ? 'Stop scheduler' : 'Start scheduler';
 
-        let html = `<div class="sidebar-list-item"><span class="sidebar-status-dot ${statusDot}"></span><span class="sidebar-list-item-title">${statusText}</span></div>`;
+        let html = `<div class="sidebar-list-item sidebar-scheduler-status">
+            <span class="sidebar-status-dot ${statusDot}"></span>
+            <span class="sidebar-list-item-title">${statusText}</span>
+            <button class="sidebar-list-item-btn" data-action="${toggleAction}" title="${toggleTitle}">${toggleIcon}</button>
+        </div>`;
 
         if (current_task) {
             html += `<div class="sidebar-section-subheader">Current</div>`;
@@ -161,10 +196,23 @@ export const schedulerSection = {
 
         const btn = e.target.closest('[data-action]');
         if (!btn) return;
+        const action = btn.dataset.action;
+
+        // Daemon start/stop toggle (not tied to a task row).
+        if (action === 'scheduler-start' || action === 'scheduler-stop') {
+            btn.disabled = true;
+            try {
+                const path = action === 'scheduler-start' ? '/api/scheduler/start' : '/api/scheduler/stop';
+                await fetch(path, { method: 'POST' });
+            } catch (e) { console.warn('Scheduler toggle failed', e); }
+            // Daemon takes a moment to spin up / write its state file.
+            setTimeout(() => this.refresh(body), 1500);
+            return;
+        }
+
         const item = btn.closest('[data-task]');
         if (!item) return;
         const task = item.dataset.task;
-        const action = btn.dataset.action;
         try {
             if (action === 'run') {
                 await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -13,6 +13,24 @@ const SERVICE_SESSIONS = new Set([
 ]);
 export function isService(name) { return SERVICE_SESSIONS.has(name); }
 
+// Merge config-defined custom services into the Services column. Fire-and-forget
+// on load; re-render once they arrive so flagged sessions hop to the right group.
+async function loadCustomServices() {
+    try {
+        const res = await fetch('/api/services/custom');
+        if (!res.ok) return;
+        const { names } = await res.json();
+        let changed = false;
+        for (const n of names || []) {
+            if (!SERVICE_SESSIONS.has(n)) { SERVICE_SESSIONS.add(n); changed = true; }
+        }
+        if (changed) notifyListeners();
+    } catch {
+        // Portal offline / endpoint missing — built-in services still group fine.
+    }
+}
+loadCustomServices();
+
 let allSessions = [];
 const listeners = new Set();
 


### PR DESCRIPTION
## What & why

Fixes the scheduler sidebar dead-end (showed "Scheduler not running" with no toggle and no task info) and closes the boot gap where `agentwire dev` only spawned the agent session — never the portal/TTS/STT/scheduler.

## Scheduler sidebar (`scheduler-section.js`)
- **Start/Stop toggle** (▶/⏸) wired to the existing `/api/scheduler/start|stop` endpoints (previously unused by the UI).
- **Board always renders** — even when the daemon is stopped — using `/api/scheduler/board`: overdue times (red), per-task last-status dots (failed/complete/running). `_state` is `null` (→ "Scheduler unavailable") only when the portal itself is unreachable.
- **`scheduler.autostart`** config (default `true`) — the portal boots the scheduler daemon on startup.

## Boot orchestration
- New **`agentwire up`**: boots portal → TTS → STT → autostart custom services, then runs `agentwire dev`. Scheduler rides along via the portal autostart. TTS skipped for `none`/`runpod` backends; STT skipped without `stt.url`; `--no-tts`/`--no-stt`/`--dev` supported.
- `agentwire dev` is unchanged (agent session only). Local service starters gained `attach=False` for detached boot.

## Custom services
- **`services.custom`** config list (`name`/`project`/`autostart`/`roles`/`type`, plus string shorthand) + **`/api/services/custom`** endpoint.
- The sidebar merges these names into the **Services column** (was a hardcoded-only allowlist).

## Docs
- Updated `agentwire-cli`, `agentwire-config`, `agentwire-desktop-ui` skills.

## Verification
- Config parsing (dict + shorthand, path expansion, autostart filter) ✅
- `/api/services/custom` and `/api/scheduler/live` return correctly; scheduler auto-starts on portal boot ✅
- Edited JS passes `node --check` ✅

## Follow-up (not in this PR)
The scheduler's auto-commit (`scheduler.py:964`) does `git add -A` on the whole project (excluding only `.agentwire.yml`), so a task running against a repo with unrelated uncommitted work commits all of it under `scheduler: <task> (<status>)`. Worth scoping to task-touched files or making opt-in.

Built by [dotdev.dev](https://dotdev.dev)