### PR TITLE
feat(platform): user-defined services — autostart on portal launch, health checks, watchdog, CLI, MCP

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -45,6 +45,15 @@ agentwire portal stop           # stop portal
 agentwire portal restart        # stop + start
 agentwire portal status         # check health
 
+# Custom services (registered long-running sessions — services.custom in config;
+# autostart on portal launch, health-checked + restarted by the portal watchdog)
+agentwire services list         # registry: autostart/restart/healthcheck per service
+agentwire services status       # run healthchecks now (exit 1 if something's down)
+agentwire services status name  # one service
+agentwire services up <name>    # start (also clears 'down' state)
+agentwire services up --all     # start all autostart services (skips downed)
+agentwire services down <name>  # stop AND keep stopped (watchdog won't respawn)
+
 # TTS/STT servers
 agentwire tts start|stop|status # TTS server management
 agentwire stt start|stop|status # STT server management

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -84,14 +84,25 @@ services:  # Where services run (for multi-machine setups)
     session_name: "agentwire-tts"
   stt:
     session_name: "agentwire-stt"
-  custom:  # User-defined service sessions — boot with `agentwire up`,
-           #   shown in the portal's Services column
+  custom:  # User-defined service sessions — autostart on portal launch AND
+           #   `agentwire up`, health-checked by the portal watchdog, shown in
+           #   the portal's Services column. Manage with `agentwire services ...`.
+           #   The notifications bridge is a built-in registry entry (override
+           #   by defining a service with its name).
     - name: "agent-brain"          # tmux session name (required)
       project: "~/projects/brain"  # project dir; defaults to dev source dir
-      autostart: true              # boot with `agentwire up` (default true)
+      autostart: true              # boot on portal launch / `agentwire up` (default true)
       roles: "brain"               # optional; overrides project .agentwire.yml
       type: "claude-bypass"        # optional; session type override
-    - "simple-service"             # string shorthand = name only, autostart on
+      restart: on-failure          # never | on-failure | always (watchdog respawn
+                                   #   with 30s..10m exponential backoff; default on-failure;
+                                   #   `agentwire services down` always sticks)
+      healthcheck:                 # optional; defaults to tmux_session/60s
+        kind: tmux_session         # tmux_session | http | command
+        url: "http://..."          # for http (2xx = healthy)
+        command: "curl -sf ..."    # for command (exit 0 = healthy)
+        interval: 60               # seconds between watchdog checks
+    - "simple-service"             # string shorthand = name only, all defaults
 
 executables:  # Override executable paths (optional, auto-detected by default)
   ffmpeg: "/opt/homebrew/bin/ffmpeg"

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -108,6 +108,18 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire tts status` | `tts_status()` |
 | `agentwire stt status` | `stt_status()` |
 
+## Custom Services (2 tools)
+
+Registered long-running sessions (`services.custom` in config + the built-in
+notifications bridge). Autostarted on portal launch; health-checked and
+restarted by the portal watchdog. Start/stop is CLI-only (`agentwire services
+up|down`) — the MCP surface is read-only introspection.
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire services list` | `services_list()` |
+| `agentwire services status` | `services_status()` |
+
 ## Scheduler (8 tools)
 
 | CLI Command | MCP Tool |

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -525,53 +525,6 @@ def get_stt_session_name() -> str:
     return config.get("services", {}).get("stt", {}).get("session_name", "agentwire-stt")
 
 
-def get_notifications_session_name() -> str:
-    """Get notifications tmux session name from config."""
-    config = load_config()
-    return config.get("services", {}).get("notifications", {}).get(
-        "session_name", "agentwire-notifications"
-    )
-
-
-def _ensure_notifications_session() -> None:
-    """Spawn agentwire-notifications if it isn't already running.
-
-    The portal's idle_nag_loop sends `[IDLE NAG]` prompts to this session.
-    Without it the prompt is dropped and the user never hears the TTS reminder.
-    Safe to call repeatedly — does nothing when the session already exists.
-    Failures are non-fatal: TTS itself still works, idle nags just stay silent.
-    """
-    session_name = get_notifications_session_name()
-    if tmux_session_exists(session_name):
-        return
-
-    source_dir = get_source_dir()
-    if not source_dir:
-        return
-
-    try:
-        subprocess.run(
-            [
-                sys.executable, "-m", "agentwire", "new",
-                "-s", session_name,
-                "-p", str(source_dir),
-                "--roles", "notifications",
-                "--type", "claude-bypass",
-                "--json",
-            ],
-            check=True,
-            capture_output=True,
-            timeout=30,
-        )
-        print(f"  Spawned {session_name} (idle-nag TTS bridge).")
-    except Exception as e:
-        print(
-            f"  Warning: could not spawn {session_name}: {e}. "
-            "Idle nags will be silent until you start it manually.",
-            file=sys.stderr,
-        )
-
-
 # === Wave 2: Remote Infrastructure Helpers ===
 
 
@@ -856,7 +809,8 @@ def _start_portal_local(args, attach: bool = True) -> int:
     # Install global tmux hooks for portal sync
     _install_global_tmux_hooks()
 
-    _ensure_notifications_session()
+    # Custom services (incl. the notifications bridge) are autostarted by the
+    # portal server itself on launch — see run_server() in server.py.
 
     if attach:
         print("Portal started. Attaching... (Ctrl+B D to detach)")
