### PR TITLE
fix(tts): resolve engine from tts.options.backend, not the tier value

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -60,21 +60,25 @@ projects:
                            #  add ".env.local", ".envrc", etc. as needed)
 
 tts:
-  backend: "runpod"  # runpod | kokoro | chatterbox | chatterbox-streaming | qwen-base-0.6b | qwen-base-1.7b | qwen-custom | qwen-design | zonos-transformer | zonos-hybrid | none
-  runpod_endpoint_id: "your-endpoint-id"
-  runpod_api_key: "your-api-key"
+  backend: "default"  # tier: default (browser/OS voice, zero setup) | custom (self-hosted shim at url)
+  url: "http://localhost:8100"  # custom tier only — shim endpoint
   default_voice: "dotdev"
   voices_dir: "~/.agentwire/voices"  # Custom voice samples for cloning
+  instructions: ""  # free-text prompt passed through to the shim
+  options:  # opaque JSON passed to the shim; the bundled shim reads:
+    backend: kokoro  # engine: kokoro | chatterbox | chatterbox-streaming | qwen-base-0.6b | qwen-base-1.7b | qwen-custom | qwen-design | zonos-transformer | zonos-hybrid
   exaggeration: 0.5  # Voice expressiveness (0-1, Chatterbox)
   cfg_weight: 0.5  # CFG weight (0-1, Chatterbox)
-  runpod_timeout: 120  # API timeout for RunPod (seconds)
+  timeout: 60
 
 stt:
-  url: "http://localhost:8101"
+  backend: "default"  # tier: default (browser speech recognition) | custom (self-hosted shim at url)
+  url: "http://localhost:8101"  # custom tier only — shim endpoint
   timeout: 30
-  backend: "auto"       # auto (moonshine → faster-whisper fallback), moonshine, whisper
-  model: "base"         # Whisper model size (used when backend=whisper)
-  moonshine_model: "moonshine/base"  # moonshine/tiny (faster) or moonshine/base
+  silence_prepend_ms: 0  # prepend silence if your backend clips the first syllable
+  instructions: ""  # free-text hint passed through to the shim
+  options: {}  # opaque JSON passed to the shim (language hints, vocab biasing, ...)
+  corrections: {}  # post-transcription find/replace, e.g. {"agent wire": "agentwire"}
 
 agent:
   command: "claude --dangerously-skip-permissions"

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -1194,6 +1194,18 @@ def _get_venv_for_backend(backend: str) -> str:
     return "qwen"
 
 
