### PR TITLE
Mobile PTT page: minimal phone surface for pick-session → hold-to-talk

### DIFF
--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -168,11 +168,11 @@ def origin_allowed(origin: str, request: web.Request, allowed_origins: list) -> 
 
 
 def _is_public_path(request: web.Request) -> bool:
-    """The unauthenticated bootstrap surface: the page shell + health check."""
+    """The unauthenticated bootstrap surface: the page shells + health check."""
     if request.method != "GET":
         return False
     path = request.path
-    return path in ("/", "/health") or path.startswith("/static/")
+    return path in ("/", "/mobile", "/health") or path.startswith("/static/")
 
 
 def _extract_token(request: web.Request, is_ws: bool) -> Optional[str]:

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -211,6 +211,7 @@ class AgentWireServer:
         """Configure HTTP and WebSocket routes."""
         self.app.router.add_get("/health", self.handle_health)
         self.app.router.add_get("/", self.handle_index)
+        self.app.router.add_get("/mobile", self.handle_mobile)
         self.app.router.add_get("/ws", self.handle_dashboard_ws)
         self.app.router.add_get("/ws/{name:.+}", self.handle_websocket)
         self.app.router.add_get("/ws/terminal/{name:.+}", self.handle_terminal_ws)
@@ -880,6 +881,17 @@ class AgentWireServer:
             "default_voice": self.config.tts.default_voice,
         }
         response = aiohttp_jinja2.render_template("desktop.html", request, context)
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        return response
+
+    async def handle_mobile(self, request: web.Request) -> web.Response:
+        """Serve the mobile PTT page — minimal phone surface (#279).
+
+        Static shell on the public bootstrap surface (same exposure class as
+        `/`); every API/WS call the page makes carries the bearer token. No
+        voices fetch here — the page bootstraps via authenticated API calls.
+        """
+        response = aiohttp_jinja2.render_template("mobile.html", request, {})
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         return response
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5157,6 +5157,26 @@ body.sidebar-pinned .sidebar-tab {
     justify-content: center;
 }
 
+.sidebar-mobile-link {
+    margin-left: auto;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    text-decoration: none;
+    font-size: 15px;
+    opacity: 0.8;
+}
+
+.sidebar-mobile-link:hover {
+    border-color: var(--accent);
+    background: var(--hover);
+    opacity: 1;
+}
+
 .sidebar-voice-indicator .stop-icon,
 .sidebar-voice-indicator .spinner,
 .sidebar-voice-indicator .generating-dots,

