### PR TITLE
docs+init: recommend gitignoring .agentwire.yml; auto-gitignore on write

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -122,6 +122,8 @@ agentwire lock remove <session> # force-remove a specific lock
 agentwire projects list         # discover projects from projects_dir
 agentwire projects list --json  # JSON output for scripting
 agentwire projects create name              # mkdir + minimal .agentwire.yml (claude-bypass)
+                                            # (in git repos, .agentwire.yml is auto-added to
+                                            #  .gitignore — personal config, keep it untracked)
 agentwire projects create name --git-init   # also run `git init`
 agentwire projects create name --from URL   # git clone URL instead of mkdir
 

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -54,10 +54,13 @@ projects:
     enabled: true
     suffix: "-worktrees"
     auto_create_branch: true
-    copy_files: [".env"]   # gitignored files seeded into each new worktree
+    copy_files: [".env", ".agentwire.yml"]   # gitignored files seeded into each new worktree
                            # (git worktree add only checks out tracked files,
                            #  so .env/secrets/local config don't carry over —
-                           #  add ".env.local", ".envrc", etc. as needed)
+                           #  add ".env.local", ".envrc", etc. as needed).
+                           # Keep .agentwire.yml gitignored: a TRACKED copy means
+                           # worktree runs use the committed version (HEAD) and
+                           # silently ignore live edits — see agentwire-project-config skill.
 
 tts:
   backend: "default"  # tier: default (in-process Kokoro, zero setup — ~200MB model

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -7,6 +7,17 @@ description: Reference for per-project `.agentwire.yml` — session type, roles,
 
 Each project can have a `.agentwire.yml` in its root directory. This configures session type, roles, voice, and parent for that project.
 
+## Gitignore it (don't commit it)
+
+**`.agentwire.yml` should be gitignored, not committed.** Two reasons:
+
+1. **A tracked copy breaks worktree dispatch subtly.** Worktree-dispatched runs (scheduler tasks, missions) check out HEAD — if the file is tracked, uncommitted live edits are invisible to the run, which silently executes the stale committed version. The failure mode is confusing: the live file looks right, the run behaves wrong.
+2. **It's personal/live config, not project code.** Voice choices, email recipients, schedules, machine-specific roles — none of that belongs in a repo, especially a public one.
+
+Worktree runs still get the file: `projects.worktrees.copy_files` (default `[".env", ".agentwire.yml"]`) copies gitignored configs from the main checkout into every new worktree as live files — the live file always wins, no drift.
+
+AgentWire enforces this automatically: whenever it writes `.agentwire.yml` into a git repo (`agentwire projects create`, `agentwire new --persist`, portal project settings), it appends the file to the project's `.gitignore` unless it's already ignored — or already *tracked*. A tracked file is left alone: committing is a valid choice for teams that want shared, versioned task definitions, but they're opting into the HEAD-checkout behavior above — worktree runs use the committed version, never live edits. To switch an existing project to the recommended setup: `git rm --cached .agentwire.yml`, add it to `.gitignore`, commit.
+
 **Format is FLAT (no nesting):**
 
 ```yaml

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -151,11 +151,11 @@ roles:
 
 agentwire new -s myproject -p ~/projects/myproject
 
-# Option 2: Specify roles on command line (saves to .agentwire.yml)
-agentwire new -s myproject -p ~/projects/myproject --roles agentwire,voice
+# Option 2: Specify roles on command line, --persist saves to .agentwire.yml
+agentwire new -s myproject -p ~/projects/myproject --roles agentwire,voice --persist
 ```
 
-By default, `agentwire new --type X` is a session-level override only and never saves to `.agentwire.yml`. Use `--persist` to opt in to saving.
+By default, `agentwire new` flags (`--type`, `--roles`) are session-level overrides only and never save to `.agentwire.yml`. Use `--persist` to opt in to saving.
 
 ## Role System
 

--- a/.claude/skills/agentwire-scheduler/SKILL.md
+++ b/.claude/skills/agentwire-scheduler/SKILL.md
@@ -52,7 +52,9 @@ tasks:
 
 **Lifecycle:** branch `scheduler-<task>-<timestamp>` → run in worktree → if it produced changes, `git add -A` + commit (`scheduler: <task> — <summary>`) + push + draft PR; if it produced **nothing**, the empty worktree is removed and no PR is opened. The worktree **persists while the PR is open** (so you can spawn a session there during review) and is **reaped automatically when the PR merges or closes** (worktree + branch + session torn down). `worktree: false` tasks run in place and never commit.
 
