### PR TITLE
worktree sessions: auto-inject the standing mission briefing (worktree-mission role)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -29,6 +29,10 @@ agentwire worktree name         # new branch + worktree + STANDALONE session
                                 #   "worktree session" ALWAYS means this command — never
                                 #   `spawn --branch` (that makes a pane); add
                                 #   --type claude-bypass for autonomous workers
+                                #   Auto-injects the worktree-mission briefing role
+                                #   (isolation, no rebuild/restart, verify in-worktree,
+                                #   draft PR + notify-back) — first prompts only need
+                                #   the task itself; --no-mission opts out
 agentwire worktree name -b develop  # from specific base branch
 agentwire worktree name -c      # from repo's current branch
 agentwire worktree name -e      # checkout existing branch (no new branch)

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -174,6 +174,7 @@ Roles define agent behavior and are composable. Mix and match roles in `.agentwi
 | `voice` | Voice communication (speak/listen) |
 | `worker` | Receive tasks, execute autonomously, report back |
 | `task-runner` | Scheduled task execution |
+| `worktree-mission` | Standing briefing for `agentwire worktree` dispatches (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) — auto-injected by `agentwire worktree`, opt out with `--no-mission` |
 | `chatbot` | Conversational personality |
 | `init` | Setup wizard behavior |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The `agentwire-mcp-tools` skill has the full reference (sessions, panes, voice, 
 
 | Term | Command | What you get |
 |------|---------|--------------|
-| **Worktree session** | `agentwire worktree <name> --type claude-bypass -p <repo>` | **Standalone tmux session** named `{project}-<name>`, new branch `<name>` from origin/main, worktree under `~/worktrees/`. Survives independently; report-back via `agentwire notify-parent --to <orchestrator>`. |
+| **Worktree session** | `agentwire worktree <name> --type claude-bypass -p <repo>` | **Standalone tmux session** named `{project}-<name>`, new branch `<name>` from origin/main, worktree under `~/worktrees/`. Survives independently; report-back via `agentwire notify-parent --to <orchestrator>`. The standing mission briefing (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) is auto-injected via the bundled `worktree-mission` role — first prompts only need the task; `--no-mission` opts out. |
 | **Worker pane** | `agentwire spawn --branch <name>` | A **pane inside the current session** (pane 1+), worktree on `<name>`. Inherits the session's dashboard; idle hook reaps it. |
 
 When the owner says "worktree session", they mean the standalone session (`agentwire worktree`), **never** `spawn` panes. Worker panes are for small subtasks watched by the orchestrator; worktree sessions are for parallel autonomous missions. Always pass `--type claude-bypass` for autonomous workers — the default prompted type blocks on the first permission dialog with no one to answer it.

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -36,7 +36,15 @@ from .project_config import (
     normalize_session_type,
     save_project_config,
 )
-from .roles import RoleConfig, inject_soul, load_roles, merge_roles
+from .roles import (
+    WORKTREE_MISSION_ROLE,
+    RoleConfig,
+    inject_soul,
+    inject_worktree_mission,
+    load_roles,
+    merge_roles,
+    render_mission_placeholders,
+)
 from .worktree import ensure_worktree, parse_session_name, remove_worktree
 
 # Default config directory
@@ -3295,6 +3303,13 @@ def cmd_new(args) -> int:
             default_role = config.get("session", {}).get("default_role", "agentwire")
             role_names = [default_role] if default_role else []
 
+    # Standing mission briefing for worktree dispatches: cmd_worktree passes
+    # mission_context (branch/cwd/base/creator values) which both opts the
+    # session into the worktree-mission role and templates its placeholders.
+    mission_context = getattr(args, 'mission_context', None)
+    if mission_context:
+        role_names = inject_worktree_mission(role_names)
+
     # Always-inject the soul personality role (rides last for recency weight)
     role_names = inject_soul(role_names, load_config(), no_soul=getattr(args, 'no_soul', False))
 
@@ -3306,6 +3321,11 @@ def cmd_new(args) -> int:
         roles, missing = load_roles(role_names, project_path_for_roles)
         if missing:
             return _output_result(False, json_mode, f"Roles not found: {', '.join(missing)}")
+
+    if mission_context:
+        for role in roles:
+            if role.name == WORKTREE_MISSION_ROLE:
+                role.instructions = render_mission_placeholders(role.instructions, mission_context)
 
     # Parse session name: project, branch, machine
     project, branch, machine_id = parse_session_name(name)
@@ -4769,6 +4789,12 @@ def cmd_worktree(args) -> int:
     - --ref: detached at a ref. `agentwire worktree review-v2 --ref v2.0.0`
 
     If the worktree already exists, reattaches to the existing session.
+
+    Default/--existing dispatches auto-inject the bundled worktree-mission
+    briefing role (isolation, no live-tool mutation, in-worktree
+    verification, draft-PR + notify-back contract) with branch/cwd/base/
+    creator templated in — opt out with --no-mission. --ref dispatches skip
+    it (detached checkout, nothing to push).
     """
     json_mode = getattr(args, 'json', False)
     name = args.name
@@ -4794,13 +4820,42 @@ def cmd_worktree(args) -> int:
     session_name = f"{project_name}-{name}"
     worktree_path = worktree_dir / session_name
 
-    def _launch_session():
+    default_base = getattr(args, 'base', None) or wt_config.get("default_base", "main")
+    no_mission = getattr(args, 'no_mission', False)
+
+    def _mission_context(base_branch: str) -> dict | None:
+        """Values templated into the worktree-mission briefing role.
+
+        None (no briefing) when --no-mission is passed, or for --ref
+        dispatches — a detached review checkout has no branch to push, so
+        the finishing contract doesn't apply.
+        """
+        if no_mission or ref:
+            return None
+        creator = pane_manager.get_current_session()
+        notify_back = (
+            f'agentwire notify-parent --to {creator} "{session_name}: <one-liner + PR URL>"'
+            if creator else
+            f'agentwire notify-parent "{session_name}: <one-liner + PR URL>"'
+        )
+        return {
+            "session": session_name,
+            "branch": name,
+            "worktree_path": str(worktree_path),
+            "main_checkout": str(project_path),
+            "base_branch": base_branch,
+            "creator": creator or "your creator session",
+            "notify_back": notify_back,
+        }
+
+    def _launch_session(mission_context: dict | None = None):
         return cmd_new(type('Args', (), {
             'session': session_name, 'path': str(worktree_path), 'json': json_mode,
             'force': False, 'bare': False, 'restricted': False, 'prompted': False,
             'type': getattr(args, 'type', None), 'roles': getattr(args, 'roles', None),
             'instructions': None, 'persist': False,
             'env': getattr(args, 'env', None),
+            'mission_context': mission_context,
         })())
 
     # If worktree already exists, reattach
@@ -4812,10 +4867,11 @@ def cmd_worktree(args) -> int:
         if tmux_session_exists(session_name):
             subprocess.run(["tmux", "attach-session", "-t", session_name])
         else:
-            return _launch_session()
+            return _launch_session(_mission_context(default_base))
         return 0
 
     # Resolve the git ref to create the worktree from
+    pr_base = default_base
     if ref:
         # --ref mode: detached at a specific ref (tag, commit, branch)
         git_ref = ref
@@ -4837,7 +4893,8 @@ def cmd_worktree(args) -> int:
                 return _output_result(False, json_mode, f"Failed to detect current branch in {project_path}")
             base_branch = result.stdout.strip()
         else:
-            base_branch = getattr(args, 'base', None) or wt_config.get("default_base", "main")
+            base_branch = default_base
+        pr_base = base_branch
         git_ref = f"origin/{base_branch}"
         new_branch = name
         mode_label = f"new branch {name} from {git_ref}"
@@ -4884,7 +4941,7 @@ def cmd_worktree(args) -> int:
         print(f"Created worktree: {worktree_path}")
         print(f"Mode: {mode_label}")
 
-    return _launch_session()
+    return _launch_session(_mission_context(pr_base))
 
 
 def cmd_fork(args) -> int:
@@ -10803,6 +10860,8 @@ def main() -> int:
     wt_parser.add_argument("--project", "-p", help="Path to git repo (default: from config or cwd)")
     wt_parser.add_argument("--type", help="Session type override")
     wt_parser.add_argument("--roles", help="Comma-separated role names")
+    wt_parser.add_argument("--no-mission", dest="no_mission", action="store_true",
+                           help="Skip the auto-injected worktree-mission briefing role")
     wt_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
     wt_parser.add_argument("--json", action="store_true", help="Output as JSON")
     wt_parser.set_defaults(func=cmd_worktree)

--- a/agentwire/roles/__init__.py
+++ b/agentwire/roles/__init__.py
@@ -199,6 +199,47 @@ def inject_soul(role_names: list[str], config: dict | None = None, no_soul: bool
     return [*role_names, "soul"]
 
 
+# Bundled role carrying the standing briefing for `agentwire worktree`
+# dispatches (isolation, no live-tool mutation, in-worktree verification,
+# draft-PR + notify-back contract). Auto-applied by cmd_worktree so
+# orchestrators stop hand-writing the same briefing into every first prompt.
+WORKTREE_MISSION_ROLE = "worktree-mission"
+
+
+def inject_worktree_mission(role_names: list[str], no_mission: bool = False) -> list[str]:
+    """Append the bundled worktree-mission briefing role to a session's role list.
+
+    Applied by `agentwire worktree` at session-create time, before
+    inject_soul (so soul still rides last). Skipped when:
+    - no_mission is True (per-dispatch --no-mission flag)
+    - the role is already present (explicit --roles or project override)
+
+    Args:
+        role_names: Resolved role names for the session
+        no_mission: Per-dispatch opt-out
+
+    Returns:
+        role_names with "worktree-mission" appended, or unchanged if excluded
+    """
+    if no_mission:
+        return role_names
+    if WORKTREE_MISSION_ROLE in role_names:
+        return role_names
+    return [*role_names, WORKTREE_MISSION_ROLE]
+
+
+def render_mission_placeholders(text: str, context: dict[str, str]) -> str:
+    """Substitute ``{{key}}`` placeholders in role instructions.
+
+    Only keys present in ``context`` are replaced; unknown placeholders are
+    left intact (so a malformed context fails loudly in the rendered prompt
+    instead of silently dropping the constraint).
+    """
+    for key, value in context.items():
+        text = text.replace("{{" + key + "}}", str(value))
+    return text
+
+
 def discover_role(name: str, project_path: Path | None = None) -> Path | None:
     """Find a role file by name using discovery order.
 

--- a/agentwire/roles/worktree-mission.md
+++ b/agentwire/roles/worktree-mission.md
@@ -1,0 +1,29 @@
+---
+name: worktree-mission
+description: Standing briefing for standalone worktree mission sessions — isolation, no live-tool mutation, in-worktree verification, draft-PR + notify-back contract
+---
+
+# Worktree Mission
+
+You are a standalone worktree session on branch `{{branch}}`, cwd `{{worktree_path}}`. These standing constraints apply to every task you are given — they go without being restated in the prompt.
+
+## Isolation
+
+- Work ONLY inside `{{worktree_path}}`. Never modify the main checkout at `{{main_checkout}}` or any other checkout of this repo.
+- NEVER restart or rebuild live tools and services the rest of the system depends on. For agentwire itself that means: no `agentwire rebuild`, no `agentwire portal restart` / `portal start`, no `agentwire hooks install`.
+- Don't start dev servers on default ports — they collide with the live ones. If verification needs a server, use a non-default port.
+
+## Verification
+
+Verify in-worktree as best you can: run the test suite (e.g. `uv run pytest`), invoke modules directly, use non-default ports. If something can only be verified after merge (live portal behavior, installed-tool paths), state that explicitly in the PR body rather than skipping verification silently.
+
+## Finishing contract
+
+When the task is done:
+
+1. Commit with a clear message, following any commit-footer conventions from your global instructions.
+2. Push the branch: `git push -u origin {{branch}}`.
+3. Open a DRAFT pull request to `{{base_branch}}`. If the work tracks a GitHub issue, include `Closes #<issue>` in the PR body. The PR description is the breadcrumb: what was built, decisions locked in, surprises, verification results.
+4. Report back to your creator: `{{notify_back}}`
+
+Do not merge the PR yourself — your creator or a reviewer handles merge and worktree cleanup.

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -5,12 +5,16 @@ from pathlib import Path
 import pytest
 
 from agentwire.roles import (
+    WORKTREE_MISSION_ROLE,
     RoleConfig,
     MergedRole,
     parse_role_file,
     merge_roles,
     discover_role,
     inject_soul,
+    inject_worktree_mission,
+    load_roles,
+    render_mission_placeholders,
 )
 
 
