### PR TITLE
feat(portal): Alt/Option+` as a second collage hotkey, dead-key leak solved

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -39,7 +39,7 @@ Both share session data from `sessions-section.js` (single fetch, shared activit
 
 ## Window Collage (Mission Control)
 
-F3 / `desktop_collage` MCP / command palette → grid of live previews of every open window; click a tile to focus, Esc to exit.
+F3 or Alt/Option+` / `desktop_collage` MCP / command palette → grid of live previews of every open window; click a tile to focus, Esc to exit.
 
 **The one rule: tiles are overlay-local previews — NEVER mutate the real WinBox windows.** Session tiles stream pane content over a second monitor WS (`/ws/{sessionId}`, rendered via shared `utils/ansi.js`); artifact tiles are cloned iframes. Real windows are never moved/resized/transformed/un-minimized, so exit has nothing to restore.
 

--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -85,6 +85,11 @@ class Collage {
         area.appendChild(this._overlay);
     }
 
+    /** @returns {boolean} Whether the overlay is currently up. */
+    get active() {
+        return this._active;
+    }
+
     /**
      * Toggle the overlay.
      */

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -327,20 +327,57 @@ function setupWindowCycling() {
     }, true);  // capture phase — runs before xterm's handlers
 }
 
-// Collage — tap F3 (like macOS Mission Control) to grid all open windows; tap
-// again, press Esc, or click a window to restore.
+// Collage — tap F3 (like macOS Mission Control) or Alt/Option+` to grid all
+// open windows; tap again, press Esc, or click a window to restore.
 function setupCollage() {
     collage.init(_lookupWindowInstance);
 
-    // Capture phase on window + stopPropagation so xterm's <textarea> never sees
-    // F3 (and the browser's default Find-next is suppressed).
+    // macOS quirk: Option+` is a dead key — pressing it starts a grave-accent
+    // composition against the focused element (an xterm <textarea>) before our
+    // keydown handler even runs, and the composed '`' is delivered through the
+    // composition/input path, which preventDefault on keydown cannot cancel.
+    // Fix: swallow composition events in the CAPTURE phase on window for a
+    // short window after the hotkey fires. xterm's composition listeners live
+    // on the textarea (target phase), so stopping propagation here means the
+    // accent never reaches the PTY.
+    let suppressCompositionUntil = 0;
+    for (const type of ['compositionstart', 'compositionupdate', 'compositionend']) {
+        window.addEventListener(type, (e) => {
+            if (performance.now() > suppressCompositionUntil) return;
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            // The browser still commits the composed char into the target's
+            // value natively; xterm never saw the composition, so the residue
+            // would linger (xterm only rewrites the value through its own
+            // composition handling) and skew its position bookkeeping for the
+            // next real IME composition. Wipe it.
+            if (e.type === 'compositionend' && e.target?.classList?.contains('xterm-helper-textarea')) {
+                e.target.value = '';
+            }
+        }, true);
+    }
+
+    // Capture phase on window + stopPropagation so xterm's <textarea> never
+    // sees the keystroke (and the browser default — F3 find-next — is
+    // suppressed). Alt+` is detected via e.code: on macOS the dead key makes
+    // e.key 'Dead', never a backtick. Cmd/Ctrl+` stays the sidebar toggle.
     window.addEventListener('keydown', (e) => {
-        if (e.code !== 'F3') return;
+        const isF3 = e.code === 'F3';
+        const isAltBacktick = e.altKey && !e.metaKey && !e.ctrlKey && e.code === 'Backquote';
+        if (!isF3 && !isAltBacktick) return;
         if (isCommandPaletteOpen()) return;
         e.preventDefault();
         e.stopPropagation();
         if (e.repeat) return;  // ignore auto-repeat while the key is held
+        // Arm BEFORE toggling: collage.enter() blurs the focused terminal,
+        // which makes Chrome finalize the pending dead-key composition
+        // immediately — the suppressor must already be active for it.
+        if (isAltBacktick) suppressCompositionUntil = performance.now() + 700;
+        const wasActive = collage.active;
         collage.toggle();
+        // No-op toggle (under 2 windows): disarm so the dead key composes
+        // normally — with no collage there's nothing to protect.
+        if (isAltBacktick && collage.active === wasActive) suppressCompositionUntil = 0;
     }, true);
 }
 

--- a/docs/wiki/internals/portal.md
+++ b/docs/wiki/internals/portal.md
@@ -118,7 +118,7 @@ Sessions can be opened from the Sessions dropdown in two modes:
 
 ### Window Collage
 
