### PR TITLE
fix(portal): rewrite window collage as a live preview overlay + name labels

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-desktop-ui
-description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
+description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`), window collage (preview overlay — NEVER mutate real WinBox windows). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
 ---
 
 # Portal Desktop UI Patterns
@@ -36,6 +36,20 @@ Both share session data from `sessions-section.js` (single fetch, shared activit
 **Important:** Monitor mode must use a simple `<pre>` element, NOT xterm.js. xterm.js requires precise container dimensions for its fit addon to work correctly. Since monitor mode just displays captured text output, a `<pre>` element with `white-space: pre-wrap` and ANSI-to-HTML conversion is simpler and more reliable.
 
 **Per-session PTT** lives in the WinBox titlebar (next to the activity indicator), not as a floating button.
+
+## Window Collage (Mission Control)
+
+F3 / `desktop_collage` MCP / command palette → grid of live previews of every open window; click a tile to focus, Esc to exit.
+
+**The one rule: tiles are overlay-local previews — NEVER mutate the real WinBox windows.** Session tiles stream pane content over a second monitor WS (`/ws/{sessionId}`, rendered via shared `utils/ansi.js`); artifact tiles are cloned iframes. Real windows are never moved/resized/transformed/un-minimized, so exit has nothing to restore.
+
+Why this is load-bearing (each broke a previous implementation — full autopsy in `docs/wiki/internals/window-collage.md`):
+- Faking `winbox.min` corrupts WinBox's internal min-stack → later minimizes re-lay windows out as 250×35px bars, with duplicate entries compounding per cycle.
+- WinBox animates geometry over 300ms → `getBoundingClientRect` right after a write returns mid-transition garbage.
+- Resizing a terminal window fires ResizeObserver → `fitAddon.fit()` + PTY resize per frame → resizes the real tmux session and corrupts the xterm WebGL layer (transparent windows).
+- `registerWindow`/`setActiveWindow` auto-minimize all others (single-window mode) → any window event mid-overlay fights manual layouts.
+
+**Z-index landscape:** WinBox windows (inline, grows from 10) < collage overlay (1400) < toasts (1500) < modals (2000) < command palette (3000) < sidebar (9001) < tile drag overlay (99999).
 
 ## Artifact Windows
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -2096,27 +2096,170 @@ body .winbox.max {
     display: none;
 }
 
-/* Collage — dim scrim behind the window grid collage. Grid windows are
- * raised above this via inline z-index (see collage.js). Clicking the
- * scrim (the gaps between tiles) exits the overlay. */
+/* Collage — Mission Control overlay of live window previews (collage.js).
+ * The tiles are overlay-local preview cards (mini Monitor views / cloned
+ * iframes), never the real windows, so nothing here may target .winbox.
+ * No backdrop-filter on the backdrop: a blur filter leaves a stale compositor
+ * layer behind when the overlay is removed (windows render translucent until
+ * the next repaint). Flat dim only. */
 .collage-overlay {
     position: absolute;
     top: var(--menu-height);
     left: 0;
     right: 0;
     bottom: var(--taskbar-height);
-    /* No backdrop-filter here: a blur filter on this scrim leaves a stale
-     * compositor layer when the overlay is removed, so the window that returns
-     * to full size renders translucent/transparent until the next repaint (a
-     * click). The flat dim below gives the same overlay affordance without the
-     * GPU-layer hazard. */
-    background: rgba(0, 0, 0, 0.55);
-    opacity: 1;
-    transition: opacity 0.15s ease;
+    /* Fully opaque: any translucency lets the maximized window behind ghost
+     * through the gaps between tiles (bright artifact pages especially). */
+    background: #0a0c10;
+    display: flex;
+    animation: collage-fade-in 0.14s ease-out;
 }
 
 .collage-overlay.hidden {
     display: none;
+}
+
+@keyframes collage-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.collage-grid {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    display: grid;
+    gap: 14px;
+    padding: 18px;
+}
+
+.collage-card {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+/* Teal hover affordance — outline adds no layout shift. */
+.collage-card:hover {
+    outline: 2px solid #2dd4bf;
+    outline-offset: 2px;
+}
+
+/* The currently-active window's card. */
+.collage-card.is-active {
+    border-color: var(--accent);
+}
+
+.collage-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 30px;
+    padding: 0 10px;
+    flex: none;
+    border-bottom: 1px solid var(--chrome-border);
+}
+
+.collage-card-icon {
+    width: 16px;
+    height: 16px;
+    flex: none;
+    border-radius: 3px;
+    background-size: cover;
+    background-position: center;
+}
+
+.collage-card-title {
+    font-size: 13px;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.collage-card-body {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    background: #000;
+    overflow: hidden;
+}
+
+.collage-card-body.collage-card-empty {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 16%;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+/* Big centered session-name label — primary identification at a glance.
+ * Size set per-grid via --collage-label-size (tracks cell height). Fades on
+ * hover so the live preview underneath stays inspectable. Plain rgba pill —
+ * no backdrop-filter (stale compositor layer hazard, see module header). */
+.collage-card-label {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+    max-width: 88%;
+    padding: 0.28em 0.95em;
+    border-radius: 999px;
+    background: rgba(8, 10, 14, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    color: #fff;
+    font-size: var(--collage-label-size, 22px);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    pointer-events: none;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+    transition: opacity 0.15s ease;
+}
+
+.collage-card:hover .collage-card-label {
+    opacity: 0.12;
+}
+
+/* Miniature canvas: rendered at full desktop-area size, then scaled into the
+ * card body (transform set inline by collage.js). Overlay-local element — the
+ * transform never touches a real window. */
+.collage-mini {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform-origin: center;
+    overflow: hidden;
+    background: #000;
+    pointer-events: none;
+}
+
+.collage-mini-pre {
+    margin: 0;
+    padding: 8px 12px;
+    background: #000;
+    color: #e6edf3;
+    font-family: "FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace;
+    font-size: 16px;
+    line-height: 1.4;
+    white-space: pre;
+}
+
+.collage-mini-iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff;
 }
 
 /* ListWindow component */

--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -1,44 +1,63 @@
 /**
- * Collage - window collage overlay.
+ * Collage — Mission Control overlay of live window previews.
  *
- * Lays every open window into a grid so the whole desktop can be scanned at once.
- * Click any tile to focus that window and exit; Esc exits restoring the prior state.
+ * F3 (or the desktop_collage MCP tool, or the command palette) lays a preview
+ * of every open window into a grid so the whole desktop can be scanned at once.
+ * Click a tile to focus that window; Esc, F3, or clicking the backdrop exits.
  *
- * The portal runs in single-window mode (one maximized window, the rest minimized),
- * so "prior state" is just: which window was active + each window's minimized flag +
- * any tile zones.
+ * The tiles are NOT the real windows. Each tile is a lightweight live view:
+ * session windows stream the same pane content as Monitor mode over their own
+ * monitor WebSocket (/ws/{sessionId} — the server pushes the current screen on
+ * connect and re-broadcasts on change); artifact windows render a cloned
+ * iframe. The real WinBox windows are never moved, resized, transformed,
+ * minimized, or restored by this module — entering and exiting the collage is
+ * pure DOM addition/removal in an overlay layer.
  *
- * Tiles are the live windows, placed via CSS `transform: translate()+scale()` — NOT
- * by resizing them. Resizing a live window that hosts an xterm down to a grid cell
- * and back corrupts its GPU compositing layer: the background renders transparent
- * and nothing (refresh, reflow, even a real click or window resize) repaints it.
- * A transform is a cheap GPU op that reuses the window's existing full-size raster,
- * so the layer never re-rasters small. The active window's geometry is left fully
- * untouched (only transformed); minimized windows are first grown to the full box,
- * then scaled into their cell. Exit just drops the transform.
+ * That constraint is the whole design. The previous implementation manipulated
+ * the real windows (un-minimize, grow, transform-scale into a grid, restore on
+ * exit) and was structurally unfixable:
+ *   - faking `winbox.min` corrupted WinBox's internal min-stack, so any later
+ *     minimize re-laid stale entries out as 250px-wide taskbar bars (the
+ *     "windows shrink to thin bars" bug) and duplicated stack entries grew
+ *     worse every enter/exit cycle;
+ *   - WinBox animates left/top/width/height over 300ms, so any geometry read
+ *     taken right after a write measured mid-transition garbage;
+ *   - growing a hidden window to full size fired its ResizeObserver every
+ *     animation frame → fitAddon.fit() + PTY resize spam → the real tmux
+ *     session got resized and the xterm WebGL layer corrupted (transparent
+ *     window backgrounds);
+ *   - registerWindow/setActiveWindow enforce single-window mode (minimize all
+ *     others), so any window event mid-overlay re-minimized the tiles
+ *     (windows vanishing) while relayout fought to undo it.
+ * A preview overlay sidesteps all of it: there is no state to restore, so
+ * there is nothing to corrupt.
  *
  * @module collage
  */
 
 import { desktop } from './desktop-manager.js';
-import { tileManager } from './tile-manager.js';
+import { ansiToHtml } from './utils/ansi.js';
+import { isCommandPaletteOpen } from './command-palette.js';
 
-/** z-index band: scrim sits at BASE, grid windows above it. */
-const SCRIM_Z = 5000;
+/** Overlay z-index: above all windows (WinBox's focus counter sets inline
+ * z-indexes that grow from 10), below notification toasts (1500), modals
+ * (2000), the command palette (3000), and the sidebar (9001) — all of those
+ * must stay usable on top of the collage. */
+const OVERLAY_Z = 1400;
 
 class Collage {
     constructor() {
         /** @type {boolean} */
         this._active = false;
 
-        /** @type {HTMLElement|null} */
-        this._scrim = null;
+        /** @type {HTMLElement|null} Backdrop + grid root (created in init) */
+        this._overlay = null;
 
-        /** @type {Object|null} Pre-collage state snapshot */
-        this._snapshot = null;
+        /** @type {HTMLElement|null} Current grid element */
+        this._grid = null;
 
-        /** @type {Array<{el: HTMLElement, fn: Function}>} Per-window click handlers */
-        this._clickHandlers = [];
+        /** @type {Array<{ws: WebSocket|null}>} Per-tile live resources */
+        this._tiles = [];
 
         /** @type {Array<Function>} desktop event unsubscribe fns (active only) */
         this._unsubs = [];
@@ -50,19 +69,20 @@ class Collage {
     }
 
     /**
-     * Initialize. Creates the scrim element (hidden) inside the desktop area.
+     * Initialize. Creates the overlay element (hidden) inside the desktop area.
      * @param {function(string): (object|null)} [lookupInstance] - Resolves a
-     *   window id to its SessionWindow/ArtifactWindow instance (for refit on exit).
+     *   window id to its SessionWindow/ArtifactWindow instance.
      */
     init(lookupInstance) {
         if (typeof lookupInstance === 'function') this._lookup = lookupInstance;
         const area = document.getElementById('desktopArea');
         if (!area) return;
-        this._scrim = document.createElement('div');
-        this._scrim.className = 'collage-overlay hidden';
-        this._scrim.style.zIndex = String(SCRIM_Z);
-        this._scrim.addEventListener('click', () => this.exit());
-        area.appendChild(this._scrim);
+        this._overlay = document.createElement('div');
+        this._overlay.className = 'collage-overlay hidden';
+        this._overlay.style.zIndex = String(OVERLAY_Z);
+        // Backdrop click (the gaps between tiles) exits; tile clicks stop propagation.
+        this._overlay.addEventListener('click', () => this.exit());
+        area.appendChild(this._overlay);
     }
 
     /**
@@ -73,123 +93,53 @@ class Collage {
     }
 
     /**
-     * Enter Collage: restore every window and lay them into a grid.
+     * Enter the collage: build a live preview tile for every open window.
      */
     enter() {
-        if (this._active) return;
+        if (this._active || !this._overlay) return;
         const ids = [...desktop.windows.keys()];
         if (ids.length < 2) return;  // nothing to collage
 
-        // Snapshot the single-window state so we can restore it on Esc.
-        const minimized = new Map();
-        for (const [id, winbox] of desktop.windows) {
-            minimized.set(id, !!winbox.min);
-        }
-        this._snapshot = {
-            activeId: desktop.getActiveWindow(),
-            minimized,
-            tileStates: new Map(desktop.tileStates),
-        };
-
-        // Clear tile states BEFORE laying out — otherwise tile-manager's
-        // window_restored handler re-tiles each window to its old zone, fighting
-        // the grid. The snapshot above lets us put them back on exit.
-        desktop.tileStates.clear();
-
-        // macOS Option+` is a dead key: its grave accent commits via the
-        // composition/input path (not keydown), so stopPropagation on the hotkey
-        // can't block it leaking into the focused terminal. Blur the active
-        // element so the composed ` has no target; _refitActive refocuses on exit.
-        if (document.activeElement && typeof document.activeElement.blur === 'function') {
-            document.activeElement.blur();
-        }
-
         this._active = true;
