### PR TITLE
feat(portal): security hardening — origin checks + token auth (#247)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -45,6 +45,8 @@ agentwire portal start          # start in tmux
 agentwire portal stop           # stop portal
 agentwire portal restart        # stop + start
 agentwire portal status         # check health
+agentwire portal token          # print the auth token (devices enter it once)
+agentwire portal token --rotate # generate a new token (re-enter on devices)
 
 # Scratch pad (shared notes — portal drawer Alt+N; file: ~/.agentwire/scratchpad.json)
 agentwire scratchpad list       # list notes (newest first)

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -32,12 +32,21 @@ These scripts are **not** managed by agentwire — they're local to each machine
 
 ```yaml
 server:
-  host: "127.0.0.1"  # default; set "0.0.0.0" to allow LAN/phone access — portal has NO auth (see SECURITY.md)
+  host: "127.0.0.1"  # default; "0.0.0.0" allows LAN/phone access and requires the auth token (see SECURITY.md)
   port: 8765
   activity_threshold_seconds: 3  # Seconds before session considered idle
   ssl:
     cert: "~/.agentwire/cert.pem"
     key: "~/.agentwire/key.pem"
+  # Auth token: unset = use ~/.agentwire/portal.token (auto-generated on first
+  # non-loopback start; print/rotate with `agentwire portal token [--rotate]`).
+  # Set a string to override the file; "" disables auth (loopback binds only —
+  # the portal refuses to start on 0.0.0.0 with auth disabled).
+  # auth_token: ""
+  # Extra browser origins allowed on state-changing requests (exact
+  # scheme://host[:port]). The portal's own origin and localhost always pass.
+  # Needed when fronting with Cloudflare Tunnel:
+  allowed_origins: []  # e.g. ["https://portal.example.com"]
 
 projects:
   dir: "~/projects"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ agentwire portal start
 
 **Honest setup time:** ~15 minutes for the full experience (certs, tmux config, voice). Text-only portal works immediately; TTS needs a GPU or RunPod account.
 
-> **Network & trust model.** The portal binds `127.0.0.1` by default — local only. To use it from your phone, set `server.host: 0.0.0.0` in `~/.agentwire/config.yaml` and understand what that means: **anyone who can reach the port can drive your sessions** (there is no auth yet). Use it on a trusted LAN only. Never port-forward it or run it on a public-facing VPS. Details in [SECURITY.md](SECURITY.md).
+> **Network & trust model.** The portal binds `127.0.0.1` by default — local only. To use it from your phone, set `server.host: 0.0.0.0` in `~/.agentwire/config.yaml`. Non-loopback binds require an auth token (auto-generated on first start; print it with `agentwire portal token`) — your phone prompts for it once, then remembers it. Origin checks reject cross-site browser requests on every bind. Still: keep it on a trusted LAN. Never port-forward it or run it on a public-facing VPS — for internet access use Cloudflare Tunnel + Zero Trust. Details in [SECURITY.md](SECURITY.md).
 
 <details>
 <summary><strong>Platform-specific instructions</strong></summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,15 +47,17 @@ See `docs/wiki/internals/damage-control.md` for details.
 
 ## Trust Model
 
-The portal **has no built-in authentication or authorization on its API endpoints**. This is by design — agentwire is built for a local-network trust perimeter, typically running on the same machine as the operator's browser or behind a Cloudflare Tunnel + Zero Trust gate (see `docs/wiki/deployment/remote-access.md`).
+The portal enforces two security layers in-process:
 
-The portal binds `127.0.0.1:8765` by default — local only. Phone/tablet access requires explicitly opting into LAN exposure with `server.host: 0.0.0.0` in `~/.agentwire/config.yaml`; everything below applies the moment you do.
+1. **Origin validation (always on).** Every state-changing request (POST/PUT/DELETE/PATCH) and WebSocket upgrade with an `Origin` header must match the portal's own origin, a localhost equivalent, or an entry in `server.allowed_origins` (exact `scheme://host[:port]` strings — needed when fronting with Cloudflare Tunnel, where the browser's origin is the tunnel domain). Mismatches get a 403 and a log line. Requests without an Origin header (curl, CLI, scripts) pass — CSRF is a browser vector. This protects loopback-only users from malicious pages firing cross-site requests at `localhost:8765`.
+
+2. **Bearer-token auth (required for non-loopback binds).** The portal binds `127.0.0.1:8765` by default — local only. Binding anything else (`0.0.0.0`, a LAN IP) auto-generates a token at `~/.agentwire/portal.token` (mode 0600) and requires it on every request outside the public bootstrap surface (`GET /`, `/health`, `/static/*`): `Authorization: Bearer <token>` on HTTP, `agentwire.bearer.<token>` WebSocket subprotocol. The portal **refuses to start** on a non-loopback bind with auth explicitly disabled. Print the token with `agentwire portal token`; rotate with `--rotate`. Browsers prompt once per device and store it in localStorage.
+
+Token configuration (`server.auth_token` in `~/.agentwire/config.yaml`): unset = use the token file (auto-generated); any string = explicit override; `""` = auth disabled, allowed only on loopback binds. Tokens are compared constant-time and redacted from the config served to the portal's config editor.
 
 What this means in practice:
 
-- **Anyone who can reach the portal port can drive it.** All `/api/*` endpoints (scheduler control, missions dispatch, project deletion, artifact upload, desktop window control) execute without auth.
-- **Do not expose the portal directly to the public internet.** Use either firewall rules limiting access to trusted IPs, or front it with an auth gateway. Cloudflare Tunnel + Zero Trust is the recommended pattern; details in the deployment docs.
-- **Project deletion via `/api/projects/delete`** validates the path is absolute, contains no `..`, contains no shell metacharacters, and is not in a protected list. Local execution uses argv form (no shell); SSH execution uses `shlex.quote` per argument. These mitigations don't substitute for perimeter security — they reduce blast radius if the perimeter fails.
-- **CSRF / Origin checks are not enforced** on state-changing POSTs. A browser inside the trust perimeter that loads attacker-controlled content could be coerced into making requests to the portal. If your portal is reachable from a browser on a less-trusted network, add an origin check or fence it behind an auth proxy.
-
-If you need authentication, the recommended path is **Cloudflare Tunnel + Zero Trust** rather than adding auth in-process: identity, MFA, audit, and revocation are all handled upstream and survive process restarts.
+- **LAN exposure (`server.host: 0.0.0.0`) is protected by the token.** Someone on your network who can reach the port gets 401s until they present it. Treat the token like a password; rotate it if a device is lost.
+- **Do not expose the portal directly to the public internet.** Token auth raises the bar on a trusted LAN; it is not a substitute for identity, MFA, audit, and revocation. For anything internet-facing, front it with **Cloudflare Tunnel + Zero Trust** (see `docs/wiki/deployment/remote-access.md`) and add your tunnel domain to `server.allowed_origins`.
+- **Project deletion via `/api/projects/delete`** validates the path is absolute, contains no `..`, contains no shell metacharacters, and is not in a protected list. Local execution uses argv form (no shell); SSH execution uses `shlex.quote` per argument. These mitigations reduce blast radius if the perimeter fails.
+- **Self-hosted TTS/STT servers are a separate trust domain** — they have no auth of their own and are out of scope here.

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -553,6 +553,22 @@ def _get_machine_config(machine_id: str) -> dict | None:
     return None
 
 
+def _portal_auth_curl_args() -> list[str]:
+    """curl args carrying the portal auth token, if one is configured."""
+    from .security import get_local_portal_token
+
+    token = get_local_portal_token()
+    return ["-H", f"Authorization: Bearer {token}"] if token else []
+
+
+def _portal_auth_headers() -> dict:
+    """Headers carrying the portal auth token, if one is configured."""
+    from .security import get_local_portal_token
+
+    token = get_local_portal_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
 def _portal_api(method: str, path: str, data: dict | None = None, timeout: int = 10) -> dict | None:
     """Make an API request to the portal using curl (reliable with self-signed certs).
 
@@ -563,6 +579,7 @@ def _portal_api(method: str, path: str, data: dict | None = None, timeout: int =
     url = f"{portal_url}{path}"
 
     cmd = ["curl", "-sk", "--max-time", str(timeout), "-o", "-", "-w", "\n%{http_code}"]
+    cmd.extend(_portal_auth_curl_args())
     if method == "POST":
         cmd.extend(["-X", "POST", "-H", "Content-Type: application/json"])
         if data is not None:
@@ -722,6 +739,7 @@ def _notify_portal_sessions_changed():
             "https://localhost:8765/api/sessions/refresh",
             method="POST",
             data=b"",
+            headers=_portal_auth_headers(),
         )
         urllib.request.urlopen(req, timeout=2, context=ctx)
     except Exception:
@@ -1093,6 +1111,55 @@ def cmd_portal_status(args) -> int:
             if direct_url != url:
                 print(f"  Also checked: {direct_url}")
         return 1
+
+
+def cmd_portal_token(args) -> int:
+    """Print (or rotate) the portal auth token."""
+    from .security import (
+        TOKEN_FILE,
+        generate_token,
+        get_local_portal_token,
+        write_token_file,
+    )
+
+    config = load_config()
+    override = config.get("server", {}).get("auth_token")
+
+    if getattr(args, "rotate", False):
+        token = generate_token()
+        write_token_file(token)
+        print(token)
+        print(f"\nNew token written to {TOKEN_FILE}", file=sys.stderr)
+        print(
+            "Restart the portal (agentwire portal restart) and re-enter the "
+            "token on remote devices.",
+            file=sys.stderr,
+        )
+        if override:
+            print(
+                "Warning: server.auth_token is set in config.yaml and overrides "
+                "the token file — rotation has no effect until it's removed.",
+                file=sys.stderr,
+            )
+        return 0
+
+    if override == "":
+        print("Portal auth is disabled (server.auth_token: \"\" in config.yaml).", file=sys.stderr)
+        return 1
+
+    token = get_local_portal_token()
+    if not token:
+        print(
+            "No token configured yet — it's generated on first portal start, "
+            "or run `agentwire portal token --rotate` to create one now.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(token)
+    if override:
+        print("(from server.auth_token override in config.yaml)", file=sys.stderr)
+    return 0
 
 
 def cmd_portal_restart(args) -> int:
@@ -2043,7 +2110,7 @@ def _check_portal_connections(session: str, portal_url: str) -> tuple[bool, str]
         try:
             req = urllib.request.Request(
                 f"{portal_url}/api/sessions/{session_name}/connections",
-                headers={"Accept": "application/json"},
+                headers={"Accept": "application/json", **_portal_auth_headers()},
             )
 
             with urllib.request.urlopen(req, context=ctx, timeout=5) as response:
@@ -2343,6 +2410,7 @@ def cmd_open(args) -> int:
         resp = requests.post(
             f"{portal_url}/api/desktop/window/open",
             json=body,
+            headers=_portal_auth_headers(),
             verify=False,
             timeout=10,
         )
@@ -2658,7 +2726,7 @@ def _remote_say(text: str, session: str, portal_url: str) -> int:
         req = urllib.request.Request(
             f"{portal_url}/api/say/{session}",
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_portal_auth_headers()},
         )
 
         # 90 second timeout to handle RunPod cold starts
@@ -2764,7 +2832,7 @@ def cmd_notify(args) -> int:
         req = urllib.request.Request(
             f"{portal_url}/api/notify",
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_portal_auth_headers()},
             method="POST"
         )
 
@@ -5624,7 +5692,8 @@ def _ping_scratchpad_changed() -> None:
         ctx.verify_mode = _ssl.CERT_NONE
         req = urllib.request.Request(
             f"{portal_url}/api/scratchpad/changed", data=b"{}",
-            headers={"Content-Type": "application/json"}, method="POST",
+            headers={"Content-Type": "application/json", **_portal_auth_headers()},
+            method="POST",
         )
         urllib.request.urlopen(req, timeout=3, context=ctx)
     except Exception:
@@ -10176,6 +10245,15 @@ def main() -> int:
         "generate-certs", help="Generate SSL certificates"
     )
     portal_certs.set_defaults(func=cmd_generate_certs)
+
+    # portal token
+    portal_token = portal_subparsers.add_parser(
+        "token", help="Print the portal auth token (required for non-loopback binds)"
+    )
+    portal_token.add_argument(
+        "--rotate", action="store_true", help="Generate and save a new token"
+    )
+    portal_token.set_defaults(func=cmd_portal_token)
 
     # === tts command group ===
     tts_parser = subparsers.add_parser("tts", help="Manage TTS server")

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -53,13 +53,20 @@ class SSLConfig:
 class ServerConfig:
     """WebSocket server configuration."""
 
-    # Local-only by default. The portal has no auth — binding 0.0.0.0 hands
-    # session control to anyone who can reach the port. Opt into LAN exposure
-    # explicitly via `server.host: 0.0.0.0` in config (see SECURITY.md).
+    # Local-only by default. Opt into LAN exposure explicitly via
+    # `server.host: 0.0.0.0` in config — non-loopback binds require an auth
+    # token (auto-generated at ~/.agentwire/portal.token; see SECURITY.md).
     host: str = "127.0.0.1"
     port: int = 8765
     ssl: SSLConfig = field(default_factory=SSLConfig)
     activity_threshold_seconds: float = 3.0  # Time in seconds before session is considered idle
+    # Exact origins (scheme://host[:port]) allowed on cross-origin browser
+    # requests, e.g. a Cloudflare Tunnel domain. The portal's own origin and
+    # localhost equivalents are always allowed.
+    allowed_origins: list = field(default_factory=list)
+    # None = use ~/.agentwire/portal.token (auto-generated). "" = auth
+    # disabled (loopback binds only). Any other string = explicit override.
+    auth_token: Optional[str] = None
 
 
 @dataclass
@@ -432,6 +439,9 @@ def _dict_to_config(data: dict) -> Config:
         port=server_data.get("port", 8765),
         ssl=ssl,
         activity_threshold_seconds=server_data.get("activity_threshold_seconds", 3.0),
+        allowed_origins=server_data.get("allowed_origins") or [],
+        # "" (explicit disable) must survive — don't collapse it to None.
+        auth_token=server_data.get("auth_token"),
     )
 
     # Projects

--- a/agentwire/hooks/agentwire-permission.sh
+++ b/agentwire/hooks/agentwire-permission.sh
@@ -117,9 +117,28 @@ get_portal_url() {
 
 base_url=$(get_portal_url)
 
+# Portal auth token: server.auth_token in config.yaml overrides the token file
+get_portal_token() {
+    if [ -f "$HOME/.agentwire/config.yaml" ]; then
+        local override=$(grep -E "^\s*auth_token:" "$HOME/.agentwire/config.yaml" 2>/dev/null | head -1 | sed 's/.*auth_token:[[:space:]]*//' | tr -d '"'"'" || true)
+        if [ -n "$override" ]; then
+            echo "$override"
+            return
+        fi
+    fi
+    if [ -f "$HOME/.agentwire/portal.token" ]; then
+        tr -d '\n' < "$HOME/.agentwire/portal.token"
+    fi
+}
+
+token=$(get_portal_token)
+auth_args=()
+[ -n "$token" ] && auth_args=(-H "Authorization: Bearer $token")
+
 # POST to portal and wait for response (5 minute timeout)
 response=$(curl -s -X POST "${base_url}/api/permission/${session}" \
     -H "Content-Type: application/json" \
+    "${auth_args[@]}" \
     -d "$input" \
     --max-time 300 \
     --insecure 2>/dev/null)

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -792,10 +792,15 @@ def transcribe(audio_base64: str, format: str = "webm") -> str:
     portal_url = get_portal_url()
     url = f"{portal_url}/transcribe"
 
+    from .security import get_local_portal_token
+
+    token = get_local_portal_token()
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+
     try:
         # Create multipart form data
         files = {"audio": (f"audio.{format}", audio_bytes, mime_type)}
-        response = requests.post(url, files=files, verify=False, timeout=60)
+        response = requests.post(url, files=files, headers=headers, verify=False, timeout=60)
 
         if response.status_code != 200:
             return f"Transcription request failed: HTTP {response.status_code}"
@@ -2747,14 +2752,19 @@ def _portal_request(method: str, path: str, body: dict | None = None) -> dict:
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+    from .security import get_local_portal_token
+
+    token = get_local_portal_token()
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+
     url = f"{get_portal_url()}{path}"
     try:
         if method == "GET":
-            resp = requests.get(url, verify=False, timeout=10)
+            resp = requests.get(url, headers=headers, verify=False, timeout=10)
         elif method == "DELETE":
-            resp = requests.delete(url, verify=False, timeout=10)
+            resp = requests.delete(url, headers=headers, verify=False, timeout=10)
         else:
-            resp = requests.post(url, json=body or {}, verify=False, timeout=10)
+            resp = requests.post(url, json=body or {}, headers=headers, verify=False, timeout=10)
 
         if resp.status_code != 200:
             return {"success": False, "error": f"HTTP {resp.status_code}"}

--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -275,6 +275,12 @@ server:
   ssl:
     cert: "~/.agentwire/cert.pem"
     key: "~/.agentwire/key.pem"
+  # Auth token lives at ~/.agentwire/portal.token (print: agentwire portal token).
+  # Uncomment to override; "" disables auth (loopback binds only).
+  # auth_token: ""
+  # Extra browser origins allowed to call the portal, e.g. a Cloudflare
+  # Tunnel domain. The portal's own origin and localhost always pass.
+  allowed_origins: []
 
 projects:
   dir: "{projects_dir}"
@@ -309,6 +315,19 @@ services:
     config_path = CONFIG_DIR / "config.yaml"
     config_path.write_text(config_content)
     print_success(f"Created {config_path}")
+
+    # Portal auth token — required because the config binds 0.0.0.0
+    from .security import TOKEN_FILE, generate_token, read_token_file, write_token_file
+
+    token = read_token_file()
+    if token is None:
+        token = generate_token()
+        write_token_file(token)
+        print_success(f"Created {TOKEN_FILE}")
+    print()
+    print_info("Portal auth token (paste into your phone's browser when prompted):")
+    print(f"  {token}")
+    print_info("Show it again anytime: agentwire portal token")
 
     # Empty machines.json
     machines_path = CONFIG_DIR / "machines.json"

--- a/agentwire/overnight.py
+++ b/agentwire/overnight.py
@@ -427,7 +427,10 @@ def _notify_portal(item_id: str, status: str, summary: str = "") -> None:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         from .config import get_config
+        from .security import get_local_portal_token
+
         portal_url = get_config().portal.url
+        token = get_local_portal_token()
 
         requests.post(
             f"{portal_url}/api/notify",
@@ -437,6 +440,7 @@ def _notify_portal(item_id: str, status: str, summary: str = "") -> None:
                 "status": status,
                 "summary": summary,
             },
+            headers={"Authorization": f"Bearer {token}"} if token else {},
             verify=False,
             timeout=5,
         )

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -727,6 +727,14 @@ def _write_live_state(**fields) -> None:
         pass
 
 
+def _portal_auth_headers() -> dict:
+    """Headers carrying the portal auth token, if one is configured."""
+    from .security import get_local_portal_token
+
+    token = get_local_portal_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
 def _notify_portal(task_name: str, status: str, duration: int, summary: str) -> None:
     """POST a scheduler_task_complete notification to the portal."""
     try:
@@ -746,6 +754,7 @@ def _notify_portal(task_name: str, status: str, duration: int, summary: str) -> 
                 "duration": duration,
                 "summary": summary,
             },
+            headers=_portal_auth_headers(),
             verify=False,
             timeout=timeout,
         )
@@ -770,6 +779,7 @@ def _notify_portal_state() -> None:
         requests.post(
             f"{portal_url}/api/notify",
             json={"event": "scheduler_state", "running": True, **state},
+            headers=_portal_auth_headers(),
             verify=False,
             timeout=timeout,
         )

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -1,0 +1,220 @@
+"""Portal security: Origin validation (CSRF guard) and bearer-token auth.
+
+Two layers, both enforced by a single aiohttp middleware:
+
+1. Origin check — on every state-changing request (POST/PUT/DELETE/PATCH) and
+   WebSocket upgrade, a present ``Origin`` header must match the portal's own
+   origin, a localhost equivalent, or an entry in ``server.allowed_origins``.
+   Absent Origin is allowed (curl/CLI/scripts don't send one). Always on.
+
+2. Token auth — when an auth token is configured, every request outside the
+   public bootstrap surface (``GET /``, ``/health``, ``/static/*``) must carry
+   it: ``Authorization: Bearer <token>`` on HTTP, or a
+   ``Sec-WebSocket-Protocol: agentwire.bearer.<token>`` subprotocol on
+   WebSocket upgrades. Required whenever the bind is non-loopback.
+
+The token lives at ``~/.agentwire/portal.token`` (0600, auto-generated).
+``server.auth_token`` in config overrides it: ``""`` disables auth (loopback
+binds only), any other string replaces the file token.
+"""
+
+import hmac
+import ipaddress
+import logging
+import secrets
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlsplit
+
+import yaml
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+MUTATING_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
+TOKEN_FILE = Path.home() / ".agentwire" / "portal.token"
+WS_PROTOCOL_PREFIX = "agentwire.bearer."
+_LOCALHOST_NAMES = {"localhost", "127.0.0.1", "::1"}
+
+
+# ---------------------------------------------------------------------------
+# Token lifecycle
+
+
+def generate_token() -> str:
+    """Generate a new portal auth token (32 bytes, urlsafe)."""
+    return secrets.token_urlsafe(32)
+
+
+def read_token_file() -> Optional[str]:
+    """Read the token file. None if missing or empty."""
+    try:
+        token = TOKEN_FILE.read_text().strip()
+    except OSError:
+        return None
+    return token or None
+
+
+def write_token_file(token: str) -> None:
+    """Write the token file with owner-only permissions."""
+    TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TOKEN_FILE.write_text(token + "\n")
+    TOKEN_FILE.chmod(0o600)
+
+
+def resolve_auth_token(config) -> Optional[str]:
+    """Effective token: config override wins, else the token file.
+
+    ``server.auth_token`` semantics: None = use token file, "" = auth
+    disabled, anything else = explicit override.
+    """
+    if config.server.auth_token is not None:
+        return config.server.auth_token or None
+    return read_token_file()
+
+
+def ensure_auth_token(config) -> Optional[str]:
+    """Resolve the token, auto-generating the token file when nothing is set.
+
+    Returns None only when auth is explicitly disabled (auth_token: "").
+    """
+    if config.server.auth_token == "":
+        return None
+    token = resolve_auth_token(config)
+    if token is None:
+        token = generate_token()
+        write_token_file(token)
+        logger.info("Generated portal auth token at %s", TOKEN_FILE)
+    return token
+
+
+def get_local_portal_token() -> Optional[str]:
+    """Token for local callers (CLI, MCP, daemons, hooks) hitting the portal.
+
+    Reads ``server.auth_token`` from ~/.agentwire/config.yaml if set,
+    else the token file. Standalone so raw-dict config consumers can use it.
+    """
+    config_path = Path.home() / ".agentwire" / "config.yaml"
+    try:
+        data = yaml.safe_load(config_path.read_text()) or {}
+        override = data.get("server", {}).get("auth_token")
+        if override is not None:
+            return str(override) or None
+    except OSError:
+        pass
+    return read_token_file()
+
+
+# ---------------------------------------------------------------------------
+# Bind / startup policy
+
+
+def is_loopback_host(host: str) -> bool:
+    """True when the bind host only accepts local connections."""
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # Hostnames and anything unparseable: assume reachable from outside.
+        return False
+
+
+def validate_startup_security(config) -> None:
+    """Refuse non-loopback binds without an auth token.
+
+    Call after ``ensure_auth_token()`` has populated config.server.auth_token.
+    """
+    if not is_loopback_host(config.server.host) and not config.server.auth_token:
+        raise SystemExit(
+            f"Refusing to start: server.host is {config.server.host!r} (reachable "
+            "from the network) but portal auth is disabled (server.auth_token: \"\" "
+            "in config). Either remove auth_token from config to use the generated "
+            "token, run `agentwire portal token --rotate` to create one, or bind "
+            "to 127.0.0.1."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Request checks
+
+
+def _is_websocket_upgrade(request: web.Request) -> bool:
+    return request.headers.get("Upgrade", "").lower() == "websocket"
+
+
+def _effective_port(scheme: str, netloc_port: Optional[int]) -> int:
+    if netloc_port:
+        return netloc_port
+    return 443 if scheme in ("https", "wss") else 80
+
+
+def origin_allowed(origin: str, request: web.Request, allowed_origins: list) -> bool:
+    """Whether a browser Origin may make state-changing requests."""
+    if origin in allowed_origins:
+        return True
+    # The portal's own origin (request.host includes the port when non-default)
+    if origin == f"{request.scheme}://{request.host}":
+        return True
+    # Localhost equivalents on the same effective port
+    parsed = urlsplit(origin)
+    own = urlsplit(f"{request.scheme}://{request.host}")
+    return (
+        parsed.hostname in _LOCALHOST_NAMES
+        and own.hostname in _LOCALHOST_NAMES
+        and _effective_port(parsed.scheme, parsed.port)
+        == _effective_port(request.scheme, own.port)
+    )
+
+
+def _is_public_path(request: web.Request) -> bool:
+    """The unauthenticated bootstrap surface: the page shell + health check."""
+    if request.method != "GET":
+        return False
+    path = request.path
+    return path in ("/", "/health") or path.startswith("/static/")
+
+
+def _extract_token(request: web.Request, is_ws: bool) -> Optional[str]:
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[len("Bearer "):]
+    if is_ws:
+        for proto in request.headers.get("Sec-WebSocket-Protocol", "").split(","):
+            proto = proto.strip()
+            if proto.startswith(WS_PROTOCOL_PREFIX):
+                return proto[len(WS_PROTOCOL_PREFIX):]
+    return None
+
+
+def create_security_middleware(auth_token: Optional[str], allowed_origins: list):
+    """Build the aiohttp middleware enforcing origin + token policy."""
+
+    @web.middleware
+    async def security_middleware(request: web.Request, handler):
+        is_ws = _is_websocket_upgrade(request)
+
+        # Origin check: browser CSRF guard on mutations + WS upgrades.
+        if request.method in MUTATING_METHODS or is_ws:
+            origin = request.headers.get("Origin")
+            if origin and not origin_allowed(origin, request, allowed_origins):
+                logger.warning(
+                    "Rejected %s %s from disallowed origin %s",
+                    request.method, request.path, origin,
+                )
+                raise web.HTTPForbidden(text="Origin not allowed")
+
+        # Token check: everything except the public bootstrap surface.
+        if auth_token and not _is_public_path(request):
+            provided = _extract_token(request, is_ws)
+            if not provided or not hmac.compare_digest(
+                provided.encode(), auth_token.encode()
+            ):
+                raise web.HTTPUnauthorized(
+                    text="Missing or invalid auth token",
+                    headers={"WWW-Authenticate": 'Bearer realm="agentwire"'},
+                )
+
+        return await handler(request)
+
+    return security_middleware

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -40,6 +40,8 @@ from .security import (
     WS_PROTOCOL_PREFIX,
     create_security_middleware,
     ensure_auth_token,
+    is_loopback_host,
+    resolve_auth_token,
     validate_startup_security,
 )
 from .worktree import parse_session_name
@@ -5014,10 +5016,15 @@ projects:
 
 async def run_server(config: Config):
     """Run the AgentWire server."""
-    # Resolve (auto-generating if needed) the auth token before the server is
-    # built — the security middleware reads it from config. Non-loopback
-    # binds without a token refuse to start.
-    config.server.auth_token = ensure_auth_token(config)
+    # Resolve the auth token before the server is built — the security
+    # middleware reads it from config. Non-loopback binds auto-generate a
+    # token and refuse to start without one; loopback binds only enforce a
+    # token if one is already configured (origin checks cover the browser
+    # vector locally).
+    if is_loopback_host(config.server.host):
+        config.server.auth_token = resolve_auth_token(config)
+    else:
+        config.server.auth_token = ensure_auth_token(config)
     validate_startup_security(config)
 
     server = AgentWireServer(config)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -36,6 +36,12 @@ from aiohttp import web
 
 from .cached_status import CachedStatusChecker
 from .config import Config, load_config
+from .security import (
+    WS_PROTOCOL_PREFIX,
+    create_security_middleware,
+    ensure_auth_token,
+    validate_startup_security,
+)
 from .worktree import parse_session_name
 
 __version__ = "1.3.0"
@@ -146,7 +152,16 @@ class AgentWireServer:
         self.stt = None
         self.agent = None
         self._http_session: aiohttp.ClientSession | None = None  # For TTS HTTP calls
-        self.app = web.Application()
+        # Origin + token enforcement. The middleware is a pure function of
+        # config — run_server() resolves the token file into
+        # config.server.auth_token before constructing the server.
+        self.app = web.Application(
+            middlewares=[
+                create_security_middleware(
+                    config.server.auth_token, config.server.allowed_origins
+                )
+            ]
+        )
         self._setup_jinja2()
         self._setup_routes()
 
@@ -718,9 +733,25 @@ class AgentWireServer:
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         return response
 
+    def _ws_response(self, request: web.Request) -> web.WebSocketResponse:
+        """WebSocketResponse that echoes the auth bearer subprotocol.
+
+        Browsers pass the token as `Sec-WebSocket-Protocol:
+        agentwire.bearer.<token>` (validated by the security middleware before
+        the handler runs) and close the socket unless the server echoes the
+        protocol back.
+        """
+        offered = [
+            p.strip()
+            for p in request.headers.get("Sec-WebSocket-Protocol", "").split(",")
+            if p.strip()
+        ]
+        bearer = tuple(p for p in offered if p.startswith(WS_PROTOCOL_PREFIX))
+        return web.WebSocketResponse(protocols=bearer)
+
     async def handle_dashboard_ws(self, request: web.Request) -> web.WebSocketResponse:
         """WebSocket endpoint for dashboard updates (sessions, machines, config)."""
-        ws = web.WebSocketResponse()
+        ws = self._ws_response(request)
         await ws.prepare(request)
 
         self.dashboard_clients.add(ws)
@@ -1575,7 +1606,7 @@ class AgentWireServer:
     async def handle_websocket(self, request: web.Request) -> web.WebSocketResponse:
         """Handle WebSocket connections for a session."""
         name = request.match_info["name"]
-        ws = web.WebSocketResponse()
+        ws = self._ws_response(request)
         await ws.prepare(request)
 
         # Get or create session
@@ -1634,7 +1665,7 @@ class AgentWireServer:
         # Browser passes initial terminal size as query params to avoid 80x24 flash
         init_cols = int(request.rel_url.query.get("cols", 80))
         init_rows = int(request.rel_url.query.get("rows", 24))
-        ws = web.WebSocketResponse()
+        ws = self._ws_response(request)
         await ws.prepare(request)
 
         proc = None
@@ -3221,9 +3252,9 @@ class AgentWireServer:
             try:
                 content = config_path.read_text()
                 # SECURITY: Redact sensitive fields before returning
-                # Matches patterns like: runpod_api_key: "secret" or runpod_api_key: secret
+                # Matches patterns like: runpod_api_key: "secret" or auth_token: secret
                 content = re.sub(
-                    r'(runpod_api_key\s*:\s*)["\']?[^"\'\n]+["\']?',
+                    r'((?:runpod_api_key|auth_token)\s*:\s*)["\']?[^"\'\n]+["\']?',
                     r'\1"[REDACTED]"',
                     content
                 )
@@ -4983,6 +5014,12 @@ projects:
 
 async def run_server(config: Config):
     """Run the AgentWire server."""
+    # Resolve (auto-generating if needed) the auth token before the server is
+    # built — the security middleware reads it from config. Non-loopback
+    # binds without a token refuse to start.
+    config.server.auth_token = ensure_auth_token(config)
+    validate_startup_security(config)
+
     server = AgentWireServer(config)
     await server.init_backends()
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -1044,7 +1044,8 @@ body {
     opacity: 0.7;
 }
 
-.quicktask-form input[type="text"] {
+.quicktask-form input[type="text"],
+.quicktask-form input[type="password"] {
     background: var(--background);
     border: 1px solid var(--chrome-border);
     border-radius: 4px;
@@ -1054,9 +1055,23 @@ body {
     font-family: inherit;
 }
 
-.quicktask-form input[type="text"]:focus {
+.quicktask-form input[type="text"]:focus,
+.quicktask-form input[type="password"]:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+.quicktask-hint {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.quicktask-hint code {
+    font-family: monospace;
+    background: var(--background);
+    padding: 1px 4px;
+    border-radius: 3px;
 }
 
 .quicktask-pills {

--- a/agentwire/static/js/api.js
+++ b/agentwire/static/js/api.js
@@ -1,0 +1,48 @@
+/**
+ * Centralized portal API access — bearer-token auth.
+ *
+ * The portal requires an auth token whenever one is configured (always, for
+ * non-loopback binds). The token is entered once per device via the token
+ * modal, stored in localStorage, and attached to every request:
+ *   - HTTP: `Authorization: Bearer <token>` (use apiFetch everywhere)
+ *   - WebSocket: `agentwire.bearer.<token>` subprotocol (use wsProtocols())
+ *
+ * On a 401, apiFetch raises the token modal (one shared instance across
+ * concurrent failures) and retries after entry.
+ */
+
+import { showTokenModal } from './token-modal.js';
+
+const TOKEN_KEY = 'agentwire_token';
+
+export function getToken() {
+    return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token) {
+    localStorage.setItem(TOKEN_KEY, token);
+}
+
+/** Subprotocol list for `new WebSocket(url, wsProtocols())`. */
+export function wsProtocols() {
+    const token = getToken();
+    return token ? [`agentwire.bearer.${token}`] : undefined;
+}
+
+let tokenPrompt = null; // concurrent 401s share one modal
+
+export async function apiFetch(url, options = {}) {
+    const headers = new Headers(options.headers || {});
+    const token = getToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+
+    const resp = await fetch(url, { ...options, headers });
+    if (resp.status !== 401) return resp;
+
+    // Token missing/stale — prompt once, then retry with the new token.
+    if (!tokenPrompt) {
+        tokenPrompt = showTokenModal().finally(() => { tokenPrompt = null; });
+    }
+    await tokenPrompt;
+    return apiFetch(url, options);
+}

--- a/agentwire/static/js/artifact-window.js
+++ b/agentwire/static/js/artifact-window.js
@@ -5,6 +5,7 @@
  * in a sandboxed iframe within a WinBox window.
  */
 
+import { apiFetch, getToken } from './api.js';
 import { desktop } from './desktop-manager.js';
 
 export class ArtifactWindow {
@@ -28,6 +29,7 @@ export class ArtifactWindow {
         this.winbox = null;
         this.iframe = null;
         this.isOpen = false;
+        this._objectUrl = null; // blob URL for token-authed artifact loads
     }
 
     /**
@@ -56,6 +58,7 @@ export class ArtifactWindow {
             this.iframe.src = 'about:blank';
             this.iframe = null;
         }
+        this._revokeObjectUrl();
 
         if (this.winbox) {
             const wb = this.winbox;
@@ -92,7 +95,7 @@ export class ArtifactWindow {
      */
     reload() {
         if (this.iframe) {
-            this.iframe.src = this._resolveUrl();
+            this._setIframeSrc();
         }
     }
 
@@ -168,6 +171,39 @@ export class ArtifactWindow {
         return this.url.startsWith('http://') || this.url.startsWith('https://');
     }
 
+    _revokeObjectUrl() {
+        if (this._objectUrl) {
+            URL.revokeObjectURL(this._objectUrl);
+            this._objectUrl = null;
+        }
+    }
+
+    /**
+     * Point the iframe at the artifact. Plain iframe GETs can't carry the
+     * Authorization header, so when token auth is active we fetch the
+     * portal-served artifact with credentials and load it as a blob URL.
+     * Note: relative sub-resources inside multi-file artifacts won't resolve
+     * under a blob URL — self-contained HTML is the supported shape there.
+     */
+    async _setIframeSrc() {
+        const resolved = this._resolveUrl();
+        if (this._isExternalUrl() || !getToken()) {
+            this.iframe.src = resolved;
+            return;
+        }
+        try {
+            const resp = await apiFetch(resolved);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const blob = await resp.blob();
+            this._revokeObjectUrl();
+            this._objectUrl = URL.createObjectURL(blob);
+            this.iframe.src = this._objectUrl;
+        } catch (e) {
+            // Fall back to a direct load; the iframe error handler reports it.
+            this.iframe.src = resolved;
+        }
+    }
+
     _loadUrl() {
         if (!this.winbox) return;
 
@@ -205,7 +241,7 @@ export class ArtifactWindow {
             }
         });
 
-        this.iframe.src = this._resolveUrl();
+        this._setIframeSrc();
         content.insertBefore(this.iframe, content.firstChild);
     }
 }

--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -35,6 +35,7 @@
  * @module collage
  */
 
+import { wsProtocols } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { ansiToHtml } from './utils/ansi.js';
 import { isCommandPaletteOpen } from './command-palette.js';
@@ -327,7 +328,7 @@ class Collage {
         const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
         let ws = null;
         try {
-            ws = new WebSocket(`${protocol}//${location.host}/ws/${inst.sessionId}`);
+            ws = new WebSocket(`${protocol}//${location.host}/ws/${inst.sessionId}`, wsProtocols());
         } catch (e) {
             return;
         }

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -14,6 +14,7 @@
  * (/api/create, /api/projects/create) are unchanged.
  */
 
+import { apiFetch } from './api.js';
 import { normalizeMachine, sameMachine } from './session-id.js';
 import { isService } from './sidebar/sessions-section.js';
 
@@ -79,7 +80,7 @@ function matches(query, text) {
 async function loadProjects() {
     if (projectsCache) return projectsCache;
     try {
-        const res = await fetch('/api/projects');
+        const res = await apiFetch('/api/projects');
         const data = await res.json();
         projectsCache = data.projects || [];
     } catch (e) {
@@ -91,12 +92,12 @@ async function loadProjects() {
 async function loadSessions() {
     const out = [];
     try {
-        const r = await fetch('/api/sessions/local');
+        const r = await apiFetch('/api/sessions/local');
         const d = await r.json();
         out.push(...(d.sessions || []));
     } catch (e) { /* ignore */ }
     try {
-        const r = await fetch('/api/sessions/remote');
+        const r = await apiFetch('/api/sessions/remote');
         const d = await r.json();
         const names = new Set(out.map((s) => s.name));
         for (const s of (d.sessions || [])) {
@@ -122,7 +123,7 @@ async function spawnAndOpen({ name, path, machine }) {
         const url = machine
             ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
             : '/api/sessions/local';
-        const r = await fetch(url);
+        const r = await apiFetch(url);
         const d = await r.json().catch(() => ({}));
         const sessions = d.sessions || (d.machines || []).flatMap((m) => m.sessions || []);
         if (sessions.some((s) => s.name === name && sameMachine(s.machine, machine))) {
@@ -132,7 +133,7 @@ async function spawnAndOpen({ name, path, machine }) {
         }
     } catch (e) { /* fall through and create */ }
 
-    const res = await fetch('/api/create', {
+    const res = await apiFetch('/api/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, path, machine }),
@@ -235,7 +236,7 @@ function bindNewProjectForm(form) {
         }
         showProgress(cloneUrl ? `Cloning ${cloneUrl}…` : `Creating ${name}…`);
         try {
-            const res = await fetch('/api/projects/create', {
+            const res = await apiFetch('/api/projects/create', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name, clone_url: cloneUrl || undefined, git_init: gitInit }),
@@ -366,7 +367,7 @@ function bindWorktreeForm(form) {
         const proj = findProject(project);
         showProgress(pullFirst ? `Pulling ${base} and starting ${branch}…` : `Starting ${branch}…`);
         try {
-            const res = await fetch('/api/create', {
+            const res = await apiFetch('/api/create', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -10,6 +10,8 @@
  * @module desktop-manager
  */
 
+import { apiFetch, wsProtocols } from './api.js';
+
 // Reconnect configuration
 const INITIAL_RECONNECT_DELAY = 1000;
 const MAX_RECONNECT_DELAY = 30000;
@@ -91,14 +93,18 @@ class DesktopManager {
         const url = `${protocol}//${location.host}/ws`;
 
         try {
-            this.ws = new WebSocket(url);
+            // Re-reads the token each attempt, so reconnects pick up a
+            // freshly entered token.
+            this.ws = new WebSocket(url, wsProtocols());
         } catch (err) {
             console.error('[DesktopManager] Failed to create WebSocket:', err);
             this.scheduleReconnect();
             return;
         }
 
+        let opened = false;
         this.ws.onopen = () => {
+            opened = true;
             this.reconnectAttempts = 0;
             this.emit('connect');
         };
@@ -106,6 +112,14 @@ class DesktopManager {
         this.ws.onclose = (event) => {
             this.ws = null;
             this.emit('disconnect');
+
+            // Handshake never completed — likely a 401 from token auth.
+            // Probe the API once: apiFetch raises the token modal on 401,
+            // and the page reloads after entry.
+            if (!opened && !this.tokenProbeFired) {
+                this.tokenProbeFired = true;
+                apiFetch('/api/sessions/local').catch(() => {});
+            }
 
             if (!this.intentionalDisconnect) {
                 this.scheduleReconnect();
@@ -625,7 +639,7 @@ class DesktopManager {
     async fetchSessions() {
         // Local sessions first (fast), then merge remote when SSH completes.
         try {
-            const localRes = await fetch('/api/sessions/local');
+            const localRes = await apiFetch('/api/sessions/local');
             const localData = await localRes.json();
             this.sessions = localData.sessions || [];
             this.emit('sessions', this.sessions);
@@ -634,7 +648,7 @@ class DesktopManager {
         }
 
         // Fire-and-forget: merge remote sessions when they arrive
-        fetch('/api/sessions/remote').then(async (res) => {
+        apiFetch('/api/sessions/remote').then(async (res) => {
             try {
                 const data = await res.json();
                 const remote = data.sessions || [];
@@ -657,7 +671,7 @@ class DesktopManager {
      */
     async fetchMachines() {
         try {
-            const response = await fetch('/api/machines');
+            const response = await apiFetch('/api/machines');
             const data = await response.json();
 
             // API returns array directly, not {machines: [...]}
@@ -676,7 +690,7 @@ class DesktopManager {
      */
     async fetchConfig() {
         try {
-            const response = await fetch('/api/config');
+            const response = await apiFetch('/api/config');
             const data = await response.json();
 
             this.config = data || {};

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -7,6 +7,7 @@
  * - List windows for sessions/machines/config
  */
 
+import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
@@ -842,7 +843,7 @@ async function processGlobalRecording() {
         formData.append('audio', blob, 'recording.webm');
 
         // Transcribe
-        const transcribeRes = await fetch('/transcribe', {
+        const transcribeRes = await apiFetch('/transcribe', {
             method: 'POST',
             body: formData
         });
@@ -850,7 +851,7 @@ async function processGlobalRecording() {
 
         if (text && text.trim()) {
             // Send to agentwire session with voice prompt
-            await fetch('/send/agentwire', {
+            await apiFetch('/send/agentwire', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/agentwire/static/js/icon-manager.js
+++ b/agentwire/static/js/icon-manager.js
@@ -9,6 +9,8 @@
  * - User override: manual icon selection
  */
 
+import { apiFetch } from './api.js';
+
 /**
  * IconManager handles icon assignment for a specific category
  */
@@ -42,7 +44,7 @@ export class IconManager {
 
         this._loadPromise = (async () => {
             try {
-                const response = await fetch(`/api/icons/${this.type}`);
+                const response = await apiFetch(`/api/icons/${this.type}`);
                 if (response.ok) {
                     const data = await response.json();
                     this.customIcons = data.custom || [];

--- a/agentwire/static/js/new-project-modal.js
+++ b/agentwire/static/js/new-project-modal.js
@@ -6,6 +6,8 @@
  *   - "Initialize empty git repo" checkbox (ignored when a clone URL is set)
  */
 
+import { apiFetch } from './api.js';
+
 let modalEl = null;
 let lastFocus = null;
 let onCreatedCb = null;
@@ -100,7 +102,7 @@ async function handleSubmit(e) {
     showProgress(cloneUrl ? `Cloning ${cloneUrl}…` : `Creating ${name}…`);
 
     try {
-        const res = await fetch('/api/projects/create', {
+        const res = await apiFetch('/api/projects/create', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -5,6 +5,7 @@
  * supports dismiss and click-to-open-session.
  */
 
+import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 
 const NOTIFICATIONS_SESSION = 'agentwire-notifications';
@@ -32,7 +33,7 @@ class NotificationsPanel {
 
     async _restore() {
         try {
-            const resp = await fetch('/api/desktop/notifications');
+            const resp = await apiFetch('/api/desktop/notifications');
             if (!resp.ok) return;
             const data = await resp.json();
             const notifications = data.notifications || [];
@@ -112,7 +113,7 @@ class NotificationsPanel {
     async _dismissToast(id) {
         this._removeToast(id, true);
         try {
-            await fetch('/api/desktop/notification/dismiss', {
+            await apiFetch('/api/desktop/notification/dismiss', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ id }),

--- a/agentwire/static/js/safety-shared.js
+++ b/agentwire/static/js/safety-shared.js
@@ -3,6 +3,8 @@
  * the full Safety review WinBox window.
  */
 
+import { apiFetch } from './api.js';
+
 export const DECISION_LABELS = {
     blocked: 'BLOCKED',
     asked: 'ASKED',
@@ -56,26 +58,26 @@ export function eventRow(e) {
 }
 
 export async function fetchSafetyStatus() {
-    try { return await fetch('/api/safety/status').then((r) => r.json()); } catch { return {}; }
+    try { return await apiFetch('/api/safety/status').then((r) => r.json()); } catch { return {}; }
 }
 
 export async function fetchSafetyLogs(decisionFilter = '', limit = 200) {
     const qs = `?limit=${limit}${decisionFilter ? '&decision=' + encodeURIComponent(decisionFilter) : ''}`;
     try {
-        const data = await fetch('/api/safety/logs' + qs).then((r) => r.json());
+        const data = await apiFetch('/api/safety/logs' + qs).then((r) => r.json());
         return data.entries || [];
     } catch { return []; }
 }
 
 export async function fetchSafetyRules() {
     try {
-        const data = await fetch('/api/safety/rules').then((r) => r.json());
+        const data = await apiFetch('/api/safety/rules').then((r) => r.json());
         return data.rules || [];
     } catch { return []; }
 }
 
 export async function postSafetyConfig(payload) {
-    return fetch('/api/safety/config', {
+    return apiFetch('/api/safety/config', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/agentwire/static/js/scratchpad.js
+++ b/agentwire/static/js/scratchpad.js
@@ -12,6 +12,7 @@
  * selections are not DOM selections and are out of scope for v1).
  */
 
+import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { armDeadKeySuppressor } from './dead-key-suppressor.js';
 
@@ -203,7 +204,7 @@ class ScratchPad {
 
     async _fetchNotes() {
         try {
-            const resp = await fetch('/api/scratchpad');
+            const resp = await apiFetch('/api/scratchpad');
             if (!resp.ok) return;
             this.notes = (await resp.json()).notes || [];
             this._render();
@@ -212,7 +213,7 @@ class ScratchPad {
 
     async _apiAdd(text, source = null) {
         try {
-            const resp = await fetch('/api/scratchpad/notes', {
+            const resp = await apiFetch('/api/scratchpad/notes', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ text, source }),
@@ -230,7 +231,7 @@ class ScratchPad {
         this.saveTimers.set(id, setTimeout(async () => {
             this.saveTimers.delete(id);
             try {
-                await fetch(`/api/scratchpad/notes/${id}`, {
+                await apiFetch(`/api/scratchpad/notes/${id}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ text }),
@@ -241,7 +242,7 @@ class ScratchPad {
 
     async _apiRemove(id) {
         try {
-            await fetch(`/api/scratchpad/notes/${id}`, { method: 'DELETE' });
+            await apiFetch(`/api/scratchpad/notes/${id}`, { method: 'DELETE' });
         } catch { /* broadcast will reconcile */ }
     }
 

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -7,6 +7,7 @@
  */
 
 
+import { apiFetch, wsProtocols } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { sessionIcons } from './icon-manager.js';
 import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
@@ -638,7 +639,7 @@ export class SessionWindow {
             this.ws = null;
         }
 
-        this.ws = new WebSocket(url);
+        this.ws = new WebSocket(url, wsProtocols());
 
         if (this.mode === 'terminal') {
             // Binary data for terminal mode
@@ -909,7 +910,7 @@ export class SessionWindow {
         // For remote sessions, check if the session still exists before reconnecting
         if (this.machine) {
             try {
-                const response = await fetch(`/api/sessions/remote`);
+                const response = await apiFetch(`/api/sessions/remote`);
                 const data = await response.json();
                 // Flatten sessions from all machines: {machines: [{sessions: [...]}]} -> [...]
                 const allSessions = (data.machines || []).flatMap(m => m.sessions || []);
@@ -1096,7 +1097,7 @@ export class SessionWindow {
             const formData = new FormData();
             formData.append('audio', blob, 'recording.webm');
 
-            const transcribeRes = await fetch('/transcribe', {
+            const transcribeRes = await apiFetch('/transcribe', {
                 method: 'POST',
                 body: formData,
             });
@@ -1115,7 +1116,7 @@ export class SessionWindow {
             }
 
             // Step 2: Send to session with voice prompt hint
-            const sendRes = await fetch(`/send/${this.sessionId}`, {
+            const sendRes = await apiFetch(`/send/${this.sessionId}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/agentwire/static/js/sidebar/artifacts-section.js
+++ b/agentwire/static/js/sidebar/artifacts-section.js
@@ -1,9 +1,11 @@
+
+import { apiFetch } from '../api.js';
 export const artifactsSection = {
     title: 'Artifacts',
     async mount(body) { await this.refresh(body); },
     async refresh(body) {
         try {
-            const res = await fetch('/api/artifacts');
+            const res = await apiFetch('/api/artifacts');
             const items = await res.json();
             if (!items.length) {
                 body.innerHTML = '<div class="sidebar-empty">No artifacts</div>';
@@ -34,7 +36,7 @@ export const artifactsSection = {
             openArtifactWindow(name, name);
         } else if (btn.dataset.action === 'delete') {
             try {
-                await fetch(`/api/artifacts/${encodeURIComponent(name)}`, { method: 'DELETE' });
+                await apiFetch(`/api/artifacts/${encodeURIComponent(name)}`, { method: 'DELETE' });
                 await this.refresh(body);
             } catch (e) { console.warn('Failed to delete artifact', e); }
         }

--- a/agentwire/static/js/sidebar/config-section.js
+++ b/agentwire/static/js/sidebar/config-section.js
@@ -1,3 +1,4 @@
+import { apiFetch } from '../api.js';
 import {
     getTerminalFontSize, getOverride,
     setTerminalFontSize, clearTerminalFontSize,
@@ -43,7 +44,7 @@ export const configSection = {
     async mount(body) { await this.refresh(body); },
     async refresh(body) {
         try {
-            const res = await fetch('/api/config?format=display');
+            const res = await apiFetch('/api/config?format=display');
             const data = await res.json();
             const items = data.items || [];
             const itemHtml = items.map(({ key, value }) => {

--- a/agentwire/static/js/sidebar/machines-section.js
+++ b/agentwire/static/js/sidebar/machines-section.js
@@ -1,10 +1,12 @@
+
+import { apiFetch } from '../api.js';
 export const machinesSection = {
     title: 'Machines',
     autoRefreshMs: 10000,
     async mount(body) { await this.refresh(body); },
     async refresh(body) {
         try {
-            const res = await fetch('/api/machines');
+            const res = await apiFetch('/api/machines');
             const data = await res.json();
             const machines = Array.isArray(data) ? data : (data.machines || []);
             if (!machines.length) {
@@ -37,7 +39,7 @@ export const machinesSection = {
         if (btn.dataset.action === 'new-session') {
             try {
                 const machine = machineId === 'local' ? null : machineId;
-                const res = await fetch('/api/create', {
+                const res = await apiFetch('/api/create', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ machine }),

--- a/agentwire/static/js/sidebar/missions-section.js
+++ b/agentwire/static/js/sidebar/missions-section.js
@@ -7,6 +7,7 @@
  * the server and refreshes automatically.
  */
 
+import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 
 export const missionsSection = {
@@ -28,7 +29,7 @@ export const missionsSection = {
 
     async refresh(body) {
         try {
-            const res = await fetch('/api/missions/list');
+            const res = await apiFetch('/api/missions/list');
             this._state = res.ok ? await res.json() : null;
         } catch (e) {
             this._state = null;
@@ -45,7 +46,7 @@ export const missionsSection = {
         this._busy = true;
         const endpoint = action === 'tick' ? '/api/missions/tick' : '/api/missions/gc';
         try {
-            await fetch(endpoint, { method: 'POST' });
+            await apiFetch(endpoint, { method: 'POST' });
         } catch (e) {
             console.warn('mission action failed', action, e);
         } finally {

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -1,3 +1,4 @@
+import { apiFetch } from '../api.js';
 import { normalizeMachine, sameMachine } from '../session-id.js';
 
 export const projectsSection = {
@@ -32,7 +33,7 @@ export const projectsSection = {
 
     async refresh(body) {
         try {
-            const res = await fetch('/api/projects');
+            const res = await apiFetch('/api/projects');
             const data = await res.json();
             const projects = data.projects || [];
             if (!projects.length) {
@@ -111,7 +112,7 @@ export const projectsSection = {
             const url = machine
                 ? `/api/sessions/remote?machine=${encodeURIComponent(machine)}`
                 : '/api/sessions/local';
-            const r = await fetch(url);
+            const r = await apiFetch(url);
             const d = await r.json().catch(() => ({}));
             const sessions = d.sessions
                 || (d.machines || []).flatMap((m) => m.sessions || []);
@@ -123,7 +124,7 @@ export const projectsSection = {
 
         // Create fresh session
         try {
-            const res = await fetch('/api/create', {
+            const res = await apiFetch('/api/create', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name, path, machine }),

--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -1,3 +1,4 @@
+import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 
 const COLLAPSED_KEY = 'scheduler-section-collapsed';
@@ -60,8 +61,8 @@ export const schedulerSection = {
         if (this._collapsed === null) this._collapsed = _loadCollapsed();
         try {
             const [liveRes, boardRes] = await Promise.all([
-                fetch('/api/scheduler/live'),
-                fetch('/api/scheduler/board'),
+                apiFetch('/api/scheduler/live'),
+                apiFetch('/api/scheduler/board'),
             ]);
             const live = liveRes.ok ? await liveRes.json() : null;
             const board = boardRes.ok ? await boardRes.json() : null;
@@ -203,7 +204,7 @@ export const schedulerSection = {
             btn.disabled = true;
             try {
                 const path = action === 'scheduler-start' ? '/api/scheduler/start' : '/api/scheduler/stop';
-                await fetch(path, { method: 'POST' });
+                await apiFetch(path, { method: 'POST' });
             } catch (e) { console.warn('Scheduler toggle failed', e); }
             // Daemon takes a moment to spin up / write its state file.
             setTimeout(() => this.refresh(body), 1500);
@@ -215,11 +216,11 @@ export const schedulerSection = {
         const task = item.dataset.task;
         try {
             if (action === 'run') {
-                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });
+                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });
             } else if (action === 'enable') {
-                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/enable`, { method: 'POST' });
+                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/enable`, { method: 'POST' });
             } else if (action === 'disable') {
-                await fetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/disable`, { method: 'POST' });
+                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/disable`, { method: 'POST' });
             }
             await this.refresh(body);
         } catch (e) { console.warn('Scheduler action failed', e); }

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -1,3 +1,4 @@
+import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 import { buildSessionId, normalizeMachine } from '../session-id.js';
 
@@ -17,7 +18,7 @@ export function isService(name) { return SERVICE_SESSIONS.has(name); }
 // on load; re-render once they arrive so flagged sessions hop to the right group.
 async function loadCustomServices() {
     try {
-        const res = await fetch('/api/services/custom');
+        const res = await apiFetch('/api/services/custom');
         if (!res.ok) return;
         const { names } = await res.json();
         let changed = false;
@@ -119,7 +120,7 @@ function initData() {
 
 async function fetchSessions() {
     try {
-        const localRes = await fetch('/api/sessions/local');
+        const localRes = await apiFetch('/api/sessions/local');
         const localData = await localRes.json();
         allSessions = localData.sessions || [];
         notifyListeners();
@@ -127,7 +128,7 @@ async function fetchSessions() {
         allSessions = [];
         notifyListeners();
     }
-    fetch('/api/sessions/remote').then(async (res) => {
+    apiFetch('/api/sessions/remote').then(async (res) => {
         try {
             const data = await res.json();
             const remote = data.sessions || [];
@@ -222,7 +223,7 @@ export const sessionsSection = {
                     payload.worktree = true;
                     payload.branch = branch;
                 }
-                const res = await fetch('/api/create', {
+                const res = await apiFetch('/api/create', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload),

--- a/agentwire/static/js/token-modal.js
+++ b/agentwire/static/js/token-modal.js
@@ -1,0 +1,92 @@
+/**
+ * Token entry modal — one-time per device auth for the portal.
+ *
+ * Shown by apiFetch on 401. The user pastes the token from
+ * `agentwire portal token`; we verify it against the API, persist it via
+ * api.js, then reload the page so every WebSocket and initial data load
+ * reconnects with credentials.
+ */
+
+import { setToken } from './api.js';
+
+let modalEl = null;
+
+function renderModal() {
+    return `<div class="modal-overlay" id="tokenModalOverlay">
+        <div class="modal quicktask-modal">
+            <div class="modal-header">
+                <h3>Connect to AgentWire</h3>
+            </div>
+            <div class="modal-body">
+                <div class="quicktask-error" data-error hidden></div>
+                <form class="quicktask-form">
+                    <label class="quicktask-field">
+                        <span class="quicktask-label">Auth token</span>
+                        <input type="password" name="token" placeholder="Paste your portal token" autocomplete="off" required />
+                    </label>
+                    <p class="quicktask-hint">Run <code>agentwire portal token</code> on the portal machine to see it. You only need to do this once per device.</p>
+                    <div class="quicktask-footer">
+                        <button type="submit" class="quicktask-btn-submit">Connect</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>`;
+}
+
+function showError(text) {
+    const el = modalEl?.querySelector('[data-error]');
+    if (!el) return;
+    el.textContent = text;
+    el.hidden = false;
+}
+
+async function verifyToken(token) {
+    // Raw fetch (not apiFetch) — a 401 here must not recurse into the modal.
+    try {
+        const resp = await fetch('/api/sessions/local', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        return resp.status !== 401;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Show the modal; resolves once a valid token has been stored.
+ * In practice the page reloads on success, so callers' retries are moot.
+ */
+export function showTokenModal() {
+    return new Promise((resolve) => {
+        if (modalEl) return; // already visible; existing promise governs
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = renderModal();
+        modalEl = wrapper.firstElementChild;
+        document.body.appendChild(modalEl);
+
+        const form = modalEl.querySelector('.quicktask-form');
+        const input = modalEl.querySelector('input[name="token"]');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const token = input.value.trim();
+            if (!token) return;
+            const btn = form.querySelector('.quicktask-btn-submit');
+            btn.disabled = true;
+            btn.textContent = 'Connecting…';
+            if (await verifyToken(token)) {
+                setToken(token);
+                modalEl.remove();
+                modalEl = null;
+                resolve();
+                // Reconnect everything (WebSockets, initial loads) with auth.
+                location.reload();
+            } else {
+                btn.disabled = false;
+                btn.textContent = 'Connect';
+                showError('Invalid token — check `agentwire portal token` and try again.');
+            }
+        });
+        input.focus();
+    });
+}

--- a/agentwire/static/js/utils/auto-refresh.js
+++ b/agentwire/static/js/utils/auto-refresh.js
@@ -10,11 +10,13 @@
  *
  * Usage:
  *     async function fetchMachines() {
- *         const machines = await fetch('/api/machines').then(r => r.json());
+ *         const machines = await apiFetch('/api/machines').then(r => r.json());
  *         setupAutoRefresh(machines, machinesWindow, 'status', 'checking', 2000);
  *         return machines;
  *     }
  */
+
+import { apiFetch } from '../api.js';
 
 /**
  * Setup auto-refresh for items with checking status

--- a/tests/integration/test_server_websockets.py
+++ b/tests/integration/test_server_websockets.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
@@ -42,6 +43,20 @@ async def portal_client(tmp_path, monkeypatch):
     # Subprocess shouldn't fire from any WS path we test.
     server.run_agentwire_cmd = AsyncMock(return_value=(True, {"sessions": []}))
 
+    async with TestClient(TestServer(server.app)) as client:
+        yield client, server
+
+
+@pytest.fixture
+async def portal_client_with_token(tmp_path):
+    """Server with bearer-token auth enforced on WS upgrades."""
+    config = load_config(tmp_path / "nonexistent.yaml")
+    config.server.auth_token = "testtoken123"
+    server = AgentWireServer(config)
+    server.agent = MagicMock()
+    server.agent.get_output = MagicMock(return_value="initial scrollback")
+    server.agent.machines = []
+    server.run_agentwire_cmd = AsyncMock(return_value=(True, {"sessions": []}))
     async with TestClient(TestServer(server.app)) as client:
         yield client, server
 
@@ -181,5 +196,84 @@ class TestTerminalWebSocket:
             except asyncio.TimeoutError:
                 pass
         assert "local-session" in server.active_sessions
+
+
+# ---------------------------------------------------------------------------
+# Security: WS upgrade auth (subprotocol bearer) + Origin validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestWebSocketSecurity:
+    async def test_ws_without_token_rejected(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        with pytest.raises(aiohttp.WSServerHandshakeError) as exc:
+            await client.ws_connect("/ws")
+        assert exc.value.status == 401
+
+    async def test_ws_wrong_token_rejected(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        with pytest.raises(aiohttp.WSServerHandshakeError) as exc:
+            await client.ws_connect(
+                "/ws/test-session", protocols=("agentwire.bearer.wrong",)
+            )
+        assert exc.value.status == 401
+
+    async def test_ws_with_token_connects_and_echoes_protocol(
+        self, portal_client_with_token
+    ):
+        client, _ = portal_client_with_token
+        async with client.ws_connect(
+            "/ws/test-session", protocols=("agentwire.bearer.testtoken123",)
+        ) as ws:
+            assert ws.protocol == "agentwire.bearer.testtoken123"
+            msg = await _recv_json(ws)
+            assert msg["type"] == "output"
+
+    async def test_ws_bearer_header_also_accepted(self, portal_client_with_token):
+        """Non-browser WS clients can use a plain Authorization header."""
+        client, _ = portal_client_with_token
+        async with client.ws_connect(
+            "/ws/test-session",
+            headers={"Authorization": "Bearer testtoken123"},
+        ) as ws:
+            msg = await _recv_json(ws)
+            assert msg["type"] == "output"
+
+    async def test_ws_evil_origin_rejected_even_with_token(
+        self, portal_client_with_token
+    ):
+        client, _ = portal_client_with_token
+        with pytest.raises(aiohttp.WSServerHandshakeError) as exc:
+            await client.ws_connect(
+                "/ws/test-session",
+                protocols=("agentwire.bearer.testtoken123",),
+                headers={"Origin": "https://evil.example"},
+            )
+        assert exc.value.status == 403
+
+    async def test_terminal_ws_with_token_and_query_params(
+        self, portal_client_with_token
+    ):
+        client, server = portal_client_with_token
+        # Token via subprotocol coexists with cols/rows query params.
+        async with client.ws_connect(
+            "/ws/terminal/local-session?cols=80&rows=24",
+            protocols=("agentwire.bearer.testtoken123",),
+        ) as ws:
+            try:
+                await asyncio.wait_for(ws.receive(), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
+        assert "local-session" in server.active_sessions
+
+    async def test_ws_no_token_configured_open(self, portal_client):
+        """Loopback default: no token configured, WS connects as before."""
+        client, _ = portal_client
+        async with client.ws_connect("/ws/test-session") as ws:
+            msg = await _recv_json(ws)
+            assert msg["type"] == "output"
+
+
 
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -390,9 +390,10 @@ class TestPortalRequest:
         from agentwire.mcp_server import _portal_request
         self.fn = _portal_request
 
+    @patch("agentwire.security.get_local_portal_token", return_value="tok123")
     @patch("agentwire.mcp_server.get_portal_url", return_value="https://localhost:8765")
     @patch("requests.get")
-    def test_get_request(self, mock_get, mock_url):
+    def test_get_request(self, mock_get, mock_url, mock_token):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"success": True, "windows": []}
@@ -400,7 +401,10 @@ class TestPortalRequest:
         result = self.fn("GET", "/api/desktop/windows")
         assert result == {"success": True, "windows": []}
         mock_get.assert_called_once_with(
-            "https://localhost:8765/api/desktop/windows", verify=False, timeout=10
+            "https://localhost:8765/api/desktop/windows",
+            headers={"Authorization": "Bearer tok123"},
+            verify=False,
+            timeout=10,
         )
 
     @patch("agentwire.mcp_server.get_portal_url", return_value="https://localhost:8765")

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -17,14 +17,39 @@ from agentwire.server import AgentWireServer
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-async def portal_client(tmp_path):
-    """Create an AgentWireServer and wrap in TestClient."""
+def _make_config(tmp_path, auth_token=None, allowed_origins=None):
     config = load_config(tmp_path / "nonexistent.yaml")
     # Override artifacts dir to use temp path
     config.artifacts = type(config.artifacts)(dir=tmp_path / "artifacts", max_size_mb=10)
-    (tmp_path / "artifacts").mkdir()
-    server = AgentWireServer(config)
+    (tmp_path / "artifacts").mkdir(exist_ok=True)
+    config.server.auth_token = auth_token
+    if allowed_origins:
+        config.server.allowed_origins = allowed_origins
+    return config
+
+
+@pytest.fixture
+async def portal_client(tmp_path):
+    """Create an AgentWireServer and wrap in TestClient."""
+    server = AgentWireServer(_make_config(tmp_path))
+    async with TestClient(TestServer(server.app)) as client:
+        yield client, server
+
+
+@pytest.fixture
+async def portal_client_with_token(tmp_path):
+    """Portal with bearer-token auth enforced."""
+    server = AgentWireServer(_make_config(tmp_path, auth_token="testtoken123"))
+    async with TestClient(TestServer(server.app)) as client:
+        yield client, server
+
+
+@pytest.fixture
+async def portal_client_with_origins(tmp_path):
+    """Portal with an allowed_origins entry (tunnel-domain case)."""
+    server = AgentWireServer(
+        _make_config(tmp_path, allowed_origins=["https://portal.example.com"])
+    )
     async with TestClient(TestServer(server.app)) as client:
         yield client, server
 
@@ -314,6 +339,120 @@ class TestApiNotify:
         client, server = portal_client
         resp = await client.post("/api/notify", json={"session": "test"})
         assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Security middleware: Origin validation (CSRF guard)
+# ---------------------------------------------------------------------------
+
+
+class TestOriginValidation:
+    async def test_post_without_origin_allowed(self, portal_client):
+        """curl/CLI requests don't send Origin and must keep working."""
+        client, server = portal_client
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            server.broadcast_dashboard = AsyncMock()
+            resp = await client.post("/api/notify", json={"event": "x"})
+        assert resp.status != 403
+
+    async def test_post_own_origin_allowed(self, portal_client):
+        client, server = portal_client
+        own = f"http://{client.host}:{client.port}"
+        server.broadcast_dashboard = AsyncMock()
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            resp = await client.post(
+                "/api/notify", json={"event": "x"}, headers={"Origin": own}
+            )
+        assert resp.status != 403
+
+    async def test_post_evil_origin_rejected(self, portal_client):
+        client, _ = portal_client
+        resp = await client.post(
+            "/api/notify", json={"event": "x"},
+            headers={"Origin": "https://evil.example"},
+        )
+        assert resp.status == 403
+
+    async def test_non_api_mutators_covered(self, portal_client):
+        """Mutating routes outside /api/ (upload, transcribe) are guarded too."""
+        client, _ = portal_client
+        for path in ("/upload", "/transcribe"):
+            resp = await client.post(
+                path, headers={"Origin": "https://evil.example"}
+            )
+            assert resp.status == 403, path
+
+    async def test_get_with_evil_origin_allowed(self, portal_client):
+        """Origin check only applies to state-changing methods."""
+        client, _ = portal_client
+        resp = await client.get(
+            "/health", headers={"Origin": "https://evil.example"}
+        )
+        assert resp.status == 200
+
+    async def test_allowed_origins_entry(self, portal_client_with_origins):
+        client, server = portal_client_with_origins
+        server.broadcast_dashboard = AsyncMock()
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            resp = await client.post(
+                "/api/notify", json={"event": "x"},
+                headers={"Origin": "https://portal.example.com"},
+            )
+        assert resp.status != 403
+
+
+# ---------------------------------------------------------------------------
+# Security middleware: bearer-token auth
+# ---------------------------------------------------------------------------
+
+
+AUTH = {"Authorization": "Bearer testtoken123"}
+
+
+class TestTokenAuth:
+    async def test_missing_token_401(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.get("/api/sessions/local")
+        assert resp.status == 401
+        assert resp.headers["WWW-Authenticate"].startswith("Bearer")
+
+    async def test_wrong_token_401(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.get(
+            "/api/sessions/local", headers={"Authorization": "Bearer nope"}
+        )
+        assert resp.status == 401
+
+    async def test_right_token_ok(self, portal_client_with_token):
+        client, server = portal_client_with_token
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            resp = await client.get("/api/sessions/local", headers=AUTH)
+        assert resp.status == 200
+
+    async def test_mutation_requires_token(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.post("/api/notify", json={"event": "x"})
+        assert resp.status == 401
+
+    async def test_public_surface_open(self, portal_client_with_token):
+        """The page shell + health must load so the token modal can render."""
+        client, _ = portal_client_with_token
+        assert (await client.get("/health")).status == 200
+        assert (await client.get("/")).status == 200
+        resp = await client.get("/static/js/api.js")
+        assert resp.status != 401
+
+    async def test_no_token_configured_open(self, portal_client):
+        """Loopback default: no token configured behaves as before."""
+        client, server = portal_client
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            resp = await client.get("/api/sessions/local")
+        assert resp.status == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,150 @@
+"""Unit tests for agentwire.security — origin policy, token lifecycle, bind policy."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import security
+from agentwire.config import load_config
+
+
+# ---------------------------------------------------------------------------
+# Loopback detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsLoopbackHost:
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost", "127.0.0.5"])
+    def test_loopback(self, host):
+        assert security.is_loopback_host(host) is True
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.5", "myhost.lan"])
+    def test_non_loopback(self, host):
+        assert security.is_loopback_host(host) is False
+
+
+# ---------------------------------------------------------------------------
+# Origin policy
+# ---------------------------------------------------------------------------
+
+
+def _request(scheme="https", host="192.168.2.10:8765"):
+    return SimpleNamespace(scheme=scheme, host=host)
+
+
+class TestOriginAllowed:
+    def test_own_origin(self):
+        assert security.origin_allowed(
+            "https://192.168.2.10:8765", _request(), []
+        )
+
+    def test_evil_origin_rejected(self):
+        assert not security.origin_allowed("https://evil.example", _request(), [])
+
+    def test_allowed_origins_entry(self):
+        # Cloudflare Tunnel: public https origin, portal itself plain http
+        assert security.origin_allowed(
+            "https://portal.example.com",
+            _request(scheme="http", host="127.0.0.1:8765"),
+            ["https://portal.example.com"],
+        )
+
+    def test_localhost_equivalents_same_port(self):
+        # Browser at https://localhost:8765 posting to 127.0.0.1:8765
+        assert security.origin_allowed(
+            "https://localhost:8765", _request(host="127.0.0.1:8765"), []
+        )
+
+    def test_localhost_wrong_port_rejected(self):
+        assert not security.origin_allowed(
+            "https://localhost:9999", _request(host="127.0.0.1:8765"), []
+        )
+
+    def test_localhost_origin_to_lan_host_rejected(self):
+        # Origin is loopback but the portal is reached via a LAN IP — a page
+        # on the *remote* user's machine shouldn't pass as same-site.
+        assert not security.origin_allowed(
+            "https://localhost:8765", _request(host="192.168.2.10:8765"), []
+        )
+
+    def test_default_port_normalization(self):
+        assert security.origin_allowed(
+            "https://localhost", _request(host="127.0.0.1:443"), []
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def token_file(tmp_path, monkeypatch):
+    path = tmp_path / "portal.token"
+    monkeypatch.setattr(security, "TOKEN_FILE", path)
+    return path
+
+
+class TestTokenLifecycle:
+    def _config(self, tmp_path, auth_token=None):
+        config = load_config(tmp_path / "nonexistent.yaml")
+        config.server.auth_token = auth_token
+        return config
+
+    def test_generate_token_length(self):
+        token = security.generate_token()
+        assert len(token) >= 32
+
+    def test_ensure_generates_file(self, token_file, tmp_path):
+        config = self._config(tmp_path)
+        token = security.ensure_auth_token(config)
+        assert token
+        assert token_file.read_text().strip() == token
+        assert (token_file.stat().st_mode & 0o777) == 0o600
+
+    def test_ensure_respects_existing_file(self, token_file, tmp_path):
+        token_file.write_text("existing-token\n")
+        config = self._config(tmp_path)
+        assert security.ensure_auth_token(config) == "existing-token"
+
+    def test_config_override_wins(self, token_file, tmp_path):
+        token_file.write_text("file-token\n")
+        config = self._config(tmp_path, auth_token="override-token")
+        assert security.ensure_auth_token(config) == "override-token"
+        # Override must not rewrite the file
+        assert token_file.read_text().strip() == "file-token"
+
+    def test_explicit_disable(self, token_file, tmp_path):
+        token_file.write_text("file-token\n")
+        config = self._config(tmp_path, auth_token="")
+        assert security.ensure_auth_token(config) is None
+        assert security.resolve_auth_token(config) is None
+
+    def test_read_missing_file(self, token_file):
+        assert security.read_token_file() is None
+
+
+# ---------------------------------------------------------------------------
+# Startup guard
+# ---------------------------------------------------------------------------
+
+
+class TestValidateStartupSecurity:
+    def _config(self, tmp_path, host, auth_token):
+        config = load_config(tmp_path / "nonexistent.yaml")
+        config.server.host = host
+        config.server.auth_token = auth_token
+        return config
+
+    def test_non_loopback_without_token_refuses(self, tmp_path):
+        config = self._config(tmp_path, "0.0.0.0", None)
+        with pytest.raises(SystemExit):
+            security.validate_startup_security(config)
+
+    def test_non_loopback_with_token_passes(self, tmp_path):
+        config = self._config(tmp_path, "0.0.0.0", "tok")
+        security.validate_startup_security(config)
+
+    def test_loopback_without_token_passes(self, tmp_path):
+        config = self._config(tmp_path, "127.0.0.1", None)
+        security.validate_startup_security(config)


### PR DESCRIPTION
Closes #247

## What was built

Two in-process security layers on the portal, per the issue's plan:

**1. Origin validation (always on) — the CSRF guard**
- Single aiohttp middleware in new `agentwire/security.py` (the app had zero middleware before; all routes registered centrally, so one middleware covers everything)
- Applies to all mutating methods (POST/PUT/DELETE/PATCH — method-based, so `/upload`, `/transcribe`, `/send/{name}` are covered without a path list) and WebSocket upgrades
- Absent Origin → allow (curl/CLI/scripts keep working). Present Origin must match the portal's own origin, a localhost equivalent on the same port, or `server.allowed_origins` (exact strings; the Cloudflare Tunnel case). Mismatch → 403 + log line naming the origin

**2. Bearer-token auth (required for non-loopback binds)**
- Token lives at `~/.agentwire/portal.token` (0600), auto-generated on first non-loopback start. `server.auth_token` config overrides it: `""` = disabled (loopback only), string = explicit override
- Portal **refuses to start** on a non-loopback bind with auth disabled
- HTTP: `Authorization: Bearer`; WS: `agentwire.bearer.<token>` subprotocol — validated by the middleware *before* `ws.prepare()` (clean HTTP 401 at upgrade; all three WS handlers stream immediately after prepare, so first-message auth was racy), echoed back by the handlers
- `hmac.compare_digest`; 401 + `WWW-Authenticate: Bearer realm="agentwire"`
- Public bootstrap surface (no token): `GET /`, `/health`, `/static/*` — so the token modal can render
- `agentwire portal token [--rotate]` CLI; `agentwire init` generates + prints the token (init template still binds 0.0.0.0 — now honest from day one)
- Token attached at every local caller: `_portal_api` curl + 5 urllib/requests sites in `__main__.py`, MCP `_portal_request` + transcribe, scheduler notify ×2, overnight notify, `agentwire-permission.sh`

**3. Portal UI**
- New `static/js/api.js` (`apiFetch` wrapper + `wsProtocols()`) and `static/js/token-modal.js` (one-time-per-device entry, verifies, stores in localStorage, reloads to reconnect everything)
- All 49 fetch sites across 17 modules migrated to `apiFetch` — no shims, pre-launch
- WS connects (dashboard, monitor, terminal, collage tiles) carry the subprotocol; failed dashboard handshake probes the API once so a stale token raises the modal
- Artifact iframes blob-load via `apiFetch` when a token is set (iframes can't carry headers); unchanged for external URLs / token-less local use

**4. Docs**: SECURITY.md trust model rewritten (no longer says "no auth"), README network note, agentwire-config + agentwire-cli skills.

## Decisions locked in

- **Token file over config field** (user-approved): `GET /api/config` serves raw config.yaml to the config editor, and auto-generation must not rewrite hand-edited YAML. `auth_token` also added to the config redaction regex for override users
- **Loopback binds don't auto-generate** a token — the issue says optional there; origin checks cover the browser vector locally. Zero friction for local-only users, enforcement the moment the bind goes wide
- **Subprotocol over query param** for WS: no token in URLs/access logs; `secrets.token_urlsafe` is valid RFC 6455 token chars

## Surprises

- Multi-file artifact dirs (e.g. handoff bundles) lose relative sub-resource refs under blob URLs when token auth is active — self-contained HTML is the supported shape there (noted in code)
- 2 pre-existing test failures on main, unrelated: `test_session_send_cross_session` (stale assertion vs council-era message format) and `test_router_with_new_review` (order-dependent; passes in isolation)

## Verification

- 36 new tests: `tests/unit/test_security.py` (loopback/origin/lifecycle/startup-guard), origin+token HTTP matrices in `test_portal_api.py`, WS subprotocol/401/403 matrix in `test_server_websockets.py` — 1172 passing
- Live against the rebuilt portal (binds 0.0.0.0, token auto-generated at 0600): POST without Origin → 200, evil Origin → 403, own origin → 200; no/wrong token → 401 + WWW-Authenticate, right token → 200; `/` + `/static` public → 200
- Local tooling with enforcement on: `agentwire portal token`, `agentwire say` (authed `/api/say`), installed permission hook carries the token, `agentwire doctor` all-green

Built by [dotdev.dev](https://dotdev.dev)