### PR TITLE
fix(scheduler): honor exit_on_complete: false — stop killing persistent sessions

### DIFF
--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -165,11 +165,13 @@ ${summary_content}"
         task_name=$(jq -r '.task // ""' "$task_context_file" 2>/dev/null)
         summary_file=$(jq -r '.summary_file // ""' "$task_context_file" 2>/dev/null)
         idle_count=$(jq -r '.idle_count // 0' "$task_context_file" 2>/dev/null)
-        exit_on_complete=$(jq -r '.exit_on_complete // true' "$task_context_file" 2>/dev/null)
+        # NOTE: jq's // operator coerces false to the default (false // true == true),
+        # so boolean fields must use an explicit null check to honor a stored false.
+        exit_on_complete=$(jq -r 'if .exit_on_complete == null then true else .exit_on_complete end' "$task_context_file" 2>/dev/null)
         mode=$(jq -r '.mode // "standard"' "$task_context_file" 2>/dev/null)
         max_iterations=$(jq -r '.max_iterations // 3' "$task_context_file" 2>/dev/null)
         iteration=$(jq -r '.iteration // 1' "$task_context_file" 2>/dev/null)
-        loop_review=$(jq -r '.loop_review // true' "$task_context_file" 2>/dev/null)
+        loop_review=$(jq -r 'if .loop_review == null then true else .loop_review end' "$task_context_file" 2>/dev/null)
         loop_delay=$(jq -r '.loop_delay // 0' "$task_context_file" 2>/dev/null)
         original_prompt=$(jq -r '.original_prompt // ""' "$task_context_file" 2>/dev/null)
 
@@ -309,6 +311,13 @@ complete | incomplete | error
               sleep 3
               echo "[$(date -Iseconds)] TASK: killing tmux session" >> "$dlog"
               tmux kill-session -t "$tmux_session" 2>/dev/null &
+            else
+              # Persistent session (exit_on_complete: false): leave it running,
+              # but still remove the context file — ensure's completion poll
+              # blocks until it's gone, and later interactive idles must take
+              # the normal (non-task) path.
+              rm "$task_context_file" 2>/dev/null
+              echo "[$(date -Iseconds)] TASK: exit_on_complete=false, session left alive, cleaned up task context" >> "$dlog"
             fi
           fi
         fi

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -982,6 +982,19 @@ def _pre_create_session(task: SchedulerTask) -> None:
         print(f"[{_ts()}] Warning: Failed to pre-create session {task.session}: {result.stderr.strip()}")
 
 
+def _task_is_persistent(task: SchedulerTask) -> bool:
+    """Whether the project task opts out of session teardown (exit_on_complete: false).
+
+    Persistent sessions double as interactive receivers — the scheduler must
+    not kill them at dispatch. `ensure` reuses the live session instead.
+    """
+    from .tasks import load_task
+    try:
+        return not load_task(Path(task.project), task.task).exit_on_complete
+    except Exception:
+        return False
+
+
 def _is_git_repo(project: str) -> bool:
     """True if `project` is inside a git work tree."""
     if not project:
