### PR TITLE
portal: close button on sidebar session items — graceful /exit + tmux kill (#264)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3760,8 +3760,47 @@ def cmd_info(args) -> int:
     return 0
 
 
+# Shell commands that mean "no agent running" in a pane — kill directly,
+# nothing to /exit.
+_SHELL_COMMANDS = {"zsh", "bash", "fish", "sh", "dash", "tcsh", "ksh", "nu", "login"}
+
+
+def _pane0_state(session: str) -> tuple[str | None, str | None]:
+    """Return (current_command, current_path) for pane 0, or (None, None)."""
+    result = subprocess.run(
+        ["tmux", "display-message", "-t", f"{session}.0", "-p",
+         "#{pane_current_command}\t#{pane_current_path}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return None, None
+    parts = result.stdout.strip().split("\t", 1)
+    command = parts[0] if parts and parts[0] else None
+    path = parts[1] if len(parts) > 1 and parts[1] else None
+    return command, path
+
+
+def _wants_graceful_exit(session_type: str | None, pane_command: str | None) -> bool:
+    """Whether a session should get /exit before kill.
+
+    Claude-type sessions (claude-*, claudeglm-*, or no declared type) get a
+    graceful /exit. Bare shells and pi-* sessions don't speak /exit — plain
+    tmux kill. If pane 0 is just sitting at a shell, there's no agent to exit.
+    """
+    if pane_command is None or pane_command in _SHELL_COMMANDS:
+        return False
+    if session_type == "bare" or (session_type or "").startswith("pi-"):
+        return False
+    return True
+
+
 def cmd_kill(args) -> int:
-    """Kill a tmux session or pane (with clean Claude exit).
+    """Kill a tmux session or pane (graceful /exit first, then kill).
+
+    Claude sessions get /exit and we wait for the agent to actually
+    terminate (up to --timeout) before killing tmux. Non-Claude types
+    (bare, pi-*) fall through to a plain tmux kill. --force skips the
+    graceful step entirely.
 
     Supports remote sessions with session@machine format.
     Use --pane N to kill a specific pane in the current session.
@@ -3769,6 +3808,8 @@ def cmd_kill(args) -> int:
     session_full = getattr(args, 'session', None)
     pane_index = getattr(args, 'pane', None)
     json_mode = getattr(args, 'json', False)
+    force = getattr(args, 'force', False)
+    timeout = getattr(args, 'timeout', 10)
 
     # Handle pane mode (auto-detect session from environment)
     if pane_index is not None:
@@ -3814,32 +3855,59 @@ def cmd_kill(args) -> int:
         if machine is None:
             return _output_result(False, json_mode, f"Machine '{machine_id}' not found in machines.json")
 
-        # Check if session exists
-        check_cmd = f"tmux has-session -t {shlex.quote(session)} 2>/dev/null"
-        result = _run_remote(machine_id, check_cmd)
-        if result.returncode != 0:
+        # Check if session exists + grab pane 0 state in one round-trip
+        q = shlex.quote(session)
+        state_cmd = (
+            f"tmux display-message -t {q}.0 -p "
+            "'#{pane_current_command}\t#{pane_current_path}' 2>/dev/null"
+        )
+        result = _run_remote(machine_id, state_cmd)
+        if result.returncode != 0 or not result.stdout.strip():
             return _output_result(False, json_mode, f"Session '{session}' not found on {machine_id}")
 
-        # Send /exit to Claude first for clean shutdown (target pane 0 specifically)
-        exit_cmd = f"tmux send-keys -t {shlex.quote(session)}.0 /exit Enter"
-        _run_remote(machine_id, exit_cmd)
-        if not json_mode:
-            print(f"Sent /exit to {session_full}, waiting 3s...")
-        time.sleep(3)
+        parts = result.stdout.strip().split("\t", 1)
+        pane_command = parts[0] if parts and parts[0] else None
+        pane_path = parts[1] if len(parts) > 1 and parts[1] else None
+        session_type = _get_remote_session_type(machine_id, pane_path) if pane_path else None
+
+        graceful = not force and _wants_graceful_exit(session_type, pane_command)
+        agent_exited = False
+        if graceful:
+            # Send /exit to Claude first for clean shutdown (target pane 0 specifically)
+            _run_remote(machine_id, f"tmux send-keys -t {q}.0 /exit Enter")
+            if not json_mode:
+                print(f"Sent /exit to {session_full}, waiting for agent to exit (up to {timeout}s)...")
+            # Poll over SSH (1s interval — each check is a round-trip)
+            poll_cmd = (
+                f"tmux display-message -t {q}.0 -p '#{{pane_current_command}}' 2>/dev/null"
+                " || echo __GONE__"
+            )
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                time.sleep(1)
+                poll = _run_remote(machine_id, poll_cmd)
+                current = poll.stdout.strip()
+                if current == "__GONE__" or not current or current in _SHELL_COMMANDS:
+                    agent_exited = True
+                    break
 
         # Kill the session
-        kill_cmd = f"tmux kill-session -t {shlex.quote(session)}"
-        _run_remote(machine_id, kill_cmd)
+        _run_remote(machine_id, f"tmux kill-session -t {q} 2>/dev/null")
         if not json_mode:
             print(f"Killed session '{session_full}'")
 
         _notify_portal_sessions_changed()
 
         if json_mode:
-            _output_json({"success": True, "session": session_full})
+            _output_json({
+                "success": True,
+                "session": session_full,
+                "graceful": graceful,
+                "agent_exited": agent_exited,
+            })
         return 0
 
-    # Local: existing logic
+    # Local
     result = subprocess.run(
         ["tmux", "has-session", "-t", session],
         capture_output=True
@@ -3847,17 +3915,33 @@ def cmd_kill(args) -> int:
     if result.returncode != 0:
         return _output_result(False, json_mode, f"Session '{session}' not found")
 
-    # Send /exit to Claude first for clean shutdown
-    # Target pane 0 specifically and capture output to avoid terminal noise
-    subprocess.run(
-        ["tmux", "send-keys", "-t", f"{session}.0", "/exit", "Enter"],
-        capture_output=True
-    )
-    if not json_mode:
-        print(f"Sent /exit to {session}, waiting 3s...")
-    time.sleep(3)
+    pane_command, pane_path = _pane0_state(session)
+    session_type = _get_session_type_from_path(pane_path) if pane_path else None
 
-    # Kill the session
+    graceful = not force and _wants_graceful_exit(session_type, pane_command)
+    agent_exited = False
+    if graceful:
+        # Send /exit to Claude first for clean shutdown
+        # Target pane 0 specifically and capture output to avoid terminal noise
+        subprocess.run(
+            ["tmux", "send-keys", "-t", f"{session}.0", "/exit", "Enter"],
+            capture_output=True
+        )
+        if not json_mode:
+            print(f"Sent /exit to {session}, waiting for agent to exit (up to {timeout}s)...")
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            time.sleep(0.5)
+            if subprocess.run(["tmux", "has-session", "-t", session], capture_output=True).returncode != 0:
+                # Agent exit took the whole session down
+                agent_exited = True
+                break
+            current, _ = _pane0_state(session)
+            if current is None or current in _SHELL_COMMANDS:
+                agent_exited = True
+                break
+
+    # Kill the session (no-op if the agent exit already tore it down)
     subprocess.run(["tmux", "kill-session", "-t", session], capture_output=True)
     if not json_mode:
         print(f"Killed session '{session}'")
@@ -3865,7 +3949,12 @@ def cmd_kill(args) -> int:
     _notify_portal_sessions_changed()
 
     if json_mode:
-        _output_json({"success": True, "session": session_full})
+        _output_json({
+            "success": True,
+            "session": session_full,
+            "graceful": graceful,
+            "agent_exited": agent_exited,
+        })
     return 0
 
 
@@ -10442,9 +10531,11 @@ def main() -> int:
     info_parser.set_defaults(func=cmd_info)
 
     # === kill command (top-level) ===
-    kill_parser = subparsers.add_parser("kill", help="Kill a session or pane (clean shutdown)")
+    kill_parser = subparsers.add_parser("kill", help="Kill a session or pane (graceful /exit, then tmux kill)")
     kill_parser.add_argument("-s", "--session", help="Session name (supports session@machine)")
     kill_parser.add_argument("--pane", type=int, help="Target pane index (auto-detects session)")
+    kill_parser.add_argument("--force", action="store_true", help="Skip graceful /exit, kill tmux session immediately")
+    kill_parser.add_argument("--timeout", type=int, default=10, help="Seconds to wait for agent to exit after /exit (default: 10)")
     kill_parser.add_argument("--json", action="store_true", help="Output as JSON")
     kill_parser.set_defaults(func=cmd_kill)
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -684,6 +684,30 @@ body {
     flex-wrap: wrap;
 }
 
+/* Session kill button — hidden until the row is hovered; confirm/killing
+   states stay visible so the second click can't lose its target. */
+.sidebar-session-close {
+    display: none;
+}
+
+.sidebar-session-card:hover .sidebar-session-close,
+.sidebar-session-close.is-confirm,
+.sidebar-session-close.is-killing {
+    display: inline-block;
+}
+
+.sidebar-session-close.is-confirm {
+    border-color: var(--error);
+    color: var(--error);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.sidebar-session-close.is-killing {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .sidebar-session-path {
     font-size: 13px;
     color: var(--text-muted);

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -35,12 +35,27 @@ loadCustomServices();
 let allSessions = [];
 const listeners = new Set();
 
+// Close-button state: session name → confirm-expiry timer / in-flight kill.
+// Lives at module level so it survives the frequent activity re-renders.
+const pendingClose = new Map();
+const killingSessions = new Set();
+
 export function getAllSessions() { return allSessions; }
 export function onSessionsChanged(fn) { listeners.add(fn); }
 
 function notifyListeners() { for (const fn of listeners) fn(); }
 
-export function renderCard(s) {
+function renderCloseButton(name) {
+    if (killingSessions.has(name)) {
+        return '<button class="sidebar-list-item-btn sidebar-session-close is-killing" data-action="close" title="Shutting down…" disabled>…</button>';
+    }
+    if (pendingClose.has(name)) {
+        return '<button class="sidebar-list-item-btn sidebar-session-close is-confirm" data-action="close" title="Click again to kill the session">sure?</button>';
+    }
+    return '<button class="sidebar-list-item-btn sidebar-list-item-btn-danger sidebar-session-close" data-action="close" title="Kill session (graceful /exit, then tmux kill)">✕</button>';
+}
+
+export function renderCard(s, opts = {}) {
     const name = s.name || '';
     const machine = normalizeMachine(s.machine);
     const id = buildSessionId(name, machine);
@@ -60,6 +75,7 @@ export function renderCard(s) {
             <span class="sidebar-session-name">${name}</span>
             <button class="sidebar-list-item-btn" data-action="connect" title="Connect">▸</button>
             <button class="sidebar-list-item-btn" data-action="monitor" title="Monitor">👁</button>
+            ${opts.closable ? renderCloseButton(name) : ''}
         </div>
         ${path ? `<div class="sidebar-session-row2"><span class="sidebar-session-path">${path}</span></div>` : ''}
         ${tagsHtml ? `<div class="sidebar-session-row3">${tagsHtml}</div>` : ''}
@@ -82,9 +98,46 @@ export async function handleSessionClick(e) {
     const session = item.dataset.session;
     const machine = normalizeMachine(item.dataset.machine);
     const action = btn.dataset.action;
+    if (action === 'close') {
+        handleCloseClick(session);
+        return;
+    }
     const { openSessionTerminal } = await import('../desktop.js');
     if (action === 'connect') openSessionTerminal(session, 'terminal', machine);
     else if (action === 'monitor') openSessionTerminal(session, 'monitor', machine);
+}
+
+// First click arms an inline "sure?" confirm (auto-reverts after 3s);
+// second click does the real teardown: graceful /exit + tmux kill via
+// DELETE /api/sessions/{name} (thin wrapper over `agentwire kill`).
+async function handleCloseClick(session) {
+    if (killingSessions.has(session)) return;
+    const timer = pendingClose.get(session);
+    if (timer === undefined) {
+        pendingClose.set(session, setTimeout(() => {
+            pendingClose.delete(session);
+            notifyListeners();
+        }, 3000));
+        notifyListeners();
+        return;
+    }
+    clearTimeout(timer);
+    pendingClose.delete(session);
+    killingSessions.add(session);
+    notifyListeners();
+    try {
+        const res = await apiFetch(`/api/sessions/${encodeURIComponent(session)}`, { method: 'DELETE' });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+        // The portal broadcasts sessions_update after the kill; drop the row
+        // locally too so the sidebar doesn't wait on the round-trip.
+        allSessions = allSessions.filter(s => (s.name || '') !== session);
+    } catch (err) {
+        console.error(`Failed to kill session ${session}:`, err);
+    } finally {
+        killingSessions.delete(session);
+        notifyListeners();
+    }
 }
 
 // Data fetching + WebSocket events (registered once by sessionsSection)
@@ -253,7 +306,7 @@ export const sessionsSection = {
         if (!work.length && !this._formType) {
             html += '<div class="sidebar-empty">No sessions</div>';
         } else {
-            html += work.map(s => renderCard(s)).join('');
+            html += work.map(s => renderCard(s, { closable: true })).join('');
         }
         body.innerHTML = html;
         body.onclick = (e) => {


### PR DESCRIPTION
Closes #264

## What was built

A ✕ on each **Sessions** row in the portal sidebar that does the real teardown — graceful `/exit` to the agent, then `tmux kill-session` — distinct from the existing window ✕ which only closes the WinBox.

### CLI (single source of truth)

`agentwire kill -s <name>` is now properly graceful by default (no new flag needed — graceful IS the default, per the issue's suggestion):

- Reads pane 0's current command + the session type from `.agentwire.yml` at the pane's cwd.
- **Claude-type sessions** (`claude-*`, `claudeglm-*`, or undeclared type) with an agent actually running: sends `/exit`, then **polls every 0.5s for real agent exit** (pane command back to a shell, or session self-terminated) up to `--timeout` (default 10s) — replacing the old fixed `sleep 3`. Then kills tmux.
- **`bare` / `pi-*` sessions, or pane 0 idle at a shell**: plain tmux kill, no `/exit` typed into something that doesn't speak it.
- New flags: `--force` (skip graceful entirely), `--timeout N`. `--json` now reports `graceful` and `agent_exited`.
- Remote (`session@machine`) gets the same flow over SSH (1s poll interval to bound round-trips).

### Portal

No new route needed — `DELETE /api/sessions/{name}` already existed as a thin `run_agentwire_cmd(["kill", "-s", name])` wrapper and broadcasts `session_closed` + `sessions_update`. No direct tmux calls in server.py.

### Sidebar UI (`static/js/sidebar/sessions-section.js`)

- Hover a Sessions row → ✕ appears (danger-style button, hidden at rest).
- First click → inline **"sure?"** confirm (red), auto-reverts after 3s. Second click → "…" killing state → DELETE.
- Confirm/killing state lives in module-level maps keyed by session name, so the section's frequent activity-event re-renders can't wipe an armed confirm; the CSS keeps confirm/killing visible without hover.
- `renderCard(s, {closable})` — only the Sessions section passes `closable: true`; **Services rows render no ✕** (verified: 5 service cards, 0 close buttons).
- Open-window auto-close and row removal ride the existing `session_closed` / `sessions_update` broadcasts — no new frontend plumbing.

## Decisions locked in

- Graceful is the **default** for `kill` (not an opt-in flag) — improves every existing caller (worker reaper, missions GC, portal) for free; `--force` is the escape hatch.
- Poll-for-exit instead of fixed sleep: fast sessions die in ~1s instead of always 3s; stuck agents get a bounded 10s before the hammer.
- Inline second-click confirm (no modal), 3s auto-revert.

## Verification

CLI (run from this branch against disposable tmux sessions):
- bare session (shell in pane 0): `graceful: false`, killed instantly, no `/exit` sent ✅
- session whose pane-0 process exits on `/exit` input: `graceful: true, agent_exited: true`, dead in ~1.2s ✅
- session whose agent ignores `/exit` (python REPL): waits full `--timeout`, then killed, `agent_exited: false` ✅
- `--force`: instant kill, `graceful: false` ✅

UI (portal served from this branch, driven via Chrome):
- ✕ hidden at rest, revealed on row hover ✅
- first click → red "sure?"; left alone >3s it auto-reverted (misclick protection observed working — a stranded second click just re-arms) ✅
- second click → "…" state → tmux session gone, row disappeared via broadcast ✅
- session with an open Monitor window: window auto-closed from OPEN WINDOWS when the session died ✅
- Services section rows: no ✕ ✅
- Existing window-✕ untouched (still only closes the window) ✅

Built by [dotdev.dev](https://dotdev.dev)