### PR TITLE
Seed gitignored files (.env) into new worktrees

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -44,6 +44,11 @@ projects:
   worktrees:
     enabled: true
     suffix: "-worktrees"
+    auto_create_branch: true
+    copy_files: [".env"]   # gitignored files seeded into each new worktree
+                           # (git worktree add only checks out tracked files,
+                           #  so .env/secrets/local config don't carry over —
+                           #  add ".env.local", ".envrc", etc. as needed)
 
 tts:
   backend: "runpod"  # runpod | kokoro | chatterbox | chatterbox-streaming | qwen-base-0.6b | qwen-base-1.7b | qwen-custom | qwen-design | zonos-transformer | zonos-hybrid | none

--- a/.claude/skills/agentwire-scheduler/SKILL.md
+++ b/.claude/skills/agentwire-scheduler/SKILL.md
@@ -52,6 +52,8 @@ tasks:
 
 **Lifecycle:** branch `scheduler-<task>-<timestamp>` → run in worktree → if it produced changes, `git add -A` + commit (`scheduler: <task> — <summary>`) + push + draft PR; if it produced **nothing**, the empty worktree is removed and no PR is opened. The worktree **persists while the PR is open** (so you can spawn a session there during review) and is **reaped automatically when the PR merges or closes** (worktree + branch + session torn down). `worktree: false` tasks run in place and never commit.
 
+**Seeded files:** `git worktree add` only checks out *tracked* files, so gitignored secrets/config (`.env` etc.) won't be in a fresh worktree — an agent that needs them to authenticate would fail. The files listed in `projects.worktrees.copy_files` (default `[".env"]`) are copied from the main repo into every new worktree. They stay gitignored there, so they're never committed.
+
 ## Scheduler Task Scheduling
 
 Each task has a `schedule` field (replaces the old `interval`). The scheduler uses `_compute_next_eligible()` as the single source of truth for when a task becomes eligible.

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -66,6 +66,10 @@ class WorktreesConfig:
     enabled: bool = True
     suffix: str = "-worktrees"
     auto_create_branch: bool = True
+    # Gitignored files that `git worktree add` won't carry over (it only
+    # checks out tracked files). These are copied from the main repo into
+    # each fresh worktree so agents have the secrets/config they need.
+    copy_files: list = field(default_factory=lambda: [".env"])
 
 
 @dataclass
@@ -410,6 +414,7 @@ def _dict_to_config(data: dict) -> Config:
         enabled=worktrees_data.get("enabled", True),
         suffix=worktrees_data.get("suffix", "-worktrees"),
         auto_create_branch=worktrees_data.get("auto_create_branch", True),
+        copy_files=worktrees_data.get("copy_files", [".env"]),
     )
     projects = ProjectsConfig(
         dir=projects_data.get("dir", "~/projects"),

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -64,6 +64,7 @@ def ensure_worktree(
     worktree_path: Path,
     auto_create_branch: bool = True,
     commit: str | None = None,
+    copy_files: list[str] | None = None,
 ) -> bool:
     """Ensure a git worktree exists for the given branch.
 
@@ -73,6 +74,8 @@ def ensure_worktree(
         worktree_path: Path where the worktree should be created
         auto_create_branch: If True, create branch if it doesn't exist
         commit: Optional commit/ref to start the worktree from (default: HEAD)
+        copy_files: Gitignored files to seed into the fresh worktree. None
+            resolves the configured default (projects.worktrees.copy_files).
 
     Returns:
         True if worktree exists or was created successfully, False otherwise
@@ -96,40 +99,72 @@ def ensure_worktree(
     )
     branch_exists = result.returncode == 0
 
-    # Build git worktree add command
-    # git worktree add [-b branch] <path> [<commit-ish>]
-    cmd = ["git", "worktree", "add", str(worktree_path)]
-
     if branch_exists:
-        cmd.append(branch)
-        # Create worktree first, then checkout specific commit if requested
-        result = subprocess.run(cmd, cwd=project_path, capture_output=True)
+        result = subprocess.run(
+            ["git", "worktree", "add", str(worktree_path), branch],
+            cwd=project_path, capture_output=True,
+        )
         if result.returncode != 0:
             return False
         if commit:
             # Detach HEAD at requested commit inside the worktree
             checkout = subprocess.run(
                 ["git", "checkout", commit],
-                cwd=worktree_path,
-                capture_output=True,
+                cwd=worktree_path, capture_output=True,
             )
-            return checkout.returncode == 0
-        return True
+            if checkout.returncode != 0:
+                return False
     elif auto_create_branch:
-        cmd.extend(["-b", branch])
+        cmd = ["git", "worktree", "add", "-b", branch, str(worktree_path)]
         if commit:
             cmd.append(commit)  # git worktree add -b branch path <commit> is native
+        result = subprocess.run(cmd, cwd=project_path, capture_output=True)
+        if result.returncode != 0:
+            return False
     else:
         return False
 
-    # Create worktree
-    result = subprocess.run(
-        cmd,
-        cwd=project_path,
-        capture_output=True,
-    )
+    _seed_worktree_files(project_path, worktree_path, copy_files)
+    return True
 
-    return result.returncode == 0
+
+def _seed_worktree_files(
+    project_path: Path,
+    worktree_path: Path,
+    copy_files: list[str] | None = None,
+) -> None:
+    """Copy gitignored-but-needed files (e.g. .env) into a fresh worktree.
+
+    `git worktree add` only checks out tracked files — untracked/ignored
+    files like .env, .env.local, or local config never come along, so an
+    agent working in the worktree can't authenticate. Copy a configured
+    seed list (relative paths) from the main repo. Best-effort: missing
+    sources are skipped and copy errors are swallowed. Files that are
+    gitignored in the repo stay ignored in the worktree, so they're never
+    committed.
+    """
+    if copy_files is None:
+        try:
+            from .config import load_config
+            copy_files = load_config().projects.worktrees.copy_files
+        except Exception:
+            copy_files = []
+
+    import shutil
+
+    for rel in copy_files or []:
+        src = project_path / rel
+        dst = worktree_path / rel
+        if not src.exists() or dst.exists():
+            continue
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if src.is_dir():
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+        except Exception:
+            pass  # best-effort — a missing seed file shouldn't fail dispatch
 
 
 def list_worktrees(project_path: Path) -> list[dict]:

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -1,5 +1,6 @@
 """Tests for agentwire/worktree.py — Session name parsing, paths."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from agentwire.worktree import (
     get_session_path,
     is_git_repo,
     get_project_type,
+    ensure_worktree,
 )
 
 
