### PR TITLE
feat(portal): Mission Control window collage overlay (#211)

### DIFF
--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2727,6 +2727,22 @@ def desktop_minimize_all() -> str:
 
 
 @mcp.tool()
+def desktop_mission_control() -> str:
+    """Toggle Mission Control in the portal desktop.
+
+    Lays every open window into a grid collage so they can all be seen at once;
+    toggling again (or the user clicking a tile / pressing Esc) exits the overlay.
+
+    Returns:
+        Success message or error description.
+    """
+    data = _portal_request("POST", "/api/desktop/mission-control")
+    if data.get("success"):
+        return "Mission Control toggled."
+    return f"Failed to toggle Mission Control: {data.get('error', 'Unknown error')}"
+
+
+@mcp.tool()
 def desktop_layout(windows: list[dict]) -> str:
     """Apply a multi-window layout to the portal desktop.
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -222,6 +222,7 @@ class AgentWireServer:
         self.app.router.add_post("/api/desktop/window/focus", self.api_desktop_focus)
         self.app.router.add_post("/api/desktop/window/tile", self.api_desktop_tile)
         self.app.router.add_post("/api/desktop/window/minimize-all", self.api_desktop_minimize_all)
+        self.app.router.add_post("/api/desktop/mission-control", self.api_desktop_mission_control)
         self.app.router.add_post("/api/desktop/layout", self.api_desktop_layout)
         # Desktop notifications
         self.app.router.add_post("/api/desktop/notification", self.api_desktop_notification)
@@ -983,6 +984,11 @@ class AgentWireServer:
     async def api_desktop_minimize_all(self, request):
         """POST /api/desktop/window/minimize-all — minimize all windows."""
         await self.broadcast_dashboard("desktop_minimize_all", {})
+        return web.json_response({"success": True})
+
+    async def api_desktop_mission_control(self, request):
+        """POST /api/desktop/mission-control — toggle the Mission Control window collage."""
+        await self.broadcast_dashboard("desktop_mission_control", {})
         return web.json_response({"success": True})
 
     async def api_desktop_layout(self, request):

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -2096,6 +2096,26 @@ body .winbox.max {
     display: none;
 }
 
+/* Mission Control — dim scrim behind the window grid collage. Grid windows are
+ * raised above this via inline z-index (see mission-control.js). Clicking the
+ * scrim (the gaps between tiles) exits the overlay. */
+.mission-control-overlay {
+    position: absolute;
+    top: var(--menu-height);
+    left: 0;
+    right: 0;
+    bottom: var(--taskbar-height);
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(2px);
+    opacity: 1;
+    transition: opacity 0.15s ease;
+}
+
+.mission-control-overlay.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
 /* ListWindow component */
 .list-window {
     display: flex;

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -35,6 +35,11 @@ const COMMANDS = [
     { id: 'new-session', icon: '▶', label: 'New session', keywords: 'create new session start spawn run project', run: () => setView('new-session') },
     { id: 'worktree', icon: '⎇', label: 'New worktree', keywords: 'worktree branch quicktask task feat fix base', run: () => setView('worktree') },
     { id: 'open-session', icon: '👁', label: 'Open session', keywords: 'open attach connect existing session', run: () => setView('open-session') },
+    { id: 'mission-control', icon: '▦', label: 'Mission Control', keywords: 'mission control collage grid windows overview show all', run: async () => {
+        closeCommandPalette();
+        const { missionControl } = await import('./mission-control.js');
+        missionControl.enter();
+    } },
 ];
 
 // ---------------------------------------------------------------------------

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -320,6 +320,10 @@ class DesktopManager {
                 this.emit('desktop_minimize_all', {});
                 break;
 
+            case 'desktop_mission_control':
+                this.emit('desktop_mission_control', {});
+                break;
+
             case 'desktop_apply_layout':
                 this.emit('desktop_apply_layout', { windows: msg.windows });
                 break;

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -9,6 +9,7 @@
 
 import { desktop } from './desktop-manager.js';
 import { tileManager } from './tile-manager.js';
+import { missionControl } from './mission-control.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { sidebar } from './sidebar.js';
@@ -73,6 +74,7 @@ async function init() {
     setupPageUnload();
     setupGlobalPtt();
     setupWindowCycling();
+    setupMissionControl();
 
     // Set up event listeners BEFORE fetching data
     desktop.on('disconnect', () => updateConnectionStatus(false));
@@ -183,6 +185,10 @@ async function init() {
 
     desktop.on('desktop_minimize_all', () => {
         desktop.minimizeAllExcept(null);
+    });
+
+    desktop.on('desktop_mission_control', () => {
+        missionControl.toggle();
     });
 
     desktop.on('desktop_apply_layout', ({ windows }) => {
@@ -319,6 +325,20 @@ function setupWindowCycling() {
         updateTaskbarActive(nextId);
         saveTaskbarState();
     }, true);  // capture phase — runs before xterm's handlers
+}
+
+// Mission Control — Alt/Option + ` collages all open windows into a grid.
+function setupMissionControl() {
+    missionControl.init();
+    // Capture phase on window: xterm's <textarea> swallows keydown otherwise.
+    // Detect via e.code, NOT e.key — on macOS Option+` is a dead key (grave accent)
+    // so e.key is "Dead", never a backtick. (Cmd/Ctrl+` is the sidebar toggle.)
+    window.addEventListener('keydown', (e) => {
+        if (!e.altKey || e.code !== 'Backquote') return;
+        if (isCommandPaletteOpen()) return;
+        e.preventDefault();
+        missionControl.toggle();
+    }, true);
 }
 
 // Clean up on page unload

--- a/agentwire/static/js/mission-control.js
+++ b/agentwire/static/js/mission-control.js
@@ -1,0 +1,210 @@
+/**
+ * Mission Control - window collage overlay.
+ *
+ * Lays every open window into a grid so the whole desktop can be scanned at once.
+ * Click any tile to focus that window and exit; Esc exits restoring the prior state.
+ *
+ * The portal runs in single-window mode (one maximized window, the rest minimized),
+ * so "prior state" is just: which window was active + each window's minimized flag +
+ * any tile zones. Live windows act as the tiles — no snapshots, no scaling. Grid
+ * placement reuses tileManager.layoutGrid (same move/resize/refit pipeline as tiling).
+ *
+ * @module mission-control
+ */
+
+import { desktop } from './desktop-manager.js';
+import { tileManager } from './tile-manager.js';
+
+/** z-index band: scrim sits at BASE, grid windows above it. */
+const SCRIM_Z = 5000;
+
+class MissionControl {
+    constructor() {
+        /** @type {boolean} */
+        this._active = false;
+
+        /** @type {HTMLElement|null} */
+        this._scrim = null;
+
+        /** @type {Object|null} Pre-collage state snapshot */
+        this._snapshot = null;
+
+        /** @type {Array<{el: HTMLElement, fn: Function}>} Per-window click handlers */
+        this._clickHandlers = [];
+
+        /** @type {Array<Function>} desktop event unsubscribe fns (active only) */
+        this._unsubs = [];
+
+        this._onKeydown = this._onKeydown.bind(this);
+    }
+
+    /**
+     * Initialize. Creates the scrim element (hidden) inside the desktop area.
+     */
+    init() {
+        const area = document.getElementById('desktopArea');
+        if (!area) return;
+        this._scrim = document.createElement('div');
+        this._scrim.className = 'mission-control-overlay hidden';
+        this._scrim.style.zIndex = String(SCRIM_Z);
+        this._scrim.addEventListener('click', () => this.exit());
+        area.appendChild(this._scrim);
+    }
+
+    /**
+     * Toggle the overlay.
+     */
+    toggle() {
+        this._active ? this.exit() : this.enter();
+    }
+
+    /**
+     * Enter Mission Control: restore every window and lay them into a grid.
+     */
+    enter() {
+        if (this._active) return;
+        const ids = [...desktop.windows.keys()];
+        if (ids.length < 2) return;  // nothing to collage
+
+        // Snapshot the single-window state so we can restore it on Esc.
+        const minimized = new Map();
+        for (const [id, winbox] of desktop.windows) {
+            minimized.set(id, !!winbox.min);
+        }
+        this._snapshot = {
+            activeId: desktop.getActiveWindow(),
+            minimized,
+            tileStates: new Map(desktop.tileStates),
+        };
+
+        // Clear tile states BEFORE restoring — otherwise tile-manager's
+        // window_restored handler re-tiles each window to its old zone, fighting
+        // the grid. The snapshot above lets us put them back on exit.
+        desktop.tileStates.clear();
+
+        // Restore every minimized window so it can take a grid slot.
+        for (const [id, winbox] of desktop.windows) {
+            if (winbox && winbox.min) {
+                desktop._safeWinBoxOp(winbox, 'restore', id);
+            }
+        }
+
+        this._active = true;
+        this._showScrim();
+        this._layout(ids);
+
+        document.addEventListener('keydown', this._onKeydown, true);
+        this._unsubs.push(
+            desktop.on('window_registered', () => this._relayout()),
+            desktop.on('window_unregistered', () => this._relayout()),
+            desktop.on('session_closed', () => this._relayout()),
+        );
+    }
+
+    /**
+     * Exit Mission Control.
+     * @param {string|null} focusId - If given, that window becomes the single
+     *   maximized window (click-to-focus). Otherwise the pre-collage state restores.
+     */
+    exit(focusId = null) {
+        if (!this._active) return;
+        this._active = false;
+
+        document.removeEventListener('keydown', this._onKeydown, true);
+        this._unsubs.forEach((fn) => { try { fn(); } catch (e) {} });
+        this._unsubs = [];
+        this._clearClickHandlers();
+        this._hideScrim();
+
+        // Drop transient grid styling/z-index from every window.
+        for (const [, winbox] of desktop.windows) {
+            if (winbox?.window) {
+                winbox.window.classList.remove('tiled');
+                winbox.window.style.zIndex = '';
+            }
+        }
+
+        const snap = this._snapshot;
+        this._snapshot = null;
+
+        if (focusId && desktop.windows.has(focusId)) {
+            // Commit to the clicked window: single-window mode, rest minimized.
+            desktop.setActiveWindow(focusId);
+            return;
+        }
+
+        if (!snap) return;
+
+        // Esc: restore exact prior state — re-tile what was tiled, then re-maximize
+        // the prior active window (setActiveWindow minimizes all non-tiled others).
+        for (const [id, zone] of snap.tileStates) {
+            if (desktop.windows.has(id)) tileManager._tileWindow(id, zone);
+        }
+        if (snap.activeId && desktop.windows.has(snap.activeId) && !desktop.tileStates.has(snap.activeId)) {
+            desktop.setActiveWindow(snap.activeId);
+        } else if (desktop.tileStates.size === 0) {
+            desktop.minimizeAllExcept(null);
+        }
+    }
+
+    // ============================================
+    // Internals
+    // ============================================
+
+    /**
+     * Lay the given windows into the grid and (re)wire click-to-focus + z-index.
+     * @param {string[]} ids
+     */
+    _layout(ids) {
+        tileManager.layoutGrid(ids);
+        this._clearClickHandlers();
+        ids.forEach((id, i) => {
+            const winbox = desktop.getWindow(id);
+            if (!winbox?.window) return;
+            // Stack above the scrim.
+            winbox.window.style.zIndex = String(SCRIM_Z + 1 + i);
+            // Capture-phase click anywhere in the window focuses it and exits.
+            const fn = (e) => { e.stopPropagation(); this.exit(id); };
+            winbox.window.addEventListener('click', fn, true);
+            this._clickHandlers.push({ el: winbox.window, fn });
+        });
+    }
+
+    /**
+     * Re-run the layout against the current window set (handles mid-overlay churn).
+     */
+    _relayout() {
+        if (!this._active) return;
+        const ids = [...desktop.windows.keys()];
+        if (ids.length < 2) { this.exit(); return; }
+        // A newly-registered window may have minimized the others (registerWindow
+        // behavior) — restore everything before re-gridding.
+        for (const [id, winbox] of desktop.windows) {
+            if (winbox && winbox.min) desktop._safeWinBoxOp(winbox, 'restore', id);
+        }
+        this._layout(ids);
+    }
+
+    _onKeydown(e) {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            this.exit();
+        }
+    }
+
+    _clearClickHandlers() {
+        this._clickHandlers.forEach(({ el, fn }) => el.removeEventListener('click', fn, true));
+        this._clickHandlers = [];
+    }
+
+    _showScrim() {
+        if (this._scrim) this._scrim.classList.remove('hidden');
+    }
+
+    _hideScrim() {
+        if (this._scrim) this._scrim.classList.add('hidden');
+    }
+}
+
+export const missionControl = new MissionControl();

--- a/agentwire/static/js/tile-manager.js
+++ b/agentwire/static/js/tile-manager.js
@@ -290,6 +290,59 @@ class TileManager {
     }
 
     /**
+     * Lay a set of windows out into a grid collage across the desktop area.
+     *
+     * Reuses the same move/resize mechanics as _tileWindow (strip .max, position
+     * via winbox.move/resize, emit window_tiled so terminals refit) but for an
+     * arbitrary N-cell grid. Unlike tiling, this is a transient view: it does NOT
+     * write desktop.tileStates, so nothing persists or re-applies on restore.
+     *
+     * @param {string[]} ids - Window identifiers to place, in grid order
+     * @param {number} [gutter=8] - Pixel gap between tiles and around the edges
+     */
+    layoutGrid(ids, gutter = 8) {
+        if (!this.desktopArea || !ids.length) return;
+
+        const rect = this.desktopArea.getBoundingClientRect();
+        const n = ids.length;
+
+        // Fit cols×rows to the desktop aspect ratio so tiles stay close to the
+        // viewport shape rather than squashed. cols = ceil(sqrt(n * aspect)).
+        const aspect = rect.width / rect.height;
+        let cols = Math.max(1, Math.round(Math.sqrt(n * aspect)));
+        cols = Math.min(cols, n);
+        let rows = Math.ceil(n / cols);
+        // Avoid a trailing near-empty row when one more column packs it tighter.
+        while (cols > 1 && (cols - 1) * rows >= n) cols--;
+        rows = Math.ceil(n / cols);
+
+        const cellW = (rect.width - gutter * (cols + 1)) / cols;
+        const cellH = (rect.height - gutter * (rows + 1)) / rows;
+
+        ids.forEach((id, i) => {
+            const winbox = desktop.getWindow(id);
+            if (!winbox || !winbox.window) return;
+
+            const col = i % cols;
+            const row = Math.floor(i / cols);
+            const x = rect.left + gutter + col * (cellW + gutter);
+            const y = rect.top + gutter + row * (cellH + gutter);
+
+            // Strip maximized state — .max CSS uses !important and overrides move/resize.
+            winbox.window.classList.remove('max');
+            winbox.max = false;
+            // Reuse .tiled for the smooth left/top/width/height transition.
+            winbox.window.classList.add('tiled');
+
+            winbox.move(x, y);
+            winbox.resize(cellW, cellH);
+
+            // Trigger terminal refit after the transition (same wiring as tiling).
+            desktop.emit('window_tiled', { id });
+        });
+    }
+
+    /**
      * Re-maximize a window (remove tiling).
      * @param {string} id - Window identifier
      */


### PR DESCRIPTION
## What

Adds a Mission Control–style overlay to the portal. `Alt/Option + \`` lays **every open window** into a grid collage so an orchestrator running many session windows can scan them all at once; click any tile to focus that window and exit, `Esc` exits restoring the prior single-window state.

Closes #211.

## How

Thin layer over the existing window stack (WinBox registry + `tile-manager` move/resize/refit). **No new dependencies** — live windows are the tiles (resize + `fitAddon.fit()`, never `transform: scale`/snapshots).

| File | Change |
|------|--------|
| `tile-manager.js` | New `layoutGrid(ids)` — generalizes the tiling pipeline to an N-cell grid fitted to the desktop aspect ratio. Transient (no `tileStates`). |
| `mission-control.js` *(new)* | Overlay lifecycle: snapshot single-window state, **clear `tileStates` before restoring** (else `window_restored` re-tiles and fights the grid), grid behind a dim scrim, click-to-focus + Esc, mid-overlay churn via `desktop` events. |
| `desktop.js` | Capture-phase hotkey on `window`. |
| `command-palette.js` | "Mission Control" entry. |
| `desktop.css` | `.mission-control-overlay` scrim; grid reuses `.winbox.tiled` transition. |
| `server.py` / `mcp_server.py` / `desktop-manager.js` | `desktop_mission_control` parity so an orchestrator agent can toggle the collage (mirrors `desktop_minimize_all`). |

## Key decisions

- **Hotkey `Alt/Option + \``**, detected via `e.altKey && e.code === 'Backquote'` — *not* `e.key`. On macOS `Option + \`` is a dead key (grave-accent composition) so `e.key` is `"Dead"`, never a backtick. `Cmd/Ctrl + \`` is already the sidebar toggle.
- **Capture phase on `window`** — xterm's `<textarea>` swallows keydown otherwise (same pattern as Tab-cycling).
- **Single-window-mode aware** — the portal keeps one window maximized and the rest minimized, so "prior state" is just active id + per-window `min` + tile zones; Esc restores exactly that, click commits to the chosen window.

## Verification

- ✅ Syntax: `node --check` on all changed JS, `ast.parse` on Python.
- ✅ New route: `POST /api/desktop/mission-control` → `{"success": true}`.
- ✅ Worktree portal boots clean and serves all changed assets (mission-control.js, palette entry, CSS, hotkey).
- ⚠️ **Interactive click-path not exercised** — the Chrome extension isn't connected in this session. Needs a manual pass: open 4–6 mixed windows, `Alt/Option + \`` → grid, click a tile → focus+exit, Esc → restore, 12–16 windows for jank, and the macOS dead-key check (Option+` must not type a grave accent into a focused terminal).

Built by [dotdev.dev](https://dotdev.dev)