@@ -203,6 +207,100 @@ class TestInjectSoul:
         assert role.tools == []
         assert role.disallowed_tools == []
         assert role.instructions
+
+
+# --- worktree-mission (#291) ---
+
+MISSION_CONTEXT = {
+    "session": "agentwire-dev-fix-bug",
+    "branch": "fix-bug",
+    "worktree_path": "/Users/x/worktrees/agentwire-dev-fix-bug",
+    "main_checkout": "/Users/x/projects/agentwire-dev",
+    "base_branch": "main",
+    "creator": "agentwire",
+    "notify_back": 'agentwire notify-parent --to agentwire "agentwire-dev-fix-bug: <one-liner + PR URL>"',
+}
+
+
+class TestInjectWorktreeMission:
+    def test_appended(self):
+        assert inject_worktree_mission(["agentwire"]) == ["agentwire", "worktree-mission"]
+
+    def test_empty_list(self):
+        assert inject_worktree_mission([]) == ["worktree-mission"]
+
+    def test_no_double_add(self):
+        assert inject_worktree_mission(["worktree-mission"]) == ["worktree-mission"]
+        assert inject_worktree_mission(["agentwire", "worktree-mission"]) == [
+            "agentwire",
+            "worktree-mission",
+        ]
+
+    def test_no_mission_flag(self):
+        assert inject_worktree_mission(["agentwire"], no_mission=True) == ["agentwire"]
+
+    def test_input_not_mutated(self):
+        names = ["agentwire"]
+        inject_worktree_mission(names)
+        assert names == ["agentwire"]
+
+    def test_soul_still_rides_last(self):
+        # cmd_new injects mission first, then soul — soul keeps recency weight
+        names = inject_soul(inject_worktree_mission(["agentwire"]))
+        assert names == ["agentwire", "worktree-mission", "soul"]
+
+
+class TestRenderMissionPlaceholders:
+    def test_substitutes_known_keys(self):
+        text = "Branch `{{branch}}` from `{{base_branch}}`."
+        out = render_mission_placeholders(text, MISSION_CONTEXT)
+        assert out == "Branch `fix-bug` from `main`."
+
+    def test_unknown_placeholder_left_intact(self):
+        out = render_mission_placeholders("Hello {{mystery}}", MISSION_CONTEXT)
+        assert out == "Hello {{mystery}}"
+
+    def test_non_string_values_coerced(self):
+        out = render_mission_placeholders("PR #{{n}}", {"n": 42})
+        assert out == "PR #42"
+
+
+class TestBundledWorktreeMissionRole:
+    def test_discoverable_and_pure(self):
+        """worktree-mission must parse and not widen or narrow tool permissions."""
+        path = discover_role(WORKTREE_MISSION_ROLE)
+        assert path is not None
+        role = parse_role_file(path)
+        assert role is not None
+        assert role.name == WORKTREE_MISSION_ROLE
+        assert role.tools == []
+        assert role.disallowed_tools == []
+        assert role.instructions
+
+    def test_briefing_covers_the_standing_rules(self):
+        role = parse_role_file(discover_role(WORKTREE_MISSION_ROLE))
+        for needle in [
+            "{{worktree_path}}",
+            "{{main_checkout}}",
+            "{{branch}}",
+            "{{base_branch}}",
+            "{{notify_back}}",
+            "agentwire rebuild",
+            "portal restart",
+            "DRAFT",
+            "Closes #",
+        ]:
+            assert needle in role.instructions, f"briefing missing: {needle}"
+
+    def test_renders_fully_with_mission_context(self):
+        """All placeholders in the bundled role resolve from cmd_worktree's context."""
+        roles, missing = load_roles([WORKTREE_MISSION_ROLE])
+        assert missing == []
+        rendered = render_mission_placeholders(roles[0].instructions, MISSION_CONTEXT)
+        assert "{{" not in rendered
+        assert "/Users/x/worktrees/agentwire-dev-fix-bug" in rendered
+        assert "git push -u origin fix-bug" in rendered
+        assert 'agentwire notify-parent --to agentwire' in rendered
 
 
 # --- council roles (#213) ---


