### PR TITLE
fix: remove dead task.output.notify reads crashing task show / ensure --dry-run

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -8444,8 +8444,6 @@ def cmd_ensure(args) -> int:
                 print(f"  {preview_template(cmd, ctx)}")
             print()
 
-        if task.output.notify:
-            print(f"Notification: {task.output.notify}")
         if task.output.save:
             print(f"Save output to: {preview_template(task.output.save, ctx)}")
 
@@ -9016,7 +9014,7 @@ def cmd_task_show(args) -> int:
             "pre": [{"name": p.name, "cmd": p.cmd, "required": p.required, "validate": p.validate, "timeout": p.timeout} for p in task.pre],
             "on_task_end": task.on_task_end,
             "post": task.post,
-            "output": {"capture": task.output.capture, "save": task.output.save, "notify": task.output.notify},
+            "output": {"capture": task.output.capture, "save": task.output.save},
             "validation_issues": issues,
         })
         return 0
@@ -9055,12 +9053,9 @@ def cmd_task_show(args) -> int:
             print(f"  {cmd}")
         print()
 
-    if task.output.notify or task.output.save:
+    if task.output.save:
         print("Output:")
-        if task.output.save:
-            print(f"  Save to: {task.output.save}")
-        if task.output.notify:
-            print(f"  Notify: {task.output.notify}")
+        print(f"  Save to: {task.output.save}")
 
     if issues:
         print(f"\nValidation issues: {', '.join(issues)}")

--- a/tests/unit/test_task_cli.py
+++ b/tests/unit/test_task_cli.py
@@ -1,0 +1,70 @@
+"""Tests for task inspection CLI paths — `task show` and `ensure --dry-run`.
+
+Regression coverage for #278: OutputConfig lost its `notify` field but the
+inspection/preview code paths kept reading `task.output.notify`, crashing
+with AttributeError. Real runs were unaffected, so only these paths can rot
+silently — exercise them against a fixture task.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from agentwire.__main__ import cmd_ensure, cmd_task_show
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """Project with a task that defines output capture + save."""
+    (tmp_path / ".agentwire.yml").write_text(
+        """
+type: claude-bypass
+tasks:
+  hello:
+    prompt: "say hello"
+    output:
+      capture: 20
+      save: /tmp/hello-output.txt
+"""
+    )
+    return tmp_path
+
+
+def _ns(**kwargs):
+    return argparse.Namespace(**kwargs)
+
+
+class TestTaskShow:
+    def test_text_output(self, project_dir, monkeypatch, capsys):
+        monkeypatch.chdir(project_dir)
+        rc = cmd_task_show(_ns(task="hello", json=False))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Task: hello" in out
+        assert "Save to: /tmp/hello-output.txt" in out
+
+    def test_json_output(self, project_dir, monkeypatch, capsys):
+        monkeypatch.chdir(project_dir)
+        rc = cmd_task_show(_ns(task="hello", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["name"] == "hello"
+        assert data["output"] == {"capture": 20, "save": "/tmp/hello-output.txt"}
+
+
+class TestEnsureDryRun:
+    def test_dry_run(self, project_dir, capsys):
+        rc = cmd_ensure(
+            _ns(
+                session="test-task-cli-278",
+                task="hello",
+                project=str(project_dir),
+                dry_run=True,
+                json=False,
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "=== DRY RUN ===" in out
+        assert "Save output to: /tmp/hello-output.txt" in out


### PR DESCRIPTION
## What

`agentwire task show` (text + `--json`) and `agentwire ensure --dry-run` crashed with `AttributeError: 'OutputConfig' object has no attribute 'notify'` — the field was removed from `OutputConfig` (idle notifications replaced it) but three call sites in `agentwire/__main__.py` still read `task.output.notify`. Real (non-dry-run) ensure runs were unaffected; only the inspection/preview paths hit the dead attribute.

## Changes

- Deleted the three dead reads outright (no-backwards-compat rule — field is gone, nothing re-added):
  - `ensure --dry-run` notification print
  - `task show --json` output dict (`notify` key dropped)
  - `task show` text output block
- Swept the repo for other `output.notify` remnants — code, docs, and skills are clean (the project-config skill already documents only `capture`/`save`).
- Added `tests/unit/test_task_cli.py`: regression tests exercising `task show` (text + JSON) and `ensure --dry-run` against a fixture task with an `output:` block, so inspection paths can't silently rot again.

## Verification

- Reproduced all three crashes pre-fix via `uv run python -m agentwire` against a test `.agentwire.yml`; all three paths run clean post-fix (exit 0, no traceback, JSON parses).
- `uv run pytest`: 1326 passed, 1 failed — `test_terminal_registers_client_in_session` fails identically on a clean stash of this branch (pre-existing, unrelated).

Closes #278

Built by [dotdev.dev](https://dotdev.dev)