### PR TITLE
fix(tests): stale session_send assertion + missions notified-PR state leak

### DIFF
--- a/tests/integration/test_missions_lifecycle.py
+++ b/tests/integration/test_missions_lifecycle.py
@@ -24,6 +24,7 @@ def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setattr(state, "STATE_DIR", state_dir)
     monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
     monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(state, "NOTIFIED_PRS_PATH", state_dir / "notified_prs.json")
     monkeypatch.setattr(feedback_router, "SUMMARIES_DIR", tmp_path / "summaries")
     locks_dir = tmp_path / "locks"
     locks_dir.mkdir()
@@ -71,6 +72,7 @@ def world(monkeypatch, isolated_state):
         comments_made: list = []
         killed_sessions: list = []
         removed_worktrees: list = []
+        notifications_sent: list = []
 
     w = World()
     w.issues = []
@@ -81,6 +83,7 @@ def world(monkeypatch, isolated_state):
     w.comments_made = []
     w.killed_sessions = []
     w.removed_worktrees = []
+    w.notifications_sent = []
 
     # github wrappers
     monkeypatch.setattr(github, "list_issues", lambda repo, **kw: list(w.issues))
@@ -112,6 +115,12 @@ def world(monkeypatch, isolated_state):
     def _remove(path):
         w.removed_worktrees.append(path)
     monkeypatch.setattr(gc, "remove_worktree", _remove)
+
+    # PR-opened email — record instead of sending
+    def _notify(repo_name, issue, pr):
+        w.notifications_sent.append({"repo": repo_name, "issue": issue.number, "pr": pr.number})
+        return True, "stub-message-id"
+    monkeypatch.setattr(feedback_router, "_notify_pr_ready", _notify)
 
     return w
 
@@ -150,9 +159,11 @@ def test_full_lifecycle(world, cfg, projects_dir):
         url="https://github.com/o/r/pull/42", is_draft=True,
     )
 
-    # Run feedback router with no new reviews yet → noop
+    # Run feedback router with no new reviews yet → sends the one-time
+    # "draft PR ready" email, no review routing
     report = feedback_router.route_feedback(cfg)
-    assert report.routed == []
+    assert [r["event"] for r in report.routed] == ["pr_opened_email"]
+    assert world.notifications_sent == [{"repo": "owner/agentwire-dev", "issue": 195, "pr": 42}]
     assert any("no new reviews" in s.get("reason", "") for s in report.skipped)
 
     # --- 3. Reviewer leaves a review ---
@@ -205,6 +216,7 @@ def test_full_lifecycle(world, cfg, projects_dir):
     assert wt in world.removed_worktrees
     # State for this PR was cleared
     assert state.last_routed_review(42) is None
+    assert not state.is_pr_notified(42)
     # The session is no longer active
     assert expected_session not in world.active_sessions
 

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -59,7 +59,8 @@ class TestSessionTools:
         mock_cmd.return_value = _success()
         session_send(session="worker", message="do task")
         sent_msg = mock_cmd.call_args[0][0][3]  # args[3] = message
-        assert "[From: orchestrator]" in sent_msg
+        assert '[MESSAGE FROM SESSION "orchestrator"' in sent_msg
+        assert 'session_send(session="orchestrator"' in sent_msg
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     @patch("agentwire.mcp_server.get_caller_session", return_value=None)

--- a/tests/unit/test_missions_cli.py
+++ b/tests/unit/test_missions_cli.py
@@ -22,6 +22,7 @@ def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setattr(state, "STATE_DIR", state_dir)
     monkeypatch.setattr(state, "LAST_TICK_PATH", state_dir / "last_tick.json")
     monkeypatch.setattr(state, "ROUTED_REVIEWS_PATH", state_dir / "routed_reviews.json")
+    monkeypatch.setattr(state, "NOTIFIED_PRS_PATH", state_dir / "notified_prs.json")
     monkeypatch.setattr(feedback_router, "SUMMARIES_DIR", summaries_dir)
 
 
