### PR TITLE
feat: once-per-announcement welcome modal — reach the userbase between releases (#255)

### DIFF
--- a/agentwire/static/announcements.json
+++ b/agentwire/static/announcements.json
@@ -1,0 +1,19 @@
+{
+  "announcements": [
+    {
+      "id": "2026-06-idea-first-capture",
+      "emoji": "💡",
+      "title": "New idea? Cmd+K and go.",
+      "date": "2026-06-08",
+      "body": "AgentWire can now spin up a whole project from a single sentence. Press Cmd/Ctrl+K (or the New idea button), type — or speak — what you want to build, and it scaffolds the folder, starts an agent, and hands it your idea as the first message. You watch it get to work the moment the window opens.",
+      "highlights": [
+        "Idea-first capture — type an idea, get a running agent",
+        "Instant voice mode — browser speech in and out, zero setup"
+      ],
+      "cta": {
+        "label": "See what's in v1.31",
+        "url": "https://github.com/dotdevdotdev/agentwire-dev/releases/tag/v1.31.0"
+      }
+    }
+  ]
+}

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -1001,6 +1001,151 @@ body {
 }
 
 /* =========================================================================
+   Announcement modal (userbase welcome card)
+   ========================================================================= */
+
+.announcement-overlay {
+    z-index: 2100;  /* above standard modals, below the command palette */
+    animation: announcement-fade 180ms ease-out;
+}
+
+.announcement-overlay .announcement-modal {
+    width: 460px;
+    max-width: 92vw;
+    padding: 28px 28px 22px;
+    text-align: center;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 7%, var(--chrome)) 0%, var(--chrome) 60%);
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--chrome-border));
+    border-radius: 12px;
+    animation: announcement-rise 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.announcement-dismiss {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 15px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+
+.announcement-dismiss:hover {
+    color: var(--text);
+    background: var(--background);
+}
+
+.announcement-emoji {
+    font-size: 40px;
+    line-height: 1;
+    margin-bottom: 10px;
+}
+
+.announcement-title {
+    margin: 0 0 4px;
+    font-size: 21px;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.announcement-date {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 14px;
+}
+
+.announcement-body {
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--text);
+    opacity: 0.92;
+    margin-bottom: 16px;
+    text-align: left;
+}
+
+.announcement-highlights {
+    list-style: none;
+    margin: 0 0 20px;
+    padding: 0;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.announcement-highlights li {
+    position: relative;
+    padding: 8px 12px 8px 34px;
+    background: var(--background);
+    border: 1px solid var(--chrome-border);
+    border-radius: 6px;
+    font-size: 14px;
+    color: var(--text);
+}
+
+.announcement-highlights li::before {
+    content: "✦";
+    position: absolute;
+    left: 12px;
+    top: 8px;
+    color: var(--accent);
+}
+
+.announcement-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+
+.announcement-cta {
+    flex: 1;
+    padding: 10px 16px;
+    background: var(--accent);
+    color: var(--background);
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 14px;
+    text-decoration: none;
+    text-align: center;
+}
+
+.announcement-cta:hover {
+    filter: brightness(1.08);
+}
+
+.announcement-ok {
+    flex: 1;
+    padding: 10px 16px;
+    background: transparent;
+    border: 1px solid var(--chrome-border);
+    border-radius: 6px;
+    color: var(--text);
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.announcement-ok:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+@keyframes announcement-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes announcement-rise {
+    from { opacity: 0; transform: translateY(12px) scale(0.98); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* =========================================================================
    Quicktask modal
    ========================================================================= */
 

--- a/agentwire/static/js/announcement-modal.js
+++ b/agentwire/static/js/announcement-modal.js
@@ -1,0 +1,147 @@
+/**
+ * Announcement modal — once-per-announcement welcome card for the userbase.
+ *
+ * Content is a single JSON file (agentwire/static/announcements.json) edited
+ * on `main`. It plays two roles:
+ *   - Remote source: fetched from raw.githubusercontent on load, so an edit
+ *     on `main` reaches every user on their next portal open — no upgrade.
+ *   - Bundled fallback: the same file ships in the package and is served at
+ *     /static/announcements.json, used when the remote GET fails (offline).
+ *
+ * The fetch is a single unauthenticated GET with nothing about the user in
+ * it — no telemetry. Content fields are rendered as ESCAPED TEXT (the
+ * frontend owns all markup), so even though the body comes from a URL there
+ * is no injection surface; the CTA url is validated to http(s).
+ *
+ * Show logic: the newest announcement whose id isn't in the dismissed set
+ * (localStorage). Dismiss via the button, the ✕, Esc, or backdrop click.
+ */
+
+const REMOTE_URL = 'https://raw.githubusercontent.com/dotdevdotdev/agentwire-dev/main/agentwire/static/announcements.json';
+const LOCAL_URL = '/static/announcements.json';
+const SEEN_KEY = 'aw-announcements-seen';
+const FETCH_TIMEOUT_MS = 4000;
+
+let modalEl = null;
+let escHandler = null;
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
+}
+
+function seenIds() {
+    try {
+        const raw = localStorage.getItem(SEEN_KEY);
+        const arr = raw ? JSON.parse(raw) : [];
+        return Array.isArray(arr) ? arr : [];
+    } catch {
+        return [];
+    }
+}
+
+function markSeen(id) {
+    const ids = seenIds();
+    if (!ids.includes(id)) {
+        ids.push(id);
+        try { localStorage.setItem(SEEN_KEY, JSON.stringify(ids)); } catch { /* ignore */ }
+    }
+}
+
+async function fetchJson(url) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+    try {
+        // No credentials, no caching, nothing about the user goes out.
+        const resp = await fetch(url, { signal: ctrl.signal, cache: 'no-store', credentials: 'omit' });
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/** A valid, safe http(s) URL, or null. */
+function safeUrl(url) {
+    try {
+        const u = new URL(String(url));
+        return (u.protocol === 'https:' || u.protocol === 'http:') ? u.href : null;
+    } catch {
+        return null;
+    }
+}
+
+/** First announcement (in file order — newest first) the user hasn't dismissed. */
+function pickUnseen(data) {
+    const list = Array.isArray(data?.announcements) ? data.announcements : [];
+    const seen = seenIds();
+    return list.find((a) => a && typeof a.id === 'string' && a.id && !seen.includes(a.id)) || null;
+}
+
+function renderModal(a) {
+    const emoji = a.emoji ? `<div class="announcement-emoji">${escapeHtml(a.emoji)}</div>` : '';
+    const date = a.date ? `<div class="announcement-date">${escapeHtml(a.date)}</div>` : '';
+    const highlights = Array.isArray(a.highlights) && a.highlights.length
+        ? `<ul class="announcement-highlights">${a.highlights
+            .map((h) => `<li>${escapeHtml(h)}</li>`).join('')}</ul>`
+        : '';
+    const ctaUrl = a.cta && safeUrl(a.cta.url);
+    const cta = ctaUrl
+        ? `<a class="announcement-cta" href="${escapeHtml(ctaUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(a.cta.label || 'Learn more')}</a>`
+        : '';
+    return `<div class="modal-overlay announcement-overlay" id="announcementOverlay">
+        <div class="modal announcement-modal" role="dialog" aria-label="Announcement" aria-modal="true">
+            <button class="announcement-dismiss" data-action="dismiss" title="Dismiss" aria-label="Dismiss">✕</button>
+            ${emoji}
+            <h2 class="announcement-title">${escapeHtml(a.title || 'What’s new')}</h2>
+            ${date}
+            <div class="announcement-body">${escapeHtml(a.body || '')}</div>
+            ${highlights}
+            <div class="announcement-footer">
+                ${cta}
+                <button class="announcement-ok" data-action="dismiss">Got it</button>
+            </div>
+        </div>
+    </div>`;
+}
+
+function close(id) {
+    if (id) markSeen(id);
+    if (escHandler) { document.removeEventListener('keydown', escHandler); escHandler = null; }
+    modalEl?.remove();
+    modalEl = null;
+}
+
+function show(a) {
+    if (modalEl) return;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = renderModal(a);
+    modalEl = wrapper.firstElementChild;
+    document.body.appendChild(modalEl);
+
+    modalEl.addEventListener('click', (e) => {
+        if (e.target === modalEl || e.target.closest('[data-action="dismiss"]')) {
+            close(a.id);
+        }
+    });
+    escHandler = (e) => { if (e.key === 'Escape') close(a.id); };
+    document.addEventListener('keydown', escHandler);
+}
+
+/**
+ * Fetch announcements (remote first, bundled fallback) and show the newest
+ * unseen one. Fails silently — an announcement is never worth a broken portal.
+ */
+export async function initAnnouncements() {
+    try {
+        const data = (await fetchJson(REMOTE_URL)) || (await fetchJson(LOCAL_URL));
+        if (!data) return;
+        const a = pickUnseen(data);
+        if (a) show(a);
+    } catch {
+        /* never let an announcement break the desktop */
+    }
+}

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -32,6 +32,7 @@ import { armDeadKeySuppressor, disarmDeadKeySuppressor } from './dead-key-suppre
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import * as browserStt from './voice/browser-stt.js';
 import { voicePromptWrap } from './voice/prompt.js';
+import { initAnnouncements } from './announcement-modal.js';
 
 // State - track open windows
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
@@ -251,6 +252,10 @@ async function init() {
 
     // Fetch initial data in the background (will emit events to listeners above)
     desktop.fetchSessions();
+
+    // Show a userbase announcement if there's a new one (non-blocking,
+    // fails silently — never holds up or breaks the desktop).
+    initAnnouncements();
 }
 
 /**

--- a/tests/unit/test_announcements.py
+++ b/tests/unit/test_announcements.py
@@ -1,0 +1,54 @@
+"""The bundled announcements.json must parse and match the modal's schema.
+
+It ships in the wheel as the offline fallback AND is the remote source the
+portal fetches from `main`, so a malformed entry would reach every user.
+This guards the shape the frontend (announcement-modal.js) renders.
+"""
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+ANNOUNCEMENTS = Path(__file__).resolve().parents[2] / "agentwire" / "static" / "announcements.json"
+
+
+@pytest.fixture(scope="module")
+def data():
+    assert ANNOUNCEMENTS.exists(), f"missing {ANNOUNCEMENTS}"
+    return json.loads(ANNOUNCEMENTS.read_text())
+
+
+def test_top_level_shape(data):
+    assert isinstance(data, dict)
+    assert isinstance(data.get("announcements"), list)
+
+
+def test_ids_present_and_unique(data):
+    ids = [a["id"] for a in data["announcements"]]
+    assert all(isinstance(i, str) and i for i in ids), "every announcement needs a non-empty string id"
+    assert len(ids) == len(set(ids)), "announcement ids must be unique (dedup is by id)"
+
+
+def test_required_and_typed_fields(data):
+    for a in data["announcements"]:
+        assert isinstance(a.get("title"), str) and a["title"], f"{a.get('id')}: title required"
+        assert isinstance(a.get("body"), str) and a["body"], f"{a.get('id')}: body required"
+        if "highlights" in a:
+            assert isinstance(a["highlights"], list)
+            assert all(isinstance(h, str) for h in a["highlights"])
+        if "emoji" in a:
+            assert isinstance(a["emoji"], str)
+        if "date" in a:
+            assert isinstance(a["date"], str)
+
+
+def test_cta_is_safe_https(data):
+    for a in data["announcements"]:
+        cta = a.get("cta")
+        if cta is None:
+            continue
+        assert isinstance(cta.get("label"), str) and cta["label"], f"{a['id']}: cta needs a label"
+        scheme = urlparse(cta.get("url", "")).scheme
+        assert scheme in ("http", "https"), f"{a['id']}: cta url must be http(s)"


### PR DESCRIPTION
Closes #255

## What

A polished vanilla HTML/CSS/JS modal that shows a single announcement once per user. Content lives in **one JSON file** edited on `main` — change it and every user sees it on their next portal open, no upgrade needed. It's how we reach the ~15 people running AgentWire between releases.

## How it works

- **One file, two roles:** `agentwire/static/announcements.json`
  - **Remote source:** the portal fetches it from `raw.githubusercontent.com/.../main/agentwire/static/announcements.json` on load
  - **Bundled fallback:** the same file ships in the wheel, served at `/static/announcements.json`, used only if the remote GET fails (offline)
- **Privacy:** a single unauthenticated GET with `credentials: omit`, `cache: no-store`, 4s AbortController timeout — nothing about the user goes out, no telemetry
- **Safety:** content is structured data (`id`/`emoji`/`title`/`body`/`highlights`/`cta`/`date`) rendered as **escaped text** — the frontend owns all markup, so a URL-sourced field has no injection path; the CTA url is validated to http(s) and opened `noopener`
- **Show-once:** newest announcement whose `id` isn't in localStorage `aw-announcements-seen`; dismiss via Got it / ✕ / Esc / backdrop. Bump the id (or add a new entry) to re-show
- Fails silently — an announcement is never worth a broken desktop

## To announce something

Edit `agentwire/static/announcements.json` on `main` (new entry at the top, fresh `id`). Done — no release.

## Verification

- **Live (Chrome):** seeded v1.31 announcement renders (emoji header, title, date, body, two highlight chips, green CTA + Got it); dismiss writes the id to localStorage and removes it; reload → stays gone
- `test_announcements.py` validates the bundled JSON shape (ids present + unique, required fields typed, CTA url http(s)) so a typo can't reach users
- 1247 tests green

Built by [dotdev.dev](https://dotdev.dev)