### PR TITLE
feat: second announcement channel — persistent sidebar banner

### DIFF
--- a/agentwire/static/announcements.json
+++ b/agentwire/static/announcements.json
@@ -1,7 +1,19 @@
 {
   "announcements": [
     {
+      "id": "evergreen-feedback-2026-06",
+      "placement": "banner",
+      "emoji": "👋",
+      "title": "You're an early one",
+      "body": "AgentWire is young and shaped by the handful of people running it. Bug, idea, or just hello — open an issue, it's read.",
+      "cta": {
+        "label": "Open an issue",
+        "url": "https://github.com/dotdevdotdev/agentwire-dev/issues/new"
+      }
+    },
+    {
       "id": "2026-06-idea-first-capture",
+      "placement": "modal",
       "emoji": "💡",
       "title": "New idea? Cmd+K and go.",
       "date": "2026-06-08",

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -4965,6 +4965,59 @@ body.sidebar-pinned .sidebar-tab {
     opacity: 1;
 }
 
+/* Sidebar announcement banner (evergreen userbase note — see announcement-modal.js) */
+.announcement-banner {
+    position: relative;
+    flex-basis: 100%;
+    padding: calc(var(--spacing-base) * 1.25);
+    margin-bottom: var(--spacing-base);
+    border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--chrome-border));
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius, 6px);
+    background: color-mix(in srgb, var(--accent) 6%, var(--chrome));
+    font-size: 11px;
+    line-height: 1.45;
+}
+
+.announcement-banner-title {
+    font-weight: 600;
+    color: var(--accent);
+    margin-bottom: 4px;
+    padding-right: 14px;  /* clear the ✕ */
+}
+
+.announcement-banner-body {
+    color: var(--text-secondary, inherit);
+}
+
+.announcement-banner-cta {
+    display: inline-block;
+    margin-top: 6px;
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.announcement-banner-cta:hover {
+    text-decoration: underline;
+}
+
+.announcement-banner-dismiss {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 11px;
+    opacity: 0.6;
+}
+
+.announcement-banner-dismiss:hover {
+    opacity: 1;
+}
+
 /* Edit-before-send transcript bars (default STT tier) */
 .sidebar-transcript-bar,
 .wb-transcript-bar {

--- a/agentwire/static/js/announcement-modal.js
+++ b/agentwire/static/js/announcement-modal.js
@@ -1,5 +1,5 @@
 /**
- * Announcement modal — once-per-announcement welcome card for the userbase.
+ * Announcements — userbase messaging in two channels, one source file.
  *
  * Content is a single JSON file (agentwire/static/announcements.json) edited
  * on `main`. It plays two roles:
@@ -8,13 +8,17 @@
  *   - Bundled fallback: the same file ships in the package and is served at
  *     /static/announcements.json, used when the remote GET fails (offline).
  *
+ * Each entry's `placement` picks the channel:
+ *   - "modal" (default) — big centered splash for the moments that matter.
+ *   - "banner" — a quiet, persistent strip in the sidebar footer for
+ *     evergreen notes (a link, a tip, an ask).
+ * Both show the newest entry whose id isn't in the shared dismissed set
+ * (localStorage `aw-announcements-seen`); dismiss is per-id.
+ *
  * The fetch is a single unauthenticated GET with nothing about the user in
  * it — no telemetry. Content fields are rendered as ESCAPED TEXT (the
  * frontend owns all markup), so even though the body comes from a URL there
  * is no injection surface; the CTA url is validated to http(s).
- *
- * Show logic: the newest announcement whose id isn't in the dismissed set
- * (localStorage). Dismiss via the button, the ✕, Esc, or backdrop click.
  */
 
 const REMOTE_URL = 'https://raw.githubusercontent.com/dotdevdotdev/agentwire-dev/main/agentwire/static/announcements.json';
@@ -74,11 +78,14 @@ function safeUrl(url) {
     }
 }
 
-/** First announcement (in file order — newest first) the user hasn't dismissed. */
-function pickUnseen(data) {
-    const list = Array.isArray(data?.announcements) ? data.announcements : [];
+/** Newest (file order) unseen announcement matching `placement` (default "modal"). */
+function pickUnseen(list, placement) {
     const seen = seenIds();
-    return list.find((a) => a && typeof a.id === 'string' && a.id && !seen.includes(a.id)) || null;
+    return list.find((a) => (
+        a && typeof a.id === 'string' && a.id
+        && (a.placement || 'modal') === placement
+        && !seen.includes(a.id)
+    )) || null;
 }
 
 function renderModal(a) {
@@ -108,14 +115,14 @@ function renderModal(a) {
     </div>`;
 }
 
-function close(id) {
+function closeModal(id) {
     if (id) markSeen(id);
     if (escHandler) { document.removeEventListener('keydown', escHandler); escHandler = null; }
     modalEl?.remove();
     modalEl = null;
 }
 
-function show(a) {
+function showModal(a) {
     if (modalEl) return;
     const wrapper = document.createElement('div');
     wrapper.innerHTML = renderModal(a);
@@ -124,23 +131,47 @@ function show(a) {
 
     modalEl.addEventListener('click', (e) => {
         if (e.target === modalEl || e.target.closest('[data-action="dismiss"]')) {
-            close(a.id);
+            closeModal(a.id);
         }
     });
-    escHandler = (e) => { if (e.key === 'Escape') close(a.id); };
+    escHandler = (e) => { if (e.key === 'Escape') closeModal(a.id); };
     document.addEventListener('keydown', escHandler);
 }
 
+function renderBanner(a) {
+    const slot = document.getElementById('sidebarAnnouncementBanner');
+    if (!slot) return;
+    const ctaUrl = a.cta && safeUrl(a.cta.url);
+    const title = a.emoji ? `${escapeHtml(a.emoji)} ${escapeHtml(a.title || '')}` : escapeHtml(a.title || '');
+    const cta = ctaUrl
+        ? `<a class="announcement-banner-cta" href="${escapeHtml(ctaUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(a.cta.label || 'Learn more')} →</a>`
+        : '';
+    slot.innerHTML = `<div class="announcement-banner">
+        <button class="announcement-banner-dismiss" data-action="dismiss" title="Dismiss" aria-label="Dismiss announcement">✕</button>
+        ${title ? `<div class="announcement-banner-title">${title}</div>` : ''}
+        ${a.body ? `<div class="announcement-banner-body">${escapeHtml(a.body)}</div>` : ''}
+        ${cta}
+    </div>`;
+    slot.querySelector('[data-action="dismiss"]')?.addEventListener('click', () => {
+        markSeen(a.id);
+        slot.innerHTML = '';
+    });
+}
+
 /**
- * Fetch announcements (remote first, bundled fallback) and show the newest
- * unseen one. Fails silently — an announcement is never worth a broken portal.
+ * Fetch announcements (remote first, bundled fallback) and surface the newest
+ * unseen entry per channel: a centered modal and a sidebar-footer banner.
+ * Fails silently — an announcement is never worth a broken portal.
  */
 export async function initAnnouncements() {
     try {
         const data = (await fetchJson(REMOTE_URL)) || (await fetchJson(LOCAL_URL));
-        if (!data) return;
-        const a = pickUnseen(data);
-        if (a) show(a);
+        const list = Array.isArray(data?.announcements) ? data.announcements : [];
+        if (!list.length) return;
+        const modal = pickUnseen(list, 'modal');
+        if (modal) showModal(modal);
+        const banner = pickUnseen(list, 'banner');
+        if (banner) renderBanner(banner);
     } catch {
         /* never let an announcement break the desktop */
     }

--- a/agentwire/templates/desktop.html
+++ b/agentwire/templates/desktop.html
@@ -38,6 +38,7 @@
             <!-- Phase 3: list panel accordion sections mount here -->
         </div>
         <div class="sidebar-footer">
+            <div class="sidebar-announcement-slot" id="sidebarAnnouncementBanner"></div>
             <div class="instant-mode-banner" id="instantModeBanner" hidden>
                 <div class="instant-mode-banner-title">⚡ Instant voice mode</div>
                 <div class="instant-mode-banner-body">

--- a/tests/unit/test_announcements.py
+++ b/tests/unit/test_announcements.py
@@ -44,6 +44,12 @@ def test_required_and_typed_fields(data):
             assert isinstance(a["date"], str)
 
 
+def test_placement_valid(data):
+    for a in data["announcements"]:
+        placement = a.get("placement", "modal")
+        assert placement in ("modal", "banner"), f"{a['id']}: placement must be modal|banner"
+
+
 def test_cta_is_safe_https(data):
     for a in data["announcements"]:
         cta = a.get("cta")


### PR DESCRIPTION
Builds on #256. Adds a **second userbase-messaging channel** so the modal and a sidebar banner do different jobs, both driven from the same `announcements.json`.

## Two channels, one file

Each entry's `placement` picks the channel:
- **`modal`** (default) — the big centered splash for the moments that matter. Once-per-id, attention-grabbing.
- **`banner`** — a quiet, persistent strip in the **sidebar footer** (next to the Instant Voice Mode banner) for evergreen notes: a link, a tip, an ask. Persists until dismissed.

Both surface the newest unseen entry of their kind; dismiss is **per-id**, shared dismissed set (`aw-announcements-seen`). Same remote-fetch, same escaped-text safety, same edit-on-`main`-reaches-everyone workflow.

## To use it

In `announcements.json`, set `"placement": "banner"` on an entry for the sidebar strip, or `"modal"` (or omit) for the splash. Seeded one evergreen banner entry (a feedback nudge) alongside the v1.31 modal as a live example.

## Verification

- **Live (Chrome):** banner renders in the sidebar footer — accent left-border, title/body/CTA, ✕ dismiss — matching the voice-banner family; modal still shows once per id and is unaffected
- Confirmed the remote-first design: the portal serves `main`'s copy, so a banner only goes live once merged (this PR) — local edits are correctly shadowed until then
- `test_announcements.py` validates `placement ∈ {modal, banner}`; 1248 tests green

Built by [dotdev.dev](https://dotdev.dev)