### PR TITLE
feat(roles): bundle a 'soul' personality role, always-injected into human-facing sessions

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -8,6 +8,7 @@ description: Full `agentwire` CLI command reference — session/pane management,
 ```bash
 # Session management
 agentwire new -s name           # not: tmux new-session
+agentwire new -s name --no-soul # skip the always-injected soul personality role
 agentwire send -s name "prompt" # not: tmux send-keys
 agentwire send-keys -s name key1 key2  # raw keys with pauses
 agentwire output -s name        # not: tmux capture-pane

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -194,4 +194,8 @@ overnight:
 
 session:
   default_role: "agentwire"  # Default role for new sessions
+  inject_soul: true          # Append the bundled 'soul' personality role to every human-facing
+                             # session (appended last for recency weight). Headless roles
+                             # (worker, task-runner, notifications) and soul/soul-* sessions
+                             # are excluded automatically; per-session opt-out: --no-soul on new/dev
 ```

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -36,7 +36,7 @@ from .project_config import (
     normalize_session_type,
     save_project_config,
 )
-from .roles import RoleConfig, load_roles, merge_roles
+from .roles import RoleConfig, inject_soul, load_roles, merge_roles
 from .worktree import ensure_worktree, parse_session_name, remove_worktree
 
 # Default config directory
@@ -3122,6 +3122,9 @@ def cmd_new(args) -> int:
             default_role = config.get("session", {}).get("default_role", "agentwire")
             role_names = [default_role] if default_role else []
 
+    # Always-inject the soul personality role (rides last for recency weight)
+    role_names = inject_soul(role_names, load_config(), no_soul=getattr(args, 'no_soul', False))
+
     # Load and validate roles
     roles: list[RoleConfig] = []
     if role_names:
@@ -4428,19 +4431,18 @@ def cmd_recreate(args) -> int:
     if type_arg:
         # CLI flag specified - use it directly and normalize (session-level only, not saved)
         session_type_str = normalize_session_type(type_arg, agent_type)
-        roles = None
-        if project_config and project_config.roles:
-            roles, _ = load_roles(project_config.roles, session_path)
     elif project_config:
         # Use existing config
         session_type_str = normalize_session_type(project_config.type.value, agent_type)
-        roles = None
-        if project_config.roles:
-            roles, _ = load_roles(project_config.roles, session_path)
     else:
         # Default to agent-bypass based on detected agent
         session_type_str = f"{agent_type}-bypass"
-        roles = None
+
+    role_names = list(project_config.roles) if project_config and project_config.roles else []
+    role_names = inject_soul(role_names, load_config())
+    roles = None
+    if role_names:
+        roles, _ = load_roles(role_names, session_path)
 
     # Build agent command
     agent = build_agent_command(session_type_str, roles)
@@ -4705,19 +4707,18 @@ def cmd_fork(args) -> int:
         if type_arg:
             # CLI flag specified - use it directly
             session_type_str = normalize_session_type(type_arg, agent_type)
-            roles = None
-            if source_config and source_config.roles:
-                roles, _ = load_roles(source_config.roles, Path(source_path))
         elif source_config:
             # Use source config
             session_type_str = normalize_session_type(source_config.type.value, agent_type)
-            roles = None
-            if source_config.roles:
-                roles, _ = load_roles(source_config.roles, Path(source_path))
         else:
             # Default to agent-bypass based on detected agent
             session_type_str = f"{agent_type}-bypass"
-            roles = None
+
+        role_names = list(source_config.roles) if source_config and source_config.roles else []
+        role_names = inject_soul(role_names, load_config())
+        roles = None
+        if role_names:
+            roles, _ = load_roles(role_names, Path(source_path))
 
         # Build agent command
         agent = build_agent_command(session_type_str, roles)
@@ -4798,19 +4799,18 @@ def cmd_fork(args) -> int:
         if type_arg:
             # CLI flag specified - use it directly
             session_type_str = normalize_session_type(type_arg, agent_type)
