### PR TITLE
docs(tmux): surface the recommended tmux config + add focus-events and window-size largest

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ pip install agentwire-dev
 
 </details>
 
+> **tmux config matters.** Default tmux has no mouse scroll, a tiny scrollback, and broken copy UX — see [Recommended tmux config](docs/wiki/quickstart.md#recommended-tmux-config), or let `agentwire init` install it for you.
+
 ---
 
 ## Features

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -58,6 +58,24 @@ def _check_tmux_installed() -> bool:
     return True
 
 
+def _tmux_global_option(name: str) -> str | None:
+    """Read a global tmux option from the running server.
+
+    Returns the option value ("on"/"off"/...), or None when no server is
+    running or the option can't be read.
+    """
+    try:
+        r = subprocess.run(
+            ["tmux", "show-option", "-gv", name],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
 def _check_config_exists() -> bool:
     """Check ~/.agentwire/config.yaml exists; print init hint if not."""
     config_path = CONFIG_DIR / "config.yaml"
@@ -6054,6 +6072,22 @@ def cmd_doctor(args) -> int:
     tmux_path = shutil.which("tmux")
     if tmux_path:
         print(f"  [ok] tmux: {tmux_path}")
+        # Server-side options that make or break the agent UX (warn-only —
+        # config is user preference, not a broken install). Only checkable
+        # when a tmux server is running.
+        for opt, why in (
+            ("focus-events", "Claude Code shows a setup tip on every session start"),
+            ("mouse", "no mouse scroll or text selection in agent panes"),
+        ):
+            val = _tmux_global_option(opt)
+            if val is None:
+                break  # no running tmux server — nothing to inspect
+            if val == "on":
+                print(f"  [ok] tmux {opt}: on")
+            else:
+                print(f"  [..] tmux {opt}: {val} — {why}")
+                print("     Recommended config: agentwire init (tmux step), or see")
+                print("     docs/wiki/quickstart.md#recommended-tmux-config")
     else:
         print("  [!!] tmux: not found (required)")
         print("     macOS: brew install tmux")

--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -353,7 +353,8 @@ services:
         print()
         tmux_choice = prompt_choice(
             "AgentWire includes a recommended tmux config with mouse scroll,\n"
-            "50k line history, vi copy mode, and a status bar with git/CPU/RAM.",
+            "50k line history, vi copy mode, focus events for Claude Code,\n"
+            "and a status bar with git/CPU/RAM.",
             [
                 ("skip", "Keep my existing config (no changes)"),
                 ("backup", "Install recommended config (backs up existing to .tmux.conf.bak)"),
@@ -366,6 +367,7 @@ services:
         print(f"  {CYAN}•{RESET} Mouse scroll through agent output")
         print(f"  {CYAN}•{RESET} 50k line scrollback buffer")
         print(f"  {CYAN}•{RESET} Vi copy mode (v to select, y to yank)")
+        print(f"  {CYAN}•{RESET} Focus events (silences Claude Code's per-session setup tip)")
         print(f"  {CYAN}•{RESET} Status bar with git branch, CPU/RAM, working dir")
         print(f"  {CYAN}•{RESET} Click/drag disabled (prevents accidental agent interaction)")
         print()

--- a/agentwire/templates/tmux.conf
+++ b/agentwire/templates/tmux.conf
@@ -9,6 +9,10 @@
 # Enable mouse support — scroll through agent output, click panes, resize
 set -g mouse on
 
+# Focus events — Claude Code uses these to detect terminal focus
+# (without this, Claude Code shows a setup tip on every session start)
+set -g focus-events on
+
 # Large scrollback buffer — agent sessions produce a lot of output
 set -g history-limit 50000
 
@@ -19,6 +23,16 @@ setw -g pane-base-index 0
 
 # Renumber windows when one is closed (no gaps)
 set -g renumber-windows on
+
+# Use largest connected client size — prevents a small attached client
+# (e.g. the portal Monitor view) from shrinking windows for everyone
+set -g window-size largest
+
+# Re-assert largest on attach and new-session — explicit resize-window calls
+# (portal terminal, `agentwire resize`) flip a window to "manual" size mode;
+# these hooks flip it back to automatic
+set-hook -g client-attached 'set-option -t "#{session_name}" window-size largest'
+set-hook -g after-new-session 'set-option window-size largest'
 
 # No delay after pressing Escape (important for vi-mode users)
 set -s escape-time 0

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -32,6 +32,36 @@ agentwire doctor      # one-shot diagnostic — confirms tmux, ffmpeg, hooks, cl
 
 `agentwire doctor` reports anything missing with a fix suggestion. Re-run until it's all green.
 
+### Recommended tmux config
+
+AgentWire's whole UX is "tmux as the agent canvas" — but tmux's defaults fight it: no mouse scroll, a 2,000-line scrollback that loses agent transcripts, broken text selection, and a Claude Code setup tip on every session start (`focus-events off`).
+
+The fastest fix: **`agentwire init`** offers to install the full recommended config (backing up any existing `~/.tmux.conf` first; it never clobbers without asking). The bundled template lives at `agentwire/templates/tmux.conf` and also adds a status bar, pane-split bindings, and click/drag protection so stray clicks can't poke an agent.
+
+Already have a `~/.tmux.conf` you'd rather merge into? These are the settings that matter:
+
+```tmux
+set -g focus-events on        # Claude Code uses these; silences its per-session tip
+set -g mouse on               # scroll through agent output
+set -g history-limit 50000    # default 2000 is too small for agent transcripts
+set -s escape-time 0          # no delay after Esc
+
+# True color
+set -g default-terminal "screen-256color"
+set -ga terminal-overrides ",xterm-256color:Tc"
+
+# Copying that works: vi-style copy mode, selection survives mouse-drag end
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+unbind -T copy-mode-vi MouseDragEnd1Pane
+
+# Multiple clients (portal Monitor + your terminal) without window shrinking
+set -g window-size largest
+```
+
+`agentwire doctor` warns if the running tmux server has `focus-events` or `mouse` off.
+
 ---
 
 ## 2. Your first session

--- a/tests/unit/test_tmux_template.py
+++ b/tests/unit/test_tmux_template.py
@@ -1,0 +1,67 @@
+"""Tests for the bundled tmux config template and its documentation (issue #225).
+
+agentwire's UX assumes a sane tmux config — mouse scroll, large scrollback,
+working copy mode, focus events for Claude Code. These tests pin the settings
+in the bundled template and make sure the docs actually point users at them.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+TEMPLATE = REPO / "agentwire" / "templates" / "tmux.conf"
+QUICKSTART = REPO / "docs" / "wiki" / "quickstart.md"
+README = REPO / "README.md"
+
+
+class TestBundledTemplate:
+    """The settings that make or break the agent UX must stay in the template."""
+
+    @pytest.mark.parametrize("setting", [
+        "set -g focus-events on",        # silences Claude Code's per-session tip
+        "set -g mouse on",               # scroll through agent output
+        "set -g history-limit 50000",    # agent transcripts outgrow the 2000 default
+        "set -s escape-time 0",
+        'set -g default-terminal "screen-256color"',
+        'set -ga terminal-overrides ",xterm-256color:Tc"',
+        # The copy stack: vi mode, vim-style select/yank, selection survives drag end
+        "setw -g mode-keys vi",
+        "bind -T copy-mode-vi v send -X begin-selection",
+        "bind -T copy-mode-vi y send -X copy-selection-and-cancel",
+        "unbind -T copy-mode-vi MouseDragEnd1Pane",
+        # Multi-client sizing: portal Monitor must not shrink windows, and
+        # explicit resize-window calls must not lock manual mode permanently
+        "set -g window-size largest",
+        "set-hook -g client-attached",
+        "set-hook -g after-new-session",
+    ])
+    def test_required_setting_present(self, setting):
+        assert setting in TEMPLATE.read_text(), f"template missing: {setting}"
+
+    def test_pane_base_index_stays_zero(self):
+        # Pane 0 = orchestrator is a convention agentwire hooks rely on.
+        assert "setw -g pane-base-index 0" in TEMPLATE.read_text()
+
+
+class TestDocs:
+    """quickstart must document the config; README must link to it."""
+
+    def test_quickstart_has_tmux_section(self):
+        text = QUICKSTART.read_text()
+        assert "### Recommended tmux config" in text
+        for setting in ("focus-events on", "mouse on", "history-limit 50000",
+                        "MouseDragEnd1Pane", "agentwire init"):
+            assert setting in text, f"quickstart tmux section missing: {setting}"
+
+    def test_readme_links_quickstart_tmux_section(self):
+        assert "quickstart.md#recommended-tmux-config" in README.read_text()
+
+
+class TestOnboardingTemplatePath:
+    """The onboarding flow's template path must resolve to the shipped file."""
+
+    def test_template_exists_at_onboarding_path(self):
+        import agentwire.onboarding as onboarding
+        bundled = Path(onboarding.__file__).parent / "templates" / "tmux.conf"
+        assert bundled.exists()


### PR DESCRIPTION
Closes #225

## The twist

The thing #225 proposes **already shipped**: `agentwire/templates/tmux.conf` is a full recommended config, and `agentwire init` offers to install it (declined-by-default for existing configs, with backup — exactly the issue's optional ask). But the quickstart and README never mention it, which is how the issue got filed proposing something we already had. The fix is mostly discoverability — plus two real template gaps.

## Template fixes

- **`set -g focus-events on`** — the issue's #1 item, genuinely missing from our template. Without it Claude Code shows a setup tip on every session start.
- **`window-size largest` + re-assert hooks** — upstreamed from the dev machine's live config, where it was added to solve real agentwire problems: a small attached client (the portal Monitor view) shrinking windows for everyone, and explicit `resize-window` calls (portal terminal, `agentwire resize`) locking windows into "manual" size mode. The `client-attached` / `after-new-session` hooks flip them back to automatic. The issue reporter independently runs `window-size largest` for the same reason.

## Docs

- **quickstart.md** gains `### Recommended tmux config` under Install: why tmux defaults fight the agent-canvas UX (no scroll, 2k scrollback, broken copy, focus nag), a minimal merge-snippet — **including the copy-mode stack** (vi mode, `v`/`y`, `MouseDragEnd1Pane` unbind), since working copy is non-negotiable — and a pointer to `agentwire init` for the full template.
- **README** install section links to the quickstart anchor.
- Onboarding prompt bullets now mention focus events.

## Doctor

New `_tmux_global_option()` probe. When a tmux server is running, `doctor` now warns (`[..]`, non-fatal — config is preference, not breakage) on `focus-events off` or `mouse off`, pointing at the init flow and docs anchor.

## Verification

- Template loaded on a scratch tmux server (`tmux -L aw-conf-test -f ...`): `focus-events on` (server scope), `window-size largest` + `mode-keys vi` (window scope), both hooks registered — all confirmed.
- Live on this machine: doctor correctly flagged the real `focus-events off` gap on the running server, the updated template was deployed to `~/.tmux.conf` (diff-verified strict superset — local `window-size` block was upstreamed, nothing personal lost), server reloaded, doctor now all `[ok]`.
- 17 new tests pin the template's required settings, the quickstart section, the README link, and the onboarding template path. Full suite: 942 passed, 1 pre-existing failure (fails on clean main).

Built by [dotdev.dev](https://dotdev.dev)