-        this._showScrim();
-        this._layout(ids);
+
+        // Keystrokes would otherwise still reach the focused xterm <textarea>
+        // behind the backdrop; exit() hands focus back to the active window.
+        const ae = document.activeElement;
+        if (ae && typeof ae.blur === 'function') ae.blur();
+
+        this._overlay.classList.remove('hidden');
+        this._buildGrid(ids);
 
         document.addEventListener('keydown', this._onKeydown, true);
         this._unsubs.push(
-            desktop.on('window_registered', () => this._relayout()),
-            desktop.on('window_unregistered', () => this._relayout()),
-            desktop.on('session_closed', () => this._relayout()),
-            // External activation (Tab cycle, sidebar click) sets single-window
-            // mode out from under us — tear the overlay down cleanly instead of
-            // leaving a stale active state that fights the next toggle.
-            desktop.on('active_window_changed', () => { this._snapshot = null; this._teardown(); }),
+            // Window set changed underneath us — rebuild the previews.
+            desktop.on('window_registered', () => this._rebuild()),
+            desktop.on('window_unregistered', () => this._rebuild()),
+            // Something else activated a window (Tab cycle, sidebar click, a
+            // freshly-opened window): get out of the way and show it.
+            desktop.on('active_window_changed', () => this._teardown()),
+            // Grid geometry depends on the desktop area size.
+            desktop.on('viewport_resize', () => this._rebuild()),
         );
     }
 
     /**
-     * Exit Collage.
-     * @param {string|null} focusId - If given, that window becomes the single
-     *   maximized window (click-to-focus). Otherwise the pre-collage state restores.
+     * Exit the collage.
+     * @param {string|null} focusId - If given, that window becomes the active
+     *   (maximized) window via the standard setActiveWindow path. Otherwise
+     *   the desktop is exactly as it was — nothing to restore.
      */
     exit(focusId = null) {
         if (!this._active) return;
-
-        const snap = this._snapshot;
-        this._snapshot = null;
-        this._teardown();  // sets _active=false, removes scrim/handlers/transform
+        this._teardown();
 
         if (focusId && desktop.windows.has(focusId)) {
-            // Commit to the clicked window: single-window mode, rest minimized.
-            desktop.setActiveWindow(focusId);
-        } else if (snap) {
-            // Esc/release: restore exact prior state — re-tile what was tiled, then
-            // re-maximize the prior active window (setActiveWindow minimizes others).
-            for (const [id, zone] of snap.tileStates) {
-                if (desktop.windows.has(id)) tileManager._tileWindow(id, zone);
-            }
-            if (snap.activeId && desktop.windows.has(snap.activeId) && !desktop.tileStates.has(snap.activeId)) {
-                desktop.setActiveWindow(snap.activeId);
-            } else if (desktop.tileStates.size === 0) {
-                desktop.minimizeAllExcept(null);
-            }
+            desktop.setActiveWindow(focusId);  // maximizes it, minimizes the rest
         }
 
-        // Refocus the now-active window (we blurred on enter).
-        this._refitActive();
-    }
-
-    /** Refocus + refit/repaint whichever window is now active (we blurred on enter). */
-    _refitActive() {
+        // Hand keyboard focus (back) to whichever window is now active.
         const inst = this._lookup(desktop.getActiveWindow());
-        if (!inst) return;
-        if (typeof inst.focus === 'function') inst.focus();
-        if (typeof inst.refit === 'function') inst.refit();
-    }
-
-    /**
-     * Remove all overlay chrome (scrim, key/click handlers, event subs) and the
-     * collage transform, marking inactive — WITHOUT changing window placement.
-     * Shared by exit() and the external-activation handler (Tab cycle / sidebar
-     * click). Clearing the transform snaps each window back to its full box (its
-     * raster is intact, so no corruption); setActiveWindow/minimizeAllExcept then
-     * re-maximize/minimize as needed. The inline geometry box set in _layout is
-     * left in place — this app's `.max` CSS only overrides top/height, so width/left
-     * come from inline geometry, and WinBox's minimize overwrites it for the windows
-     * that should hide.
-     */
-    _teardown() {
-        if (!this._active) return;
-        this._active = false;
-
-        document.removeEventListener('keydown', this._onKeydown, true);
-        this._unsubs.forEach((fn) => { try { fn(); } catch (e) {} });
-        this._unsubs = [];
-        this._clearClickHandlers();
-        this._hideScrim();
-
-        for (const [, winbox] of desktop.windows) {
-            const el = winbox?.window;
-            if (el) {
-                el.classList.remove('tiled');
-                el.style.transform = '';
-                el.style.transformOrigin = '';
-                el.style.zIndex = '';
-            }
-        }
+        if (inst && typeof inst.focus === 'function') inst.focus();
     }
 
     // ============================================
