### PR TITLE
sessions: usage-limit dialog recovery — detect, park, email, auto-resume (#274)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -180,6 +180,13 @@ agentwire scheduler enable|disable task     # enable/disable a task
 agentwire scheduler report [--since 8h] [--artifact]  # generate morning report HTML
 agentwire scheduler dashboard               # open scheduler dashboard
 
+# Usage-limit recovery (deterministic watchdog, see docs/wiki/usage-limit-recovery.md)
+agentwire limits tick           # one watchdog pass: sweep panes, resume what's due
+agentwire limits status         # show sessions parked on usage limits
+agentwire limits resume -s name [--force]  # manually resume a parked session now
+agentwire limits install        # install + load the launchd watchdog (60s tick)
+agentwire limits uninstall      # unload + remove the watchdog
+
 # Overnight session queue
 agentwire overnight prepare --from <session> --task "desc"  # queue session
 agentwire overnight list [--all]            # list queue items

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -185,6 +185,10 @@ scheduler:
   autostart: true        # Start the scheduler daemon when the portal boots (default: true)
   dispatch_cooldown: 60  # Seconds between task dispatches (default: 60)
 
+usage_limit:             # Usage-limit recovery watchdog (docs/wiki/usage-limit-recovery.md)
+  enabled: true          # Master switch for dialog detection/parking (default: true)
+  exclude_sessions: []   # Session names never auto-parked (gates NEW parks only)
+
 worktree:
   worktree_dir: ~/worktrees       # Where worktrees are created
   default_base: main              # Default base branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,10 @@ LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wik
 
 First-class auto-dispatcher subsystem (sibling to Sessions/Tasks/Workflows): stateless launchd orchestrators tick the GitHub issue board, spawn worker sessions in isolated worktrees for `agent-ready` issues, route PR-review feedback back to the worker, and reap on PR close. CLI under `agentwire mission ...`, 8 MCP `mission_*` tools. Full reference: [`docs/wiki/missions.md`](docs/wiki/missions.md).
 
+## Usage-Limit Recovery
+
+Deterministic (zero-LLM) recovery from the Claude Code usage-limit dialog: a launchd watchdog (`agentwire limits tick`, 60s) plus ensure's completion poll detect the dialog, park the session (option 1: stop and wait), parse the reset time, email the owner via Resend, and nudge the session to continue after reset. Park state under `~/.agentwire/usage-limit/` guards every surface — ensure exits 7 (`usage_limit`), the scheduler skips dispatch, the idle hook and overnight never reap a parked session. CLI under `agentwire limits ...`. Full reference: [`docs/wiki/usage-limit-recovery.md`](docs/wiki/usage-limit-recovery.md).
+
 ## Council
 
 Multi-soul orchestrator sitting: `agentwire-council` fans prompts out to lens sessions (`council-brain`, `council-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/prompts/`; the orchestrator collects and synthesizes with attribution. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...`, 5 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3114,6 +3114,8 @@ def cmd_list(args) -> int:
         return 0
 
     # Show sessions (original behavior)
+    from .usage_limit import is_parked as usage_limit_parked
+
     all_sessions = []
 
     # Get local sessions (skip if remote_only)
@@ -3140,6 +3142,8 @@ def cmd_list(args) -> int:
                             "type": cfg.get("type"),
                             "roles": cfg.get("roles", []),
                         }
+                        if usage_limit_parked(parts[0]):
+                            session_info["usage_limit"] = True
                         local_sessions.append(session_info)
                         all_sessions.append(session_info)
 
@@ -3216,7 +3220,8 @@ def cmd_list(args) -> int:
             for s in sessions:
                 # Remove @machine suffix for display within machine group
                 display_name = s['name'].rsplit('@', 1)[0] if '@' in s['name'] else s['name']
-                print(f"  {display_name}: {s['windows']} window(s) ({s['path']})")
+                parked_marker = " [parked: usage limit]" if s.get("usage_limit") else ""
+                print(f"  {display_name}: {s['windows']} window(s) ({s['path']}){parked_marker}")
         else:
             print("  (no sessions)")
         print()

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -8250,6 +8250,7 @@ ENSURE_EXIT_LOCK_CONFLICT = 3
 ENSURE_EXIT_PRE_FAILURE = 4
 ENSURE_EXIT_TIMEOUT = 5
 ENSURE_EXIT_SESSION_ERROR = 6
+ENSURE_EXIT_USAGE_LIMIT = 7
 
 
 def _ensure_remote(args, session: str, machine_id: str, json_mode: bool) -> int:
@@ -8358,6 +8359,16 @@ def cmd_ensure(args) -> int:
 
     if machine_id:
         return _ensure_remote(args, session, machine_id, json_mode)
+
+    # A session parked on a usage limit is waiting out the reset — never
+    # prompt or re-dispatch into it. The watchdog resumes it.
+    from .usage_limit import is_parked
+    if is_parked(session):
+        return _output_result(
+            False, json_mode,
+            f"Session '{session}' is parked on a usage limit (auto-resumes after reset)",
+            exit_code=ENSURE_EXIT_USAGE_LIMIT,
+        )
 
     # Find project path from --project flag, or session's working directory
     if hasattr(args, 'project') and args.project:
@@ -8821,6 +8832,13 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
 
         # Don't clear task context here — hook owns context file lifecycle.
         # ensure waits for hook to delete it (signals cleanup complete).
+
+        if last_status == "usage_limit":
+            # Session parked mid-task — skip on_task_end/post/PR; the watchdog
+            # nudges it after reset and the idle hook finishes the task.
+            if not json_mode:
+                print("Usage limit hit — session parked, auto-resumes after reset")
+            break
 
         if not json_mode:
             print(f"Task status: {last_status}")

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11412,6 +11412,59 @@ def main() -> int:
     m_init.add_argument("--json", action="store_true", help="Output JSON")
     m_init.set_defaults(func=mission_cli.cmd_mission_init)
 
+    # === limits command group (usage-limit recovery) ===
+    from . import limits_cli
+
+    limits_parser = subparsers.add_parser(
+        "limits",
+        help="Usage-limit recovery: detect the limit dialog, park, auto-resume",
+        description=(
+            "Deterministic recovery from Claude Code usage-limit dialogs: a "
+            "launchd watchdog ticks every minute, parks sessions sitting on "
+            "the dialog (option 1: stop and wait), emails the owner, and "
+            "nudges the session back to work after the limit resets. "
+            "See docs/wiki/usage-limit-recovery.md."
+        ),
+    )
+    limits_subparsers = limits_parser.add_subparsers(dest="limits_command")
+
+    # limits tick
+    l_tick = limits_subparsers.add_parser(
+        "tick", help="One watchdog pass: sweep panes, resume what's due"
+    )
+    l_tick.add_argument("--json", action="store_true", help="Output JSON")
+    l_tick.set_defaults(func=limits_cli.cmd_limits_tick)
+
+    # limits status
+    l_status = limits_subparsers.add_parser("status", help="Show parked sessions")
+    l_status.add_argument("--json", action="store_true", help="Output JSON")
+    l_status.set_defaults(func=limits_cli.cmd_limits_status)
+
+    # limits resume
+    l_resume = limits_subparsers.add_parser(
+        "resume", help="Manually resume a parked session now"
+    )
+    l_resume.add_argument("-s", "--session", required=True, help="Parked session name")
+    l_resume.add_argument(
+        "--force", action="store_true",
+        help="Archive the park state even if nudge delivery can't be verified",
+    )
+    l_resume.set_defaults(func=limits_cli.cmd_limits_resume)
+
+    # limits install / uninstall
+    l_install = limits_subparsers.add_parser(
+        "install", help="Install + load the launchd watchdog (60s tick)"
+    )
+    l_install.add_argument(
+        "--dry-run", action="store_true", help="Print the plist without installing"
+    )
+    l_install.set_defaults(func=limits_cli.cmd_limits_install)
+
+    l_uninstall = limits_subparsers.add_parser(
+        "uninstall", help="Unload + remove the launchd watchdog"
+    )
+    l_uninstall.set_defaults(func=limits_cli.cmd_limits_uninstall)
+
     # === council command group ===
     council_parser = subparsers.add_parser(
         "council",
@@ -11639,6 +11692,10 @@ def main() -> int:
 
     if args.command == "council" and getattr(args, "council_command", None) is None:
         council_parser.print_help()
+        return 0
+
+    if args.command == "limits" and getattr(args, "limits_command", None) is None:
+        limits_parser.print_help()
         return 0
 
     if args.command == "overnight" and getattr(args, "overnight_command", None) is None:

--- a/agentwire/completion.py
+++ b/agentwire/completion.py
@@ -313,6 +313,17 @@ def wait_for_completion_signal(
             except (json.JSONDecodeError, OSError):
                 pass  # File may be partially written, retry
 
+        # Usage-limit dialog: park deterministically (zero-LLM) and report a
+        # distinct status — the watchdog resumes the session after reset.
+        # Also honors a park the watchdog performed first.
+        from .usage_limit import check_and_park
+
+        if check_and_park(session, source="ensure"):
+            return {
+                "status": "usage_limit",
+                "summary": "Session parked on usage limit; auto-resumes after reset",
+            }
+
         # Session gone or agent crashed (fell back to bare shell)
         if not _session_has_agent(session):
             raise CompletionTimeout(
@@ -585,15 +596,17 @@ def status_to_exit_code(status: str) -> int:
     """Convert status string to exit code.
 
     Args:
-        status: Task status (complete, incomplete, failed)
+        status: Task status (complete, incomplete, failed, usage_limit)
 
     Returns:
-        Exit code (0=complete, 1=failed, 2=incomplete)
+        Exit code (0=complete, 1=failed, 2=incomplete, 7=usage_limit)
     """
     if status == "complete":
         return 0
     elif status == "failed":
         return 1
+    elif status == "usage_limit":
+        return 7
     else:
         return 2
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -382,6 +382,18 @@ class SafetyConfig:
 
 
 @dataclass
+class UsageLimitConfig:
+    """Usage-limit recovery (watchdog) knobs.
+
+    Gates NEW parks only — already-parked sessions are always resumed,
+    regardless of these settings.
+    """
+
+    enabled: bool = True  # master switch for dialog detection/parking
+    exclude_sessions: list[str] = field(default_factory=list)  # never auto-park these
+
+
+@dataclass
 class Config:
     """Root configuration for AgentWire."""
 
@@ -400,6 +412,7 @@ class Config:
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     overnight: OvernightConfig = field(default_factory=OvernightConfig)
     safety: SafetyConfig = field(default_factory=SafetyConfig)
+    usage_limit: UsageLimitConfig = field(default_factory=UsageLimitConfig)
     channels: dict = field(default_factory=dict)
 
 
@@ -672,6 +685,18 @@ def _dict_to_config(data: dict) -> Config:
         disabled_rules=[str(r) for r in disabled_rules_raw if r],
     )
 
+    # Usage-limit recovery (watchdog enable + session exclusions)
+    usage_limit_data = data.get("usage_limit", {}) or {}
+    if not isinstance(usage_limit_data, dict):
+        usage_limit_data = {}
+    exclude_sessions_raw = usage_limit_data.get("exclude_sessions", []) or []
+    if not isinstance(exclude_sessions_raw, list):
+        exclude_sessions_raw = []
+    usage_limit = UsageLimitConfig(
+        enabled=bool(usage_limit_data.get("enabled", True)),
+        exclude_sessions=[str(s) for s in exclude_sessions_raw if s],
+    )
+
     # Session defaults
     session_data = data.get("session", {}) or {}
     session = SessionConfig(
@@ -696,6 +721,7 @@ def _dict_to_config(data: dict) -> Config:
         channels=channel_configs,
         repl=repl,
         safety=safety,
+        usage_limit=usage_limit,
     )
 
 

--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -25,6 +25,13 @@ if [[ "$notification_type" == "idle_prompt" ]]; then
     tmux_session=$(tmux display -t "$TMUX_PANE" -p '#{session_name}' 2>/dev/null)
   fi
 
+  # Usage-limit park guard: a parked session is waiting out a limit reset —
+  # no summary prompts, no /exit, no kill. The watchdog resumes it (#274).
+  if [[ -n "$tmux_session" && -f "$HOME/.agentwire/usage-limit/${tmux_session}.json" ]]; then
+    log "Session $tmux_session parked on usage limit — skipping idle handling"
+    exit 0
+  fi
+
   # Try to get config from .agentwire.yml
   session_name=""
   is_chatbot=false

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -1,0 +1,191 @@
+"""CLI for usage-limit recovery — ``agentwire limits ...``.
+
+The watchdog is a stateless launchd job running ``agentwire limits tick``
+every minute: sweep all tmux panes for the usage-limit dialog, park what's
+found, and nudge parked sessions whose reset time has passed. ``install``
+writes and loads the LaunchAgent; the plist is generated here (single
+source of truth — no template file to drift).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from . import usage_limit
+
+LAUNCHD_LABEL = "dev.agentwire.usage-limit-watchdog"
+PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+LOG_PATH = Path.home() / "Library" / "Logs" / "agentwire-usage-limit-watchdog.log"
+TICK_INTERVAL = 60  # seconds — limits don't keep office hours
+
+
+def _plist_content(agentwire_bin: str) -> str:
+    home = str(Path.home())
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Usage-limit watchdog — detects the Claude Code usage-limit dialog in any
+  tmux pane, parks the session (option 1: stop and wait), and nudges it
+  back to work after the limit resets. Deterministic plain code, no agent.
+
+  Managed by `agentwire limits install` / `agentwire limits uninstall`.
+  Logs: tail -f {LOG_PATH}
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LAUNCHD_LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{agentwire_bin}</string>
+        <string>limits</string>
+        <string>tick</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>{TICK_INTERVAL}</integer>
+
+    <key>WorkingDirectory</key>
+    <string>{home}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{home}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>{home}</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>{LOG_PATH}</string>
+
+    <key>StandardErrorPath</key>
+    <string>{LOG_PATH}</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"""
+
+
+def _find_agentwire() -> str:
+    found = shutil.which("agentwire")
+    if found:
+        return found
+    return str(Path.home() / ".local" / "bin" / "agentwire")
+
+
+def _fmt_local(iso: str) -> str:
+    try:
+        return datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %I:%M%p")
+    except (ValueError, TypeError):
+        return str(iso)
+
+
+def cmd_limits_tick(args) -> int:
+    """One watchdog pass (called by launchd every minute)."""
+    result = usage_limit.tick()
+    if getattr(args, "json", False):
+        print(json.dumps(result))
+        return 0
+    if result.get("skipped"):
+        print(result["skipped"])
+        return 0
+    if result["parked"]:
+        print(f"parked: {', '.join(result['parked'])}")
+    if result["resumed"]:
+        print(f"resumed: {', '.join(result['resumed'])}")
+    if result["waiting"]:
+        print(f"waiting on reset: {', '.join(result['waiting'])}")
+    if not (result["parked"] or result["resumed"] or result["waiting"]):
+        print("no usage-limit activity")
+    return 0
+
+
+def cmd_limits_status(args) -> int:
+    """Show currently parked sessions."""
+    parked = usage_limit.list_parked()
+    if getattr(args, "json", False):
+        print(json.dumps({"parked": parked}, indent=2))
+        return 0
+    if not parked:
+        print("No sessions parked on usage limits")
+        return 0
+    print(f"{len(parked)} session(s) parked on usage limits:\n")
+    for state in parked:
+        print(f"  {state['session']}")
+        if state.get("task"):
+            print(f"    task:    {state['task']}")
+        print(f"    parked:  {_fmt_local(state.get('parked_at', ''))}")
+        print(f"    resets:  {_fmt_local(state.get('reset_at', ''))}")
+        print(f"    resumes: {_fmt_local(state.get('resume_at', ''))}"
+              + ("" if state.get("notified") else "  (notification pending)"))
+    return 0
+
+
+def cmd_limits_resume(args) -> int:
+    """Manually resume a parked session now."""
+    session = args.session
+    state = usage_limit.read_park_state(session)
+    if state is None:
+        print(f"Session '{session}' is not parked", file=sys.stderr)
+        return 1
+    if usage_limit.resume_session(state, force=getattr(args, "force", False)):
+        print(f"Resumed {session}")
+        return 0
+    print(f"Failed to resume {session} (see usage-limit-events.jsonl)", file=sys.stderr)
+    return 1
+
+
+def cmd_limits_install(args) -> int:
+    """Install + load the launchd watchdog."""
+    if sys.platform != "darwin":
+        print("limits install is macOS-only (launchd)", file=sys.stderr)
+        return 1
+
+    agentwire_bin = _find_agentwire()
+    content = _plist_content(agentwire_bin)
+
+    if getattr(args, "dry_run", False):
+        print(f"# would write: {PLIST_PATH}")
+        print(f"# then: launchctl unload/load {PLIST_PATH}")
+        print(content)
+        return 0
+
+    PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PLIST_PATH.write_text(content)
+
+    # Reload: unload is a no-op error if not loaded — ignore it.
+    subprocess.run(["launchctl", "unload", str(PLIST_PATH)], capture_output=True)
+    result = subprocess.run(
+        ["launchctl", "load", str(PLIST_PATH)], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"launchctl load failed: {result.stderr.strip()}", file=sys.stderr)
+        return 1
+
+    print(f"Installed {LAUNCHD_LABEL} (tick every {TICK_INTERVAL}s)")
+    print(f"  plist: {PLIST_PATH}")
+    print(f"  logs:  tail -f {LOG_PATH}")
+    return 0
+
+
+def cmd_limits_uninstall(args) -> int:
+    """Unload + remove the launchd watchdog."""
+    if sys.platform != "darwin":
+        print("limits uninstall is macOS-only (launchd)", file=sys.stderr)
+        return 1
+    if PLIST_PATH.exists():
+        subprocess.run(["launchctl", "unload", str(PLIST_PATH)], capture_output=True)
+        PLIST_PATH.unlink()
+        print(f"Uninstalled {LAUNCHD_LABEL}")
+    else:
+        print("Watchdog not installed")
+    return 0

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -187,7 +187,8 @@ def format_sessions(data: dict) -> str:
         windows = s.get("windows", 1)
         path = s.get("path", "")
         session_type = s.get("type", "unknown")
-        lines.append(f"  - {name} ({machine}): {windows} window(s), type={session_type}, path={path}")
+        parked = " [PARKED: usage limit, auto-resumes after reset]" if s.get("usage_limit") else ""
+        lines.append(f"  - {name} ({machine}): {windows} window(s), type={session_type}, path={path}{parked}")
 
     return "\n".join(lines)
 

--- a/agentwire/overnight.py
+++ b/agentwire/overnight.py
@@ -619,6 +619,11 @@ def check_completion(item: OvernightItem, config) -> str:
     if not _tmux_session_exists(session):
         return "complete"
 
+    # Parked on a usage limit — waiting out the reset, never "stuck"
+    from .usage_limit import is_parked
+    if is_parked(session):
+        return "running"
+
     # Agent still running?
     if _session_has_agent(session):
         # Check timeout

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -39,6 +39,7 @@ _EXIT_LOCK_CONFLICT = 3
 _EXIT_PRE_FAILURE = 4
 _EXIT_TIMEOUT = 5
 _EXIT_SESSION_ERROR = 6
+_EXIT_USAGE_LIMIT = 7
 
 _EXIT_TO_STATUS = {
     _EXIT_COMPLETE: "complete",
@@ -48,6 +49,7 @@ _EXIT_TO_STATUS = {
     _EXIT_PRE_FAILURE: "failed",
     _EXIT_TIMEOUT: "timeout",
     _EXIT_SESSION_ERROR: "failed",
+    _EXIT_USAGE_LIMIT: "usage_limit",
 }
 
 # In-flight grace period: tasks dispatched less than 2h ago are considered running
@@ -98,7 +100,7 @@ class SchedulerTask:
 @dataclass
 class TaskState:
     last_run: datetime | None = None
-    last_status: str = "never"    # complete, failed, incomplete, timeout, lock_conflict, never
+    last_status: str = "never"    # complete, failed, incomplete, timeout, lock_conflict, usage_limit, never
     last_duration: int = 0
     run_count: int = 0
     last_summary: str = ""
@@ -1268,6 +1270,20 @@ def _dispatch_inplace_task(board: Board, task: SchedulerTask, existing_state: Ta
     only (email, files outside the repo). The repo is never modified."""
     task_name = task.name
 
+    # A session parked on a usage limit is waiting out the reset — never
+    # kill it or dispatch into it. Skip without consuming last_run so the
+    # task stays eligible once the park clears.
+    from .usage_limit import is_parked
+    if is_parked(task.session):
+        _log_event("task_skipped", task=task_name, session=task.session,
+                   reason="usage_limit_parked")
+        return TaskState(
+            last_run=existing_state.last_run,
+            last_status="usage_limit",
+            last_duration=0,
+            run_count=existing_state.run_count,
+        )
+
     # Clean stale lock for this session before dispatching.
     from .locking import remove_stale_lock
     remove_stale_lock(task.session)
@@ -1403,6 +1419,22 @@ def _dispatch_worktree_task(board: Board, task: SchedulerTask, existing_state: T
                status=status, duration=duration, summary=summary,
                files_modified=files_modified, blockers=blockers_list)
     _notify_portal(task_name, status, duration, summary)
+
+    if status == "usage_limit":
+        # Session parked mid-task — committing/pushing half-done work would be
+        # wrong, and the session must stay alive for the watchdog to resume.
+        # The worktree is left in place; the session finishes via the idle
+        # hook after resume (PR must then be opened manually — see docs).
+        print(f"[{_ts()}] {task_name}: parked on usage limit — worktree + session left in place")
+        new_run_count = existing_state.run_count + 1
+        return TaskState(
+            last_run=datetime.now(timezone.utc),
+            last_status="usage_limit",
+            last_duration=duration,
+            run_count=new_run_count,
+            last_summary=summary,
+            last_gate_commit=_capture_head(task.project),
+        )
 
     pr = _finalize_worktree_pr(task, task_name, status, worktree_path, branch, summary)
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -223,6 +223,21 @@ def detect_dialog(visible: str) -> bool:
     return not tail.strip()
 
 
+def check_and_park(session: str, pane_index: int = 0, source: str = "ensure") -> bool:
+    """True iff the session is (or just became) parked on a usage limit.
+
+    The fast-path probe for polling loops (ensure's completion wait): cheap
+    when nothing is wrong, parks deterministically when the dialog is up,
+    and honors a park the watchdog already performed.
+    """
+    if is_parked(session):
+        return True
+    if detect_dialog(_capture(f"{session}.{pane_index}")):
+        park(session, pane_index, source=source)
+        return is_parked(session)
+    return False
+
+
 def detect_dialog_like(visible: str) -> bool:
     """A live select-menu that is NOT the known usage-limit dialog.
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -223,6 +223,21 @@ def detect_dialog(visible: str) -> bool:
     return not tail.strip()
 
 
+def _recovery_config() -> tuple[bool, set[str]]:
+    """(enabled, excluded session names) from config.yaml.
+
+    Gates NEW parks only — resume always drains existing park states, even
+    for sessions excluded (or the feature disabled) after they were parked.
+    """
+    try:
+        from .config import get_config
+
+        cfg = get_config().usage_limit
+        return bool(cfg.enabled), set(cfg.exclude_sessions)
+    except Exception:
+        return True, set()
+
+
 def check_and_park(session: str, pane_index: int = 0, source: str = "ensure") -> bool:
     """True iff the session is (or just became) parked on a usage limit.
 
@@ -232,6 +247,9 @@ def check_and_park(session: str, pane_index: int = 0, source: str = "ensure") ->
     """
     if is_parked(session):
         return True
+    enabled, excluded = _recovery_config()
+    if not enabled or session in excluded:
+        return False
     if detect_dialog(_capture(f"{session}.{pane_index}")):
         park(session, pane_index, source=source)
         return is_parked(session)
@@ -458,7 +476,14 @@ def _send_notification(state: dict, subject: str, body: str, mark_notified: bool
 
 
 def sweep() -> list[dict]:
-    """Scan all tmux panes for the usage-limit dialog; park what's found."""
+    """Scan all tmux panes for the usage-limit dialog; park what's found.
+
+    Respects the ``usage_limit:`` config knobs: ``enabled: false`` disables
+    new parks entirely; ``exclude_sessions`` names are never auto-parked.
+    """
+    enabled, excluded = _recovery_config()
+    if not enabled:
+        return []
     try:
         result = _tmux(
             ["list-panes", "-a", "-F",
@@ -476,6 +501,8 @@ def sweep() -> list[dict]:
             continue
         session, pane_s, command = parts
         if command.strip().lower() in _BARE_SHELLS:
+            continue
+        if session in excluded:
             continue
         if is_parked(session):
             continue

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -1,0 +1,610 @@
+"""Usage-limit dialog recovery — deterministic, zero-LLM.
+
+When a Claude Code session hits its usage limit it parks on an interactive
+dialog (``/rate-limit-options``) and blocks forever waiting for a human.
+This module detects that dialog from pane text, selects "Stop and wait for
+limit to reset", parses the reset time from the message, emails the owner,
+and nudges the session back to work after the limit resets.
+
+Every step is plain code: at the moment this fires, usage is exhausted by
+definition — no agent can run to orchestrate the recovery, and a recovery
+mechanism must be more reliable than the thing it recovers.
+
+Detection runs in two places:
+
+- ``agentwire limits tick`` — a stateless launchd watchdog (every 60s)
+  sweeping all tmux panes. Also the resume timer: a tick that finds a parked
+  session past its reset time sends the resume nudge.
+- ensure's completion poll (``completion.wait_for_completion_signal``) —
+  fast path (≤10s) for scheduler/overnight-dispatched tasks.
+
+State: one JSON file per parked session under ``~/.agentwire/usage-limit/``
+(worktree session names contain ``/`` and nest one directory down, same as
+the tasks dir). File presence in the active dir == "parked" — that is the
+guard ensure, the scheduler, the idle hook, and overnight all check so a
+parked session is never prompted, re-dispatched, or reaped. Files are
+archived to ``usage-limit/done/`` on resume.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import socket
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".agentwire" / "usage-limit"
+DONE_DIR = STATE_DIR / "done"
+EVENTS_FILE = Path.home() / ".agentwire" / "usage-limit-events.jsonl"
+
+# Owner-specified fixed resume message — the only agent involvement in the
+# whole recovery story is the parked session acting on this nudge.
+RESUME_NUDGE = (
+    "You were interrupted by a usage limit; the limit has reset. "
+    "Continue your task from where you stopped and complete it fully."
+)
+
+# The distinctive option line — anchor for "this is the usage-limit dialog".
+PARK_OPTION = "Stop and wait for limit to reset"
+# Present whenever a Claude Code select-menu is live on screen.
+MENU_FOOTER = "Enter to confirm"
+MENU_QUESTION = "What do you want to do?"
+
+# Limits reset every 5h from window start, so now+5h is a guaranteed upper
+# bound when the reset time can't be parsed from the dialog.
+FALLBACK_RESET = timedelta(hours=5)
+# A parsed reset further out than one window (+ slack) means the stated
+# clock time already passed and rolled to tomorrow — i.e. reset is done.
+MAX_WINDOW = timedelta(hours=5, minutes=15)
+# Nudge this long after the stated reset so we're safely past it.
+RESUME_BUFFER = timedelta(minutes=2)
+# Give up nudging after this many failed attempts and archive as failed.
+MAX_RESUME_ATTEMPTS = 5
+
+# Shells that indicate no agent is running in a pane (mirror completion.py).
+_BARE_SHELLS = {"zsh", "bash", "sh", "fish", "tcsh", "csh"}
+
+# e.g. "You've hit your session limit · resets 11:40pm (America/Toronto)"
+_RESET_RE = re.compile(
+    r"resets?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+
+
+# =============================================================================
+# Small utilities
+# =============================================================================
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize(text: str) -> str:
+    """Collapse all whitespace so narrow-pane line wraps can't break matches."""
+    return " ".join(text.split())
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def log_event(event: str, **fields) -> None:
+    """Append an event to the usage-limit events log (best-effort)."""
+    record = {"ts": _now().isoformat(), "event": event, **fields}
+    try:
+        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(EVENTS_FILE, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def _tmux(args: list[str], timeout: float = 5) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["tmux", *args], capture_output=True, text=True, timeout=timeout
+    )
+
+
+def _capture(target: str, scrollback: int | None = None) -> str:
+    """Capture pane text. Visible screen only unless ``scrollback`` lines given."""
+    cmd = ["capture-pane", "-t", target, "-p"]
+    if scrollback:
+        cmd += ["-S", f"-{scrollback}"]
+    try:
+        result = _tmux(cmd)
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _session_exists(session: str) -> bool:
+    try:
+        return _tmux(["has-session", "-t", f"={session}"]).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _send_key(target: str, key: str) -> None:
+    _tmux(["send-keys", "-t", target, key])
+
+
+# =============================================================================
+# State files
+# =============================================================================
+
+
+def state_path(session: str) -> Path:
+    return STATE_DIR / f"{session}.json"
+
+
+def is_parked(session: str) -> bool:
+    """True iff this session is currently parked on a usage limit."""
+    return state_path(session).exists()
+
+
+def read_park_state(session: str) -> dict | None:
+    try:
+        return json.loads(state_path(session).read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def write_park_state(state: dict) -> None:
+    _atomic_write(state_path(state["session"]), state)
+
+
+def list_parked() -> list[dict]:
+    """All active park states (excludes the done/ archive)."""
+    if not STATE_DIR.exists():
+        return []
+    states = []
+    for path in sorted(STATE_DIR.rglob("*.json")):
+        if DONE_DIR in path.parents:
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict) and data.get("session"):
+            states.append(data)
+    return states
+
+
+def archive_state(state: dict, status: str) -> None:
+    """Move a park state into done/ with a final status."""
+    state["status"] = status
+    state["archived_at"] = _now().isoformat()
+    flat = state["session"].replace("/", "_")
+    ts = _now().strftime("%Y%m%dT%H%M%S")
+    _atomic_write(DONE_DIR / f"{flat}-{ts}.json", state)
+    try:
+        state_path(state["session"]).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+# =============================================================================
+# Detection
+# =============================================================================
+
+
+def detect_dialog(visible: str) -> bool:
+    """True iff the usage-limit dialog is live on this (visible) screen.
+
+    Requires the distinctive park option AND the menu footer, and nothing
+    rendered after the menu — a pane merely *displaying* a captured dialog
+    (an orchestrator reviewing another session's output) has its own prompt
+    box below the quoted text and must not be parked.
+    """
+    norm = _normalize(visible)
+    if PARK_OPTION not in norm or MENU_FOOTER not in norm:
+        return False
+    tail = norm.rsplit(MENU_FOOTER, 1)[1]
+    # A live menu ends the screen: "Enter to confirm · Esc to cancel".
+    tail = tail.replace("·", " ").replace("Esc to cancel", " ")
+    return not tail.strip()
+
+
+def detect_dialog_like(visible: str) -> bool:
+    """A live select-menu that is NOT the known usage-limit dialog.
+
+    Used to log dialog-text drift across Claude Code versions — never acted
+    on, only surfaced via ``unmatched_dialog`` events.
+    """
+    norm = _normalize(visible)
+    if MENU_QUESTION not in norm or MENU_FOOTER not in norm:
+        return False
+    return not detect_dialog(visible)
+
+
+def parse_reset_time(text: str, now: datetime | None = None) -> datetime | None:
+    """Parse the limit reset time from dialog/scrollback text.
+
+    Matches e.g. "resets 11:40pm (America/Toronto)" — last occurrence wins
+    (the freshest message is lowest in the scrollback). Returns an aware UTC
+    datetime, ``now`` if the stated time already passed (reset is done), or
+    None if nothing parseable is found.
+    """
+    now = now or _now()
+    matches = list(_RESET_RE.finditer(_normalize(text)))
+    if not matches:
+        return None
+    hour_s, minute_s, meridiem, tz_name = matches[-1].groups()
+
+    hour = int(hour_s) % 12
+    if meridiem.lower() == "pm":
+        hour += 12
+    minute = int(minute_s) if minute_s else 0
+    if hour > 23 or minute > 59:
+        return None
+
+    tzinfo = None
+    if tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            tzinfo = ZoneInfo(tz_name.strip())
+        except Exception:
+            tzinfo = None
+    if tzinfo is None:
+        tzinfo = datetime.now().astimezone().tzinfo
+
+    local_now = now.astimezone(tzinfo)
+    candidate = local_now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= local_now:
+        candidate += timedelta(days=1)
+    if candidate - local_now > MAX_WINDOW:
+        # Stated clock time already passed today — the reset has happened.
+        return now
+    return candidate.astimezone(timezone.utc)
+
+
+# =============================================================================
+# Park
+# =============================================================================
+
+
+def _task_info(session: str) -> dict:
+    """Best-effort context for notifications: task name + project path."""
+    info: dict = {}
+    task_file = Path.home() / ".agentwire" / "tasks" / f"{session}.json"
+    try:
+        ctx = json.loads(task_file.read_text())
+        if isinstance(ctx, dict) and ctx.get("task"):
+            info["task"] = ctx["task"]
+    except (OSError, json.JSONDecodeError):
+        pass
+    try:
+        result = _tmux(["display-message", "-p", "-t", session, "#{pane_current_path}"])
+        if result.returncode == 0 and result.stdout.strip():
+            info["project_path"] = result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return info
+
+
+def park(session: str, pane_index: int = 0, source: str = "watchdog") -> dict | None:
+    """Park a session sitting on the usage-limit dialog.
+
+    Selects option 1 ("Stop and wait for limit to reset"), parses the reset
+    time, writes the park state file, and sends the owner notification.
+    Idempotent: an already-parked session is a no-op. Returns the park state,
+    or None if the session wasn't actually on the dialog.
+    """
+    if is_parked(session):
+        return None
+
+    target = f"{session}.{pane_index}"
+    visible = _capture(target)
+    if not detect_dialog(visible):
+        return None
+
+    now = _now()
+    scrollback = _capture(target, scrollback=300)
+    reset_at = parse_reset_time(scrollback or visible, now)
+    parse_failed = reset_at is None
+    if parse_failed:
+        reset_at = now + FALLBACK_RESET
+        log_event(
+            "reset_parse_failed", session=session, pane=pane_index,
+            excerpt=_normalize(visible)[-500:],
+        )
+
+    # Select option 1 and confirm; verify the menu actually dismissed.
+    for attempt in range(2):
+        _send_key(target, "1")
+        time.sleep(0.3)
+        _send_key(target, "Enter")
+        time.sleep(1.0)
+        if not detect_dialog(_capture(target)):
+            break
+        if attempt == 1:
+            log_event("park_confirm_failed", session=session, pane=pane_index)
+
+    state = {
+        "session": session,
+        "pane": pane_index,
+        "status": "parked",
+        "source": source,
+        "detected_at": now.isoformat(),
+        "parked_at": _now().isoformat(),
+        "reset_at": reset_at.isoformat(),
+        "resume_at": (reset_at + RESUME_BUFFER).isoformat(),
+        "reset_parse_failed": parse_failed,
+        "notified": False,
+        "resume_attempts": 0,
+        "excerpt": _normalize(visible)[-500:],
+        **_task_info(session),
+    }
+    write_park_state(state)
+    log_event(
+        "session_parked", session=session, pane=pane_index, source=source,
+        reset_at=state["reset_at"], resume_at=state["resume_at"],
+        task=state.get("task"),
+    )
+    _notify_parked(state)
+    return state
+
+
+def _fmt_local(iso: str) -> str:
+    try:
+        return (
+            datetime.fromisoformat(iso)
+            .astimezone()
+            .strftime("%Y-%m-%d %I:%M%p %Z")
+        )
+    except ValueError:
+        return iso
+
+
+def _notify_parked(state: dict) -> bool:
+    """Email the owner that a session is parked. Plain Resend call, no agent."""
+    session = state["session"]
+    lines = [
+        f"Session **{session}** on `{socket.gethostname()}` hit a usage limit "
+        "and was parked (option 1: stop and wait for limit to reset).",
+        "",
+        f"- **Task:** {state.get('task') or '(none — not a tracked task)'}",
+        f"- **Project:** {state.get('project_path') or 'unknown'}",
+        f"- **Detected:** {_fmt_local(state['detected_at'])}",
+        f"- **Limit resets:** {_fmt_local(state['reset_at'])}"
+        + (" (unparsed — assumed +5h window)" if state.get("reset_parse_failed") else ""),
+        f"- **Auto-resume:** {_fmt_local(state['resume_at'])}",
+        "",
+        "The session will be nudged automatically after reset — no action needed.",
+        "",
+        "```",
+        state.get("excerpt", ""),
+        "```",
+    ]
+    return _send_notification(
+        state,
+        subject=f"[agentwire] usage limit: {session} parked until {_fmt_local(state['reset_at'])}",
+        body="\n".join(lines),
+        mark_notified=True,
+    )
+
+
+def _notify_resumed(state: dict) -> None:
+    session = state["session"]
+    _send_notification(
+        state,
+        subject=f"[agentwire] usage limit reset: {session} resumed",
+        body=(
+            f"Session **{session}** on `{socket.gethostname()}` was nudged to "
+            f"continue after its usage limit reset.\n\n"
+            f"- **Task:** {state.get('task') or '(none)'}\n"
+            f"- **Parked:** {_fmt_local(state['parked_at'])}\n"
+            f"- **Resumed:** {_fmt_local(_now().isoformat())}"
+        ),
+        mark_notified=False,
+    )
+
+
+def _send_notification(state: dict, subject: str, body: str, mark_notified: bool) -> bool:
+    try:
+        from .channels.email import send_email
+
+        result = send_email(subject=subject, body=body)
+        if result.success:
+            if mark_notified:
+                state["notified"] = True
+                if is_parked(state["session"]):
+                    write_park_state(state)
+            log_event("notify_sent", session=state["session"], subject=subject)
+            return True
+        log_event("notify_failed", session=state["session"], error=result.error)
+    except Exception as e:
+        log_event("notify_failed", session=state["session"], error=str(e))
+    return False
+
+
+# =============================================================================
+# Sweep (detection backstop across every tmux pane)
+# =============================================================================
+
+
+def sweep() -> list[dict]:
+    """Scan all tmux panes for the usage-limit dialog; park what's found."""
+    try:
+        result = _tmux(
+            ["list-panes", "-a", "-F",
+             "#{session_name}\t#{pane_index}\t#{pane_current_command}"]
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    parked = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        session, pane_s, command = parts
+        if command.strip().lower() in _BARE_SHELLS:
+            continue
+        if is_parked(session):
+            continue
+        try:
+            pane_index = int(pane_s)
+        except ValueError:
+            continue
+
+        visible = _capture(f"{session}.{pane_index}")
+        if detect_dialog(visible):
+            state = park(session, pane_index, source="watchdog")
+            if state:
+                parked.append(state)
+        elif detect_dialog_like(visible):
+            _log_unmatched(session, pane_index, visible)
+    return parked
+
+
+def _log_unmatched(session: str, pane_index: int, visible: str) -> None:
+    """Log a dialog-like screen we don't recognize — once per distinct screen."""
+    excerpt = _normalize(visible)[-500:]
+    marker_file = STATE_DIR / ".unmatched.json"
+    try:
+        seen = json.loads(marker_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        seen = {}
+    if not isinstance(seen, dict):
+        seen = {}
+    key = f"{session}.{pane_index}"
+    digest = str(hash(excerpt))
+    if seen.get(key) == digest:
+        return
+    seen[key] = digest
+    _atomic_write(marker_file, seen)
+    log_event("unmatched_dialog", session=session, pane=pane_index, excerpt=excerpt)
+
+
+# =============================================================================
+# Resume
+# =============================================================================
+
+
+def _nudge_visible(target: str) -> bool:
+    norm = _normalize(_capture(target))
+    return "interrupted by a usage limit" in norm or "[Pasted text" in norm
+
+
+def resume_session(state: dict, force: bool = False) -> bool:
+    """Send the resume nudge to a parked session; archive state on success."""
+    session = state["session"]
+    pane = state.get("pane", 0)
+    target = f"{session}.{pane}"
+
+    if not _session_exists(session):
+        archive_state(state, "orphaned")
+        log_event("park_orphaned", session=session)
+        return False
+
+    from . import pane_manager
+
+    attempts = state.get("resume_attempts", 0)
+    try:
+        pane_manager.send_to_target(target, RESUME_NUDGE, enter=True)
+        time.sleep(2.0)
+        delivered = _nudge_visible(target)
+    except Exception as e:
+        log_event("resume_send_error", session=session, error=str(e))
+        delivered = False
+
+    if delivered or force:
+        state["resumed_at"] = _now().isoformat()
+        archive_state(state, "resumed")
+        log_event("session_resumed", session=session, attempts=attempts + 1,
+                  forced=bool(force and not delivered))
+        _notify_resumed(state)
+        return True
+
+    state["resume_attempts"] = attempts + 1
+    if state["resume_attempts"] >= MAX_RESUME_ATTEMPTS:
+        archive_state(state, "resume_failed")
+        log_event("resume_failed", session=session, attempts=state["resume_attempts"])
+        _send_notification(
+            state,
+            subject=f"[agentwire] usage limit: FAILED to resume {session}",
+            body=(
+                f"Session **{session}** could not be nudged after "
+                f"{state['resume_attempts']} attempts — it needs a human look."
+            ),
+            mark_notified=False,
+        )
+    else:
+        write_park_state(state)
+        log_event("resume_retry", session=session, attempts=state["resume_attempts"])
+    return False
+
+
+def resume_due(now: datetime | None = None) -> list[str]:
+    """Resume every parked session whose reset (+ buffer) has passed."""
+    now = now or _now()
+    resumed = []
+    for state in list_parked():
+        session = state["session"]
+        if not _session_exists(session):
+            archive_state(state, "orphaned")
+            log_event("park_orphaned", session=session)
+            continue
+        if not state.get("notified"):
+            _notify_parked(state)
+        try:
+            due = datetime.fromisoformat(state["resume_at"]) <= now
+        except (KeyError, ValueError):
+            due = True
+        if due and resume_session(state):
+            resumed.append(session)
+    return resumed
+
+
+# =============================================================================
+# Tick (the stateless watchdog entry point)
+# =============================================================================
+
+
+def tick() -> dict:
+    """One watchdog pass: sweep for dialogs, resume what's due.
+
+    Stateless and self-contained — safe to run from launchd every minute.
+    A non-blocking lock skips overlapping ticks.
+    """
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    lock_file = open(STATE_DIR / ".tick.lock", "w")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        lock_file.close()
+        return {"skipped": "tick already running"}
+
+    try:
+        parked = sweep()
+        resumed = resume_due()
+        return {
+            "parked": [s["session"] for s in parked],
+            "resumed": resumed,
+            "waiting": [s["session"] for s in list_parked()],
+        }
+    finally:
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -40,6 +40,7 @@ Headless and scheduled execution.
 
 - **[Scheduled workloads](scheduling/scheduled-workloads.md)** — `agentwire ensure`, `.agentwire.yml` task schema, overnight queue
 - **[Missions](missions.md)** — issue → branch → draft PR → review → merge orchestration; launchd-driven dispatcher + feedback router + worktree janitor
+- **[Usage-limit recovery](usage-limit-recovery.md)** — deterministic detect → park → email → auto-resume for the Claude Code usage-limit dialog; launchd watchdog, zero LLM involvement
 
 ## Integrations
 

--- a/docs/wiki/usage-limit-recovery.md
+++ b/docs/wiki/usage-limit-recovery.md
@@ -1,0 +1,148 @@
+# Usage-Limit Recovery
+
+> Living wiki page. Update this, don't create new versions.
+
+Deterministic recovery from the Claude Code usage-limit dialog. When a
+session hits its usage limit mid-task, Claude Code presents an interactive
+menu (`/rate-limit-options`) and the session blocks forever waiting for a
+human — a silent deadlock for any unattended surface (scheduled tasks,
+overnight queue, missions, worker panes). This subsystem detects the dialog,
+parks the session, emails the owner, and nudges the session back to work
+after the limit resets.
+
+**Zero LLM involvement, by design.** At the moment this fires, usage is
+exhausted by definition — no agent can run to compose an alert or schedule a
+retry. The whole loop is plain code: pane-text regex via `tmux capture-pane`,
+`send-keys`, a regex over the dialog's "resets 11:40pm (America/Toronto)"
+line, a direct Resend call, and a launchd timer. The only agent in the story
+is the parked session itself resuming when the nudge lands.
+
+## The flow
+
+```
+dialog appears ──▶ detect ──▶ park (send-keys '1' Enter) ──▶ parse reset time
+                                      │
+                                      ▼
+                          write ~/.agentwire/usage-limit/<session>.json
+                                      │
+                  ┌───────────────────┼─────────────────────┐
+                  ▼                   ▼                     ▼
+            email owner      guards everywhere      watchdog tick (60s)
+            (Resend, direct) (never reaped/         resume_at passed?
+                              re-dispatched)        send fixed nudge ──▶ session
+                                                    archive to done/      finishes
+```
+
+Detection runs in two places:
+
+| Where | Latency | Covers |
+|-------|---------|--------|
+| ensure's completion poll (`completion.wait_for_completion_signal`) | ≤10s | scheduler + overnight dispatched tasks |
+| `agentwire limits tick` watchdog sweep over **all** tmux panes | ≤60s | everything else: missions, workers (panes 1+), interactive sessions |
+
+Both call the same module: `agentwire/usage_limit.py`.
+
+### Detection details
+
+- Matches the distinctive option line **"Stop and wait for limit to reset"**
+  plus the live-menu footer **"Enter to confirm"**, whitespace-normalized so
+  narrow-pane line wraps can't break it.
+- **Visible screen only** (no scrollback) and the menu must *end* the screen
+  — a pane merely displaying a captured dialog (an orchestrator reviewing
+  another session's output) has its own prompt below the quoted text and is
+  not parked.
+- Unknown live menus ("What do you want to do?" + "Enter to confirm" without
+  the known option) are logged as `unmatched_dialog` events — the canary for
+  dialog-text drift across Claude Code versions. If a real limit dialog ever
+  stops matching, look here first.
+
+### Reset-time parsing
+
+`resets 11:40pm (America/Toronto)` → IANA zone via `zoneinfo`, rolled forward
+to the next occurrence. If the stated clock time is more than one 5h window
+away, the reset already passed → resume immediately. If nothing parses, fall
+back to **now + 5h** (limits reset every 5h from window start, so that's a
+guaranteed upper bound) and log `reset_parse_failed`. Resume fires at
+`reset_at + 2min`.
+
+## The parked state
+
+`~/.agentwire/usage-limit/<session>.json` — file presence == parked. That is
+the guard the rest of the system checks:
+
+| Surface | Behavior while parked |
+|---------|----------------------|
+| `agentwire ensure` | exits immediately with code **7** (`usage_limit`) — never prompts a parked session |
+| scheduler dispatch | skips the task (`task_skipped reason=usage_limit_parked`) without consuming `last_run`; no pre-dispatch session kill |
+| scheduler status | ensure exit 7 → `last_status: usage_limit` on the board/events |
+| idle hook (`idle-handler.sh`) | exits before any idle handling — no summary prompt typed into the dialog, no `/exit`, no kill |
+| overnight `check_completion` | reports `running`, never `stuck` |
+| `agentwire list --sessions` | `usage_limit: true` in JSON, `[parked: usage limit]` in text; flows to MCP `sessions_list` and the portal sessions API |
+
+On resume the file is archived to `~/.agentwire/usage-limit/done/` with a
+final status (`resumed` / `orphaned` / `resume_failed`), so completion then
+flows normally through the idle hook.
+
+The resume nudge is fixed text:
+
+> You were interrupted by a usage limit; the limit has reset. Continue your
+> task from where you stopped and complete it fully.
+
+Delivery is verified by recapturing the pane; up to 5 attempts across ticks,
+then `resume_failed` + an email asking for a human look.
+
+## CLI
+
+```bash
+agentwire limits tick          # one watchdog pass (what launchd runs)
+agentwire limits status        # parked sessions + reset/resume times
+agentwire limits resume -s X   # manual resume now (--force to skip verify)
+agentwire limits install       # write + load the launchd watchdog (60s tick)
+agentwire limits uninstall
+```
+
+The watchdog plist (`dev.agentwire.usage-limit-watchdog`) is generated by
+`limits install` — no template file to drift. It runs 24/7 (limits don't
+keep office hours). Logs: `~/Library/Logs/agentwire-usage-limit-watchdog.log`.
+Events: `~/.agentwire/usage-limit-events.jsonl` (`session_parked`,
+`notify_sent`, `session_resumed`, `unmatched_dialog`, `reset_parse_failed`,
+`park_orphaned`, …).
+
+## Notifications
+
+Park and resume each send one email through the existing Resend channel
+(`agentwire/channels/email.py::send_email`), pure code path. The park email
+includes task, project, detected/reset/resume times, and the dialog excerpt.
+If the send fails (no key in launchd's env, transient API error), it's
+retried on subsequent ticks until it lands (`notified: false` in the state
+file marks the pending retry).
+
+## Known limitations
+
+- **Worktree scheduler tasks**: a task parked mid-run skips the
+  commit/push/PR finalize (half-done work must not be pushed). The session
+  resumes and finishes via the idle hook, but the PR is **not** opened
+  automatically — the worktree is left in place for manual follow-up.
+- **Remote machines**: detection/park state is per-machine. The watchdog
+  only sweeps local tmux; install it on each machine that runs unattended
+  sessions.
+
+## Troubleshooting
+
+- Dialog not being parked? `tail ~/.agentwire/usage-limit-events.jsonl` —
+  an `unmatched_dialog` event means Claude Code changed the dialog text;
+  update the anchors in `agentwire/usage_limit.py` (`PARK_OPTION`,
+  `MENU_FOOTER`) and the regex `_RESET_RE`.
+- Watchdog not running? `launchctl list | grep usage-limit` and
+  `tail -f ~/Library/Logs/agentwire-usage-limit-watchdog.log`.
+- Session stuck parked after its session died? Ticks archive those as
+  `orphaned` automatically; `agentwire limits status` should be empty.
+
+## History
+
+Born from the 2026-06-10 incident: two scheduler verification runs hit the
+limit seconds after dispatch and sat on the dialog ~11 hours overnight —
+the supervising worker was polling shells, the shells were waiting on
+sessions, the sessions were waiting on a human. The manual recovery
+(select option 1, nudge after reset) completed both runs green and is
+exactly what this subsystem automates. Issue #274.

--- a/docs/wiki/usage-limit-recovery.md
+++ b/docs/wiki/usage-limit-recovery.md
@@ -91,6 +91,22 @@ The resume nudge is fixed text:
 Delivery is verified by recapturing the pane; up to 5 attempts across ticks,
 then `resume_failed` + an email asking for a human look.
 
+## Configuration
+
+`~/.agentwire/config.yaml`:
+
+```yaml
+usage_limit:
+  enabled: true            # master switch for detection/parking (default true)
+  exclude_sessions:        # sessions never auto-parked (default empty)
+    - jordan
+```
+
+These knobs gate **new parks only** — both the watchdog sweep and ensure's
+in-band detection. Already-parked sessions are always resumed and `agentwire
+limits resume` always works, even for excluded sessions or with the feature
+disabled (you can turn it off without stranding a parked session).
+
 ## CLI
 
 ```bash

--- a/tests/unit/test_idle_handler.py
+++ b/tests/unit/test_idle_handler.py
@@ -82,3 +82,24 @@ class TestSecondIdleCleanup:
             "persistent branch must remove $task_context_file — "
             "wait_for_completion_signal blocks until the context file is deleted"
         )
+
+
+class TestUsageLimitParkGuard:
+    """A session parked on a usage limit (#274) must short-circuit the hook —
+    no summary prompts, no /exit, no kill — before ANY idle handling runs."""
+
+    def test_guard_exists_and_exits_zero(self):
+        source = HOOK_PATH.read_text()
+        guard = source.find('usage-limit/${tmux_session}.json')
+        assert guard != -1, "usage-limit park guard missing from idle-handler.sh"
+        following = source[guard:guard + 300]
+        assert "exit 0" in following, "park guard must exit 0, not fall through"
+
+    def test_guard_runs_before_all_idle_handling(self):
+        source = HOOK_PATH.read_text()
+        guard = source.find('usage-limit/${tmux_session}.json')
+        worker_branch = source.find("Worker pane detected")
+        task_branch = source.find("task_context_file=")
+        assert guard != -1 and worker_branch != -1 and task_branch != -1
+        assert guard < worker_branch, "guard must precede worker-pane handling"
+        assert guard < task_branch, "guard must precede scheduled-task handling"

--- a/tests/unit/test_usage_limit.py
+++ b/tests/unit/test_usage_limit.py
@@ -1,0 +1,499 @@
+"""Tests for usage-limit dialog recovery (agentwire/usage_limit.py).
+
+The dialog fixture is the real pane capture from the 2026-06-10 incident
+(two scheduler verification runs parked on the dialog for ~11 hours).
+"""
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from agentwire import usage_limit
+
+
+# Real capture from the incident (fragmentz/scheduler-fragmentz-leads-daily).
+REAL_DIALOG = """\
+  ⎿  You've hit your session limit · resets 11:40pm (America/Toronto)
+
+✻ Baked for 23m 20s
+
+❯ /rate-limit-options
+
+────────────────────────────────────────────────────────────────────────────────
+  What do you want to do?
+
+  ❯ 1. Stop and wait for limit to reset
+    2. Switch to usage credits
+    3. Switch to Team plan
+
+  Enter to confirm · Esc to cancel
+
+"""
+
+# An orchestrator pane *displaying* a captured dialog (its own prompt below).
+DISPLAYED_DIALOG = REAL_DIALOG + """\
+```
+
+### jordan
+- Idle: 100min | Nagged: 49x
+- Type: claude-bypass
+
+❯ ready for your next instruction
+"""
+
+# A live menu that is NOT the usage-limit dialog (drift / other dialogs).
+OTHER_DIALOG = """\
+  What do you want to do?
+
+  ❯ 1. Yes, proceed
+    2. No, cancel
+
+  Enter to confirm · Esc to cancel
+"""
+
+# Narrow pane: the option line wraps mid-phrase.
+WRAPPED_DIALOG = """\
+  What do you want to do?
+
+  ❯ 1. Stop and wait for limit
+  to reset
+    2. Switch to usage credits
+
+  Enter to confirm · Esc to
+  cancel
+"""
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    """Point all state/event paths into tmp and never send real email."""
+    state_dir = tmp_path / "usage-limit"
+    monkeypatch.setattr(usage_limit, "STATE_DIR", state_dir)
+    monkeypatch.setattr(usage_limit, "DONE_DIR", state_dir / "done")
+    monkeypatch.setattr(usage_limit, "EVENTS_FILE", tmp_path / "events.jsonl")
+    monkeypatch.setattr(
+        usage_limit, "_send_notification", lambda *a, **k: False
+    )
+    monkeypatch.setattr(usage_limit.time, "sleep", lambda s: None)
+    return state_dir
+
+
+def events(tmp_path=None):
+    path = usage_limit.EVENTS_FILE
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+# =============================================================================
+# Detection
+# =============================================================================
+
+
+class TestDetectDialog:
+    def test_real_incident_capture(self):
+        assert usage_limit.detect_dialog(REAL_DIALOG) is True
+
+    def test_wrapped_narrow_pane(self):
+        assert usage_limit.detect_dialog(WRAPPED_DIALOG) is True
+
+    def test_displayed_capture_is_not_live(self):
+        # A pane quoting the dialog (orchestrator review) must not match.
+        assert usage_limit.detect_dialog(DISPLAYED_DIALOG) is False
+
+    def test_other_menus_dont_match(self):
+        assert usage_limit.detect_dialog(OTHER_DIALOG) is False
+
+    def test_plain_output_doesnt_match(self):
+        assert usage_limit.detect_dialog("$ make test\nAll green\n") is False
+        assert usage_limit.detect_dialog("") is False
+
+    def test_scrollback_remnant_with_prompt_below(self):
+        # After parking, the menu text may linger above a live prompt.
+        text = REAL_DIALOG + "\n❯ \n"
+        assert usage_limit.detect_dialog(text) is False
+
+
+class TestDetectDialogLike:
+    def test_unknown_menu_is_dialog_like(self):
+        assert usage_limit.detect_dialog_like(OTHER_DIALOG) is True
+
+    def test_known_dialog_is_not_dialog_like(self):
+        assert usage_limit.detect_dialog_like(REAL_DIALOG) is False
+
+    def test_plain_output_is_not_dialog_like(self):
+        assert usage_limit.detect_dialog_like("compiling...") is False
+
+
+# =============================================================================
+# Reset time parsing
+# =============================================================================
+
+TORONTO = ZoneInfo("America/Toronto")
+
+
+class TestParseResetTime:
+    def test_real_capture(self):
+        now = datetime(2026, 6, 10, 22, 30, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time(REAL_DIALOG, now)
+        assert result == datetime(2026, 6, 10, 23, 40, tzinfo=TORONTO)
+        assert result.tzinfo == timezone.utc
+
+    def test_rolls_past_midnight(self):
+        now = datetime(2026, 6, 10, 23, 0, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time("resets 1:05am (America/Toronto)", now)
+        assert result == datetime(2026, 6, 11, 1, 5, tzinfo=TORONTO)
+
+    def test_stated_time_already_passed_means_reset_done(self):
+        # Dialog said 11:40pm; we only noticed at 11:50pm. Tomorrow-11:40pm
+        # is outside one 5h window, so the reset already happened.
+        now = datetime(2026, 6, 10, 23, 50, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time("resets 11:40pm (America/Toronto)", now)
+        assert result == now
+
+    def test_no_minutes_and_at_variant(self):
+        now = datetime(2026, 6, 10, 13, 0, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time("resets at 3pm (America/Toronto)", now)
+        assert result == datetime(2026, 6, 10, 15, 0, tzinfo=TORONTO)
+
+    def test_12am_and_12pm(self):
+        now = datetime(2026, 6, 10, 22, 0, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time("resets 12:15am (America/Toronto)", now)
+        assert result == datetime(2026, 6, 11, 0, 15, tzinfo=TORONTO)
+
+        now = datetime(2026, 6, 10, 10, 0, tzinfo=TORONTO)
+        result = usage_limit.parse_reset_time("resets 12:30pm (America/Toronto)", now)
+        assert result == datetime(2026, 6, 10, 12, 30, tzinfo=TORONTO)
+
+    def test_last_match_wins(self):
+        now = datetime(2026, 6, 10, 20, 0, tzinfo=TORONTO)
+        text = "resets 9:00pm (America/Toronto)\n...\nresets 11:40pm (America/Toronto)"
+        result = usage_limit.parse_reset_time(text, now)
+        assert result == datetime(2026, 6, 10, 23, 40, tzinfo=TORONTO)
+
+    def test_unknown_timezone_falls_back_to_local(self):
+        now = datetime(2026, 6, 10, 20, 0, tzinfo=timezone.utc)
+        result = usage_limit.parse_reset_time("resets 11:40pm (Mars/Olympus)", now)
+        assert result is not None
+
+    def test_no_timezone_uses_local(self):
+        now = datetime(2026, 6, 10, 20, 0, tzinfo=timezone.utc)
+        assert usage_limit.parse_reset_time("resets 11:40pm", now) is not None
+
+    def test_unparseable_returns_none(self):
+        assert usage_limit.parse_reset_time("no limits here", _now_utc()) is None
+        assert usage_limit.parse_reset_time("", _now_utc()) is None
+
+
+def _now_utc():
+    return datetime.now(timezone.utc)
+
+
+# =============================================================================
+# State files
+# =============================================================================
+
+
+class TestState:
+    def test_roundtrip_and_is_parked(self):
+        state = {"session": "mysession", "status": "parked"}
+        usage_limit.write_park_state(state)
+        assert usage_limit.is_parked("mysession") is True
+        assert usage_limit.read_park_state("mysession") == state
+        assert usage_limit.list_parked() == [state]
+
+    def test_worktree_session_names_nest(self):
+        state = {"session": "fragmentz/scheduler-leads-daily", "status": "parked"}
+        usage_limit.write_park_state(state)
+        assert usage_limit.is_parked("fragmentz/scheduler-leads-daily") is True
+        assert usage_limit.list_parked() == [state]
+
+    def test_archive_moves_out_of_active(self):
+        state = {"session": "proj/branch", "status": "parked"}
+        usage_limit.write_park_state(state)
+        usage_limit.archive_state(state, "resumed")
+        assert usage_limit.is_parked("proj/branch") is False
+        assert usage_limit.list_parked() == []
+        archived = list(usage_limit.DONE_DIR.glob("*.json"))
+        assert len(archived) == 1
+        data = json.loads(archived[0].read_text())
+        assert data["status"] == "resumed"
+        assert data["archived_at"]
+
+    def test_not_parked_when_nothing_written(self):
+        assert usage_limit.is_parked("ghost") is False
+        assert usage_limit.list_parked() == []
+
+
+# =============================================================================
+# Park
+# =============================================================================
+
+
+class FakeTmux:
+    """Scriptable stand-in for usage_limit._tmux."""
+
+    def __init__(self, screens):
+        # screens: list of visible-screen strings; each capture pops the next
+        # (last one repeats).
+        self.screens = list(screens)
+        self.sent_keys = []
+
+    def __call__(self, args, timeout=5):
+        cmd = args[0]
+        if cmd == "capture-pane":
+            text = self.screens[0]
+            if len(self.screens) > 1:
+                self.screens.pop(0)
+            return subprocess.CompletedProcess(args, 0, stdout=text, stderr="")
+        if cmd == "send-keys":
+            self.sent_keys.append(args[-1])
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if cmd == "display-message":
+            return subprocess.CompletedProcess(args, 0, stdout="/tmp/proj\n", stderr="")
+        if cmd == "has-session":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if cmd == "list-panes":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="unknown")
+
+
+class TestPark:
+    def test_parks_and_writes_state(self, monkeypatch):
+        # Captures: park() detect → scrollback → confirm (dismissed)
+        fake = FakeTmux([REAL_DIALOG, REAL_DIALOG, "❯ waiting...\n"])
+        monkeypatch.setattr(usage_limit, "_tmux", fake)
+
+        now = datetime(2026, 6, 11, 2, 30, tzinfo=timezone.utc)  # 22:30 Toronto
+        monkeypatch.setattr(usage_limit, "_now", lambda: now)
+
+        state = usage_limit.park("fragmentz/leads", pane_index=0)
+
+        assert state is not None
+        assert fake.sent_keys == ["1", "Enter"]
+        assert state["status"] == "parked"
+        assert state["reset_parse_failed"] is False
+        # 11:40pm Toronto == 03:40 UTC
+        assert state["reset_at"] == "2026-06-11T03:40:00+00:00"
+        assert state["resume_at"] == "2026-06-11T03:42:00+00:00"
+        assert usage_limit.is_parked("fragmentz/leads")
+        assert any(e["event"] == "session_parked" for e in events())
+
+    def test_idempotent_when_already_parked(self, monkeypatch):
+        usage_limit.write_park_state({"session": "s1", "status": "parked"})
+        fake = FakeTmux([REAL_DIALOG])
+        monkeypatch.setattr(usage_limit, "_tmux", fake)
+        assert usage_limit.park("s1") is None
+        assert fake.sent_keys == []
+
+    def test_no_dialog_no_park(self, monkeypatch):
+        fake = FakeTmux(["just normal output\n"])
+        monkeypatch.setattr(usage_limit, "_tmux", fake)
+        assert usage_limit.park("s1") is None
+        assert not usage_limit.is_parked("s1")
+        assert fake.sent_keys == []
+
+    def test_unparseable_reset_falls_back_5h(self, monkeypatch):
+        dialog = WRAPPED_DIALOG  # no "resets ..." line anywhere
+        fake = FakeTmux([dialog, dialog, ""])
+        monkeypatch.setattr(usage_limit, "_tmux", fake)
+        now = datetime(2026, 6, 11, 2, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(usage_limit, "_now", lambda: now)
+
+        state = usage_limit.park("s1")
+        assert state["reset_parse_failed"] is True
+        assert state["reset_at"] == "2026-06-11T07:00:00+00:00"
+        assert any(e["event"] == "reset_parse_failed" for e in events())
+
+    def test_retries_menu_confirm_once(self, monkeypatch):
+        # Menu survives the first 1+Enter, dismissed after the second.
+        fake = FakeTmux([REAL_DIALOG, REAL_DIALOG, REAL_DIALOG, "❯\n"])
+        monkeypatch.setattr(usage_limit, "_tmux", fake)
+        state = usage_limit.park("s1")
+        assert state is not None
+        assert fake.sent_keys == ["1", "Enter", "1", "Enter"]
+
+
+# =============================================================================
+# Resume
+# =============================================================================
+
+
+class TestResume:
+    def _parked(self, session="s1", resume_at=None, **extra):
+        state = {
+            "session": session,
+            "pane": 0,
+            "status": "parked",
+            "detected_at": "2026-06-11T02:30:00+00:00",
+            "parked_at": "2026-06-11T02:30:05+00:00",
+            "reset_at": "2026-06-11T03:40:00+00:00",
+            "resume_at": resume_at or "2026-06-11T03:42:00+00:00",
+            "notified": True,
+            "resume_attempts": 0,
+            **extra,
+        }
+        usage_limit.write_park_state(state)
+        return state
+
+    def test_resume_sends_nudge_and_archives(self, monkeypatch):
+        state = self._parked()
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: True)
+        sent = []
+        monkeypatch.setattr(
+            usage_limit, "_capture",
+            lambda target, scrollback=None: f"> {usage_limit.RESUME_NUDGE}\n",
+        )
+        import agentwire.pane_manager as pm
+        monkeypatch.setattr(
+            pm, "send_to_target", lambda target, text, enter=True: sent.append((target, text))
+        )
+
+        assert usage_limit.resume_session(state) is True
+        assert sent == [("s1.0", usage_limit.RESUME_NUDGE)]
+        assert not usage_limit.is_parked("s1")
+        assert any(e["event"] == "session_resumed" for e in events())
+
+    def test_resume_dead_session_archives_orphaned(self, monkeypatch):
+        state = self._parked()
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: False)
+        assert usage_limit.resume_session(state) is False
+        assert not usage_limit.is_parked("s1")
+        archived = json.loads(next(usage_limit.DONE_DIR.glob("*.json")).read_text())
+        assert archived["status"] == "orphaned"
+
+    def test_resume_failure_increments_attempts(self, monkeypatch):
+        state = self._parked()
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: True)
+        monkeypatch.setattr(usage_limit, "_capture", lambda *a, **k: "no echo here")
+        import agentwire.pane_manager as pm
+        monkeypatch.setattr(pm, "send_to_target", lambda *a, **k: None)
+
+        assert usage_limit.resume_session(state) is False
+        assert usage_limit.read_park_state("s1")["resume_attempts"] == 1
+
+    def test_resume_gives_up_after_max_attempts(self, monkeypatch):
+        state = self._parked(resume_attempts=usage_limit.MAX_RESUME_ATTEMPTS - 1)
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: True)
+        monkeypatch.setattr(usage_limit, "_capture", lambda *a, **k: "")
+        import agentwire.pane_manager as pm
+        monkeypatch.setattr(pm, "send_to_target", lambda *a, **k: None)
+
+        assert usage_limit.resume_session(state) is False
+        assert not usage_limit.is_parked("s1")
+        archived = json.loads(next(usage_limit.DONE_DIR.glob("*.json")).read_text())
+        assert archived["status"] == "resume_failed"
+
+    def test_resume_due_only_past_resume_at(self, monkeypatch):
+        self._parked(session="due", resume_at="2026-06-11T03:42:00+00:00")
+        self._parked(session="later", resume_at="2026-06-11T09:00:00+00:00")
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: True)
+        resumed_calls = []
+
+        def fake_resume(state, force=False):
+            resumed_calls.append(state["session"])
+            usage_limit.archive_state(state, "resumed")
+            return True
+
+        monkeypatch.setattr(usage_limit, "resume_session", fake_resume)
+
+        now = datetime(2026, 6, 11, 4, 0, tzinfo=timezone.utc)
+        assert usage_limit.resume_due(now) == ["due"]
+        assert resumed_calls == ["due"]
+        assert usage_limit.is_parked("later")
+
+    def test_resume_due_archives_orphans_early(self, monkeypatch):
+        self._parked(session="gone", resume_at="2026-06-11T09:00:00+00:00")
+        monkeypatch.setattr(usage_limit, "_session_exists", lambda s: False)
+        now = datetime(2026, 6, 11, 4, 0, tzinfo=timezone.utc)
+        assert usage_limit.resume_due(now) == []
+        assert not usage_limit.is_parked("gone")
+
+
+# =============================================================================
+# Sweep
+# =============================================================================
+
+
+class TestSweep:
+    def test_sweep_parks_dialog_panes(self, monkeypatch):
+        panes = "work\t0\tnode\nidle\t0\tzsh\nworker\t2\tclaude"
+        screens = {
+            "work.0": REAL_DIALOG,
+            "worker.2": "normal output",
+        }
+
+        def fake_tmux(args, timeout=5):
+            if args[0] == "list-panes":
+                return subprocess.CompletedProcess(args, 0, stdout=panes, stderr="")
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(usage_limit, "_tmux", fake_tmux)
+        monkeypatch.setattr(
+            usage_limit, "_capture",
+            lambda target, scrollback=None: screens.get(target, ""),
+        )
+        parked_calls = []
+        monkeypatch.setattr(
+            usage_limit, "park",
+            lambda session, pane_index=0, source="watchdog": parked_calls.append(
+                (session, pane_index)
+            ) or {"session": session},
+        )
+
+        result = usage_limit.sweep()
+        assert parked_calls == [("work", 0)]  # zsh pane skipped, normal pane no match
+        assert [s["session"] for s in result] == ["work"]
+
+    def test_sweep_logs_unmatched_dialog_once(self, monkeypatch):
+        panes = "odd\t0\tnode"
+
+        def fake_tmux(args, timeout=5):
+            if args[0] == "list-panes":
+                return subprocess.CompletedProcess(args, 0, stdout=panes, stderr="")
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(usage_limit, "_tmux", fake_tmux)
+        monkeypatch.setattr(
+            usage_limit, "_capture", lambda target, scrollback=None: OTHER_DIALOG
+        )
+
+        usage_limit.sweep()
+        usage_limit.sweep()  # same screen → no duplicate event
+        unmatched = [e for e in events() if e["event"] == "unmatched_dialog"]
+        assert len(unmatched) == 1
+        assert "Yes, proceed" in unmatched[0]["excerpt"]
+
+    def test_sweep_skips_already_parked(self, monkeypatch):
+        usage_limit.write_park_state({"session": "work", "status": "parked"})
+        panes = "work\t0\tnode"
+
+        def fake_tmux(args, timeout=5):
+            if args[0] == "list-panes":
+                return subprocess.CompletedProcess(args, 0, stdout=panes, stderr="")
+            raise AssertionError("should not capture a parked session")
+
+        monkeypatch.setattr(usage_limit, "_tmux", fake_tmux)
+        assert usage_limit.sweep() == []
+
+
+# =============================================================================
+# Tick
+# =============================================================================
+
+
+class TestTick:
+    def test_tick_runs_sweep_then_resume(self, monkeypatch):
+        order = []
+        monkeypatch.setattr(
+            usage_limit, "sweep", lambda: order.append("sweep") or []
+        )
+        monkeypatch.setattr(
+            usage_limit, "resume_due", lambda now=None: order.append("resume") or []
+        )
+        result = usage_limit.tick()
+        assert order == ["sweep", "resume"]
+        assert result == {"parked": [], "resumed": [], "waiting": []}

--- a/tests/unit/test_usage_limit.py
+++ b/tests/unit/test_usage_limit.py
@@ -13,6 +13,9 @@ import pytest
 
 from agentwire import usage_limit
 
+# Original reader, captured before the autouse fixture stubs it per-test.
+_ORIG_RECOVERY_CONFIG = usage_limit._recovery_config
+
 
 # Real capture from the incident (fragmentz/scheduler-fragmentz-leads-daily).
 REAL_DIALOG = """\
@@ -78,6 +81,8 @@ def isolated_state(tmp_path, monkeypatch):
         usage_limit, "_send_notification", lambda *a, **k: False
     )
     monkeypatch.setattr(usage_limit.time, "sleep", lambda s: None)
+    # Default knobs — individual tests override to exercise the config gate.
+    monkeypatch.setattr(usage_limit, "_recovery_config", lambda: (True, set()))
     return state_dir
 
 
@@ -467,6 +472,43 @@ class TestSweep:
         assert len(unmatched) == 1
         assert "Yes, proceed" in unmatched[0]["excerpt"]
 
+    def test_sweep_disabled_by_config(self, monkeypatch):
+        monkeypatch.setattr(usage_limit, "_recovery_config", lambda: (False, set()))
+
+        def boom(*a, **k):
+            raise AssertionError("disabled sweep must not touch tmux")
+
+        monkeypatch.setattr(usage_limit, "_tmux", boom)
+        assert usage_limit.sweep() == []
+
+    def test_sweep_skips_excluded_sessions(self, monkeypatch):
+        monkeypatch.setattr(
+            usage_limit, "_recovery_config", lambda: (True, {"precious"})
+        )
+        panes = "precious\t0\tnode\nother\t0\tnode"
+
+        def fake_tmux(args, timeout=5):
+            if args[0] == "list-panes":
+                return subprocess.CompletedProcess(args, 0, stdout=panes, stderr="")
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(usage_limit, "_tmux", fake_tmux)
+        captured = []
+        monkeypatch.setattr(
+            usage_limit, "_capture",
+            lambda target, scrollback=None: captured.append(target) or REAL_DIALOG,
+        )
+        parked_calls = []
+        monkeypatch.setattr(
+            usage_limit, "park",
+            lambda session, pane_index=0, source="watchdog": parked_calls.append(session)
+            or {"session": session},
+        )
+
+        usage_limit.sweep()
+        assert parked_calls == ["other"]
+        assert "precious.0" not in captured  # excluded session never captured
+
     def test_sweep_skips_already_parked(self, monkeypatch):
         usage_limit.write_park_state({"session": "work", "status": "parked"})
         panes = "work\t0\tnode"
@@ -512,6 +554,76 @@ class TestCheckAndPark:
             usage_limit, "_capture", lambda target, scrollback=None: "working...\n"
         )
         assert usage_limit.check_and_park("s1") is False
+
+    def test_disabled_gates_new_parks(self, monkeypatch):
+        monkeypatch.setattr(usage_limit, "_recovery_config", lambda: (False, set()))
+        monkeypatch.setattr(
+            usage_limit, "_capture", lambda target, scrollback=None: REAL_DIALOG
+        )
+        assert usage_limit.check_and_park("s1") is False
+        assert not usage_limit.is_parked("s1")
+
+    def test_excluded_session_gates_new_parks(self, monkeypatch):
+        monkeypatch.setattr(usage_limit, "_recovery_config", lambda: (True, {"s1"}))
+        monkeypatch.setattr(
+            usage_limit, "_capture", lambda target, scrollback=None: REAL_DIALOG
+        )
+        assert usage_limit.check_and_park("s1") is False
+        assert not usage_limit.is_parked("s1")
+
+    def test_already_parked_wins_over_exclusion(self, monkeypatch):
+        # Exclusion gates NEW parks only — an existing park is still honored.
+        usage_limit.write_park_state({"session": "s1", "status": "parked"})
+        monkeypatch.setattr(usage_limit, "_recovery_config", lambda: (False, {"s1"}))
+        assert usage_limit.check_and_park("s1") is True
+
+
+# =============================================================================
+# Config knobs (usage_limit: section in config.yaml)
+# =============================================================================
+
+
+class TestRecoveryConfig:
+    def test_defaults_when_section_absent(self):
+        from agentwire.config import _dict_to_config
+
+        cfg = _dict_to_config({})
+        assert cfg.usage_limit.enabled is True
+        assert cfg.usage_limit.exclude_sessions == []
+
+    def test_section_parsed(self):
+        from agentwire.config import _dict_to_config
+
+        cfg = _dict_to_config({
+            "usage_limit": {
+                "enabled": False,
+                "exclude_sessions": ["jordan", "fragmentz"],
+            }
+        })
+        assert cfg.usage_limit.enabled is False
+        assert cfg.usage_limit.exclude_sessions == ["jordan", "fragmentz"]
+
+    def test_malformed_section_falls_back_to_defaults(self):
+        from agentwire.config import _dict_to_config
+
+        cfg = _dict_to_config({"usage_limit": "nonsense"})
+        assert cfg.usage_limit.enabled is True
+        assert cfg.usage_limit.exclude_sessions == []
+
+        cfg = _dict_to_config({"usage_limit": {"exclude_sessions": "not-a-list"}})
+        assert cfg.usage_limit.exclude_sessions == []
+
+    def test_recovery_config_reads_config_object(self, monkeypatch):
+        import agentwire.config as config_mod
+        from agentwire.config import UsageLimitConfig
+
+        class FakeConfig:
+            usage_limit = UsageLimitConfig(enabled=False, exclude_sessions=["a", "b"])
+
+        monkeypatch.setattr(config_mod, "get_config", lambda: FakeConfig())
+        # The autouse fixture stubs usage_limit._recovery_config — call the
+        # original (captured at import, before the fixture patched it).
+        assert _ORIG_RECOVERY_CONFIG() == (False, {"a", "b"})
 
 
 # =============================================================================

--- a/tests/unit/test_usage_limit.py
+++ b/tests/unit/test_usage_limit.py
@@ -481,6 +481,61 @@ class TestSweep:
 
 
 # =============================================================================
+# check_and_park (ensure's fast-path probe)
+# =============================================================================
+
+
+class TestCheckAndPark:
+    def test_already_parked_short_circuits(self, monkeypatch):
+        usage_limit.write_park_state({"session": "s1", "status": "parked"})
+
+        def boom(*a, **k):
+            raise AssertionError("must not capture when already parked")
+
+        monkeypatch.setattr(usage_limit, "_capture", boom)
+        assert usage_limit.check_and_park("s1") is True
+
+    def test_dialog_parks(self, monkeypatch):
+        monkeypatch.setattr(
+            usage_limit, "_capture", lambda target, scrollback=None: REAL_DIALOG
+        )
+        monkeypatch.setattr(
+            usage_limit, "park",
+            lambda session, pane_index=0, source="ensure": usage_limit.write_park_state(
+                {"session": session, "status": "parked"}
+            ),
+        )
+        assert usage_limit.check_and_park("s1", source="ensure") is True
+
+    def test_normal_screen_is_false(self, monkeypatch):
+        monkeypatch.setattr(
+            usage_limit, "_capture", lambda target, scrollback=None: "working...\n"
+        )
+        assert usage_limit.check_and_park("s1") is False
+
+
+# =============================================================================
+# Status / exit-code mappings (ensure + scheduler integration)
+# =============================================================================
+
+
+class TestStatusMappings:
+    def test_completion_exit_code(self):
+        from agentwire.completion import status_to_exit_code
+
+        assert status_to_exit_code("usage_limit") == 7
+        assert status_to_exit_code("complete") == 0
+        assert status_to_exit_code("failed") == 1
+        assert status_to_exit_code("incomplete") == 2
+
+    def test_scheduler_status_map(self):
+        from agentwire.scheduler import _EXIT_TO_STATUS, _EXIT_USAGE_LIMIT
+
+        assert _EXIT_USAGE_LIMIT == 7
+        assert _EXIT_TO_STATUS[7] == "usage_limit"
+
+
+# =============================================================================
 # Tick
 # =============================================================================
 


### PR DESCRIPTION
Closes #274

## What

Deterministic recovery from the Claude Code usage-limit dialog — the silent deadlock that parked two scheduler runs for ~11h on 2026-06-10. **Zero LLM involvement** (the locked constraint): pane-text regex, send-keys, a regex over the dialog's reset-time line, a direct Resend call, and a launchd timer. The only agent in the story is the parked session resuming on the nudge.

## Design

- **`agentwire/usage_limit.py`** — shared plain-code module. Detection is anchored on the real incident dialog capture (recovered from transcripts, now the test fixture): `"Stop and wait for limit to reset"` + `"Enter to confirm"`, whitespace-normalized (narrow-pane wraps), **visible screen only**, and the menu must end the screen — a pane merely *displaying* a captured dialog (orchestrator reviewing session output) is not parked. Unknown live menus are logged as `unmatched_dialog` (the version-drift canary).
- **Reset parsing**: `resets 11:40pm (America/Toronto)` → zoneinfo, rolled forward; stated-time-already-passed ⇒ resume now; unparseable ⇒ now+5h (guaranteed upper bound, limits reset every 5h) + `reset_parse_failed` event. Resume at reset+2min.
- **Timer = stateless launchd watchdog** (`agentwire limits tick`, StartInterval 60, 24/7, mission-dispatcher pattern). Each tick: sweep all tmux panes → park new dialogs (send-keys `1` Enter + confirm) → resume parked sessions past `resume_at` (fixed nudge via pane_manager + capture-verify, 5 attempts then `resume_failed` + email). Plist generated by `agentwire limits install` — no template file to drift.
- **Fast path**: ensure's completion poll (where ensure sat 11h in the incident) detects in-band ≤10s and exits new code **7** → scheduler status `usage_limit`.
- **Never reaped, never re-dispatched** — park state file (`~/.agentwire/usage-limit/<session>.json`) guards every surface: ensure exits 7 immediately; scheduler skips dispatch without consuming `last_run` (and skips pre-dispatch kill); idle-handler.sh exits before any idle handling; overnight `check_completion` never marks parked as stuck.
- **Surfaces**: scheduler board/events show `usage_limit`; `agentwire list --sessions --json` gains `usage_limit: true` (flows to portal API untouched); MCP `sessions_list` renders a PARKED marker; `agentwire limits status` lists parked sessions.
- **Notify**: park + resume emails via `channels/email.py::send_email` directly; failures retried every tick until sent.

## Verification

- **52 new unit tests** (`tests/unit/test_usage_limit.py` + idle-handler guard tests) — full suite **1243 passed**.
- **Simulated end-to-end on this machine**: scratch tmux session printing the real dialog with a near-future reset time → `agentwire limits tick` parked it (option 1 sent, `12:27pm (America/Toronto)` parsed to correct UTC, state written, **real Resend email delivered**), swept 9 other live sessions with zero false positives → fast-forwarded `resume_at` → next tick delivered the nudge into the pane, archived state to `done/` as `resumed`, sent the resumed email. Events log captured the full trail.

## Config knobs (review condition 1)

```yaml
usage_limit:
  enabled: true          # master switch for detection/parking (default true)
  exclude_sessions: []   # session names never auto-parked
```

Gates **new parks only** (watchdog sweep + ensure in-band detection); resume always drains existing park states, so disabling never strands a parked session. Parsed in `config.py` (`UsageLimitConfig`), unit-tested (defaults, parsing, malformed-section fallback, sweep/check_and_park gating, parked-wins-over-exclusion).

## Clean-env proof (review condition 3)

Run with a parked-dialog scratch session live, no shell environment beyond PATH+HOME:

```
$ env -i PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" HOME=$HOME \
    <worktree>/.venv/bin/agentwire limits tick --json
{"parked": ["limits-e2e-test"], "resumed": [], "waiting": ["limits-e2e-test"]}

events.jsonl:
{"event": "session_parked", "session": "limits-e2e-test", "reset_at": "2026-06-11T16:38:00+00:00", ...}
{"event": "notify_sent", "session": "limits-e2e-test", "subject": "[agentwire] usage limit: limits-e2e-test parked until 2026-06-11 12:38PM EDT"}
```

Email delivered with **zero shell env** — `__main__.py` calls `load_dotenv()` on the global `~/.agentwire/` dotenv file at import, so the Resend key resolves with only HOME set (no shell env needed). `agentwire limits resume` under the same clean env also delivered the resumed email and archived the state.

Note on the literally-prescribed `PATH=/usr/bin:/bin:/usr/local/bin`: on this ARM Mac tmux lives in `/opt/homebrew/bin`, so that PATH makes the tick a clean no-op (no crash, nothing swept). The PATH above is exactly what the generated LaunchAgent plist sets — i.e. the real launchd environment — which is why the plist includes `/opt/homebrew/bin` and `~/.local/bin`.

## Known limitations

- Worktree scheduler tasks that park skip the commit/push/PR finalize (half-done work must not be pushed); session finishes after resume but the PR needs manual follow-up. Documented in the wiki page.
- Watchdog is per-machine (local tmux only) — install on each machine running unattended sessions.

## Post-merge activation (owner)

```
agentwire rebuild && agentwire portal restart --dev   # picks up code + idle-handler symlink
agentwire limits install                              # load the launchd watchdog
```

Docs: `docs/wiki/usage-limit-recovery.md` (+ INDEX, CLAUDE.md blurb, CLI skill).

Built by [dotdev.dev](https://dotdev.dev)