-**Seeded files:** `git worktree add` only checks out *tracked* files, so gitignored secrets/config (`.env` etc.) won't be in a fresh worktree — an agent that needs them to authenticate would fail. The files listed in `projects.worktrees.copy_files` (default `[".env"]`) are copied from the main repo into every new worktree. They stay gitignored there, so they're never committed.
+**Seeded files:** `git worktree add` only checks out *tracked* files, so gitignored secrets/config (`.env`, `.agentwire.yml`) won't be in a fresh worktree — an agent that needs them to authenticate would fail. The files listed in `projects.worktrees.copy_files` (default `[".env", ".agentwire.yml"]`) are copied from the main repo into every new worktree. They stay gitignored there, so they're never committed.
+
+**Keep `.agentwire.yml` gitignored, not tracked.** Worktree runs check out HEAD — if the project *tracks* `.agentwire.yml`, uncommitted live edits to it are silently invisible to the run, which executes the stale committed version (and `copy_files` won't overwrite a tracked checkout). Gitignored + seeded via `copy_files` means the live file always wins. See the `agentwire-project-config` skill.
 
 ## Scheduler Task Scheduling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The `agentwire-mcp-tools` skill has the full reference (sessions, panes, voice, 
 | `wiki/` | LLM-maintained knowledge base (Karpathy LLM Wiki pattern) |
 | `logs/` | Audit logs for damage-control |
 
-Per-project config lives in `.agentwire.yml` at the project root — see `agentwire-project-config` skill for fields and task schema. For pi sessions (zai, deepseek, openai, etc.), see the `agentwire-pi` skill.
+Per-project config lives in `.agentwire.yml` at the project root — **keep it gitignored** (personal config; a tracked copy makes worktree-dispatched runs silently use the stale committed version). See `agentwire-project-config` skill for fields and task schema. For pi sessions (zai, deepseek, openai, etc.), see the `agentwire-pi` skill.
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Agent responses are spoken back — Kokoro neural voice out of the box, or any T
 AgentWire supports orchestrator/worker patterns for complex tasks:
 
 ```yaml
-# .agentwire.yml in your project
+# .agentwire.yml in your project (keep it gitignored — it's personal config,
+# and tracked copies break worktree dispatch; agentwire adds it to .gitignore for you)
 type: claude-bypass
 roles:
   - agentwire

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7465,7 +7465,7 @@ _VALID_PROJECT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 def cmd_projects_create(args) -> int:
     """Create a new local project: make the directory, optionally git-init or clone, and write .agentwire.yml."""
     from .config import get_config
-    from .project_config import ProjectConfig, SessionType, save_project_config
+    from .project_config import ProjectConfig, SessionType, ensure_gitignored, save_project_config
 
     name = (args.name or "").strip()
     clone_url = (getattr(args, "from_url", None) or "").strip() or None
@@ -7518,6 +7518,7 @@ def cmd_projects_create(args) -> int:
     except OSError as e:
         return _fail(f"Failed to create directory: {e}")
 
+    gitignore_updated = ensure_gitignored(project_path)
     config = ProjectConfig(type=SessionType.from_str("claude-bypass"), roles=[], voice=None)
     if not save_project_config(config, project_path):
         return _fail("Created project directory but failed to write .agentwire.yml")
@@ -7538,6 +7539,8 @@ def cmd_projects_create(args) -> int:
             print(f"  Cloned from: {clone_url}")
         elif do_git_init:
             print("  Initialized empty git repository")
+        if gitignore_updated:
+            print("  Added .agentwire.yml to .gitignore (personal config — keep it untracked)")
     return 0
 
 

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -4,6 +4,7 @@ Project-level configuration (.agentwire.yml).
 This file lives in project directories and is the source of truth for session config.
 """
 
+import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -269,6 +270,57 @@ def save_project_config(config: ProjectConfig, project_dir: Path) -> bool:
     try:
         with open(config_file, "w") as f:
             yaml.safe_dump(config.to_dict(), f, default_flow_style=False, sort_keys=False)
+        ensure_gitignored(project_dir)
+        return True
+    except Exception:
+        return False
+
+
+def ensure_gitignored(project_dir: Path) -> bool:
+    """Ensure .agentwire.yml is gitignored in the project's repo.
+
+    .agentwire.yml is personal/live config (voices, schedules, email
+    recipients), and a tracked copy breaks worktree dispatch: worktree runs
+    check out HEAD, so uncommitted live edits to a tracked file are silently
+    ignored. Worktree runs get the live file via projects.worktrees.copy_files
+    instead. A file that is already tracked is left alone — that's a
+    deliberate choice to share versioned config.
+
+    Args:
+        project_dir: Project root (the directory containing .agentwire.yml)
+
+    Returns:
+        True if .gitignore was modified, False otherwise.
+    """
+    project_dir = Path(project_dir).resolve()
+    try:
+        in_repo = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=project_dir, capture_output=True, timeout=10,
+        )
+        if in_repo.returncode != 0:
+            return False
+
+        # Already tracked = deliberate team choice; don't fight it
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", ".agentwire.yml"],
+            cwd=project_dir, capture_output=True, timeout=10,
+        )
+        if tracked.returncode == 0:
+            return False
+
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", ".agentwire.yml"],
+            cwd=project_dir, capture_output=True, timeout=10,
+        )
+        if ignored.returncode == 0:
+            return False
+
+        gitignore = project_dir / ".gitignore"
+        existing = gitignore.read_text() if gitignore.exists() else ""
+        prefix = "" if not existing or existing.endswith("\n") else "\n"
+        with open(gitignore, "a") as f:
+            f.write(f"{prefix}# AgentWire personal config — keep untracked (worktree dispatch + privacy)\n.agentwire.yml\n")
         return True
     except Exception:
         return False

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -660,6 +660,8 @@ class AgentWireServer:
             try:
                 with open(yaml_path, "w") as f:
                     yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+                from .project_config import ensure_gitignored
+                ensure_gitignored(Path(cwd))
                 return True
             except Exception as e:
                 logger.warning(f"Failed to write {yaml_path}: {e}")

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -90,6 +90,8 @@ This is why bug fixes land in one place: change the CLI, the portal and MCP tool
 
 Lives at the project root. Defines the session type, roles, voice, parent (for cross-session notifications), and named tasks. See `agentwire-project-config` skill for the full schema.
 
+**Gitignore it.** It's personal/live config (voices, schedules, notification addresses) — not project code. Tracking it also breaks worktree dispatch subtly: worktree runs check out HEAD, so uncommitted live edits to a tracked file are silently ignored. Gitignored, it's seeded into worktrees via `projects.worktrees.copy_files` (default includes it), so the live file always wins. AgentWire adds it to `.gitignore` automatically whenever it writes the file into a git repo.
+
 ```yaml
 type: claude-auto
 roles: [task-runner]

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -62,7 +62,7 @@ The agentwire web UI + REST/WebSocket API at `https://localhost:8765`. Wraps CLI
 
 ## P — Project Config
 
-`.agentwire.yml` at a project root. Defines `type:` (session type), `roles:`, `voice:`, `parent:`, and named `tasks:`. Picked up automatically when `agentwire new` targets a path that contains it. → `agentwire-project-config` skill in `.claude/skills/`.
+`.agentwire.yml` at a project root. Defines `type:` (session type), `roles:`, `voice:`, `parent:`, and named `tasks:`. Picked up automatically when `agentwire new` targets a path that contains it. **Keep it gitignored** — it's personal config, and a tracked copy makes worktree-dispatched runs use the stale committed version instead of live edits (`projects.worktrees.copy_files` seeds the live file into worktrees). → `agentwire-project-config` skill in `.claude/skills/`.
 
 ## R — Role
 

--- a/docs/wiki/missions.md
+++ b/docs/wiki/missions.md
@@ -81,6 +81,8 @@ missions:
 
 Unknown repo shorts in the project override are silently ignored — the global config is the source of truth for which repos are mission-eligible.
 
+Keep `.agentwire.yml` gitignored (the standard recommendation — see the `agentwire-project-config` skill): mission workers run in worktrees checked out from a git ref, so a *tracked* copy means uncommitted live edits to it are invisible to the worker; gitignored, the live file is seeded in via `projects.worktrees.copy_files`.
+
 ## CLI
 
 All commands print human-readable output by default; pass `--json` for structured output that the portal / MCP tools consume.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -78,7 +78,7 @@ That creates:
 - a tmux session named `hello`
 - a Claude Code agent in pane 0 (the *orchestrator*)
 
-If `~/projects/hello/.agentwire.yml` exists, its session type / roles / voice are picked up automatically. Want one written for you? Add `--roles agentwire,voice` or `--type claude-bypass --persist` and AgentWire saves the config — and, in a git repo, adds `.agentwire.yml` to `.gitignore`. **Keep it gitignored**: it's personal config (voices, schedules, notification addresses), and a tracked copy makes worktree-dispatched runs silently use the stale committed version instead of your live edits.
+If `~/projects/hello/.agentwire.yml` exists, its session type / roles / voice are picked up automatically. Want one written for you? Add `--persist` (e.g. `--roles agentwire,voice --persist` or `--type claude-bypass --persist`) and AgentWire saves the config — and, in a git repo, adds `.agentwire.yml` to `.gitignore`. Without `--persist`, flags are session-level overrides only. **Keep it gitignored**: it's personal config (voices, schedules, notification addresses), and a tracked copy makes worktree-dispatched runs silently use the stale committed version instead of your live edits.
 
 Talk to it from another terminal:
 

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -77,7 +77,8 @@ agentwire new -s hello -p ~/projects/hello
 That creates:
 - a tmux session named `hello`
 - a Claude Code agent in pane 0 (the *orchestrator*)
-- a per-project config at `~/projects/hello/.agentwire.yml` if there isn't one already
+
+If `~/projects/hello/.agentwire.yml` exists, its session type / roles / voice are picked up automatically. Want one written for you? Add `--roles agentwire,voice` or `--type claude-bypass --persist` and AgentWire saves the config — and, in a git repo, adds `.agentwire.yml` to `.gitignore`. **Keep it gitignored**: it's personal config (voices, schedules, notification addresses), and a tracked copy makes worktree-dispatched runs silently use the stale committed version instead of your live edits.
 
 Talk to it from another terminal:
 
@@ -128,7 +129,7 @@ needs `server.host: 0.0.0.0` + certs + the portal token (see SECURITY.md).
 
 ## 4. Your first scheduled task
 
-Define a task in `~/projects/hello/.agentwire.yml`:
+Define a task in `~/projects/hello/.agentwire.yml` (gitignored — see §2):
 
 ```yaml
 type: claude-auto      # safer than claude-bypass for unattended work

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -19,7 +19,7 @@ Both are orchestrated by `~/.agentwire/scheduler.yaml` and the AgentWire schedul
 
 ## Task Definition Schema
 
-Define tasks in `.agentwire.yml`:
+Define tasks in `.agentwire.yml` — **keep that file gitignored**. Worktree-dispatched runs check out HEAD, so if the file is tracked, uncommitted live edits to a task prompt are silently ignored and the run executes the stale committed version. Gitignored, the live file is seeded into every worktree via `projects.worktrees.copy_files` (default `[".env", ".agentwire.yml"]`) and always wins. See the `agentwire-project-config` skill.
 
 ```yaml
 type: claude-auto    # Recommended for overnight work — see claude-auto below

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -8,6 +8,7 @@ from agentwire.project_config import (
     SessionType,
     ProjectConfig,
     SafetyConfig,
+    ensure_gitignored,
     normalize_session_type,
     find_project_config,
     load_project_config,
@@ -295,3 +296,53 @@ class TestProjectConfigSafety:
         assert loaded is not None
         assert len(loaded.safety.allowed_paths) == 1
         assert loaded.safety.allowed_paths[0]["path"] == "dist/*"
+
+
+# --- ensure_gitignored ---
+
+def _git(repo, *args):
+    import subprocess
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo, capture_output=True, text=True, check=True,
+    )
+
+
+class TestEnsureGitignored:
+    def test_non_git_dir_is_noop(self, tmp_path):
+        assert ensure_gitignored(tmp_path) is False
+        assert not (tmp_path / ".gitignore").exists()
+
+    def test_adds_entry_in_git_repo(self, tmp_path):
+        _git(tmp_path, "init")
+        assert ensure_gitignored(tmp_path) is True
+        assert ".agentwire.yml" in (tmp_path / ".gitignore").read_text()
+
+    def test_idempotent_when_already_ignored(self, tmp_path):
+        _git(tmp_path, "init")
+        assert ensure_gitignored(tmp_path) is True
+        before = (tmp_path / ".gitignore").read_text()
+        assert ensure_gitignored(tmp_path) is False
+        assert (tmp_path / ".gitignore").read_text() == before
+
+    def test_respects_tracked_file(self, tmp_path):
+        _git(tmp_path, "init")
+        (tmp_path / ".agentwire.yml").write_text("type: claude-bypass\n")
+        _git(tmp_path, "add", ".agentwire.yml")
+        _git(tmp_path, "commit", "-m", "track config")
+        assert ensure_gitignored(tmp_path) is False
+        assert not (tmp_path / ".gitignore").exists()
+
+    def test_appends_after_missing_trailing_newline(self, tmp_path):
+        _git(tmp_path, "init")
+        (tmp_path / ".gitignore").write_text("*.log")  # no trailing newline
+        assert ensure_gitignored(tmp_path) is True
+        lines = (tmp_path / ".gitignore").read_text().splitlines()
+        assert "*.log" in lines
+        assert ".agentwire.yml" in lines
+
+    def test_save_project_config_gitignores(self, tmp_path):
+        _git(tmp_path, "init")
+        config = ProjectConfig(type=SessionType.CLAUDE_BYPASS)
+        assert save_project_config(config, tmp_path) is True
+        assert ".agentwire.yml" in (tmp_path / ".gitignore").read_text()


### PR DESCRIPTION
Closes #273

## What

Establishes and documents the recommendation: **`.agentwire.yml` should be gitignored, not committed** — and makes AgentWire enforce it automatically wherever it writes the file.

## Why

1. **Tracked `.agentwire.yml` breaks worktree dispatch subtly.** Worktree-dispatched runs (scheduler tasks, missions) check out HEAD — uncommitted live edits to a tracked file are silently ignored, and `copy_files` seeding won't overwrite a tracked checkout (verified: `_seed_worktree_files` skips when `dst.exists()`). The run quietly executes the stale committed version.
2. **It's personal/live config** — voices, schedules, email recipients, machine-specific roles. None of it belongs in a repo, especially a public one.

## Code

- `project_config.py`: new `ensure_gitignored(project_dir)` — appends `.agentwire.yml` to the project's `.gitignore` when in a git repo, unless already ignored **or already tracked** (a tracked file = deliberate team choice; left alone, trade-off documented). Called from `save_project_config()`.
- `__main__.py` `projects create`: prints "Added .agentwire.yml to .gitignore" when it did.
- `server.py` portal project-settings write (local path): same enforcement.
- 6 new unit tests (`TestEnsureGitignored`): non-git no-op, add, idempotency, tracked-file respect, missing-trailing-newline append, save integration.

## Docs sweep (every surface that introduces the file)

| Surface | Change |
|---|---|
| `agentwire-project-config` skill | New prominent "Gitignore it" section: both reasons, copy_files mechanism, team-tracking nuance, `git rm --cached` migration |
| `agentwire-scheduler` skill | Fixed stale `copy_files` default (`[".env"]` → `[".env", ".agentwire.yml"]`, drifted since #265) + tracked-file gotcha |
| `agentwire-config` skill | Fixed same stale default in example + note |
| `agentwire-cli` skill | `projects create` now notes the auto-gitignore |
| wiki quickstart | Fixed inaccurate "agentwire new creates .agentwire.yml" claim (only `--persist`/`--roles` writes it) + gitignore guidance |
| wiki glossary / architecture / missions / scheduled-workloads | Recommendation + gotcha where the file is introduced |
| README, CLAUDE.md | One-line guidance at the yaml example / config pointer |

## Nuance preserved

Teams that genuinely want shared, versioned task definitions can keep committing it — `ensure_gitignored` never fights a tracked file, and the docs explain the HEAD-checkout behavior they're opting into rather than forbidding it.

## Verification

- `uv run --extra dev pytest`: 1329 passed; the 1 failure (`test_terminal_registers_client_in_session`) is pre-existing on clean HEAD (reproduced via `git stash`), unrelated.
- grep confirms every guidance surface carries the recommendation; this repo's own `.gitignore` already has the entry (reference pattern).

## Out of scope (other repos, flagged for owner)

Issue task "audit own projects" (fragmentz tracks `.agentwire.yml` with family email addresses; check personal-briefings) touches other repos — not done from this worktree.

Built by [dotdev.dev](https://dotdev.dev)