### PR TITLE
fix(portal): TTS shim page-load stall + phone-usable sidebar (from #271 fork findings)

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -432,7 +432,7 @@ class AgentWireServer:
         try:
             async with self._http_session.get(
                 f"{self.config.tts.url}/voices",
-                timeout=aiohttp.ClientTimeout(total=10),
+                timeout=aiohttp.ClientTimeout(total=2),
             ) as resp:
                 if resp.status == 200:
                     data = await resp.json()
@@ -693,9 +693,18 @@ class AgentWireServer:
 
     async def _get_voices(self) -> list[str]:
         """Available TTS voices: Kokoro presets on the default tier (once
-        the engine is ready), the shim's list on the custom tier."""
+        the engine is ready), the shim's list on the custom tier.
+
+        Custom-tier results are cached for 30s so an unreachable shim
+        can't stall every page load (handle_index awaits this)."""
         if self.config.tts.backend == "custom":
-            return await self._tts_get_voices()
+            now = time.time()
+            cached = getattr(self, "_voices_cache", None)
+            if cached and now - cached[0] < 30:
+                return cached[1]
+            voices = await self._tts_get_voices()
+            self._voices_cache = (now, voices)
+            return voices
         if self.config.tts.backend == "default" and self.kokoro.ready:
             from .tts.engines.kokoro import PRESET_VOICES
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5507,3 +5507,22 @@ body.sidebar-pinned .sidebar-tab {
     background: var(--accent);
     color: var(--background);
 }
+
+/* ── Mobile (≤768px): sidebar tab gets a real tap target, and the open
+   sidebar leaves a tap-outside strip so it can always be closed
+   (close tab would otherwise sit off-screen past a 400px sidebar).
+   Derived from the wang2yn84 fork (654b7f3). ── */
+@media (max-width: 768px) {
+    :root {
+        --sidebar-width: min(400px, 85vw);
+        --sidebar-tab-width: 32px;
+        --sidebar-tab-height: 64px;
+    }
+
+    .sidebar-tab {
+        opacity: 0.9;
+        font-size: 20px;
+        background: var(--accent);
+        color: var(--background);
+    }
+}

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -649,3 +649,56 @@ class TestVoiceStatus:
         resp = await client.get("/api/voices")
         assert resp.status == 200
         assert await resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Custom-tier voices cache (#271 — unreachable shim must not stall page load)
+# ---------------------------------------------------------------------------
+
+
+class TestVoicesCache:
+    async def test_custom_tier_voices_cached(self, portal_client):
+        client, server = portal_client
+        calls = []
+
+        async def fake_fetch():
+            calls.append(1)
+            return ["alpha", "beta"]
+
+        server.config.tts.backend = "custom"
+        server.config.tts.url = "http://localhost:8100"
+        server._tts_get_voices = fake_fetch
+
+        resp = await client.get("/api/voices")
+        assert await resp.json() == ["alpha", "beta"]
+        resp = await client.get("/api/voices")
+        assert await resp.json() == ["alpha", "beta"]
+        assert len(calls) == 1  # second hit served from cache
+
+    async def test_cache_expires(self, portal_client):
+        client, server = portal_client
+        calls = []
+
+        async def fake_fetch():
+            calls.append(1)
+            return ["alpha"]
+
+        server.config.tts.backend = "custom"
+        server.config.tts.url = "http://localhost:8100"
+        server._tts_get_voices = fake_fetch
+
+        await client.get("/api/voices")
+        ts, voices = server._voices_cache
+        server._voices_cache = (ts - 31, voices)  # age past the 30s TTL
+        await client.get("/api/voices")
+        assert len(calls) == 2
+
+    async def test_default_tier_never_fetches(self, portal_client):
+        client, server = portal_client
+
+        async def fail_fetch():
+            raise AssertionError("default tier must not hit the shim")
+
+        server._tts_get_voices = fail_fetch
+        resp = await client.get("/api/voices")
+        assert resp.status == 200


### PR DESCRIPTION
## What

Two small fixes confirmed during the #271 wang2yn84-fork investigation — both derived from fork commits, re-verified and reimplemented against current main.

### 1. Unreachable custom TTS shim stalled every page load (fork `f2729a0`)

`handle_index` awaits `_get_voices()`; on the custom tier that was an HTTP fetch with a **10s timeout**, so a shim on an unroutable host blocked every `GET /` for the full 10 seconds. The fork's exact bug shape (backend `none` / empty URL) no longer exists since Kokoro became the default tier — but this variant reproduced.

Fix: voices fetch timeout 10s → 2s (matching the `_probe_shim` fail-fast pattern) + 30s cache on the custom-tier voices list (mirroring `_voice_status_cache`). Dead shim now costs ≤2s once per 30s; healthy shim isn't re-fetched per load.

**Verified**: dev portal with `tts.url` pointed at a blackhole IP — `GET /` went 10s → 2.0s first hit, 1ms cached. 3 new unit tests in `tests/unit/test_portal_api.py` (cache hit, TTL expiry, default tier never fetches); full file passes (52 tests).

### 2. Sidebar nearly unusable — and a one-way trap — on phones (fork `654b7f3`)

The tab is a 20×40px half-opacity target. Worse: the open sidebar is fixed 400px and `body.sidebar-open` puts the close tab at `left: var(--sidebar-width)` — on a sub-400px phone the close control sits **off-screen** with no ESC key. One-way trap.

Fix (≤768px): tab grows to 32×64 with accent background; sidebar capped at `min(400px, 85vw)` so a tap-outside strip always remains and the close tab stays on-screen. The fork's open-by-default behavior was deliberately skipped — deferred to the mobile-page follow-up proposed on #271.

**Verified**: Chrome at 390×844 — tab clearly visible, sidebar opens at 85vw with the close chevron on-screen.

## Refs

Part of #271 (investigation findings posted there). Credit to [@wang2yn84](https://github.com/wang2yn84) for surfacing both.

Built by [dotdev.dev](https://dotdev.dev)