--- a/agentwire/static/css/mobile.css
+++ b/agentwire/static/css/mobile.css
@@ -1,0 +1,425 @@
+/* Mobile PTT page (#279) — standalone phone surface.
+   Deliberately not desktop.css: that sheet styles the WinBox desktop
+   (overflow hidden, window chrome, sidebar) and would fight this layout.
+   Theme tokens mirror desktop.css :root so the pages look related. */
+
+:root {
+    --spacing-base: 8px;
+
+    --background: #000000;
+    --accent: #4ade80;
+    --text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --chrome: #1a1a1a;
+    --chrome-border: #2a2a2a;
+    --hover: rgba(74, 222, 128, 0.1);
+    --error: #f87171;
+    --primary-subtle: rgba(74, 222, 128, 0.3);
+    --primary-glow: rgba(74, 222, 128, 0.4);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: var(--background);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 16px;
+    overscroll-behavior: none;
+}
+
+.mobile-app {
+    display: flex;
+    flex-direction: column;
+    height: 100dvh;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left);
+}
+
+/* Header */
+
+.mobile-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-base);
+    padding: calc(var(--spacing-base) * 1.5);
+    border-bottom: 1px solid var(--chrome-border);
+    flex-shrink: 0;
+}
+
+.mobile-logo {
+    width: 24px;
+    height: 24px;
+}
+
+.mobile-title {
+    font-weight: 600;
+    flex: 1;
+}
+
+.mobile-desktop-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 13px;
+    padding: 4px 10px;
+    border: 1px solid var(--chrome-border);
+    border-radius: 6px;
+}
+
+/* Voice indicator: idle (dim) / speaking (accent pulse) */
+
+.mobile-voice-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--chrome-border);
+    flex-shrink: 0;
+}
+
+.mobile-voice-indicator.speaking {
+    background: var(--accent);
+    animation: mobile-pulse 1s ease-in-out infinite;
+}
+
+@keyframes mobile-pulse {
+    50% { box-shadow: 0 0 0 6px var(--primary-subtle); }
+}
+
+/* Session picker */
+
+.mobile-sessions {
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--chrome-border);
+    max-height: 32dvh;
+    display: flex;
+    flex-direction: column;
+}
+
+.mobile-sessions-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-base) calc(var(--spacing-base) * 1.5) 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
+.mobile-refresh {
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 18px;
+    padding: 2px 8px;
+    cursor: pointer;
+}
+
+.mobile-session-list {
+    overflow-y: auto;
+    padding: var(--spacing-base) calc(var(--spacing-base) * 1.5);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.mobile-session {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-base);
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    background: var(--chrome);
+    color: var(--text);
+    font-size: 15px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.mobile-session.selected {
+    border-color: var(--accent);
+    background: var(--hover);
+}
+
+.mobile-session-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mobile-session-activity {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--chrome-border);
+    flex-shrink: 0;
+}
+
+.mobile-session-activity.active {
+    background: var(--accent);
+}
+
+.mobile-empty {
+    color: var(--text-muted);
+    font-size: 14px;
+    padding: var(--spacing-base) 0;
+}
+
+/* Transcript */
+
+.mobile-transcript {
+    flex: 1;
+    overflow-y: auto;
+    padding: calc(var(--spacing-base) * 1.5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-base);
+}
+
+.mobile-entry {
+    max-width: 88%;
+    padding: 10px 12px;
+    border-radius: 10px;
+    font-size: 15px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.mobile-entry-you {
+    align-self: flex-end;
+    background: var(--hover);
+    border: 1px solid var(--primary-subtle);
+}
+
+.mobile-entry-session {
+    align-self: flex-start;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+}
+
+.mobile-entry-error {
+    align-self: center;
+    color: var(--error);
+    font-size: 13px;
+}
+
+.mobile-entry-label {
+    display: block;
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 2px;
+}
+
+/* Edit-before-send bar */
+
+.mobile-edit-bar {
+    display: flex;
+    gap: 6px;
+    padding: var(--spacing-base) calc(var(--spacing-base) * 1.5);
+    border-top: 1px solid var(--chrome-border);
+    flex-shrink: 0;
+}
+
+.mobile-edit-input {
+    flex: 1;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    background: var(--chrome);
+    color: var(--text);
+    font-size: 16px; /* ≥16px so iOS Safari doesn't zoom on focus */
+}
+
+.mobile-edit-send,
+.mobile-edit-dismiss {
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    background: var(--chrome);
+    color: var(--text);
+    font-size: 16px;
+    padding: 0 14px;
+    cursor: pointer;
+}
+
+.mobile-edit-send {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+/* Footer: status + the big button */
+
+.mobile-footer {
+    flex-shrink: 0;
+    padding: var(--spacing-base) calc(var(--spacing-base) * 1.5)
+             calc(var(--spacing-base) * 1.5 + env(safe-area-inset-bottom));
+    border-top: 1px solid var(--chrome-border);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-base);
+}
+
+.mobile-status {
+    font-size: 12px;
+    color: var(--text-muted);
+    min-height: 1.2em;
+    text-align: center;
+}
+
+.mobile-status.error {
+    color: var(--error);
+}
+
+.mobile-ptt {
+    width: 100%;
+    min-height: 96px;
+    border: 2px solid var(--accent);
+    border-radius: 16px;
+    background: var(--chrome);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    cursor: pointer;
+    /* Hold-to-talk on touch: no scroll/zoom gestures, no long-press
+       selection or callout stealing the hold. */
+    touch-action: none;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+}
+
+.mobile-ptt:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.mobile-ptt-icon {
+    font-size: 32px;
+}
+
+.mobile-ptt-label {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.mobile-ptt.recording {
+    border-color: var(--error);
+    background: rgba(248, 113, 113, 0.12);
+    animation: mobile-recording 1.2s ease-in-out infinite;
+}
+
+@keyframes mobile-recording {
+    50% { box-shadow: 0 0 0 8px rgba(248, 113, 113, 0.18); }
+}
+
+.mobile-ptt.processing {
+    border-color: var(--text-muted);
+    animation: none;
+}
+
+/* Token modal — markup rendered by token-modal.js (shared with desktop,
+   which styles these classes in desktop.css; this page carries its own). */
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: calc(var(--spacing-base) * 2);
+    z-index: 2000;
+}
+
+.modal {
+    width: 100%;
+    max-width: 420px;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.modal-header {
+    padding: calc(var(--spacing-base) * 1.5);
+    border-bottom: 1px solid var(--chrome-border);
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.modal-body {
+    padding: calc(var(--spacing-base) * 1.5);
+}
+
+.quicktask-error {
+    color: var(--error);
+    font-size: 13px;
+    margin-bottom: var(--spacing-base);
+}
+
+.quicktask-field {
+    display: block;
+}
+
+.quicktask-label {
+    display: block;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+}
+
+.quicktask-field input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    background: var(--background);
+    color: var(--text);
+    font-size: 16px;
+}
+
+.quicktask-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.quicktask-hint code {
+    color: var(--accent);
+}
+
+.quicktask-footer {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.quicktask-btn-submit {
+    padding: 10px 18px;
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    background: var(--accent);
+    color: var(--background);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.quicktask-btn-submit:disabled {
+    opacity: 0.6;
+}

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -1,0 +1,485 @@
+/**
+ * Mobile PTT page (#279) — pick session → hold to talk → transcript → send.
+ *
+ * A standalone phone surface, not the WinBox desktop. Auth follows the portal
+ * convention: the page shell is public, every API call goes through apiFetch
+ * (bearer token + 401 token modal) and the session WebSocket authenticates
+ * via the wsProtocols() subprotocol.
+ *
+ * Voice tiers mirror the desktop session window:
+ *   - default STT: browser SpeechRecognition (Chrome) — no audio upload
+ *   - custom STT: MediaRecorder → POST /transcribe
+ * TTS replies arrive over the per-session WS (smart routing treats this page
+ * as a connected client): `speak_text` (browser synthesis) or `audio` (WAV).
+ */
+
+import { apiFetch, wsProtocols } from './api.js';
+import * as browserStt from './voice/browser-stt.js';
+import * as browserTts from './voice/browser-tts.js';
+import { voicePromptWrap } from './voice/prompt.js';
+
+const SESSION_KEY = 'agentwire_mobile_session';
+
+const els = {
+    sessionList: document.getElementById('sessionList'),
+    refresh: document.getElementById('refreshSessions'),
+    transcript: document.getElementById('transcript'),
+    editBar: document.getElementById('editBar'),
+    editInput: document.getElementById('editInput'),
+    editSend: document.getElementById('editSend'),
+    editDismiss: document.getElementById('editDismiss'),
+    status: document.getElementById('statusLine'),
+    ptt: document.getElementById('pttButton'),
+    pttIcon: document.querySelector('.mobile-ptt-icon'),
+    pttLabel: document.querySelector('.mobile-ptt-label'),
+    voiceIndicator: document.getElementById('voiceIndicator'),
+};
+
+let voiceStatus = null;
+let sessions = [];
+let selectedSession = null;
+let pttState = 'idle'; // idle | recording | processing
+let sttCancelled = false;
+let mediaRecorder = null;
+let audioChunks = [];
+
+// ---------------------------------------------------------------------------
+// Status + transcript
+// ---------------------------------------------------------------------------
+
+function setStatus(text, isError = false) {
+    els.status.textContent = text;
+    els.status.classList.toggle('error', isError);
+}
+
+function addEntry(kind, text, label = null) {
+    const entry = document.createElement('div');
+    entry.className = `mobile-entry mobile-entry-${kind}`;
+    if (label) {
+        const labelEl = document.createElement('span');
+        labelEl.className = 'mobile-entry-label';
+        labelEl.textContent = label;
+        entry.appendChild(labelEl);
+    }
+    entry.appendChild(document.createTextNode(text));
+    els.transcript.appendChild(entry);
+    els.transcript.scrollTop = els.transcript.scrollHeight;
+}
+
+function setSpeaking(speaking) {
+    els.voiceIndicator.classList.toggle('speaking', speaking);
+    els.voiceIndicator.title = speaking ? 'Speaking' : 'Idle';
+}
+
+// ---------------------------------------------------------------------------
+// Session picker
+// ---------------------------------------------------------------------------
+
+async function loadSessions() {
+    try {
+        const res = await apiFetch('/api/sessions/local');
+        const data = await res.json();
+        sessions = data.sessions || [];
+    } catch {
+        sessions = [];
+    }
+
+    // The voice orchestrator first, the rest alphabetical
+    sessions.sort((a, b) => {
+        if (a.name === 'agentwire') return -1;
+        if (b.name === 'agentwire') return 1;
+        return a.name.localeCompare(b.name);
+    });
+
+    const stored = localStorage.getItem(SESSION_KEY);
+    const names = sessions.map(s => s.name);
+    const pick = names.includes(selectedSession) ? selectedSession
+        : names.includes(stored) ? stored
+        : names.includes('agentwire') ? 'agentwire'
+        : names[0] || null;
+
+    renderSessions();
+    if (pick && pick !== selectedSession) selectSession(pick);
+    else if (!pick) setStatus('No sessions running — start one from the desktop', true);
+}
+
+function renderSessions() {
+    els.sessionList.innerHTML = '';
+    if (sessions.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'mobile-empty';
+        empty.textContent = 'No local sessions.';
+        els.sessionList.appendChild(empty);
+        return;
+    }
+    for (const s of sessions) {
+        const btn = document.createElement('button');
+        btn.className = 'mobile-session' + (s.name === selectedSession ? ' selected' : '');
+        btn.dataset.name = s.name;
+
+        const dot = document.createElement('span');
+        dot.className = 'mobile-session-activity' + (s.activity ? ' active' : '');
+        const name = document.createElement('span');
+        name.className = 'mobile-session-name';
+        name.textContent = s.name;
+        btn.append(dot, name);
+
+        btn.addEventListener('click', () => selectSession(s.name));
+        els.sessionList.appendChild(btn);
+    }
+}
+
+function selectSession(name) {
+    selectedSession = name;
+    try { localStorage.setItem(SESSION_KEY, name); } catch {}
+    for (const btn of els.sessionList.querySelectorAll('.mobile-session')) {
+        btn.classList.toggle('selected', btn.dataset.name === name);
+    }
+    els.ptt.disabled = false;
+    setStatus(`Talking to ${name}`);
+    connectSessionWs(name);
+}
+
+// ---------------------------------------------------------------------------
+// Per-session WebSocket — TTS replies (speak_text / audio) + tts_start text
+// ---------------------------------------------------------------------------
+
+let ws = null;
+let wsReconnectTimer = null;
+let wsReconnectDelay = 1000;
+let tokenProbeFired = false;
+
+function connectSessionWs(name) {
+    clearTimeout(wsReconnectTimer);
+    if (ws) {
+        ws.onclose = null;
+        try { ws.close(); } catch {}
+        ws = null;
+    }
+
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    let socket;
+    try {
+        socket = new WebSocket(`${protocol}//${location.host}/ws/${name}`, wsProtocols());
+    } catch {
+        scheduleWsReconnect(name);
+        return;
+    }
+    ws = socket;
+
+    let opened = false;
+    socket.onopen = () => {
+        opened = true;
+        wsReconnectDelay = 1000;
+    };
+    socket.onmessage = (event) => {
+        let msg;
+        try { msg = JSON.parse(event.data); } catch { return; }
+        switch (msg.type) {
+            case 'tts_start':
+                // The reply text — show it whether playback is audio or speech
+                if (msg.text) addEntry('session', msg.text, msg.session || name);
+                setSpeaking(true);
+                break;
+            case 'speak_text':
+                if (msg.text) {
+                    setSpeaking(true);
+                    browserTts.speak(msg.text, { onEnd: () => setSpeaking(false) });
+                }
+                break;
+            case 'audio':
+                if (msg.data) queueAudio(msg.data);
+                break;
+            // `output` (terminal polling) and lock messages are irrelevant here
+        }
+    };
+    socket.onclose = () => {
+        if (ws !== socket) return;
+        ws = null;
+        // Handshake never completed — likely a 401. Probe the API once so
+        // apiFetch raises the token modal (page reloads after entry).
+        if (!opened && !tokenProbeFired) {
+            tokenProbeFired = true;
+            apiFetch('/api/sessions/local').catch(() => {});
+        }
+        scheduleWsReconnect(name);
+    };
+}
+
+function scheduleWsReconnect(name) {
+    clearTimeout(wsReconnectTimer);
+    wsReconnectTimer = setTimeout(() => {
+        if (selectedSession === name) connectSessionWs(name);
+    }, wsReconnectDelay);
+    wsReconnectDelay = Math.min(wsReconnectDelay * 2, 15000);
+}
+
+// ---------------------------------------------------------------------------
+// Audio playback (custom-tier WAV chunks) — sequential queue, unlocked by
+// the first PTT press (iOS requires a user gesture before audio can play)
+// ---------------------------------------------------------------------------
+
+let audioContext = null;
+const audioQueue = [];
+let audioPlaying = false;
+
+function ensureAudioContext() {
+    if (!audioContext) {
+        audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    if (audioContext.state === 'suspended') {
+        audioContext.resume().catch(() => {});
+    }
+    return audioContext;
+}
+
+function queueAudio(base64Data) {
+    audioQueue.push(base64Data);
+    if (!audioPlaying) playNextAudio();
+}
+
+async function playNextAudio() {
+    const base64Data = audioQueue.shift();
+    if (!base64Data) {
+        audioPlaying = false;
+        setSpeaking(false);
+        return;
+    }
+    audioPlaying = true;
+    setSpeaking(true);
+    try {
+        const binary = atob(base64Data);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+        const ctx = ensureAudioContext();
+        const buffer = await ctx.decodeAudioData(bytes.buffer);
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(ctx.destination);
+        source.onended = () => playNextAudio();
+        source.start(0);
+    } catch (err) {
+        console.error('[Mobile] Audio playback failed:', err);
+        playNextAudio();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PTT — pointer events with capture, same pattern as the titlebar PTT
+// ---------------------------------------------------------------------------
+
+function setupPtt() {
+    const onDown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        ensureAudioContext(); // unlock playback while we have a user gesture
+        els.ptt.setPointerCapture?.(e.pointerId);
+        startRecording();
+    };
+    const onUp = (e) => {
+        e.stopPropagation();
+        els.ptt.releasePointerCapture?.(e.pointerId);
+        if (pttState === 'recording') stopRecording();
+    };
+    const onCancel = (e) => {
+        els.ptt.releasePointerCapture?.(e.pointerId);
+        if (pttState === 'recording') cancelRecording();
+    };
+    els.ptt.addEventListener('pointerdown', onDown, true);
+    els.ptt.addEventListener('pointerup', onUp, true);
+    els.ptt.addEventListener('pointercancel', onCancel);
+    // A long-press context menu would break the hold mid-recording
+    els.ptt.addEventListener('contextmenu', (e) => e.preventDefault());
+}
+
+function usesBrowserStt() {
+    return voiceStatus?.stt?.backend !== 'custom';
+}
+
+function setPttState(state) {
+    pttState = state;
+    els.ptt.classList.remove('recording', 'processing');
+    if (state === 'recording') {
+        els.ptt.classList.add('recording');
+        els.pttIcon.textContent = '🔴';
+        els.pttLabel.textContent = 'Release to send';
+    } else if (state === 'processing') {
+        els.ptt.classList.add('processing');
+        els.pttIcon.textContent = '🎤';
+        els.pttLabel.textContent = 'Transcribing…';
+    } else {
+        els.pttIcon.textContent = '🎤';
+        els.pttLabel.textContent = 'Hold to talk';
+    }
+}
+
+async function startRecording() {
+    if (pttState !== 'idle' || !selectedSession) return;
+    hideEditBar();
+
+    if (usesBrowserStt()) {
+        if (!browserStt.isSupported()) {
+            setStatus('No speech recognition in this browser — set stt.backend: custom for phone STT', true);
+            return;
+        }
+        sttCancelled = false;
+        const ok = browserStt.start({
+            onFinal: (text) => {
+                setPttState('idle');
+                if (!sttCancelled && text) showEditBar(text);
+            },
+            onError: (err) => {
+                setStatus(`Speech recognition failed: ${err}`, true);
+                setPttState('idle');
+            },
+        }, voiceStatus?.corrections || {});
+        if (ok) setPttState('recording');
+        return;
+    }
+
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        audioChunks = [];
+        const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+            ? 'audio/webm;codecs=opus'
+            : (MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '');
+        mediaRecorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+        mediaRecorder.ondataavailable = (e) => {
+            if (e.data.size > 0) audioChunks.push(e.data);
+        };
+        mediaRecorder.onstop = () => {
+            stream.getTracks().forEach(track => track.stop());
+            if (audioChunks.length > 0 && pttState === 'processing') {
+                transcribeUpload(new Blob(audioChunks, { type: mediaRecorder.mimeType || 'audio/webm' }));
+            }
+        };
+        mediaRecorder.start();
+        setPttState('recording');
+    } catch (err) {
+        console.error('[Mobile] Failed to start recording:', err);
+        setStatus('Microphone access denied', true);
+        setPttState('idle');
+    }
+}
+
+function stopRecording() {
+    if (pttState !== 'recording') return;
+    setPttState('processing');
+    if (usesBrowserStt()) {
+        browserStt.stop(); // onFinal fires from onend
+        return;
+    }
+    mediaRecorder?.stop();
+}
+
+function cancelRecording() {
+    if (usesBrowserStt()) {
+        sttCancelled = true;
+        browserStt.stop();
+        setPttState('idle');
+        return;
+    }
+    audioChunks = [];
+    mediaRecorder?.stop();
+    setPttState('idle');
+}
+
+async function transcribeUpload(blob) {
+    try {
+        const formData = new FormData();
+        formData.append('audio', blob, 'recording.webm');
+        const res = await apiFetch('/transcribe', { method: 'POST', body: formData });
+        const data = await res.json();
+        if (data.error) throw new Error(data.error);
+        const text = data.text?.trim();
+        if (text) showEditBar(text);
+        else setStatus('No speech detected', true);
+    } catch (err) {
+        console.error('[Mobile] Transcription failed:', err);
+        setStatus(err.message || 'Transcription failed', true);
+    } finally {
+        setPttState('idle');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Edit-before-send bar + send
+// ---------------------------------------------------------------------------
+
+function showEditBar(text) {
+    els.editInput.value = text;
+    els.editBar.hidden = false;
+    els.editInput.focus();
+    els.editInput.select();
+}
+
+function hideEditBar() {
+    els.editBar.hidden = true;
+    els.editInput.value = '';
+}
+
+async function sendText(text) {
+    if (!selectedSession) return;
+    addEntry('you', text, 'You');
+    setStatus(`Sending to ${selectedSession}…`);
+    try {
+        const res = await apiFetch(`/send/${selectedSession}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: voicePromptWrap(text) }),
+        });
+        const data = await res.json();
+        if (data.error) throw new Error(data.error);
+        setStatus(`Talking to ${selectedSession}`);
+    } catch (err) {
+        console.error('[Mobile] Send failed:', err);
+        addEntry('error', err.message || 'Send failed');
+        setStatus(`Talking to ${selectedSession}`);
+    }
+}
+
+function setupEditBar() {
+    const send = () => {
+        const value = els.editInput.value.trim();
+        hideEditBar();
+        if (value) sendText(value);
+    };
+    els.editSend.addEventListener('click', send);
+    els.editDismiss.addEventListener('click', hideEditBar);
+    els.editInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); send(); }
+        else if (e.key === 'Escape') { e.preventDefault(); hideEditBar(); }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+async function loadVoiceStatus() {
+    try {
+        const res = await apiFetch('/api/voice-status');
+        voiceStatus = await res.json();
+    } catch {
+        // Fail toward the zero-dependency tier (matches desktop-manager)
+        voiceStatus = {
+            stt: { backend: 'default', available: true },
+            tts: { backend: 'default', available: true },
+            corrections: {},
+        };
+    }
+}
+
+async function init() {
+    setupPtt();
+    setupEditBar();
+    els.refresh.addEventListener('click', loadSessions);
+
+    // voice-status first: on a fresh device this 401s and raises the token
+    // modal; after entry the page reloads with credentials.
+    await loadVoiceStatus();
+    await loadSessions();
+}
+
+init();

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -8,7 +8,7 @@
  *
  * Voice tiers mirror the desktop session window:
  *   - default STT: browser SpeechRecognition (Chrome) — no audio upload
- *   - custom STT: MediaRecorder → POST /transcribe
+ *   - cloud/custom STT: MediaRecorder → POST /transcribe
  * TTS replies arrive over the per-session WS (smart routing treats this page
  * as a connected client): `speak_text` (browser synthesis) or `audio` (WAV).
  */
@@ -294,7 +294,7 @@ function setupPtt() {
 }
 
 function usesBrowserStt() {
-    return voiceStatus?.stt?.backend !== 'custom';
+    return !['cloud', 'custom'].includes(voiceStatus?.stt?.backend);
 }
 
 function setPttState(state) {
@@ -320,7 +320,7 @@ async function startRecording() {
 
     if (usesBrowserStt()) {
         if (!browserStt.isSupported()) {
-            setStatus('No speech recognition in this browser — set stt.backend: custom for phone STT', true);
+            setStatus('No speech recognition in this browser — set stt.backend: cloud or custom for phone STT', true);
             return;
         }
         sttCancelled = false;

--- a/agentwire/templates/desktop.html
+++ b/agentwire/templates/desktop.html
@@ -62,6 +62,7 @@
                 <span class="ptt-icon">🎤</span>
             </button>
             <div class="sidebar-voice-indicator" id="sidebarVoiceIndicator" title="AgentWire idle"><div class="stop-icon"></div></div>
+            <a class="sidebar-mobile-link" href="/mobile" title="Mobile PTT page — pick a session, hold to talk">📱</a>
         </div>
     </aside>
 

--- a/agentwire/templates/mobile.html
+++ b/agentwire/templates/mobile.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+
+{% block title %}AgentWire Mobile{% endblock %}
+
+{% block styles %}
+<link rel="stylesheet" href="/static/css/mobile.css">
+{% endblock %}
+
+{% block content %}
+<div class="mobile-app">
+    <header class="mobile-header">
+        <img src="/static/favicon.png" alt="" class="mobile-logo">
+        <span class="mobile-title">AgentWire</span>
+        <span class="mobile-voice-indicator" id="voiceIndicator" title="Idle"></span>
+        <a href="/" class="mobile-desktop-link">Desktop</a>
+    </header>
+
+    <section class="mobile-sessions">
+        <div class="mobile-sessions-head">
+            <span>Sessions</span>
+            <button class="mobile-refresh" id="refreshSessions" title="Refresh sessions" aria-label="Refresh sessions">↻</button>
+        </div>
+        <div class="mobile-session-list" id="sessionList">
+            <div class="mobile-empty">Loading sessions…</div>
+        </div>
+    </section>
+
+    <section class="mobile-transcript" id="transcript" aria-live="polite"></section>
+
+    <div class="mobile-edit-bar" id="editBar" hidden>
+        <input type="text" class="mobile-edit-input" id="editInput"
+               aria-label="Voice transcript — edit then send" autocomplete="off">
+        <button class="mobile-edit-send" id="editSend" title="Send">➤</button>
+        <button class="mobile-edit-dismiss" id="editDismiss" title="Discard">✕</button>
+    </div>
+
+    <footer class="mobile-footer">
+        <div class="mobile-status" id="statusLine">Connecting…</div>
+        <button class="mobile-ptt" id="pttButton" disabled>
+            <span class="mobile-ptt-icon">🎤</span>
+            <span class="mobile-ptt-label">Hold to talk</span>
+        </button>
+    </footer>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="/static/js/mobile.js"></script>
+{% endblock %}

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -508,10 +508,11 @@ class TestTokenAuth:
         assert resp.status == 401
 
     async def test_public_surface_open(self, portal_client_with_token):
-        """The page shell + health must load so the token modal can render."""
+        """The page shells + health must load so the token modal can render."""
         client, _ = portal_client_with_token
         assert (await client.get("/health")).status == 200
         assert (await client.get("/")).status == 200
+        assert (await client.get("/mobile")).status == 200
         resp = await client.get("/static/js/api.js")
         assert resp.status != 401
 
@@ -522,6 +523,39 @@ class TestTokenAuth:
             mock_cmd.return_value = (True, {"sessions": []})
             resp = await client.get("/api/sessions/local")
         assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# /mobile page (#279 — phone PTT surface)
+# ---------------------------------------------------------------------------
+
+
+class TestMobilePage:
+    async def test_mobile_serves_shell(self, portal_client):
+        client, _ = portal_client
+        resp = await client.get("/mobile")
+        assert resp.status == 200
+        body = await resp.text()
+        assert "/static/js/mobile.js" in body
+        assert "pttButton" in body
+
+    async def test_mobile_no_cache(self, portal_client):
+        client, _ = portal_client
+        resp = await client.get("/mobile")
+        assert "no-store" in resp.headers.get("Cache-Control", "")
+
+    async def test_mobile_public_with_token(self, portal_client_with_token):
+        """Same exposure class as `/` — the shell loads without a token so
+        the token modal can render; the APIs it calls stay guarded."""
+        client, _ = portal_client_with_token
+        resp = await client.get("/mobile")
+        assert resp.status == 200
+
+    async def test_mobile_only_get_is_public(self, portal_client_with_token):
+        """_is_public_path is GET-only — a POST to /mobile still needs auth."""
+        client, _ = portal_client_with_token
+        resp = await client.post("/mobile")
+        assert resp.status == 401
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #279

## What

A dedicated lightweight `/mobile` page for the phone use case — not a responsive retrofit of the WinBox desktop. Pick a session, hold the big button, talk, glance at the transcript, send. Design signal credit to [@wang2yn84](https://github.com/wang2yn84) (#271 fork investigation).

### Pieces

- **`/mobile` route** (`server.py:handle_mobile`) serving a static shell (`templates/mobile.html`), no-cache, no voices fetch — the page bootstraps via authenticated API calls after load.
- **Public-path change** (`security.py:_is_public_path`): `/mobile` joins the GET-only bootstrap surface, same exposure class as `/`. Nothing new is exposed — every API/WS call still carries the bearer token.
- **`static/js/mobile.js`**: session picker from `/api/sessions/local` via `apiFetch` (agentwire sorted first, selection persisted in localStorage); hold-to-talk via pointer events with `setPointerCapture` (the proven titlebar-PTT pattern) plus `touch-action: none` / contextmenu suppression so long-press doesn't break the hold; voice-tier aware STT (browser SpeechRecognition on the default tier, MediaRecorder → `/transcribe` upload on custom); edit-before-send transcript bar; send via `POST /send/{session}` with the shared `voicePromptWrap`.
- **TTS replies**: the page connects to the per-session WS (`/ws/{name}`, token via `wsProtocols()` subprotocol) — smart routing then treats the phone as a connected client. Handles `tts_start` (reply text into the transcript), `speak_text` (browser synthesis via shared `voice/browser-tts.js`), and `audio` (sequential WAV queue through an AudioContext unlocked on the first PTT press, for iOS gesture rules).
- **Auth on a fresh device**: first API call 401s → shared token modal (`token-modal.js`) → reload with credentials, exactly like the desktop. WS handshake failure probes the API once to raise the modal (desktop-manager pattern). `mobile.css` carries its own copy of the modal styles since the page deliberately doesn't load `desktop.css`.
- **Desktop sidebar**: 📱 link to `/mobile` in the footer. No UA sniffing, no redirects.

### #271 security-review pitfalls — all avoided

- No raw `fetch()` anywhere — `apiFetch`/`wsProtocols` only (the fork's mobile.html 401'd against current main for this reason).
- No UA-sniffing `handle_index`; the desktop link is the entry point.
- No personal config baked in (the fork hardcoded session names/icons and a skip-list).
- No new endpoints, ports, or daemons; only a GET-only static shell joins the public surface.

## Out of scope (per issue)

Terminal rendering, window management, STT backend switching UI (#280).

## Verification

- 4 new unit tests (`TestMobilePage`) + `/mobile` added to the public-surface auth test, mirroring existing `test_portal_api.py` style: shell serves with the expected markup, no-cache header, public under token auth, POST still 401s.
- `uv run pytest`: 1327 passed; the 1 failure (`test_terminal_registers_client_in_session`) is pre-existing on a clean checkout (environment-dependent terminal-WS test), verified via `git stash`.
- `node --check` on the new module.
- **Real-phone + tunnel verification (fresh-device token flow → pick session → hold-to-talk → text lands in tmux, over `agentwire tunnels up`) happens post-merge** — this worktree can't run the installed portal.

Built by [dotdev.dev](https://dotdev.dev)