### PR DESCRIPTION
Closes #291

## What was built

`agentwire worktree` now auto-injects the standing mission briefing so dispatchers stop hand-writing it into every first prompt. A new bundled **`worktree-mission` role** (`agentwire/roles/worktree-mission.md`) carries the five standing rules — worktree isolation, never rebuild/restart the live tool or start dev servers on default ports, verify in-worktree, finish with commit→push→DRAFT PR (`Closes #N`), report back via `agentwire notify-parent --to <creator>` — with `{{branch}}` / `{{worktree_path}}` / `{{main_checkout}}` / `{{base_branch}}` / `{{notify_back}}` templated in at session-create time.

## Decisions locked in

- **Mechanism mirrors the soul role**: `inject_worktree_mission()` appends the role name (before `inject_soul`, so soul keeps recency weight); `cmd_new` accepts a `mission_context` dict from `cmd_worktree` that both opts the session in and drives `render_mission_placeholders()`. Rendering is restricted to the worktree-mission role so `{{...}}` in other role bodies is never mangled.
- **Creator** comes from `pane_manager.get_current_session()` — the same source `cmd_new` records into session metadata since #276 — and is baked into the `{{notify_back}}` command concretely. When created outside tmux, the briefing falls back to bare `agentwire notify-parent` (config-parent resolution).
- **`--ref` dispatches skip the briefing** — a detached review checkout has no branch to push, so the finishing contract doesn't apply. Default and `--existing` modes get it; `--no-mission` opts out everywhere. The reattach-launch path (worktree exists, session died) also injects.
- **Role is portable**: no hardcoded commit footers (it defers to the user's global instructions) and the no-rebuild rule is phrased generally with agentwire's commands as the concrete example, since the role ships in the PyPI package.
- The missions auto-dispatcher spawns via `agentwire new -s project/branch`, not `cmd_worktree`, so its prompt is untouched — folding it (and a shorter `spawn --branch` pane variant) onto this role is a follow-up.

## Verification

- `uv run pytest tests/unit` — 1376 passed. New tests in `tests/unit/test_roles.py` mirror the `inject_soul` suite: injection/dedup/opt-out, placeholder rendering (unknown placeholders left intact, loud failure), bundled-role purity (no tool widening), briefing coverage of all standing rules, and a full-render check (no `{{` left, concrete push/notify commands present).
- Full suite: 1444 passed, 1 pre-existing failure (`test_server_websockets.py::test_terminal_registers_client_in_session`) — fails identically on a clean tree, unrelated.
- Simulated the real assembly path in-worktree (roles → render → `build_agent_command('claude-bypass')`): merged `--append-system-prompt` payload contains the fully-rendered briefing with concrete branch/cwd/creator values.
- **Post-merge**: the live no-briefing dispatch test (`agentwire worktree test-mission --type claude-bypass` + ask the fresh agent its operating constraints) has to happen after `agentwire rebuild` on main — the installed CLI can't pick this code up from a worktree, and rebuild is forbidden in-mission.

Built by [dotdev.dev](https://dotdev.dev)