@@ -1229,8 +1183,6 @@ def _start_tts_local(args, venv_override: str | None = None, attach: bool = True
     subprocess.run([
         "tmux", "send-keys", "-t", session_name, tts_cmd, "Enter",
     ])
-
-    _ensure_notifications_session()
 
     if attach:
         print("TTS server started. Attaching... (Ctrl+B D to detach)")
@@ -3393,8 +3345,10 @@ def cmd_new(args) -> int:
     # directory of another active session. Two agents sharing the same working tree
     # is the dangerous footgun (one's dirty state visible to the other, branches
     # mixing). Worktree sessions (project/branch) get unique paths and won't trip
-    # this. --force overrides.
-    if not args.force:
+    # this. --force overrides; --allow-shared-dir bypasses ONLY this guard
+    # (without --force's kill-replace of an existing same-name session — service
+    # respawns must never destroy a concurrently-created healthy instance).
+    if not args.force and not getattr(args, "allow_shared_dir", False):
         target = str(session_path.resolve()) if session_path.exists() else str(session_path)
         panes_result = subprocess.run(
             ["tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}"],
@@ -5656,23 +5610,144 @@ def cmd_dev(args) -> int:
     return 0
 
 
-def _start_custom_service(svc) -> None:
-    """Start a custom service session (detached) if not already running."""
-    if tmux_session_exists(svc.name):
-        print(f"  [ok] {svc.name} (already running)")
-        return
+# === Services Commands ===
 
-    project = svc.project or str(get_source_dir())
-    cmd = [sys.executable, "-m", "agentwire", "new", "-s", svc.name, "-p", project, "--json"]
-    if svc.roles:
-        cmd.extend(["--roles", svc.roles])
-    if svc.type:
-        cmd.extend(["--type", svc.type])
-    try:
-        subprocess.run(cmd, check=True, capture_output=True, timeout=60)
-        print(f"  [ok] {svc.name} (started)")
-    except Exception as e:
-        print(f"  [!!] {svc.name}: {e}", file=sys.stderr)
+def _load_services_registry():
+    """(config, registry) for the services commands."""
+    from . import services as services_mod
+    from .config import load_config as load_config_typed
+    cfg = load_config_typed()
+    return services_mod, services_mod.registry(cfg)
+
+
+def _find_service(services_mod, reg, name: str):
+    for svc in reg:
+        if svc.name == name:
+            return svc
+    return None
+
+
+def cmd_services_list(args) -> int:
+    """List registered custom services (built-ins + config-defined)."""
+    json_mode = getattr(args, "json", False)
+    services_mod, reg = _load_services_registry()
+    disabled = services_mod.load_disabled()
+
+    entries = [{
+        "name": svc.name,
+        "project": svc.project,
+        "autostart": svc.autostart,
+        "restart": svc.restart,
+        "healthcheck": {"kind": svc.healthcheck.kind, "interval": svc.healthcheck.interval},
+        "roles": svc.roles,
+        "type": svc.type,
+        "disabled": svc.name in disabled,
+    } for svc in reg]
+
+    if json_mode:
+        _output_json({"success": True, "services": entries})
+        return 0
+
+    if not entries:
+        print("No custom services registered (services.custom in ~/.agentwire/config.yaml).")
+        return 0
+    for e in entries:
+        flags = []
+        if not e["autostart"]:
+            flags.append("autostart off")
+        if e["disabled"]:
+            flags.append("disabled")
+        suffix = f" [{', '.join(flags)}]" if flags else ""
+        print(f"  {e['name']}  restart={e['restart']}  "
+              f"healthcheck={e['healthcheck']['kind']}/{e['healthcheck']['interval']}s{suffix}")
+        if e["project"]:
+            print(f"    project: {e['project']}")
+    return 0
+
+
+def cmd_services_status(args) -> int:
+    """Health status for one or all custom services (runs healthchecks now).
+
+    Exit 0 when everything that should be running is healthy, 1 otherwise.
+    """
+    json_mode = getattr(args, "json", False)
+    name = getattr(args, "name", None)
+    services_mod, reg = _load_services_registry()
+
+    if name:
+        svc = _find_service(services_mod, reg, name)
+        if svc is None:
+            return _output_result(False, json_mode, f"Unknown service: {name}")
+        reg = [svc]
+
+    statuses = [services_mod.service_status(svc) for svc in reg]
+    # Disabled / autostart-off services aren't expected to be running
+    all_ok = all(s["healthy"] or s["disabled"] or not s["autostart"] for s in statuses)
+
+    if json_mode:
+        # Always exit 0 in JSON mode — the payload carries all_healthy, and
+        # callers (portal watchdog) need the data precisely when unhealthy.
+        _output_json({"success": True, "all_healthy": all_ok, "services": statuses})
+        return 0
+
+    for s in statuses:
+        if s["healthy"]:
+            mark = "[ok]"
+        elif s["disabled"] or not s["autostart"]:
+            mark = "[..]"
+        else:
+            mark = "[!!]"
+        extra = " (disabled)" if s["disabled"] else ("" if s["autostart"] else " (autostart off)")
+        print(f"  {mark} {s['name']}: {s['detail']}{extra}")
+    return 0 if all_ok else 1
+
+
+def cmd_services_up(args) -> int:
+    """Start a service (clears any 'down' state), or --all autostart services."""
+    json_mode = getattr(args, "json", False)
+    name = getattr(args, "name", None)
+    services_mod, reg = _load_services_registry()
+
+    if getattr(args, "all", False):
+        from .config import load_config as load_config_typed
+        results = services_mod.start_all_autostart(load_config_typed())
+        ok = all(r.get("ok", True) for r in results)
+        if json_mode:
+            # Always exit 0 in JSON mode — per-service results carry the
+            # failures; the portal autostart needs them either way.
+            _output_json({"success": ok, "results": results})
+            return 0
+        for r in results:
+            if "skipped" in r:
+                print(f"  [..] {r['name']}: {r['skipped']}")
+            else:
+                print(f"  [{'ok' if r['ok'] else '!!'}] {r['name']}: {r['result']}")
+        return 0 if ok else 1
+
+    if not name:
+        return _output_result(False, json_mode, "Service name required (or --all)")
+    svc = _find_service(services_mod, reg, name)
+    if svc is None:
+        return _output_result(False, json_mode, f"Unknown service: {name}")
+
+    services_mod.set_disabled(name, False)
+    ok, msg = services_mod.start_service(svc)
+    return _output_result(ok, json_mode, f"{name}: {msg}", name=name, result=msg)
+
+
+def cmd_services_down(args) -> int:
+    """Stop a service and keep it stopped (watchdog and up --all skip it)."""
+    json_mode = getattr(args, "json", False)
+    name = args.name
+    services_mod, reg = _load_services_registry()
+    if _find_service(services_mod, reg, name) is None:
+        return _output_result(False, json_mode, f"Unknown service: {name}")
+
+    # Disable BEFORE killing so the watchdog can't race a respawn
+    services_mod.set_disabled(name, True)
+    ok, msg = services_mod.stop_service(name)
+    return _output_result(ok, json_mode, f"{name}: {msg} (disabled until 'services up {name}')",
+                          name=name, result=msg, disabled=True)
 
 
 def cmd_up(args) -> int:
@@ -5736,12 +5811,16 @@ def cmd_up(args) -> int:
     else:
         print("  STT skipped (no stt.url configured).")
 
-    # Custom services
-    custom = [s for s in cfg.services.custom if s.autostart]
-    if custom:
-        print("Starting custom services...")
-        for svc in custom:
-            _start_custom_service(svc)
+    # Custom services (same shared path as portal-launch autostart)
+    from . import services as services_mod
+    print("Starting custom services...")
+    for r in services_mod.start_all_autostart(cfg):
+        if "skipped" in r:
+            print(f"  [..] {r['name']}: {r['skipped']}")
+        elif r.get("ok"):
+            print(f"  [ok] {r['name']} ({r['result']})")
+        else:
+            print(f"  [!!] {r['name']}: {r['result']}", file=sys.stderr)
 
     print()
     # Finally, the dev session (creates + attaches the agentwire session)
@@ -6174,16 +6253,28 @@ def cmd_doctor(args) -> int:
             print(f"  [..] {label}: not found ({why})")
             print("     Run: agentwire hooks install")
 
-    # Check notifications bridge session (drives idle-nag TTS)
-    notif_session = get_notifications_session_name()
-    if tmux_session_exists(notif_session):
-        print(f"  [ok] Notifications session: {notif_session}")
-    else:
-        print(f"  [!!] Notifications session: {notif_session} not running")
-        print("     The portal's idle-nag prompts will be silent. Start TTS or "
-              "portal to auto-spawn it, or run: agentwire new -s "
-              f"{notif_session} -p {get_source_dir()} --roles notifications --type claude-bypass")
-        issues_found += 1
+    # Check custom services (registry-driven: built-in notifications bridge
+    # + user-defined services from services.custom)
+    print("\nChecking custom services...")
+    from . import services as services_mod
+    from .config import load_config as _load_config_typed
+    try:
+        _svc_cfg = _load_config_typed()
+        _svc_disabled = services_mod.load_disabled()
+        for svc in services_mod.registry(_svc_cfg):
+            healthy, detail = services_mod.run_healthcheck(svc)
+            if healthy:
+                print(f"  [ok] Service {svc.name}: {detail}")
+            elif svc.name in _svc_disabled:
+                print(f"  [..] Service {svc.name}: stopped via 'services down' ({detail})")
+            elif not svc.autostart:
+                print(f"  [..] Service {svc.name}: not running (autostart off, {detail})")
+            else:
+                print(f"  [!!] Service {svc.name}: unhealthy — {detail}")
+                print(f"     Run: agentwire services up {svc.name}")
+                issues_found += 1
+    except Exception as e:
+        print(f"  [..] Could not check custom services: {e}")
 
     # 5. Validate config
     print("\nChecking configuration...")
@@ -10243,6 +10334,9 @@ def main() -> int:
     new_parser.add_argument("-s", "--session", required=True, help="Session name (project, project/branch, or project/branch@machine)")
     new_parser.add_argument("-p", "--path", help="Working directory (default: ~/projects/<name>)")
     new_parser.add_argument("-f", "--force", action="store_true", help="Replace existing session")
+    new_parser.add_argument("--allow-shared-dir", action="store_true",
+                            help="Allow attaching to a directory that already has active sessions "
+                                 "(unlike --force, never replaces an existing same-name session)")
     # Session type
     new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-<provider>, pi-<provider>-restricted, pi-<provider>-readonly, standard, worker, voice) — e.g. pi-zai, pi-deepseek")
     # Roles
@@ -10792,6 +10886,47 @@ def main() -> int:
     lock_remove_parser.add_argument("session", help="Session name")
     lock_remove_parser.add_argument("--json", action="store_true", help="Output JSON")
     lock_remove_parser.set_defaults(func=cmd_lock_remove)
+
+    # === services command group ===
+    services_parser = subparsers.add_parser(
+        "services",
+        help="Manage user-defined services (long-running registered sessions)",
+        description=(
+            "Custom services are long-running agentwire sessions registered in "
+            "services.custom in ~/.agentwire/config.yaml. They autostart on portal "
+            "launch and `agentwire up`, and the portal watchdog health-checks them "
+            "(restart: never | on-failure | always, with backoff). "
+            "The notifications bridge session is a built-in registry entry."
+        ),
+    )
+    services_subparsers = services_parser.add_subparsers(dest="services_command")
+
+    services_list_parser = services_subparsers.add_parser("list", help="List registered services")
+    services_list_parser.add_argument("--json", action="store_true", help="Output JSON")
+    services_list_parser.set_defaults(func=cmd_services_list)
+
+    services_status_parser = services_subparsers.add_parser(
+        "status", help="Run healthchecks and report per-service status"
+    )
+    services_status_parser.add_argument("name", nargs="?", help="Service name (default: all)")
+    services_status_parser.add_argument("--json", action="store_true", help="Output JSON")
+    services_status_parser.set_defaults(func=cmd_services_status)
+
+    services_up_parser = services_subparsers.add_parser(
+        "up", help="Start a service (clears 'down' state)"
+    )
+    services_up_parser.add_argument("name", nargs="?", help="Service name")
+    services_up_parser.add_argument("--all", action="store_true",
+                                    help="Start all autostart services (skips downed ones)")
+    services_up_parser.add_argument("--json", action="store_true", help="Output JSON")
+    services_up_parser.set_defaults(func=cmd_services_up)
+
+    services_down_parser = services_subparsers.add_parser(
+        "down", help="Stop a service and keep it stopped"
+    )
+    services_down_parser.add_argument("name", help="Service name")
+    services_down_parser.add_argument("--json", action="store_true", help="Output JSON")
+    services_down_parser.set_defaults(func=cmd_services_down)
 
     # === scheduler command group ===
     scheduler_parser = subparsers.add_parser(

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -183,13 +183,34 @@ class ServiceConfig:
 
 
 @dataclass
+class HealthcheckConfig:
+    """How a custom service's health is probed.
+
+    kind:
+      tmux_session (default) — healthy when the tmux session exists
+      http                   — healthy when GET `url` returns 2xx
+      command                — healthy when `command` exits 0
+    """
+
+    kind: str = "tmux_session"
+    url: Optional[str] = None       # for kind: http
+    command: Optional[str] = None   # for kind: command
+    interval: int = 60              # seconds between watchdog checks
+
+
+@dataclass
 class CustomServiceConfig:
     """A user-defined session that behaves like a service.
 
-    Custom services show up in the portal's Services column and are booted
-    by `agentwire up`. A service is just an agentwire session created in a
+    Custom services show up in the portal's Services column, are booted by
+    `agentwire up` AND on portal launch, and are watched by the portal's
+    service watchdog. A service is just an agentwire session created in a
     project directory; `roles`/`type` override the project's .agentwire.yml
     when set.
+
+    restart: never | on-failure | always — what the watchdog does when the
+    healthcheck fails ("always" behaves like "on-failure" for tmux services;
+    manual `agentwire services down` always sticks regardless of policy).
     """
 
     name: str
@@ -197,6 +218,8 @@ class CustomServiceConfig:
     autostart: bool = True
     roles: Optional[str] = None  # comma-separated; overrides project .agentwire.yml
     type: Optional[str] = None   # session type override (e.g. claude-bypass)
+    restart: str = "on-failure"  # never | on-failure | always
+    healthcheck: HealthcheckConfig = field(default_factory=HealthcheckConfig)
 
     def __post_init__(self):
         if self.project:
@@ -495,12 +518,21 @@ def _dict_to_config(data: dict) -> Config:
         if isinstance(entry, str):
             custom_services.append(CustomServiceConfig(name=entry))
         elif isinstance(entry, dict) and entry.get("name"):
+            hc_data = entry.get("healthcheck") or {}
+            healthcheck = HealthcheckConfig(
+                kind=hc_data.get("kind", "tmux_session"),
+                url=hc_data.get("url"),
+                command=hc_data.get("command"),
+                interval=hc_data.get("interval", 60),
+            )
             custom_services.append(CustomServiceConfig(
                 name=entry["name"],
                 project=entry.get("project"),
                 autostart=entry.get("autostart", True),
                 roles=entry.get("roles"),
                 type=entry.get("type"),
+                restart=entry.get("restart", "on-failure"),
+                healthcheck=healthcheck,
             ))
     services = ServicesConfig(
         portal=portal_service,

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2356,6 +2356,74 @@ def session_notify(event: str, session: str | None = None) -> str:
 
 
 # =============================================================================
+# Services Tools
+# =============================================================================
+
+
+@mcp.tool()
+def services_list() -> str:
+    """List registered custom services (long-running registered sessions).
+
+    Custom services autostart on portal launch / `agentwire up` and are
+    health-checked by the portal watchdog. Includes the built-in
+    notifications bridge plus services.custom entries from config.
+
+    Returns:
+        Each service with its project, restart policy, healthcheck, and flags.
+    """
+    data = run_agentwire_cmd(["services", "list"])
+    if not data.get("success"):
+        return f"Failed to list services: {data.get('error', 'Unknown error')}"
+    services = data.get("services", [])
+    if not services:
+        return "No custom services registered."
+    lines = []
+    for s in services:
+        flags = []
+        if not s.get("autostart"):
+            flags.append("autostart off")
+        if s.get("disabled"):
+            flags.append("disabled")
+        suffix = f" [{', '.join(flags)}]" if flags else ""
+        hc = s.get("healthcheck", {})
+        lines.append(f"- {s['name']}: restart={s.get('restart')}, "
+                     f"healthcheck={hc.get('kind')}/{hc.get('interval')}s{suffix}")
+        if s.get("project"):
+            lines.append(f"  project: {s['project']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def services_status() -> str:
+    """Health status for all custom services (runs healthchecks now).
+
+    Returns:
+        Per-service health with detail; flags services that should be
+        running but aren't.
+    """
+    data = run_agentwire_cmd(["services", "status"])
+    if not data.get("success"):
+        return f"Failed to get services status: {data.get('error', 'Unknown error')}"
+    statuses = data.get("services", [])
+    if not statuses:
+        return "No custom services registered."
+    lines = []
+    for s in statuses:
+        if s.get("healthy"):
+            mark = "ok"
+        elif s.get("disabled") or not s.get("autostart"):
+            mark = ".."
+        else:
+            mark = "!!"
+        extra = " (disabled)" if s.get("disabled") else (
+            "" if s.get("autostart") else " (autostart off)")
+        lines.append(f"[{mark}] {s['name']}: {s.get('detail')}{extra}")
+    all_healthy = data.get("all_healthy")
+    lines.append(f"\nAll healthy: {'yes' if all_healthy else 'NO'}")
+    return "\n".join(lines)
+
+
+# =============================================================================
 # Tunnel Tools
 # =============================================================================
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1455,6 +1455,116 @@ class AgentWireServer:
                 logger.debug("[IdleNag] Error: %s", e)
                 await asyncio.sleep(NAG_INTERVAL)
 
+    async def autostart_custom_services(self):
+        """Boot autostart custom services shortly after portal launch.
+
+        This is the reboot fix for #214: the launchd plist runs
+        `agentwire portal start`, not `agentwire up`, so the server itself
+        is the convergence point. Delegates to the CLI (single source of
+        truth) — `services up --all` is idempotent and skips downed services.
+        """
+        await asyncio.sleep(5)  # let the portal finish binding first
+        try:
+            success, result = await self.run_agentwire_cmd(["services", "up", "--all"])
+            if success:
+                started = [r["name"] for r in result.get("results", []) if r.get("result") == "started"]
+                if started:
+                    logger.info("[Services] Autostarted: %s", ", ".join(started))
+                else:
+                    logger.info("[Services] All autostart services already running")
+            else:
+                logger.warning("[Services] Autostart failed: %s", result.get("error"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("[Services] Autostart error: %s", e)
+
+    async def _notify_service_event(self, name: str, text: str, speak: bool):
+        """Toast (+ optional TTS) for a service watchdog event."""
+        notification_id = f"svc-{name}-{str(uuid.uuid4())[:8]}"
+        # Replace any active toast for this service
+        stale = [nid for nid, n in self.active_notifications.items()
+                 if n.get("session") == f"service:{name}"]
+        for nid in stale:
+            self.active_notifications.pop(nid, None)
+            await self.broadcast_dashboard("notification_dismiss", {"id": nid})
+        notification = {
+            "id": notification_id,
+            "text": text,
+            "session": f"service:{name}",
+            "priority": "high",
+            "timestamp": time.time(),
+        }
+        self.active_notifications[notification_id] = notification
+        await self.broadcast_dashboard("notification", notification)
+        if speak:
+            await self.run_agentwire_cmd(["say", text], json_output=False)
+
+    async def service_watchdog_loop(self):
+        """Background task: healthcheck registered custom services.
+
+        Per-service cadence from healthcheck.interval. On failure: toast +
+        TTS on the healthy→unhealthy transition, then respawn per the
+        service's restart policy with exponential backoff (WatchdogState in
+        services.py — pure and unit-tested). `services down` services are
+        skipped entirely. Backoff state is in-memory; a portal restart
+        resets it, which is fine.
+        """
+        from .services import WatchdogState
+
+        TICK = 15  # seconds between scheduling passes
+        states: dict[str, WatchdogState] = {}
+        last_check: dict[str, float] = {}
+
+        logger.info("[Watchdog] Service watchdog started")
+        await asyncio.sleep(30)  # let autostart finish before first checks
+
+        while True:
+            try:
+                now = time.time()
+                success, result = await self.run_agentwire_cmd(["services", "status"])
+                if not success:
+                    logger.debug("[Watchdog] status failed: %s", result.get("error"))
+                    await asyncio.sleep(TICK)
+                    continue
+
+                for status in result.get("services", []):
+                    name = status["name"]
+                    interval = status.get("healthcheck", {}).get("interval", 60)
+                    if now - last_check.get(name, 0) < interval:
+                        continue
+                    last_check[name] = now
+
+                    if status.get("disabled") or not status.get("autostart"):
+                        states.pop(name, None)  # not managed while opted out
+                        continue
+
+                    state = states.setdefault(name, WatchdogState())
+                    actions = state.on_check(now, status["healthy"], status.get("restart", "on-failure"))
+
+                    for action in actions:
+                        if action == "notify_down":
+                            logger.warning("[Watchdog] %s unhealthy: %s", name, status.get("detail"))
+                            await self._notify_service_event(
+                                name, f"Service {name} is down ({status.get('detail')})", speak=True)
+                        elif action == "notify_recovered":
+                            logger.info("[Watchdog] %s recovered", name)
+                            await self._notify_service_event(
+                                name, f"Service {name} recovered", speak=False)
+                        elif action == "restart":
+                            logger.info("[Watchdog] Restarting %s (attempt %d)",
+                                        name, state.restart_count)
+                            await self.run_agentwire_cmd(["services", "up", name])
+
+                await asyncio.sleep(TICK)
+
+            except asyncio.CancelledError:
+                logger.info("[Watchdog] Service watchdog stopped")
+                break
+            except Exception as e:
+                logger.debug("[Watchdog] Error: %s", e)
+                await asyncio.sleep(TICK)
+
     async def handle_websocket(self, request: web.Request) -> web.WebSocketResponse:
         """Handle WebSocket connections for a session."""
         name = request.match_info["name"]
@@ -4830,6 +4940,14 @@ async def run_server(config: Config):
     # Start idle nag loop (TTS reminders for idle sessions with open windows)
     idle_nag_task = asyncio.create_task(server.idle_nag_loop())
 
+    # Autostart custom services (incl. the notifications bridge) — the portal
+    # is the convergence point, so launchd/`portal start`/`agentwire up` all
+    # bring services back without a separate `agentwire up` run.
+    autostart_task = asyncio.create_task(server.autostart_custom_services())
+
+    # Watchdog: healthcheck registered services, notify + restart per policy
+    watchdog_task = asyncio.create_task(server.service_watchdog_loop())
+
     # Sessions are now fetched dynamically from tmux + .agentwire.yml
     # No cache to rebuild or periodically refresh
 
@@ -4860,11 +4978,12 @@ async def run_server(config: Config):
         while True:
             await asyncio.sleep(3600)
     finally:
-        monitor_task.cancel()
-        try:
-            await monitor_task
-        except asyncio.CancelledError:
-            pass
+        for task in (monitor_task, idle_nag_task, autostart_task, watchdog_task):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         await server.close_backends()
         await runner.cleanup()
 

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -1,0 +1,285 @@
+"""Custom service registry, health checks, and watchdog policy.
+
+A custom service is a long-running agentwire session registered in
+``services.custom`` in ``~/.agentwire/config.yaml``. This module is the
+single source of truth for service lifecycle logic — the CLI commands
+(``agentwire services ...``), ``agentwire up``, ``agentwire doctor``, and
+the portal's autostart + watchdog all call into it.
+
+State: ``~/.agentwire/services-state.json`` records services the user has
+manually stopped (``agentwire services down``) so neither ``up --all`` nor
+the watchdog resurrects them.
+"""
+
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from .config import Config, CustomServiceConfig, HealthcheckConfig
+
+STATE_FILE = Path.home() / ".agentwire" / "services-state.json"
+
+# Watchdog restart backoff: 30s, 60s, 120s, ... capped at 10 minutes.
+BACKOFF_BASE = 30
+BACKOFF_CAP = 600
+
+
+# ─────────────────────────────────────────────────────────────
+# Disabled-state file (manual `services down` must stick)
+# ─────────────────────────────────────────────────────────────
+
+
+def load_disabled() -> set[str]:
+    """Names of services manually stopped via `agentwire services down`."""
+    try:
+        data = json.loads(STATE_FILE.read_text())
+        return set(data.get("disabled", []))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+
+def set_disabled(name: str, disabled: bool) -> None:
+    """Add/remove a service from the disabled set."""
+    current = load_disabled()
+    if disabled:
+        current.add(name)
+    else:
+        current.discard(name)
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps({"disabled": sorted(current)}, indent=2))
+
+
+# ─────────────────────────────────────────────────────────────
+# Registry
+# ─────────────────────────────────────────────────────────────
+
+
+def _raw_services_config() -> dict:
+    """Raw `services:` mapping from config.yaml (for fields the typed
+    Config doesn't carry, e.g. notifications session_name)."""
+    try:
+        config_path = Path.home() / ".agentwire" / "config.yaml"
+        data = yaml.safe_load(config_path.read_text()) or {}
+        return data.get("services", {}) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+def notifications_session_name() -> str:
+    """The idle-nag TTS bridge session name (configurable, rarely changed)."""
+    return (
+        _raw_services_config()
+        .get("notifications", {})
+        .get("session_name", "agentwire-notifications")
+    )
+
+
+def _source_dir() -> str:
+    """agentwire source dir (dev.source_dir), project for built-in services."""
+    try:
+        config_path = Path.home() / ".agentwire" / "config.yaml"
+        data = yaml.safe_load(config_path.read_text()) or {}
+        source = data.get("dev", {}).get("source_dir", "~/projects/agentwire-dev")
+    except (OSError, yaml.YAMLError):
+        source = "~/projects/agentwire-dev"
+    return str(Path(source).expanduser())
+
+
+def registry(cfg: Config) -> list[CustomServiceConfig]:
+    """All managed services: built-ins first, then user-defined.
+
+    The notifications session (idle-nag TTS bridge) is a built-in registry
+    entry — same lifecycle as user services (autostart, watchdog, doctor).
+    A user-defined service with the same name overrides the built-in.
+    """
+    notif_name = notifications_session_name()
+    user_services = list(cfg.services.custom)
+    if any(s.name == notif_name for s in user_services):
+        return user_services
+
+    notifications = CustomServiceConfig(
+        name=notif_name,
+        project=_source_dir(),
+        autostart=True,
+        roles="notifications",
+        type="claude-bypass",
+        restart="on-failure",
+        healthcheck=HealthcheckConfig(),  # tmux_session, 60s
+    )
+    return [notifications, *user_services]
+
+
+# ─────────────────────────────────────────────────────────────
+# Health checks
+# ─────────────────────────────────────────────────────────────
+
+
+def _tmux_session_exists(name: str) -> bool:
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", f"={name}"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def run_healthcheck(svc: CustomServiceConfig) -> tuple[bool, str]:
+    """Probe a service's health. Returns (healthy, detail)."""
+    hc = svc.healthcheck
+    if hc.kind == "http":
+        if not hc.url:
+            return False, "healthcheck kind 'http' requires url"
+        from .tunnels import test_service_health
+        healthy, error = test_service_health(hc.url, timeout=5)
+        return healthy, error or "2xx"
+    if hc.kind == "command":
+        if not hc.command:
+            return False, "healthcheck kind 'command' requires command"
+        try:
+            result = subprocess.run(
+                hc.command, shell=True, capture_output=True, timeout=10,
+            )
+            if result.returncode == 0:
+                return True, "exit 0"
+            return False, f"exit {result.returncode}"
+        except subprocess.TimeoutExpired:
+            return False, "healthcheck timed out (10s)"
+        except Exception as e:
+            return False, str(e)
+    # Default: tmux_session
+    if _tmux_session_exists(svc.name):
+        return True, "session exists"
+    return False, "session not found"
+
+
+def service_status(svc: CustomServiceConfig) -> dict:
+    """Full status for one service (runs its healthcheck now)."""
+    healthy, detail = run_healthcheck(svc)
+    return {
+        "name": svc.name,
+        "running": _tmux_session_exists(svc.name),
+        "healthy": healthy,
+        "detail": detail,
+        "disabled": svc.name in load_disabled(),
+        "autostart": svc.autostart,
+        "restart": svc.restart,
+        "healthcheck": {"kind": svc.healthcheck.kind, "interval": svc.healthcheck.interval},
+        "project": svc.project,
+    }
+
+
+# ─────────────────────────────────────────────────────────────
+# Start / stop
+# ─────────────────────────────────────────────────────────────
+
+
+def start_service(svc: CustomServiceConfig) -> tuple[bool, str]:
+    """Start a service session (detached) if not already running. Idempotent."""
+    if _tmux_session_exists(svc.name):
+        return True, "already running"
+
+    project = svc.project or _source_dir()
+    # --allow-shared-dir: registering a service is explicit intent — skip the
+    # guard that refuses a second session on a project dir with active sessions
+    # (the built-in notifications entry shares the source dir with portal/tts).
+    # Deliberately NOT --force: concurrent spawns (autostart + watchdog + manual
+    # `services up`) must degrade to a harmless "already exists", never
+    # kill-replace a healthy instance that won the race.
+    cmd = [sys.executable, "-m", "agentwire", "new", "-s", svc.name, "-p", project,
+           "--allow-shared-dir", "--json"]
+    if svc.roles:
+        cmd.extend(["--roles", svc.roles])
+    if svc.type:
+        cmd.extend(["--type", svc.type])
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=60)
+        return True, "started"
+    except subprocess.CalledProcessError as e:
+        if _tmux_session_exists(svc.name):
+            return True, "already running"  # lost a benign spawn race
+        stderr = (e.stderr or b"").decode(errors="replace").strip()
+        return False, stderr or str(e)
+    except Exception as e:
+        return False, str(e)
+
+
+def stop_service(name: str) -> tuple[bool, str]:
+    """Kill a service's tmux session."""
+    if not _tmux_session_exists(name):
+        return True, "not running"
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "agentwire", "kill", "-s", name, "--json"],
+            check=True, capture_output=True, timeout=30,
+        )
+        return True, "stopped"
+    except Exception as e:
+        return False, str(e)
+
+
+def start_all_autostart(cfg: Config) -> list[dict]:
+    """Start every `autostart: true` service that isn't manually disabled.
+
+    The shared boot path for `agentwire up` AND portal launch. Idempotent.
+    Returns per-service results.
+    """
+    disabled = load_disabled()
+    results = []
+    for svc in registry(cfg):
+        if not svc.autostart:
+            results.append({"name": svc.name, "skipped": "autostart off"})
+            continue
+        if svc.name in disabled:
+            results.append({"name": svc.name, "skipped": "disabled (services down)"})
+            continue
+        ok, msg = start_service(svc)
+        results.append({"name": svc.name, "ok": ok, "result": msg})
+    return results
+
+
+# ─────────────────────────────────────────────────────────────
+# Watchdog policy (pure — the portal's loop feeds it check results)
+# ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class WatchdogState:
+    """Per-service restart/notify policy state.
+
+    `on_check` is called by the watchdog after each healthcheck and returns
+    the actions to take: notify_down / notify_recovered fire only on
+    transitions; restart is gated by exponential backoff and the service's
+    restart policy ("never" only notifies; "on-failure"/"always" respawn).
+    """
+
+    healthy: bool | None = None   # None until first check
+    restart_count: int = 0
+    next_restart_at: float = 0.0
+
+    def on_check(self, now: float, healthy: bool, restart_policy: str) -> list[str]:
+        actions: list[str] = []
+        was_healthy = self.healthy
+        self.healthy = healthy
+
+        if healthy:
+            if was_healthy is False:
+                actions.append("notify_recovered")
+            self.restart_count = 0
+            self.next_restart_at = 0.0
+            return actions
+
+        # Unhealthy
+        if was_healthy is not False:  # transition (or first-ever check)
+            actions.append("notify_down")
+
+        if restart_policy in ("on-failure", "always") and now >= self.next_restart_at:
+            actions.append("restart")
+            backoff = min(BACKOFF_BASE * (2 ** self.restart_count), BACKOFF_CAP)
+            self.restart_count += 1
+            self.next_restart_at = now + backoff
+
+        return actions

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -22,6 +22,7 @@ How AgentWire runs AI agents — session types, REPLs, and permission models.
 
 - **[claude-code-auto-mode](sessions/claude-code-auto-mode.md)** — Auto mode session type with classifier safety net
 - **[pi](sessions/pi.md)** — Pi coding agent (multi-provider: zai, deepseek, openai, openrouter, …)
+- **[Custom services](services.md)** — registered long-running sessions: autostart on portal launch, watchdog health checks + restart with backoff, `agentwire services` CLI
 
 ## Communication
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -1,0 +1,74 @@
+# Custom Services
+
+> Living document. Update this, don't create new versions.
+
+A **custom service** is a long-running agentwire session you register once and never babysit again: it boots when the portal boots (including after a reboot), the portal watchdog health-checks it, and a dead service gets a toast + TTS alert and an automatic respawn with backoff. Examples: a work-tracker session that receives `/log-work` pushes, a monitoring agent, a cron-companion session.
+
+The notifications bridge (`agentwire-notifications`, the idle-nag TTS session) is a **built-in registry entry** — it gets the same lifecycle, with no bespoke code path.
+
+## Registering a service
+
+`services.custom` in `~/.agentwire/config.yaml`:
+
+```yaml
+services:
+  custom:
+    - name: work-tracker             # tmux session name (required)
+      project: ~/projects/tracker    # project dir (default: dev source dir)
+      type: claude-bypass            # optional session-type override
+      roles: tracker                 # optional roles override (comma-separated)
+      autostart: true                # boot on portal launch / `agentwire up` (default)
+      restart: on-failure            # never | on-failure | always (default on-failure)
+      healthcheck:
+        kind: tmux_session           # tmux_session (default) | http | command
+        interval: 60                 # seconds between watchdog checks
+    - "simple-service"               # string shorthand: name only, all defaults
+```
+
+Healthcheck kinds:
+
+| Kind | Healthy when |
+|------|--------------|
+| `tmux_session` (default) | the tmux session exists |
+| `http` | GET `url` returns 2xx |
+| `command` | `command` exits 0 (10s timeout) |
+
+## Lifecycle
+
+```
+portal launch ──► services up --all ──► watchdog (every interval)
+                  (autostart, skips        │
+                   downed services)        ├─ healthy ──────────── quiet
+                                           ├─ goes down ─────────► toast + TTS, respawn
+                                           │                       (backoff 30s→10m)
+                                           └─ recovers ──────────► toast
+```
+
+- **Autostart** happens in the portal server itself (`run_server()`), so every start path converges: a reboot via the launchd plist (`agentwire portal start`), `agentwire portal restart`, and `agentwire up` all bring services back. No separate step.
+- **Watchdog** (`service_watchdog_loop` in server.py) checks each service on its `interval`. Failure → toast + TTS on the transition, then respawns per `restart` policy with exponential backoff (30s, 60s, ... capped at 10m; reset on recovery). `restart: never` only notifies. `always` behaves like `on-failure` for tmux services.
+- **Manual stop sticks**: `agentwire services down <name>` records the service as disabled in `~/.agentwire/services-state.json` *before* killing it — neither the watchdog nor `up --all` resurrects it until `agentwire services up <name>`.
+
+## CLI
+
+```bash
+agentwire services list           # registry + autostart/restart/healthcheck/disabled
+agentwire services status        # run healthchecks now; exit 1 if something's down
+agentwire services status NAME   # one service
+agentwire services up NAME       # start (clears 'down' state)
+agentwire services up --all      # all autostart services (skips downed)
+agentwire services down NAME     # stop and keep stopped
+```
+
+`--json` everywhere. Note: `status --json` always exits 0 — the payload carries `all_healthy`, and machine consumers (the watchdog) need the data precisely when something is unhealthy.
+
+MCP (read-only introspection for agents): `services_list()`, `services_status()`.
+
+`agentwire doctor` includes a registry-driven services section: `[ok]` healthy, `[!!]` should-be-running-but-isn't (with the fix command), `[..]` downed or autostart-off.
+
+## Internals
+
+Single source of truth: `agentwire/services.py` — registry synthesis (built-ins + config), healthcheck runners, start/stop, disabled-state file, and the pure `WatchdogState` policy class (unit-tested backoff/notify matrix). The CLI commands wrap it; `agentwire up` and the portal's autostart + watchdog call the CLI (`services up --all`, `services status`), never duplicate the logic.
+
+Portal Services column: the sidebar fetches `/api/services/custom` and groups those session names under Services automatically.
+
+Deliberately out of scope (for now): per-project services in `.agentwire.yml`, sidebar health badges.

--- a/tests/unit/test_server_async.py
+++ b/tests/unit/test_server_async.py
@@ -93,3 +93,40 @@ class TestAsyncRunAgentwireCmd:
             await server.run_agentwire_cmd(["say", "hi"], json_output=False)
             cmd_args = mock_exec.call_args[0]
             assert "--json" not in cmd_args
+
+
+class TestServiceAutostartAndWatchdog:
+    """Portal-side service lifecycle (#214) — thin shells over the CLI."""
+
+    async def test_autostart_calls_services_up_all(self, server, monkeypatch):
+        # Collapse the politeness delay so the test is instant.
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        server.run_agentwire_cmd = AsyncMock(return_value=(True, {"results": [
+            {"name": "tracker", "ok": True, "result": "started"},
+        ]}))
+        await server.autostart_custom_services()
+        server.run_agentwire_cmd.assert_awaited_once_with(["services", "up", "--all"])
+
+    async def test_notify_service_event_broadcasts_and_speaks(self, server):
+        server.broadcast_dashboard = AsyncMock()
+        server.run_agentwire_cmd = AsyncMock(return_value=(True, {}))
+        await server._notify_service_event("tracker", "Service tracker is down", speak=True)
+        # Toast stored + broadcast
+        assert any(n["session"] == "service:tracker"
+                   for n in server.active_notifications.values())
+        server.broadcast_dashboard.assert_awaited()
+        msg_type = server.broadcast_dashboard.await_args[0][0]
+        assert msg_type == "notification"
+        # TTS via the say CLI
+        server.run_agentwire_cmd.assert_awaited_once_with(
+            ["say", "Service tracker is down"], json_output=False)
+
+    async def test_notify_replaces_stale_toast_for_same_service(self, server):
+        server.broadcast_dashboard = AsyncMock()
+        server.run_agentwire_cmd = AsyncMock(return_value=(True, {}))
+        await server._notify_service_event("tracker", "down", speak=False)
+        await server._notify_service_event("tracker", "recovered", speak=False)
+        toasts = [n for n in server.active_notifications.values()
+                  if n["session"] == "service:tracker"]
+        assert len(toasts) == 1
+        assert toasts[0]["text"] == "recovered"

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,295 @@
+"""Tests for agentwire/services.py — registry, healthchecks, watchdog policy (#214)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentwire import services
+from agentwire.config import (
+    Config,
+    CustomServiceConfig,
+    HealthcheckConfig,
+    ServicesConfig,
+    _dict_to_config,
+)
+from agentwire.services import WatchdogState, BACKOFF_BASE, BACKOFF_CAP
+
+
+@pytest.fixture
+def state_file(tmp_path, monkeypatch):
+    f = tmp_path / "services-state.json"
+    monkeypatch.setattr(services, "STATE_FILE", f)
+    return f
+
+
+class TestDisabledState:
+    def test_empty_when_missing(self, state_file):
+        assert services.load_disabled() == set()
+
+    def test_round_trip(self, state_file):
+        services.set_disabled("work-tracker", True)
+        assert services.load_disabled() == {"work-tracker"}
+        services.set_disabled("work-tracker", False)
+        assert services.load_disabled() == set()
+
+    def test_corrupt_file_treated_as_empty(self, state_file):
+        state_file.write_text("not json {")
+        assert services.load_disabled() == set()
+
+
+class TestConfigParsing:
+    """healthcheck/restart fields parse; string shorthand keeps working."""
+
+    def test_full_dict_entry(self):
+        cfg = _dict_to_config({"services": {"custom": [{
+            "name": "tracker",
+            "project": "/tmp/tracker",
+            "restart": "never",
+            "healthcheck": {"kind": "http", "url": "http://x/health", "interval": 30},
+        }]}})
+        svc = cfg.services.custom[0]
+        assert svc.restart == "never"
+        assert svc.healthcheck.kind == "http"
+        assert svc.healthcheck.url == "http://x/health"
+        assert svc.healthcheck.interval == 30
+
+    def test_defaults(self):
+        cfg = _dict_to_config({"services": {"custom": [{"name": "tracker"}]}})
+        svc = cfg.services.custom[0]
+        assert svc.restart == "on-failure"
+        assert svc.healthcheck.kind == "tmux_session"
+        assert svc.healthcheck.interval == 60
+
+    def test_string_shorthand(self):
+        cfg = _dict_to_config({"services": {"custom": ["tracker"]}})
+        svc = cfg.services.custom[0]
+        assert svc.name == "tracker"
+        assert svc.restart == "on-failure"
+        assert svc.healthcheck.kind == "tmux_session"
+
+
+class TestRegistry:
+    def _cfg(self, custom):
+        return Config(services=ServicesConfig(custom=custom))
+
+    def test_builtin_notifications_synthesized(self, monkeypatch):
+        monkeypatch.setattr(services, "notifications_session_name",
+                            lambda: "agentwire-notifications")
+        reg = services.registry(self._cfg([]))
+        assert reg[0].name == "agentwire-notifications"
+        assert reg[0].roles == "notifications"
+        assert reg[0].type == "claude-bypass"
+        assert reg[0].restart == "on-failure"
+
+    def test_user_services_appended(self, monkeypatch):
+        monkeypatch.setattr(services, "notifications_session_name",
+                            lambda: "agentwire-notifications")
+        user = CustomServiceConfig(name="tracker")
+        reg = services.registry(self._cfg([user]))
+        assert [s.name for s in reg] == ["agentwire-notifications", "tracker"]
+
+    def test_user_override_replaces_builtin(self, monkeypatch):
+        monkeypatch.setattr(services, "notifications_session_name",
+                            lambda: "agentwire-notifications")
+        override = CustomServiceConfig(name="agentwire-notifications", restart="never")
+        reg = services.registry(self._cfg([override]))
+        assert len(reg) == 1
+        assert reg[0].restart == "never"
+
+
+class TestRunHealthcheck:
+    def test_command_exit_zero_healthy(self):
+        svc = CustomServiceConfig(name="x", healthcheck=HealthcheckConfig(
+            kind="command", command="true"))
+        healthy, detail = services.run_healthcheck(svc)
+        assert healthy is True
+
+    def test_command_exit_nonzero_unhealthy(self):
+        svc = CustomServiceConfig(name="x", healthcheck=HealthcheckConfig(
+            kind="command", command="false"))
+        healthy, detail = services.run_healthcheck(svc)
+        assert healthy is False
+        assert "exit 1" in detail
+
+    def test_command_missing_command(self):
+        svc = CustomServiceConfig(name="x", healthcheck=HealthcheckConfig(kind="command"))
+        healthy, detail = services.run_healthcheck(svc)
+        assert healthy is False and "requires command" in detail
+
+    def test_http_missing_url(self):
+        svc = CustomServiceConfig(name="x", healthcheck=HealthcheckConfig(kind="http"))
+        healthy, detail = services.run_healthcheck(svc)
+        assert healthy is False and "requires url" in detail
+
+    def test_tmux_session_kind(self, monkeypatch):
+        svc = CustomServiceConfig(name="x")  # default tmux_session
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        assert services.run_healthcheck(svc) == (True, "session exists")
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        assert services.run_healthcheck(svc) == (False, "session not found")
+
+
+class TestStartAllAutostart:
+    def _cfg(self, custom):
+        return Config(services=ServicesConfig(custom=custom))
+
+    def test_skips_disabled_and_non_autostart(self, state_file, monkeypatch):
+        monkeypatch.setattr(services, "notifications_session_name", lambda: "notif")
+        started = []
+        monkeypatch.setattr(services, "start_service",
+                            lambda svc: (started.append(svc.name) or True, "started"))
+        services.set_disabled("downed", True)
+        cfg = self._cfg([
+            CustomServiceConfig(name="downed"),
+            CustomServiceConfig(name="manual", autostart=False),
+            CustomServiceConfig(name="normal"),
+        ])
+        results = services.start_all_autostart(cfg)
+        assert started == ["notif", "normal"]
+        by_name = {r["name"]: r for r in results}
+        assert by_name["downed"]["skipped"].startswith("disabled")
+        assert by_name["manual"]["skipped"] == "autostart off"
+        assert by_name["normal"]["ok"] is True
+
+
+class TestWatchdogState:
+    """The pure restart/notify policy — the heart of the watchdog."""
+
+    def test_first_check_healthy_no_actions(self):
+        s = WatchdogState()
+        assert s.on_check(1000, True, "on-failure") == []
+
+    def test_transition_to_down_notifies_and_restarts(self):
+        s = WatchdogState()
+        s.on_check(1000, True, "on-failure")
+        actions = s.on_check(1060, False, "on-failure")
+        assert actions == ["notify_down", "restart"]
+
+    def test_first_ever_check_unhealthy_notifies(self):
+        s = WatchdogState()
+        assert "notify_down" in s.on_check(1000, False, "on-failure")
+
+    def test_recovery_notifies_once(self):
+        s = WatchdogState()
+        s.on_check(1000, False, "on-failure")
+        actions = s.on_check(1060, True, "on-failure")
+        assert actions == ["notify_recovered"]
+        # Staying healthy is quiet
+        assert s.on_check(1120, True, "on-failure") == []
+
+    def test_never_policy_notifies_but_never_restarts(self):
+        s = WatchdogState()
+        for t in (1000, 1060, 1120):
+            actions = s.on_check(t, False, "never")
+            assert "restart" not in actions
+        # Only the first failure notified
+        assert s.healthy is False
+
+    def test_backoff_grows_and_caps(self):
+        s = WatchdogState()
+        now = 1000.0
+        delays = []
+        # Drive repeated failures, always past the backoff gate
+        for _ in range(8):
+            actions = s.on_check(now, False, "on-failure")
+            assert "restart" in actions
+            delays.append(s.next_restart_at - now)
+            now = s.next_restart_at  # jump exactly to the next allowed attempt
+        assert delays[0] == BACKOFF_BASE
+        assert delays[1] == BACKOFF_BASE * 2
+        assert delays[-1] == BACKOFF_CAP
+        assert max(delays) == BACKOFF_CAP
+
+    def test_no_restart_while_backing_off(self):
+        s = WatchdogState()
+        s.on_check(1000, False, "on-failure")  # restart, next at 1030
+        actions = s.on_check(1010, False, "on-failure")
+        assert actions == []  # still down, not yet allowed to retry
+
+    def test_recovery_resets_backoff(self):
+        s = WatchdogState()
+        for _ in range(4):
+            s.on_check(1000 + s.next_restart_at, False, "on-failure")
+        s.on_check(5000, True, "on-failure")
+        assert s.restart_count == 0 and s.next_restart_at == 0.0
+        actions = s.on_check(5060, False, "on-failure")
+        assert "restart" in actions
+        assert s.next_restart_at - 5060 == BACKOFF_BASE
+
+    def test_always_policy_behaves_like_on_failure(self):
+        s = WatchdogState()
+        actions = s.on_check(1000, False, "always")
+        assert actions == ["notify_down", "restart"]
+
+
+class TestServiceStatus:
+    def test_status_shape(self, state_file, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        svc = CustomServiceConfig(name="tracker", project="/tmp/x")
+        status = services.service_status(svc)
+        assert status["name"] == "tracker"
+        assert status["running"] is True
+        assert status["healthy"] is True
+        assert status["disabled"] is False
+        assert status["restart"] == "on-failure"
+        assert status["healthcheck"] == {"kind": "tmux_session", "interval": 60}
+
+    def test_disabled_flag(self, state_file, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        services.set_disabled("tracker", True)
+        status = services.service_status(CustomServiceConfig(name="tracker"))
+        assert status["disabled"] is True and status["healthy"] is False
+
+
+class TestServicesCLI:
+    """cmd_services_* — JSON contracts the portal watchdog depends on."""
+
+    @pytest.fixture
+    def cli(self, state_file, monkeypatch):
+        from agentwire import __main__ as main_mod
+        monkeypatch.setattr(services, "notifications_session_name", lambda: "notif")
+        monkeypatch.setattr(services, "_source_dir", lambda: "/tmp/src")
+        cfg = Config(services=ServicesConfig(custom=[CustomServiceConfig(name="tracker")]))
+        monkeypatch.setattr("agentwire.config.load_config", lambda *a, **k: cfg)
+        return main_mod
+
+    def _args(self, **kw):
+        import argparse
+        defaults = {"json": True, "name": None, "all": False}
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_list_json(self, cli, capsys):
+        assert cli.cmd_services_list(self._args()) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert [s["name"] for s in data["services"]] == ["notif", "tracker"]
+
+    def test_status_json_always_exit_zero(self, cli, capsys, monkeypatch):
+        # Even with everything down, JSON mode must exit 0 — the watchdog
+        # needs the payload precisely when services are unhealthy.
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        assert cli.cmd_services_status(self._args()) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["all_healthy"] is False
+
+    def test_up_clears_disabled_and_starts(self, cli, capsys, monkeypatch):
+        started = []
+        monkeypatch.setattr(services, "start_service",
+                            lambda svc: (started.append(svc.name) or True, "started"))
+        services.set_disabled("tracker", True)
+        assert cli.cmd_services_up(self._args(name="tracker")) == 0
+        assert started == ["tracker"]
+        assert "tracker" not in services.load_disabled()
+
+    def test_down_disables_then_stops(self, cli, capsys, monkeypatch):
+        calls = []
+        monkeypatch.setattr(services, "stop_service",
+                            lambda name: (calls.append(("stop", name, "tracker" in services.load_disabled())) or True, "stopped"))
+        assert cli.cmd_services_down(self._args(name="tracker")) == 0
+        # Disabled flag was already set when stop ran (no watchdog race)
+        assert calls == [("stop", "tracker", True)]
+        assert "tracker" in services.load_disabled()
+
+    def test_unknown_service(self, cli, capsys):
+        assert cli.cmd_services_up(self._args(name="nope")) == 1


### PR DESCRIPTION
Closes #214

## The reboot fix (Phase 1 — headline acceptance)

The launchd plist runs `agentwire portal start`, not `agentwire up`, and custom-service autostart only lived in `cmd_up` — so registered services never survived a reboot. **The portal server is now the convergence point**: `run_server()` autostarts `autostart: true` services on launch and hosts the watchdog. launchd kickstart, `portal start`, `portal restart`, and `agentwire up` all converge on one path (`services up --all`).

## Architecture (CLI is SSOT)

New module **`agentwire/services.py`** owns all lifecycle logic; the portal's autostart + watchdog and `cmd_up` are thin callers of `agentwire services ... --json`.

- **Registry**: built-in `agentwire-notifications` entry + `services.custom`; a user definition with the same name overrides the built-in.
- **Healthchecks**: `tmux_session` (default) | `http` (2xx) | `command` (exit 0), per-service `interval` (60s default).
- **`WatchdogState`** (pure, unit-tested): notify on transitions only; restart per policy (`never` | `on-failure` default | `always`) with exponential backoff 30s→10m, reset on recovery.
- **`services down` sticks**: disabled-state file written *before* the kill — neither the watchdog nor `up --all` resurrects a manually-stopped service.

## Phase-by-phase

- **CLI**: `agentwire services list | status [name] | up <name>|--all | down <name>`. JSON mode always exits 0 (payload carries per-service results — the watchdog needs them precisely when something is down; this bit me live before I fixed it).
- **Watchdog** (`service_watchdog_loop`, mirrors `idle_nag_loop`): toast + TTS on failure via the existing notification broadcast, recovery toast, respawn via `services up <name>`.
- **Doctor**: registry-driven services section (`[ok]`/`[!!]`/`[..]` for downed/autostart-off), replacing the bespoke notifications check.
- **MCP**: `services_list()` / `services_status()` read-only tools.
- **Phase 5 (notifications migration)**: `_ensure_notifications_session` + `get_notifications_session_name` deleted; the bridge is a registry entry with the same lifecycle. No bespoke spawn path left.
- **Docs**: `docs/wiki/services.md` + INDEX; `agentwire-cli` / `agentwire-config` / `agentwire-mcp-tools` skills.

## The interesting bug: `--force` kill-replace

Service spawns must bypass the shared-working-dir guard (the notifications entry shares the source dir with portal/tts), but `agentwire new --force` *also* kill-replaces an existing same-name session — so concurrent spawns (autostart + watchdog + manual `services up`) could destroy the healthy instance that won the race. New **`agentwire new --allow-shared-dir`** bypasses only the guard; `start_service` uses it and treats a lost race as "already running".

(Confession from live testing: the dramatic "service dies after 5 seconds" symptom that led me here turned out to be my own zsh quoting — unquoted `=name` in `tmux has-session -t =name` is zsh filename expansion, so my liveness checks were lying. The race hazard is real and the fix stands, but the corpse was fake.)

## Verified live on this machine

- `agentwire portal restart` → test service autostarted by the server (no `agentwire up`), confirmed via portal log + session creation timestamp.
- `agentwire kill` on the service → watchdog detected in **8s**, respawned, **alive again 15s after the kill**; toast + TTS fired.
- `services down` → stayed down through 84s (2+ watchdog intervals); status/doctor show `[..]` without flagging an issue; `services up` cleared the state and restarted it.
- Built-in notifications entry: healthy in registry/status/doctor with zero bespoke code.
- Test suite: **976 passed** (50 new across `test_services.py`, `test_server_async.py`, config parsing; 1 pre-existing failure, fails on clean main). Config restored to its pre-test state after verification.

## Out of scope (noted for follow-up)
- Per-project services in `.agentwire.yml` (deferred by the issue)
- Sidebar health badges
- Typed-config tidy of `get_portal/tts/stt_session_name` (the issue's own "optional, not required")

Built by [dotdev.dev](https://dotdev.dev)