### PR TITLE
fix(gtm): Phase 0 funnel repair — broken assets, portal bind default, unified positioning

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -32,7 +32,7 @@ These scripts are **not** managed by agentwire — they're local to each machine
 
 ```yaml
 server:
-  host: "0.0.0.0"
+  host: "127.0.0.1"  # default; set "0.0.0.0" to allow LAN/phone access — portal has NO auth (see SECURITY.md)
   port: 8765
   activity_threshold_seconds: 3  # Seconds before session considered idle
   ssl:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://pypi.org/project/agentwire-dev/"><img src="https://img.shields.io/pypi/v/agentwire-dev?color=green" alt="PyPI"></a>
   <a href="https://pypi.org/project/agentwire-dev/"><img src="https://img.shields.io/pypi/pyversions/agentwire-dev" alt="Python"></a>
   <a href="https://github.com/dotdevdotdev/agentwire-dev/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dotdevdotdev/agentwire-dev" alt="License"></a>
-  <a href="https://discord.gg/bspFZNTdUr"><img src="https://img.shields.io/discord/1234567890?color=5865F2&label=discord" alt="Discord"></a>
+  <a href="https://discord.gg/bspFZNTdUr"><img src="https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 ---
@@ -28,10 +28,6 @@ Old way: Get up. Walk to computer. Type.
 ## What It Does
 
 Push-to-talk voice control for [Claude Code](https://github.com/anthropics/claude-code) or any AI coding assistant running in tmux.
-
-<p align="center">
-  <img src="https://agentwire.dev/images/demo.gif" alt="Demo" width="600">
-</p>
 
 ```
 Phone → AgentWire Portal → tmux session → Claude Code
@@ -62,6 +58,10 @@ agentwire portal start
 ```
 
 **Requirements:** Python 3.10+, tmux, ffmpeg, Claude Code
+
+**Honest setup time:** ~15 minutes for the full experience (certs, tmux config, voice). Text-only portal works immediately; TTS needs a GPU or RunPod account.
+
+> **Network & trust model.** The portal binds `127.0.0.1` by default — local only. To use it from your phone, set `server.host: 0.0.0.0` in `~/.agentwire/config.yaml` and understand what that means: **anyone who can reach the port can drive your sessions** (there is no auth yet). Use it on a trusted LAN only. Never port-forward it or run it on a public-facing VPS. Details in [SECURITY.md](SECURITY.md).
 
 <details>
 <summary><strong>Platform-specific instructions</strong></summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,9 @@ See `docs/wiki/internals/damage-control.md` for details.
 
 ## Trust Model
 
-The portal (HTTPS server bound to `0.0.0.0:8765` by default) **has no built-in authentication or authorization on its API endpoints**. This is by design — agentwire is built for a local-network trust perimeter, typically running on the same machine as the operator's browser or behind a Cloudflare Tunnel + Zero Trust gate (see `docs/wiki/deployment/remote-access.md`).
+The portal **has no built-in authentication or authorization on its API endpoints**. This is by design — agentwire is built for a local-network trust perimeter, typically running on the same machine as the operator's browser or behind a Cloudflare Tunnel + Zero Trust gate (see `docs/wiki/deployment/remote-access.md`).
+
+The portal binds `127.0.0.1:8765` by default — local only. Phone/tablet access requires explicitly opting into LAN exposure with `server.host: 0.0.0.0` in `~/.agentwire/config.yaml`; everything below applies the moment you do.
 
 What this means in practice:
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -53,7 +53,10 @@ class SSLConfig:
 class ServerConfig:
     """WebSocket server configuration."""
 
-    host: str = "0.0.0.0"
+    # Local-only by default. The portal has no auth — binding 0.0.0.0 hands
+    # session control to anyone who can reach the port. Opt into LAN exposure
+    # explicitly via `server.host: 0.0.0.0` in config (see SECURITY.md).
+    host: str = "127.0.0.1"
     port: int = 8765
     ssl: SSLConfig = field(default_factory=SSLConfig)
     activity_threshold_seconds: float = 3.0  # Time in seconds before session is considered idle
@@ -425,7 +428,7 @@ def _dict_to_config(data: dict) -> Config:
         key=ssl_data.get("key"),
     )
     server = ServerConfig(
-        host=server_data.get("host", "0.0.0.0"),
+        host=server_data.get("host", "127.0.0.1"),
         port=server_data.get("port", 8765),
         ssl=ssl,
         activity_threshold_seconds=server_data.get("activity_threshold_seconds", 3.0),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -103,7 +103,8 @@ class TestLoadConfig:
         config = load_config(tmp_path / "nonexistent.yaml")
         assert isinstance(config, Config)
         assert config.server.port == 8765
-        assert config.server.host == "0.0.0.0"
+        # Local-only by default — the portal has no auth (see SECURITY.md)
+        assert config.server.host == "127.0.0.1"
 
     def test_from_yaml(self, config_file):
         config = load_config(config_file)


### PR DESCRIPTION
Phase 0 of #245 (agentwire-dev items; website items delegated to the agentwire-website session).

## Changes

- **README**: removed the 404'd `demo.gif` (the real video is Phase 1 — a broken hero is worse than none); Discord badge placeholder server ID `1234567890` → static badge with the real invite; honest **~15-minute setup** expectation added; **network & trust model** note in the quickstart.
- **Portal binds `127.0.0.1` by default** — the council's hard blocker. Phone/LAN access is now an explicit `server.host: 0.0.0.0` opt-in, documented at the decision point (the portal has no auth). SECURITY.md trust model updated to match. Existing configs with an explicit `host` are unaffected. TTS/STT binds unchanged (LAN services by design, out of SECURITY.md scope).
- **One-liner unified**: GitHub repo description now leads with the README's "Talk to your AI coding agents. From anywhere." (set via `gh repo edit`).

## Verification

- `pytest tests/unit/` — 1068 passed (1 pre-existing failure on main, unrelated)
- Fresh-default check: `load_config()` with no file → `server.host == "127.0.0.1"` (test updated with rationale comment)
- Explicit-config check: `~/.agentwire/config.yaml` with `host: 0.0.0.0` still wins (existing fixtures cover this)

Not closing #245 — Phases 1–4 (demo video, friction collapse, spikes, weekly review) remain.

Built by [dotdev.dev](https://dotdev.dev)