@@ -63,6 +64,7 @@ def stub_world(monkeypatch, cfg):
         created_sessions: list = []
         prompts_sent: list = []
         wait_ready_response: bool = True
+        notifications_sent: list = []
         # gc side-effects
         kill_calls: list = []
         remove_calls: list = []
@@ -80,6 +82,7 @@ def stub_world(monkeypatch, cfg):
     w.labels_created = []
     w.created_sessions = []
     w.prompts_sent = []
+    w.notifications_sent = []
     w.kill_calls = []
     w.remove_calls = []
 
@@ -144,6 +147,13 @@ def stub_world(monkeypatch, cfg):
         w.remove_calls.append(path)
 
     monkeypatch.setattr(gc, "remove_worktree", _remove)
+
+    # Never send real PR-opened emails from tests
+    def _stub_notify(repo_name, issue, pr):
+        w.notifications_sent.append({"repo": repo_name, "issue": issue.number, "pr": pr.number})
+        return True, "stub-message-id"
+
+    monkeypatch.setattr(feedback_router, "_notify_pr_ready", _stub_notify)
 
     return w
 
@@ -357,6 +367,7 @@ class TestRouteFeedback:
         assert data["routed"] == [] and data["skipped"] == []
 
     def test_router_with_new_review(self, stub_world, capsys):
+        state.mark_pr_notified(42)  # pretend PR already announced
         stub_world.active_sessions = ["agentwire-dev/mission-195-foo-bar"]
         stub_world.prs_by_branch[("owner/agentwire-dev", "mission-195-foo-bar")] = PullRequest(
             number=42, state="OPEN", head_ref="mission-195-foo-bar",


### PR DESCRIPTION
Closes #249.

## What was actually happening

**Failure 1** was the simple one: `test_session_send_cross_session` asserted the old `[From: orchestrator]` prefix; the format changed to the `MESSAGE FROM SESSION "..."` reply-instruction block during the council/soul work. Assertion updated.

**Failure 2** was nastier than a flake. The `isolated_state` fixtures in `tests/unit/test_missions_cli.py` **and** `tests/integration/test_missions_lifecycle.py` patched `STATE_DIR` / `LAST_TICK_PATH` / `ROUTED_REVIEWS_PATH` but forgot `NOTIFIED_PRS_PATH` — so both modules read and wrote the **real** `~/.agentwire/missions/state/notified_prs.json`. The chain in a full-suite run:

1. `tests/integration` runs first (alphabetical). The lifecycle test's gc step reaps PR 42 → `forget_pr(42)` deletes 42 from the real home-dir file.
2. `test_missions_cli`'s router test then sees PR 42 as never-notified → fires the `pr_opened_email` path → `routed` has 2 entries instead of 1 → fail.
3. That path called the real `_notify_pr_ready`, which **sent a real Resend email every full-suite run** (the `detail` UUID in the failure output is a Resend message id), and re-added 42 to the real file — which is why the test passed again in isolation.

The lifecycle test's `routed == []` assertion on the first router tick was itself only passing *because* of the polluted real file.

## Fix

- Patch `NOTIFIED_PRS_PATH` in both fixtures (matching `test_missions_feedback_router.py` / `test_missions_gc.py` / `test_missions_state.py`, which already did).
- Stub `_notify_pr_ready` in both test worlds so no test in these modules can ever send real email, regardless of future test additions.
- `test_router_with_new_review`: pre-mark PR 42 notified (same idiom as the feedback_router tests) — keeps it focused on review routing.
- Lifecycle test now asserts the `pr_opened_email` event on first tick and `not is_pr_notified(42)` after gc reap — the notification is part of the lifecycle, so test it instead of hiding it.
- Cleaned the polluted real state file (removed test PR 42; real PRs 206/207/209 kept).

## Verification

- `uv run pytest tests/ -q` → **1174 passed** (full suite)
- `tests/unit/test_missions_cli.py::TestRouteFeedback` + lifecycle + mcp_tools_args in isolation → 40 passed
- Real `~/.agentwire/missions/state/notified_prs.json` unchanged after suite runs

Built by [dotdev.dev](https://dotdev.dev)