### PR TITLE
sessions: route interactive prompts to the parent session (#276)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -17,6 +17,9 @@ agentwire send -s name --wait-ready --timeout 60 -- "prompt"
                                 #   trust-prompt auto-accept), verified delivery,
                                 #   exit 1 if unverified; local only
 agentwire send-keys -s name key1 key2  # raw keys with pauses
+agentwire send-keys -s name --pane 2 key  # target a specific pane
+agentwire new -s name --created-by orch  # record creator (prompt-routing parent);
+                                #   default: calling tmux session; '' opts out
 agentwire output -s name        # not: tmux capture-pane
 agentwire info -s name          # session metadata (cwd, panes) as JSON
 agentwire kill -s name          # not: tmux kill-session
@@ -78,6 +81,17 @@ agentwire say "text"            # speak (auto-routes to browser or local)
 agentwire say -s name "text"    # speak to specific session
 agentwire notify-parent "text"   # notify parent session (worker→orchestrator)
 agentwire notify-parent --to name "text" # notify specific session
+agentwire notify-parent --raw --to name "text"  # verbatim, no [NOTIFY ...] prefix
+                                # (delivery is safety-gated: refuses targets showing a
+                                #  live dialog / bare shells / parked sessions, verified paste)
+
+# Prompt routing (interactive prompts → parent session; see wiki sessions/prompt-routing.md)
+agentwire prompts status        # pending prompt markers
+agentwire prompts tick          # run one sweep now (watchdog does this every 60s)
+agentwire prompts answer -s name --pane 0 --expect <hash> 2  # guarded answer:
+                                #   re-detects + hash-compares before sending keys —
+                                #   NEVER answer dialogs with raw send-keys
+agentwire prompts clear -s name --pane 1  # drop a marker
 agentwire listen start|stop|cancel  # voice recording
 
 # Voice cloning

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -22,6 +22,8 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire fork -s name -t project/branch` | `session_fork(session="...", target="...")` |
 | `agentwire fork -s name -t project/branch --commit abc` | `session_fork(session="...", target="...", commit="abc")` |
 
+**Note:** `session_create` (via `agentwire new`) records the calling session as the new session's creator — interactive prompts (permission/plan/AskUserQuestion) in the child then route back to you as `[PROMPT from ...]` messages. Answer them with `agentwire prompts answer -s <session> --expect <hash> <key>` via Bash (guarded compare-and-send), NEVER with raw `session_send_keys` — a late keystroke races the portal and can type into the child's input or abort its turn.
+
 ## Pane Management (9 tools)
 
 | CLI Command | MCP Tool |

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -95,6 +95,10 @@ tasks:
 
 **Exit codes:** 0=complete, 1=failed, 2=incomplete, 3=lock conflict, 4=pre failure, 5=timeout, 6=session error
 
+## Parent Resolution (prompt routing + notifications)
+
+For prompt routing (#276), a session's parent resolves in this order: **creator recorded at `agentwire new` time** (session metadata, `--created-by` to override) → **`.agentwire.yml` `parent:`** → none. Worker panes always route to pane 0 of their own session. Interactive prompts (permission/plan/AskUserQuestion) hitting a child are texted to that parent; answer only via `agentwire prompts answer` (guarded), never raw send-keys.
+
 ## Hierarchical Idle Notifications
 
 When a session goes idle, it notifies up the hierarchy via `agentwire notify-parent` (text-only, no audio):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,10 @@ First-class auto-dispatcher subsystem (sibling to Sessions/Tasks/Workflows): sta
 
 Deterministic (zero-LLM) recovery from the Claude Code usage-limit dialog: a launchd watchdog (`agentwire limits tick`, 60s) plus ensure's completion poll detect the dialog, park the session (option 1: stop and wait), parse the reset time, email the owner via Resend, and nudge the session to continue after reset. Park state under `~/.agentwire/usage-limit/` guards every surface — ensure exits 7 (`usage_limit`), the scheduler skips dispatch, the idle hook and overnight never reap a parked session. CLI under `agentwire limits ...`. Full reference: [`docs/wiki/usage-limit-recovery.md`](docs/wiki/usage-limit-recovery.md).
 
+## Prompt Routing
+
+Interactive prompts (permission, plan-approval, AskUserQuestion) hitting a child session are routed as text to its parent/orchestrator — hook path for permissions (seconds), pane-sweep riding the limits watchdog for the rest (≤60s). Parent resolution: worker pane → pane 0; else creator recorded at `agentwire new`; else `.agentwire.yml` `parent:`. Answer ONLY with `agentwire prompts answer -s <session> --expect <hash> <key>` (compare-and-send; raw send-keys races the portal). Deliveries are safety-gated (never paste into a live menu, a bare shell, or a parked session). CLI under `agentwire prompts ...`. Full reference: [`docs/wiki/sessions/prompt-routing.md`](docs/wiki/sessions/prompt-routing.md).
+
 ## Council
 
 Multi-soul orchestrator sitting: `agentwire-council` fans prompts out to lens sessions (`council-brain`, `council-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/prompts/`; the orchestrator collects and synthesizes with attribution. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...`, 5 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2843,6 +2843,23 @@ def store_session_metadata(session_name: str, metadata: dict) -> None:
         pass
 
 
+def _record_session_creator(session_name: str, created_by: str | None, via: str) -> None:
+    """Record which session created this one (merge-preserving).
+
+    The creator becomes the session's parent for prompt routing
+    (prompt_router.resolve_parent), winning over .agentwire.yml `parent:`.
+    """
+    if not created_by or created_by == session_name.split("@")[0]:
+        return
+    metadata = get_session_metadata(session_name)
+    metadata.update({
+        "created_by": created_by,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "created_via": via,
+    })
+    store_session_metadata(session_name, metadata)
+
+
 def cmd_notify(args) -> int:
     """Send a notification to the portal about session/pane state changes.
 
@@ -3657,6 +3674,13 @@ def cmd_new(args) -> int:
         if not first_message_delivered and not json_mode:
             print(f"Warning: first message not delivered to '{session_name}' — paste it manually", file=sys.stderr)
 
+    # Record the creating session as parent for prompt routing. --created-by
+    # overrides; empty string opts out; default = the calling tmux session.
+    created_by = getattr(args, 'created_by', None)
+    if created_by is None:
+        created_by = pane_manager.get_current_session()
+    _record_session_creator(session_name, created_by, via="new")
+
     if json_mode:
         result = {
             "success": True,
@@ -4065,6 +4089,15 @@ def cmd_kill(args) -> int:
     subprocess.run(["tmux", "kill-session", "-t", session], capture_output=True)
     if not json_mode:
         print(f"Killed session '{session}'")
+
+    # Drop session metadata (creator record) so a future unrelated session
+    # reusing this name doesn't inherit a stale parent.
+    metadata_file = CONFIG_DIR / "sessions" / session.split("@")[0] / "metadata.json"
+    if metadata_file.exists():
+        try:
+            metadata_file.unlink()
+        except OSError:
+            pass
 
     _notify_portal_sessions_changed()
 
@@ -10649,6 +10682,9 @@ def main() -> int:
     new_parser.add_argument("--no-pull-first", dest="pull_first", action="store_false", help="Skip the fetch — branch from the local copy of <base> as-is")
     new_parser.add_argument("--first-message", dest="first_message",
                             help="After the agent boots, deliver this as its first message (verified; local sessions only)")
+    new_parser.add_argument("--created-by", dest="created_by",
+                            help="Record this session as the creator/parent for prompt routing "
+                                 "(default: the calling tmux session; pass '' to opt out)")
     new_parser.add_argument("--json", action="store_true", help="Output as JSON")
     new_parser.set_defaults(func=cmd_new)
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2857,7 +2857,7 @@ def _record_session_creator(session_name: str, created_by: str | None, via: str)
     """
     if not created_by or created_by == session_name.split("@")[0]:
         return
-    metadata = get_session_metadata(session_name)
+    metadata = load_session_metadata(session_name)
     metadata.update({
         "created_by": created_by,
         "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11532,6 +11532,10 @@ def main() -> int:
     )
     l_uninstall.set_defaults(func=limits_cli.cmd_limits_uninstall)
 
+    # === prompts command group (prompt routing, rides the limits watchdog) ===
+    from . import prompts_cli
+    prompts_cli.register_prompts_parser(subparsers)
+
     # === council command group ===
     council_parser = subparsers.add_parser(
         "council",

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2418,32 +2418,38 @@ def cmd_notify_parent(args) -> int:
         if parent:
             target_session = parent
 
-    # Build notification message
-    source = current_session or "unknown"
-    if current_pane is not None and current_pane > 0:
-        notification = f"[NOTIFY from {source} pane {current_pane}] {text}"
+    # Build notification message (--raw sends verbatim — queued messages
+    # already carry their own [WORKER SUMMARY ...] / [PROMPT ...] headers)
+    if getattr(args, 'raw', False):
+        notification = text
     else:
-        notification = f"[NOTIFY from {source}] {text}"
-
-    try:
-        if target_session:
-            if target_session == current_session and current_pane == 0:
-                print("Cannot notify own pane", file=sys.stderr)
-                return 1
-            pane_manager.send_to_pane(target_session, 0, notification)
-            if not getattr(args, 'quiet', False):
-                print(f"Notified {target_session}")
-        elif current_pane is not None and current_pane > 0 and current_session:
-            pane_manager.send_to_pane(current_session, 0, notification)
-            if not getattr(args, 'quiet', False):
-                print(f"Notified {current_session} pane 0")
+        source = current_session or "unknown"
+        if current_pane is not None and current_pane > 0:
+            notification = f"[NOTIFY from {source} pane {current_pane}] {text}"
         else:
-            print("No target session (set 'parent' in .agentwire.yml or use --to)", file=sys.stderr)
+            notification = f"[NOTIFY from {source}] {text}"
+
+    if target_session:
+        if target_session == current_session and current_pane == 0:
+            print("Cannot notify own pane", file=sys.stderr)
             return 1
-    except Exception as e:
-        print(f"Failed to send notification: {e}", file=sys.stderr)
+    elif current_pane is not None and current_pane > 0 and current_session:
+        target_session = current_session
+    else:
+        print("No target session (set 'parent' in .agentwire.yml or use --to)", file=sys.stderr)
         return 1
 
+    # safe_deliver refuses targets where a paste could do damage (live
+    # dialog on screen, bare shell, parked session) and verifies the paste
+    # actually landed. Callers (queue processor) retry on failure.
+    from agentwire import prompt_router
+
+    delivered, reason = prompt_router.safe_deliver(target_session, 0, notification)
+    if not delivered:
+        print(f"Notification not delivered to {target_session}: {reason}", file=sys.stderr)
+        return 1
+    if not getattr(args, 'quiet', False):
+        print(f"Notified {target_session}")
     return 0
 
 
@@ -10573,6 +10579,8 @@ def main() -> int:
     notify_cmd_parser.add_argument("text", nargs="*", help="Notification message")
     notify_cmd_parser.add_argument("--to", type=str, metavar="SESSION", help="Target session (default: parent from .agentwire.yml)")
     notify_cmd_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
+    notify_cmd_parser.add_argument("--raw", action="store_true",
+                                   help="Send the message verbatim (no [NOTIFY from ...] prefix)")
     notify_cmd_parser.set_defaults(func=cmd_notify_parent)
 
     # === open command (artifact windows) ===

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -4474,6 +4474,10 @@ def cmd_send_keys(args) -> int:
     # Parse session@machine format
     session, machine_id = _parse_session_target(session_full)
 
+    # Optional pane targeting (worker panes); None targets the session.
+    pane = getattr(args, 'pane', None)
+    target = f"{session}.{pane}" if pane is not None else session
+
     if machine_id:
         # Remote: SSH and run tmux commands
         machine = _get_machine_config(machine_id)
@@ -4482,10 +4486,10 @@ def cmd_send_keys(args) -> int:
             return 1
 
         # Build remote command with pauses between keys
-        quoted_session = shlex.quote(session)
+        quoted_target = shlex.quote(target)
         cmd_parts = []
         for i, key in enumerate(keys):
-            cmd_parts.append(f"tmux send-keys -t {quoted_session} {shlex.quote(key)}")
+            cmd_parts.append(f"tmux send-keys -t {quoted_target} {shlex.quote(key)}")
             if i < len(keys) - 1:
                 cmd_parts.append("sleep 0.1")
 
@@ -4512,14 +4516,14 @@ def cmd_send_keys(args) -> int:
     # Send each key group with a pause between
     for i, key in enumerate(keys):
         subprocess.run(
-            ["tmux", "send-keys", "-t", session, key],
+            ["tmux", "send-keys", "-t", target, key],
             check=True
         )
         # Brief pause between key groups (not after last one)
         if i < len(keys) - 1:
             time.sleep(0.1)
 
-    print(f"Sent keys to {session}")
+    print(f"Sent keys to {target}")
     return 0
 
 
@@ -10658,6 +10662,8 @@ def main() -> int:
         "send-keys", help="Send raw keys to a session (with pause between groups)"
     )
     send_keys_parser.add_argument("-s", "--session", required=True, help="Target session (supports session@machine)")
+    send_keys_parser.add_argument("--pane", type=int, default=None,
+                                  help="Target a specific pane index (default: the session's active pane)")
     send_keys_parser.add_argument("keys", nargs="*", help="Key groups to send (e.g., 'hello world' Enter)")
     send_keys_parser.set_defaults(func=cmd_send_keys)
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -394,6 +394,14 @@ class UsageLimitConfig:
 
 
 @dataclass
+class PromptRouterConfig:
+    """Interactive-prompt routing (worker prompts → parent session) knobs."""
+
+    enabled: bool = True  # master switch for the sweep + hook-path routing
+    exclude_sessions: list[str] = field(default_factory=list)  # never route these
+
+
+@dataclass
 class Config:
     """Root configuration for AgentWire."""
 
@@ -413,6 +421,7 @@ class Config:
     overnight: OvernightConfig = field(default_factory=OvernightConfig)
     safety: SafetyConfig = field(default_factory=SafetyConfig)
     usage_limit: UsageLimitConfig = field(default_factory=UsageLimitConfig)
+    prompt_router: PromptRouterConfig = field(default_factory=PromptRouterConfig)
     channels: dict = field(default_factory=dict)
 
 
@@ -697,6 +706,18 @@ def _dict_to_config(data: dict) -> Config:
         exclude_sessions=[str(s) for s in exclude_sessions_raw if s],
     )
 
+    # Prompt routing (worker prompts → parent session)
+    prompt_router_data = data.get("prompt_router", {}) or {}
+    if not isinstance(prompt_router_data, dict):
+        prompt_router_data = {}
+    pr_exclude_raw = prompt_router_data.get("exclude_sessions", []) or []
+    if not isinstance(pr_exclude_raw, list):
+        pr_exclude_raw = []
+    prompt_router = PromptRouterConfig(
+        enabled=bool(prompt_router_data.get("enabled", True)),
+        exclude_sessions=[str(s) for s in pr_exclude_raw if s],
+    )
+
     # Session defaults
     session_data = data.get("session", {}) or {}
     session = SessionConfig(
@@ -722,6 +743,7 @@ def _dict_to_config(data: dict) -> Config:
         repl=repl,
         safety=safety,
         usage_limit=usage_limit,
+        prompt_router=prompt_router,
     )
 
 

--- a/agentwire/hooks/agentwire-permission.sh
+++ b/agentwire/hooks/agentwire-permission.sh
@@ -89,6 +89,23 @@ if [ -z "$session" ]; then
     exit 1
 fi
 
+# Enrich the payload with pane context (#276: lets the portal route the
+# prompt to a parent session and answer the right pane). Best-effort —
+# any failure leaves the original payload untouched.
+pane_index="0"
+tmux_session=""
+if [ -n "$TMUX_PANE" ]; then
+    pane_index=$(tmux display -t "$TMUX_PANE" -p '#{pane_index}' 2>/dev/null || echo "0")
+    tmux_session=$(tmux display -t "$TMUX_PANE" -p '#{session_name}' 2>/dev/null || echo "")
+fi
+enriched=$(printf '%s' "$input" | PANE_INDEX="$pane_index" TMUX_SESSION="$tmux_session" python3 -c "
+import json, os, sys
+d = json.load(sys.stdin)
+d['pane_index'] = int(os.environ.get('PANE_INDEX') or 0)
+d['tmux_session'] = os.environ.get('TMUX_SESSION', '')
+print(json.dumps(d))" 2>/dev/null)
+[ -n "$enriched" ] && input="$enriched"
+
 # Get portal URL from global config
 # Priority: 1. ~/.agentwire/portal_url file, 2. config.yaml server section, 3. default
 get_portal_url() {
@@ -135,12 +152,13 @@ token=$(get_portal_token)
 auth_args=()
 [ -n "$token" ] && auth_args=(-H "Authorization: Bearer $token")
 
-# POST to portal and wait for response (5 minute timeout)
+# POST to portal and wait for response. 310s: must outlive the server's own
+# 300s wait so its timeout-deny JSON reaches us instead of a curl abort.
 response=$(curl -s -X POST "${base_url}/api/permission/${session}" \
     -H "Content-Type: application/json" \
     "${auth_args[@]}" \
     -d "$input" \
-    --max-time 300 \
+    --max-time 310 \
     --insecure 2>/dev/null)
 
 # Check if curl succeeded

--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Handle Claude Code notifications
-# Uses agentwire alert for text-only notifications to parent (no audio)
+# Uses agentwire notify-parent for text-only notifications to parent (no audio)
 # Worker panes queue notifications with summary file path, then auto-kill
 
 DEBUG_LOG="/tmp/claude-hook-debug.log"
@@ -29,6 +29,15 @@ if [[ "$notification_type" == "idle_prompt" ]]; then
   # no summary prompts, no /exit, no kill. The watchdog resumes it (#274).
   if [[ -n "$tmux_session" && -f "$HOME/.agentwire/usage-limit/${tmux_session}.json" ]]; then
     log "Session $tmux_session parked on usage limit — skipping idle handling"
+    exit 0
+  fi
+
+  # Prompt-routing guard (#276): this pane is blocked on an interactive
+  # prompt that was routed to its parent. Pasting the summary instruction
+  # would answer the dialog (paste + Enter), and killing the pane would reap
+  # a worker the parent is about to unblock. Skip until the marker clears.
+  if [[ -n "$tmux_session" && -n "$pane_index" && -f "$HOME/.agentwire/prompt-router/${tmux_session}.${pane_index}.json" ]]; then
+    log "Pane ${tmux_session}.${pane_index} has a routed prompt pending — skipping idle handling"
     exit 0
   fi
 
@@ -125,15 +134,24 @@ List files you modified or created with brief descriptions
 ${summary_content}"
           echo "[$(date -Iseconds)] BG: message built, queuing notification" >> "$dlog"
 
-          # Queue the notification
+          # Queue the notification (same mkdir lock as the queue processor —
+          # an append racing the processor's head-trim would lose a message)
           queue_dir="$HOME/.agentwire/queues"
           queue_file="${queue_dir}/${tmux_session}.jsonl"
+          lock_dir="${queue_dir}/${tmux_session}.lock"
           mkdir -p "$queue_dir"
 
           # Append to queue as JSON line
           escaped_message=$(printf '%s' "$message" | jq -Rs .)
           timestamp=$(date +%s)000
+          lock_tries=0
+          while ! mkdir "$lock_dir" 2>/dev/null; do
+            lock_tries=$((lock_tries + 1))
+            [[ $lock_tries -ge 50 ]] && break
+            sleep 0.1
+          done
           echo "{\"timestamp\":${timestamp},\"message\":${escaped_message}}" >> "$queue_file"
+          rmdir "$lock_dir" 2>/dev/null
           echo "[$(date -Iseconds)] BG: queued notification" >> "$dlog"
 
           # Start queue processor if not running
@@ -355,7 +373,7 @@ complete | incomplete | error
       elif [[ -n "$parent_session" ]]; then
         # Orchestrator pane with parent: notify parent
         message="${session_name} is idle"
-        $AGENTWIRE alert -q --to "$parent_session" "$message" 2>/dev/null &
+        $AGENTWIRE notify-parent -q --to "$parent_session" "$message" 2>/dev/null &
       fi
     fi
   fi

--- a/agentwire/hooks/queue-processor.sh
+++ b/agentwire/hooks/queue-processor.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 # Queue processor for agentwire notifications
-# Sends queued alerts with 15-second gaps to prevent overwhelming orchestrators
+# Sends queued messages with 15-second gaps to prevent overwhelming orchestrators.
+# Delivery is `agentwire notify-parent --raw` (verified paste + pre-paste safety
+# checks); failed deliveries are requeued with an attempt count instead of dropped.
 
 DEBUG_LOG="/tmp/queue-processor-debug.log"
 log() { echo "[$(date -Iseconds)] $*" >> "$DEBUG_LOG"; }
 
-# Clear tmux context so alert command doesn't think we're in a pane
+# Clear tmux context so notify-parent doesn't think we're in a pane
 unset TMUX TMUX_PANE
 
-# Load env vars for Telegram notifications
+# Load env vars
 for envfile in "$HOME/.agentwire/.env" ".env"; do
     [[ -f "$envfile" ]] && while IFS='=' read -r key value; do
         [[ -n "$key" && "$key" != \#* ]] && export "$key=$value"
@@ -22,7 +24,9 @@ SESSION="$1"
 log "Started for session=$SESSION agentwire=$AGENTWIRE"
 QUEUE_FILE="$HOME/.agentwire/queues/${SESSION}.jsonl"
 PID_FILE="$HOME/.agentwire/queues/${SESSION}.pid"
+LOCK_DIR="$HOME/.agentwire/queues/${SESSION}.lock"
 DELAY=15
+MAX_ATTEMPTS=20  # ~5 minutes of 15s retries before a message is dropped
 
 # Write our PID
 echo $$ > "$PID_FILE"
@@ -30,49 +34,72 @@ echo $$ > "$PID_FILE"
 # Cleanup on exit
 cleanup() {
     rm -f "$PID_FILE"
+    rmdir "$LOCK_DIR" 2>/dev/null
 }
 trap cleanup EXIT
 
+# mkdir-based lock around queue mutation (macOS has no flock(1)); appenders
+# (idle-handler, prompt_router.enqueue) take the same lock. Best-effort: after
+# a 5s spin we proceed anyway rather than wedge the queue forever.
+acquire_lock() {
+    local tries=0
+    while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+        tries=$((tries + 1))
+        if [[ $tries -ge 50 ]]; then
+            log "Lock timeout, proceeding without lock"
+            return 0
+        fi
+        sleep 0.1
+    done
+}
+release_lock() { rmdir "$LOCK_DIR" 2>/dev/null; }
+
 # Process queue until empty
 while true; do
-    # Check if queue file exists and has content
     if [[ ! -f "$QUEUE_FILE" ]] || [[ ! -s "$QUEUE_FILE" ]]; then
-        # Queue empty, exit
         exit 0
     fi
 
-    # Read first line
     LINE=$(head -n 1 "$QUEUE_FILE")
 
     if [[ -z "$LINE" ]]; then
         exit 0
     fi
 
-    # Extract message from JSON using jq
     MESSAGE=$(echo "$LINE" | jq -r '.message // ""' 2>/dev/null)
+    ATTEMPTS=$(echo "$LINE" | jq -r '.attempts // 0' 2>/dev/null)
+    DELIVERED=true
 
     if [[ -n "$MESSAGE" ]]; then
-        log "Sending alert to $SESSION: ${MESSAGE:0:50}..."
-        # Send alert to session's pane 0
-        if "$AGENTWIRE" alert -q --to "$SESSION" "$MESSAGE" 2>>"$DEBUG_LOG"; then
-            log "Alert sent successfully"
+        log "Sending to $SESSION (attempt $((ATTEMPTS + 1))): ${MESSAGE:0:50}..."
+        if "$AGENTWIRE" notify-parent -q --raw --to "$SESSION" "$MESSAGE" 2>>"$DEBUG_LOG"; then
+            log "Delivered"
         else
-            log "Alert failed with exit code $?"
+            DELIVERED=false
+            log "Delivery refused/failed (exit $?)"
         fi
     else
-        log "Empty message, skipping"
+        log "Empty message, dropping"
     fi
 
-    # Remove first line from queue (atomic via temp file)
+    # Mutate the queue under the lock: drop the head; if delivery failed and
+    # attempts remain, requeue at the tail with attempts+1.
+    acquire_lock
     TEMP_FILE=$(mktemp)
     tail -n +2 "$QUEUE_FILE" > "$TEMP_FILE" 2>/dev/null
+    if [[ "$DELIVERED" == false && -n "$MESSAGE" ]]; then
+        if [[ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]]; then
+            echo "$LINE" | jq -c '.attempts = ((.attempts // 0) + 1)' >> "$TEMP_FILE" 2>/dev/null
+        else
+            log "Dropping message after $ATTEMPTS attempts: ${MESSAGE:0:80}"
+        fi
+    fi
     mv "$TEMP_FILE" "$QUEUE_FILE"
+    release_lock
 
-    # Check if more items remain
     if [[ ! -s "$QUEUE_FILE" ]]; then
         exit 0
     fi
 
-    # Wait before processing next
     sleep $DELAY
 done

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -90,22 +90,38 @@ def _fmt_local(iso: str) -> str:
 
 
 def cmd_limits_tick(args) -> int:
-    """One watchdog pass (called by launchd every minute)."""
+    """One watchdog pass (called by launchd every minute).
+
+    Runs the usage-limit sweep FIRST, then prompt routing (#276) — the
+    ordering guarantees a usage-limit dialog is parked before the prompt
+    sweep ever looks at the pane.
+    """
+    from agentwire import prompt_router
+
     result = usage_limit.tick()
+    prompts = prompt_router.tick()
     if getattr(args, "json", False):
-        print(json.dumps(result))
+        print(json.dumps({**result, "prompts": prompts}))
         return 0
     if result.get("skipped"):
         print(result["skipped"])
-        return 0
-    if result["parked"]:
-        print(f"parked: {', '.join(result['parked'])}")
-    if result["resumed"]:
-        print(f"resumed: {', '.join(result['resumed'])}")
-    if result["waiting"]:
-        print(f"waiting on reset: {', '.join(result['waiting'])}")
-    if not (result["parked"] or result["resumed"] or result["waiting"]):
-        print("no usage-limit activity")
+    else:
+        if result["parked"]:
+            print(f"parked: {', '.join(result['parked'])}")
+        if result["resumed"]:
+            print(f"resumed: {', '.join(result['resumed'])}")
+        if result["waiting"]:
+            print(f"waiting on reset: {', '.join(result['waiting'])}")
+        if not (result["parked"] or result["resumed"] or result["waiting"]):
+            print("no usage-limit activity")
+    routed = prompts.get("routed") or []
+    deferred = prompts.get("deferred") or []
+    if routed:
+        print("prompts routed: " + ", ".join(
+            f"{e['session']}.{e['pane']}→{e['parent']}" for e in routed))
+    if deferred:
+        print("prompts deferred: " + ", ".join(
+            f"{e['session']}.{e['pane']}" for e in deferred))
     return 0
 
 

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from .usage_limit import (
     PARK_OPTION,
     _normalize,
+    _session_exists,
+    _tmux,
 )
 from .usage_limit import detect_dialog as _usage_limit_dialog
 
@@ -174,6 +176,84 @@ def _detect_question(clean: str, norm: str) -> "PromptInfo | None":
     if not options:
         return None
     return PromptInfo(kind="question", question=question, options=options)
+
+
+# =============================================================================
+# Parent resolution
+# =============================================================================
+
+# pane_current_command values that indicate an agent runs in a pane.
+# Claude Code panes report the node binary or a bare version string
+# (e.g. "2.1.170"); pi panes report node.
+_AGENT_COMMAND_RE = re.compile(r"^(node|claude|\d+\.\d+\.\d+\S*)$")
+
+_SESSIONS_META_DIR = Path.home() / ".agentwire" / "sessions"
+
+
+def _read_creator(session: str) -> "str | None":
+    """The session recorded as creator at `agentwire new` time, if any."""
+    metadata_file = _SESSIONS_META_DIR / session.split("@")[0] / "metadata.json"
+    try:
+        metadata = json.loads(metadata_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    creator = metadata.get("created_by")
+    return creator if isinstance(creator, str) and creator else None
+
+
+def pane_command(session: str, pane_index: int) -> str:
+    """The pane's current command ('' on any error)."""
+    try:
+        result = _tmux([
+            "display", "-t", f"{session}.{pane_index}",
+            "-p", "#{pane_current_command}",
+        ])
+    except Exception:
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def is_agent_pane(session: str, pane_index: int) -> bool:
+    return bool(_AGENT_COMMAND_RE.match(pane_command(session, pane_index)))
+
+
+def resolve_parent(
+    session: str, pane_index: int, project_path: "str | None" = None
+) -> "tuple[str, int] | None":
+    """The (session, pane) that should be told about this pane's prompt.
+
+    Precedence:
+      1. Worker pane (index > 0) -> pane 0 of the same session.
+      2. Creator recorded at `agentwire new` time (session metadata).
+      3. `.agentwire.yml` `parent:` field (project_path's config).
+      4. None -> human-only behavior, unchanged.
+
+    Depth-1 and local-machine only. Never returns the source pane itself or
+    a dead session. (Whether the target pane is safe to paste into is the
+    delivery layer's job — see safe_deliver.)
+    """
+    if pane_index > 0:
+        return (session, 0)
+
+    bare = session.split("@")[0]
+    creator = _read_creator(bare)
+    if creator and creator != bare and _session_exists(creator):
+        return (creator, 0)
+
+    parent = _parent_from_config(project_path)
+    if parent and parent != bare and _session_exists(parent):
+        return (parent, 0)
+
+    return None
+
+
+def _parent_from_config(project_path: "str | None") -> "str | None":
+    try:
+        from .project_config import get_parent_from_config
+
+        return get_parent_from_config(Path(project_path) if project_path else None)
+    except Exception:
+        return None
 
 
 def detect_prompt(visible: str) -> "PromptInfo | None":

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -1,0 +1,199 @@
+"""Interactive-prompt routing — notify a parent session when a child blocks.
+
+When a session hits an interactive gate (permission confirmation, plan-mode
+approval, AskUserQuestion), the human paths (audio + portal dialog) already
+fire. This module adds the agent path: detect the prompt, resolve the
+session's parent/orchestrator, and deliver a short text notification the
+parent can act on (inspect the pane, answer with a guarded keystroke).
+
+Two detection paths feed the same routing core:
+  - hook path (seconds): the permission hook POSTs to the portal, which calls
+    ``notify_permission_request()`` directly — no pane parsing needed.
+  - sweep path (<=60s): ``tick()`` rides the usage-limit watchdog and scans
+    every pane for plan-approval / AskUserQuestion / permission dialogs that
+    fire no hooks.
+
+Routing never auto-answers and never blocks the prompt itself: no parent
+(or an unsafe delivery target) degrades to the existing human-only behavior.
+
+State:
+  ~/.agentwire/prompt-router/{session}.{pane}.json   active-prompt markers
+  ~/.agentwire/prompt-router-events.jsonl            audit log
+"""
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import timedelta
+from pathlib import Path
+
+from .usage_limit import (
+    PARK_OPTION,
+    _normalize,
+)
+from .usage_limit import detect_dialog as _usage_limit_dialog
+
+STATE_DIR = Path.home() / ".agentwire" / "prompt-router"
+EVENTS_FILE = Path.home() / ".agentwire" / "prompt-router-events.jsonl"
+
+# A prompt the parent never answered re-notifies after this long.
+RENOTIFY_TTL = timedelta(minutes=10)
+# Hook-source permission markers suppress the sweep's permission detector
+# for slightly longer than the portal's 300s wait.
+HOOK_MARKER_TTL = timedelta(minutes=6)
+# Markers whose pane vanished are garbage-collected after this long.
+MARKER_GC_TTL = timedelta(minutes=30)
+
+# Every routed message starts with this; the detector treats its presence on
+# a screen as poison so a delivered notification can never be re-detected.
+MESSAGE_PREFIX = "[PROMPT from "
+
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m|\x1b\].*?\x07")
+
+# AskUserQuestion UI blocks (moved from server.py — single source of truth).
+# Format: ☐ Header\n\nQuestion?\n\n❯ 1. Label\n     Description\n  2. Label...
+# Multi-tab format: ←  ☐ Tab1  ☐ Tab2  ✔ Submit  →\n\nQuestion?...
+ASK_PATTERN = re.compile(
+    r"☐\s+(\S+)"  # ☐ followed by first word only (active tab name)
+    r".*?\n\s*\n"  # Rest of header line + blank line
+    r"((?:.+\n)+?)"  # Question text (one or more lines, non-greedy)
+    r"\s*\n"  # Blank line before options
+    r"((?:[❯\s]+\d+\.\s+.+\n(?:\s{3,}.+\n)?)+)",  # Options block
+    re.MULTILINE | re.DOTALL,
+)
+
+# Simple format without ☐ header (e.g. "Ready to submit?\n\n❯ 1. Submit")
+ASK_PATTERN_SIMPLE = re.compile(
+    r"\n([^\n☐❯]+\?)\s*\n"  # Question ending with ? (no ☐ or ❯)
+    r"\s*\n"  # Blank line
+    r"((?:[❯\s]+\d+\.\s+.+\n(?:\s{3,}.+\n)?)+)",  # Options block
+    re.MULTILINE,
+)
+
+# Anchors and liveness footers observed in real captures (the test fixtures
+# embed those captures verbatim). A LIVE dialog ends the visible screen at
+# its hint footer; a *quoted* dialog (a pane displaying a capture) has its
+# own input box / status bar below, so the ends-with check fails.
+_PLAN_ANCHOR = "ready to execute. Would you like to proceed?"
+_PLAN_QUESTION_RE = re.compile(r"Would you like to\s+proceed\?")
+_PERMISSION_QUESTION_RE = re.compile(r"Do you want\b[\s\S]{0,160}?\?")
+_LIVE_TAIL = {
+    "permission": re.compile(r"(Tab to\s+amend|ctrl\+e to\s+explain)\s*$"),
+    "plan": re.compile(r"ctrl\+g to edit in\s+VS Code\s+·\s+\S+\.md\s*$"),
+    "question": re.compile(r"Esc to cancel\s*$"),
+}
+
+
+@dataclass
+class PromptInfo:
+    kind: str  # "permission" | "plan" | "question"
+    question: str
+    options: list[dict] = field(default_factory=list)  # {number,label,description}
+    summary: str = ""  # one-line context (tool/command for permissions)
+
+    def content_hash(self) -> str:
+        labels = " ".join(o.get("label", "") for o in self.options)
+        raw = _normalize(f"{self.kind} {self.question} {labels}")
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def parse_ask_options(options_block: str) -> list[dict]:
+    """Parse numbered options from a dialog's options block."""
+    options = []
+    current_option = None
+
+    for line in options_block.split("\n"):
+        line = ANSI_PATTERN.sub("", line)
+        option_match = re.match(r"[❯\s]*(\d+)\.\s+(.+)", line)
+        if option_match:
+            if current_option:
+                options.append(current_option)
+            current_option = {
+                "number": int(option_match.group(1)),
+                "label": option_match.group(2).strip(),
+                "description": "",
+            }
+        elif current_option and line.strip():
+            current_option["description"] = line.strip()
+
+    if current_option:
+        options.append(current_option)
+
+    return options
+
+
+def _is_live(norm: str, kind: str) -> bool:
+    return bool(_LIVE_TAIL[kind].search(norm))
+
+
+def _detect_plan(clean: str, norm: str) -> "PromptInfo | None":
+    if _PLAN_ANCHOR not in norm or not _is_live(norm, "plan"):
+        return None
+    q = _PLAN_QUESTION_RE.search(clean)
+    options = parse_ask_options(clean[q.end():]) if q else []
+    if not options:
+        return None
+    return PromptInfo(
+        kind="plan", question="Would you like to proceed?", options=options
+    )
+
+
+def _detect_permission(clean: str, norm: str) -> "PromptInfo | None":
+    if not _is_live(norm, "permission"):
+        return None
+    q = _PERMISSION_QUESTION_RE.search(clean)
+    if not q:
+        return None
+    options = parse_ask_options(clean[q.end():])
+    if not options:
+        return None
+    return PromptInfo(
+        kind="permission",
+        question=_normalize(q.group(0)),
+        options=options,
+        summary=_normalize(clean[max(0, q.start() - 250):q.start()])[-200:],
+    )
+
+
+def _detect_question(clean: str, norm: str) -> "PromptInfo | None":
+    if not _is_live(norm, "question"):
+        return None
+    match = ASK_PATTERN.search(clean) or ASK_PATTERN_SIMPLE.search(clean)
+    if not match:
+        return None
+    if len(match.groups()) == 3:
+        question = _normalize(match.group(2))
+        options_start = match.start(3)
+    else:
+        question = _normalize(match.group(1))
+        options_start = match.start(2)
+    # Parse from the options block to the end of the screen so options that
+    # render after a separator rule (e.g. "4. Chat about this") are kept.
+    options = parse_ask_options(clean[options_start:])
+    if not options:
+        return None
+    return PromptInfo(kind="question", question=question, options=options)
+
+
+def detect_prompt(visible: str) -> "PromptInfo | None":
+    """Classify a live interactive prompt on a pane screen, if any.
+
+    Returns None for: empty screens, the usage-limit dialog (owned by
+    usage_limit.py), screens containing a routed notification (poison
+    marker — prevents self-triggering loops), and quoted dialogs (liveness
+    footer check fails — see _LIVE_TAIL).
+    """
+    clean = ANSI_PATTERN.sub("", visible)
+    norm = _normalize(clean)
+    if not norm:
+        return None
+    if MESSAGE_PREFIX in norm:
+        return None
+    if PARK_OPTION in norm or _usage_limit_dialog(visible):
+        return None
+    for detector in (_detect_plan, _detect_permission, _detect_question):
+        info = detector(clean, norm)
+        if info:
+            return info
+    return None

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -21,15 +21,18 @@ State:
   ~/.agentwire/prompt-router-events.jsonl            audit log
 """
 
+import fcntl
 import hashlib
 import json
 import re
+import subprocess
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from .usage_limit import (
     PARK_OPTION,
+    _atomic_write,
     _capture,
     _normalize,
     _now,
@@ -333,3 +336,327 @@ def detect_prompt(visible: str) -> "PromptInfo | None":
         if info:
             return info
     return None
+
+
+# =============================================================================
+# Markers (presence-based dedupe) + events
+# =============================================================================
+
+
+def _log_event(event: str, **fields) -> None:
+    record = {"ts": _now().isoformat(), "event": event, **fields}
+    try:
+        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(EVENTS_FILE, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def marker_path(session: str, pane_index: int) -> Path:
+    # Worktree session names contain "/" and nest a directory level, same as
+    # usage_limit.state_path. The bash idle-handler guard tests the literal
+    # "$HOME/.agentwire/prompt-router/${session}.${pane}.json" string — keep
+    # these in lockstep.
+    return STATE_DIR / f"{session}.{pane_index}.json"
+
+
+def read_marker(session: str, pane_index: int) -> "dict | None":
+    try:
+        return json.loads(marker_path(session, pane_index).read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def write_marker(session: str, pane_index: int, **fields) -> dict:
+    marker = {"session": session, "pane": pane_index, **fields}
+    _atomic_write(marker_path(session, pane_index), marker)
+    return marker
+
+
+def clear_marker(session: str, pane_index: int) -> None:
+    try:
+        marker_path(session, pane_index).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _marker_age(marker: dict, field_name: str = "detected_at") -> "timedelta | None":
+    try:
+        return _now() - datetime.fromisoformat(marker[field_name])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def list_markers() -> list[dict]:
+    if not STATE_DIR.exists():
+        return []
+    markers = []
+    for path in sorted(STATE_DIR.rglob("*.json")):
+        if path.name.startswith("."):
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict) and data.get("session") is not None:
+            markers.append(data)
+    return markers
+
+
+# =============================================================================
+# Routing
+# =============================================================================
+
+
+def build_message(session: str, pane_index: int, info: PromptInfo) -> str:
+    """The notification a parent receives. Deliberately paraphrased: no `❯`,
+    no menu-style option block, no dialog footer text — a delivered message
+    must never look like a live dialog to the sweep (see MESSAGE_PREFIX
+    poison + screen_shows_live_menu)."""
+    labels = ", ".join(
+        f"{o['number']}={o['label']}" for o in info.options if o.get("label")
+    )
+    deadline = (
+        "~5 minutes (portal permission timeout)"
+        if info.kind == "permission"
+        else "none — blocks until answered"
+    )
+    summary = f" Context: {info.summary}" if info.summary else ""
+    return (
+        f"{MESSAGE_PREFIX}{session} pane {pane_index}] kind={info.kind} — "
+        f"a session you are responsible for is blocked on an interactive prompt. "
+        f"Question: {info.question}{summary} "
+        f"Option keys: {labels}. Deadline: {deadline}. "
+        f"Inspect FIRST: agentwire output -s '{session}' (MCP: pane_output/session_output). "
+        f"Answer ONLY via: agentwire prompts answer -s '{session}' --pane {pane_index} "
+        f"--expect {info.content_hash()} <key> — it verifies the same prompt is still "
+        f"live before sending the key. Do not blanket-approve; if unsure, do nothing "
+        f"(the human was also notified)."
+    )
+
+
+def route_prompt(
+    session: str,
+    pane_index: int,
+    info: PromptInfo,
+    source: str = "sweep",
+    project_path: "str | None" = None,
+) -> "str | None":
+    """Resolve the parent and deliver the notification. Never raises.
+
+    Writes a marker either way: delivered markers dedupe future sweeps,
+    deferred/no-parent markers make retries cheap and keep the idle-handler
+    reap guard active while the pane is blocked. Returns the parent session
+    name when delivery succeeded, else None.
+    """
+    try:
+        content_hash = info.content_hash()
+        parent = resolve_parent(session, pane_index, project_path)
+        if parent is None:
+            write_marker(
+                session, pane_index,
+                kind=info.kind, hash=content_hash, source=source,
+                parent=None, status="no_parent",
+                detected_at=_now().isoformat(), notified_at=None,
+            )
+            _log_event("no_parent", session=session, pane=pane_index, kind=info.kind)
+            return None
+
+        target_session, target_pane = parent
+        delivered, reason = safe_deliver(
+            target_session, target_pane, build_message(session, pane_index, info)
+        )
+        write_marker(
+            session, pane_index,
+            kind=info.kind, hash=content_hash, source=source,
+            parent=target_session, status=reason,
+            detected_at=_now().isoformat(),
+            notified_at=_now().isoformat() if delivered else None,
+        )
+        _log_event(
+            "prompt_routed" if delivered else "route_deferred",
+            session=session, pane=pane_index, kind=info.kind,
+            parent=target_session, status=reason,
+        )
+        return target_session if delivered else None
+    except Exception as exc:  # routing must never break a caller
+        _log_event("route_failed", session=session, pane=pane_index, error=str(exc))
+        return None
+
+
+def notify_permission_request(session: str, pane_index: int, data: dict) -> "str | None":
+    """Hook-path entry: the portal received a PermissionRequest POST.
+
+    Builds the PromptInfo from the hook payload (no pane parsing needed) and
+    routes it. Sync + best-effort; the server calls this in an executor.
+    """
+    tool_name = data.get("tool_name", "unknown")
+    tool_input = data.get("tool_input") or {}
+    if tool_name == "Bash":
+        detail = str(tool_input.get("command", ""))[:300]
+        summary = f"run: {detail}" if detail else "run a command"
+    elif tool_name in ("Edit", "Write"):
+        summary = f"{tool_name.lower()} {tool_input.get('file_path', 'a file')}"
+    else:
+        detail = json.dumps(tool_input, sort_keys=True)[:300]
+        summary = f"use {tool_name} {detail}".strip()
+    info = PromptInfo(
+        kind="permission",
+        question=f"Claude wants to {summary}",
+        options=[
+            {"number": 1, "label": "allow", "description": ""},
+            {"number": 2, "label": "allow always", "description": ""},
+            {"number": 3, "label": "deny (Escape also denies)", "description": ""},
+        ],
+    )
+    return route_prompt(session, pane_index, info, source="hook")
+
+
+# =============================================================================
+# Guarded answer (compare-and-send)
+# =============================================================================
+
+
+def answer(
+    session: str, pane_index: int, expect_hash: str, keys: list[str]
+) -> "tuple[bool, str]":
+    """Send *keys* to the pane only if the expected prompt is still live.
+
+    This is the race guard: a human may have answered via the portal (or the
+    prompt may have expired) between notification and the parent's answer —
+    a stray keystroke would land in the child's input box, and a stray
+    Escape would abort its in-flight turn. First answer wins; the loser
+    no-ops here.
+    """
+    visible = _capture(f"{session}.{pane_index}")
+    info = detect_prompt(visible)
+    if info is None:
+        clear_marker(session, pane_index)
+        return False, "no live prompt on the pane (already answered or gone)"
+    if info.content_hash() != expect_hash:
+        return False, (
+            f"a DIFFERENT prompt is live (kind={info.kind}, "
+            f"hash={info.content_hash()}) — inspect before answering"
+        )
+    for key in keys:
+        _tmux(["send-keys", "-t", f"{session}.{pane_index}", key])
+    clear_marker(session, pane_index)
+    _log_event(
+        "prompt_answered", session=session, pane=pane_index,
+        kind=info.kind, keys=keys,
+    )
+    return True, f"sent {' '.join(keys)} to {session}.{pane_index}"
+
+
+# =============================================================================
+# Sweep + tick
+# =============================================================================
+
+
+def _router_config() -> "tuple[bool, set[str]]":
+    """(enabled, excluded session names) from config.yaml."""
+    try:
+        from .config import get_config
+
+        cfg = get_config().prompt_router
+        return bool(cfg.enabled), set(cfg.exclude_sessions)
+    except Exception:
+        return True, set()
+
+
+def sweep() -> dict:
+    """Scan all agent panes for live interactive prompts and route them.
+
+    Marker lifecycle per pane:
+      no prompt on screen      -> clear any marker (answered/gone; identical
+                                  future prompts will re-notify)
+      same prompt, delivered   -> silent until RENOTIFY_TTL, then re-deliver
+      same prompt, deferred    -> retry delivery
+      different prompt         -> route fresh
+      hook-source permission   -> sweep stays out while the marker is fresh
+                                  (the portal owns that prompt's lifecycle)
+    """
+    enabled, excluded = _router_config()
+    if not enabled:
+        return {"routed": [], "deferred": [], "active": []}
+    try:
+        result = _tmux(
+            ["list-panes", "-a", "-F",
+             "#{session_name}\t#{pane_index}\t#{pane_current_command}\t#{pane_current_path}"]
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return {"routed": [], "deferred": [], "active": []}
+    if result.returncode != 0:
+        return {"routed": [], "deferred": [], "active": []}
+
+    routed, deferred, active = [], [], []
+    seen_panes = set()
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) != 4:
+            continue
+        session, pane_s, command, pane_path = parts
+        try:
+            pane_index = int(pane_s)
+        except ValueError:
+            continue
+        seen_panes.add((session, pane_index))
+
+        # Only Claude Code panes produce these dialogs; a vim/less pane
+        # *displaying* dialog text must never match.
+        if not _AGENT_COMMAND_RE.match(command.strip()):
+            continue
+        if session in excluded or _is_parked(session):
+            continue
+
+        info = detect_prompt(_capture(f"{session}.{pane_index}"))
+        marker = read_marker(session, pane_index)
+
+        if info is None:
+            if marker:
+                clear_marker(session, pane_index)
+            continue
+
+        if marker and marker.get("hash") == info.content_hash():
+            if (
+                marker.get("source") == "hook"
+                and info.kind == "permission"
+                and (_marker_age(marker) or timedelta(0)) < HOOK_MARKER_TTL
+            ):
+                active.append({"session": session, "pane": pane_index, "kind": info.kind})
+                continue
+            if marker.get("notified_at"):
+                age = _marker_age(marker, "notified_at")
+                if age is not None and age < RENOTIFY_TTL:
+                    active.append({"session": session, "pane": pane_index, "kind": info.kind})
+                    continue
+            # deferred (or TTL-expired) -> try again
+
+        parent = route_prompt(session, pane_index, info, project_path=pane_path)
+        entry = {"session": session, "pane": pane_index, "kind": info.kind, "parent": parent}
+        (routed if parent else deferred).append(entry)
+
+    # GC markers whose pane no longer exists.
+    for marker in list_markers():
+        key = (marker.get("session"), marker.get("pane"))
+        if key in seen_panes:
+            continue
+        age = _marker_age(marker)
+        if age is None or age > MARKER_GC_TTL:
+            clear_marker(*key)
+
+    return {"routed": routed, "deferred": deferred, "active": active}
+
+
+def tick() -> dict:
+    """One watchdog pass; rides `agentwire limits tick` (after the
+    usage-limit sweep, so its dialog is parked before we ever look)."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    lock_file = STATE_DIR / ".tick.lock"
+    with open(lock_file, "w") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return {"skipped": "tick already running"}
+        return sweep()

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -30,11 +30,14 @@ from pathlib import Path
 
 from .usage_limit import (
     PARK_OPTION,
+    _capture,
     _normalize,
+    _now,
     _session_exists,
     _tmux,
 )
 from .usage_limit import detect_dialog as _usage_limit_dialog
+from .usage_limit import is_parked as _is_parked
 
 STATE_DIR = Path.home() / ".agentwire" / "prompt-router"
 EVENTS_FILE = Path.home() / ".agentwire" / "prompt-router-events.jsonl"
@@ -254,6 +257,59 @@ def _parent_from_config(project_path: "str | None") -> "str | None":
         return get_parent_from_config(Path(project_path) if project_path else None)
     except Exception:
         return None
+
+
+# =============================================================================
+# Delivery
+# =============================================================================
+
+
+def screen_shows_live_menu(visible: str) -> bool:
+    """True if a live select-menu/dialog appears to be on screen.
+
+    Used as a pre-paste safety check: pasting text + Enter into a pane whose
+    screen ends in a menu would CONFIRM the highlighted option. Deliberately
+    broader than detect_prompt — quoted-dialog subtleties don't matter here,
+    and a screen that merely *looks* like a menu defers delivery one cycle.
+    """
+    clean = ANSI_PATTERN.sub("", visible)
+    norm = _normalize(clean)
+    if not norm:
+        return False
+    if _usage_limit_dialog(visible):
+        return True
+    if norm.rstrip().endswith("Enter to confirm · Esc to cancel"):
+        return True
+    return any(rx.search(norm) for rx in _LIVE_TAIL.values())
+
+
+def safe_deliver(target_session: str, target_pane: int, text: str) -> "tuple[bool, str]":
+    """Deliver *text* to the target pane, refusing unsafe targets.
+
+    Refusals (returned as (False, reason), retried by the next sweep tick):
+      target_gone       session no longer exists
+      target_parked     usage-limit parked — paste would corrupt the resume
+      target_not_agent  pane runs a shell/editor — pasted text could EXECUTE
+      target_dialog     pane shows its own live menu — Enter would answer it
+
+    Delivery itself is session_ready.send_verified (marker = the message's
+    own [PROMPT ...] prefix line), so a silent tmux paste failure reports
+    as not-delivered instead of being assumed sent.
+    """
+    if not _session_exists(target_session):
+        return False, "target_gone"
+    if _is_parked(target_session):
+        return False, "target_parked"
+    if not is_agent_pane(target_session, target_pane):
+        return False, "target_not_agent"
+    if screen_shows_live_menu(_capture(f"{target_session}.{target_pane}")):
+        return False, "target_dialog"
+
+    from .session_ready import derive_check_fragment, send_verified
+
+    marker = derive_check_fragment(text)
+    ok = send_verified(target_session, text, marker=marker or None)
+    return (ok, "delivered" if ok else "delivery_unverified")
 
 
 def detect_prompt(visible: str) -> "PromptInfo | None":

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -512,6 +512,29 @@ def notify_permission_request(session: str, pane_index: int, data: dict) -> "str
         )
         return route_prompt(session, pane_index, info, source="hook")
 
+    # AskUserQuestion fires the hook in prompted sessions too (drill-verified
+    # 2026-06-11) and the payload carries the question + options — mirror the
+    # on-screen dialog. (The screen adds trailing "Type something." / "Chat
+    # about this" options; the marker bridges the hash, kinds match.)
+    if tool_name == "AskUserQuestion":
+        questions = tool_input.get("questions") or []
+        first = questions[0] if isinstance(questions, list) and questions else {}
+        options = [
+            {
+                "number": i + 1,
+                "label": str(o.get("label", "")),
+                "description": str(o.get("description", "")),
+            }
+            for i, o in enumerate(first.get("options") or [])
+            if isinstance(o, dict)
+        ]
+        info = PromptInfo(
+            kind="question",
+            question=str(first.get("question") or "AskUserQuestion dialog"),
+            options=options,
+        )
+        return route_prompt(session, pane_index, info, source="hook")
+
     if tool_name == "Bash":
         detail = str(tool_input.get("command", ""))[:300]
         summary = f"run: {detail}" if detail else "run a command"

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -493,6 +493,25 @@ def notify_permission_request(session: str, pane_index: int, data: dict) -> "str
     """
     tool_name = data.get("tool_name", "unknown")
     tool_input = data.get("tool_input") or {}
+
+    # ExitPlanMode fires the PermissionRequest hook too (live-verified
+    # 2026-06-11) but renders the plan-approval dialog, whose options differ
+    # from a permission dialog's — mirror what's actually on screen.
+    if tool_name == "ExitPlanMode":
+        plan = str(tool_input.get("plan", ""))[:300]
+        info = PromptInfo(
+            kind="plan",
+            question="Plan approval: Would you like to proceed?",
+            options=[
+                {"number": 1, "label": "Yes, and use auto mode", "description": ""},
+                {"number": 2, "label": "Yes, manually approve edits", "description": ""},
+                {"number": 3, "label": "No", "description": ""},
+                {"number": 4, "label": "Tell Claude what to change", "description": ""},
+            ],
+            summary=plan,
+        )
+        return route_prompt(session, pane_index, info, source="hook")
+
     if tool_name == "Bash":
         detail = str(tool_input.get("command", ""))[:300]
         summary = f"run: {detail}" if detail else "run a command"
@@ -535,10 +554,19 @@ def answer(
         clear_marker(session, pane_index)
         return False, "no live prompt on the pane (already answered or gone)"
     if info.content_hash() != expect_hash:
-        return False, (
-            f"a DIFFERENT prompt is live (kind={info.kind}, "
-            f"hash={info.content_hash()}) — inspect before answering"
-        )
+        # Hook-routed permission notifications carry a payload-derived hash
+        # that can't be recomputed from the screen; the marker bridges the
+        # two — same expected hash, same kind, a live prompt of that kind.
+        marker = read_marker(session, pane_index)
+        if not (
+            marker
+            and marker.get("hash") == expect_hash
+            and marker.get("kind") == info.kind
+        ):
+            return False, (
+                f"a DIFFERENT prompt is live (kind={info.kind}, "
+                f"hash={info.content_hash()}) — inspect before answering"
+            )
     for key in keys:
         _tmux(["send-keys", "-t", f"{session}.{pane_index}", key])
     clear_marker(session, pane_index)
@@ -618,14 +646,20 @@ def sweep() -> dict:
                 clear_marker(session, pane_index)
             continue
 
+        # A fresh hook-routed marker keeps the sweep off this pane entirely.
+        # NOT hash- or kind-gated: the hook's hash derives from the tool
+        # payload (never equals the screen hash), and ExitPlanMode arrives
+        # via the hook but renders as a plan dialog. Only one dialog can be
+        # live on a pane — a fresh hook marker means the portal owns it.
+        if (
+            marker
+            and marker.get("source") == "hook"
+            and (_marker_age(marker) or timedelta(0)) < HOOK_MARKER_TTL
+        ):
+            active.append({"session": session, "pane": pane_index, "kind": info.kind})
+            continue
+
         if marker and marker.get("hash") == info.content_hash():
-            if (
-                marker.get("source") == "hook"
-                and info.kind == "permission"
-                and (_marker_age(marker) or timedelta(0)) < HOOK_MARKER_TTL
-            ):
-                active.append({"session": session, "pane": pane_index, "kind": info.kind})
-                continue
             if marker.get("notified_at"):
                 age = _marker_age(marker, "notified_at")
                 if age is not None and age < RENOTIFY_TTL:

--- a/agentwire/prompts_cli.py
+++ b/agentwire/prompts_cli.py
@@ -1,0 +1,126 @@
+"""CLI for prompt routing — ``agentwire prompts ...``.
+
+The sweep rides the usage-limit watchdog (``agentwire limits tick``, every
+60s); these commands are the manual/diagnostic surface plus the guarded
+answer primitive parents are told to use.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from . import prompt_router
+
+
+def _fmt_local(iso: str | None) -> str:
+    if not iso:
+        return "-"
+    try:
+        return datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %I:%M%p")
+    except (ValueError, TypeError):
+        return str(iso)
+
+
+def cmd_prompts_tick(args) -> int:
+    """Run one prompt sweep now (the watchdog does this every minute)."""
+    result = prompt_router.tick()
+    if getattr(args, "json", False):
+        print(json.dumps(result))
+        return 0
+    if result.get("skipped"):
+        print(result["skipped"])
+        return 0
+    for entry in result.get("routed", []):
+        print(f"routed: {entry['session']}.{entry['pane']} ({entry['kind']}) → {entry['parent']}")
+    for entry in result.get("deferred", []):
+        print(f"deferred: {entry['session']}.{entry['pane']} ({entry['kind']})")
+    for entry in result.get("active", []):
+        print(f"active: {entry['session']}.{entry['pane']} ({entry['kind']})")
+    if not any(result.get(k) for k in ("routed", "deferred", "active")):
+        print("no live prompts")
+    return 0
+
+
+def cmd_prompts_status(args) -> int:
+    """Show active prompt markers (prompts awaiting an answer)."""
+    markers = prompt_router.list_markers()
+    if getattr(args, "json", False):
+        print(json.dumps({"markers": markers}, indent=2))
+        return 0
+    if not markers:
+        print("No prompts pending")
+        return 0
+    for m in markers:
+        notified = _fmt_local(m.get("notified_at"))
+        print(
+            f"{m['session']}.{m['pane']}  kind={m.get('kind')}  "
+            f"status={m.get('status')}  parent={m.get('parent') or '-'}  "
+            f"hash={m.get('hash')}  notified={notified}"
+        )
+    return 0
+
+
+def cmd_prompts_clear(args) -> int:
+    """Drop a prompt marker (forces re-detection/re-notification next tick)."""
+    session = args.session
+    pane = getattr(args, "pane", 0) or 0
+    prompt_router.clear_marker(session, pane)
+    if not getattr(args, "json", False):
+        print(f"Cleared marker for {session}.{pane}")
+    else:
+        print(json.dumps({"success": True, "session": session, "pane": pane}))
+    return 0
+
+
+def cmd_prompts_answer(args) -> int:
+    """Answer a routed prompt — only if the same prompt is still live.
+
+    Re-captures the pane, re-detects the prompt, and compares the content
+    hash from the notification (--expect) before sending any key. A human
+    may have answered first via the portal: first answer wins, this no-ops.
+    """
+    session = args.session
+    pane = getattr(args, "pane", 0) or 0
+    keys = args.keys
+    ok, message = prompt_router.answer(session, pane, args.expect, keys)
+    if getattr(args, "json", False):
+        print(json.dumps({"success": ok, "message": message}))
+    else:
+        print(message)
+    return 0 if ok else 1
+
+
+def register_prompts_parser(subparsers) -> None:
+    prompts_parser = subparsers.add_parser(
+        "prompts", help="Interactive-prompt routing (worker prompts → parent session)"
+    )
+    prompts_sub = prompts_parser.add_subparsers(dest="prompts_cmd")
+
+    tick_parser = prompts_sub.add_parser("tick", help="Run one prompt sweep now")
+    tick_parser.add_argument("--json", action="store_true", help="Output JSON")
+    tick_parser.set_defaults(func=cmd_prompts_tick)
+
+    status_parser = prompts_sub.add_parser("status", help="Show pending prompt markers")
+    status_parser.add_argument("--json", action="store_true", help="Output JSON")
+    status_parser.set_defaults(func=cmd_prompts_status)
+
+    clear_parser = prompts_sub.add_parser("clear", help="Drop a prompt marker")
+    clear_parser.add_argument("-s", "--session", required=True, help="Session name")
+    clear_parser.add_argument("--pane", type=int, default=0, help="Pane index (default 0)")
+    clear_parser.add_argument("--json", action="store_true", help="Output JSON")
+    clear_parser.set_defaults(func=cmd_prompts_clear)
+
+    answer_parser = prompts_sub.add_parser(
+        "answer", help="Answer a routed prompt (guarded: verifies the prompt is still live)"
+    )
+    answer_parser.add_argument("-s", "--session", required=True, help="Session name")
+    answer_parser.add_argument("--pane", type=int, default=0, help="Pane index (default 0)")
+    answer_parser.add_argument("--expect", required=True,
+                               help="Content hash from the [PROMPT ...] notification")
+    answer_parser.add_argument("keys", nargs="+",
+                               help="tmux keys to send (e.g. 2, or: 1 Enter)")
+    answer_parser.add_argument("--json", action="store_true", help="Output JSON")
+    answer_parser.set_defaults(func=cmd_prompts_answer)
+
+    prompts_parser.set_defaults(func=cmd_prompts_status)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -34,6 +34,7 @@ import jinja2
 import yaml
 from aiohttp import web
 
+from . import prompt_router
 from .cached_status import CachedStatusChecker
 from .config import Config, load_config
 from .security import (
@@ -2180,51 +2181,15 @@ class AgentWireServer:
     # Patterns for say command detection
     # Matches: say "text", agentwire say "text", agentwire say -s session "text"
     SAY_PATTERN = re.compile(r'(?:agentwire\s+)?say\s+(?:-s\s+\S+\s+)?(?:"([^"]+)"|\'([^\']+)\')', re.IGNORECASE)
-    ANSI_PATTERN = re.compile(r'\x1b\[[0-9;]*m|\x1b\].*?\x07')
-
-    # Pattern to detect AskUserQuestion UI blocks
-    # Format: ☐ Header\n\nQuestion?\n\n❯ 1. Label\n     Description\n  2. Label...
-    # Multi-tab format: ←  ☐ Tab1  ☐ Tab2  ✔ Submit  →\n\nQuestion?...
-    ASK_PATTERN = re.compile(
-        r'☐\s+(\S+)'              # ☐ followed by first word only (active tab name)
-        r'.*?\n\s*\n'             # Rest of header line + blank line
-        r'((?:.+\n)+?)'           # Question text (one or more lines, non-greedy)
-        r'\s*\n'                  # Blank line before options
-        r'((?:[❯\s]+\d+\.\s+.+\n(?:\s{3,}.+\n)?)+)',  # Options block
-        re.MULTILINE | re.DOTALL
-    )
-
-    # Simple format without ☐ header (e.g., "Ready to submit?\n\n❯ 1. Submit\n  2. Cancel")
-    ASK_PATTERN_SIMPLE = re.compile(
-        r'\n([^\n☐❯]+\?)\s*\n'    # Question ending with ? (not containing ☐ or ❯)
-        r'\s*\n'                   # Blank line
-        r'((?:[❯\s]+\d+\.\s+.+\n(?:\s{3,}.+\n)?)+)',  # Options block
-        re.MULTILINE
-    )
+    # Dialog/ANSI patterns live in prompt_router (single source of truth,
+    # shared with the pane-sweep prompt detector).
+    ANSI_PATTERN = prompt_router.ANSI_PATTERN
+    ASK_PATTERN = prompt_router.ASK_PATTERN
+    ASK_PATTERN_SIMPLE = prompt_router.ASK_PATTERN_SIMPLE
 
     def _parse_ask_options(self, options_block: str) -> list[dict]:
         """Parse numbered options from AskUserQuestion block."""
-        options = []
-        current_option = None
-
-        for line in options_block.split('\n'):
-            line = self.ANSI_PATTERN.sub('', line)
-            option_match = re.match(r'[❯\s]*(\d+)\.\s+(.+)', line)
-            if option_match:
-                if current_option:
-                    options.append(current_option)
-                current_option = {
-                    'number': int(option_match.group(1)),
-                    'label': option_match.group(2).strip(),
-                    'description': '',
-                }
-            elif current_option and line.strip():
-                current_option['description'] = line.strip()
-
-        if current_option:
-            options.append(current_option)
-
-        return options
+        return prompt_router.parse_ask_options(options_block)
 
     async def _poll_output(self, session: Session):
         """Poll agent output and broadcast to session clients."""

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -145,6 +145,7 @@ class PendingPermission:
     request: dict  # The permission request from Claude Code
     event: asyncio.Event = field(default_factory=asyncio.Event)  # Signals when user responds
     decision: dict | None = None  # The user's decision
+    pane_index: int = 0  # Pane the dialog is on (worker panes > 0)
 
 
 @dataclass
@@ -4104,7 +4105,22 @@ projects:
                     })
 
             # Create pending permission request (normal/prompted mode)
-            session.pending_permission = PendingPermission(request=data)
+            try:
+                pane_index = int(data.get("pane_index") or 0)
+            except (TypeError, ValueError):
+                pane_index = 0
+            session.pending_permission = PendingPermission(request=data, pane_index=pane_index)
+
+            # Route to the parent/orchestrator session, if one resolves
+            # (#276). Best-effort and non-blocking for the dialog itself;
+            # placed AFTER the restricted-mode branch so auto-denied tools
+            # never spam a parent. The hook payload's tmux_session (the real
+            # tmux name) beats the URL name, which may be a project alias.
+            tmux_name = str(data.get("tmux_session") or "") or name
+            parent_notified = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: prompt_router.notify_permission_request(tmux_name, pane_index, data),
+            )
 
             # Broadcast permission request to all clients (Task 3.1)
             await self._broadcast(session, {
@@ -4112,10 +4128,13 @@ projects:
                 "tool_name": tool_name,
                 "tool_input": tool_input,
                 "message": message,
+                "parent_notified": parent_notified,
             })
 
             # Generate TTS announcement (Task 3.6)
-            await self._announce_permission_request(name, tool_name, tool_input)
+            await self._announce_permission_request(
+                name, tool_name, tool_input, parent_notified=parent_notified
+            )
 
             # Wait for user decision with 5 minute timeout
             try:
@@ -4124,6 +4143,9 @@ projects:
                 logger.warning(f"[{name}] Permission request timed out")
                 session.pending_permission = None
                 await self._broadcast(session, {"type": "permission_timeout"})
+                await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: prompt_router.clear_marker(tmux_name, pane_index)
+                )
                 return web.json_response({
                     "decision": "deny",
                     "message": "Permission request timed out (5 minutes)"
@@ -4132,6 +4154,9 @@ projects:
             # Return the decision to the hook script
             decision = session.pending_permission.decision
             session.pending_permission = None
+            await asyncio.get_event_loop().run_in_executor(
+                None, lambda: prompt_router.clear_marker(tmux_name, pane_index)
+            )
 
             logger.info(f"[{name}] Permission decision: {decision}")
             return web.json_response(decision)
@@ -4163,24 +4188,44 @@ projects:
             if not session.pending_permission:
                 return web.json_response({"error": "No pending permission request"}, status=400)
 
+            # Capture pane/session context BEFORE signaling — the waiting
+            # request handler nulls pending_permission as soon as it wakes.
+            pane_index = session.pending_permission.pane_index
+            pending_request = session.pending_permission.request
+            tmux_name = str(pending_request.get("tmux_session") or "") or name
+
             # Store decision and signal the waiting request
             session.pending_permission.decision = {"decision": decision}
             if decision == "deny":
                 session.pending_permission.decision["message"] = data.get("message", "User denied permission")
             session.pending_permission.event.set()
 
-            # Send keystroke to session to respond to Claude's interactive prompt
-            # Use CLI for consistent behavior (handles local and remote via session@machine format)
+            # Send keystroke to the pane the dialog is on — CONDITIONALLY.
+            # The parent session may have answered via `agentwire prompts
+            # answer` moments earlier: a late '1' would type into the freed
+            # input box, and a late Escape would abort the child's next turn.
+            # Re-capture and only send if a live menu is still on screen.
             try:
                 import subprocess
 
-                if decision == "custom":
+                dialog_live = await asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: prompt_router.screen_shows_live_menu(
+                        prompt_router._capture(f"{tmux_name}.{pane_index}")
+                    ),
+                )
+                if not dialog_live:
+                    logger.info(
+                        f"[{name}] Dialog already gone (answered elsewhere) — skipping keystroke"
+                    )
+                elif decision == "custom":
                     # Custom feedback: send "3", then message, then Enter
                     custom_message = data.get("message", "")
                     if custom_message:
                         # send-keys handles pauses between key groups
                         subprocess.run(
-                            ["agentwire", "send-keys", "-s", name, "3", custom_message, "Enter"],
+                            ["agentwire", "send-keys", "-s", tmux_name,
+                             "--pane", str(pane_index), "3", custom_message, "Enter"],
                             check=True, capture_output=True
                         )
                         logger.info(f"[{name}] Sent custom feedback: {custom_message[:50]}...")
@@ -4193,12 +4238,17 @@ projects:
                     }
                     keystroke = keystroke_map.get(decision, "Escape")
                     subprocess.run(
-                        ["agentwire", "send-keys", "-s", name, keystroke],
+                        ["agentwire", "send-keys", "-s", tmux_name,
+                         "--pane", str(pane_index), keystroke],
                         check=True, capture_output=True
                     )
-                    logger.info(f"[{name}] Sent keystroke '{keystroke}' to session")
+                    logger.info(f"[{name}] Sent keystroke '{keystroke}' to {tmux_name}.{pane_index}")
             except Exception as e:
                 logger.error(f"[{name}] Failed to send keystroke: {e}")
+
+            await asyncio.get_event_loop().run_in_executor(
+                None, lambda: prompt_router.clear_marker(tmux_name, pane_index)
+            )
 
             # Broadcast permission_resolved to all clients (Task 3.7)
             await self._broadcast(session, {
@@ -4212,7 +4262,10 @@ projects:
             logger.error(f"Permission respond failed: {e}")
             return web.json_response({"error": str(e)}, status=500)
 
-    async def _announce_permission_request(self, session_name: str, tool_name: str, tool_input: dict):
+    async def _announce_permission_request(
+        self, session_name: str, tool_name: str, tool_input: dict,
+        parent_notified: "str | None" = None,
+    ):
         """Generate TTS announcement for permission request (Task 3.6)."""
         # Build a natural announcement message
         if tool_name == "Edit":
@@ -4232,6 +4285,10 @@ projects:
             text = f"Claude wants to run a command: {command}"
         else:
             text = f"Claude wants to use {tool_name}"
+
+        if parent_notified:
+            # The human knows an agent may handle it before they get there.
+            text += f". Also routed to {parent_notified}"
 
         await self._say_to_room(session_name, text)
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -29,6 +29,7 @@ archived to ``usage-limit/done/`` on resume.
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import json
 import os
 import re
@@ -532,7 +533,10 @@ def _log_unmatched(session: str, pane_index: int, visible: str) -> None:
     if not isinstance(seen, dict):
         seen = {}
     key = f"{session}.{pane_index}"
-    digest = str(hash(excerpt))
+    # sha256, NOT hash(): str hashing is randomized per process, and every
+    # launchd tick is a fresh process — hash() never matched, so the dedupe
+    # was a no-op and unmatched dialogs re-logged every 60s.
+    digest = hashlib.sha256(excerpt.encode()).hexdigest()[:16]
     if seen.get(key) == digest:
         return
     seen[key] = digest

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -25,6 +25,7 @@ How AgentWire runs AI agents — session types, REPLs, and permission models.
 - **[Window sizing](sessions/window-sizing.md)** — how tmux `window-size` policies interact with the portal (v1.33+ behavior change, healing stuck windows, policy picker)
 - **[Custom services](services.md)** — registered long-running sessions: autostart on portal launch, watchdog health checks + restart with backoff, `agentwire services` CLI
 - **[Council](council.md)** — multi-soul orchestrator sitting: fan a prompt out to lens sessions (brain, conscience, gut, critic, …), collect via file inbox, synthesize with attribution
+- **[Prompt routing](sessions/prompt-routing.md)** — permission/plan/AskUserQuestion prompts in a child session route to its parent (hook path + watchdog sweep); guarded `agentwire prompts answer`, no auto-answering
 
 ## Communication
 

--- a/docs/wiki/sessions/prompt-routing.md
+++ b/docs/wiki/sessions/prompt-routing.md
@@ -1,0 +1,125 @@
+# Prompt routing — interactive prompts go to the parent session
+
+> Living document. Update this, don't create new versions.
+
+When a child/worker session hits an interactive gate — a permission
+confirmation, a plan-mode approval (ExitPlanMode), an AskUserQuestion dialog —
+the human paths (audio alert + portal dialog) still fire, **and** the
+session's parent/orchestrator gets a text notification with enough context to
+inspect and answer. No parent → behavior is exactly what it was before.
+
+Issue #276. Core module: `agentwire/prompt_router.py`.
+
+## Detection paths
+
+| Path | Latency | Covers | How |
+|------|---------|--------|-----|
+| **Hook** | seconds | Permission prompts | `agentwire-permission.sh` POSTs to `/api/permission/{session}` with `pane_index` + `tmux_session`; the portal routes before waiting on the human |
+| **Sweep** | ≤60s | Plan-approval, AskUserQuestion, permission (backstop) | Rides the usage-limit watchdog: `agentwire limits tick` runs `usage_limit.tick()` **then** `prompt_router.tick()` — a usage-limit dialog parks before the prompt sweep ever sees it |
+
+The sweep only looks at Claude Code panes (`pane_current_command` of `node`/
+`claude`/a version string) and uses real-capture-derived detectors with a
+**liveness check**: a live dialog ends the screen at its hint footer; a pane
+merely *displaying* a quoted dialog has its own input box below and never
+matches. Screens containing `[PROMPT from ` (our own notification) are poison
+and never match — that's the loop guard.
+
+## Parent resolution (precedence)
+
+1. **Worker pane** (index > 0) → pane 0 of the same session.
+2. **Creator**: `agentwire new` records the calling tmux session in
+   `~/.agentwire/sessions/{name}/metadata.json` (`--created-by` overrides,
+   `--created-by ''` opts out; `agentwire kill` removes it).
+3. **`.agentwire.yml` `parent:`** field.
+4. None → human-only, unchanged.
+
+Depth-1 and local-machine only. Remote (`@machine`) parents are out of scope:
+each machine's own watchdog sweeps its panes; cross-machine delivery falls
+back to human-only.
+
+## Delivery safety
+
+Every delivery goes through `safe_deliver()` (also used by
+`agentwire notify-parent`, which fixed the dead `agentwire alert` path):
+
+- **target_dialog** — the target pane shows a live menu: paste + Enter would
+  *answer it*. Deferred, retried next tick.
+- **target_not_agent** — pane 0 runs a shell: pasted text would *execute*.
+- **target_parked** — usage-limit parked; a paste would corrupt the resume.
+- **target_gone** — session died.
+- Sends are verified (`send_verified`): a silent tmux paste failure reports
+  as undelivered and retries.
+
+The message itself is paraphrased — no `❯`, no option block, no dialog footer
+text — so it can never be re-detected as a dialog.
+
+## Answering (the race guard)
+
+The notification tells the parent to answer **only** via:
+
+```bash
+agentwire prompts answer -s <session> --pane <n> --expect <hash> <key> [key...]
+```
+
+It re-captures the pane, re-detects the prompt, and compares the content hash
+from the notification before sending any key. A human may have answered first
+via the portal — first answer wins, the loser no-ops. The portal's own
+respond keystroke is equally guarded (re-capture, skip if the dialog is gone)
+and pane-aware.
+
+Never answer with raw `send-keys`: a stray `1` types into the freed input
+box, a stray `Escape` aborts the child's in-flight turn.
+
+## Markers + dedupe
+
+`~/.agentwire/prompt-router/{session}.{pane}.json`, presence-based:
+
+- Dialog detected → routed once, marker written (sha256 of normalized
+  kind+question+options — stable across pane-width re-wraps).
+- Dialog gone on a later sweep → marker cleared (an identical future prompt
+  re-notifies).
+- Still unanswered after 10 min → re-notified (`RENOTIFY_TTL`).
+- Hook-source permission markers keep the sweep out (the portal owns that
+  prompt's lifecycle, ~6 min TTL).
+- The **idle-handler honors markers**: a pane with a routed prompt pending is
+  never summary-prompted or auto-killed.
+
+Events log: `~/.agentwire/prompt-router-events.jsonl` (`prompt_routed`,
+`route_deferred`, `no_parent`, `prompt_answered`, `route_failed`).
+
+## CLI
+
+```bash
+agentwire prompts status                  # pending prompt markers
+agentwire prompts tick                    # run one sweep now
+agentwire prompts answer -s S --expect H 2   # guarded answer
+agentwire prompts clear -s S --pane 1     # drop a marker
+```
+
+## Config
+
+```yaml
+prompt_router:
+  enabled: true            # default
+  exclude_sessions: []     # never route prompts from these sessions
+```
+
+## Troubleshooting
+
+- **Parent never notified**: check `agentwire prompts status` and the events
+  log. `no_parent` → the session has no creator metadata and no yml parent.
+  `route_deferred` with `target_dialog`/`target_not_agent` → the parent pane
+  wasn't safe to paste into; it retries every tick.
+- **Re-notification spam**: shouldn't happen (presence markers + sha256). If
+  it does, the dialog text likely redraws with changing content — file it
+  with the capture.
+- **Dialog text drift** (new Claude Code version): detectors anchor on real
+  captures in `tests/unit/test_prompt_router.py`; unmatched menu-like screens
+  land in the usage-limit `unmatched_dialog` events. Re-capture and update
+  the fixtures.
+- **pi sessions**: not covered (different dialog text, no hooks).
+
+## Related
+
+- [Usage-limit recovery](../usage-limit-recovery.md) — same watchdog, runs
+  first each tick.

--- a/docs/wiki/usage-limit-recovery.md
+++ b/docs/wiki/usage-limit-recovery.md
@@ -124,6 +124,11 @@ Events: `~/.agentwire/usage-limit-events.jsonl` (`session_parked`,
 `notify_sent`, `session_resumed`, `unmatched_dialog`, `reset_parse_failed`,
 `park_orphaned`, …).
 
+Since #276 the tick is the general pane watchdog: after the usage-limit
+sweep it also runs the [prompt-routing sweep](sessions/prompt-routing.md)
+(`prompt_router.tick()`) — ordering guarantees a usage-limit dialog is parked
+before prompt routing ever looks at the pane.
+
 ## Notifications
 
 Park and resume each send one email through the existing Resend channel

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -702,3 +702,126 @@ class TestVoicesCache:
         server._tts_get_voices = fail_fetch
         resp = await client.get("/api/voices")
         assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# Permission endpoints — parent routing + conditional respond (#276)
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionRouting:
+    async def _start_request(self, client, server, session="myproj", pane=2,
+                             tmux_session="real-sess"):
+        import asyncio
+
+        task = asyncio.create_task(client.post(f"/api/permission/{session}", json={
+            "tool_name": "Bash",
+            "tool_input": {"command": "git push"},
+            "pane_index": pane,
+            "tmux_session": tmux_session,
+        }))
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            sess = server.active_sessions.get(session)
+            if sess and sess.pending_permission:
+                return task, sess
+        raise AssertionError("pending_permission never appeared")
+
+    async def test_request_routes_to_parent_and_respond_sends_pane_keystroke(
+        self, portal_client
+    ):
+        client, server = portal_client
+        server._say_to_room = AsyncMock()
+        with patch(
+            "agentwire.server.prompt_router.notify_permission_request",
+            return_value="orch",
+        ) as notify, patch(
+            "agentwire.server.prompt_router.clear_marker"
+        ) as clear, patch(
+            "agentwire.server.prompt_router.screen_shows_live_menu",
+            return_value=True,
+        ), patch(
+            "agentwire.server.prompt_router._capture", return_value=""
+        ), patch("subprocess.run") as run:
+            task, sess = await self._start_request(client, server)
+            assert sess.pending_permission.pane_index == 2
+
+            # Routed with the real tmux session name + pane from the hook.
+            notify.assert_called_once()
+            assert notify.call_args[0][0] == "real-sess"
+            assert notify.call_args[0][1] == 2
+
+            resp = await client.post(
+                "/api/permission/myproj/respond", json={"decision": "allow"}
+            )
+            assert resp.status == 200
+            body = await (await task).json()
+            assert body["decision"] == "allow"
+
+            keystroke_calls = [
+                c for c in run.call_args_list
+                if c.args and c.args[0][:2] == ["agentwire", "send-keys"]
+            ]
+            assert keystroke_calls, "no keystroke sent"
+            assert keystroke_calls[0].args[0] == [
+                "agentwire", "send-keys", "-s", "real-sess", "--pane", "2", "1"
+            ]
+            clear.assert_called()
+
+    async def test_respond_skips_keystroke_when_dialog_gone(self, portal_client):
+        client, server = portal_client
+        server._say_to_room = AsyncMock()
+        with patch(
+            "agentwire.server.prompt_router.notify_permission_request",
+            return_value=None,
+        ), patch(
+            "agentwire.server.prompt_router.clear_marker"
+        ), patch(
+            # Parent (or human in the terminal) already answered: no live
+            # menu on the pane — a late keystroke must NOT be sent.
+            "agentwire.server.prompt_router.screen_shows_live_menu",
+            return_value=False,
+        ), patch(
+            "agentwire.server.prompt_router._capture", return_value=""
+        ), patch("subprocess.run") as run:
+            task, sess = await self._start_request(client, server)
+            resp = await client.post(
+                "/api/permission/myproj/respond", json={"decision": "deny"}
+            )
+            assert resp.status == 200
+            body = await (await task).json()
+            assert body["decision"] == "deny"
+
+            keystroke_calls = [
+                c for c in run.call_args_list
+                if c.args and c.args[0][:2] == ["agentwire", "send-keys"]
+            ]
+            assert keystroke_calls == []
+
+    async def test_broadcast_carries_parent_notified(self, portal_client):
+        client, server = portal_client
+        server._say_to_room = AsyncMock()
+        broadcasts = []
+
+        async def fake_broadcast(session, message):
+            broadcasts.append(message)
+
+        server._broadcast = fake_broadcast
+        with patch(
+            "agentwire.server.prompt_router.notify_permission_request",
+            return_value="orch",
+        ), patch(
+            "agentwire.server.prompt_router.clear_marker"
+        ), patch(
+            "agentwire.server.prompt_router.screen_shows_live_menu",
+            return_value=True,
+        ), patch(
+            "agentwire.server.prompt_router._capture", return_value=""
+        ), patch("subprocess.run"):
+            task, sess = await self._start_request(client, server)
+            requests = [m for m in broadcasts if m.get("type") == "permission_request"]
+            assert requests and requests[0]["parent_notified"] == "orch"
+            await client.post(
+                "/api/permission/myproj/respond", json={"decision": "allow"}
+            )
+            await task

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -625,6 +625,28 @@ class TestAnswer:
         prompt_router.answer("child", 0, expected, ["2"])
         assert prompt_router.read_marker("child", 0) is None
 
+    def test_marker_bridges_hook_payload_hash(self, monkeypatch):
+        # Hook-routed permission: --expect carries a payload-derived hash the
+        # screen can't reproduce; the marker (same hash, same kind) bridges
+        # it (live-verified failure mode: unanswerable prompt, 2026-06-11).
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PERMISSION_BASH)
+        prompt_router.write_marker(
+            "child", 0, kind="permission", hash="payload-hash", source="hook"
+        )
+        ok, msg = prompt_router.answer("child", 0, "payload-hash", ["1"])
+        assert ok
+        assert self.sent_keys == [["send-keys", "-t", "child.0", "1"]]
+
+    def test_marker_does_not_bridge_kind_mismatch(self, monkeypatch):
+        # A plan dialog live + a stale permission marker must still refuse.
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PLAN_APPROVAL)
+        prompt_router.write_marker(
+            "child", 0, kind="permission", hash="payload-hash", source="hook"
+        )
+        ok, msg = prompt_router.answer("child", 0, "payload-hash", ["1"])
+        assert not ok and "DIFFERENT prompt" in msg
+        assert self.sent_keys == []
+
 
 class TestSweep:
     PANES = "orch\t0\t2.1.170\t/p/orch\nchild\t0\t2.1.170\t/p/child\nshelly\t0\tzsh\t/p/x"
@@ -691,10 +713,12 @@ class TestSweep:
         assert len(self.routed) == 2
 
     def test_hook_marker_suppresses_permission_sweep(self):
+        # The hook's hash derives from the tool payload and NEVER equals the
+        # sweep's screen-derived hash — suppression must not be hash-gated
+        # (live-verified failure mode: double notification, 2026-06-11).
         self.screens["child.0"] = PERMISSION_BASH
-        info = detect_prompt(PERMISSION_BASH)
         prompt_router.write_marker(
-            "child", 0, kind="permission", hash=info.content_hash(),
+            "child", 0, kind="permission", hash="payload-derived-hash",
             source="hook", detected_at=prompt_router._now().isoformat(),
             notified_at=None, parent="orch", status="delivered",
         )
@@ -741,3 +765,61 @@ class TestContentHash:
         wide = PromptInfo(kind="plan", question="Would you like to proceed?")
         wrapped = PromptInfo(kind="plan", question="Would you like\nto   proceed?")
         assert wide.content_hash() == wrapped.content_hash()
+
+
+class TestRecordSessionCreator:
+    def test_records_and_merges(self, tmp_path, monkeypatch):
+        import agentwire.__main__ as cli
+
+        monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
+        cli.store_session_metadata("child", {"existing": "kept"})
+        cli._record_session_creator("child", "orch", via="new")
+        meta = cli.load_session_metadata("child")
+        assert meta["created_by"] == "orch"
+        assert meta["created_via"] == "new"
+        assert meta["existing"] == "kept"
+
+    def test_self_and_empty_creator_skipped(self, tmp_path, monkeypatch):
+        import agentwire.__main__ as cli
+
+        monkeypatch.setattr(cli, "CONFIG_DIR", tmp_path)
+        cli._record_session_creator("child", "child", via="new")
+        cli._record_session_creator("child", "", via="new")
+        cli._record_session_creator("child", None, via="new")
+        assert cli.load_session_metadata("child") == {}
+
+
+class TestNotifyPermissionRequest:
+    @pytest.fixture(autouse=True)
+    def _wire(self, router_home, monkeypatch):
+        self.routed = []
+        monkeypatch.setattr(
+            prompt_router,
+            "route_prompt",
+            lambda s, p, info, source="hook", project_path=None: self.routed.append(
+                (s, p, info, source)
+            )
+            or "orch",
+        )
+
+    def test_bash_summary(self):
+        prompt_router.notify_permission_request(
+            "child", 0, {"tool_name": "Bash", "tool_input": {"command": "git push"}}
+        )
+        _, _, info, source = self.routed[0]
+        assert info.kind == "permission" and source == "hook"
+        assert "git push" in info.question
+
+    def test_exit_plan_mode_maps_to_plan_kind(self):
+        # ExitPlanMode fires the hook but renders the plan dialog — the
+        # notification must carry the plan dialog's kind + options or the
+        # sweep/answer kinds disagree (live-verified 2026-06-11).
+        prompt_router.notify_permission_request(
+            "child", 0,
+            {"tool_name": "ExitPlanMode", "tool_input": {"plan": "Do the thing"}},
+        )
+        _, _, info, _ = self.routed[0]
+        assert info.kind == "plan"
+        assert info.summary == "Do the thing"
+        assert [o["number"] for o in info.options] == [1, 2, 3, 4]
+        assert info.options[0]["label"] == "Yes, and use auto mode"

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -374,6 +374,106 @@ class TestIsAgentPane:
             assert prompt_router.is_agent_pane("s", 0) is expected, command
 
 
+class TestScreenShowsLiveMenu:
+    def test_dialog_screens(self):
+        for screen in (
+            PERMISSION_BASH,
+            PERMISSION_WRITE,
+            PLAN_APPROVAL,
+            QUESTION_SIMPLE,
+            USAGE_LIMIT_DIALOG,
+        ):
+            assert prompt_router.screen_shows_live_menu(screen) is True
+
+    def test_safe_screens(self):
+        assert prompt_router.screen_shows_live_menu(PLAIN_OUTPUT) is False
+        assert prompt_router.screen_shows_live_menu("") is False
+
+    def test_routed_notification_with_dialog_below_is_still_unsafe(self):
+        # The detector's poison-marker rule must NOT weaken the pre-paste
+        # check: a screen with both our prefix AND a live menu stays unsafe.
+        assert prompt_router.screen_shows_live_menu(ROUTED_NOTIFICATION) is True
+
+
+class TestSafeDeliver:
+    @pytest.fixture(autouse=True)
+    def _safe_world(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_session_exists", lambda s: True)
+        monkeypatch.setattr(prompt_router, "_is_parked", lambda s: False)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PLAIN_OUTPUT)
+        self.sent = []
+        import agentwire.session_ready as session_ready
+
+        monkeypatch.setattr(
+            session_ready,
+            "send_verified",
+            lambda session, message, marker=None, **kw: self.sent.append(
+                (session, message)
+            )
+            or True,
+        )
+
+    def test_delivers_to_safe_target(self):
+        ok, reason = prompt_router.safe_deliver("orch", 0, "[PROMPT from w pane 1] hi")
+        assert ok and reason == "delivered"
+        assert self.sent == [("orch", "[PROMPT from w pane 1] hi")]
+
+    def test_refuses_dead_session(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_session_exists", lambda s: False)
+        assert prompt_router.safe_deliver("orch", 0, "x") == (False, "target_gone")
+        assert self.sent == []
+
+    def test_refuses_parked_session(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_is_parked", lambda s: True)
+        assert prompt_router.safe_deliver("orch", 0, "x") == (False, "target_parked")
+        assert self.sent == []
+
+    def test_refuses_shell_pane(self, monkeypatch):
+        # Pasting into a shell would EXECUTE the message text.
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: False)
+        assert prompt_router.safe_deliver("orch", 0, "x") == (False, "target_not_agent")
+        assert self.sent == []
+
+    def test_refuses_target_showing_dialog(self, monkeypatch):
+        # Paste + Enter into a live menu would CONFIRM the highlighted option.
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PERMISSION_BASH)
+        assert prompt_router.safe_deliver("orch", 0, "x") == (False, "target_dialog")
+        assert self.sent == []
+
+    def test_unverified_send_reported(self, monkeypatch):
+        import agentwire.session_ready as session_ready
+
+        monkeypatch.setattr(
+            session_ready, "send_verified", lambda *a, **kw: False
+        )
+        ok, reason = prompt_router.safe_deliver("orch", 0, "x")
+        assert not ok and reason == "delivery_unverified"
+
+
+class TestHookScriptsUseRealCommands:
+    HOOKS_DIR = (
+        __import__("pathlib").Path(__file__).resolve().parent.parent.parent
+        / "agentwire"
+        / "hooks"
+    )
+
+    def test_no_nonexistent_alert_command(self):
+        # `agentwire alert` never existed — every delivery through it was
+        # silently dropped (#276). Guard against reintroduction.
+        for script in ("idle-handler.sh", "queue-processor.sh"):
+            source = (self.HOOKS_DIR / script).read_text()
+            assert " alert " not in source.replace("alert-activity", ""), script
+
+    def test_queue_processor_uses_notify_parent_raw(self):
+        source = (self.HOOKS_DIR / "queue-processor.sh").read_text()
+        assert "notify-parent -q --raw --to" in source
+
+    def test_idle_handler_has_prompt_router_guard(self):
+        source = (self.HOOKS_DIR / "idle-handler.sh").read_text()
+        assert ".agentwire/prompt-router/" in source
+
+
 class TestContentHash:
     def test_stable_across_calls(self):
         a = detect_prompt(PERMISSION_BASH).content_hash()

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -1,0 +1,321 @@
+"""Tests for prompt_router — prompt detection, routing, markers, delivery.
+
+Dialog fixtures are real `tmux capture-pane -p` output captured 2026-06-11
+from Claude Code 2.x panes (fixture-gen session) and from the stuck worker
+incident that motivated #276.
+"""
+
+import pytest
+
+from agentwire import prompt_router
+from agentwire.prompt_router import PromptInfo, detect_prompt, parse_ask_options
+
+# =============================================================================
+# Fixtures — real captures, verbatim
+# =============================================================================
+
+PERMISSION_BASH = """\
+ ⚠ 1 setup issue: MCP · /doctor
+
+ ▎ Fable 5 is here! Our newest model for complex, long-running work
+ ▎ Included in your plan limits until Jun 22, then switch to usage credits to
+ ▎ continue.
+
+❯ Run this exact bash command: touch /tmp/fixture-test-file.txt
+
+⏺ Bash(touch /tmp/fixture-test-file.txt)
+  ⎿  Waiting…
+
+────────────────────────────────────────────────────────────────────────────────
+ Bash command
+
+   touch /tmp/fixture-test-file.txt
+   Create empty test file in /tmp
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to tmp/ from this project
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+"""
+
+PERMISSION_WRITE = """\
+❯ Now use your Edit tool to add a line saying hello to /tmp/fixture-gen/test.md
+  (create it with Write if needed)
+
+⏺ Write(/tmp/fixture-gen/test.md)
+
+────────────────────────────────────────────────────────────────────────────────
+ Create file
+ ../../../tmp/fixture-gen/test.md
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  1 hello
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+ Do you want to create test.md?
+ ❯ 1. Yes
+   2. Yes, allow all edits during this session (shift+tab)
+   3. No
+
+ Esc to cancel · Tab to amend
+"""
+
+# Narrow-pane wrap from the 2026-06-11 stuck-worker incident (#276).
+PERMISSION_WRAPPED = """\
+ This command requires
+ approval
+ Do you want to
+ proceed?
+ ❯ 1. Yes
+  2Yes, and    : gh
+   don’t ask   issue *
+   again for
+   3. No
+ Esc to cancel · Tab
+ to amend · ctrl+e to
+ explain
+"""
+
+PLAN_APPROVAL = """\
+
+────────────────────────────────────────────────────────────────────────────────
+ Ready to code?
+
+ Here is Claude's plan:
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+ Plan
+
+ Add a README.md to /private/tmp/fixture-gen briefly describing the folder's
+ purpose and its current contents (test.md).
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+
+────────────────────────────────────────────────────────────────────────────────
+ Claude has written up a plan and is ready to execute. Would you like to
+ proceed?
+
+ ❯ 1. Yes, and use auto mode
+   2. Yes, manually approve edits
+   3. No, refine with Ultraplan on Claude Code on the web
+   4. Tell Claude what to change
+      shift+tab to approve with this feedback
+
+ ctrl+g to edit in  VS Code  · ~/.claude/plans/robust-scribbling-blum.md
+"""
+
+QUESTION_SIMPLE = """\
+      1 hello
+
+⏺ Created /tmp/fixture-gen/test.md with a "hello" line.
+
+✻ Brewed for 9s
+
+❯ Use the AskUserQuestion tool to ask me one question: 'Which color should the
+  banner be?' with options 'Teal' (description: matches brand) and 'Orange'
+  (description: high contrast).
+────────────────────────────────────────────────────────────────────────────────
+ ☐ Banner color
+
+Which color should the banner be?
+
+❯ 1. Teal
+     matches brand
+  2. Orange
+     high contrast
+  3. Type something.
+────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+"""
+
+QUESTION_TABBED = """\
+❯ Use AskUserQuestion ONCE with TWO questions in the same call: question 1
+  header 'Color', question 'Which color?' options Teal/Orange; question 2
+  header 'Size', question 'Which size?' options Small/Large.
+────────────────────────────────────────────────────────────────────────────────
+←  ☐ Color  ☐ Size  ✔ Submit  →
+
+Which color?
+
+❯ 1. Teal
+     Teal color option
+  2. Orange
+     Orange color option
+  3. Type something.
+────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+# A pane DISPLAYING a captured permission dialog: the quote sits mid-screen
+# with the pane's own input box + status bar below. Must never match.
+QUOTED_DIALOG = """\
+  ──────────────────────────────────────────────────────────────────────────────
+  ──
+   Bash command
+
+     touch /tmp/fixture-test-file.txt
+     Create empty test file in /tmp
+
+   Do you want to proceed?
+   ❯ 1. Yes
+     2. Yes, and always allow access to tmp/ from this project
+     3. No
+
+   Esc to cancel · Tab to amend · ctrl+e to explain
+
+✻ Crunched for 8s
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  /private/tmp/fixture-gen                           claude-fable-5  $2.02  3m
+  [██████████████████████████████████████████████████████████████████░░░░] 95%
+  ⏸ plan mode on (shift+tab to cycle) · ← for agents
+"""
+
+USAGE_LIMIT_DIALOG = """\
+ You've hit your session limit · resets 11:40pm (America/Toronto)
+
+ What do you want to do?
+ ❯ 1. Stop and wait for limit to reset
+   2. Switch to usage credits
+   3. Switch to Team plan
+
+ Enter to confirm · Esc to cancel
+"""
+
+PLAIN_OUTPUT = """\
+⏺ Running tests...
+  ⎿  142 passed in 3.2s
+
+✻ Baked for 12s
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ~/projects/demo                                    claude-fable-5  $0.10  1m
+"""
+
+ROUTED_NOTIFICATION = """\
+❯ working on the task
+
+[PROMPT from worker-1 pane 0] kind=permission Claude wants to run: git push
+Options: Yes, Yes always, No. Deadline: 300s.
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend
+"""
+
+
+# =============================================================================
+# Detection
+# =============================================================================
+
+
+class TestDetectPrompt:
+    def test_permission_bash(self):
+        info = detect_prompt(PERMISSION_BASH)
+        assert info is not None
+        assert info.kind == "permission"
+        assert info.question == "Do you want to proceed?"
+        assert [o["number"] for o in info.options] == [1, 2, 3]
+        assert info.options[0]["label"] == "Yes"
+        assert "touch /tmp/fixture-test-file.txt" in info.summary
+
+    def test_permission_write(self):
+        info = detect_prompt(PERMISSION_WRITE)
+        assert info is not None
+        assert info.kind == "permission"
+        assert info.question == "Do you want to create test.md?"
+        assert len(info.options) == 3
+
+    def test_permission_wrapped_narrow_pane(self):
+        info = detect_prompt(PERMISSION_WRAPPED)
+        assert info is not None
+        assert info.kind == "permission"
+        assert "Do you want to" in info.question
+
+    def test_plan_approval(self):
+        info = detect_prompt(PLAN_APPROVAL)
+        assert info is not None
+        assert info.kind == "plan"
+        assert [o["number"] for o in info.options] == [1, 2, 3, 4]
+        assert info.options[0]["label"] == "Yes, and use auto mode"
+
+    def test_plan_not_misdetected_as_question(self):
+        # ASK_PATTERN_SIMPLE would happily match "proceed?\n\n❯ 1." —
+        # ordering must let the plan detector claim it first.
+        info = detect_prompt(PLAN_APPROVAL)
+        assert info.kind == "plan"
+
+    def test_question_simple(self):
+        info = detect_prompt(QUESTION_SIMPLE)
+        assert info is not None
+        assert info.kind == "question"
+        assert info.question == "Which color should the banner be?"
+        labels = [o["label"] for o in info.options]
+        assert "Teal" in labels and "Orange" in labels
+        # Option rendered after the separator rule is still captured.
+        assert "Chat about this" in labels
+
+    def test_question_tabbed(self):
+        info = detect_prompt(QUESTION_TABBED)
+        assert info is not None
+        assert info.kind == "question"
+        assert info.question == "Which color?"
+
+    def test_quoted_dialog_not_live(self):
+        assert detect_prompt(QUOTED_DIALOG) is None
+
+    def test_usage_limit_dialog_excluded(self):
+        assert detect_prompt(USAGE_LIMIT_DIALOG) is None
+
+    def test_plain_output(self):
+        assert detect_prompt(PLAIN_OUTPUT) is None
+
+    def test_empty_screen(self):
+        assert detect_prompt("") is None
+        assert detect_prompt("\n\n  \n") is None
+
+    def test_routed_notification_is_poison(self):
+        # A screen containing our own message prefix must never be detected,
+        # even if a dialog is also visible — prevents notification loops.
+        assert detect_prompt(ROUTED_NOTIFICATION) is None
+
+
+class TestParseAskOptions:
+    def test_labels_and_descriptions(self):
+        block = "❯ 1. Teal\n     matches brand\n  2. Orange\n     high contrast\n"
+        options = parse_ask_options(block)
+        assert options == [
+            {"number": 1, "label": "Teal", "description": "matches brand"},
+            {"number": 2, "label": "Orange", "description": "high contrast"},
+        ]
+
+    def test_strips_ansi(self):
+        block = "\x1b[1m❯ 1. Yes\x1b[0m\n  2. No\n"
+        options = parse_ask_options(block)
+        assert [o["label"] for o in options] == ["Yes", "No"]
+
+
+class TestContentHash:
+    def test_stable_across_calls(self):
+        a = detect_prompt(PERMISSION_BASH).content_hash()
+        b = detect_prompt(PERMISSION_BASH).content_hash()
+        assert a == b
+
+    def test_differs_by_prompt(self):
+        a = detect_prompt(PERMISSION_BASH).content_hash()
+        b = detect_prompt(PERMISSION_WRITE).content_hash()
+        assert a != b
+
+    def test_wrap_invariant(self):
+        # Same logical prompt re-wrapped at a different width hashes equal.
+        wide = PromptInfo(kind="plan", question="Would you like to proceed?")
+        wrapped = PromptInfo(kind="plan", question="Would you like\nto   proceed?")
+        assert wide.content_hash() == wrapped.content_hash()

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -823,3 +823,22 @@ class TestNotifyPermissionRequest:
         assert info.summary == "Do the thing"
         assert [o["number"] for o in info.options] == [1, 2, 3, 4]
         assert info.options[0]["label"] == "Yes, and use auto mode"
+
+    def test_ask_user_question_maps_to_question_kind(self):
+        # AskUserQuestion fires the hook in prompted sessions (drill-verified
+        # 2026-06-11); the payload carries the question + options.
+        prompt_router.notify_permission_request(
+            "child", 0,
+            {"tool_name": "AskUserQuestion", "tool_input": {"questions": [{
+                "question": "Ship it?",
+                "header": "Ship",
+                "options": [
+                    {"label": "Yes", "description": "ship now"},
+                    {"label": "No", "description": "hold"},
+                ],
+            }]}},
+        )
+        _, _, info, source = self.routed[0]
+        assert info.kind == "question" and source == "hook"
+        assert info.question == "Ship it?"
+        assert [o["label"] for o in info.options] == ["Yes", "No"]

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -303,6 +303,77 @@ class TestParseAskOptions:
         assert [o["label"] for o in options] == ["Yes", "No"]
 
 
+class TestResolveParent:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_SESSIONS_META_DIR", tmp_path / "sessions")
+        monkeypatch.setattr(prompt_router, "_session_exists", lambda s: True)
+        monkeypatch.setattr(prompt_router, "_parent_from_config", lambda p: None)
+        self.tmp_path = tmp_path
+
+    def _write_creator(self, session, creator):
+        d = self.tmp_path / "sessions" / session
+        d.mkdir(parents=True)
+        (d / "metadata.json").write_text(
+            '{"created_by": "%s", "created_via": "new"}' % creator
+        )
+
+    def test_worker_pane_routes_to_pane_zero(self):
+        assert prompt_router.resolve_parent("orch", 3) == ("orch", 0)
+
+    def test_creator_metadata_wins(self, monkeypatch):
+        self._write_creator("child", "orch")
+        monkeypatch.setattr(prompt_router, "_parent_from_config", lambda p: "yml-parent")
+        assert prompt_router.resolve_parent("child", 0) == ("orch", 0)
+
+    def test_yml_parent_fallback(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_parent_from_config", lambda p: "yml-parent")
+        assert prompt_router.resolve_parent("child", 0) == ("yml-parent", 0)
+
+    def test_no_parent(self):
+        assert prompt_router.resolve_parent("standalone", 0) is None
+
+    def test_self_creator_skipped(self):
+        self._write_creator("child", "child")
+        assert prompt_router.resolve_parent("child", 0) is None
+
+    def test_dead_creator_falls_through(self, monkeypatch):
+        self._write_creator("child", "gone")
+        monkeypatch.setattr(
+            prompt_router, "_session_exists", lambda s: s != "gone"
+        )
+        monkeypatch.setattr(prompt_router, "_parent_from_config", lambda p: "yml-parent")
+        assert prompt_router.resolve_parent("child", 0) == ("yml-parent", 0)
+
+    def test_self_yml_parent_skipped(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_parent_from_config", lambda p: "child")
+        assert prompt_router.resolve_parent("child", 0) is None
+
+    def test_machine_suffix_stripped(self):
+        self._write_creator("child", "orch")
+        assert prompt_router.resolve_parent("child@studio", 0) == ("orch", 0)
+
+
+class TestIsAgentPane:
+    def test_command_classification(self, monkeypatch):
+        cases = {
+            "node": True,
+            "claude": True,
+            "2.1.170": True,
+            "zsh": False,
+            "bash": False,
+            "vim": False,
+            "less": False,
+            "python3": False,
+            "": False,
+        }
+        for command, expected in cases.items():
+            monkeypatch.setattr(
+                prompt_router, "pane_command", lambda s, p, c=command: c
+            )
+            assert prompt_router.is_agent_pane("s", 0) is expected, command
+
+
 class TestContentHash:
     def test_stable_across_calls(self):
         a = detect_prompt(PERMISSION_BASH).content_hash()

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -474,6 +474,257 @@ class TestHookScriptsUseRealCommands:
         assert ".agentwire/prompt-router/" in source
 
 
+@pytest.fixture
+def router_home(tmp_path, monkeypatch):
+    """Isolate marker state + events under a temp dir."""
+    monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
+    monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "events.jsonl")
+    return tmp_path
+
+
+def _events(tmp_path):
+    path = tmp_path / "events.jsonl"
+    if not path.exists():
+        return []
+    import json
+
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+class TestMarkers:
+    def test_roundtrip(self, router_home):
+        prompt_router.write_marker("sess", 1, kind="plan", hash="abc")
+        marker = prompt_router.read_marker("sess", 1)
+        assert marker["kind"] == "plan" and marker["hash"] == "abc"
+        prompt_router.clear_marker("sess", 1)
+        assert prompt_router.read_marker("sess", 1) is None
+
+    def test_worktree_session_names_nest(self, router_home):
+        prompt_router.write_marker("proj/branch", 0, kind="question", hash="x")
+        assert prompt_router.read_marker("proj/branch", 0)["hash"] == "x"
+        assert (prompt_router.STATE_DIR / "proj" / "branch.0.json").exists()
+
+    def test_list_markers_skips_dotfiles(self, router_home):
+        prompt_router.write_marker("a", 0, kind="plan", hash="h1")
+        prompt_router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (prompt_router.STATE_DIR / ".tick.lock").write_text("")
+        assert len(prompt_router.list_markers()) == 1
+
+
+class TestBuildMessage:
+    def test_message_is_not_detectable_as_dialog(self, router_home):
+        info = detect_prompt(PERMISSION_BASH)
+        message = prompt_router.build_message("worker", 0, info)
+        # The notification must never look like a live dialog to the sweep
+        # (self-trigger loop) or to the pre-paste safety check.
+        assert "❯" not in message
+        assert "Esc to cancel" not in message
+        assert "Enter to confirm" not in message
+        assert detect_prompt(message) is None
+        assert message.startswith("[PROMPT from worker pane 0] kind=permission")
+
+    def test_message_carries_answer_contract(self, router_home):
+        info = detect_prompt(PLAN_APPROVAL)
+        message = prompt_router.build_message("child", 0, info)
+        assert f"--expect {info.content_hash()}" in message
+        assert "agentwire prompts answer -s 'child' --pane 0" in message
+        assert "1=Yes, and use auto mode" in message
+
+
+class TestRoutePrompt:
+    @pytest.fixture(autouse=True)
+    def _wire(self, router_home, monkeypatch):
+        self.home = router_home
+        self.delivered = []
+        monkeypatch.setattr(
+            prompt_router, "resolve_parent", lambda s, p, pp=None: ("orch", 0)
+        )
+        monkeypatch.setattr(
+            prompt_router,
+            "safe_deliver",
+            lambda ts, tp, text: self.delivered.append((ts, text)) or (True, "delivered"),
+        )
+
+    def test_routes_and_marks(self):
+        info = detect_prompt(PLAN_APPROVAL)
+        parent = prompt_router.route_prompt("child", 0, info)
+        assert parent == "orch"
+        assert self.delivered[0][0] == "orch"
+        marker = prompt_router.read_marker("child", 0)
+        assert marker["status"] == "delivered" and marker["notified_at"]
+        assert _events(self.home)[0]["event"] == "prompt_routed"
+
+    def test_no_parent_marks_without_delivery(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
+        info = detect_prompt(PLAN_APPROVAL)
+        assert prompt_router.route_prompt("solo", 0, info) is None
+        assert self.delivered == []
+        assert prompt_router.read_marker("solo", 0)["status"] == "no_parent"
+        assert _events(self.home)[0]["event"] == "no_parent"
+
+    def test_deferred_delivery_marks_unnotified(self, monkeypatch):
+        monkeypatch.setattr(
+            prompt_router, "safe_deliver", lambda *a: (False, "target_dialog")
+        )
+        info = detect_prompt(PLAN_APPROVAL)
+        assert prompt_router.route_prompt("child", 0, info) is None
+        marker = prompt_router.read_marker("child", 0)
+        assert marker["status"] == "target_dialog" and marker["notified_at"] is None
+
+    def test_never_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            prompt_router, "resolve_parent",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        info = detect_prompt(PLAN_APPROVAL)
+        assert prompt_router.route_prompt("child", 0, info) is None
+        assert _events(self.home)[0]["event"] == "route_failed"
+
+
+class TestAnswer:
+    @pytest.fixture(autouse=True)
+    def _wire(self, router_home, monkeypatch):
+        self.sent_keys = []
+
+        def fake_tmux(args, timeout=5):
+            self.sent_keys.append(args)
+
+            class R:
+                returncode = 0
+                stdout = ""
+
+            return R()
+
+        monkeypatch.setattr(prompt_router, "_tmux", fake_tmux)
+
+    def test_answers_live_matching_prompt(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PLAN_APPROVAL)
+        expected = detect_prompt(PLAN_APPROVAL).content_hash()
+        ok, msg = prompt_router.answer("child", 0, expected, ["2"])
+        assert ok
+        assert self.sent_keys == [["send-keys", "-t", "child.0", "2"]]
+
+    def test_refuses_when_prompt_gone(self, monkeypatch):
+        # Human answered first via portal → no-op, no stray keystroke.
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PLAIN_OUTPUT)
+        ok, msg = prompt_router.answer("child", 0, "whatever", ["2"])
+        assert not ok and "no live prompt" in msg
+        assert self.sent_keys == []
+
+    def test_refuses_when_prompt_changed(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PERMISSION_BASH)
+        plan_hash = detect_prompt(PLAN_APPROVAL).content_hash()
+        ok, msg = prompt_router.answer("child", 0, plan_hash, ["1"])
+        assert not ok and "DIFFERENT prompt" in msg
+        assert self.sent_keys == []
+
+    def test_clears_marker_on_answer(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: PLAN_APPROVAL)
+        prompt_router.write_marker("child", 0, kind="plan", hash="h")
+        expected = detect_prompt(PLAN_APPROVAL).content_hash()
+        prompt_router.answer("child", 0, expected, ["2"])
+        assert prompt_router.read_marker("child", 0) is None
+
+
+class TestSweep:
+    PANES = "orch\t0\t2.1.170\t/p/orch\nchild\t0\t2.1.170\t/p/child\nshelly\t0\tzsh\t/p/x"
+
+    @pytest.fixture(autouse=True)
+    def _wire(self, router_home, monkeypatch):
+        self.home = router_home
+        self.screens = {"orch.0": PLAIN_OUTPUT, "child.0": PLAN_APPROVAL,
+                        "shelly.0": PLAN_APPROVAL}
+        self.routed = []
+
+        def fake_tmux(args, timeout=5):
+            class R:
+                returncode = 0
+                stdout = self.PANES
+
+            return R()
+
+        monkeypatch.setattr(prompt_router, "_tmux", fake_tmux)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: self.screens.get(t, ""))
+        monkeypatch.setattr(prompt_router, "_router_config", lambda: (True, set()))
+        monkeypatch.setattr(prompt_router, "_is_parked", lambda s: False)
+        monkeypatch.setattr(
+            prompt_router, "resolve_parent", lambda s, p, pp=None: ("orch", 0)
+        )
+        monkeypatch.setattr(
+            prompt_router,
+            "safe_deliver",
+            lambda ts, tp, text: self.routed.append(ts) or (True, "delivered"),
+        )
+
+    def test_routes_dialog_and_skips_shell_pane(self):
+        result = prompt_router.sweep()
+        assert [e["session"] for e in result["routed"]] == ["child"]
+        # zsh pane shows the same dialog text but is not an agent pane.
+        assert all(e["session"] != "shelly" for e in result["routed"])
+
+    def test_second_sweep_is_silent(self):
+        prompt_router.sweep()
+        result = prompt_router.sweep()
+        assert result["routed"] == []
+        assert [e["session"] for e in result["active"]] == ["child"]
+        assert len(self.routed) == 1
+
+    def test_marker_cleared_when_prompt_gone(self):
+        prompt_router.sweep()
+        assert prompt_router.read_marker("child", 0)
+        self.screens["child.0"] = PLAIN_OUTPUT
+        prompt_router.sweep()
+        assert prompt_router.read_marker("child", 0) is None
+
+    def test_renotifies_after_ttl(self, monkeypatch):
+        prompt_router.sweep()
+        marker = prompt_router.read_marker("child", 0)
+        # Backdate the notification past the TTL.
+        from datetime import timedelta as td
+
+        old = (prompt_router._now() - prompt_router.RENOTIFY_TTL - td(minutes=1)).isoformat()
+        marker["notified_at"] = old
+        prompt_router.write_marker("child", 0, **{k: v for k, v in marker.items()
+                                                  if k not in ("session", "pane")})
+        result = prompt_router.sweep()
+        assert [e["session"] for e in result["routed"]] == ["child"]
+        assert len(self.routed) == 2
+
+    def test_hook_marker_suppresses_permission_sweep(self):
+        self.screens["child.0"] = PERMISSION_BASH
+        info = detect_prompt(PERMISSION_BASH)
+        prompt_router.write_marker(
+            "child", 0, kind="permission", hash=info.content_hash(),
+            source="hook", detected_at=prompt_router._now().isoformat(),
+            notified_at=None, parent="orch", status="delivered",
+        )
+        result = prompt_router.sweep()
+        assert result["routed"] == []
+        assert self.routed == []
+
+    def test_excluded_session_skipped(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_router_config", lambda: (True, {"child"}))
+        result = prompt_router.sweep()
+        assert result["routed"] == []
+
+    def test_disabled_config(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_router_config", lambda: (False, set()))
+        assert prompt_router.sweep() == {"routed": [], "deferred": [], "active": []}
+
+    def test_parked_session_skipped(self, monkeypatch):
+        monkeypatch.setattr(prompt_router, "_is_parked", lambda s: s == "child")
+        result = prompt_router.sweep()
+        assert result["routed"] == []
+
+    def test_gc_drops_orphaned_old_markers(self):
+        from datetime import timedelta as td
+
+        old = (prompt_router._now() - prompt_router.MARKER_GC_TTL - td(minutes=1)).isoformat()
+        prompt_router.write_marker("dead-sess", 2, kind="plan", hash="h", detected_at=old)
+        prompt_router.sweep()
+        assert prompt_router.read_marker("dead-sess", 2) is None
+
+
 class TestContentHash:
     def test_stable_across_calls(self):
         a = detect_prompt(PERMISSION_BASH).content_hash()


### PR DESCRIPTION
## What

Interactive prompts hitting a child/worker session — permission confirmations, plan-mode approvals (ExitPlanMode), AskUserQuestion dialogs — now route as text notifications to the session's parent/orchestrator, alongside the unchanged human paths (audio + portal). The parent inspects the pane and answers through a guarded compare-and-send primitive. No parent → behavior byte-identical to before. Never auto-answers.

Closes #276

## Architecture

- **Hook path (seconds):** `agentwire-permission.sh` ships `pane_index` + the real tmux session name; `/api/permission/{session}` routes to the resolved parent after the restricted-mode branch, broadcasts `parent_notified`, mentions it in TTS. ExitPlanMode turns out to fire this hook too (live-verified) — mapped to `kind=plan` with the real plan-dialog options.
- **Sweep path (≤60s):** `prompt_router.tick()` rides the existing limits watchdog (`agentwire limits tick` runs the usage-limit sweep first, so its dialog parks before we look). Detectors built from verbatim live captures, with a liveness footer check (quoted dialogs never match) and a poison marker (`[PROMPT from ` on screen → never match; loop-proof).
- **Parent resolution:** worker pane → pane 0; else creator recorded at `agentwire new` (`--created-by` override / `''` opt-out, cleaned on `kill`); else `.agentwire.yml` `parent:`. Depth-1, local-only.
- **Delivery safety (`safe_deliver`)**: refuses targets showing a live menu (paste+Enter would answer it), bare-shell panes (paste would execute), parked sessions; verified paste; deferred deliveries retry each tick.
- **Guarded answer:** `agentwire prompts answer -s S --pane N --expect <hash> <key>` re-detects and hash-compares before sending; the portal's respond keystroke is equally conditional (re-capture, skip if dialog gone) and now pane-aware. First answer wins, the loser no-ops.
- **Markers:** presence-based dedupe under `~/.agentwire/prompt-router/` (sha256 of normalized content — also fixed `_log_unmatched`'s per-process `hash()` no-op dedupe), 10-min renotify TTL, idle-handler honors markers (never summary-pastes or reaps a blocked pane).

## Pre-existing bug fixed en route

**Worker→parent delivery was dead**: `idle-handler.sh` and `queue-processor.sh` called `agentwire alert` — a command that has never existed — and the processor dropped each message after the failed attempt (a June-10 worker summary was still stranded in the queue). Delivery now goes through `notify-parent` (`--raw` for pre-headered messages) behind the same safety gates, with requeue-with-attempts, an mkdir lock around queue mutation, and verified pastes.

## Surface changes

- New: `agentwire prompts tick|status|clear|answer`, `prompt_router:` config block (`enabled`, `exclude_sessions`), events at `~/.agentwire/prompt-router-events.jsonl`
- Changed: `agentwire new --created-by`, `agentwire send-keys --pane`, `agentwire notify-parent --raw`, permission hook payload + curl 310s, `PendingPermission.pane_index`
- Docs: `docs/wiki/sessions/prompt-routing.md`, INDEX, usage-limit cross-link, CLAUDE.md section, skills (cli / mcp-tools / project-config)

## Verification

- 1324 unit tests pass; 66 in `test_prompt_router.py` against verbatim fixtures (permission Bash/Write/narrow-wrapped, plan dialog, simple+tabbed AskUserQuestion, quoted-dialog negative, usage-limit exclusion, routed-notification poison)
- **Live on this machine**, full cycles: child permission prompt → `[PROMPT ...]` in the parent ~5s → `prompts answer` → child unblocked, marker cleared. Same for plan approval (hook) and AskUserQuestion (sweep). No-parent session → `no_parent` event, human-only unchanged. Manual `prompts tick` while a hook-routed dialog is live → suppressed, no double-notify.
- Live testing caught and fixed 3 real bugs unit tests missed (wrong helper name crashing `agentwire new`; hash/kind-gated sweep suppression double-notifying; unanswerable payload-derived hashes — now bridged via the marker).

Built by [dotdev.dev](https://dotdev.dev)