-F3 (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
+F3 or Alt/Option+` (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
 
 ### Simultaneous Operation
 

--- a/docs/wiki/internals/window-collage.md
+++ b/docs/wiki/internals/window-collage.md
@@ -2,7 +2,7 @@
 
 > Living wiki. Update this page, don't create new versions.
 
-F3 (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, F3, or clicking the backdrop exits.
+F3 or Alt/Option+` (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, the hotkey again, or clicking the backdrop exits.
 
 Module: `agentwire/static/js/collage.js`. Styles: the `.collage-*` block in `agentwire/static/css/desktop.css`. Hotkey wiring: `setupCollage()` in `agentwire/static/js/desktop.js`.
 
@@ -27,6 +27,7 @@ Any future feature that wants to show multiple windows at once — exposé varia
 | **Click-to-focus** | Tile click → tear down overlay → `desktop.setActiveWindow(id)` — the same battle-tested path as a sidebar tab click. Nothing collage-specific touches window state. |
 | **Mid-overlay churn** | `window_registered` / `window_unregistered` → rebuild the grid. `active_window_changed` (Tab cycle, sidebar click, a freshly-opened window's focus) → tear down and get out of the way. `viewport_resize` → rebuild. |
 | **Keyboard** | Entering blurs the focused element so keystrokes can't leak into the xterm `<textarea>` behind the backdrop; exit refocuses the active window. Esc is capture-phase and defers to the command palette when it's open. |
+| **Alt/Option+` dead key** | On macOS, Option+` starts a grave-accent composition against the focused xterm textarea *before* keydown fires, and the composed `` ` `` arrives via `composition*` events that `preventDefault()` cannot cancel — the reason this hotkey leaked backticks historically. `setupCollage()` swallows composition events at the **window capture phase** for ~700ms after the hotkey (xterm's composition listeners are target-phase on the textarea, so nothing reaches the PTY) and clears the textarea's value on the suppressed `compositionend` (the browser commits the char natively; residue would skew xterm's composition position bookkeeping). The suppressor is disarmed if the toggle was a no-op (<2 windows), so the dead key composes normally when the collage isn't in play. |
 
 Tile sockets are closed on every teardown/rebuild — verified by watching the server's `Client connected (total: N)` logs stay flat across many cycles.
 


### PR DESCRIPTION
## What

Alt/Option+` now toggles the window collage alongside F3 — the originally-intended hotkey, previously abandoned because it leaked backticks into focused terminals.

## The root cause (why every keydown fix failed)

On macOS, Option+` is a **dead key**: the OS starts a grave-accent composition against the focused element (xterm's hidden `<textarea>`) *before* any keydown handler runs, and the composed `` ` `` is delivered through `composition*` events — which `preventDefault()` on keydown **cannot cancel**. The leak never traveled through the keydown path at all.

## The fix

Suppress the composition channel itself (`setupCollage()` in `desktop.js`):

1. Alt+Backquote keydown (via `e.code` — `e.key` is `"Dead"` on macOS) arms a ~700ms suppression window, then toggles the collage.
2. Composition events are swallowed at the **window capture phase** during that window. xterm's composition listeners sit on the textarea (target phase), so the accent never reaches the PTY.
3. The suppressed `compositionend` also clears the textarea's value — the browser commits the composed char natively, and that residue skews xterm's composition position bookkeeping for later real IME input (found empirically).
4. No-op toggles (<2 windows) disarm immediately so dead-key typing behaves normally when the collage isn't in play; the bounded window leaves real IME composition (CJK etc.) unaffected.

Includes a public `collage.active` getter and doc updates (wiki dead-key section, portal page, desktop-ui skill).

## Verification

Controlled composition experiment against a scratch bash terminal, `tmux capture-pane` as ground truth:

| Case | Result |
|---|---|
| Control: synthetic composition, no hotkey | backtick **reaches the PTY** (reproduces the historical leak through xterm's composition path) |
| Treatment: identical composition + hotkey keydown | collage opens, **PTY untouched**, textarea value cleared |
| Composition after the 700ms window | flows normally (suppression not sticky → IME-safe) |
| Post-exit typing | clean (refocus works) |
| F3 / Cmd+K palette / Cmd-Ctrl+` sidebar toggle | unaffected |
| Real physical Option+` | confirmed by hand on macOS |

Built by [dotdev.dev](https://dotdev.dev)