@@ -197,112 +147,220 @@ class Collage {
     // ============================================
 
     /**
-     * Lay the given windows into the grid via transforms and (re)wire
-     * click-to-focus + z-index. Every tile is translated+scaled into its cell —
-     * never resized (see module header for why resizing corrupts the xterm layer).
+     * Remove the overlay chrome: subscriptions, key handler, tile sockets, grid
+     * DOM. The real windows were never touched, so this is the entire exit path.
+     */
+    _teardown() {
+        if (!this._active) return;
+        this._active = false;
+        document.removeEventListener('keydown', this._onKeydown, true);
+        this._unsubs.forEach((fn) => { try { fn(); } catch (e) {} });
+        this._unsubs = [];
+        this._destroyTiles();
+        this._overlay.classList.add('hidden');
+    }
+
+    /** Close every tile's WebSocket and drop the grid DOM. */
+    _destroyTiles() {
+        for (const tile of this._tiles) {
+            if (tile.ws) {
+                try {
+                    tile.ws.onmessage = null;
+                    tile.ws.onclose = null;
+                    tile.ws.close();
+                } catch (e) {}
+            }
+        }
+        this._tiles = [];
+        if (this._grid) {
+            this._grid.remove();
+            this._grid = null;
+        }
+    }
+
+    /**
+     * Rebuild the grid against the current window set (mid-overlay churn).
+     */
+    _rebuild() {
+        if (!this._active) return;
+        this._destroyTiles();
+        const ids = [...desktop.windows.keys()];
+        if (ids.length < 2) { this.exit(); return; }
+        this._buildGrid(ids);
+    }
+
+    /**
+     * Build the preview grid for the given window ids.
      * @param {string[]} ids
      */
-    _layout(ids) {
+    _buildGrid(ids) {
         const area = document.getElementById('desktopArea');
         if (!area) return;
-        const rect = area.getBoundingClientRect();
+        const areaRect = area.getBoundingClientRect();
         const n = ids.length;
 
-        // Grid sizing — fit cols×rows to the desktop aspect (matches the look of
-        // the old tile-grid layout).
-        const aspect = rect.width / rect.height;
+        // Fit cols×rows to the desktop aspect so cells stay window-shaped.
+        const aspect = areaRect.width / Math.max(1, areaRect.height);
         let cols = Math.max(1, Math.round(Math.sqrt(n * aspect)));
         cols = Math.min(cols, n);
         let rows = Math.ceil(n / cols);
         while (cols > 1 && (cols - 1) * rows >= n) cols--;
         rows = Math.ceil(n / cols);
-        const gutter = 8;
-        const cellW = (rect.width - gutter * (cols + 1)) / cols;
-        const cellH = (rect.height - gutter * (rows + 1)) / rows;
 
-        // Canonical full box = the currently-active (maximized) window's rendered
-        // rect — used to grow a minimized window's collapsed bar back to full before
-        // it's scaled down.
-        const activeEl = desktop.getWindow(desktop.getActiveWindow())?.window;
-        let box = (activeEl && !activeEl.classList.contains('min')) ? activeEl.getBoundingClientRect() : null;
-        if (!box || !box.width || !box.height) box = rect;
+        this._grid = document.createElement('div');
+        this._grid.className = 'collage-grid';
+        this._grid.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+        this._grid.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+        // Name-label size tracks cell height: big on a sparse grid, smaller (but
+        // never tiny) on a dense one. Matches the .collage-card-label CSS var.
+        const cellH = (areaRect.height - 18 * 2 - 14 * (rows - 1)) / rows;
+        this._grid.style.setProperty(
+            '--collage-label-size',
+            `${Math.round(Math.min(30, Math.max(15, cellH * 0.09)))}px`,
+        );
 
-        this._clearClickHandlers();
-        ids.forEach((id, i) => {
-            const winbox = desktop.getWindow(id);
-            const el = winbox?.window;
-            if (!el) return;
+        const activeId = desktop.getActiveWindow();
+        for (const id of ids) {
+            this._grid.appendChild(this._buildTile(id, id === activeId, areaRect));
+        }
+        this._overlay.appendChild(this._grid);
 
-            // CRITICAL: never change the geometry of a window that's already shown
-            // at full size — resizing a live xterm window is exactly what corrupts
-            // its compositing layer (transparent background). We only ever SCALE it
-            // via transform below, leaving its real size + .max class untouched.
-            // Minimized windows are collapsed to a tiny bar, so those (and only
-            // those) we grow to the full box first, while still hidden.
-            if (el.classList.contains('min')) {
-                el.classList.remove('min');
-                winbox.min = false;
-                el.style.left = Math.round(box.left) + 'px';
-                el.style.top = Math.round(box.top) + 'px';
-                el.style.width = Math.round(box.width) + 'px';
-                el.style.height = Math.round(box.height) + 'px';
-            }
-
-            // Measure THIS window's actual rect, then place + shrink it into the
-            // cell with a transform (cheap GPU op, no re-raster). Uniform scale +
-            // centered = letterboxed thumbnail that lands exactly in its cell.
-            const wb = el.getBoundingClientRect();
-            if (!wb.width || !wb.height) return;
-            const col = i % cols;
-            const row = Math.floor(i / cols);
-            const cellX = rect.left + gutter + col * (cellW + gutter);
-            const cellY = rect.top + gutter + row * (cellH + gutter);
-            const scale = Math.min(cellW / wb.width, cellH / wb.height);
-            const drawW = wb.width * scale;
-            const drawH = wb.height * scale;
-            const tx = cellX + (cellW - drawW) / 2 - wb.left;
-            const ty = cellY + (cellH - drawH) / 2 - wb.top;
-
-            el.style.transformOrigin = 'top left';
-            el.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
-            el.style.zIndex = String(SCRIM_Z + 1 + i);
-
-            // Capture-phase click anywhere in the window focuses it and exits.
-            const fn = (e) => { e.stopPropagation(); this.exit(id); };
-            el.addEventListener('click', fn, true);
-            this._clickHandlers.push({ el, fn });
-        });
+        // Scale each miniature into its tile body. Overlay elements have no
+        // geometry transitions, so measuring right after append is exact.
+        for (const mini of this._grid.querySelectorAll('.collage-mini')) {
+            const body = mini.parentElement;
+            const scale = Math.min(
+                body.clientWidth / Math.max(1, areaRect.width),
+                body.clientHeight / Math.max(1, areaRect.height),
+                1,
+            );
+            mini.style.transform = `translate(-50%, -50%) scale(${scale})`;
+        }
     }
 
     /**
-     * Re-run the layout against the current window set (handles mid-overlay churn).
+     * Build one preview tile: header (icon + window title) + live content.
+     * @param {string} id - Window id
+     * @param {boolean} isActive - Whether this is the currently-active window
+     * @param {DOMRect} areaRect - Desktop area rect (miniatures render at this size)
      */
-    _relayout() {
-        if (!this._active) return;
-        const ids = [...desktop.windows.keys()];
-        if (ids.length < 2) { this.exit(); return; }
-        this._layout(ids);
+    _buildTile(id, isActive, areaRect) {
+        const winbox = desktop.getWindow(id);
+        const inst = this._lookup(id);
+
+        const card = document.createElement('div');
+        card.className = 'collage-card' + (isActive ? ' is-active' : '');
+        card.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.exit(id);
+        });
+
+        const header = document.createElement('div');
+        header.className = 'collage-card-header';
+        // Reuse the window's existing titlebar icon (background-image on .wb-icon).
+        const iconBg = winbox?.window?.querySelector('.wb-icon')?.style.backgroundImage;
+        if (iconBg && iconBg !== 'none') {
+            const icon = document.createElement('span');
+            icon.className = 'collage-card-icon';
+            icon.style.backgroundImage = iconBg;
+            header.appendChild(icon);
+        }
+        const title = document.createElement('span');
+        title.className = 'collage-card-title';
+        title.textContent = (winbox && winbox.title) || id;
+        header.appendChild(title);
+        card.appendChild(header);
+
+        const body = document.createElement('div');
+        body.className = 'collage-card-body';
+        card.appendChild(body);
+
+        if (inst && typeof inst.session === 'string') {
+            this._mountSessionPreview(body, inst, areaRect);
+        } else if (inst && inst.iframe && inst.iframe.src) {
+            this._mountArtifactPreview(body, inst, areaRect);
+        } else {
+            body.classList.add('collage-card-empty');
+            body.textContent = 'no preview';
+        }
+
+        // Big centered name label — the primary identification when tiles are
+        // small. Session name (no mode suffix) / artifact title; fades on hover
+        // so the live content underneath stays inspectable.
+        const label = document.createElement('div');
+        label.className = 'collage-card-label';
+        label.textContent =
+            (inst && typeof inst.session === 'string') ? inst.sessionId
+            : (inst && inst.title) ? inst.title
+            : ((winbox && winbox.title) || id);
+        body.appendChild(label);
+
+        return card;
+    }
+
+    /** Fixed-size miniature canvas, centered + scaled into the tile body. */
+    _makeMini(body, areaRect) {
+        const mini = document.createElement('div');
+        mini.className = 'collage-mini';
+        mini.style.width = Math.round(areaRect.width) + 'px';
+        mini.style.height = Math.round(areaRect.height) + 'px';
+        body.appendChild(mini);
+        return mini;
+    }
+
+    /**
+     * Live session preview: a mini Monitor view over the session's monitor
+     * WebSocket. The server pushes the current screen immediately on connect
+     * and re-broadcasts whenever the pane content changes.
+     */
+    _mountSessionPreview(body, inst, areaRect) {
+        const mini = this._makeMini(body, areaRect);
+        const pre = document.createElement('pre');
+        pre.className = 'collage-mini-pre';
+        mini.appendChild(pre);
+
+        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        let ws = null;
+        try {
+            ws = new WebSocket(`${protocol}//${location.host}/ws/${inst.sessionId}`);
+        } catch (e) {
+            return;
+        }
+        ws.onmessage = (event) => {
+            let msg;
+            try { msg = JSON.parse(event.data); } catch (e) { return; }
+            if (msg.type === 'output' && msg.data) {
+                pre.innerHTML = ansiToHtml(msg.data);
+                // Bottom-anchor: the tail of the capture is the live screen.
+                mini.scrollTop = mini.scrollHeight;
+            } else if (msg.type === 'audio' && msg.data) {
+                // Same behavior as an open Monitor window — play session audio.
+                // desktop._playAudio dedupes at the device level, so a real
+                // window attached to the same session won't double-play.
+                desktop._playAudio(msg.data, inst.sessionId);
+            }
+        };
+        this._tiles.push({ ws });
+    }
+
+    /** Live artifact preview: a cloned iframe at desktop size, scaled down. */
+    _mountArtifactPreview(body, inst, areaRect) {
+        const mini = this._makeMini(body, areaRect);
+        const iframe = document.createElement('iframe');
+        iframe.className = 'collage-mini-iframe';
+        const sandbox = inst.iframe.getAttribute('sandbox');
+        if (sandbox) iframe.setAttribute('sandbox', sandbox);
+        iframe.src = inst.iframe.src;
+        mini.appendChild(iframe);
+        this._tiles.push({ ws: null });
     }
 
     _onKeydown(e) {
-        if (e.key === 'Escape') {
+        if (e.key === 'Escape' && !isCommandPaletteOpen()) {
             e.preventDefault();
             e.stopPropagation();
             this.exit();
         }
-    }
-
-    _clearClickHandlers() {
-        this._clickHandlers.forEach(({ el, fn }) => el.removeEventListener('click', fn, true));
-        this._clickHandlers = [];
-    }
-
-    _showScrim() {
-        if (this._scrim) this._scrim.classList.remove('hidden');
-    }
-
-    _hideScrim() {
-        if (this._scrim) this._scrim.classList.add('hidden');
     }
 }
 

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -327,33 +327,20 @@ function setupWindowCycling() {
     }, true);  // capture phase — runs before xterm's handlers
 }
 