@@ -79,3 +81,55 @@ class TestGetProjectType:
 
     def test_scratch_without_git(self, tmp_path):
         assert get_project_type(tmp_path) == "scratch"
+
+
+# --- ensure_worktree seeding (gitignored files like .env) ---
+
+class TestWorktreeSeeding:
+    def _repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        def git(*a):
+            return subprocess.run(["git", "-C", str(repo), *a],
+                                  capture_output=True, text=True)
+
+        git("init", "-q")
+        git("config", "user.email", "t@t")
+        git("config", "user.name", "t")
+        (repo / ".gitignore").write_text("secret.env\n")
+        (repo / "README.md").write_text("hi\n")
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        return repo, git
+
+    def test_seeds_listed_file_and_keeps_it_ignored(self, tmp_path):
+        repo, git = self._repo(tmp_path)
+        (repo / "secret.env").write_text("API_KEY=abc\n")  # gitignored, in main only
+
+        wt = tmp_path / "repo-worktrees" / "feature"
+        assert ensure_worktree(repo, "feature", wt, copy_files=["secret.env"])
+
+        # Seeded into the worktree...
+        assert (wt / "secret.env").read_text() == "API_KEY=abc\n"
+        # ...and still gitignored there, so it's never committed.
+        status = subprocess.run(["git", "-C", str(wt), "status", "--porcelain"],
+                                capture_output=True, text=True).stdout
+        assert "secret.env" not in status
+
+    def test_only_listed_files_copied(self, tmp_path):
+        repo, git = self._repo(tmp_path)
+        (repo / "secret.env").write_text("k\n")
+        (repo / "other.local").write_text("nope\n")  # untracked, not listed
+
+        wt = tmp_path / "repo-worktrees" / "f2"
+        ensure_worktree(repo, "f2", wt, copy_files=["secret.env"])
+        assert (wt / "secret.env").exists()
+        assert not (wt / "other.local").exists()
+
+    def test_missing_seed_file_is_noop(self, tmp_path):
+        repo, _ = self._repo(tmp_path)
+        wt = tmp_path / "repo-worktrees" / "f3"
+        # Listed file doesn't exist — creation still succeeds.
+        assert ensure_worktree(repo, "f3", wt, copy_files=["secret.env"])
+        assert not (wt / "secret.env").exists()


### PR DESCRIPTION
## Problem

`git worktree add` does a clean checkout of **tracked files only**. Gitignored/untracked files — `.env`, secrets, local config — never carry over to a fresh worktree. So an agent spawned in a worktree (scheduler worktree+PR tasks, missions, manual `agentwire new -s proj/branch`) can't authenticate against APIs that need those secrets.

## Fix

`ensure_worktree` now copies a configured seed list from the main repo into each new worktree right after creation:

```yaml
projects:
  worktrees:
    copy_files: [".env"]   # add .env.local, .envrc, etc. as needed
```

- Single chokepoint (`agentwire/worktree.py`) → covers **every** worktree creator (scheduler, missions, manual `new`).
- Best-effort: missing sources skipped, copy errors swallowed (never fails dispatch).
- Seeded files stay **gitignored in the worktree**, so they're never committed (verified in tests).

## Tests (`16 passed` in test_worktree)

`TestWorktreeSeeding`: copies a listed gitignored file and keeps it ignored; copies only listed files (not other untracked files); missing seed file is a no-op.

## Docs
`agentwire-config` + `agentwire-scheduler` skills; wiki `patterns/git-worktree-untracked-files`.

Built by [dotdev.dev](https://dotdev.dev)