### PR TITLE
fix(portal): stop pinning tmux windows into manual size mode

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -4165,7 +4165,7 @@ def cmd_jump(args) -> int:
 
 
 def cmd_resize(args) -> int:
-    """Resize tmux window to fit the largest attached client."""
+    """Re-fit tmux window to its attached clients per the window-size policy."""
     json_mode = getattr(args, 'json', False)
     session = getattr(args, 'session', None)
 
@@ -4176,8 +4176,11 @@ def cmd_resize(args) -> int:
             return _output_result(False, json_mode, "Not in a tmux session. Use -s to specify session.")
 
     try:
+        # Unset any window-level window-size override (e.g. manual mode left
+        # by resize-window -x/-y) so the configured policy re-fits the window.
+        # resize-window -A would resize once but leave manual mode set (#258).
         result = subprocess.run(
-            ["tmux", "resize-window", "-A", "-t", session],
+            ["tmux", "set-option", "-w", "-t", session, "-u", "window-size"],
             capture_output=True,
             text=True,
         )
@@ -4188,7 +4191,7 @@ def cmd_resize(args) -> int:
         if json_mode:
             _output_json({"success": True, "session": session})
         else:
-            print(f"Resized {session} to fit largest client")
+            print(f"Re-fit {session} to attached clients per window-size policy")
 
         return 0
 
@@ -10480,7 +10483,7 @@ def main() -> int:
     jump_parser.set_defaults(func=cmd_jump)
 
     # === resize command (top-level) ===
-    resize_parser = subparsers.add_parser("resize", help="Resize window to fit largest client")
+    resize_parser = subparsers.add_parser("resize", help="Re-fit window to attached clients per window-size policy")
     resize_parser.add_argument("-s", "--session", help="Target session (default: auto-detect)")
     resize_parser.add_argument("--json", action="store_true", help="Output as JSON")
     resize_parser.set_defaults(func=cmd_resize)

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -1266,7 +1266,10 @@ def pane_jump(session: str | None = None, pane: int = 0) -> str:
 
 @mcp.tool()
 def pane_resize(session: str | None = None) -> str:
-    """Resize tmux window to fit the largest client.
+    """Re-fit tmux window to its attached clients per the window-size policy.
+
+    Clears any manual size pin so the configured policy (largest/latest/
+    smallest) governs again.
 
     Args:
         session: Session name (defaults to current session if in tmux)
@@ -1280,7 +1283,7 @@ def pane_resize(session: str | None = None) -> str:
 
     data = run_agentwire_cmd(args)
     if data.get("success"):
-        return "Window resized to fit largest client."
+        return "Window re-fit to attached clients per window-size policy."
     return f"Failed to resize: {data.get('error', 'Unknown error')}"
 
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -57,6 +57,31 @@ PASTE_CHUNK_SIZE = 128  # bytes per write
 PASTE_CHUNK_DELAY = 0.01  # seconds between chunks
 
 
