### PR TITLE
mobile: Sessions | Services tabs, per-session transcripts, session-state visuals

### DIFF
--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -456,7 +456,8 @@ def route_prompt(
         if parent is None:
             write_marker(
                 session, pane_index,
-                kind=info.kind, hash=content_hash, source=source,
+                kind=info.kind, question=info.question,
+                hash=content_hash, source=source,
                 parent=None, status="no_parent",
                 detected_at=_now().isoformat(), notified_at=None,
             )
@@ -469,7 +470,8 @@ def route_prompt(
         )
         write_marker(
             session, pane_index,
-            kind=info.kind, hash=content_hash, source=source,
+            kind=info.kind, question=info.question,
+            hash=content_hash, source=source,
             parent=target_session, status=reason,
             detected_at=_now().isoformat(),
             notified_at=_now().isoformat() if delivered else None,

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1434,6 +1434,55 @@ class AgentWireServer:
 
         return "active" if time_since_last_output <= threshold else "idle"
 
+    def _compute_session_states(self, sessions: list[dict]) -> None:
+        """Glanceable per-session state for the mobile page (#290).
+
+        Annotates each session dict with `state` (and `state_kind` /
+        `state_hint` when blocked on a prompt). Precedence:
+
+          off         pane 0 runs no agent (Claude exited → bare shell);
+                      also the fallback for anything unrecognized/errored —
+                      when in doubt show off, never a false working/idle
+          needs_input prompt-router marker or live pending_permission
+          working     recent output (activity_threshold_seconds)
+          idle        agent present, nothing pending, no recent output
+        """
+        from . import prompt_router
+
+        try:
+            markers: dict[str, dict] = {}
+            for m in prompt_router.list_markers():
+                markers.setdefault(str(m.get("session", "")).split("@")[0], m)
+        except Exception:
+            markers = {}
+
+        for s in sessions:
+            name = s.get("name", "")
+            state, kind, hint = "off", None, None
+            try:
+                if name and prompt_router.is_agent_pane(name, 0):
+                    marker = markers.get(name.split("@")[0])
+                    session_obj = self.active_sessions.get(name)
+                    pending = session_obj.pending_permission if session_obj else None
+                    if marker:
+                        state = "needs_input"
+                        kind = marker.get("kind")
+                        hint = marker.get("question") or None
+                    elif pending:
+                        state = "needs_input"
+                        kind = "permission"
+                        tool = pending.request.get("tool_name", "")
+                        hint = f"Claude wants to use {tool}" if tool else "Permission requested"
+                    elif self._get_global_session_activity(name) == "active":
+                        state = "working"
+                    else:
+                        state = "idle"
+            except Exception:
+                state, kind, hint = "off", None, None
+            s["state"] = state
+            s["state_kind"] = kind
+            s["state_hint"] = hint
+
     async def monitor_all_sessions(self):
         """Background task to monitor all session activity for dashboard indicators.
 
@@ -2367,6 +2416,10 @@ class AgentWireServer:
             # Add activity status
             for s in sessions:
                 s["activity"] = self._get_global_session_activity(s.get("name", ""))
+
+            # Computed state (off/needs_input/working/idle) — shells out to
+            # tmux per session, so keep it off the event loop.
+            await asyncio.to_thread(self._compute_session_states, sessions)
 
             return web.json_response({"sessions": sessions})
         except Exception as e:

--- a/agentwire/static/css/mobile.css
+++ b/agentwire/static/css/mobile.css
@@ -16,6 +16,10 @@
     --error: #f87171;
     --primary-subtle: rgba(74, 222, 128, 0.3);
     --primary-glow: rgba(74, 222, 128, 0.4);
+    --attention: #fbbf24;
+    --attention-subtle: rgba(251, 191, 36, 0.12);
+    --attention-glow: rgba(251, 191, 36, 0.25);
+    --off: #4b5563;
 }
 
 * {
@@ -157,8 +161,9 @@ html, body {
 
 .mobile-session {
     display: flex;
-    align-items: center;
-    gap: var(--spacing-base);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
     width: 100%;
     padding: 12px;
     border: 1px solid var(--chrome-border);
@@ -175,6 +180,12 @@ html, body {
     background: var(--hover);
 }
 
+.mobile-session-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-base);
+}
+
 .mobile-session-name {
     flex: 1;
     overflow: hidden;
@@ -182,16 +193,79 @@ html, body {
     white-space: nowrap;
 }
 
-.mobile-session-activity {
-    width: 8px;
-    height: 8px;
+/* Session-state visuals (#290): working / idle / needs_input / off.
+   Animations only on working + needs_input cards — idle and off stay
+   static so a screenful of quiet sessions costs nothing. */
+
+.mobile-session-state {
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
     background: var(--chrome-border);
     flex-shrink: 0;
 }
 
-.mobile-session-activity.active {
+.mobile-session.state-working {
+    border-color: var(--primary-subtle);
+    animation: mobile-breathe 2.4s ease-in-out infinite;
+}
+
+.mobile-session.state-working .mobile-session-state {
     background: var(--accent);
+}
+
+@keyframes mobile-breathe {
+    50% {
+        border-color: var(--accent);
+        box-shadow: 0 0 12px var(--primary-glow);
+    }
+}
+
+.mobile-session.state-idle .mobile-session-state {
+    background: var(--text-muted);
+}
+
+.mobile-session.state-needs_input {
+    border-color: var(--attention);
+    background: var(--attention-subtle);
+    animation: mobile-attention 1.1s ease-in-out infinite;
+}
+
+.mobile-session.state-needs_input .mobile-session-state {
+    background: var(--attention);
+}
+
+@keyframes mobile-attention {
+    50% { box-shadow: 0 0 0 5px var(--attention-glow); }
+}
+
+.mobile-session.state-off {
+    opacity: 0.55;
+}
+
+.mobile-session.state-off .mobile-session-state {
+    background: var(--off);
+}
+
+.mobile-session-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mobile-session.state-needs_input .mobile-session-hint {
+    color: var(--attention);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .mobile-session,
+    .mobile-status::before,
+    .mobile-voice-indicator,
+    .mobile-ptt {
+        animation: none !important;
+    }
 }
 
 .mobile-empty {
@@ -305,6 +379,39 @@ html, body {
 
 .mobile-status.error {
     color: var(--error);
+}
+
+/* "Talking to X" mirrors the selected session's state (#290) */
+
+.mobile-status.state-working::before,
+.mobile-status.state-idle::before,
+.mobile-status.state-needs_input::before,
+.mobile-status.state-off::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 6px;
+    background: var(--chrome-border);
+}
+
+.mobile-status.state-working::before {
+    background: var(--accent);
+    animation: mobile-pulse 1.2s ease-in-out infinite;
+}
+
+.mobile-status.state-idle::before {
+    background: var(--text-muted);
+}
+
+.mobile-status.state-needs_input::before {
+    background: var(--attention);
+    animation: mobile-attention 1.1s ease-in-out infinite;
+}
+
+.mobile-status.state-off::before {
+    background: var(--off);
 }
 
 .mobile-ptt {

--- a/agentwire/static/css/mobile.css
+++ b/agentwire/static/css/mobile.css
@@ -105,11 +105,37 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: var(--spacing-base);
     padding: var(--spacing-base) calc(var(--spacing-base) * 1.5) 0;
-    font-size: 12px;
+}
+
+/* Sessions | Services tabs (#288) */
+
+.mobile-tabs {
+    display: flex;
+    gap: 6px;
+    flex: 1;
+}
+
+.mobile-tab {
+    flex: 1;
+    max-width: 160px;
+    min-height: 40px;
+    padding: 8px 14px;
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    background: var(--chrome);
+    color: var(--text-muted);
+    font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.mobile-tab.selected {
+    border-color: var(--accent);
+    background: var(--hover);
+    color: var(--text);
 }
 
 .mobile-refresh {

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -16,7 +16,7 @@
 
 import { apiFetch } from './api.js';
 import { normalizeMachine, sameMachine } from './session-id.js';
-import { isService } from './sidebar/sessions-section.js';
+import { isService } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 
 const PILL_TYPES = ['feat', 'fix', 'chore', 'refactor', 'docs'];

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -14,6 +14,7 @@
  */
 
 import { apiFetch, wsProtocols } from './api.js';
+import { isService, loadCustomServices } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 import * as browserTts from './voice/browser-tts.js';
 import { voicePromptWrap } from './voice/prompt.js';
@@ -22,6 +23,8 @@ const SESSION_KEY = 'agentwire_mobile_session';
 
 const els = {
     sessionList: document.getElementById('sessionList'),
+    tabSessions: document.getElementById('tabSessions'),
+    tabServices: document.getElementById('tabServices'),
     refresh: document.getElementById('refreshSessions'),
     transcript: document.getElementById('transcript'),
     editBar: document.getElementById('editBar'),
@@ -38,6 +41,7 @@ const els = {
 let voiceStatus = null;
 let sessions = [];
 let selectedSession = null;
+let activeTab = 'sessions'; // 'sessions' | 'services' — classification shared with the desktop sidebar
 let pttState = 'idle'; // idle | recording | processing
 let sttCancelled = false;
 let mediaRecorder = null;
@@ -52,7 +56,18 @@ function setStatus(text, isError = false) {
     els.status.classList.toggle('error', isError);
 }
 
-function addEntry(kind, text, label = null) {
+// Per-session conversations (#289): entries are keyed by session and the
+// visible transcript follows the selection. In-memory only — survives session
+// switches, not reloads.
+const transcripts = new Map(); // session name → [{kind, text, label}]
+
+function addEntry(session, kind, text, label = null) {
+    if (!transcripts.has(session)) transcripts.set(session, []);
+    transcripts.get(session).push({ kind, text, label });
+    if (session === selectedSession) appendEntryEl(kind, text, label);
+}
+
+function appendEntryEl(kind, text, label) {
     const entry = document.createElement('div');
     entry.className = `mobile-entry mobile-entry-${kind}`;
     if (label) {
@@ -66,6 +81,13 @@ function addEntry(kind, text, label = null) {
     els.transcript.scrollTop = els.transcript.scrollHeight;
 }
 
+function renderTranscript() {
+    els.transcript.innerHTML = '';
+    for (const e of transcripts.get(selectedSession) || []) {
+        appendEntryEl(e.kind, e.text, e.label);
+    }
+}
+
 function setSpeaking(speaking) {
     els.voiceIndicator.classList.toggle('speaking', speaking);
     els.voiceIndicator.title = speaking ? 'Speaking' : 'Idle';
@@ -76,6 +98,7 @@ function setSpeaking(speaking) {
 // ---------------------------------------------------------------------------
 
 async function loadSessions() {
+    const firstLoad = selectedSession === null;
     try {
         const res = await apiFetch('/api/sessions/local');
         const data = await res.json();
@@ -98,21 +121,36 @@ async function loadSessions() {
         : names.includes('agentwire') ? 'agentwire'
         : names[0] || null;
 
+    // On first load, open the tab holding the restored selection so the
+    // highlighted card is visible (e.g. last talked to a service session).
+    if (firstLoad && pick) setTab(isService(pick) ? 'services' : 'sessions', { render: false });
+
     renderSessions();
     if (pick && pick !== selectedSession) selectSession(pick);
     else if (!pick) setStatus('No sessions running — start one from the desktop', true);
 }
 
+function setTab(tab, { render = true } = {}) {
+    activeTab = tab;
+    for (const btn of [els.tabSessions, els.tabServices]) {
+        const selected = btn.dataset.tab === tab;
+        btn.classList.toggle('selected', selected);
+        btn.setAttribute('aria-selected', String(selected));
+    }
+    if (render) renderSessions();
+}
+
 function renderSessions() {
     els.sessionList.innerHTML = '';
-    if (sessions.length === 0) {
+    const visible = sessions.filter(s => isService(s.name || '') === (activeTab === 'services'));
+    if (visible.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'mobile-empty';
-        empty.textContent = 'No local sessions.';
+        empty.textContent = activeTab === 'services' ? 'No services.' : 'No local sessions.';
         els.sessionList.appendChild(empty);
         return;
     }
-    for (const s of sessions) {
+    for (const s of visible) {
         const btn = document.createElement('button');
         btn.className = 'mobile-session' + (s.name === selectedSession ? ' selected' : '');
         btn.dataset.name = s.name;
@@ -130,6 +168,11 @@ function renderSessions() {
 }
 
 function selectSession(name) {
+    if (name !== selectedSession) {
+        // Pending audio belongs to the previous session — drop it.
+        audioQueue.length = 0;
+        setSpeaking(false);
+    }
     selectedSession = name;
     try { localStorage.setItem(SESSION_KEY, name); } catch {}
     for (const btn of els.sessionList.querySelectorAll('.mobile-session')) {
@@ -137,6 +180,7 @@ function selectSession(name) {
     }
     els.ptt.disabled = false;
     setStatus(`Talking to ${name}`);
+    renderTranscript();
     connectSessionWs(name);
 }
 
@@ -175,20 +219,23 @@ function connectSessionWs(name) {
     socket.onmessage = (event) => {
         let msg;
         try { msg = JSON.parse(event.data); } catch { return; }
+        // Messages land in the transcript of the session they belong to —
+        // never blindly into whatever view is open (#289).
+        const from = msg.session || name;
         switch (msg.type) {
             case 'tts_start':
                 // The reply text — show it whether playback is audio or speech
-                if (msg.text) addEntry('session', msg.text, msg.session || name);
-                setSpeaking(true);
+                if (msg.text) addEntry(from, 'session', msg.text, from);
+                if (from === selectedSession) setSpeaking(true);
                 break;
             case 'speak_text':
-                if (msg.text) {
+                if (msg.text && from === selectedSession) {
                     setSpeaking(true);
                     browserTts.speak(msg.text, { onEnd: () => setSpeaking(false) });
                 }
                 break;
             case 'audio':
-                if (msg.data) queueAudio(msg.data);
+                if (msg.data && from === selectedSession) queueAudio(msg.data);
                 break;
             // `output` (terminal polling) and lock messages are irrelevant here
         }
@@ -421,10 +468,13 @@ function hideEditBar() {
 
 async function sendText(text) {
     if (!selectedSession) return;
-    addEntry('you', text, 'You');
-    setStatus(`Sending to ${selectedSession}…`);
+    // Pin the target: if the user switches sessions while the send is in
+    // flight, the entry (and any error) stays with the session it went to.
+    const target = selectedSession;
+    addEntry(target, 'you', text, 'You');
+    setStatus(`Sending to ${target}…`);
     try {
-        const res = await apiFetch(`/send/${selectedSession}`, {
+        const res = await apiFetch(`/send/${target}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ text: voicePromptWrap(text) }),
@@ -434,7 +484,7 @@ async function sendText(text) {
         setStatus(`Talking to ${selectedSession}`);
     } catch (err) {
         console.error('[Mobile] Send failed:', err);
-        addEntry('error', err.message || 'Send failed');
+        addEntry(target, 'error', err.message || 'Send failed');
         setStatus(`Talking to ${selectedSession}`);
     }
 }
@@ -475,10 +525,15 @@ async function init() {
     setupPtt();
     setupEditBar();
     els.refresh.addEventListener('click', loadSessions);
+    els.tabSessions.addEventListener('click', () => setTab('sessions'));
+    els.tabServices.addEventListener('click', () => setTab('services'));
 
     // voice-status first: on a fresh device this 401s and raises the token
     // modal; after entry the page reloads with credentials.
     await loadVoiceStatus();
+    // Custom services must be merged before the first render so config-defined
+    // services land on the Services tab (same allowlist as the desktop sidebar).
+    await loadCustomServices();
     await loadSessions();
 }
 

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -151,19 +151,47 @@ function renderSessions() {
         return;
     }
     for (const s of visible) {
+        const state = s.state || 'off';
         const btn = document.createElement('button');
-        btn.className = 'mobile-session' + (s.name === selectedSession ? ' selected' : '');
+        btn.className = `mobile-session state-${state}` + (s.name === selectedSession ? ' selected' : '');
         btn.dataset.name = s.name;
 
+        const row = document.createElement('span');
+        row.className = 'mobile-session-row';
         const dot = document.createElement('span');
-        dot.className = 'mobile-session-activity' + (s.activity ? ' active' : '');
+        dot.className = 'mobile-session-state';
         const name = document.createElement('span');
         name.className = 'mobile-session-name';
         name.textContent = s.name;
-        btn.append(dot, name);
+        row.append(dot, name);
+        btn.append(row);
+
+        // One-line hint: what a blocked session is waiting on; off cards
+        // stay tappable but say why they're muted.
+        const hint = state === 'needs_input' ? (s.state_hint || 'Waiting on you')
+            : state === 'off' ? 'no agent running'
+            : null;
+        if (hint) {
+            const hintEl = document.createElement('span');
+            hintEl.className = 'mobile-session-hint';
+            hintEl.textContent = hint;
+            btn.append(hintEl);
+        }
 
         btn.addEventListener('click', () => selectSession(s.name));
         els.sessionList.appendChild(btn);
+    }
+    updateHeaderState();
+}
+
+// Mirror the selected session's state on the "Talking to X" status line (#290)
+const SESSION_STATES = ['working', 'idle', 'needs_input', 'off'];
+
+function updateHeaderState() {
+    const s = sessions.find(x => x.name === selectedSession);
+    const state = s ? (s.state || 'off') : 'off';
+    for (const st of SESSION_STATES) {
+        els.status.classList.toggle(`state-${st}`, st === state);
     }
 }
 
@@ -180,6 +208,7 @@ function selectSession(name) {
     }
     els.ptt.disabled = false;
     setStatus(`Talking to ${name}`);
+    updateHeaderState();
     renderTranscript();
     connectSessionWs(name);
 }
@@ -535,6 +564,12 @@ async function init() {
     // services land on the Services tab (same allowlist as the desktop sidebar).
     await loadCustomServices();
     await loadSessions();
+
+    // Keep the state visuals (#290) live — poll-based v1, paused while the
+    // page is backgrounded so it stays battery-friendly.
+    setInterval(() => {
+        if (document.visibilityState === 'visible') loadSessions();
+    }, 5000);
 }
 
 init();

--- a/agentwire/static/js/service-classification.js
+++ b/agentwire/static/js/service-classification.js
@@ -1,0 +1,43 @@
+/**
+ * Session classification — which sessions are infrastructure "services"
+ * (portal, scheduler, TTS/STT, config-defined custom services) vs working
+ * sessions. Single source of truth shared by the desktop sidebar, the
+ * command palette, and the mobile page.
+ */
+
+import { apiFetch } from './api.js';
+
+const SERVICE_SESSIONS = new Set([
+    'agentwire-portal',
+    'agentwire-tts',
+    'agentwire-stt',
+    'agentwire-scheduler',
+    'agentwire-notifications',
+]);
+
+export function isService(name) { return SERVICE_SESSIONS.has(name); }
+
+// Merge config-defined custom services (services.custom in config.yaml) into
+// the built-in allowlist. Idempotent — concurrent callers share one fetch.
+// Resolves true if any names were added, so callers can re-render.
+let loadPromise = null;
+export function loadCustomServices() {
+    if (!loadPromise) {
+        loadPromise = (async () => {
+            try {
+                const res = await apiFetch('/api/services/custom');
+                if (!res.ok) return false;
+                const { names } = await res.json();
+                let changed = false;
+                for (const n of names || []) {
+                    if (!SERVICE_SESSIONS.has(n)) { SERVICE_SESSIONS.add(n); changed = true; }
+                }
+                return changed;
+            } catch {
+                // Portal offline / endpoint missing — built-in services still group fine.
+                return false;
+            }
+        })();
+    }
+    return loadPromise;
+}

--- a/agentwire/static/js/sidebar/services-section.js
+++ b/agentwire/static/js/sidebar/services-section.js
@@ -1,4 +1,5 @@
-import { getAllSessions, isService, renderCard, handleSessionClick, onSessionsChanged } from './sessions-section.js';
+import { getAllSessions, renderCard, handleSessionClick, onSessionsChanged } from './sessions-section.js';
+import { isService } from '../service-classification.js';
 
 export const servicesSection = {
     title: 'Services',

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -1,36 +1,14 @@
 import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 import { buildSessionId, normalizeMachine } from '../session-id.js';
+import { isService, loadCustomServices } from '../service-classification.js';
 
 // Shared state across sessions and services sections
 export const activityStates = new Map();
 
-const SERVICE_SESSIONS = new Set([
-    'agentwire-portal',
-    'agentwire-tts',
-    'agentwire-stt',
-    'agentwire-scheduler',
-    'agentwire-notifications',
-]);
-export function isService(name) { return SERVICE_SESSIONS.has(name); }
-
 // Merge config-defined custom services into the Services column. Fire-and-forget
 // on load; re-render once they arrive so flagged sessions hop to the right group.
-async function loadCustomServices() {
-    try {
-        const res = await apiFetch('/api/services/custom');
-        if (!res.ok) return;
-        const { names } = await res.json();
-        let changed = false;
-        for (const n of names || []) {
-            if (!SERVICE_SESSIONS.has(n)) { SERVICE_SESSIONS.add(n); changed = true; }
-        }
-        if (changed) notifyListeners();
-    } catch {
-        // Portal offline / endpoint missing — built-in services still group fine.
-    }
-}
-loadCustomServices();
+loadCustomServices().then((changed) => { if (changed) notifyListeners(); });
 
 let allSessions = [];
 const listeners = new Set();

--- a/agentwire/templates/mobile.html
+++ b/agentwire/templates/mobile.html
@@ -17,7 +17,10 @@
 
     <section class="mobile-sessions">
         <div class="mobile-sessions-head">
-            <span>Sessions</span>
+            <div class="mobile-tabs" role="tablist" aria-label="Session groups">
+                <button class="mobile-tab selected" id="tabSessions" role="tab" aria-selected="true" data-tab="sessions">Sessions</button>
+                <button class="mobile-tab" id="tabServices" role="tab" aria-selected="false" data-tab="services">Services</button>
+            </div>
             <button class="mobile-refresh" id="refreshSessions" title="Refresh sessions" aria-label="Refresh sessions">↻</button>
         </div>
         <div class="mobile-session-list" id="sessionList">

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -563,6 +563,94 @@ class TestMobilePage:
 
 
 # ---------------------------------------------------------------------------
+# Session state computation (#290 — mobile state visuals)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStateComputation:
+    """Precedence: off → needs_input → working → idle; off on any doubt."""
+
+    def _compute(self, tmp_path, monkeypatch, sessions, *, agent=True, markers=None):
+        from agentwire import prompt_router
+
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: agent)
+        monkeypatch.setattr(prompt_router, "list_markers", lambda: markers or [])
+        server = AgentWireServer(_make_config(tmp_path))
+        server._compute_session_states(sessions)
+        return server
+
+    def test_off_when_no_agent_in_pane0(self, tmp_path, monkeypatch):
+        sessions = [{"name": "foo"}]
+        self._compute(tmp_path, monkeypatch, sessions, agent=False)
+        assert sessions[0]["state"] == "off"
+
+    def test_off_beats_marker(self, tmp_path, monkeypatch):
+        """A stale marker on an agent-less session must not show needs_input."""
+        sessions = [{"name": "foo"}]
+        self._compute(
+            tmp_path, monkeypatch, sessions, agent=False,
+            markers=[{"session": "foo", "pane": 0, "kind": "permission"}],
+        )
+        assert sessions[0]["state"] == "off"
+
+    def test_off_on_classification_error(self, tmp_path, monkeypatch):
+        """When in doubt show off — never a false working/idle."""
+        from agentwire import prompt_router
+
+        def boom(s, p):
+            raise RuntimeError("tmux exploded")
+
+        monkeypatch.setattr(prompt_router, "is_agent_pane", boom)
+        monkeypatch.setattr(prompt_router, "list_markers", lambda: [])
+        server = AgentWireServer(_make_config(tmp_path))
+        sessions = [{"name": "foo"}]
+        server._compute_session_states(sessions)
+        assert sessions[0]["state"] == "off"
+
+    def test_needs_input_from_marker_with_hint(self, tmp_path, monkeypatch):
+        sessions = [{"name": "foo"}]
+        self._compute(
+            tmp_path, monkeypatch, sessions,
+            markers=[{
+                "session": "foo", "pane": 0, "kind": "permission",
+                "question": "Claude wants to run: rm build/",
+            }],
+        )
+        assert sessions[0]["state"] == "needs_input"
+        assert sessions[0]["state_kind"] == "permission"
+        assert sessions[0]["state_hint"] == "Claude wants to run: rm build/"
+
+    def test_needs_input_from_pending_permission(self, tmp_path, monkeypatch):
+        from agentwire.server import PendingPermission, Session, SessionConfig
+
+        sessions = [{"name": "foo"}]
+        server = self._compute(tmp_path, monkeypatch, [])
+        session = Session(name="foo", config=SessionConfig())
+        session.pending_permission = PendingPermission(request={"tool_name": "Bash"})
+        server.active_sessions["foo"] = session
+        server._compute_session_states(sessions)
+        assert sessions[0]["state"] == "needs_input"
+        assert sessions[0]["state_kind"] == "permission"
+        assert "Bash" in sessions[0]["state_hint"]
+
+    def test_working_from_recent_output(self, tmp_path, monkeypatch):
+        import time
+
+        sessions = [{"name": "foo"}]
+        server = self._compute(tmp_path, monkeypatch, [])
+        server.session_activity["foo"] = {"last_output_timestamp": time.time()}
+        server._compute_session_states(sessions)
+        assert sessions[0]["state"] == "working"
+
+    def test_idle_when_agent_quiet(self, tmp_path, monkeypatch):
+        sessions = [{"name": "foo"}]
+        self._compute(tmp_path, monkeypatch, sessions)
+        assert sessions[0]["state"] == "idle"
+        assert sessions[0]["state_kind"] is None
+        assert sessions[0]["state_hint"] is None
+
+
+# ---------------------------------------------------------------------------
 # Restricted mode (permission API)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -538,6 +538,10 @@ class TestMobilePage:
         body = await resp.text()
         assert "/static/js/mobile.js" in body
         assert "pttButton" in body
+        # Sessions | Services tabs (#288) — Sessions selected by default
+        assert 'id="tabSessions"' in body
+        assert 'id="tabServices"' in body
+        assert '<button class="mobile-tab selected" id="tabSessions"' in body
 
     async def test_mobile_no_cache(self, portal_client):
         client, _ = portal_client


### PR DESCRIPTION
Closes #288
Closes #289
Closes #290

## What

Three mobile-page missions on one branch (found together during the first live tablet test), in two commits: tabs + per-session transcripts, then the state visuals.

### Sessions | Services tabs (#288)

- The `/mobile` session picker gets a tab bar — **Sessions** (default) | **Services** — so orchestrator sessions aren't crowded out by infra (`agentwire-portal`, scheduler, TTS/STT, custom services). Tabs, not an accordion, per owner preference.
- **SSOT classification**: `SERVICE_SESSIONS` + `isService()` + `loadCustomServices()` moved out of the desktop sidebar into a new shared module `static/js/service-classification.js`, imported by `sessions-section.js`, `services-section.js`, `command-palette.js`, and `mobile.js`. No duplicated allowlist, and the mobile bundle doesn't drag in `desktop-manager.js`. `loadCustomServices()` is idempotent (shared promise) and still merges config-defined custom services from `/api/services/custom`.
- Big touch targets (40px+ tabs), mobile.css theme variables, selected-session highlight and "Talking to X" unchanged from either tab. On first load the tab holding the restored selection opens so the highlighted card is visible.

### Per-session transcripts (#289)

- Transcript entries are keyed by session in an in-memory map; tapping a session swaps the visible conversation (and reconnects the WS) instead of appending everything to one global list.
- Incoming WS messages route to the session they belong to (`msg.session || connected name`) — never blindly into whatever view is open. `speak_text`/`audio` playback applies to the selected session only; pending audio and the speaking indicator reset on switch.
- Sends pin their target: if you switch sessions while a send is in flight, the entry and any error land with the session it went to.

### Session-state visuals (#290)

- **Server**: `/api/sessions/local` annotates each session with computed `state` + `state_kind`/`state_hint`, precedence `off → needs_input → working → idle`:
  - `off` — pane 0 runs no agent (reuses `prompt_router.is_agent_pane`); also the fallback for anything unrecognized/errored, never a false working/idle
  - `needs_input` — `prompt_router.list_markers()` (markers now persist the prompt `question` for the hint) or live `pending_permission` on the Session object
  - `working` — existing `last_output_timestamp` vs `activity_threshold_seconds`
  - The per-session tmux shell-outs run via `asyncio.to_thread`, off the event loop.
- **Mobile**: cards in both tabs + the "Talking to X" status line show the state — breathing green glow (working), steady dim dot (idle), amber pulse with a one-line question hint (needs-you), dark muted but still-tappable card with "no agent running" (off). CSS-only animations limited to working/needs-you, `prefers-reduced-motion` respected, 5s visibility-gated poll keeps states live.

## Verification

- `uv run pytest`: 1439 passed; the 1 failure (`test_terminal_registers_client_in_session`) is the same environment-dependent pre-existing failure documented in PR #284.
- New tests: mobile shell asserts the tab markup (Sessions selected by default); `TestSessionStateComputation` covers all four states, marker hint passthrough, off-beats-marker precedence, and the error→off fallback.
- `node --input-type=module --check` on every touched JS module; the mobile import graph is plain ES modules (`mobile.js → service-classification.js → api.js`), no desktop-manager dependency.
- Manual 390px-viewport verification (tabs filter, transcript swap, four live states, needs-you → working → idle transition) happens post-merge on the installed portal — this worktree can't restart it.

Built by [dotdev.dev](https://dotdev.dev)