-// Collage — HOLD Alt/Option + ` to grid all open windows; release to restore.
+// Collage — tap F3 (like macOS Mission Control) to grid all open windows; tap
+// again, press Esc, or click a window to restore.
 function setupCollage() {
     collage.init(_lookupWindowInstance);
-    let held = false;
 
     // Capture phase on window + stopPropagation so xterm's <textarea> never sees
-    // the keystroke (otherwise a stray ` leaks into the focused session). Detect
-    // via e.code, NOT e.key — on macOS Option+` is a dead key (grave accent) so
-    // e.key is "Dead", never a backtick. (Cmd/Ctrl+` is the sidebar toggle.)
+    // F3 (and the browser's default Find-next is suppressed).
     window.addEventListener('keydown', (e) => {
-        if (!e.altKey || e.code !== 'Backquote') return;
+        if (e.code !== 'F3') return;
         if (isCommandPaletteOpen()) return;
         e.preventDefault();
         e.stopPropagation();
-        if (held) return;  // ignore key auto-repeat while held
-        held = true;
-        collage.enter();
-    }, true);
-
-    // Release either the backquote or Alt to end the peek.
-    window.addEventListener('keyup', (e) => {
-        if (!held) return;
-        if (e.code !== 'Backquote' && e.key !== 'Alt') return;
-        e.preventDefault();
-        e.stopPropagation();
-        held = false;
-        collage.exit();
+        if (e.repeat) return;  // ignore auto-repeat while the key is held
+        collage.toggle();
     }, true);
 }
 
