### PR TITLE
feat(portal): desktop-notification toggle in Config sidebar

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -770,6 +770,25 @@ body {
     border-color: var(--accent);
 }
 
+.sidebar-notif-mute {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-muted);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.sidebar-notif-mute input[type="checkbox"] {
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
+.sidebar-display-hint {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
 /* Voice Indicator States */
 #sidebarVoiceIndicator {
     display: flex;

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -15,6 +15,7 @@ import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { sidebar } from './sidebar.js';
 import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
+import { notificationsActive } from './notification-prefs.js';
 import { configSection } from './sidebar/config-section.js';
 import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
@@ -315,19 +316,16 @@ function handleSessionRenamed({ old_name, new_name }) {
  * Shows desktop notification for background session activity.
  */
 function handleWindowActivity({ session }) {
-    // Only notify if session window is not focused
-    if (desktop.getActiveWindow() !== session) {
-        // Request notification permission if needed
-        if (Notification.permission === 'granted') {
-            new Notification(`Activity in ${session}`, {
-                body: 'Session has new output',
-                icon: '/static/img/icon-192.png',
-                tag: `activity-${session}`,  // Prevent duplicate notifications
-            });
-        } else if (Notification.permission !== 'denied') {
-            Notification.requestPermission();
-        }
-    }
+    // Only notify if the session window isn't the one you're looking at.
+    if (desktop.getActiveWindow() === session) return;
+    // Respects browser permission + the Config sidebar mute toggle.
+    // Enabling is done explicitly from Config → Desktop notifications, not here.
+    if (!notificationsActive()) return;
+    new Notification(`Activity in ${session}`, {
+        body: 'Session has new output',
+        icon: '/static/img/icon-192.png',
+        tag: `activity-${session}`,  // Prevent duplicate notifications
+    });
 }
 
 // Tab / Shift+Tab to cycle open windows

--- a/agentwire/static/js/notification-prefs.js
+++ b/agentwire/static/js/notification-prefs.js
@@ -1,0 +1,56 @@
+/**
+ * Desktop notification preferences — frontend-only, per-browser.
+ *
+ * Two independent layers:
+ *  - Browser permission ('default' | 'granted' | 'denied') — owned by the
+ *    browser, requested via enableNotifications(). The portal can ask but
+ *    cannot grant it; that's a per-origin browser decision.
+ *  - A local "muted" toggle — lets the user silence bubbles without revoking
+ *    the OS permission. Persisted in localStorage.
+ *
+ * Changing either dispatches `notification-pref-change` on window so the
+ * Config sidebar (and anything else) can repaint.
+ */
+
+const MUTE_KEY = 'notificationsMuted';
+export const NOTIFICATION_PREF_EVENT = 'notification-pref-change';
+
+export function notificationsSupported() {
+    return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+/** 'unsupported' | 'default' | 'granted' | 'denied' */
+export function getPermission() {
+    return notificationsSupported() ? Notification.permission : 'unsupported';
+}
+
+export function isMuted() {
+    return localStorage.getItem(MUTE_KEY) === '1';
+}
+
+export function setMuted(muted) {
+    if (muted) localStorage.setItem(MUTE_KEY, '1');
+    else localStorage.removeItem(MUTE_KEY);
+    window.dispatchEvent(new CustomEvent(NOTIFICATION_PREF_EVENT));
+}
+
+/** True only when a bubble should actually be shown right now. */
+export function notificationsActive() {
+    return getPermission() === 'granted' && !isMuted();
+}
+
+/**
+ * Ask the browser for permission if it hasn't been decided yet.
+ * Returns the resulting permission string. No-op (returns current state) if
+ * already granted/denied or unsupported.
+ */
+export async function enableNotifications() {
+    if (!notificationsSupported()) return 'unsupported';
+    let perm = Notification.permission;
+    if (perm === 'default') {
+        try { perm = await Notification.requestPermission(); }
+        catch { perm = Notification.permission; }
+    }
+    window.dispatchEvent(new CustomEvent(NOTIFICATION_PREF_EVENT));
+    return perm;
+}

--- a/agentwire/static/js/sidebar/config-section.js
+++ b/agentwire/static/js/sidebar/config-section.js
@@ -4,6 +4,9 @@ import {
     setTerminalFontSize, clearTerminalFontSize,
     FONT_SIZE_MIN, FONT_SIZE_MAX, FONT_SIZE_EVENT,
 } from '../terminal-font-prefs.js';
+import {
+    getPermission, isMuted, setMuted, enableNotifications,
+} from '../notification-prefs.js';
 
 function renderDisplayPrefs() {
     const current = getTerminalFontSize();
@@ -18,6 +21,55 @@ function renderDisplayPrefs() {
             <button class="sidebar-display-reset" data-action="reset" title="Reset to auto">↺</button>
         </div>
     </div>`;
+}
+
+function renderNotificationPrefs() {
+    const perm = getPermission();
+    const muted = isMuted();
+
+    let status, control = '';
+    if (perm === 'unsupported') {
+        status = '<em>not supported</em>';
+    } else if (perm === 'denied') {
+        status = '<em>blocked</em>';
+        control = '<span class="sidebar-display-hint">Allow in browser site settings</span>';
+    } else if (perm === 'default') {
+        status = '<em>off</em>';
+        control = '<button class="sidebar-display-reset" data-action="enable-notifs">Enable</button>';
+    } else { // granted
+        status = muted ? 'muted' : 'on';
+        control = `<label class="sidebar-notif-mute"><input type="checkbox" data-action="mute-notifs"${muted ? ' checked' : ''}/> Mute</label>`;
+    }
+
+    return `<div class="sidebar-display-prefs" data-notif-block>
+        <div class="sidebar-display-row">
+            <label class="sidebar-config-key">Desktop notifications</label>
+            <span class="sidebar-display-value" data-notif="status">${status}</span>
+        </div>
+        ${control ? `<div class="sidebar-display-row">${control}</div>` : ''}
+    </div>`;
+}
+
+function bindNotificationPrefs(body) {
+    const repaint = () => {
+        const block = body.querySelector('[data-notif-block]');
+        if (!block) return;
+        const tmp = document.createElement('div');
+        tmp.innerHTML = renderNotificationPrefs();
+        block.replaceWith(tmp.firstElementChild);
+        wire();
+    };
+    function wire() {
+        body.querySelector('[data-action="enable-notifs"]')?.addEventListener('click', async () => {
+            await enableNotifications();
+            repaint();
+        });
+        body.querySelector('[data-action="mute-notifs"]')?.addEventListener('change', (e) => {
+            setMuted(e.target.checked);
+            repaint();
+        });
+    }
+    wire();
 }
 
 function bindDisplayPrefs(body) {
@@ -54,11 +106,13 @@ export const configSection = {
                 else if (typeof value === 'object') display = `<code>${JSON.stringify(value)}</code>`;
                 return `<div class="sidebar-config-item"><span class="sidebar-config-key">${key}</span><span class="sidebar-config-val">${display}</span></div>`;
             }).join('');
-            body.innerHTML = renderDisplayPrefs() + itemHtml;
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + itemHtml;
             bindDisplayPrefs(body);
+            bindNotificationPrefs(body);
         } catch (e) {
-            body.innerHTML = renderDisplayPrefs() + '<div class="sidebar-empty">Failed to load config</div>';
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + '<div class="sidebar-empty">Failed to load config</div>';
             bindDisplayPrefs(body);
+            bindNotificationPrefs(body);
         }
     },
 };


### PR DESCRIPTION
## Why

Native OS notification bubbles (the ones that pop up and need dismissing per session-activity) were gated solely on the browser `Notification` permission. That permission was only ever granted via a **silent** `requestPermission()` fired on random session activity in `desktop.js` — invisible and undiscoverable.

Because the permission is **per-browser / per-origin** (not part of agentwire), the same agentwire version showed bubbles on one machine and not another, with no UI to explain or control it.

## What

Adds an explicit control under **Config → Desktop notifications** in the left sidebar:

| Browser permission | UI |
|---|---|
| `default` | status **off** + **Enable** button (triggers the prompt) |
| `granted` | status **on** + **Mute** checkbox (silence without revoking OS permission) |
| `denied` | status **blocked** + hint to allow in browser site settings |
| unsupported | status **not supported** |

- New per-browser prefs module `notification-prefs.js` (localStorage-backed, mirrors `terminal-font-prefs.js`).
- `config-section.js` renders the toggle in the same display-prefs block as terminal-font.
- `desktop.js` now gates the bubble on `notificationsActive()` (granted **AND** not muted) instead of an inline permission check, and the **silent auto-`requestPermission()` is removed** — no surprise prompts; the sidebar is the one discoverable enable path.

## Verification

- Config sidebar shows the row in each permission state; Enable prompts, Mute toggles, status repaints live.
- Bubble only fires for activity in a **non-focused** session window (unchanged), and only when granted + unmuted.

Built by [dotdev.dev](https://dotdev.dev)