### PR TITLE
feat(sessions): 'agentwire council' multi-soul orchestrator sitting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,10 @@ LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wik
 
 First-class auto-dispatcher subsystem (sibling to Sessions/Tasks/Workflows): stateless launchd orchestrators tick the GitHub issue board, spawn worker sessions in isolated worktrees for `agent-ready` issues, route PR-review feedback back to the worker, and reap on PR close. CLI under `agentwire mission ...`, 8 MCP `mission_*` tools. Full reference: [`docs/wiki/missions.md`](docs/wiki/missions.md).
 
+## Council
+
+Multi-soul orchestrator sitting: `agentwire-council` fans prompts out to lens sessions (`council-brain`, `council-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/prompts/`; the orchestrator collects and synthesizes with attribution. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...`, 5 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).
+
 ## Reference Skills
 
 Reference detail lives in skills under `.claude/skills/` — invoke as needed:

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11115,6 +11115,7 @@ def main() -> int:
 
     # === mission command group ===
     from .missions import cli as mission_cli
+    from .council import cli as council_cli
 
     mission_parser = subparsers.add_parser(
         "mission",
@@ -11201,6 +11202,91 @@ def main() -> int:
     m_init.add_argument("repo", help="Repo short name (from config) or owner/repo form")
     m_init.add_argument("--json", action="store_true", help="Output JSON")
     m_init.set_defaults(func=mission_cli.cmd_mission_init)
+
+    # === council command group ===
+    council_parser = subparsers.add_parser(
+        "council",
+        help="Multi-soul council: fan a prompt out to lens sessions, synthesize",
+        description=(
+            "An agentwire-council orchestrator session fans prompts out to a "
+            "roster of lens souls (brain, conscience, gut, critic, historian, "
+            "devils-advocate), collects their takes through a file inbox, and "
+            "synthesizes. See docs/wiki/council.md."
+        ),
+    )
+    council_subparsers = council_parser.add_subparsers(dest="council_command")
+
+    # council start
+    c_start = council_subparsers.add_parser(
+        "start", help="Start a sitting: orchestrator + all soul sessions"
+    )
+    c_start.add_argument(
+        "--roster", help="Comma-separated lens names (default: full bundled roster)"
+    )
+    c_start.add_argument("--type", help="Session type (default: claude-bypass)")
+    c_start.add_argument("--model", help="Model override for all council sessions")
+    c_start.add_argument(
+        "--force", action="store_true", help="Tear down a live sitting first"
+    )
+    c_start.add_argument("--json", action="store_true", help="Output JSON")
+    c_start.set_defaults(func=council_cli.cmd_council_start)
+
+    # council stop
+    c_stop = council_subparsers.add_parser(
+        "stop", help="Kill the sitting's sessions (prompt history kept)"
+    )
+    c_stop.add_argument("--json", action="store_true", help="Output JSON")
+    c_stop.set_defaults(func=council_cli.cmd_council_stop)
+
+    # council status
+    c_status = council_subparsers.add_parser(
+        "status", help="Sitting state, session liveness, open prompts"
+    )
+    c_status.add_argument("--json", action="store_true", help="Output JSON")
+    c_status.set_defaults(func=council_cli.cmd_council_status)
+
+    # council ask
+    c_ask = council_subparsers.add_parser(
+        "ask", help="Fan a prompt out to every soul in the sitting"
+    )
+    c_ask.add_argument("prompt", nargs="?", help="Prompt text (or --file / stdin)")
+    c_ask.add_argument("--file", help="Read prompt text from a file")
+    c_ask.add_argument("--json", action="store_true", help="Output JSON")
+    c_ask.set_defaults(func=council_cli.cmd_council_ask)
+
+    # council collect
+    c_collect = council_subparsers.add_parser(
+        "collect", help="Wait for every soul's take/ack/pass (or timeout)"
+    )
+    c_collect.add_argument("--prompt", type=int, help="Prompt id (default: latest)")
+    c_collect.add_argument(
+        "--timeout", type=float, default=120, help="Soft timeout in seconds (default: 120)"
+    )
+    c_collect.add_argument(
+        "--no-wait", action="store_true", help="Snapshot once, don't block"
+    )
+    c_collect.add_argument("--json", action="store_true", help="Output JSON")
+    c_collect.set_defaults(func=council_cli.cmd_council_collect)
+
+    # council reply (run by souls)
+    c_reply = council_subparsers.add_parser(
+        "reply", help="File a soul's reply: --take / --ack / --pass"
+    )
+    c_reply.add_argument("--prompt", type=int, help="Prompt id (default: latest)")
+    c_reply.add_argument(
+        "--take", action="store_true", help="Substantive take (text required)"
+    )
+    c_reply.add_argument(
+        "--ack", action="store_true", help="Researching — follow-up coming"
+    )
+    c_reply.add_argument(
+        "--pass", action="store_true", help="Nothing to add through this lens"
+    )
+    c_reply.add_argument("--soul", help="Lens name (default: inferred from session)")
+    c_reply.add_argument("--text", help="Reply text")
+    c_reply.add_argument("--file", help="Read reply text from a file")
+    c_reply.add_argument("--json", action="store_true", help="Output JSON")
+    c_reply.set_defaults(func=council_cli.cmd_council_reply)
 
     # === overnight command group ===
     overnight_parser = subparsers.add_parser(
@@ -11340,6 +11426,10 @@ def main() -> int:
 
     if args.command == "mission" and getattr(args, "mission_command", None) is None:
         mission_parser.print_help()
+        return 0
+
+    if args.command == "council" and getattr(args, "council_command", None) is None:
+        council_parser.print_help()
         return 0
 
     if args.command == "overnight" and getattr(args, "overnight_command", None) is None:

--- a/agentwire/council/__init__.py
+++ b/agentwire/council/__init__.py
@@ -1,0 +1,17 @@
+"""The agentwire council — a multi-soul orchestrator session group (#213).
+
+An ``agentwire-council`` orchestrator session fans user prompts out to a
+roster of lens sessions (``council-brain``, ``council-conscience``, …), each
+carrying the shared ``council-member`` protocol role plus its own
+``council-<lens>`` role. Souls reply through a file-based inbox
+(``~/.agentwire/council/prompts/NNNN/replies/``) with exactly one of: a
+substantive **take**, an **ack** (researching, follow-up coming), or a
+**pass** (nothing to add). The orchestrator collects and synthesizes,
+attributed by lens.
+
+Modules:
+
+- ``state``  — sitting lifecycle state (roster, sessions, prompt counter)
+- ``inbox``  — per-prompt reply inbox (the fan-out/collect protocol)
+- ``cli``    — handlers for ``agentwire council ...`` subcommands
+"""

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import time
 from typing import Any
 
 from agentwire.council import inbox, state
@@ -103,6 +104,31 @@ def send_to_session(session: str, message: str) -> None:
     from agentwire import pane_manager
 
     pane_manager.send_to_target(f"{session}.0", message, enter=True)
+
+
+def capture_session(session: str, lines: int = 60) -> str:
+    from agentwire import pane_manager
+
+    return pane_manager.capture_pane(session, 0, lines=lines)
+
+
+def send_verified(session: str, message: str, marker: str, retries: int = 1) -> bool:
+    """Send a message and verify it actually landed in the pane.
+
+    A freshly-booted Claude session renders its banner before its input
+    handler is wired — a paste in that window vanishes silently (same gray
+    zone the mission dispatcher documents). After sending, confirm ``marker``
+    is visible in the pane; retry once if not.
+    """
+    for _ in range(retries + 1):
+        send_to_session(session, message)
+        time.sleep(2.0)
+        try:
+            if marker in capture_session(session):
+                return True
+        except Exception:
+            pass
+    return False
 
 
 def wait_ready(session: str, timeout: float = 45.0) -> bool:
@@ -329,6 +355,7 @@ def cmd_council_ask(args) -> int:
         f"  agentwire council reply --prompt {prompt_id} --pass"
     )
 
+    marker = f"[COUNCIL PROMPT #{prompt_id}]"
     live = list_live_sessions()
     sent_to: list[str] = []
     failed: list[dict] = []
@@ -337,8 +364,10 @@ def cmd_council_ask(args) -> int:
             failed.append({"soul": lens, "error": "session not running"})
             continue
         try:
-            send_to_session(session, message)
-            sent_to.append(lens)
+            if send_verified(session, message, marker):
+                sent_to.append(lens)
+            else:
+                failed.append({"soul": lens, "error": "delivery not confirmed in pane"})
         except Exception as e:  # tmux failures shouldn't kill the whole fan-out
             failed.append({"soul": lens, "error": str(e)})
 
@@ -414,16 +443,20 @@ def cmd_council_reply(args) -> int:
     except (ValueError, FileNotFoundError) as e:
         return _emit_error(args, str(e))
 
+    nudged = None
     if is_followup:
         # Deterministic nudge — doesn't rely on the soul remembering to notify.
+        # Verified like the fan-out; the follow-up is on disk regardless, so a
+        # failed nudge only delays relay until the next collect.
         try:
-            send_to_session(
+            nudged = send_verified(
                 sitting.orchestrator,
                 f"[COUNCIL FOLLOW-UP] {soul} filed a follow-up on prompt "
                 f"#{prompt_id} — run council_collect({prompt_id}) and relay it.",
+                "[COUNCIL FOLLOW-UP]",
             )
         except Exception:
-            pass  # follow-up is on disk regardless; next collect finds it
+            nudged = False
 
     payload = {
         "success": True,
@@ -431,6 +464,7 @@ def cmd_council_reply(args) -> int:
         "soul": soul,
         "kind": kind,
         "followup": is_followup,
+        "nudged": nudged,
         "path": str(path),
     }
     return _emit(

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -1,0 +1,440 @@
+"""CLI handlers for ``agentwire council ...``.
+
+Argparse wiring lives in ``agentwire/__main__.py``; handlers receive an
+``argparse.Namespace`` and return an exit code. Every handler supports
+``--json`` so the MCP layer can shell out and parse structured output.
+
+Subcommands:
+
+- ``start``   — spin up the orchestrator + lens soul sessions (a *sitting*)
+- ``stop``    — kill the sitting's sessions, clear state (history kept)
+- ``status``  — sitting + per-session liveness + open prompts
+- ``ask``     — fan a prompt out to every soul (creates the inbox first)
+- ``collect`` — block until every soul has filed take/ack/pass, or timeout
+- ``reply``   — file a soul's reply (souls run this via Bash)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+from agentwire.council import inbox, state
+
+# --- output helpers -----------------------------------------------------------
+
+
+def _emit(args, payload: dict[str, Any], human: str = "", exit_code: int = 0) -> int:
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, default=str))
+    elif human:
+        print(human)
+    return exit_code
+
+
+def _emit_error(args, message: str, exit_code: int = 1) -> int:
+    if getattr(args, "json", False):
+        print(json.dumps({"success": False, "error": message}, indent=2))
+    else:
+        print(f"error: {message}", file=sys.stderr)
+    return exit_code
+
+
+# --- side-effecting helpers (monkeypatched in tests) ---------------------------
+
+
+def list_live_sessions() -> set[str]:
+    """Names of all running agentwire sessions."""
+    result = subprocess.run(
+        ["agentwire", "list", "--sessions", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        return set()
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return set()
+    sessions = data.get("sessions", []) if isinstance(data, dict) else []
+    return {s.get("name", "") for s in sessions if isinstance(s, dict)} - {""}
+
+
+def create_session(name: str, roles: list[str], session_type: str, model: str | None) -> None:
+    """Create one council session via ``agentwire new`` in the shared workspace.
+
+    Raises ``RuntimeError`` on failure.
+    """
+    cmd = [
+        "agentwire", "new",
+        "-s", name,
+        "-p", str(state.WORKSPACE_DIR),
+        "--roles", ",".join(roles),
+        "--type", session_type,
+        "--allow-shared-dir",
+        "--json",
+    ]
+    if model:
+        cmd += ["--model", model]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"agentwire new failed for {name} (rc={result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
+def kill_session(name: str) -> bool:
+    """Kill a session; True if the command succeeded."""
+    result = subprocess.run(
+        ["agentwire", "kill", "-s", name, "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode == 0
+
+
+def send_to_session(session: str, message: str) -> None:
+    """Inject a message into a session's pane 0 (same primitive as missions)."""
+    from agentwire import pane_manager
+
+    pane_manager.send_to_target(f"{session}.0", message, enter=True)
+
+
+def wait_ready(session: str, timeout: float = 45.0) -> bool:
+    """Wait until a council session's agent is ready for input."""
+    from agentwire.missions.dispatcher import wait_for_session_ready
+
+    return wait_for_session_ready(session, timeout=timeout)
+
+
+def current_session() -> str | None:
+    from agentwire import pane_manager
+
+    return pane_manager.get_current_session()
+
+
+# --- workspace ------------------------------------------------------------------
+
+
+def _write_workspace(session_type: str) -> None:
+    """Workspace dir all council sessions run in.
+
+    ``parent: agentwire-council`` routes any ``agentwire notify`` from a soul
+    to the orchestrator for free.
+    """
+    state.WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
+    (state.WORKSPACE_DIR / ".agentwire.yml").write_text(
+        f"type: {session_type}\nparent: {state.ORCHESTRATOR_SESSION}\n"
+    )
+
+
+# --- handlers -------------------------------------------------------------------
+
+
+def cmd_council_start(args) -> int:
+    roster_arg = getattr(args, "roster", None)
+    roster = (
+        [r.strip() for r in roster_arg.split(",") if r.strip()]
+        if roster_arg
+        else list(state.DEFAULT_ROSTER)
+    )
+    for lens in roster:
+        if not state.valid_lens(lens):
+            return _emit_error(args, f"invalid lens name: {lens!r}")
+
+    sitting = state.read_sitting()
+    if sitting is not None:
+        live = list_live_sessions()
+        still_up = [s for s in (*sitting.sessions.values(), sitting.orchestrator) if s in live]
+        if still_up and not getattr(args, "force", False):
+            return _emit_error(
+                args,
+                f"a council sitting is already active ({', '.join(still_up)}) — "
+                "use 'agentwire council stop' or --force",
+            )
+        # Stale or --force: tear down what's left before restarting.
+        for s in still_up:
+            kill_session(s)
+        state.clear_sitting()
+
+    session_type = getattr(args, "type", None) or "claude-bypass"
+    model = getattr(args, "model", None)
+    _write_workspace(session_type)
+
+    sessions: dict[str, str] = {}
+    failed: list[dict] = []
+
+    try:
+        create_session(
+            state.ORCHESTRATOR_SESSION, ["council-orchestrator"], session_type, model
+        )
+    except RuntimeError as e:
+        return _emit_error(args, f"failed to start orchestrator: {e}")
+
+    for lens in roster:
+        name = state.session_for(lens)
+        try:
+            create_session(name, ["council-member", f"council-{lens}"], session_type, model)
+            sessions[lens] = name
+        except RuntimeError as e:
+            failed.append({"soul": lens, "error": str(e)})
+
+    # Sessions boot concurrently; wait for each to be input-ready so an
+    # immediate `council ask` doesn't paste into a half-booted pane.
+    not_ready = [
+        s
+        for s in (state.ORCHESTRATOR_SESSION, *sessions.values())
+        if not wait_ready(s)
+    ]
+
+    state.write_sitting(
+        state.Sitting(
+            orchestrator=state.ORCHESTRATOR_SESSION,
+            roster=[lens for lens in roster if lens in sessions],
+            sessions=sessions,
+            started_at=state.now_iso(),
+            session_type=session_type,
+        )
+    )
+
+    payload = {
+        "success": not failed and not not_ready,
+        "orchestrator": state.ORCHESTRATOR_SESSION,
+        "sessions": sessions,
+        "failed": failed,
+        "not_ready": not_ready,
+    }
+    human = (
+        f"Council sitting started: {state.ORCHESTRATOR_SESSION} + "
+        f"{len(sessions)} souls ({', '.join(sessions)})"
+    )
+    if failed:
+        human += f"\nfailed: {', '.join(f['soul'] for f in failed)}"
+    if not_ready:
+        human += f"\nnot ready after wait: {', '.join(not_ready)}"
+    return _emit(args, payload, human, exit_code=0 if payload["success"] else 1)
+
+
+def cmd_council_stop(args) -> int:
+    sitting = state.read_sitting()
+    if sitting is None:
+        return _emit_error(args, "no active council sitting")
+
+    live = list_live_sessions()
+    killed: list[str] = []
+    not_running: list[str] = []
+    for name in (*sitting.sessions.values(), sitting.orchestrator):
+        if name in live and kill_session(name):
+            killed.append(name)
+        else:
+            not_running.append(name)
+    state.clear_sitting()
+
+    payload = {"success": True, "killed": killed, "not_running": not_running}
+    return _emit(
+        args,
+        payload,
+        f"Council sitting stopped ({len(killed)} sessions killed). Prompt history kept.",
+    )
+
+
+def cmd_council_status(args) -> int:
+    sitting = state.read_sitting()
+    if sitting is None:
+        return _emit(
+            args,
+            {"success": True, "running": False},
+            "No active council sitting.",
+        )
+
+    live = list_live_sessions()
+    souls = [
+        {"soul": lens, "session": name, "alive": name in live}
+        for lens, name in sitting.sessions.items()
+    ]
+    prompts = []
+    for pid in range(1, sitting.next_prompt_id):
+        pending = inbox.pending_souls(pid, sitting.roster)
+        prompts.append(
+            {
+                "id": pid,
+                "complete": not pending,
+                "replied": [s for s in sitting.roster if s not in pending],
+                "pending": pending,
+            }
+        )
+
+    payload = {
+        "success": True,
+        "running": True,
+        "orchestrator": sitting.orchestrator,
+        "orchestrator_alive": sitting.orchestrator in live,
+        "started_at": sitting.started_at,
+        "souls": souls,
+        "prompts": prompts,
+    }
+    lines = [
+        f"Council sitting (started {sitting.started_at})",
+        f"  orchestrator: {sitting.orchestrator} "
+        f"[{'alive' if payload['orchestrator_alive'] else 'DOWN'}]",
+    ]
+    for s in souls:
+        lines.append(f"  {s['soul']}: {s['session']} [{'alive' if s['alive'] else 'DOWN'}]")
+    for p in prompts:
+        status = "complete" if p["complete"] else f"pending: {', '.join(p['pending'])}"
+        lines.append(f"  prompt #{p['id']}: {status}")
+    return _emit(args, payload, "\n".join(lines))
+
+
+def _prompt_text_from(args) -> str | None:
+    """Prompt/reply body from positional/--text, --file, or stdin."""
+    text = getattr(args, "text", None)
+    if text:
+        return text
+    file_arg = getattr(args, "file", None)
+    if file_arg:
+        try:
+            return open(file_arg).read()
+        except OSError:
+            return None
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    return None
+
+
+def cmd_council_ask(args) -> int:
+    sitting = state.read_sitting()
+    if sitting is None:
+        return _emit_error(args, "no active council sitting — run 'agentwire council start'")
+
+    prompt_text = getattr(args, "prompt", None) or _prompt_text_from(args)
+    if not prompt_text or not prompt_text.strip():
+        return _emit_error(args, "no prompt text (positional, --file, or stdin)")
+    prompt_text = prompt_text.strip()
+
+    prompt_id = state.allocate_prompt_id()
+    inbox.create_prompt(prompt_id, prompt_text, sitting.roster)  # inbox before any send
+
+    message = (
+        f"[COUNCIL PROMPT #{prompt_id}]\n"
+        f"{prompt_text}\n\n"
+        f"Reply through your lens with exactly one of:\n"
+        f'  agentwire council reply --prompt {prompt_id} --take --text "<your take>"\n'
+        f"  agentwire council reply --prompt {prompt_id} --ack\n"
+        f"  agentwire council reply --prompt {prompt_id} --pass"
+    )
+
+    live = list_live_sessions()
+    sent_to: list[str] = []
+    failed: list[dict] = []
+    for lens, session in sitting.sessions.items():
+        if session not in live:
+            failed.append({"soul": lens, "error": "session not running"})
+            continue
+        try:
+            send_to_session(session, message)
+            sent_to.append(lens)
+        except Exception as e:  # tmux failures shouldn't kill the whole fan-out
+            failed.append({"soul": lens, "error": str(e)})
+
+    payload = {
+        "success": bool(sent_to),
+        "prompt_id": prompt_id,
+        "sent_to": sent_to,
+        "failed": failed,
+    }
+    human = f"Prompt #{prompt_id} fanned out to {len(sent_to)} souls."
+    if failed:
+        human += f" Failed: {', '.join(f['soul'] for f in failed)}"
+    return _emit(args, payload, human, exit_code=0 if sent_to else 1)
+
+
+def cmd_council_collect(args) -> int:
+    sitting = state.read_sitting()
+    if sitting is None:
+        return _emit_error(args, "no active council sitting")
+
+    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id()
+    if not prompt_id:
+        return _emit_error(args, "no prompts asked yet")
+
+    result = inbox.collect(
+        prompt_id,
+        sitting.roster,
+        timeout=float(getattr(args, "timeout", 120)),
+        wait=not getattr(args, "no_wait", False),
+    )
+    result["success"] = True
+
+    status = (
+        "complete" if result["complete"] else f"pending: {', '.join(result['pending'])}"
+    )
+    lines = [f"Prompt #{prompt_id}: {status}"]
+    for r in result["replies"]:
+        lines.append(f"\n--- {r['soul']} ({r['kind']}) ---\n{r['text']}")
+    return _emit(args, result, "\n".join(lines))
+
+
+def cmd_council_reply(args) -> int:
+    kinds = [k for k in inbox.KINDS if getattr(args, k.replace("-", "_"), False)]
+    if len(kinds) != 1:
+        return _emit_error(args, "specify exactly one of --take / --ack / --pass")
+    kind = kinds[0]
+
+    sitting = state.read_sitting()
+    if sitting is None:
+        return _emit_error(args, "no active council sitting")
+
+    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id()
+    if not prompt_id:
+        return _emit_error(args, "no prompts asked yet")
+
+    soul = getattr(args, "soul", None)
+    if not soul:
+        session = current_session()
+        if session and session.startswith("council-"):
+            soul = session[len("council-") :]
+    if not soul:
+        return _emit_error(args, "could not infer soul — pass --soul <lens>")
+
+    # Only --take falls back to stdin; ack/pass must not block on a pipe.
+    text = (
+        (_prompt_text_from(args) if kind == "take" else getattr(args, "text", None)) or ""
+    )
+    if kind == "take" and not text.strip():
+        return _emit_error(args, "--take requires text (--text, --file, or stdin)")
+
+    try:
+        path, is_followup = inbox.write_reply(prompt_id, soul, kind, text)
+    except (ValueError, FileNotFoundError) as e:
+        return _emit_error(args, str(e))
+
+    if is_followup:
+        # Deterministic nudge — doesn't rely on the soul remembering to notify.
+        try:
+            send_to_session(
+                sitting.orchestrator,
+                f"[COUNCIL FOLLOW-UP] {soul} filed a follow-up on prompt "
+                f"#{prompt_id} — run council_collect({prompt_id}) and relay it.",
+            )
+        except Exception:
+            pass  # follow-up is on disk regardless; next collect finds it
+
+    payload = {
+        "success": True,
+        "prompt_id": prompt_id,
+        "soul": soul,
+        "kind": kind,
+        "followup": is_followup,
+        "path": str(path),
+    }
+    return _emit(
+        args,
+        payload,
+        f"Filed {'follow-up ' if is_followup else ''}{kind} from {soul} on prompt #{prompt_id}.",
+    )

--- a/agentwire/council/inbox.py
+++ b/agentwire/council/inbox.py
@@ -1,0 +1,185 @@
+"""Per-prompt reply inbox — the council's fan-out/collect protocol.
+
+Layout under ``~/.agentwire/council/prompts/``::
+
+    0003/
+      prompt.md                 # fanned-out prompt text
+      meta.json                 # {id, created_at, roster}
+      replies/
+        brain.take.md           # substantive take
+        conscience.ack.md       # researching, follow-up coming
+        conscience.followup-1.md  # the substantive follow-up
+        gut.pass.md             # nothing to add (synthesis omits)
+
+The reply *kind* is encoded in the filename — ``ls`` is the protocol, no
+frontmatter parsing. A soul's initial round is complete once it has any of
+``take|ack|pass``; later ``--take`` replies from the same soul become numbered
+``followup-N`` files.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agentwire.council import state
+
+KINDS = ("take", "ack", "pass")
+
+
+@dataclass
+class Reply:
+    soul: str
+    kind: str  # take | ack | pass | followup
+    text: str
+    path: Path
+    written_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "soul": self.soul,
+            "kind": self.kind,
+            "text": self.text,
+            "path": str(self.path),
+            "written_at": self.written_at,
+        }
+
+
+def prompt_dir(prompt_id: int) -> Path:
+    return state.PROMPTS_DIR / f"{prompt_id:04d}"
+
+
+def replies_dir(prompt_id: int) -> Path:
+    return prompt_dir(prompt_id) / "replies"
+
+
+def create_prompt(prompt_id: int, text: str, roster: list[str]) -> Path:
+    """Create the prompt dir + inbox. Must exist before any fan-out send."""
+    pdir = prompt_dir(prompt_id)
+    replies = pdir / "replies"
+    replies.mkdir(parents=True, exist_ok=True)
+    (pdir / "prompt.md").write_text(text)
+    meta = {
+        "id": prompt_id,
+        "created_at": state.now_iso(),
+        "roster": list(roster),
+    }
+    (pdir / "meta.json").write_text(json.dumps(meta, indent=2))
+    return pdir
+
+
+def read_meta(prompt_id: int) -> dict:
+    meta_path = prompt_dir(prompt_id) / "meta.json"
+    try:
+        data = json.loads(meta_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _initial_reply(prompt_id: int, soul: str) -> Path | None:
+    """The soul's initial take/ack/pass file, or None if not yet filed."""
+    for kind in KINDS:
+        path = replies_dir(prompt_id) / f"{soul}.{kind}.md"
+        if path.exists():
+            return path
+    return None
+
+
+def write_reply(prompt_id: int, soul: str, kind: str, text: str) -> tuple[Path, bool]:
+    """File a reply. Returns ``(path, is_followup)``.
+
+    First reply from a soul lands as ``<soul>.<kind>.md``. Once an initial
+    reply exists, only further ``take`` replies are allowed — they become
+    ``<soul>.followup-N.md`` (the ack-and-research delivery path).
+    """
+    if kind not in KINDS:
+        raise ValueError(f"invalid reply kind: {kind!r} (expected one of {KINDS})")
+    rdir = replies_dir(prompt_id)
+    if not rdir.is_dir():
+        raise FileNotFoundError(f"no inbox for council prompt #{prompt_id}")
+
+    if _initial_reply(prompt_id, soul) is None:
+        path = rdir / f"{soul}.{kind}.md"
+        path.write_text(text)
+        return path, False
+
+    if kind != "take":
+        raise ValueError(
+            f"{soul} already filed an initial reply for prompt #{prompt_id}; "
+            "only follow-up takes are allowed after that"
+        )
+    n = 1
+    while (rdir / f"{soul}.followup-{n}.md").exists():
+        n += 1
+    path = rdir / f"{soul}.followup-{n}.md"
+    path.write_text(text)
+    return path, True
+
+
+def list_replies(prompt_id: int) -> list[Reply]:
+    """All filed replies for a prompt, initial rounds first, then follow-ups."""
+    rdir = replies_dir(prompt_id)
+    if not rdir.is_dir():
+        return []
+    out: list[Reply] = []
+    for path in sorted(rdir.glob("*.md")):
+        stem_parts = path.stem.rsplit(".", 1)
+        if len(stem_parts) != 2:
+            continue
+        soul, marker = stem_parts
+        kind = "followup" if marker.startswith("followup-") else marker
+        if kind not in (*KINDS, "followup"):
+            continue
+        written_at = datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).isoformat()
+        out.append(
+            Reply(soul=soul, kind=kind, text=path.read_text(), path=path, written_at=written_at)
+        )
+    out.sort(key=lambda r: (r.kind == "followup", r.written_at))
+    return out
+
+
+def pending_souls(prompt_id: int, roster: list[str]) -> list[str]:
+    """Roster souls that haven't filed their initial take/ack/pass yet."""
+    return [s for s in roster if _initial_reply(prompt_id, s) is None]
+
+
+def initial_round_complete(prompt_id: int, roster: list[str]) -> bool:
+    return not pending_souls(prompt_id, roster)
+
+
+def collect(
+    prompt_id: int,
+    roster: list[str],
+    timeout: float = 120.0,
+    poll: float = 1.0,
+    wait: bool = True,
+) -> dict:
+    """Block until every roster soul has filed an initial reply, or timeout.
+
+    Returns ``{prompt_id, complete, timed_out, replies, pending}``. With
+    ``wait=False`` it snapshots once and returns immediately. Re-collecting a
+    complete prompt returns instantly (the follow-up re-collect path).
+    """
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    while True:
+        pending = pending_souls(prompt_id, roster)
+        if not pending or not wait:
+            break
+        if time.monotonic() >= deadline:
+            timed_out = True
+            break
+        time.sleep(poll)
+    return {
+        "prompt_id": prompt_id,
+        "complete": not pending,
+        "timed_out": timed_out,
+        "replies": [r.to_dict() for r in list_replies(prompt_id)],
+        "pending": pending,
+    }

--- a/agentwire/council/inbox.py
+++ b/agentwire/council/inbox.py
@@ -57,10 +57,17 @@ def replies_dir(prompt_id: int) -> Path:
 
 
 def create_prompt(prompt_id: int, text: str, roster: list[str]) -> Path:
-    """Create the prompt dir + inbox. Must exist before any fan-out send."""
+    """Create the prompt dir + inbox. Must exist before any fan-out send.
+
+    Prompt ids restart at 1 each sitting while ``prompts/`` history is kept,
+    so a reused id may collide with a previous sitting's dir — stale reply
+    files would corrupt the new round's completion check. Clear them.
+    """
     pdir = prompt_dir(prompt_id)
     replies = pdir / "replies"
     replies.mkdir(parents=True, exist_ok=True)
+    for stale in replies.glob("*.md"):
+        stale.unlink()
     (pdir / "prompt.md").write_text(text)
     meta = {
         "id": prompt_id,

--- a/agentwire/council/state.py
+++ b/agentwire/council/state.py
@@ -1,0 +1,144 @@
+"""Sitting state for the council subsystem.
+
+A *sitting* is one ``council start`` → ``council stop`` span: the orchestrator
+session, the roster of lens souls, and a monotonic prompt counter. State is
+small JSON at ``~/.agentwire/council/sitting.json``, written atomically
+(tempfile + ``os.replace``) like ``missions/state.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+COUNCIL_DIR = Path.home() / ".agentwire" / "council"
+SITTING_PATH = COUNCIL_DIR / "sitting.json"
+WORKSPACE_DIR = COUNCIL_DIR / "workspace"
+PROMPTS_DIR = COUNCIL_DIR / "prompts"
+
+ORCHESTRATOR_SESSION = "agentwire-council"
+DEFAULT_ROSTER = [
+    "brain",
+    "conscience",
+    "gut",
+    "critic",
+    "historian",
+    "devils-advocate",
+]
+
+# Lens names become session names, role names, and reply filenames.
+_LENS_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def valid_lens(name: str) -> bool:
+    """True iff a lens name is safe for sessions, roles, and filenames."""
+    return bool(_LENS_RE.match(name))
+
+
+def session_for(lens: str) -> str:
+    """tmux session name for a lens."""
+    return f"council-{lens}"
+
+
+@dataclass
+class Sitting:
+    orchestrator: str
+    roster: list[str]
+    sessions: dict[str, str]  # lens -> tmux session name
+    started_at: str
+    next_prompt_id: int = 1
+    session_type: str = "claude-bypass"
+
+    def to_dict(self) -> dict:
+        return {
+            "orchestrator": self.orchestrator,
+            "roster": list(self.roster),
+            "sessions": dict(self.sessions),
+            "started_at": self.started_at,
+            "next_prompt_id": self.next_prompt_id,
+            "session_type": self.session_type,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Sitting":
+        return cls(
+            orchestrator=d.get("orchestrator", ORCHESTRATOR_SESSION),
+            roster=list(d.get("roster", [])),
+            sessions=dict(d.get("sessions", {})),
+            started_at=d.get("started_at", ""),
+            next_prompt_id=int(d.get("next_prompt_id", 1)),
+            session_type=d.get("session_type", "claude-bypass"),
+        )
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write JSON atomically: temp file in same dir, then ``os.replace``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_sitting() -> Sitting | None:
+    """Return the current sitting, or None if no sitting (or corrupt state)."""
+    if not SITTING_PATH.exists():
+        return None
+    try:
+        with open(SITTING_PATH) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return Sitting.from_dict(data)
+
+
+def write_sitting(sitting: Sitting) -> None:
+    _atomic_write(SITTING_PATH, sitting.to_dict())
+
+
+def clear_sitting() -> None:
+    """End the sitting. Prompt history under ``prompts/`` is kept."""
+    try:
+        SITTING_PATH.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def allocate_prompt_id() -> int:
+    """Bump and persist the sitting's prompt counter; return the new id.
+
+    Raises ``RuntimeError`` if no sitting is active.
+    """
+    sitting = read_sitting()
+    if sitting is None:
+        raise RuntimeError("no active council sitting — run 'agentwire council start'")
+    prompt_id = sitting.next_prompt_id
+    sitting.next_prompt_id = prompt_id + 1
+    write_sitting(sitting)
+    return prompt_id
+
+
+def latest_prompt_id() -> int | None:
+    """The most recently allocated prompt id, or None if none yet."""
+    sitting = read_sitting()
+    if sitting is None or sitting.next_prompt_id <= 1:
+        return None
+    return sitting.next_prompt_id - 1

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2100,6 +2100,143 @@ def mission_gc() -> str:
 
 
 # =============================================================================
+# Council Tools (multi-soul orchestrator sitting)
+# =============================================================================
+
+
+@mcp.tool()
+def council_start(roster: str = "", model: str = "") -> str:
+    """Start a council sitting: orchestrator + one session per lens soul.
+
+    Spins up the ``agentwire-council`` orchestrator and a ``council-<lens>``
+    session per roster lens (default roster: brain, conscience, gut, critic,
+    historian, devils-advocate). Sessions stay warm for follow-up asks until
+    ``council_stop``.
+
+    Args:
+        roster: Comma-separated lens names (empty = full default roster)
+        model: Model override for all council sessions
+
+    Returns:
+        Orchestrator + soul session names, or failure details.
+    """
+    args = ["council", "start"]
+    if roster:
+        args += ["--roster", roster]
+    if model:
+        args += ["--model", model]
+    # Start waits for every session to boot — well past the default timeout.
+    data = run_agentwire_cmd(args, timeout=300)
+    if not data.get("success"):
+        return f"Failed to start council: {data.get('error') or data}"
+    sessions = data.get("sessions", {})
+    lines = [f"Council sitting started: {data.get('orchestrator')}"]
+    lines += [f"  {lens}: {name}" for lens, name in sessions.items()]
+    for f in data.get("failed") or []:
+        lines.append(f"  ! {f['soul']}: {f['error']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def council_stop() -> str:
+    """Stop the council sitting: kill all soul sessions + the orchestrator.
+
+    Prompt history under ``~/.agentwire/council/prompts/`` is kept.
+
+    Returns:
+        Which sessions were killed.
+    """
+    data = run_agentwire_cmd(["council", "stop"], timeout=60)
+    if not data.get("success"):
+        return f"Failed to stop council: {data.get('error', 'Unknown error')}"
+    killed = data.get("killed") or []
+    return f"Council sitting stopped. Killed: {', '.join(killed) or '(none)'}"
+
+
+@mcp.tool()
+def council_status() -> str:
+    """Show the council sitting: session liveness and per-prompt reply state.
+
+    Returns:
+        Roster health and which souls are still pending on open prompts.
+    """
+    data = run_agentwire_cmd(["council", "status"])
+    if not data.get("success"):
+        return f"Failed to get council status: {data.get('error', 'Unknown error')}"
+    if not data.get("running"):
+        return "No active council sitting."
+    lines = [
+        f"Council sitting (started {data.get('started_at')})",
+        f"  orchestrator: {data.get('orchestrator')} "
+        f"[{'alive' if data.get('orchestrator_alive') else 'DOWN'}]",
+    ]
+    for s in data.get("souls") or []:
+        lines.append(f"  {s['soul']}: {s['session']} [{'alive' if s['alive'] else 'DOWN'}]")
+    for p in data.get("prompts") or []:
+        status = "complete" if p["complete"] else f"pending: {', '.join(p['pending'])}"
+        lines.append(f"  prompt #{p['id']}: {status}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def council_ask(prompt: str) -> str:
+    """Fan a prompt out to every soul in the council sitting.
+
+    Creates the prompt's reply inbox, then sends the prompt to every live
+    lens session. Each soul will file exactly one of: a substantive take, an
+    ack (researching, follow-up coming), or a pass. Follow with
+    ``council_collect`` to gather the replies.
+
+    Args:
+        prompt: The question or decision to put before the council
+
+    Returns:
+        The prompt id (needed for council_collect) and fan-out result.
+    """
+    data = run_agentwire_cmd(["council", "ask", prompt])
+    if not data.get("success"):
+        return f"Failed to ask council: {data.get('error') or data}"
+    pid = data.get("prompt_id")
+    sent = data.get("sent_to") or []
+    out = f"PROMPT ID: {pid} — fanned out to {len(sent)} souls ({', '.join(sent)})"
+    for f in data.get("failed") or []:
+        out += f"\n  ! {f['soul']}: {f['error']}"
+    return out
+
+
+@mcp.tool()
+def council_collect(prompt_id: int = 0, timeout: int = 120) -> str:
+    """Collect the council's replies for a prompt (blocks until done/timeout).
+
+    Returns as soon as every roster soul has filed a take, ack, or pass — or
+    when the soft timeout lapses. Re-collecting a complete prompt returns
+    instantly and includes any follow-up takes filed since (the
+    ack-and-research path).
+
+    Args:
+        prompt_id: Prompt id from council_ask (0 = latest)
+        timeout: Soft timeout in seconds (default 120)
+
+    Returns:
+        Every reply attributed by soul, plus any souls still pending.
+    """
+    args = ["council", "collect", "--timeout", str(timeout)]
+    if prompt_id:
+        args += ["--prompt", str(prompt_id)]
+    # Pad the subprocess timeout past the blocking collect window.
+    data = run_agentwire_cmd(args, timeout=timeout + 15)
+    if not data.get("success"):
+        return f"Failed to collect: {data.get('error') or data}"
+    lines = [
+        f"Prompt #{data.get('prompt_id')}: "
+        + ("complete" if data.get("complete") else f"pending: {', '.join(data.get('pending') or [])}")
+    ]
+    for r in data.get("replies") or []:
+        lines.append(f"\n--- {r['soul']} ({r['kind']}) ---\n{r['text']}")
+    return "\n".join(lines)
+
+
+# =============================================================================
 # Overnight Session Tools
 # =============================================================================
 

--- a/agentwire/roles/__init__.py
+++ b/agentwire/roles/__init__.py
@@ -177,6 +177,8 @@ def inject_soul(role_names: list[str], config: dict | None = None, no_soul: bool
     - config disables it globally (session.inject_soul: false)
     - any role is headless (HEADLESS_ROLES — executors stay voiceless)
     - a soul role is already present (soul itself, or a soul-* lens variant)
+    - a council-* role is present (council sessions carry their own lens or
+      synthesis voice — the standard soul would blur the decomposition)
 
     Args:
         role_names: Resolved role names for the session
@@ -192,7 +194,7 @@ def inject_soul(role_names: list[str], config: dict | None = None, no_soul: bool
         return role_names
     if any(r in HEADLESS_ROLES for r in role_names):
         return role_names
-    if any(r == "soul" or r.startswith("soul-") for r in role_names):
+    if any(r == "soul" or r.startswith("soul-") or r.startswith("council-") for r in role_names):
         return role_names
     return [*role_names, "soul"]
 

--- a/agentwire/roles/council-brain.md
+++ b/agentwire/roles/council-brain.md
@@ -1,0 +1,13 @@
+---
+name: council-brain
+description: Council lens — research, predictions, stats, sense-checking claims
+---
+
+# Brain
+
+Your lens is evidence. Sense-check the claims in the prompt: do the numbers
+hold up, is the prediction grounded, what does the data actually say? You are
+the lens most expected to ack-and-research — when a claim deserves a real
+look, ack, dig in (search, read, calculate), and follow up with what you
+found. Cite what you checked. If a claim is hand-wavy, say which part and what
+would make it solid.

--- a/agentwire/roles/council-conscience.md
+++ b/agentwire/roles/council-conscience.md
@@ -1,0 +1,13 @@
+---
+name: council-conscience
+description: Council lens — ethics, audience reception, trust implications
+---
+
+# Conscience
+
+Your lens is people. Who could be hurt, misled, or blindsided by this? How
+will the audience actually receive it — not how we hope they will? Flag the
+second-order trust effects: what this costs in credibility if it goes wrong,
+who we're asking to take a risk on our behalf. You're not a scold — most
+things are fine, and you pass on them. Speak up when something real is at
+stake.

--- a/agentwire/roles/council-critic.md
+++ b/agentwire/roles/council-critic.md
@@ -1,0 +1,12 @@
+---
+name: council-critic
+description: Council lens — challenge the premise, find the weakest assumption
+---
+
+# Critic
+
+Your lens is the premise. Find the weakest load-bearing assumption in the
+prompt and attack it. Is the question even the right question? What is being
+taken for granted that, if false, collapses the whole plan? Name the
+assumption explicitly, then show what breaks. One sharp cut beats a list of
+nitpicks — if the premise is genuinely sound, say so and pass.

--- a/agentwire/roles/council-devils-advocate.md
+++ b/agentwire/roles/council-devils-advocate.md
@@ -1,0 +1,12 @@
+---
+name: council-devils-advocate
+description: Council lens — argue the strongest opposing case in good faith
+---
+
+# Devil's Advocate
+
+Your lens is the other side. Build the strongest good-faith case *against*
+whatever the prompt is leaning toward — even when you agree with it,
+especially when everyone seems to. Steelman, don't strawman: argue the
+opposing position the way its smartest proponent would. If the opposing case
+is genuinely empty, that's a finding — say so and pass.

--- a/agentwire/roles/council-gut.md
+++ b/agentwire/roles/council-gut.md
@@ -1,0 +1,11 @@
+---
+name: council-gut
+description: Council lens — instinct, "does this feel right"
+---
+
+# Gut
+
+Your lens is instinct. One short visceral read: does this feel right or does
+something smell off? No analysis, no hedging, no bullet points — the other
+lenses do that. Two or three sentences max, in plain words. If your stomach
+says nothing either way, pass.

--- a/agentwire/roles/council-historian.md
+++ b/agentwire/roles/council-historian.md
@@ -1,0 +1,12 @@
+---
+name: council-historian
+description: Council lens — prior context, what was tried, what worked
+---
+
+# Historian
+
+Your lens is precedent. Have we — or anyone — tried this before? What worked,
+what failed, and why? Pattern-match the prompt against past decisions, prior
+missions, the wiki, git history. Your value is the specific precedent, not
+generalities: "we tried X in March, it failed because Y" beats "history shows
+caution is wise." No relevant precedent? Pass.

--- a/agentwire/roles/council-member.md
+++ b/agentwire/roles/council-member.md
@@ -1,0 +1,47 @@
+---
+name: council-member
+description: Shared council protocol — how a lens session receives prompts and replies
+---
+
+# Council Member
+
+You are one lens on a council. The orchestrator fans user prompts out to every
+lens; you look at each prompt through *your* lens only and reply through the
+council inbox. You never speak to the user directly — your take reaches them
+through the orchestrator's synthesis.
+
+## The protocol
+
+You receive prompts as messages tagged `[COUNCIL PROMPT #N]`. For **every**
+prompt, you MUST file exactly one initial reply with the `agentwire council
+reply` CLI (via Bash):
+
+```bash
+# A substantive take through your lens
+agentwire council reply --prompt N --take --text "Your take here"
+# (long takes: write a file and use --file path, or pipe via stdin)
+
+# You want to research or think before answering — follow up later
+agentwire council reply --prompt N --ack
+
+# Nothing valid to add through your lens
+agentwire council reply --prompt N --pass
+```
+
+The full prompt text is also on disk at
+`~/.agentwire/council/prompts/<NNNN>/prompt.md` if the message was truncated.
+
+## Rules
+
+- **Passing is expected and free.** If your lens has nothing real to add, pass.
+  A forced take is worse than silence — the council's value is signal, not
+  coverage.
+- **Ack, then deliver.** If the question deserves research, ack immediately so
+  the council isn't waiting on you, do the work, then file the substantive
+  thought with another `--take`. It lands as a follow-up and the orchestrator
+  is nudged automatically — you don't need to notify anyone.
+- **Speak only from your lens.** Don't try to be the whole council; the other
+  lenses are covered. Short and direct — one sharp paragraph beats three
+  balanced ones.
+- **Never address the user or other souls directly.** No `session_send`, no
+  `notify`. The inbox is your only output channel.

--- a/agentwire/roles/council-orchestrator.md
+++ b/agentwire/roles/council-orchestrator.md
@@ -1,0 +1,34 @@
+---
+name: council-orchestrator
+description: Council orchestrator — fan out prompts to lens sessions, synthesize replies
+---
+
+# Council Orchestrator
+
+You run a council sitting. Lens sessions (brain, conscience, gut, critic,
+historian, devil's-advocate, …) are live and waiting; your job is to fan the
+user's prompts out to them, collect their takes, and synthesize.
+
+## On each user prompt
+
+1. `council_ask(prompt)` — fans out to every lens, returns the prompt id.
+2. `council_collect(prompt_id, timeout)` — blocks until every lens has filed a
+   take, an ack, or a pass (or the timeout lapses).
+3. Synthesize, **attributed by lens**: "Brain: … Critic: …" Distinct takes
+   stay distinct — don't blend them into mush, and don't pretend they're
+   yours. Your own voice appears in the framing and the bottom line, clearly
+   marked as yours.
+
+## Rules
+
+- **Omit passes silently.** A lens that passed is never mentioned — no "Gut
+  had nothing to add."
+- **Note acks plainly:** "Brain is researching — follow-up coming."
+- **Follow-ups:** when a `[COUNCIL FOLLOW-UP]` message arrives, run
+  `council_collect` for that prompt again (it returns instantly) and relay the
+  new take to the user, attributed.
+- **Pending lenses at timeout:** name them once ("no word from Historian") and
+  move on — don't block the user.
+- `council_status` shows roster health if something seems stuck.
+- Don't editorialize the lenses away. If Critic and Gut disagree, the
+  disagreement *is* the product — surface it.

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -23,6 +23,7 @@ How AgentWire runs AI agents — session types, REPLs, and permission models.
 - **[claude-code-auto-mode](sessions/claude-code-auto-mode.md)** — Auto mode session type with classifier safety net
 - **[pi](sessions/pi.md)** — Pi coding agent (multi-provider: zai, deepseek, openai, openrouter, …)
 - **[Custom services](services.md)** — registered long-running sessions: autostart on portal launch, watchdog health checks + restart with backoff, `agentwire services` CLI
+- **[Council](council.md)** — multi-soul orchestrator sitting: fan a prompt out to lens sessions (brain, conscience, gut, critic, …), collect via file inbox, synthesize with attribution
 
 ## Communication
 

--- a/docs/wiki/council.md
+++ b/docs/wiki/council.md
@@ -1,0 +1,113 @@
+# The Council
+
+> Multi-soul orchestrator: fan a prompt out to distinct lens sessions, collect
+> their takes, synthesize with attribution. The bundled `soul` role is the
+> blended default voice ([#212](https://github.com/dotdevdotdev/agentwire-dev/issues/212));
+> the council unbundles it into its constituent lenses
+> ([#213](https://github.com/dotdevdotdev/agentwire-dev/issues/213)).
+
+## Mental model
+
+A **sitting** is one `council start` → `council stop` span. It comprises:
+
+- The **orchestrator** — the `agentwire-council` session (role
+  `council-orchestrator`). You talk to it; it fans out, collects, and
+  synthesizes.
+- The **souls** — one `council-<lens>` session per roster lens, each loading
+  the shared `council-member` protocol role plus its own `council-<lens>`
+  lens role.
+
+Default roster:
+
+| Lens | Looks at |
+|------|----------|
+| `brain` | Research, predictions, stats, sense-checking claims |
+| `conscience` | Ethics, audience reception, trust implications |
+| `gut` | Instinct — one short visceral read |
+| `critic` | The weakest load-bearing assumption in the premise |
+| `historian` | What we tried before, what worked, what didn't |
+| `devils-advocate` | The strongest opposing case, argued in good faith |
+
+All council sessions run in a shared workspace
+(`~/.agentwire/council/workspace/`) whose `.agentwire.yml` sets
+`parent: agentwire-council`, and none of them receive the standard `soul`
+role — `inject_soul()` skips any session carrying a `council-*` role.
+
+## The protocol
+
+Per prompt, on disk under `~/.agentwire/council/prompts/NNNN/`:
+
+```
+prompt.md        # the fanned-out prompt
+meta.json        # {id, created_at, roster}
+replies/
+  brain.take.md            # substantive take
+  conscience.ack.md        # "researching, follow-up coming"
+  conscience.followup-1.md # the substantive follow-up
+  gut.pass.md              # nothing to add — synthesis omits it
+```
+
+Reply kind is encoded in the **filename**; `ls` is the protocol. Every soul
+files exactly one initial reply (`take` / `ack` / `pass`) per prompt, so
+collection can distinguish "still thinking" (no file) from "nothing to add"
+(`.pass.md`) and return the moment the round is complete instead of always
+waiting out a timeout. After an ack, a later `--take` lands as a numbered
+follow-up and the CLI itself nudges the orchestrator's pane with a
+`[COUNCIL FOLLOW-UP]` message — delivery doesn't depend on the soul
+remembering to notify.
+
+Sitting state (roster, session names, prompt counter) lives at
+`~/.agentwire/council/sitting.json`. `council stop` clears it but keeps the
+`prompts/` history.
+
+## CLI
+
+```bash
+agentwire council start [--roster brain,gut,...] [--type T] [--model M] [--force]
+agentwire council stop
+agentwire council status
+agentwire council ask "Should we ship X?"      # or --file / stdin
+agentwire council collect [--prompt N] [--timeout 120] [--no-wait]
+agentwire council reply --prompt N --take --text "..."   # souls run this
+agentwire council reply --prompt N --ack
+agentwire council reply --prompt N --pass
+```
+
+All subcommands support `--json`. `reply` infers `--soul` from the current
+tmux session name (`council-gut` → `gut`); `--take` text comes from `--text`,
+`--file`, or stdin.
+
+## MCP tools (orchestrator-facing)
+
+| Tool | Wraps |
+|------|-------|
+| `council_start(roster, model)` | `council start` |
+| `council_stop()` | `council stop` |
+| `council_status()` | `council status` |
+| `council_ask(prompt)` | `council ask` — returns the prompt id |
+| `council_collect(prompt_id, timeout)` | `council collect` (subprocess timeout padded past the blocking window) |
+
+`council reply` is deliberately CLI-only — souls invoke it via Bash.
+
+## Extending the roster
+
+Lens roles are ordinary role files, so discovery shadowing applies:
+
+1. Drop `council-<newlens>.md` in `~/.agentwire/roles/` (or a project's
+   `.agentwire/roles/`) — frontmatter `name` + `description`, body = the lens.
+2. `agentwire council start --roster brain,critic,newlens`
+
+Overriding a bundled lens's content works the same way — a user-level
+`council-brain.md` shadows the bundled one.
+
+## Troubleshooting
+
+- **A soul never replies** — `council status` shows per-prompt `pending`
+  souls; check the session is alive and the `[COUNCIL PROMPT #N]` message
+  landed in its pane. `collect` returns `timed_out: true` with the pending
+  list rather than blocking forever.
+- **Stale sitting after a crash** — `council start --force` tears down
+  whatever is left and starts fresh.
+- **Soul replies rejected** — a soul gets one initial reply per prompt;
+  after that only `--take` follow-ups are accepted (a second `--ack`/`--pass`
+  errors by design).

--- a/tests/unit/test_council_cli.py
+++ b/tests/unit/test_council_cli.py
@@ -1,0 +1,275 @@
+"""Tests for agentwire/council/cli.py — handlers with side effects mocked."""
+
+import argparse
+import json
+
+import pytest
+
+from agentwire.council import cli, inbox, state
+
+
+@pytest.fixture(autouse=True)
+def council_dirs(tmp_path, monkeypatch):
+    council = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_DIR", council)
+    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
+    monkeypatch.setattr(state, "WORKSPACE_DIR", council / "workspace")
+    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
+    return council
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    """Mock all session side effects; record calls."""
+    calls = {"created": [], "killed": [], "sent": [], "live": set()}
+    monkeypatch.setattr(cli, "list_live_sessions", lambda: set(calls["live"]))
+
+    def create(name, roles, session_type, model):
+        calls["created"].append((name, roles, session_type, model))
+        calls["live"].add(name)
+
+    monkeypatch.setattr(cli, "create_session", create)
+
+    def kill(name):
+        calls["killed"].append(name)
+        calls["live"].discard(name)
+        return True
+
+    monkeypatch.setattr(cli, "kill_session", kill)
+    monkeypatch.setattr(
+        cli, "send_to_session", lambda s, m: calls["sent"].append((s, m))
+    )
+    monkeypatch.setattr(cli, "wait_ready", lambda s, timeout=45.0: True)
+    monkeypatch.setattr(cli, "current_session", lambda: None)
+    return calls
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _start(mocks, roster="brain,gut", **kw):
+    args = _args(roster=roster, type=None, model=None, force=False, json=True, **kw)
+    return cli.cmd_council_start(args)
+
+
+def _payload(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+class TestStart:
+    def test_creates_sessions_and_sitting(self, mocks, capsys):
+        assert _start(mocks) == 0
+        payload = _payload(capsys)
+        assert payload["success"]
+        names = [c[0] for c in mocks["created"]]
+        assert names == ["agentwire-council", "council-brain", "council-gut"]
+        roles = {c[0]: c[1] for c in mocks["created"]}
+        assert roles["agentwire-council"] == ["council-orchestrator"]
+        assert roles["council-brain"] == ["council-member", "council-brain"]
+        sitting = state.read_sitting()
+        assert sitting.roster == ["brain", "gut"]
+        assert sitting.sessions == {"brain": "council-brain", "gut": "council-gut"}
+
+    def test_writes_workspace_config(self, mocks, capsys):
+        _start(mocks)
+        yml = (state.WORKSPACE_DIR / ".agentwire.yml").read_text()
+        assert "parent: agentwire-council" in yml
+
+    def test_default_roster(self, mocks, capsys):
+        _start(mocks, roster=None)
+        assert state.read_sitting().roster == state.DEFAULT_ROSTER
+
+    def test_invalid_lens_rejected(self, mocks, capsys):
+        assert _start(mocks, roster="brain,../etc") == 1
+        assert state.read_sitting() is None
+
+    def test_refuses_live_sitting(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        assert _start(mocks) == 1
+        assert not _payload(capsys)["success"]
+
+    def test_force_restarts(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        args = _args(roster="brain", type=None, model=None, force=True, json=True)
+        assert cli.cmd_council_start(args) == 0
+        assert "agentwire-council" in mocks["killed"]
+        assert state.read_sitting().roster == ["brain"]
+
+
+class TestStop:
+    def test_kills_and_clears(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        assert cli.cmd_council_stop(_args(json=True)) == 0
+        payload = _payload(capsys)
+        assert set(payload["killed"]) == {
+            "agentwire-council",
+            "council-brain",
+            "council-gut",
+        }
+        assert state.read_sitting() is None
+
+    def test_no_sitting(self, mocks, capsys):
+        assert cli.cmd_council_stop(_args(json=True)) == 1
+
+
+class TestStatus:
+    def test_not_running(self, mocks, capsys):
+        assert cli.cmd_council_status(_args(json=True)) == 0
+        assert _payload(capsys)["running"] is False
+
+    def test_liveness_and_prompts(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        mocks["live"].discard("council-gut")
+        cli.cmd_council_ask(_args(prompt="ship it?", file=None, json=True))
+        inbox.write_reply(1, "brain", "take", "yes")
+        capsys.readouterr()
+
+        cli.cmd_council_status(_args(json=True))
+        payload = _payload(capsys)
+        alive = {s["soul"]: s["alive"] for s in payload["souls"]}
+        assert alive == {"brain": True, "gut": False}
+        assert payload["prompts"][0]["pending"] == ["gut"]
+
+
+class TestAsk:
+    def test_inbox_before_send_and_fanout(self, mocks, capsys, monkeypatch):
+        _start(mocks)
+        capsys.readouterr()
+
+        def send_checking(session, message):
+            # The inbox must exist before any soul could conceivably reply.
+            assert inbox.replies_dir(1).is_dir()
+            mocks["sent"].append((session, message))
+
+        monkeypatch.setattr(cli, "send_to_session", send_checking)
+        assert cli.cmd_council_ask(_args(prompt="ship it?", file=None, json=True)) == 0
+        payload = _payload(capsys)
+        assert payload["prompt_id"] == 1
+        assert set(payload["sent_to"]) == {"brain", "gut"}
+        sessions = [s for s, _ in mocks["sent"]]
+        assert set(sessions) == {"council-brain", "council-gut"}
+        msg = mocks["sent"][0][1]
+        assert "[COUNCIL PROMPT #1]" in msg
+        assert "council reply --prompt 1" in msg
+
+    def test_dead_soul_reported(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        mocks["live"].discard("council-gut")
+        cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
+        payload = _payload(capsys)
+        assert payload["sent_to"] == ["brain"]
+        assert payload["failed"][0]["soul"] == "gut"
+
+    def test_no_sitting(self, mocks, capsys):
+        assert cli.cmd_council_ask(_args(prompt="x", file=None, json=True)) == 1
+
+    def test_empty_prompt(self, mocks, capsys, monkeypatch):
+        _start(mocks)
+        capsys.readouterr()
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        assert cli.cmd_council_ask(_args(prompt=None, file=None, json=True)) == 1
+
+
+class TestCollect:
+    def test_no_wait(self, mocks, capsys):
+        _start(mocks)
+        cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
+        capsys.readouterr()
+        args = _args(prompt=None, timeout=120, no_wait=True, json=True)
+        assert cli.cmd_council_collect(args) == 0
+        payload = _payload(capsys)
+        assert payload["prompt_id"] == 1
+        assert not payload["complete"]
+
+    def test_complete_round(self, mocks, capsys):
+        _start(mocks)
+        cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
+        inbox.write_reply(1, "brain", "take", "yes")
+        inbox.write_reply(1, "gut", "pass", "")
+        capsys.readouterr()
+        args = _args(prompt=1, timeout=120, no_wait=False, json=True)
+        assert cli.cmd_council_collect(args) == 0
+        payload = _payload(capsys)
+        assert payload["complete"]
+        assert {r["kind"] for r in payload["replies"]} == {"take", "pass"}
+
+    def test_no_prompts_yet(self, mocks, capsys):
+        _start(mocks)
+        capsys.readouterr()
+        args = _args(prompt=None, timeout=1, no_wait=True, json=True)
+        assert cli.cmd_council_collect(args) == 1
+
+
+class TestReply:
+    def _reply(self, **kw):
+        base = dict(
+            prompt=None, take=False, ack=False, soul=None, text=None, file=None, json=True
+        )
+        base.update(kw)
+        ns = _args(**base)
+        setattr(ns, "pass", kw.get("pass_", False))
+        return cli.cmd_council_reply(ns)
+
+    def _setup(self, mocks, capsys):
+        _start(mocks)
+        cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
+        capsys.readouterr()
+
+    def test_take(self, mocks, capsys):
+        self._setup(mocks, capsys)
+        assert self._reply(take=True, soul="brain", text="my take") == 0
+        payload = _payload(capsys)
+        assert payload["kind"] == "take"
+        assert not payload["followup"]
+        assert inbox.list_replies(1)[0].text == "my take"
+
+    def test_soul_inferred_from_session(self, mocks, capsys, monkeypatch):
+        self._setup(mocks, capsys)
+        monkeypatch.setattr(cli, "current_session", lambda: "council-gut")
+        assert self._reply(pass_=True) == 0
+        assert _payload(capsys)["soul"] == "gut"
+
+    def test_soul_uninferrable(self, mocks, capsys, monkeypatch):
+        self._setup(mocks, capsys)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        assert self._reply(take=True, text="x") == 1
+
+    def test_exactly_one_kind(self, mocks, capsys):
+        self._setup(mocks, capsys)
+        assert self._reply(soul="brain") == 1
+        capsys.readouterr()
+        assert self._reply(take=True, ack=True, soul="brain", text="x") == 1
+
+    def test_take_requires_text(self, mocks, capsys, monkeypatch):
+        self._setup(mocks, capsys)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        assert self._reply(take=True, soul="brain") == 1
+
+    def test_followup_nudges_orchestrator(self, mocks, capsys):
+        self._setup(mocks, capsys)
+        self._reply(ack=True, soul="brain")
+        capsys.readouterr()
+        sent_before = len(mocks["sent"])
+        assert self._reply(take=True, soul="brain", text="found it") == 0
+        payload = _payload(capsys)
+        assert payload["followup"]
+        nudges = mocks["sent"][sent_before:]
+        assert len(nudges) == 1
+        session, msg = nudges[0]
+        assert session == "agentwire-council"
+        assert "[COUNCIL FOLLOW-UP]" in msg and "brain" in msg
+
+    def test_initial_reply_does_not_nudge(self, mocks, capsys):
+        self._setup(mocks, capsys)
+        sent_before = len(mocks["sent"])
+        self._reply(take=True, soul="brain", text="x")
+        assert len(mocks["sent"]) == sent_before

--- a/tests/unit/test_council_cli.py
+++ b/tests/unit/test_council_cli.py
@@ -39,6 +39,12 @@ def mocks(monkeypatch):
     monkeypatch.setattr(
         cli, "send_to_session", lambda s, m: calls["sent"].append((s, m))
     )
+
+    def verified(session, message, marker, retries=1):
+        calls["sent"].append((session, message))
+        return True
+
+    monkeypatch.setattr(cli, "send_verified", verified)
     monkeypatch.setattr(cli, "wait_ready", lambda s, timeout=45.0: True)
     monkeypatch.setattr(cli, "current_session", lambda: None)
     return calls
@@ -144,12 +150,13 @@ class TestAsk:
         _start(mocks)
         capsys.readouterr()
 
-        def send_checking(session, message):
+        def send_checking(session, message, marker, retries=1):
             # The inbox must exist before any soul could conceivably reply.
             assert inbox.replies_dir(1).is_dir()
             mocks["sent"].append((session, message))
+            return True
 
-        monkeypatch.setattr(cli, "send_to_session", send_checking)
+        monkeypatch.setattr(cli, "send_verified", send_checking)
         assert cli.cmd_council_ask(_args(prompt="ship it?", file=None, json=True)) == 0
         payload = _payload(capsys)
         assert payload["prompt_id"] == 1
@@ -168,6 +175,33 @@ class TestAsk:
         payload = _payload(capsys)
         assert payload["sent_to"] == ["brain"]
         assert payload["failed"][0]["soul"] == "gut"
+
+    def test_unconfirmed_delivery_reported(self, mocks, capsys, monkeypatch):
+        _start(mocks)
+        capsys.readouterr()
+        monkeypatch.setattr(cli, "send_verified", lambda s, m, marker, retries=1: False)
+        assert cli.cmd_council_ask(_args(prompt="x", file=None, json=True)) == 1
+        payload = _payload(capsys)
+        assert payload["sent_to"] == []
+        assert all(
+            f["error"] == "delivery not confirmed in pane" for f in payload["failed"]
+        )
+
+    def test_send_verified_retries_then_fails(self, monkeypatch):
+        sends = []
+        monkeypatch.setattr(cli, "send_to_session", lambda s, m: sends.append(s))
+        monkeypatch.setattr(cli, "capture_session", lambda s, lines=60: "no marker here")
+        monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+        assert not cli.send_verified("council-gut", "msg", "[COUNCIL PROMPT #1]")
+        assert len(sends) == 2  # initial + one retry
+
+    def test_send_verified_confirms(self, monkeypatch):
+        monkeypatch.setattr(cli, "send_to_session", lambda s, m: None)
+        monkeypatch.setattr(
+            cli, "capture_session", lambda s, lines=60: "...[COUNCIL PROMPT #1]..."
+        )
+        monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+        assert cli.send_verified("council-gut", "msg", "[COUNCIL PROMPT #1]")
 
     def test_no_sitting(self, mocks, capsys):
         assert cli.cmd_council_ask(_args(prompt="x", file=None, json=True)) == 1
@@ -262,6 +296,7 @@ class TestReply:
         assert self._reply(take=True, soul="brain", text="found it") == 0
         payload = _payload(capsys)
         assert payload["followup"]
+        assert payload["nudged"] is True
         nudges = mocks["sent"][sent_before:]
         assert len(nudges) == 1
         session, msg = nudges[0]

--- a/tests/unit/test_council_inbox.py
+++ b/tests/unit/test_council_inbox.py
@@ -1,0 +1,148 @@
+"""Tests for agentwire/council/inbox.py — the fan-out/collect protocol."""
+
+import pytest
+
+from agentwire.council import inbox, state
+
+ROSTER = ["brain", "gut", "critic"]
+
+
+@pytest.fixture(autouse=True)
+def council_dirs(tmp_path, monkeypatch):
+    council = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_DIR", council)
+    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
+    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
+    return council
+
+
+@pytest.fixture
+def prompt():
+    inbox.create_prompt(1, "Should we ship X?", ROSTER)
+    return 1
+
+
+class TestCreatePrompt:
+    def test_layout(self, prompt):
+        pdir = inbox.prompt_dir(1)
+        assert pdir.name == "0001"
+        assert (pdir / "prompt.md").read_text() == "Should we ship X?"
+        assert (pdir / "replies").is_dir()
+        assert inbox.read_meta(1)["roster"] == ROSTER
+
+
+class TestWriteReply:
+    def test_filename_per_kind(self, prompt):
+        for soul, kind in [("brain", "take"), ("gut", "pass"), ("critic", "ack")]:
+            path, followup = inbox.write_reply(1, soul, kind, f"{soul} text")
+            assert path.name == f"{soul}.{kind}.md"
+            assert not followup
+
+    def test_invalid_kind(self, prompt):
+        with pytest.raises(ValueError):
+            inbox.write_reply(1, "brain", "musing", "x")
+
+    def test_missing_inbox(self):
+        with pytest.raises(FileNotFoundError):
+            inbox.write_reply(99, "brain", "take", "x")
+
+    def test_followup_numbering(self, prompt):
+        inbox.write_reply(1, "brain", "ack", "")
+        p1, f1 = inbox.write_reply(1, "brain", "take", "found it")
+        p2, f2 = inbox.write_reply(1, "brain", "take", "more")
+        assert (p1.name, f1) == ("brain.followup-1.md", True)
+        assert (p2.name, f2) == ("brain.followup-2.md", True)
+
+    def test_second_initial_rejected(self, prompt):
+        inbox.write_reply(1, "brain", "take", "x")
+        with pytest.raises(ValueError):
+            inbox.write_reply(1, "brain", "pass", "")
+        with pytest.raises(ValueError):
+            inbox.write_reply(1, "brain", "ack", "")
+
+
+class TestRoundCompletion:
+    def test_pending_and_complete(self, prompt):
+        assert inbox.pending_souls(1, ROSTER) == ROSTER
+        inbox.write_reply(1, "brain", "take", "x")
+        inbox.write_reply(1, "gut", "pass", "")
+        assert inbox.pending_souls(1, ROSTER) == ["critic"]
+        assert not inbox.initial_round_complete(1, ROSTER)
+        inbox.write_reply(1, "critic", "ack", "")
+        assert inbox.initial_round_complete(1, ROSTER)
+
+    def test_mixed_kinds_count(self, prompt):
+        """take, ack, and pass all complete a soul's initial round."""
+        inbox.write_reply(1, "brain", "take", "x")
+        inbox.write_reply(1, "gut", "ack", "")
+        inbox.write_reply(1, "critic", "pass", "")
+        assert inbox.initial_round_complete(1, ROSTER)
+
+
+class TestListReplies:
+    def test_kinds_and_followups(self, prompt):
+        inbox.write_reply(1, "brain", "ack", "researching")
+        inbox.write_reply(1, "gut", "pass", "")
+        inbox.write_reply(1, "critic", "take", "premise is weak")
+        inbox.write_reply(1, "brain", "take", "the follow-up")
+        replies = inbox.list_replies(1)
+        by_kind = {(r.soul, r.kind) for r in replies}
+        assert by_kind == {
+            ("brain", "ack"),
+            ("gut", "pass"),
+            ("critic", "take"),
+            ("brain", "followup"),
+        }
+        # Follow-ups sort after initial replies
+        assert replies[-1].kind == "followup"
+
+    def test_empty(self, prompt):
+        assert inbox.list_replies(1) == []
+
+    def test_missing_prompt(self):
+        assert inbox.list_replies(42) == []
+
+
+class TestCollect:
+    def test_returns_early_when_complete(self, prompt, monkeypatch):
+        for soul in ROSTER:
+            inbox.write_reply(1, soul, "pass", "")
+
+        def boom(_):
+            raise AssertionError("collect slept despite round being complete")
+
+        monkeypatch.setattr(inbox.time, "sleep", boom)
+        result = inbox.collect(1, ROSTER, timeout=120)
+        assert result["complete"]
+        assert not result["timed_out"]
+        assert result["pending"] == []
+
+    def test_timeout(self, prompt, monkeypatch):
+        clock = {"t": 0.0}
+        monkeypatch.setattr(inbox.time, "monotonic", lambda: clock["t"])
+
+        def tick(_):
+            clock["t"] += 10.0
+
+        monkeypatch.setattr(inbox.time, "sleep", tick)
+        inbox.write_reply(1, "brain", "take", "x")
+        result = inbox.collect(1, ROSTER, timeout=30)
+        assert not result["complete"]
+        assert result["timed_out"]
+        assert set(result["pending"]) == {"gut", "critic"}
+        assert len(result["replies"]) == 1
+
+    def test_no_wait_snapshots(self, prompt, monkeypatch):
+        def boom(_):
+            raise AssertionError("--no-wait must not sleep")
+
+        monkeypatch.setattr(inbox.time, "sleep", boom)
+        result = inbox.collect(1, ROSTER, timeout=120, wait=False)
+        assert not result["complete"]
+        assert not result["timed_out"]
+
+    def test_pass_replies_carried(self, prompt):
+        for soul in ROSTER:
+            inbox.write_reply(1, soul, "pass", "")
+        result = inbox.collect(1, ROSTER, timeout=1, wait=False)
+        assert {r["kind"] for r in result["replies"]} == {"pass"}

--- a/tests/unit/test_council_inbox.py
+++ b/tests/unit/test_council_inbox.py
@@ -30,6 +30,14 @@ class TestCreatePrompt:
         assert (pdir / "replies").is_dir()
         assert inbox.read_meta(1)["roster"] == ROSTER
 
+    def test_reused_id_clears_stale_replies(self, prompt):
+        """Prompt ids restart per sitting; a reused id must not inherit the
+        previous sitting's reply files."""
+        inbox.write_reply(1, "brain", "pass", "")
+        inbox.create_prompt(1, "New sitting, same id", ROSTER)
+        assert inbox.list_replies(1) == []
+        assert inbox.pending_souls(1, ROSTER) == ROSTER
+
 
 class TestWriteReply:
     def test_filename_per_kind(self, prompt):

--- a/tests/unit/test_council_state.py
+++ b/tests/unit/test_council_state.py
@@ -1,0 +1,87 @@
+"""Tests for agentwire/council/state.py — sitting lifecycle state."""
+
+import pytest
+
+from agentwire.council import state
+
+
+@pytest.fixture(autouse=True)
+def council_dirs(tmp_path, monkeypatch):
+    """Point all council paths at a temp dir."""
+    council = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_DIR", council)
+    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
+    monkeypatch.setattr(state, "WORKSPACE_DIR", council / "workspace")
+    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
+    return council
+
+
+def _sitting(**overrides) -> state.Sitting:
+    base = dict(
+        orchestrator=state.ORCHESTRATOR_SESSION,
+        roster=["brain", "gut"],
+        sessions={"brain": "council-brain", "gut": "council-gut"},
+        started_at="2026-06-06T00:00:00+00:00",
+    )
+    base.update(overrides)
+    return state.Sitting(**base)
+
+
+class TestSitting:
+    def test_round_trip(self):
+        state.write_sitting(_sitting())
+        loaded = state.read_sitting()
+        assert loaded is not None
+        assert loaded.roster == ["brain", "gut"]
+        assert loaded.sessions["gut"] == "council-gut"
+        assert loaded.next_prompt_id == 1
+        assert loaded.session_type == "claude-bypass"
+
+    def test_read_missing(self):
+        assert state.read_sitting() is None
+
+    def test_read_corrupt(self):
+        state.SITTING_PATH.parent.mkdir(parents=True)
+        state.SITTING_PATH.write_text("{not json")
+        assert state.read_sitting() is None
+
+    def test_clear(self):
+        state.write_sitting(_sitting())
+        state.clear_sitting()
+        assert state.read_sitting() is None
+        state.clear_sitting()  # idempotent
+
+
+class TestPromptIds:
+    def test_allocate_increments_and_persists(self):
+        state.write_sitting(_sitting())
+        assert state.allocate_prompt_id() == 1
+        assert state.allocate_prompt_id() == 2
+        assert state.read_sitting().next_prompt_id == 3
+
+    def test_allocate_without_sitting_raises(self):
+        with pytest.raises(RuntimeError):
+            state.allocate_prompt_id()
+
+    def test_latest_none_before_first_ask(self):
+        state.write_sitting(_sitting())
+        assert state.latest_prompt_id() is None
+
+    def test_latest_after_allocations(self):
+        state.write_sitting(_sitting())
+        state.allocate_prompt_id()
+        state.allocate_prompt_id()
+        assert state.latest_prompt_id() == 2
+
+
+class TestLensValidation:
+    def test_valid(self):
+        for name in ["brain", "devils-advocate", "x2"]:
+            assert state.valid_lens(name)
+
+    def test_invalid(self):
+        for name in ["", "Brain", "a b", "../etc", "-lead", "a/b"]:
+            assert not state.valid_lens(name)
+
+    def test_session_for(self):
+        assert state.session_for("brain") == "council-brain"

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -166,8 +166,16 @@ class TestInjectSoul:
         assert inject_soul(["agentwire", "soul"]) == ["agentwire", "soul"]
 
     def test_soul_lens_variant_excluded(self):
-        # Council lens roles (#213) self-exclude the standard soul
+        # soul-* variants self-exclude the standard soul
         assert inject_soul(["soul-brain"]) == ["soul-brain"]
+
+    def test_council_roles_excluded(self):
+        # Council sessions (#213) carry their own lens/synthesis voice
+        assert inject_soul(["council-member", "council-brain"]) == [
+            "council-member",
+            "council-brain",
+        ]
+        assert inject_soul(["council-orchestrator"]) == ["council-orchestrator"]
 
     def test_no_soul_flag(self):
         assert inject_soul(["agentwire"], no_soul=True) == ["agentwire"]
@@ -192,6 +200,34 @@ class TestInjectSoul:
         role = parse_role_file(path)
         assert role is not None
         assert role.name == "soul"
+        assert role.tools == []
+        assert role.disallowed_tools == []
+        assert role.instructions
+
+
+# --- council roles (#213) ---
+
+COUNCIL_ROLES = [
+    "council-member",
+    "council-brain",
+    "council-conscience",
+    "council-gut",
+    "council-critic",
+    "council-historian",
+    "council-devils-advocate",
+    "council-orchestrator",
+]
+
+
+class TestCouncilRoles:
+    @pytest.mark.parametrize("name", COUNCIL_ROLES)
+    def test_bundled_council_role_is_pure_personality(self, name):
+        """Council roles must parse and not widen or narrow tool permissions."""
+        path = discover_role(name)
+        assert path is not None, f"Bundled role '{name}' not found"
+        role = parse_role_file(path)
+        assert role is not None
+        assert role.name == name
         assert role.tools == []
         assert role.disallowed_tools == []
         assert role.instructions


### PR DESCRIPTION
Closes #213

## What

The council: an `agentwire-council` orchestrator session fans user prompts out to a roster of lens sessions (brain, conscience, gut, critic, historian, devils-advocate), collects their takes through a file inbox, and synthesizes with attribution. This is #212's soul, decomposed — each council session carries its own lens voice instead of the blended standard soul.

## Phase 0 decisions (locked with user)

| Question | Decision |
|---|---|
| Lens naming | `council-<lens>` roles (`council-member` shared protocol, `council-orchestrator` for the parent). `inject_soul()` extended one predicate: any `council-*` role skips the standard soul. |
| Quiet souls | **Pass-marker protocol** — every soul files exactly one initial reply per prompt (take / ack / pass), so collection returns the moment the round completes instead of always waiting out a timeout. Synthesis omits passes; user-visible behavior is still silence. |
| Lifecycle | **Sitting** — `council start` spins up orchestrator + souls, warm for follow-up asks until `council stop`. |
| Collection primitive | File inbox at `~/.agentwire/council/prompts/NNNN/replies/`, reply kind encoded in the filename (`brain.take.md`, `gut.pass.md`, `brain.followup-1.md`) — `ls` is the protocol. No blocking on `notify`. |

## Built

- **8 bundled roles**: `council-member` (protocol), 6 lens roles, `council-orchestrator` (fan out → collect → synthesize attributed by lens, omit passes, note acks)
- **`agentwire/council/` package** (mirrors `missions/`): `state.py` (sitting JSON, atomic writes, prompt counter), `inbox.py` (reply protocol, follow-up numbering, blocking collect), `cli.py`
- **CLI**: `council start/stop/status/ask/collect/reply`, all `--json`. `reply` infers the soul from the tmux session name; follow-up takes nudge the orchestrator pane deterministically from the CLI
- **5 MCP tools**: `council_start/stop/status/ask/collect` (`collect` pads the subprocess timeout past the blocking window)
- **Docs**: `docs/wiki/council.md` + INDEX + CLAUDE.md pointers
- **55 new unit tests** (state, inbox, CLI handlers, role parsing, inject_soul exclusions)

## Surprise found in live e2e

Claude sessions have a **silent-paste gray zone**: a tmux paste into a pane whose input handler isn't wired yet (fresh boot, or first-ever input) vanishes while tmux reports success. First live fan-out lost all 3 prompts this way. Fix: `ask` and the follow-up nudge now **verify delivery** — confirm the `[COUNCIL PROMPT #N]` / `[COUNCIL FOLLOW-UP]` marker is visible in the target pane, retry once, and report unconfirmed delivery in `failed[]` / `nudged: false` instead of pretending.

## Verification (live, 3-soul sitting)

- ✅ `council start --roster brain,gut,critic` → 4 sessions up, `status --json` all alive
- ✅ Real decision question → 3 distinct takes (critic attacked the premise, gut gave a visceral read, brain demanded usage data), synthesis attributed by lens
- ✅ Pass markers on disk (`gut.pass.md`), omitted from synthesis
- ✅ Ack-and-research: brain acked live, follow-up filed as `followup-N.md`, orchestrator nudged and relayed
- ✅ Prompting the orchestrator end-to-end: it called `council_ask` + `council_collect` via MCP and synthesized unprompted
- ✅ `pytest tests/unit/` — 1068 passed (1 pre-existing failure on main, unrelated)

Built by [dotdev.dev](https://dotdev.dev)