@@ -599,7 +586,7 @@ export function restoreTaskbarState() {
         // Materialize EVERY saved window — not just the active one — so they all
         // register with the desktop manager. Otherwise only the active window is a
         // real window and the rest are click-to-open placeholders, which leaves
-        // collage (Alt/Option+`) and Tab window-cycling with nothing to act on
+        // collage (F3) and Tab window-cycling with nothing to act on
         // until each other window is clicked. Open in saved order so the sidebar
         // "Open Windows" list keeps its order (open* appends to the end).
         const focusRec = (activeId && tabs.find(t => t.id === activeId)) || tabs[tabs.length - 1];

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -11,6 +11,7 @@ import { desktop } from './desktop-manager.js';
 import { sessionIcons } from './icon-manager.js';
 import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
 import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
+import { ansiToHtml } from './utils/ansi.js';
 
 const NARROW_VIEWPORT = '(max-width: 768px)';
 function pickTerminalFontSize() {
@@ -316,7 +317,7 @@ export class SessionWindow {
         this.terminal.loadAddon(this.fitAddon);
 
         // Add WebGL addon for performance (optional). Keep a reference: after a
-        // large container resize (collage grid→max) the WebGL renderer can leave
+        // large container resize (tile grid→max) the WebGL renderer can leave
         // the newly-exposed area transparent until its texture atlas is rebuilt.
         this.webglAddon = null;
         try {
@@ -704,7 +705,7 @@ export class SessionWindow {
                         desktop._playAudio(msg.data, this.sessionId);
                     } else if (msg.type === 'output' && msg.data) {
                         // Convert ANSI to HTML and display
-                        this.outputEl.innerHTML = this._ansiToHtml(msg.data);
+                        this.outputEl.innerHTML = ansiToHtml(msg.data);
                         this.outputEl.scrollTop = this.outputEl.scrollHeight;
                         // Mark activity when output received
                         this._markActivity();
@@ -784,29 +785,10 @@ export class SessionWindow {
     }
 
     /**
-     * Refit + force a full repaint. After a window snaps from a small grid cell
-     * (collage) back to maximized, xterm can leave the newly-exposed area
-     * unpainted (transparent) until the user clicks — fit() resizes the buffer
-     * but doesn't always repaint, so refresh() the whole viewport explicitly.
-     */
-    refit() {
-        if (this.mode !== 'terminal' || !this.fitAddon || !this.terminal) return;
-        requestAnimationFrame(() => {
-            try {
-                this.fitAddon.fit();
-                this._sendResize();
-                this._forceRepaint();
-            } catch (e) {
-                console.error('[refit] error:', e);
-            }
-        });
-    }
-
-    /**
      * Force a full WebGL repaint. fit() resizes the buffer but doesn't redraw, so
-     * after a window snaps back from a collage transform/grid cell the newly-exposed
-     * canvas stays transparent until interaction. The WebGL renderer needs its stale
-     * texture atlas rebuilt; then a full viewport refresh repaints every cell.
+     * after a large container resize (tile grid → maximized) the newly-exposed
+     * canvas can stay transparent until interaction. The WebGL renderer needs its
+     * stale texture atlas rebuilt; then a full viewport refresh repaints every cell.
      */
     _forceRepaint() {
         try { this.webglAddon?.clearTextureAtlas(); } catch (e) {}
@@ -968,122 +950,6 @@ export class SessionWindow {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
-    }
-
-    /**
-     * Convert ANSI escape codes to HTML for monitor mode display.
-     * Supports basic colors, 256-color, and true color (24-bit).
-     * @param {string} text - Text with ANSI codes
-     * @returns {string} HTML string
-     */
-    _ansiToHtml(text) {
-        // Escape HTML entities first
-        let html = text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-
-        // Basic 16 colors (standard + bright)
-        const basicColors = {
-            0: '#000', 1: '#cd0000', 2: '#00cd00', 3: '#cdcd00',
-            4: '#0000ee', 5: '#cd00cd', 6: '#00cdcd', 7: '#e5e5e5',
-            8: '#7f7f7f', 9: '#ff0000', 10: '#00ff00', 11: '#ffff00',
-            12: '#5c5cff', 13: '#ff00ff', 14: '#00ffff', 15: '#ffffff'
-        };
-
-        // Convert 256-color index to hex
-        const color256ToHex = (n) => {
-            if (n < 16) return basicColors[n];
-            if (n < 232) {
-                // 216 color cube: 6x6x6
-                n -= 16;
-                const r = Math.floor(n / 36) * 51;
-                const g = Math.floor((n % 36) / 6) * 51;
-                const b = (n % 6) * 51;
-                return `rgb(${r},${g},${b})`;
-            }
-            // Grayscale: 24 shades
-            const gray = (n - 232) * 10 + 8;
-            return `rgb(${gray},${gray},${gray})`;
-        };
-
-        // Track current styles
-        let fg = null, bg = null, bold = false, italic = false, underline = false;
-
-        const buildSpan = () => {
-            const styles = [];
-            if (fg) styles.push(`color:${fg}`);
-            if (bg) styles.push(`background:${bg}`);
-            if (bold) styles.push('font-weight:bold');
-            if (italic) styles.push('font-style:italic');
-            if (underline) styles.push('text-decoration:underline');
-            return styles.length ? `<span style="${styles.join(';')}">` : '';
-        };
-
-        // Process ANSI sequences
-        html = html.replace(/\x1b\[([0-9;]*)m/g, (match, codes) => {
-            const parts = (codes || '0').split(';').map(Number);
-            let i = 0;
-            let needsNewSpan = false;
-
-            while (i < parts.length) {
-                const code = parts[i];
-
-                if (code === 0) {
-                    // Reset all
-                    fg = bg = null;
-                    bold = italic = underline = false;
-                    needsNewSpan = true;
-                } else if (code === 1) {
-                    bold = true; needsNewSpan = true;
-                } else if (code === 3) {
-                    italic = true; needsNewSpan = true;
-                } else if (code === 4) {
-                    underline = true; needsNewSpan = true;
-                } else if (code === 22) {
-                    bold = false; needsNewSpan = true;
-                } else if (code === 23) {
-                    italic = false; needsNewSpan = true;
-                } else if (code === 24) {
-                    underline = false; needsNewSpan = true;
-                } else if (code >= 30 && code <= 37) {
-                    fg = basicColors[code - 30]; needsNewSpan = true;
-                } else if (code >= 90 && code <= 97) {
-                    fg = basicColors[code - 90 + 8]; needsNewSpan = true;
-                } else if (code === 39) {
-                    fg = null; needsNewSpan = true;
-                } else if (code >= 40 && code <= 47) {
-                    bg = basicColors[code - 40]; needsNewSpan = true;
-                } else if (code >= 100 && code <= 107) {
-                    bg = basicColors[code - 100 + 8]; needsNewSpan = true;
-                } else if (code === 49) {
-                    bg = null; needsNewSpan = true;
-                } else if (code === 38 && parts[i + 1] === 5) {
-                    // 256-color foreground: 38;5;N
-                    fg = color256ToHex(parts[i + 2]);
-                    i += 2; needsNewSpan = true;
-                } else if (code === 48 && parts[i + 1] === 5) {
-                    // 256-color background: 48;5;N
-                    bg = color256ToHex(parts[i + 2]);
-                    i += 2; needsNewSpan = true;
-                } else if (code === 38 && parts[i + 1] === 2) {
-                    // True color foreground: 38;2;R;G;B
-                    fg = `rgb(${parts[i + 2]},${parts[i + 3]},${parts[i + 4]})`;
-                    i += 4; needsNewSpan = true;
-                } else if (code === 48 && parts[i + 1] === 2) {
-                    // True color background: 48;2;R;G;B
-                    bg = `rgb(${parts[i + 2]},${parts[i + 3]},${parts[i + 4]})`;
-                    i += 4; needsNewSpan = true;
-                }
-                i++;
-            }
-
-            // Close previous span and open new one with current styles
-            return needsNewSpan ? `</span>${buildSpan()}` : '';
-        });
-
-        // Wrap in initial span and close at end
-        return `<span>${html}</span>`;
     }
 
     // Reconnect button handler

--- a/agentwire/static/js/utils/ansi.js
+++ b/agentwire/static/js/utils/ansi.js
@@ -1,0 +1,122 @@
+/**
+ * ansi.js — ANSI escape code → HTML conversion.
+ *
+ * Single source of truth for rendering `tmux capture-pane -e` output in the
+ * browser. Used by SessionWindow (monitor mode) and the collage preview tiles.
+ */
+
+/**
+ * Convert ANSI escape codes to HTML.
+ * Supports basic colors, 256-color, and true color (24-bit).
+ * @param {string} text - Text with ANSI codes
+ * @returns {string} HTML string
+ */
+export function ansiToHtml(text) {
+    // Escape HTML entities first
+    let html = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+
+    // Basic 16 colors (standard + bright)
+    const basicColors = {
+        0: '#000', 1: '#cd0000', 2: '#00cd00', 3: '#cdcd00',
+        4: '#0000ee', 5: '#cd00cd', 6: '#00cdcd', 7: '#e5e5e5',
+        8: '#7f7f7f', 9: '#ff0000', 10: '#00ff00', 11: '#ffff00',
+        12: '#5c5cff', 13: '#ff00ff', 14: '#00ffff', 15: '#ffffff'
+    };
+
+    // Convert 256-color index to hex
+    const color256ToHex = (n) => {
+        if (n < 16) return basicColors[n];
+        if (n < 232) {
+            // 216 color cube: 6x6x6
+            n -= 16;
+            const r = Math.floor(n / 36) * 51;
+            const g = Math.floor((n % 36) / 6) * 51;
+            const b = (n % 6) * 51;
+            return `rgb(${r},${g},${b})`;
+        }
+        // Grayscale: 24 shades
+        const gray = (n - 232) * 10 + 8;
+        return `rgb(${gray},${gray},${gray})`;
+    };
+
+    // Track current styles
+    let fg = null, bg = null, bold = false, italic = false, underline = false;
+
+    const buildSpan = () => {
+        const styles = [];
+        if (fg) styles.push(`color:${fg}`);
+        if (bg) styles.push(`background:${bg}`);
+        if (bold) styles.push('font-weight:bold');
+        if (italic) styles.push('font-style:italic');
+        if (underline) styles.push('text-decoration:underline');
+        return styles.length ? `<span style="${styles.join(';')}">` : '';
+    };
+
+    // Process ANSI sequences
+    html = html.replace(/\x1b\[([0-9;]*)m/g, (match, codes) => {
+        const parts = (codes || '0').split(';').map(Number);
+        let i = 0;
+        let needsNewSpan = false;
+
+        while (i < parts.length) {
+            const code = parts[i];
+
+            if (code === 0) {
+                // Reset all
+                fg = bg = null;
+                bold = italic = underline = false;
+                needsNewSpan = true;
+            } else if (code === 1) {
+                bold = true; needsNewSpan = true;
+            } else if (code === 3) {
+                italic = true; needsNewSpan = true;
+            } else if (code === 4) {
+                underline = true; needsNewSpan = true;
+            } else if (code === 22) {
+                bold = false; needsNewSpan = true;
+            } else if (code === 23) {
+                italic = false; needsNewSpan = true;
+            } else if (code === 24) {
+                underline = false; needsNewSpan = true;
+            } else if (code >= 30 && code <= 37) {
+                fg = basicColors[code - 30]; needsNewSpan = true;
+            } else if (code >= 90 && code <= 97) {
+                fg = basicColors[code - 90 + 8]; needsNewSpan = true;
+            } else if (code === 39) {
+                fg = null; needsNewSpan = true;
+            } else if (code >= 40 && code <= 47) {
+                bg = basicColors[code - 40]; needsNewSpan = true;
+            } else if (code >= 100 && code <= 107) {
+                bg = basicColors[code - 100 + 8]; needsNewSpan = true;
+            } else if (code === 49) {
+                bg = null; needsNewSpan = true;
+            } else if (code === 38 && parts[i + 1] === 5) {
+                // 256-color foreground: 38;5;N
+                fg = color256ToHex(parts[i + 2]);
+                i += 2; needsNewSpan = true;
+            } else if (code === 48 && parts[i + 1] === 5) {
+                // 256-color background: 48;5;N
+                bg = color256ToHex(parts[i + 2]);
+                i += 2; needsNewSpan = true;
+            } else if (code === 38 && parts[i + 1] === 2) {
+                // True color foreground: 38;2;R;G;B
+                fg = `rgb(${parts[i + 2]},${parts[i + 3]},${parts[i + 4]})`;
+                i += 4; needsNewSpan = true;
+            } else if (code === 48 && parts[i + 1] === 2) {
+                // True color background: 48;2;R;G;B
+                bg = `rgb(${parts[i + 2]},${parts[i + 3]},${parts[i + 4]})`;
+                i += 4; needsNewSpan = true;
+            }
+            i++;
+        }
+
+        // Close previous span and open new one with current styles
+        return needsNewSpan ? `</span>${buildSpan()}` : '';
+    });
+
+    // Wrap in initial span and close at end
+    return `<span>${html}</span>`;
+}

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -64,6 +64,7 @@ Voice output and input backends.
 Implementation reference for contributors and advanced users.
 
 - **[Portal](internals/portal.md)** — modes, REST API, WebSocket events
+- **[Window collage](internals/window-collage.md)** — Mission Control overlay: preview-tile architecture + why mutating real WinBox windows can never work
 - **[Shell escaping](internals/shell-escaping.md)** — how complex strings cross tmux boundaries
 - **[Damage control](internals/damage-control.md)** — safety hooks: rules, patterns, audit log
 - **[Troubleshooting](internals/troubleshooting.md)** — common issues and fixes

--- a/docs/wiki/internals/portal.md
+++ b/docs/wiki/internals/portal.md
@@ -116,6 +116,10 @@ Sessions can be opened from the Sessions dropdown in two modes:
 
 **Terminal mode** uses xterm.js with WebGL acceleration (falls back to canvas). Full terminal emulation with vim, tab completion, readline support.
 
+### Window Collage
+
+F3 (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
+
 ### Simultaneous Operation
 
 Multiple windows for the same session work together:

--- a/docs/wiki/internals/window-collage.md
+++ b/docs/wiki/internals/window-collage.md
@@ -1,0 +1,92 @@
+# Window Collage (Mission Control)
+
+> Living wiki. Update this page, don't create new versions.
+
+F3 (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, F3, or clicking the backdrop exits.
+
+Module: `agentwire/static/js/collage.js`. Styles: the `.collage-*` block in `agentwire/static/css/desktop.css`. Hotkey wiring: `setupCollage()` in `agentwire/static/js/desktop.js`.
+
+## The one rule
+
+**The tiles are previews — the real windows are never touched.**
+
+Entering and exiting the collage is pure DOM addition/removal in an overlay layer. The real WinBox windows are never moved, resized, transformed, minimized, restored, or refocused mid-overlay. Exit has no restore step because nothing changed. This is the entire design, and it is load-bearing: every prior implementation that manipulated the real windows failed in ways that could not be patched (see the autopsy below).
+
+Any future feature that wants to show multiple windows at once — exposé variants, window pickers, drag previews, "peek" modes — must follow the same rule: build overlay-local live views, never re-layout the real windows.
+
+## How it works
+
+| Piece | Implementation |
+|-------|----------------|
+| **Backdrop** | `.collage-overlay`, a fully opaque (`#0a0c10`) layer over the desktop area. Opaque is deliberate: any translucency lets the maximized window behind ghost through the gaps (bright artifact pages especially). No `backdrop-filter` — a blur here leaves a stale compositor layer that renders windows translucent after exit. |
+| **Grid** | cols = `round(sqrt(n × aspect))` fitted to the desktop area aspect, CSS Grid with `1fr` tracks. Rebuilt (not patched) on any churn. |
+| **Session tiles** | A second *monitor* WebSocket per tile (`/ws/{sessionId}`) — the server pushes the current pane content on connect and re-broadcasts on change (500ms poll). Rendered as ANSI→HTML via the shared `utils/ansi.js` into a `<pre>` sized at full desktop dimensions, then `transform: scale()`d into the tile (overlay-local element, so the transform is harmless). Bottom-anchored so the visible part is the live screen. Audio messages on tile sockets play through `desktop._playAudio` (device-level dedupe prevents double-play with a real window attached). |
+| **Artifact tiles** | A cloned `<iframe>` with the live window's `src` and sandbox attributes, scaled the same way, `pointer-events: none`. |
+| **Other windows** | Title-only fallback card ("no preview"). |
+| **Name labels** | Big centered pill (`.collage-card-label`) over each tile — session name / artifact title, sized via `--collage-label-size` (tracks cell height, 15–30px). Fades to ~12% opacity on hover so the live preview underneath stays inspectable. Plain rgba pill, no backdrop-filter. |
+| **Click-to-focus** | Tile click → tear down overlay → `desktop.setActiveWindow(id)` — the same battle-tested path as a sidebar tab click. Nothing collage-specific touches window state. |
+| **Mid-overlay churn** | `window_registered` / `window_unregistered` → rebuild the grid. `active_window_changed` (Tab cycle, sidebar click, a freshly-opened window's focus) → tear down and get out of the way. `viewport_resize` → rebuild. |
+| **Keyboard** | Entering blurs the focused element so keystrokes can't leak into the xterm `<textarea>` behind the backdrop; exit refocuses the active window. Esc is capture-phase and defers to the command palette when it's open. |
+
+Tile sockets are closed on every teardown/rebuild — verified by watching the server's `Client connected (total: N)` logs stay flat across many cycles.
+
+### Z-index landscape
+
+The overlay must sit above windows but below everything that should remain usable on top of it:
+
+| Layer | z-index |
+|-------|---------|
+| WinBox windows | inline, grows from 10 (+1 per focus) |
+| **Collage overlay** | **1400** |
+| Notification toasts | 1500 |
+| Modals | 2000 |
+| Command palette | 3000 |
+| Sidebar / sidebar tab | 9001 / 9002 |
+| Tile drag overlay | 99999 |
+
+(The original scrim used 5000, which silently put the command palette *behind* the collage.)
+
+## Autopsy: why mutating the real windows can never work
+
+The first implementations (resize-into-grid, then transform-scale-the-live-windows) burned days in whack-a-mole — every fix surfaced new edge cases. That wasn't bad luck; the approach required perfectly saving and restoring state across four systems with independent timing. The specific failure modes, so nobody re-derives them:
+
+### 1. WinBox's internal min-stack (the "thin bars" bug)
+
+WinBox keeps minimized windows in a private array. Every real `minimize()` triggers a stack re-layout that **resizes every stack entry to a ~250×35px bar** (the built-in minimize-bar UI; this app hides them via `.winbox.min { display: none }`). "Un-minimizing" a window by removing the `.min` class and faking `winbox.min = false`:
+
+- leaves the window in the stack, so any later minimize anywhere re-lays it out as a visible thin bar;
+- makes the next `minimize()` push a **duplicate** stack entry (WinBox only guards on the faked flag), so corruption compounds every enter/exit cycle — the "every fix spawns 4 new issues" feeling.
+
+Only `winbox.minimize()` / `restore()` / `maximize()` maintain that stack. Never fake the flags or classes.
+
+### 2. Geometry reads race WinBox's 300ms transition
+
+Stock WinBox CSS animates `width/height/left/top` over 300ms on every window. Setting a window's geometry and then calling `getBoundingClientRect()` returns the **old (mid-transition) box**, not the target — so any layout math based on read-after-write geometry is garbage. (This is also why FLIP animations disable transitions during measurement.) If you must read window geometry, read it from a window that hasn't been written to in >300ms, or add WinBox's `no-animation` class first.
+
+### 3. The ResizeObserver → fit() → PTY resize storm
+
+Each terminal window has a ResizeObserver wired to `fitAddon.fit()` + a `resize` message over the terminal WebSocket. Growing a hidden window to full size (or shrinking one into a grid cell) fires that observer **on every frame of the 300ms animation**, which:
+
+- spams `fit()` at transient sizes, reflowing the xterm buffer repeatedly;
+- **resizes the real PTY/tmux session** server-side — tmux clamps to the smallest attached client, so "peeking" at the desktop was resizing actual sessions for every attached client;
+- corrupts the xterm WebGL compositing layer — the window's background renders transparent after restore until a manual repaint (`_forceRepaint()` in `session-window.js` exists for the legitimate resize paths: tile ↔ maximize).
+
+### 4. Single-window-mode invariants fight any overlay layout
+
+`registerWindow()` and `setActiveWindow()` enforce one-maximized-window mode by minimizing all others. Any window event mid-overlay (a session opening, an MCP focus call, Tab cycling) re-minimized every "tile" (`display: none` → windows vanishing) while the overlay's relayout fought to undo it — two owners for the same state.
+
+### Why tiling never had these problems
+
+Drag-to-tile is a **one-way, static end-state** mutation: set geometry once, emit `window_tiled`, refit. No hidden→shown transitions, no restore-to-exact-prior-state obligation, no mid-flight measurement. The collage by contrast was a round-trip through every piece of hidden state — until the round-trip was deleted.
+
+## Scale
+
+There is no hard window-count limit — the grid formula handles any `n ≥ 2` (verified live with 15 windows / a 4×4 grid: all tiles streaming, click-to-focus instant, zero console errors, and killing 12 sessions mid-overlay live-collapsed the grid 15→3 cleanly). The practical bounds:
+
+- **Server poll cost** — each session tile holds a monitor WS, which keeps that session's `_poll_output` task running (`tmux capture-pane` every 500ms, thread-pool executor). Local sessions are a few ms each; **remote sessions poll over SSH** (hundreds of ms each), so a collage of many remote sessions is the first thing that would feel heavy. Cost exists only while the overlay is open — tile sockets close on exit.
+- **Legibility** — tiles shrink ~1/√n; beyond ~12 windows they're activity thumbnails identified by their title bars, same as macOS Mission Control.
+- **No tmux impact at any count** — monitor WSes are capture-pane based, not client attaches: no PTY, no session resize, regardless of tile count.
+
+## Known unrelated noise
+
+xterm 5.3 occasionally throws a spontaneous `Cannot read properties of undefined (reading 'dimensions')` from page-load window materialization / disposed terminals. It fires with the collage closed and predates it — don't attribute it to the overlay.


### PR DESCRIPTION
## What

Rewrites the Mission Control window collage (#211) as a **pure preview overlay** and adds per-tile session-name labels. The real WinBox windows are never moved, resized, transformed, minimized, or restored — tiles are overlay-local live views, and exit is plain DOM removal. The whole save/restore bug family (thin bars, transparent windows, vanishing windows, garbage layouts) is deleted, not patched.

## Why the old approach could never work

Days of whack-a-mole traced to four interacting root causes:

1. **WinBox min-stack corruption** — faking `winbox.min = false` left windows in WinBox's private min-stack; any later `minimize()` re-laid stale entries out as 250×35px taskbar bars, and duplicates compounded every enter/exit cycle ("thin bars", degradation over time).
2. **300ms geometry transitions** — stock WinBox CSS animates `left/top/width/height`, so `getBoundingClientRect()` right after a write returns the mid-transition box; all scale/placement math was computed against garbage.
3. **ResizeObserver → fit → PTY storm** — growing a hidden window fired its ResizeObserver per animation frame → `fitAddon.fit()` + resize messages → **the real tmux session got resized** and the xterm WebGL layer corrupted (transparent backgrounds).
4. **Single-window invariants** — `registerWindow`/`setActiveWindow` auto-minimize all others, re-minimizing tiles mid-overlay (vanishing windows) while relayout fought back.

Full autopsy + architecture: `docs/wiki/internals/window-collage.md` (added in this PR).

## How it works now

- **Session tiles** stream live pane content over a second monitor WS (`/ws/{sessionId}`) — same proven path as Monitor mode — rendered via the new shared `utils/ansi.js`, bottom-anchored, scaled into the cell with an overlay-local transform.
- **Artifact tiles** are cloned iframes (same src + sandbox), `pointer-events: none`.
- **Name labels**: big centered pill per tile, sized to grid density (15–30px), fades on hover so the preview stays inspectable.
- Click tile → teardown → `desktop.setActiveWindow(id)` (the standard sidebar-click path). Esc / F3 / backdrop → teardown only.
- Mid-overlay churn rebuilds the grid; external `active_window_changed` tears down.
- Hotkey: **F3** (Alt+` was a macOS dead key that leaked composed backticks into focused terminals).
- Overlay z-index 1400 — toasts (1500), modals (2000), command palette (3000), sidebar (9001) all stay usable above it (the palette was hidden behind the old 5000 scrim).

## Verification (live, via Chrome)

- 15-window 4×4 grid, every tile streaming; click-to-focus instant
- Rapid F3 spam, Esc, backdrop click, Tab-cycle teardown
- Session killed mid-overlay → grid live-collapsed 15→3
- New window opened mid-overlay (palette) → overlay yields to it
- Minimize/restore stress after many cycles → no thin bars
- WS client counts flat across cycles (no leaks); zero console errors
- MCP `desktop_collage` toggle verified

Built by [dotdev.dev](https://dotdev.dev)