@@ -1231,12 +1244,17 @@ def _dispatch_inplace_task(board: Board, task: SchedulerTask, existing_state: Ta
     from .locking import remove_stale_lock
     remove_stale_lock(task.session)
 
+    # Tasks with exit_on_complete: false keep a long-lived session that may be
+    # in interactive use — never kill it at dispatch; ensure reuses it as-is.
+    persistent = _task_is_persistent(task)
+
     has_overrides = bool(task.type or task.roles is not None or task.model)
     if has_overrides:
         # Scheduler has type/role overrides — kill + pre-create ourselves,
         # then let ensure reuse the session (no --fresh)
-        _kill_session(task.session)
-        _pre_create_session(task)
+        if not persistent:
+            _kill_session(task.session)
+        _pre_create_session(task)  # no-op if the session already exists
 
     cmd = [
         "agentwire", "ensure",
@@ -1245,7 +1263,7 @@ def _dispatch_inplace_task(board: Board, task: SchedulerTask, existing_state: Ta
         "--project", task.project,
         "--json",
     ]
-    if not has_overrides:
+    if not has_overrides and not persistent:
         # No type/role overrides — kill stale session so ensure creates fresh
         _kill_session(task.session)
 

--- a/tests/unit/test_idle_handler.py
+++ b/tests/unit/test_idle_handler.py
@@ -1,0 +1,84 @@
+"""Tests for agentwire/hooks/idle-handler.sh — boolean task-context reads.
+
+The hook reads booleans from the task-context JSON with jq. jq's // operator
+coerces a stored ``false`` to the right-hand default (``false // true`` evaluates
+to ``true``), which silently disabled ``exit_on_complete: false`` and killed
+persistent sessions after every scheduled run (issue #234).
+
+These tests extract the *actual* jq filters from the hook source and run them
+through real jq, so a regression back to the ``//`` idiom fails the suite.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HOOK_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "agentwire" / "hooks" / "idle-handler.sh"
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("jq") is None, reason="jq not installed"
+)
+
+
+def _extract_jq_filter(var_name: str) -> str:
+    """Pull the jq filter the hook uses to read ``var_name`` from the context file."""
+    source = HOOK_PATH.read_text()
+    match = re.search(rf"^\s*{var_name}=\$\(jq -r '([^']+)'", source, re.MULTILINE)
+    assert match, f"could not find jq read for {var_name} in idle-handler.sh"
+    return match.group(1)
+
+
+def _run_jq(jq_filter: str, payload: dict) -> str:
+    result = subprocess.run(
+        ["jq", "-r", jq_filter],
+        input=json.dumps(payload),
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.parametrize("var_name", ["exit_on_complete", "loop_review"])
+class TestBooleanContextReads:
+    """Stored booleans must round-trip; only null/absent falls back to the default."""
+
+    def test_false_is_preserved(self, var_name):
+        # The #234 regression: jq's // coerced a stored false to true.
+        jq_filter = _extract_jq_filter(var_name)
+        assert _run_jq(jq_filter, {var_name: False}) == "false"
+
+    def test_true_is_preserved(self, var_name):
+        jq_filter = _extract_jq_filter(var_name)
+        assert _run_jq(jq_filter, {var_name: True}) == "true"
+
+    def test_absent_defaults_to_true(self, var_name):
+        jq_filter = _extract_jq_filter(var_name)
+        assert _run_jq(jq_filter, {}) == "true"
+
+    def test_null_defaults_to_true(self, var_name):
+        jq_filter = _extract_jq_filter(var_name)
+        assert _run_jq(jq_filter, {var_name: None}) == "true"
+
+
+class TestSecondIdleCleanup:
+    """The context file must be removed on BOTH exit_on_complete branches —
+    ensure's completion poll blocks until the file is gone."""
+
+    def test_context_removed_when_session_left_alive(self):
+        lines = HOOK_PATH.read_text().splitlines()
+        marker = [i for i, l in enumerate(lines)
+                  if "exit_on_complete=false, session left alive" in l]
+        assert marker, "persistent branch (exit_on_complete=false) missing from hook"
+        preceding = "\n".join(lines[max(0, marker[0] - 6):marker[0]])
+        assert 'rm "$task_context_file"' in preceding, (
+            "persistent branch must remove $task_context_file — "
+            "wait_for_completion_signal blocks until the context file is deleted"
+        )

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -405,3 +405,86 @@ class TestReapWorktreePrs:
         board = self._board_with_pr()
         assert scheduler.reap_worktree_prs(board) == []
         assert killed == [] and removed == []
+
+
+class TestPersistentSessionDispatch:
+    """Tasks with exit_on_complete: false must not have their session killed
+    at dispatch time (issue #234) — the live session is reused by ensure."""
+
+    def _project(self, tmp_path, task_yaml: str):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".agentwire.yml").write_text(task_yaml)
+        return proj
+
+    def _sched_task(self, proj, **kwargs):
+        return SchedulerTask(name="t", project=str(proj), session="persist-s",
+                             task="t", schedule=Schedule(every="1h"), **kwargs)
+
+    # --- _task_is_persistent ---
+
+    def test_persistent_when_exit_on_complete_false(self, tmp_path):
+        from agentwire import scheduler
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n    exit_on_complete: false\n")
+        assert scheduler._task_is_persistent(self._sched_task(proj)) is True
+
+    def test_not_persistent_by_default(self, tmp_path):
+        from agentwire import scheduler
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n")
+        assert scheduler._task_is_persistent(self._sched_task(proj)) is False
+
+    def test_not_persistent_when_task_unloadable(self, tmp_path):
+        from agentwire import scheduler
+        task = self._sched_task(tmp_path / "missing")
+        assert scheduler._task_is_persistent(task) is False
+
+    # --- _dispatch_inplace_task kill behavior ---
+
+    def _patch_dispatch(self, monkeypatch):
+        from agentwire import scheduler
+        import agentwire.locking
+        killed, precreated = [], []
+        monkeypatch.setattr(agentwire.locking, "remove_stale_lock", lambda s: None)
+        monkeypatch.setattr(scheduler, "_kill_session", lambda s: killed.append(s))
+        monkeypatch.setattr(scheduler, "_pre_create_session", lambda t: precreated.append(t.session))
+        monkeypatch.setattr(scheduler, "_run_ensure", lambda cmd: (0, None, 1))
+        monkeypatch.setattr(scheduler, "_parse_ensure_summary", lambda t, r: ("ok", [], []))
+        monkeypatch.setattr(scheduler, "_log_event", lambda *a, **k: None)
+        monkeypatch.setattr(scheduler, "_notify_portal", lambda *a, **k: None)
+        monkeypatch.setattr(scheduler, "_capture_head", lambda p: "")
+        monkeypatch.setattr(scheduler, "save_board", lambda b: None)
+        return killed, precreated
+
+    def _dispatch(self, proj, **task_kwargs):
+        from agentwire import scheduler
+        task = self._sched_task(proj, **task_kwargs)
+        board = Board()
+        board.tasks["t"] = task
+        return scheduler._dispatch_inplace_task(board, task, TaskState())
+
+    def test_persistent_task_session_not_killed(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n    exit_on_complete: false\n")
+        killed, _ = self._patch_dispatch(monkeypatch)
+        state = self._dispatch(proj)
+        assert killed == []
+        assert state.last_status == "complete"
+
+    def test_default_task_session_killed(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n")
+        killed, _ = self._patch_dispatch(monkeypatch)
+        self._dispatch(proj)
+        assert killed == ["persist-s"]
+
+    def test_persistent_with_overrides_not_killed_but_precreated(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n    exit_on_complete: false\n")
+        killed, precreated = self._patch_dispatch(monkeypatch)
+        self._dispatch(proj, type="claude-bypass")
+        assert killed == []
+        assert precreated == ["persist-s"]  # no-op when session exists
+
+    def test_overrides_without_persistence_killed_and_precreated(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n")
+        killed, precreated = self._patch_dispatch(monkeypatch)
+        self._dispatch(proj, type="claude-bypass")
+        assert killed == ["persist-s"]
+        assert precreated == ["persist-s"]


### PR DESCRIPTION
Closes #234

## What was broken

`exit_on_complete: false` was silently ignored everywhere it mattered — any persistent session opting out of teardown got killed after (and before) every scheduled run.

## Three fixes

**1. The confirmed jq bug (`idle-handler.sh`)** — jq's `//` operator coerces a stored `false` to its default (`false // true == true`), so the hook read `exit_on_complete: false` back as `true` and sent `/exit` + `tmux kill-session` anyway. Same latent bug on `loop_review`. Both boolean reads now use `if .field == null then true else .field end`, so only null/absent falls back to the default.

**2. Context-file cleanup on the persistent path (`idle-handler.sh`)** — the second-idle branch only removed the task context file inside the `exit_on_complete=true` path. But `wait_for_completion_signal()` (completion.py:292) blocks until that file is **deleted** — with only fix 1, persistent tasks would have hung `ensure` forever (no wall-clock timeout, and the session never dies). The `false` branch now removes the context file and leaves the session alive, so later interactive idles take the normal non-task path.

**3. Dispatch-time kill (`scheduler.py`)** — the issue's "secondary observation" is confirmed in code: `_dispatch_inplace_task` killed the task's session unconditionally at dispatch start (both override and no-override paths), clobbering live persistent sessions before each run. Dispatch now loads the project task's `exit_on_complete` via `load_task()` and skips the kill for persistent sessions; `ensure` reuses the live session. `_pre_create_session` already no-ops when the session exists, so the overrides path degrades gracefully (live session → reused; dead session → re-created with overrides). Worktree tasks are untouched — they use fresh timestamped sessions where persistence doesn't apply.

## Verification

- `tests/unit/test_idle_handler.py` extracts the **actual jq filters from the hook source** and runs them through real jq — a regression back to the `//` idiom fails the suite. Also pins the context-cleanup structure of the persistent branch.
- `tests/unit/test_scheduler.py::TestPersistentSessionDispatch` covers `_task_is_persistent` (false/default/unloadable) and the dispatch kill/skip matrix (persistent × overrides).
- `bash -n` passes; full unit suite: 903 passed, 1 pre-existing failure (`test_session_send_cross_session`, fails on clean main too).

## Deploy note

The installed hook at `~/.claude/hooks/idle-handler.sh` is a copy, not a symlink — after merge, run `agentwire rebuild && agentwire hooks install` to redeploy.

Built by [dotdev.dev](https://dotdev.dev)