-            roles = None
-            if source_project_config and source_project_config.roles:
-                roles, _ = load_roles(source_project_config.roles, fork_path)
         elif source_project_config:
             # Use source config
             session_type_str = normalize_session_type(source_project_config.type.value, agent_type)
-            roles = None
-            if source_project_config.roles:
-                roles, _ = load_roles(source_project_config.roles, fork_path)
         else:
             # Default to agent-bypass based on detected agent
             session_type_str = f"{agent_type}-bypass"
-            roles = None
+
+        role_names = list(source_project_config.roles) if source_project_config and source_project_config.roles else []
+        role_names = inject_soul(role_names, load_config())
+        roles = None
+        if role_names:
+            roles, _ = load_roles(role_names, fork_path)
 
         # Find the conversation JSONL for the source session to enable context inheritance.
         # Uses history.jsonl filtered by the source tmux session's creation time to identify
@@ -4965,19 +4965,18 @@ def cmd_fork(args) -> int:
     if type_arg:
         # CLI flag specified - use it directly
         session_type_str = normalize_session_type(type_arg, agent_type)
-        roles = None
-        if source_config and source_config.roles:
-            roles, _ = load_roles(source_config.roles, config_path)
     elif source_config:
         # Use source config
         session_type_str = normalize_session_type(source_config.type.value, agent_type)
-        roles = None
-        if source_config.roles:
-            roles, _ = load_roles(source_config.roles, config_path)
     else:
         # Default to agent-bypass based on detected agent
         session_type_str = f"{agent_type}-bypass"
-        roles = None
+
+    role_names = list(source_config.roles) if source_config and source_config.roles else []
+    role_names = inject_soul(role_names, load_config())
+    roles = None
+    if role_names:
+        roles, _ = load_roles(role_names, config_path)
 
     # Build agent command
     agent = build_agent_command(session_type_str, roles)
@@ -5226,9 +5225,10 @@ def cmd_history_resume(args) -> int:
     cmd_parts = ["claude", "--resume", session_id, "--fork-session"]
     cmd_parts.extend(project_config.type.to_cli_flags())
 
-    # Load and apply roles if specified in config
-    if project_config.roles:
-        roles, missing = load_roles(project_config.roles, project_path)
+    # Load and apply roles (soul always injected for human-facing sessions)
+    role_names = inject_soul(list(project_config.roles or []), load_config())
+    if role_names:
+        roles, missing = load_roles(role_names, project_path)
         if not missing and roles:
             merged = merge_roles(roles)
             if merged.tools:
@@ -5574,8 +5574,8 @@ def cmd_dev(args) -> int:
         print(f"Project directory not found: {project_dir}", file=sys.stderr)
         return 1
 
-    # Dev session uses agentwire role by default
-    role_names = ["agentwire"]
+    # Dev session uses agentwire role by default, plus the soul personality
+    role_names = inject_soul(["agentwire"], load_config(), no_soul=getattr(args, 'no_soul', False))
     roles, missing = load_roles(role_names, project_dir)
     if missing:
         print(f"Warning: Roles not found: {', '.join(missing)}", file=sys.stderr)
@@ -10412,6 +10412,7 @@ def main() -> int:
     new_parser.add_argument("--type", help="Session type (bare, claude-bypass, claude-prompted, claude-restricted, pi-<provider>, pi-<provider>-restricted, pi-<provider>-readonly, standard, worker, voice) — e.g. pi-zai, pi-deepseek")
     # Roles
     new_parser.add_argument("--roles", help="Comma-separated list of roles (preserves existing config, defaults to agentwire for new projects)")
+    new_parser.add_argument("--no-soul", dest="no_soul", action="store_true", help="Skip soul personality role injection for this session")
     new_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
     new_parser.add_argument("--persist", action="store_true", help="Write --type/--roles to .agentwire.yml (default: session-level override only)")
     new_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable, keeps secrets out of `ps`)")
@@ -10521,6 +10522,7 @@ def main() -> int:
     dev_parser = subparsers.add_parser(
         "dev", help="Start/attach to dev agentwire session"
     )
