### PR TITLE
fix(scheduler): make worktree-dispatched tasks runnable (#245 Phase 2)

### DIFF
--- a/agentwire/completion.py
+++ b/agentwire/completion.py
@@ -163,6 +163,9 @@ def write_task_context(
     }
 
     context_file = TASKS_DIR / f"{session}.json"
+    # Worktree session names contain a slash (e.g. "proj/branch"), which
+    # nests the context file one directory down — create it.
+    context_file.parent.mkdir(parents=True, exist_ok=True)
     context_file.write_text(json.dumps(context, indent=2))
     return context_file
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -79,7 +79,9 @@ class WorktreesConfig:
     # Gitignored files that `git worktree add` won't carry over (it only
     # checks out tracked files). These are copied from the main repo into
     # each fresh worktree so agents have the secrets/config they need.
-    copy_files: list = field(default_factory=lambda: [".env"])
+    # .agentwire.yml is included because worktree-dispatched tasks can't
+    # load their task definition without it when the project gitignores it.
+    copy_files: list = field(default_factory=lambda: [".env", ".agentwire.yml"])
 
 
 @dataclass
@@ -490,7 +492,7 @@ def _dict_to_config(data: dict) -> Config:
         enabled=worktrees_data.get("enabled", True),
         suffix=worktrees_data.get("suffix", "-worktrees"),
         auto_create_branch=worktrees_data.get("auto_create_branch", True),
-        copy_files=worktrees_data.get("copy_files", [".env"]),
+        copy_files=worktrees_data.get("copy_files", [".env", ".agentwire.yml"]),
     )
     projects = ProjectsConfig(
         dir=projects_data.get("dir", "~/projects"),

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -804,10 +804,24 @@ def _parse_ensure_summary(task: SchedulerTask, result, project: str | None = Non
     files_modified: list[str] = []
     blockers: list[str] = []
 
-    # Try parsing JSON stdout from ensure --json
+    # Try parsing JSON stdout from ensure --json. Stdout may contain several
+    # concatenated JSON objects when nested commands (e.g. session creation)
+    # also print JSON — the last object is ensure's own result.
+    data = None
     if hasattr(result, "stdout") and result.stdout:
+        decoder = json.JSONDecoder()
+        text = result.stdout
+        idx = 0
+        while idx < len(text):
+            try:
+                obj, idx = decoder.raw_decode(text, idx)
+            except ValueError:
+                idx += 1
+                continue
+            if isinstance(obj, dict):
+                data = obj
+    if data:
         try:
-            data = json.loads(result.stdout)
             summary = data.get("summary", "")
             summary_file = data.get("summary_file", "")
             if summary_file:
@@ -820,8 +834,12 @@ def _parse_ensure_summary(task: SchedulerTask, result, project: str | None = Non
                     summary = summary or parsed.summary
                     files_modified = parsed.files_modified
                     blockers = parsed.blockers
-        except (json.JSONDecodeError, Exception):
+        except Exception:
             pass
+        # A failed dispatch has no summary file — record ensure's error so
+        # the failure is self-describing in events/state instead of silent.
+        if not summary and data.get("error"):
+            summary = str(data["error"])
 
     # Fallback: glob for summary files if we didn't get one
     if not summary:


### PR DESCRIPTION
Part of #245 (Phase 2 — weekly star/funnel review). Does **not** close it.

## What happened

The `weekly-stars` task (Phase 2's whole mechanism) failed silently on its first scheduled run (Mon 2026-06-08): `status=failed, duration=0`, **empty summary** — the exact silent-death failure mode Phase 2 exists to prevent. Diagnosis surfaced three stacked bugs:

1. **In-place dispatch can't run against agentwire-dev at all** — `ensure` refuses to attach a session to a project directory that's already the cwd of the long-lived portal/scheduler sessions (exit 6). Mitigation is config-side (`worktree: true` on the task, already applied live), but that path hit:
2. **Worktrees had no task definitions** — agentwire-dev gitignores `.agentwire.yml`, and `git worktree add` only checks out tracked files, so the inner ensure died with `No .agentwire.yml found`. Fix: seed `.agentwire.yml` into fresh worktrees by default (`projects.worktrees.copy_files`), alongside `.env`.
3. **`write_task_context` crashes for every worktree session** — session names contain a slash (`proj/branch`), nesting the context file under `~/.agentwire/tasks/<proj>/`, which was never created → `FileNotFoundError`. Fix: create the parent dir at write time. (tmux keeps the slash in the session name, so the bash idle-handler reads the same nested path — no other changes needed.)

Plus the observability bug that made all of this invisible:

4. **Failed dispatches recorded an empty summary** — `_parse_ensure_summary` choked on concatenated JSON objects (nested commands also print JSON) and discarded ensure's `error` field. Now it decodes the last JSON object on stdout and falls back to `error` as the summary, so a failed task's state/events say *why*.

## Verification

- Unit-tested the new parsing against all three observed stdout shapes (concatenated objects, single error object, success+summary) — correct summary extracted in each.
- `write_task_context` with a slash session name writes and cleans up correctly.
- 256 unit tests for scheduler/completion/config/worktree pass.
- End-to-end: `agentwire scheduler run weekly-stars` run live with the config-side mitigations (result recorded on #245).

**Note for deploy:** after merge, `agentwire rebuild && agentwire portal restart --dev` so the installed scheduler picks these up. Until then the live system works via the config mitigations + pre-created `~/.agentwire/tasks/agentwire-dev/` dir.

Built by [dotdev.dev](https://dotdev.dev)