+async def unpin_tmux_window(session_name: str, ssh_target: str | None = None) -> None:
+    """Clear tmux manual size mode so the window-size policy governs again.
+
+    Portal builds before v1.34 pinned windows to manual mode on every
+    browser resize (#258); this heals any window still stuck there.
+    Unsetting the window-level option restores the configured policy and
+    itself triggers a re-fit. (An explicit -A resize would not: it resizes
+    once but leaves manual mode set.)
+    """
+    cmd = ["tmux", "set-option", "-w", "-t", session_name, "-u", "window-size"]
+    if ssh_target:
+        proc = await asyncio.create_subprocess_exec(
+            "ssh", ssh_target, shlex.join(cmd),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    else:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    await proc.wait()
+
+
 def _is_allowed_in_restricted_mode(tool_name: str, tool_input: dict) -> bool:
     """Check if command is allowed in restricted mode.
 
@@ -1804,10 +1829,13 @@ class AgentWireServer:
                 os.close(slave_fd)
                 os.set_blocking(master_fd, False)
 
-                # Send initial window size to trigger tmux redraw
-                winsize = struct.pack("HHHH", 24, 80, 0, 0)
+                # Set initial PTY size from browser's reported dimensions
+                winsize = struct.pack("HHHH", init_rows, init_cols, 0, 0)
                 fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
-                logger.info(f"[Terminal] Set initial PTY size for SSH to 80x24 (fd={master_fd})")
+                logger.info(f"[Terminal] Set initial PTY size for SSH to {init_cols}x{init_rows} (fd={master_fd})")
+
+                # Heal windows pinned to manual size mode by pre-v1.34 portals
+                await unpin_tmux_window(session_name, ssh_target)
             else:
                 # Local session - use PTY
                 cmd = ["tmux", "attach", "-t", session_name]
@@ -1841,6 +1869,9 @@ class AgentWireServer:
                 winsize = struct.pack("HHHH", init_rows, init_cols, 0, 0)
                 fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
                 logger.info(f"[Terminal] Set initial PTY size to {init_cols}x{init_rows} (fd={master_fd})")
+
+                # Heal windows pinned to manual size mode by pre-v1.34 portals
+                await unpin_tmux_window(session_name)
 
             # Task: Forward tmux stdout → WebSocket
             async def forward_tmux_to_ws():
@@ -1963,40 +1994,22 @@ class AgentWireServer:
                                                         await asyncio.sleep(PASTE_CHUNK_DELAY)
 
                                 elif msg_type == "resize":
-                                    # Terminal resize
+                                    # Terminal resize: update the PTY and notify the
+                                    # tmux/ssh client via SIGWINCH. The window itself
+                                    # is sized by tmux per the window-size policy —
+                                    # never force it with resize-window -x/-y, which
+                                    # pins the window into manual mode (#258).
                                     cols = payload.get("cols", 80)
                                     rows = payload.get("rows", 24)
                                     logger.info(f"[Terminal] Resize {session_name} to {cols}x{rows}")
 
-                                    if master_fd is not None:
-                                        # Local: use TIOCSWINSZ ioctl to resize PTY
-                                        winsize = struct.pack("HHHH", rows, cols, 0, 0)
-                                        fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
-                                        # Send SIGWINCH to notify tmux of size change
-                                        if proc and proc.pid:
-                                            try:
-                                                os.kill(proc.pid, signal.SIGWINCH)
-                                            except (OSError, ProcessLookupError):
-                                                pass  # Process may have exited
-                                        # Explicitly resize the tmux window to match the browser.
-                                        # Using -x/-y instead of -A avoids the race condition where
-                                        # tmux hasn't yet processed SIGWINCH when resize-window runs.
-                                        resize_proc = await asyncio.create_subprocess_exec(
-                                            "tmux", "resize-window", "-t", session_name,
-                                            "-x", str(cols), "-y", str(rows),
-                                            stdout=asyncio.subprocess.DEVNULL,
-                                            stderr=asyncio.subprocess.DEVNULL,
-                                        )
-                                        await resize_proc.wait()
-                                    else:
-                                        # Remote: send tmux resize-window command
-                                        resize_cmd = f"tmux resize-window -t {session_name} -x {cols} -y {rows}\n"
-                                        resize_proc = await asyncio.create_subprocess_exec(
-                                            "ssh", ssh_target, "sh", "-c", resize_cmd,
-                                            stdout=asyncio.subprocess.DEVNULL,
-                                            stderr=asyncio.subprocess.DEVNULL,
-                                        )
-                                        await resize_proc.wait()
+                                    winsize = struct.pack("HHHH", rows, cols, 0, 0)
+                                    fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
+                                    if proc and proc.pid:
+                                        try:
+                                            os.kill(proc.pid, signal.SIGWINCH)
+                                        except (OSError, ProcessLookupError):
+                                            pass  # Process may have exited
 
                             except json.JSONDecodeError:
                                 logger.warning(f"[Terminal] Invalid JSON from WebSocket: {msg.data}")

--- a/tests/unit/test_terminal_resize.py
+++ b/tests/unit/test_terminal_resize.py
@@ -1,0 +1,71 @@
+"""Tests for portal terminal sizing — unpin_tmux_window + no-manual-pin guard (#258).
+
+The portal must never run tmux resize-window: -x/-y pins the window into
+manual size mode (defeating the user's window-size policy for every attached
+client), and -a/-A resize once but leave manual mode set. The only correct
+heal is unsetting the window-level window-size option, which restores the
+configured policy and itself triggers a re-fit (verified empirically on
+tmux 3.5a).
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentwire.server import unpin_tmux_window
+
+AGENTWIRE_SRC = Path(__file__).parents[2] / "agentwire"
+
+
+def _mock_subprocess():
+    proc = AsyncMock()
+    proc.wait = AsyncMock(return_value=0)
+    return proc
+
+
+class TestUnpinTmuxWindow:
+    @pytest.mark.asyncio
+    async def test_local_unsets_window_size_option(self):
+        proc = _mock_subprocess()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as exec_mock:
+            await unpin_tmux_window("myproject")
+
+        args = exec_mock.call_args.args
+        assert args == ("tmux", "set-option", "-w", "-t", "myproject", "-u", "window-size")
+        proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_remote_wraps_command_in_ssh(self):
+        proc = _mock_subprocess()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as exec_mock:
+            await unpin_tmux_window("myproject/branch", ssh_target="user@host")
+
+        args = exec_mock.call_args.args
+        assert args[0] == "ssh"
+        assert args[1] == "user@host"
+        assert args[2] == "tmux set-option -w -t myproject/branch -u window-size"
+        proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_remote_quotes_session_names(self):
+        proc = _mock_subprocess()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as exec_mock:
+            await unpin_tmux_window("my project", ssh_target="user@host")
+
+        remote_cmd = exec_mock.call_args.args[2]
+        assert "'my project'" in remote_cmd
+
+
+class TestNoManualPinRegression:
+    def test_no_resize_window_calls_anywhere(self):
+        """tmux resize-window must never be invoked: -x/-y pins manual size
+        mode and -a/-A leave it set (#258). Re-fitting is done by unsetting
+        the window-size option."""
+        for src_file in AGENTWIRE_SRC.rglob("*.py"):
+            for lineno, line in enumerate(src_file.read_text().splitlines(), 1):
+                code = line.split("#", 1)[0]
+                assert "resize-window" not in code, (
+                    f"resize-window invocation found in "
+                    f"{src_file.relative_to(AGENTWIRE_SRC)}:{lineno}: {line.strip()!r}"
+                )


### PR DESCRIPTION
Closes #258

## What was broken

The portal's terminal WebSocket ran `tmux resize-window -x/-y` on **every** browser resize. In tmux, that flips the window into **manual size mode**, which permanently disables the configured `window-size` policy (`largest`/`latest`/`smallest`) for *all* attached clients — so once the portal touched a session, a native terminal attached to the same session could no longer drive sizing.

The pin dated to `d3d003e` (v1.12.3), added to dodge a race where `resize-window -a` recalculated from stale client sizes right after SIGWINCH.

## The fix

- **Resize handler** (`server.py`): now only PTY `ioctl` + `SIGWINCH` — the portal reports its size like any normal tmux client and the window-size policy governs. The old race can't recur: there's no second sizing command to race.
- **Heal historically-pinned windows**: new `unpin_tmux_window()` runs on portal terminal attach (local + remote via ssh), unsetting the window-level `window-size` option.
- **`agentwire resize` CLI + `pane_resize` MCP**: switched from `resize-window -A` to the same unset.
- **Dead code deleted**: the ssh `resize-window` branch in the resize handler never executed (`master_fd` is never `None`; `ssh -t` propagates size via the local PTY's window-change).
- **Remote attach initial size**: uses the browser's real `cols`/`rows` query params instead of hardcoded 80×24.

## Key empirical finding (deviation from the issue's proposed fix)

The issue suggested `resize-window -A` as the un-pin. **Tested on tmux 3.5a: `-A` does NOT clear manual mode** — it resizes once and leaves `window-size manual` set, so the policy stays dead. The pin is implemented as a window-level `window-size manual` *option*; the correct heal is `set-option -w -u window-size`, which restores the configured policy **and itself triggers the re-fit** (verified by pinning to 30×10 and watching the unset alone snap it back to 97×48 under `largest`). This is also why `agentwire resize`'s old `-A` was itself a pinning operation, hence its inclusion here.

## Verification

- Unit suite: **1191 passed** (4 new in `tests/unit/test_terminal_resize.py`: heal command argv local/remote/quoting + a source-wide regression guard asserting no `resize-window` invocation exists anywhere in `agentwire/`).
- Pure-tmux experiments (two fake PTY clients, draining, different sizes): policy re-fits live under `smallest` and `largest`; pin defeats it; unset restores it.
- **Live portal e2e** (real WS client with bearer subprotocol against the dev portal): session pre-pinned to 33×11 manual → portal attach healed it to auto/120×39 → browser resize message tracked to 90×29 with no re-pin → stayed auto after disconnect.

## Behavior change (intended)

The portal no longer "always wins." Window sizing follows the user's `window-size` policy; with `largest` (the wiki-recommended config) and a bigger native terminal attached, the portal shows tmux's standard smaller-client view instead of forcing the window down to browser size.

Built by [dotdev.dev](https://dotdev.dev)