+def _get_tts_engine(args, tts_config: dict) -> str:
+    """Resolve the TTS engine to run: --backend flag, then tts.options.backend.
+
+    The top-level tts.backend is the tier (default|custom), never an engine.
+    """
+    return (
+        getattr(args, "backend", None)
+        or (tts_config.get("options") or {}).get("backend")
+        or "chatterbox"
+    )
+
+
 def _start_tts_local(args, venv_override: str | None = None, attach: bool = True) -> int:
     """Start TTS server locally in tmux.
 
@@ -1216,7 +1228,7 @@ def _start_tts_local(args, venv_override: str | None = None, attach: bool = True
     tts_config = config.get("tts", {})
     port = args.port or tts_config.get("port", 8100)
     host = args.host or tts_config.get("host", "0.0.0.0")
-    backend = getattr(args, "backend", None) or tts_config.get("backend", "chatterbox")
+    backend = _get_tts_engine(args, tts_config)
 
     # Determine venv family
     venv = venv_override or _get_venv_for_backend(backend)
@@ -1284,7 +1296,7 @@ def _start_tts_remote(ssh_target: str, machine_id: str, args) -> int:
     tts_config = config.get("tts", {})
     port = args.port or tts_config.get("port", 8100)
     host = args.host or tts_config.get("host", "0.0.0.0")
-    backend = getattr(args, "backend", None) or tts_config.get("backend", "chatterbox")
+    backend = _get_tts_engine(args, tts_config)
 
     # Build backend flag
     backend_flag = f" --backend {backend}" if backend != "chatterbox" else ""
@@ -1392,7 +1404,7 @@ def cmd_tts_serve(args) -> int:
     tts_config = config.get("tts", {})
     port = args.port or tts_config.get("port", 8100)
     host = args.host or tts_config.get("host", "0.0.0.0")
-    backend = getattr(args, "backend", None) or tts_config.get("backend", "chatterbox")
+    backend = _get_tts_engine(args, tts_config)
 
     # Determine venv family (explicit or auto-detect from backend)
     venv = getattr(args, "venv", None)
@@ -1478,8 +1490,7 @@ def cmd_tts_restart(args) -> int:
 
     # Determine backend and venv
     if not backend:
-        config = load_config()
-        backend = config.get("tts", {}).get("backend", "chatterbox")
+        backend = _get_tts_engine(args, load_config().get("tts", {}))
 
     venv = venv_override or _get_venv_for_backend(backend)
 

--- a/tests/unit/test_tts_engine_resolution.py
+++ b/tests/unit/test_tts_engine_resolution.py
@@ -1,0 +1,54 @@
+"""Tests for TTS engine resolution — _get_tts_engine / _get_venv_for_backend.
+
+The top-level tts.backend is the tier (default|custom); the engine to run
+lives in tts.options.backend (issue #261).
+"""
+
+from argparse import Namespace
+
+from agentwire.__main__ import _get_tts_engine, _get_venv_for_backend
+
+
+class TestGetTtsEngine:
+    def test_reads_options_backend(self):
+        tts_config = {"backend": "custom", "options": {"backend": "kokoro"}}
+        args = Namespace(backend=None)
+        assert _get_tts_engine(args, tts_config) == "kokoro"
+
+    def test_cli_flag_wins_over_options(self):
+        tts_config = {"backend": "custom", "options": {"backend": "kokoro"}}
+        args = Namespace(backend="zonos-transformer")
+        assert _get_tts_engine(args, tts_config) == "zonos-transformer"
+
+    def test_tier_value_is_never_treated_as_engine(self):
+        # backend: custom with no options.backend → default engine, not "custom"
+        tts_config = {"backend": "custom", "url": "http://localhost:8100"}
+        args = Namespace(backend=None)
+        assert _get_tts_engine(args, tts_config) == "chatterbox"
+
+    def test_options_none_in_yaml(self):
+        # "options:" with no keys parses to None
+        tts_config = {"backend": "custom", "options": None}
+        args = Namespace(backend=None)
+        assert _get_tts_engine(args, tts_config) == "chatterbox"
+
+    def test_empty_config(self):
+        assert _get_tts_engine(Namespace(backend=None), {}) == "chatterbox"
+
+    def test_args_without_backend_attr(self):
+        tts_config = {"options": {"backend": "qwen-base-0.6b"}}
+        assert _get_tts_engine(Namespace(), tts_config) == "qwen-base-0.6b"
+
+
+class TestVenvForResolvedEngine:
+    def test_kokoro_engine_maps_to_kokoro_venv(self):
+        # The #261 failure: custom tier + kokoro engine landed in the qwen venv
+        engine = _get_tts_engine(
+            Namespace(backend=None),
+            {"backend": "custom", "options": {"backend": "kokoro"}},
+        )
+        assert _get_venv_for_backend(engine) == "kokoro"
+
+    def test_default_engine_maps_to_chatterbox_venv(self):
+        engine = _get_tts_engine(Namespace(backend=None), {"backend": "custom"})
+        assert _get_venv_for_backend(engine) == "chatterbox"


### PR DESCRIPTION
Closes #261

## What was broken

The v1.31.0 voice rework (#252) redefined top-level `tts.backend` as a **tier** (`default` | `custom`) and moved engine selection to `tts.options.backend`. But the CLI start paths were never updated: they still read the top-level value as an engine name. Since that value is now always `custom`/`default`, it matched no engine in `_get_venv_for_backend()` and silently fell through to the **qwen** venv — so anyone self-hosting a non-qwen engine via the documented `backend: custom` config couldn't start the TTS server.

## The fix

One new resolver, used everywhere (SSOT):

```python
def _get_tts_engine(args, tts_config) -> str:
    # --backend flag wins, then tts.options.backend, then chatterbox
```

Applied at all four affected call sites:
- `_start_tts_local` (`agentwire tts start`, local)
- `_start_tts_remote` (`agentwire tts start`, remote machine)
- `cmd_tts_serve` (`agentwire tts serve`)
- `cmd_tts_restart` (remote venv-mismatch restart path)

The top-level `tts.backend` is now never treated as an engine name anywhere — remaining reads are all tier comparisons (`== "custom"`), which are correct.

## Also

- `.claude/skills/agentwire-config/SKILL.md` still documented the pre-rework schema (`backend: "runpod" | kokoro | ...`, runpod fields, old STT engine fields) — updated TTS/STT sections to the two-tier schema, matching `docs/wiki/voice/shim-contract.md` and `config.py`.

## Verification

- New `tests/unit/test_tts_engine_resolution.py` — 8 tests covering flag precedence, `options.backend` resolution, tier-value-never-an-engine, empty/None `options`, and the exact #261 failure (custom + kokoro previously landing in qwen venv).
- Full unit suite: **1187 passed**.
- Against the live config (`backend: custom`, `options.backend: kokoro`): resolver yields `kokoro → .venv-kokoro`, where pre-fix it yielded `.venv-qwen`.

Built by [dotdev.dev](https://dotdev.dev)