+    dev_parser.add_argument("--no-soul", dest="no_soul", action="store_true", help="Skip soul personality role injection for this session")
     dev_parser.set_defaults(func=cmd_dev)
 
     up_parser = subparsers.add_parser(

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -261,6 +261,7 @@ class SessionConfig:
     """Default session configuration."""
 
     default_role: str = "agentwire"  # Default role for new sessions
+    inject_soul: bool = True  # Append the bundled soul personality role to human-facing sessions
 
 
 @dataclass
@@ -608,8 +609,16 @@ def _dict_to_config(data: dict) -> Config:
         disabled_rules=[str(r) for r in disabled_rules_raw if r],
     )
 
+    # Session defaults
+    session_data = data.get("session", {}) or {}
+    session = SessionConfig(
+        default_role=session_data.get("default_role", "agentwire"),
+        inject_soul=bool(session_data.get("inject_soul", True)),
+    )
+
     return Config(
         server=server,
+        session=session,
         projects=projects,
         tts=tts,
         stt=stt,

--- a/agentwire/roles/__init__.py
+++ b/agentwire/roles/__init__.py
@@ -160,6 +160,43 @@ def merge_roles(roles: list[RoleConfig]) -> MergedRole:
     )
 
 
+# Roles whose whole job is autonomous execution — personality actively
+# conflicts with them ("run, don't ask"), so soul is never injected.
+HEADLESS_ROLES = {"worker", "task-runner", "notifications"}
+
+
+def inject_soul(role_names: list[str], config: dict | None = None, no_soul: bool = False) -> list[str]:
+    """Append the bundled soul role to a session's role list.
+
+    Soul is the always-present default personality (tone, restraint,
+    ask-vs-proceed). It rides last so it gets recency weight in the merged
+    prompt, while a deliberately-appended stricter role can still override it.
+
+    Skipped when:
+    - no_soul is True (per-session --no-soul flag)
+    - config disables it globally (session.inject_soul: false)
+    - any role is headless (HEADLESS_ROLES — executors stay voiceless)
+    - a soul role is already present (soul itself, or a soul-* lens variant)
+
+    Args:
+        role_names: Resolved role names for the session
+        config: Main config dict (from load_config()), or None to skip the check
+        no_soul: Per-session opt-out
+
+    Returns:
+        role_names with "soul" appended last, or unchanged if excluded
+    """
+    if no_soul:
+        return role_names
+    if config is not None and not config.get("session", {}).get("inject_soul", True):
+        return role_names
+    if any(r in HEADLESS_ROLES for r in role_names):
+        return role_names
+    if any(r == "soul" or r.startswith("soul-") for r in role_names):
+        return role_names
+    return [*role_names, "soul"]
+
+
 def discover_role(name: str, project_path: Path | None = None) -> Path | None:
     """Find a role file by name using discovery order.
 

--- a/agentwire/roles/soul.md
+++ b/agentwire/roles/soul.md
@@ -1,0 +1,36 @@
+---
+name: soul
+description: Default personality — voice, restraint, ask-vs-proceed
+---
+
+# Soul
+
+You're a sharp, dry, capable peer — senior-engineer energy, not an assistant. You have taste and opinions, and you don't bury them. You're warm, but you show it by being useful, not by gushing.
+
+## Voice
+
+- Lead with the answer, or the thing you just did. Context after, only if it earns its place.
+- Short. Match their register. Never pad to seem thorough.
+- Dry humor, sparingly — a little goes a long way.
+- Plain words. You're talking to a builder, not a boardroom.
+
+## Proceed vs. ask
+
+- Bias to act. They'd rather you do the obvious thing and tell them than ask permission for it.
+- Narrate the assumptions you made as you go, so they can redirect cheaply.
+- Ask only when genuinely blocked, or when it's irreversible, outward-facing, or spends money or trust. Then ask once, crisply — don't dither.
+
+## Never
+
+- No cheerleading, no "Great question!", no flattery, no warm-up throat-clearing.
+- Don't over-apologize. Own it once, fix it, move on.
+- Don't hedge in walls of caveats. One honest caveat beats five defensive ones.
+- Don't fake confidence. If it broke or you're unsure, say so plainly — with the evidence.
+
+## Always
+
+- Tell the truth, including "you're wrong about that" — respectfully, with the correction attached.
+- Push the thinking forward: the next step, the connection, the one question that unblocks.
+- Show, don't just tell — build the artifact, render the thing, when it beats prose.
+- Know what's reversible. Move fast on cheap-to-undo; slow down and flag the one-way doors.
+- Respect the human behind the work. Family, faith, focus, and time aren't interruptions to route around.

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -76,6 +76,10 @@ An entry in `~/.agentwire/scheduler.yaml` that fires on a schedule (`every:`, `a
 
 A tmux session running an AI agent (claude-*, claudeglm-*, pi-*, bare). Created with `agentwire new`. Identified by name, with `@machine` suffix for remote sessions. → [Sessions index](INDEX.md#sessions).
 
+## S — Soul
+
+The bundled default-personality role (`agentwire/roles/soul.md`) — voice, restraint, ask-vs-proceed defaults. Always injected last into every human-facing session's role list, on top of whatever roles resolve. Headless roles (worker, task-runner, notifications) and `soul`/`soul-*` sessions are excluded. Opt out globally with `session.inject_soul: false` or per session with `--no-soul`; shadow the content per project via `.agentwire/roles/soul.md`. → `agentwire-config` skill.
+
 ## T — Tunnel
 
 An SSH or Cloudflare Tunnel that exposes a local agentwire service (TTS server, portal) on a remote machine or to the public internet. → [Remote access](deployment/remote-access.md).

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -122,3 +122,15 @@ class TestLoadConfig:
     def test_default_agent_command(self, tmp_path):
         config = load_config(tmp_path / "nonexistent.yaml")
         assert "claude" in config.agent.command
+
+    def test_session_defaults(self, tmp_path):
+        config = load_config(tmp_path / "nonexistent.yaml")
+        assert config.session.default_role == "agentwire"
+        assert config.session.inject_soul is True
+
+    def test_session_from_yaml(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump({"session": {"default_role": "custom", "inject_soul": False}}))
+        config = load_config(path)
+        assert config.session.default_role == "custom"
+        assert config.session.inject_soul is False

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -10,6 +10,7 @@ from agentwire.roles import (
     parse_role_file,
     merge_roles,
     discover_role,
+    inject_soul,
 )
 
 
@@ -121,8 +122,8 @@ class TestMergeRoles:
 
 class TestDiscoverRole:
     def test_bundled_roles_found(self):
-        """All 6 bundled roles should be discoverable."""
-        for name in ["agentwire", "voice", "worker", "task-runner", "chatbot", "init"]:
+        """All bundled roles should be discoverable."""
+        for name in ["agentwire", "voice", "worker", "task-runner", "chatbot", "init", "soul"]:
             path = discover_role(name)
             assert path is not None, f"Bundled role '{name}' not found"
 
@@ -139,3 +140,58 @@ class TestDiscoverRole:
     def test_unknown_role_returns_none(self):
         path = discover_role("nonexistent-role-xyz")
         assert path is None
+
+
+# --- inject_soul ---
+
+class TestInjectSoul:
+    def test_appended_last(self):
+        assert inject_soul(["agentwire"]) == ["agentwire", "soul"]
+
+    def test_injected_with_explicit_roles(self):
+        assert inject_soul(["agentwire", "voice"]) == ["agentwire", "voice", "soul"]
+
+    def test_empty_list_gets_soul(self):
+        assert inject_soul([]) == ["soul"]
+
+    def test_headless_roles_excluded(self):
+        for headless in ["worker", "task-runner", "notifications"]:
+            assert inject_soul([headless]) == [headless]
+
+    def test_headless_mixed_excluded(self):
+        assert inject_soul(["agentwire", "worker"]) == ["agentwire", "worker"]
+
+    def test_no_double_add(self):
+        assert inject_soul(["soul"]) == ["soul"]
+        assert inject_soul(["agentwire", "soul"]) == ["agentwire", "soul"]
+
+    def test_soul_lens_variant_excluded(self):
+        # Council lens roles (#213) self-exclude the standard soul
+        assert inject_soul(["soul-brain"]) == ["soul-brain"]
+
+    def test_no_soul_flag(self):
+        assert inject_soul(["agentwire"], no_soul=True) == ["agentwire"]
+
+    def test_global_opt_out(self):
+        config = {"session": {"inject_soul": False}}
+        assert inject_soul(["agentwire"], config) == ["agentwire"]
+
+    def test_global_default_enabled(self):
+        assert inject_soul(["agentwire"], {}) == ["agentwire", "soul"]
+        assert inject_soul(["agentwire"], None) == ["agentwire", "soul"]
+
+    def test_input_not_mutated(self):
+        names = ["agentwire"]
+        inject_soul(names)
+        assert names == ["agentwire"]
+
+    def test_bundled_soul_is_pure_personality(self):
+        """soul.md must not widen or narrow tool permissions."""
+        path = discover_role("soul")
+        assert path is not None
+        role = parse_role_file(path)
+        assert role is not None
+        assert role.name == "soul"
+        assert role.tools == []
+        assert role.disallowed_tools == []
+        assert role.instructions


### PR DESCRIPTION
Closes #212

## What was built

A bundled `soul` role — the `SOUL.md` equivalent — always injected into every human-facing session's role list, riding **last** in the merged prompt for recency weight. Content drafted by the jordan session (personality through behavior and restraint, not a persona hat): sharp/dry/capable peer voice, bias-to-act + narrate assumptions, and a hard "Never" list (no cheerleading, no over-apologizing, no hedging walls, no fake confidence).

## Decisions locked in

- **Always-inject, not default-fallback** (per issue, locked 2026-06-04) — explicit `roles:` lists still get soul. `default_role` fallback untouched.
- **Appended last** — `merge_roles()` joins in list order, so soul gets recency weight; a deliberately-appended stricter role can still override.
- **Role-based exclusion** in one SSOT helper `inject_soul()` (`agentwire/roles/__init__.py`): headless roles (`worker`, `task-runner`, `notifications`), already-souled (`soul` or `soul-*` — the #213 council-lens override case), `--no-soul`, and global `session.inject_soul: false`.
- **Pure personality** — soul.md carries no `tools`/`disallowedTools`, so it can never widen or narrow permissions (test-enforced).

## Wiring

- Seven injection sites: `cmd_new`, `cmd_dev` (replaces hardcoded `["agentwire"]`), `cmd_fork` ×3 (remote/local/worktree), `cmd_recreate`, `cmd_history_resume`. `cmd_spawn` untouched — workers stay voiceless. `cmd_worktree`, MCP `session_create`, and the portal all delegate to `cmd_new`, so they're covered for free.
- `SessionConfig.inject_soul: bool = True`; **gap fix**: `_dict_to_config()` never parsed `session:` from YAML at all — `config.session.default_role` was always the dataclass default. Now parsed.
- `--no-soul` on `new`/`dev`.

## Verification

- `uv run pytest tests/`: 1066 passed; the 2 full-suite failures (`test_session_send_cross_session`, `test_router_with_new_review`) fail identically on clean `main` — pre-existing order-dependent flakiness, not introduced here.
- Live after `agentwire rebuild`:
  - `agentwire new -s soul-test` → merged prompt sections `# AgentWire` then `# Soul` (last) ✓
  - `agentwire new --roles agentwire` → soul still injected (the Option-B behavior) ✓
  - `--no-soul` → no soul ✓
  - global `session.inject_soul: false` → no soul (config restored after) ✓
  - `cmd_spawn` has no injection site; headless exclusion unit-tested ✓
- Per-project content shadow already works via `discover_role` order (existing test).

## Out of scope

Persona variants; council lens roles (#213 — `soul` vs `council-<lens>` naming settled there, this ships first).

Built by [dotdev.dev](https://dotdev.dev)