### PR TITLE
Standardize secrets on ~/.agentwire/.env — env-only keys, one doc page

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -147,21 +147,22 @@ pi:  # Pi coding agent — drives all `pi-<provider>` session types. See `agentw
     Use `agentwire fetch <url>` to fetch a page as clean markdown (Jina Reader).
 
   # Env vars injected into every pi-* session, in addition to the provider key.
-  # Useful for cross-cutting tools that need credentials in every pi session.
+  # Values are stored in plaintext here — non-secrets only. Secrets belong in
+  # ~/.agentwire/.env (docs/wiki/security/secrets.md).
   extra_env:
-    MY_SERVICE_API_KEY: "..."
+    MY_SERVICE_URL: "https://internal.example.com"
 
   # Per-provider config. Session type `pi-<name>` resolves the provider here.
   # Adding a new provider is config-only — no code changes needed. For non-built-in
   # providers (e.g. DeepSeek), also register them in `~/.pi/agent/models.json`.
+  # env_var is the NAME of the env var holding the key — the key itself lives
+  # in ~/.agentwire/.env (e.g. ZAI_API_KEY=...), never here.
   providers:
     zai:
       env_var: ZAI_API_KEY
-      api_key: "..."
       default_model: glm-5.1
     deepseek:
       env_var: DEEPSEEK_API_KEY
-      api_key: "..."
       default_model: deepseek-chat
 
 uploads:
@@ -180,8 +181,9 @@ portal:
   url: "https://localhost:8765"
 
 channels:  # Outbound-only notifications. Only email + quo ship.
+  # Keys are env-only: RESEND_API_KEY / QUO_API_KEY in ~/.agentwire/.env
+  # (docs/wiki/security/secrets.md) — never in config.yaml.
   email:
-    api_key: ""  # Resend API key (or set RESEND_API_KEY env var)
     from_address: "Echo <echo@yourdomain.com>"
     default_to: "user@example.com"
     banner_image_url: "https://yourdomain.com/images/banner.png"
@@ -189,7 +191,6 @@ channels:  # Outbound-only notifications. Only email + quo ship.
     echo_small_url: "https://yourdomain.com/images/echo-small.png"
     logo_image_url: "https://yourdomain.com/images/logo.png"
   quo:
-    api_key: ""              # or QUO_API_KEY / OPENPHONE_API_KEY env var
     from_number: "+1234567890"  # E.164 or phone number ID (PNxxx)
     default_to: "+0987654321"
 

--- a/.claude/skills/agentwire-pi/SKILL.md
+++ b/.claude/skills/agentwire-pi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-pi
-description: Pi coding agent (multi-provider) integration — `pi-<provider>` / `pi-<provider>-restricted` / `pi-<provider>-readonly` session types for any pi provider (zai, deepseek, openai, openrouter, etc.). Install (`npm install -g @mariozechner/pi-coding-agent`), config (`pi.binary`, `pi.system_prompt`, `pi.extra_env`, `pi.providers.<name>.{env_var,api_key,default_model}`), custom providers via `~/.pi/agent/models.json`, tool translation (Claude CamelCase → pi lowercase), system-prompt injection (global + role merged), built-in helper (`agentwire fetch`), limitations vs Claude Code (no MCP client, no web search, no `--disallowedTools`, no `--resume --fork-session`, no hook integration). Use when setting up pi sessions for any provider, debugging pi tool execution, or explaining when to pick pi-* vs claude-*.
+description: Pi coding agent (multi-provider) integration — `pi-<provider>` / `pi-<provider>-restricted` / `pi-<provider>-readonly` session types for any pi provider (zai, deepseek, openai, openrouter, etc.). Install (`npm install -g @mariozechner/pi-coding-agent`), config (`pi.binary`, `pi.system_prompt`, `pi.extra_env`, `pi.providers.<name>.{env_var,default_model}`; keys env-only via `~/.agentwire/.env`), custom providers via `~/.pi/agent/models.json`, tool translation (Claude CamelCase → pi lowercase), system-prompt injection (global + role merged), built-in helper (`agentwire fetch`), limitations vs Claude Code (no MCP client, no web search, no `--disallowedTools`, no `--resume --fork-session`, no hook integration). Use when setting up pi sessions for any provider, debugging pi tool execution, or explaining when to pick pi-* vs claude-*.
 ---
 
 # pi — Pi Coding Agent (multi-provider)
@@ -60,6 +60,14 @@ Pi has no permission system to bypass — variants translate directly to pi's `-
 
 ## Config
 
+Provider keys live in `~/.agentwire/.env` (docs/wiki/security/secrets.md) — config holds the env var NAME:
+
+```bash
+# ~/.agentwire/.env
+ZAI_API_KEY=...
+DEEPSEEK_API_KEY=...
+```
+
 In `~/.agentwire/config.yaml`:
 
 ```yaml
@@ -72,23 +80,22 @@ pi:
     ## Fetching URLs
     Use `agentwire fetch <url>` to fetch a page as clean markdown.
 
-  # Env vars injected into every pi-* session (in addition to the provider key)
+  # Env vars injected into every pi-* session (in addition to the provider key).
+  # Plaintext in config — non-secrets only; secrets go in ~/.agentwire/.env.
   extra_env:
-    MY_SERVICE_API_KEY: "..."
+    MY_SERVICE_URL: "https://internal.example.com"
 
   providers:
     zai:
-      env_var: ZAI_API_KEY
-      api_key: "..."
+      env_var: ZAI_API_KEY          # NAME of the env var holding the key
       default_model: glm-5.1
     deepseek:
       env_var: DEEPSEEK_API_KEY
-      api_key: "..."
       default_model: deepseek-chat
     # add more as needed: openai, openrouter, anthropic, ...
 ```
 
-Provider key flows via `tmux set-environment` so it never appears in `ps auxwww` or shell history.
+The key is read from the process environment (loaded from `~/.agentwire/.env` on every entry point) and flows to the session via `tmux set-environment`, so it never appears in `ps auxwww` or shell history.
 
 ## Custom Providers via `~/.pi/agent/models.json`
 
@@ -110,14 +117,13 @@ For providers pi doesn't ship with built-in (e.g. DeepSeek), register them as Op
 }
 ```
 
-Then in `~/.agentwire/config.yaml`:
+Then in `~/.agentwire/config.yaml` (key goes in `~/.agentwire/.env` as `DEEPSEEK_API_KEY=sk-...`):
 
 ```yaml
 pi:
   providers:
     deepseek:
       env_var: DEEPSEEK_API_KEY
-      api_key: "sk-..."
       default_model: deepseek-chat
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ When the owner says "worktree session", they mean the standalone session (`agent
 | File | Purpose |
 |------|---------|
 | `config.yaml` | Main config (see `agentwire-config` skill) |
+| `.env` | **All API keys/secrets** — the one blessed spot, loaded on every entry point. `chmod 600`. See [`docs/wiki/security/secrets.md`](docs/wiki/security/secrets.md) |
 | `machines.json` | Remote machines registry |
 | `scripts/` | Machine-specific helper scripts (TTS, startup, service wrappers). Local only, not version controlled. `~/bin/` entries should symlink here. |
 | `voices/` | Custom TTS voice samples |

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -193,10 +193,20 @@ def build_agent_command(session_type: str, roles: list[RoleConfig] | None = None
             raise ValueError(
                 f"No config for pi provider '{provider}'. "
                 f"Add pi.providers.{provider} to ~/.agentwire/config.yaml "
-                f"with at least env_var, api_key, and default_model."
+                f"with at least env_var and default_model, and put the key "
+                f"itself in ~/.agentwire/.env (docs/wiki/security/secrets.md)."
             )
         env_var = provider_cfg.get("env_var", f"{provider.upper().replace('-', '_')}_API_KEY")
-        api_key = provider_cfg.get("api_key", "")
+        if provider_cfg.get("api_key"):
+            print(
+                f"Warning: pi.providers.{provider}.api_key in config.yaml is "
+                f"ignored — put {env_var}=... in ~/.agentwire/.env instead "
+                f"(docs/wiki/security/secrets.md)",
+                file=sys.stderr,
+            )
+        # The key comes from the process environment — ~/.agentwire/.env is
+        # loaded on every entry point, so one line there is all it takes.
+        api_key = os.environ.get(env_var, "")
         default_model = provider_cfg.get("default_model", "")
 
         # Merge provider key + any global pi extra_env
@@ -6788,7 +6798,37 @@ def cmd_doctor(args) -> int:
         else:
             print(f"  [!!] Stt: cloud tier but {key_env} is not set")
             print("       The portal will refuse to start until the key is in its environment.")
+            print("       Fix: add the key to ~/.agentwire/.env (docs/wiki/security/secrets.md)")
             issues_found += 1
+
+    # 8c. Secrets — for each configured feature that needs a key, report
+    # whether its env var is present. Names only, never values. Keys live in
+    # ~/.agentwire/.env (docs/wiki/security/secrets.md), loaded on every
+    # entry point, so os.environ is the authoritative view here.
+    raw_cfg = load_config()
+    expected_keys: list[tuple[str, list[str]]] = []
+    channels_cfg = raw_cfg.get("channels", {}) or {}
+    if channels_cfg.get("email"):
+        expected_keys.append(("channels.email (Resend)", ["RESEND_API_KEY"]))
+    if channels_cfg.get("quo"):
+        expected_keys.append(
+            ("channels.quo (OpenPhone)", ["QUO_API_KEY", "OPENPHONE_API_KEY"])
+        )
+    for pname, pcfg in (raw_cfg.get("pi", {}).get("providers", {}) or {}).items():
+        p_env_var = (pcfg or {}).get(
+            "env_var", f"{pname.upper().replace('-', '_')}_API_KEY"
+        )
+        expected_keys.append((f"pi.providers.{pname}", [p_env_var]))
+    if expected_keys:
+        print("\nChecking secrets (~/.agentwire/.env)...")
+        for feature, candidates in expected_keys:
+            found = next((v for v in candidates if os.environ.get(v)), None)
+            if found:
+                print(f"  [ok] {feature}: {found} is set")
+            else:
+                print(f"  [!!] {feature}: {' / '.join(candidates)} not set")
+                print(f"       Fix: add {candidates[0]}=... to ~/.agentwire/.env")
+                issues_found += 1
 
     # 9. Validate remote machines
     print("\nChecking remote machines...")

--- a/agentwire/channels/email.py
+++ b/agentwire/channels/email.py
@@ -9,7 +9,7 @@ import os
 import random
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -34,19 +34,23 @@ class EmailConfigError(NotificationError):
 
 @dataclass
 class EmailConfig:
-    """Email notification configuration (Resend)."""
+    """Email notification configuration (Resend).
 
-    api_key: str = ""
+    The API key is env-only: RESEND_API_KEY, normally a line in
+    ~/.agentwire/.env (docs/wiki/security/secrets.md). It is never read
+    from config.yaml.
+    """
+
     from_address: str = ""
     default_to: str = ""
     banner_image_url: str = ""
     echo_image_url: str = ""
     echo_small_url: str = ""
     logo_image_url: str = ""
+    api_key: str = field(init=False, default="")
 
     def __post_init__(self):
-        if not self.api_key:
-            self.api_key = os.environ.get("RESEND_API_KEY", "")
+        self.api_key = os.environ.get("RESEND_API_KEY", "")
 
 
 # Playful greetings from Echo
@@ -225,8 +229,8 @@ def send_email(
     if not email_config.api_key:
         raise EmailConfigError(
             "Email API key not configured. "
-            "Set RESEND_API_KEY in ~/.agentwire/.env "
-            "or set channels.email.api_key in ~/.agentwire/config.yaml"
+            "Add RESEND_API_KEY=re_... to ~/.agentwire/.env "
+            "(see docs/wiki/security/secrets.md)"
         )
 
     # Determine recipients (list form — Resend's `to` field accepts an array)

--- a/agentwire/channels/quo.py
+++ b/agentwire/channels/quo.py
@@ -9,7 +9,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from .base import (
@@ -28,15 +28,19 @@ class QuoConfigError(NotificationError):
 
 @dataclass
 class QuoConfig:
-    """Quo (OpenPhone) SMS configuration."""
+    """Quo (OpenPhone) SMS configuration.
 
-    api_key: str = ""
+    The API key is env-only: QUO_API_KEY (or legacy OPENPHONE_API_KEY),
+    normally a line in ~/.agentwire/.env (docs/wiki/security/secrets.md).
+    It is never read from config.yaml.
+    """
+
     from_number: str = ""  # E.164 format (+1...) or phone number ID (PNxxx)
     default_to: str = ""
+    api_key: str = field(init=False, default="")
 
     def __post_init__(self):
-        if not self.api_key:
-            self.api_key = os.environ.get("QUO_API_KEY", "") or os.environ.get("OPENPHONE_API_KEY", "")
+        self.api_key = os.environ.get("QUO_API_KEY", "") or os.environ.get("OPENPHONE_API_KEY", "")
 
 
 API_URL = "https://api.openphone.com/v1/messages"
@@ -72,8 +76,9 @@ def send_quo_sms(
 
     if not quo_config.api_key:
         raise QuoConfigError(
-            "Quo API key not configured. Set QUO_API_KEY env var "
-            "or channels.quo.api_key in ~/.agentwire/config.yaml"
+            "Quo API key not configured. "
+            "Add QUO_API_KEY=... to ~/.agentwire/.env "
+            "(see docs/wiki/security/secrets.md)"
         )
 
     recipient = to or quo_config.default_to

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -5,7 +5,8 @@ Loads config from YAML file with sensible defaults and env var overrides.
 """
 
 import os
-from dataclasses import dataclass, field
+import sys
+from dataclasses import dataclass, field, fields as dataclass_fields
 from pathlib import Path
 from typing import Optional
 
@@ -651,10 +652,23 @@ def _dict_to_config(data: dict) -> Config:
         for name, channel_cls in ChannelRegistry._channels.items():
             if channel_cls.config_class:
                 resolved = ChannelRegistry.resolve_config(name, data)
-                if resolved:
-                    channel_configs[name] = channel_cls.config_class(**resolved)
-                else:
-                    channel_configs[name] = channel_cls.config_class()
+                # Only pass fields the dataclass accepts. Secrets (api_key)
+                # are env-only — ~/.agentwire/.env — so a stale key in yaml
+                # gets a warning, not a config-load crash.
+                allowed = {
+                    f.name for f in dataclass_fields(channel_cls.config_class) if f.init
+                }
+                unknown = sorted(set(resolved) - allowed)
+                if unknown:
+                    print(
+                        f"Warning: ignoring channels.{name} field(s) "
+                        f"{', '.join(unknown)} — secrets belong in "
+                        f"~/.agentwire/.env, never config.yaml "
+                        f"(docs/wiki/security/secrets.md)",
+                        file=sys.stderr,
+                    )
+                kwargs = {k: v for k, v in resolved.items() if k in allowed}
+                channel_configs[name] = channel_cls.config_class(**kwargs)
     except ImportError:
         pass
 

--- a/agentwire/stt/__init__.py
+++ b/agentwire/stt/__init__.py
@@ -47,9 +47,10 @@ def get_stt_backend(config: Any) -> STTBackend:
         api_key = os.environ.get(api_key_env)
         if not api_key:
             raise ValueError(
-                f"stt.backend 'cloud' requires the {api_key_env} environment variable "
-                f"in the portal's environment (set stt.cloud.api_key_env to use a "
-                f"different variable). The key is used server-side only."
+                f"stt.backend 'cloud' requires the {api_key_env} environment "
+                f"variable — add {api_key_env}=... to ~/.agentwire/.env "
+                f"(docs/wiki/security/secrets.md; set stt.cloud.api_key_env to "
+                f"use a different variable). The key is used server-side only."
             )
         base_url = cloud.get("base_url", DEFAULT_BASE_URL)
         model = cloud.get("model", DEFAULT_MODEL)

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -43,6 +43,11 @@ Headless and scheduled execution.
 - **[Missions](missions.md)** — issue → branch → draft PR → review → merge orchestration; launchd-driven dispatcher + feedback router + worktree janitor
 - **[Usage-limit recovery](usage-limit-recovery.md)** — deterministic detect → park → email → auto-resume for the Claude Code usage-limit dialog; launchd watchdog, zero LLM involvement
 
+## Security
+
+- **[Secrets & API keys](security/secrets.md)** — `~/.agentwire/.env` is the one place every key lives; which vars each feature reads; the `api_key_env` pattern for new integrations
+- **[Damage control](internals/damage-control.md)** — safety hooks: rules, patterns, audit log
+
 ## Integrations
 
 External tools wired into AgentWire.

--- a/docs/wiki/communication/channels.md
+++ b/docs/wiki/communication/channels.md
@@ -24,28 +24,31 @@ class MyChannel(SendOnlyChannel):
 
 ## Config
 
-Each channel defines its own dataclass and reads from `channels.{config_key}:` in `~/.agentwire/config.yaml`. Secrets fall back to env vars in `__post_init__`.
+Each channel defines its own dataclass and reads from `channels.{config_key}:` in `~/.agentwire/config.yaml`. **Secrets are env-only** — the key comes from an env var (one line in `~/.agentwire/.env`, see [Secrets & API keys](../security/secrets.md)), never from config.yaml. Declare it as a non-init field so yaml can't supply it:
 
 ```python
 @dataclass
 class MyConfig:
-    api_key: str = ""
     default_to: str = ""
+    api_key: str = field(init=False, default="")
 
     def __post_init__(self):
-        if not self.api_key:
-            self.api_key = os.environ.get("MY_API_KEY", "")
+        self.api_key = os.environ.get("MY_API_KEY", "")
 ```
 
 ```yaml
 # ~/.agentwire/config.yaml
 channels:
   my_channel:
-    api_key: "your-key"
     default_to: "user@example.com"
 ```
 
-The channel registry resolves config from YAML automatically — no `config.py` changes needed.
+```bash
+# ~/.agentwire/.env
+MY_API_KEY=your-key
+```
+
+The channel registry resolves config from YAML automatically — no `config.py` changes needed. Unknown yaml fields (e.g. a stale `api_key:`) are ignored with a warning rather than crashing config load.
 
 ## CLI integration
 
@@ -83,7 +86,7 @@ def my_channel_send(text: str, to: str | None = None) -> str:
 
 - [ ] `agentwire channels list` shows your channel
 - [ ] Config loads correctly from YAML
-- [ ] Env var fallback works
+- [ ] Key is read from its env var (`~/.agentwire/.env`)
 - [ ] `send()` returns success with valid config
 - [ ] `send()` returns a clear error with missing/invalid config
 - [ ] CLI command works (`agentwire my_channel --body "test"`)
@@ -104,5 +107,6 @@ except ImportError:
 
 ## Security
 
+- API keys live in `~/.agentwire/.env` only ([Secrets & API keys](../security/secrets.md)) — `RESEND_API_KEY` for email, `QUO_API_KEY` for quo. Config never holds a key, so the portal's config editor never round-trips one.
 - Each channel only reads from its own `channels.{config_key}:` slot — no cross-channel config peeking.
 - Outbound-only means there's no public webhook endpoint on the portal for a channel to attack. The portal's `/ws/{session}` is the only WS surface; channels never expose HTTP.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -172,17 +172,22 @@ The scheduler runs the prompt headless in a fresh tmux session, captures the age
 
 Channels are outbound-only — a session sends you an email or SMS without exposing any inbound surface. Two ship today: **email** (Resend) and **quo** (OpenPhone SMS).
 
-1. Add to `~/.agentwire/config.yaml`:
+1. Put your Resend key in `~/.agentwire/.env` — the one place all keys live ([Secrets & API keys](security/secrets.md)):
+
+   ```bash
+   echo 'RESEND_API_KEY=re_...' >> ~/.agentwire/.env
+   ```
+
+2. Add to `~/.agentwire/config.yaml` (no key here — config never holds secrets):
 
    ```yaml
    channels:
      email:
        from_address: "you@example.com"   # verified Resend sender
        default_to: "you@example.com"
-       # api_key falls back to RESEND_API_KEY env var
    ```
 
-2. From a session, send yourself a note:
+3. From a session, send yourself a note:
 
    ```bash
    agentwire email --subject "Task done" --body "Build green on main."

--- a/docs/wiki/security/secrets.md
+++ b/docs/wiki/security/secrets.md
@@ -1,0 +1,90 @@
+# Secrets & API Keys
+
+> Living document. Update this, don't create new versions.
+
+**Every user secret lives in one file: `~/.agentwire/.env`.** One key per
+line, classic dotenv format. Keys never go in `config.yaml`, shell profiles,
+or `.agentwire.yml` — config holds env var *names* where needed, never
+values.
+
+```bash
+# ~/.agentwire/.env
+RESEND_API_KEY=re_...
+QUO_API_KEY=...
+OPENAI_API_KEY=sk-...
+ZAI_API_KEY=...
+```
+
+```bash
+chmod 600 ~/.agentwire/.env
+```
+
+## What loads it
+
+`agentwire/__main__.py` calls `load_dotenv(~/.agentwire/.env)` on **every**
+entry point — CLI commands, the portal, the MCP server, the scheduler. Any
+code reading `os.environ` sees the keys; so does any feature added later.
+That universality is why this is the one blessed spot.
+
+Two consequences:
+
+- **Long-running processes read it at startup.** After editing the file,
+  restart what needs the new key: `agentwire portal restart`.
+- The file is **dotenv format, not shell**. Values may legally contain `&`,
+  spaces, or quotes unescaped, so **never `source` it** — an unquoted `&`
+  backgrounds half a line and silently corrupts your shell state. To pull a
+  single value out in a script:
+
+  ```bash
+  grep '^RESEND_API_KEY=' ~/.agentwire/.env | cut -d= -f2-
+  ```
+
+## Which vars each feature reads
+
+| Feature | Env var(s) | Notes |
+|---|---|---|
+| Email channel (Resend) | `RESEND_API_KEY` | [Channels](../communication/channels.md) |
+| Quo / OpenPhone SMS channel | `QUO_API_KEY` (or legacy `OPENPHONE_API_KEY`) | [Channels](../communication/channels.md) |
+| Cloud STT | var **named by** `stt.cloud.api_key_env` — `OPENAI_API_KEY` by default; `GROQ_API_KEY`, `MISTRAL_API_KEY`, … per provider | [Cloud STT](../voice/stt-cloud.md) |
+| pi providers | var **named by** `pi.providers.<name>.env_var` — `ZAI_API_KEY`, `DEEPSEEK_API_KEY`, … | [Pi sessions](../sessions/pi.md) |
+| PyPI publish (maintainers) | `PYPI_TOKEN` | release workflow only |
+
+`agentwire doctor` reports, for each configured feature, whether its
+expected var is present — names only, never values.
+
+## The `api_key_env` pattern (for new integrations)
+
+Cloud STT (#280) set the shape every new integration should copy: config
+names the env var, the env var holds the key.
+
+```yaml
+stt:
+  cloud:
+    api_key_env: "OPENAI_API_KEY"   # the NAME — the key itself never lives in config
+```
+
+Why indirection instead of a hardcoded var name: multi-provider features
+(one OpenAI-compatible endpoint among many, multiple pi providers) need the
+user to pick which key applies without agentwire knowing every provider in
+advance. Single-provider features (Resend, Quo) just hardcode their var
+name — same convention, no indirection needed.
+
+What this buys, in either form:
+
+- `config.yaml` stays shareable/committable without a redaction pass.
+- The portal's config editor never round-trips a secret to the browser.
+- One file to `chmod 600`, back up, or rotate.
+
+## Security posture
+
+- **Damage-control gives `.env` zero access for agents** — agent sessions
+  can't read, edit, or even mention the file in shell commands
+  ([damage control](../internals/damage-control.md)). Keys flow to features
+  through the process environment only.
+- **pi caveat:** provider keys are injected into pi sessions via
+  `tmux set-environment` at creation (pi can't read the dotenv file itself).
+  That keeps them out of `ps auxwww` and shell history, but anything with
+  tmux access on the box can run `tmux show-environment -t <session>`.
+  Acceptable on a single-user box; know the trade-off.
+- Server-side only: no key is ever sent to the browser or echoed by a
+  portal endpoint.

--- a/docs/wiki/sessions/pi.md
+++ b/docs/wiki/sessions/pi.md
@@ -34,7 +34,15 @@ agentwire doctor  # Should show: [ok] pi: /path/to/pi (vX.Y.Z)
 
 ### Configure Providers
 
-Add a `pi:` block to `~/.agentwire/config.yaml`:
+Put each provider's key in `~/.agentwire/.env` — the one place all keys live ([Secrets & API keys](../security/secrets.md)):
+
+```bash
+# ~/.agentwire/.env
+ZAI_API_KEY=...
+DEEPSEEK_API_KEY=...
+```
+
+Then add a `pi:` block to `~/.agentwire/config.yaml`. Config holds the env var **name** per provider, never the key:
 
 ```yaml
 pi:
@@ -46,18 +54,18 @@ pi:
     ## Fetching URLs
     Use `agentwire fetch <url>` to fetch a page as clean markdown.
 
-  # Env vars injected into every pi-* session (in addition to the provider key)
+  # Env vars injected into every pi-* session (in addition to the provider key).
+  # Values are stored in plaintext here — non-secrets only. Secrets belong in
+  # ~/.agentwire/.env (docs/wiki/security/secrets.md).
   extra_env:
-    MY_SERVICE_API_KEY: "..."
+    MY_SERVICE_URL: "https://internal.example.com"
 
   providers:
     zai:
-      env_var: ZAI_API_KEY
-      api_key: "..."
+      env_var: ZAI_API_KEY          # NAME of the env var holding the key
       default_model: glm-5.1
     deepseek:
       env_var: DEEPSEEK_API_KEY
-      api_key: "..."
       default_model: deepseek-chat
     # add more as needed: openai, openrouter, anthropic, ...
 ```
@@ -204,7 +212,7 @@ Order matters — global comes first so role-specific instructions can build on 
 
 ### Provider Key Injection
 
-Provider keys flow via `tmux set-environment` so they never appear in `ps auxwww` or shell history. Each provider entry's `env_var` is set on the session at creation time. Worker panes inherit automatically.
+The key is read from the process environment at session creation — `~/.agentwire/.env` is loaded on every agentwire entry point, so a `ZAI_API_KEY=...` line there is all it takes ([Secrets & API keys](../security/secrets.md)). It flows to the session via `tmux set-environment`, so it never appears in `ps auxwww` or shell history (it *is* visible to anything on the box via `tmux show-environment` — see the secrets page for the trade-off). Worker panes inherit automatically.
 
 If you spawn pi manually (outside of `agentwire new`), you'll need to `export <ENV_VAR>=...` yourself first.
 
@@ -237,11 +245,11 @@ pi:
 
 ### `ValueError: No config for pi provider 'X'`
 
-You requested `pi-X` but `pi.providers.X` isn't defined in `~/.agentwire/config.yaml`. Add the entry with at least `env_var`, `api_key`, and `default_model`. For non-built-in providers, also register them in `~/.pi/agent/models.json` (see "Adding a New Provider" above).
+You requested `pi-X` but `pi.providers.X` isn't defined in `~/.agentwire/config.yaml`. Add the entry with at least `env_var` and `default_model`, and put the key itself in `~/.agentwire/.env`. For non-built-in providers, also register them in `~/.pi/agent/models.json` (see "Adding a New Provider" above).
 
 ### "No models available. Set API keys in environment variables."
 
-The provider's env var (e.g. `ZAI_API_KEY`, `DEEPSEEK_API_KEY`) isn't set on the tmux session. Check `pi.providers.<provider>.api_key` is filled in. AgentWire injects the key via `tmux set-environment -t <session>` at creation time.
+The provider's env var (e.g. `ZAI_API_KEY`, `DEEPSEEK_API_KEY`) isn't set on the tmux session. Check the var has a line in `~/.agentwire/.env` and its name matches `pi.providers.<provider>.env_var`. AgentWire injects the key via `tmux set-environment -t <session>` at creation time.
 
 ### Pi shows changelog on startup
 

--- a/docs/wiki/voice/stt-cloud.md
+++ b/docs/wiki/voice/stt-cloud.md
@@ -27,11 +27,11 @@ just `backend: cloud`. The portal reads the key from the env var named by
 `api_key_env` at startup and **refuses to start** if it's missing (fail fast
 beats silent dead mics). `agentwire doctor` checks the same thing.
 
-**Where to put the key:** `~/.agentwire/.env` — agentwire loads it on every
-startup (`load_dotenv` in `__main__.py`), so a line like
-`OPENAI_API_KEY=sk-...` is all it takes. It's also covered by the
-damage-control hooks (zero-access for agents). A shell-profile `export`
-works too, but the `.env` file is the blessed spot.
+**Where to put the key:** `~/.agentwire/.env` — the one place every
+agentwire secret lives ([Secrets & API keys](../security/secrets.md)).
+agentwire loads it on every startup (`load_dotenv` in `__main__.py`), so a
+line like `OPENAI_API_KEY=sk-...` is all it takes. It's also covered by the
+damage-control hooks (zero-access for agents).
 
 ## It's generic: any OpenAI-compatible provider
 

--- a/tests/unit/test_build_agent_command.py
+++ b/tests/unit/test_build_agent_command.py
@@ -9,18 +9,17 @@ from agentwire.roles import RoleConfig
 
 
 # Mock for load_config() in __main__ used by the pi-* branch.
+# Keys are env-only (~/.agentwire/.env) — config holds the env var NAME.
 FAKE_CONFIG = {
     "pi": {
         "binary": "pi",
         "providers": {
             "zai": {
                 "env_var": "ZAI_API_KEY",
-                "api_key": "test-key-123",
                 "default_model": "glm-5.1",
             },
             "deepseek": {
                 "env_var": "DEEPSEEK_API_KEY",
-                "api_key": "test-deepseek-key",
                 "default_model": "deepseek-chat",
             },
         },
@@ -32,6 +31,13 @@ FAKE_CONFIG = {
 def mock_main_load_config():
     with patch("agentwire.__main__.load_config", return_value=FAKE_CONFIG):
         yield
+
+
+@pytest.fixture(autouse=True)
+def provider_keys_in_env(monkeypatch):
+    """Provider keys come from the process env (loaded from ~/.agentwire/.env)."""
+    monkeypatch.setenv("ZAI_API_KEY", "test-key-123")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
 
 
 class TestBuildAgentCommand:
@@ -199,6 +205,34 @@ class TestBuildAgentCommand:
         with pytest.raises(ValueError, match="pi provider 'bogus'"):
             self._build("pi-bogus")
 
+    def test_pi_yaml_api_key_ignored(self, monkeypatch, capsys):
+        """api_key in config.yaml is ignored with a warning — env is the source."""
+        config = {
+            "pi": {
+                "binary": "pi",
+                "providers": {
+                    "zai": {
+                        "env_var": "ZAI_API_KEY",
+                        "api_key": "stale-yaml-key",
+                        "default_model": "glm-5.1",
+                    },
+                },
+            },
+        }
+        monkeypatch.setenv("ZAI_API_KEY", "env-key")
+        with patch("agentwire.__main__.load_config", return_value=config):
+            cmd = self._build("pi-zai")
+        assert cmd.env == {"ZAI_API_KEY": "env-key"}
+        assert "stale-yaml-key" not in str(cmd.env)
+        assert "ignored" in capsys.readouterr().err
+
+    def test_pi_missing_env_key_skips_injection(self, monkeypatch):
+        """No key in the environment → nothing injected (pi may have its own
+        key in ~/.pi/agent/models.json)."""
+        monkeypatch.delenv("ZAI_API_KEY", raising=False)
+        cmd = self._build("pi-zai")
+        assert cmd.env == {}
+
     def test_pi_extra_env_merged_with_provider_key(self):
         """pi.extra_env merges with the provider key."""
         config = {
@@ -208,7 +242,6 @@ class TestBuildAgentCommand:
                 "providers": {
                     "zai": {
                         "env_var": "ZAI_API_KEY",
-                        "api_key": "test-key-123",
                         "default_model": "glm-5.1",
                     },
                 },
@@ -228,7 +261,6 @@ class TestBuildAgentCommand:
                 "providers": {
                     "zai": {
                         "env_var": "ZAI_API_KEY",
-                        "api_key": "test-key-123",
                         "default_model": "glm-5.1",
                     },
                 },
@@ -255,7 +287,6 @@ class TestBuildAgentCommand:
                 "providers": {
                     "zai": {
                         "env_var": "ZAI_API_KEY",
-                        "api_key": "test-key-123",
                         "default_model": "glm-5.1",
                     },
                 },
@@ -277,7 +308,6 @@ class TestBuildAgentCommand:
                 "providers": {
                     "zai": {
                         "env_var": "ZAI_API_KEY",
-                        "api_key": "test-key-123",
                         "default_model": "glm-5.1",
                     },
                 },

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -90,17 +90,33 @@ class TestBaseChannel:
 
 
 class TestEmailChannel:
-    def test_email_config_env_fallback(self, monkeypatch):
+    def test_email_config_key_from_env(self, monkeypatch):
         monkeypatch.setenv("RESEND_API_KEY", "env-key-123")
         from agentwire.channels.email import EmailConfig
         config = EmailConfig()
         assert config.api_key == "env-key-123"
 
-    def test_email_config_explicit_overrides_env(self, monkeypatch):
-        monkeypatch.setenv("RESEND_API_KEY", "env-key")
+    def test_email_config_rejects_explicit_key(self):
+        """Keys are env-only (~/.agentwire/.env) — not a config field."""
         from agentwire.channels.email import EmailConfig
-        config = EmailConfig(api_key="explicit-key")
-        assert config.api_key == "explicit-key"
+        with pytest.raises(TypeError):
+            EmailConfig(api_key="explicit-key")
+
+    def test_config_yaml_api_key_ignored(self, tmp_path, monkeypatch, capsys):
+        """A stale api_key in config.yaml warns and is ignored — env wins."""
+        monkeypatch.setenv("RESEND_API_KEY", "env-key")
+        config_data = {"channels": {"email": {
+            "api_key": "stale-yaml-key",
+            "from_address": "x@y.com",
+        }}}
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump(config_data))
+
+        from agentwire.config import load_config
+        config = load_config(config_path)
+        assert config.channels["email"].api_key == "env-key"
+        assert config.channels["email"].from_address == "x@y.com"
+        assert "api_key" in capsys.readouterr().err
 
     def test_is_html_content(self):
         from agentwire.channels.email import _is_html_content
@@ -122,7 +138,7 @@ class TestEmailChannel:
 
     def test_send_email_no_api_key(self, tmp_path, monkeypatch):
         monkeypatch.delenv("RESEND_API_KEY", raising=False)
-        config_data = {"channels": {"email": {"api_key": "", "from_address": "x@y.com"}}}
+        config_data = {"channels": {"email": {"from_address": "x@y.com"}}}
         config_path = tmp_path / "config.yaml"
         config_path.write_text(yaml.safe_dump(config_data))
 
@@ -158,7 +174,7 @@ class TestEmailChannel:
 
 
 class TestQuoChannel:
-    def test_quo_config_env_fallback(self, monkeypatch):
+    def test_quo_config_key_from_env(self, monkeypatch):
         monkeypatch.setenv("QUO_API_KEY", "quo-key-123")
         from agentwire.channels.quo import QuoConfig
         config = QuoConfig()
@@ -169,19 +185,25 @@ class TestQuoChannel:
         monkeypatch.delenv("QUO_API_KEY", raising=False)
         monkeypatch.setenv("OPENPHONE_API_KEY", "op-key-456")
         from agentwire.channels.quo import QuoConfig
-        config = QuoConfig(api_key="")
+        config = QuoConfig()
         assert config.api_key == "op-key-456"
+
+    def test_quo_config_rejects_explicit_key(self):
+        """Keys are env-only (~/.agentwire/.env) — not a config field."""
+        from agentwire.channels.quo import QuoConfig
+        with pytest.raises(TypeError):
+            QuoConfig(api_key="k")
 
     def test_quo_config_defaults(self):
         from agentwire.channels.quo import QuoConfig
-        config = QuoConfig(api_key="k")
+        config = QuoConfig()
         assert config.from_number == ""
         assert config.default_to == ""
 
     def test_send_quo_no_api_key(self, tmp_path, monkeypatch):
         monkeypatch.delenv("QUO_API_KEY", raising=False)
         monkeypatch.delenv("OPENPHONE_API_KEY", raising=False)
-        config_data = {"channels": {"quo": {"api_key": ""}}}
+        config_data = {"channels": {"quo": {}}}
         config_path = tmp_path / "config.yaml"
         config_path.write_text(yaml.safe_dump(config_data))
 
@@ -218,9 +240,9 @@ def _mock_config():
 
 
 class TestSendEmailSuccess:
-    def test_send_email_success(self, tmp_path, _mock_config):
+    def test_send_email_success(self, tmp_path, _mock_config, monkeypatch):
+        monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
         _mock_config({"channels": {"email": {
-            "api_key": "re_test_key",
             "from_address": "test@example.com",
             "default_to": "user@example.com",
         }}}, tmp_path)
@@ -236,9 +258,9 @@ class TestSendEmailSuccess:
         assert result.error is None
         mock_resend.Emails.send.assert_called_once()
 
-    def test_send_email_with_to_override(self, tmp_path, _mock_config):
+    def test_send_email_with_to_override(self, tmp_path, _mock_config, monkeypatch):
+        monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
         _mock_config({"channels": {"email": {
-            "api_key": "re_test_key",
             "from_address": "test@example.com",
             "default_to": "default@example.com",
         }}}, tmp_path)
@@ -257,8 +279,8 @@ class TestSendEmailSuccess:
 class TestSendQuoSuccess:
     def test_send_quo_success(self, tmp_path, _mock_config, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("QUO_API_KEY", "test-quo-key")
         _mock_config({"channels": {"quo": {
-            "api_key": "test-quo-key",
             "from_number": "+15551234567",
             "default_to": "+15559876543",
         }}}, tmp_path)


### PR DESCRIPTION
Closes #285

One blessed location for every user secret — `~/.agentwire/.env` — enforced in code and documented in one place.

## What changed

### Code (no-backwards-compat: keys-in-config dropped entirely)
- **Channels (email/quo):** `api_key` is no longer a config field — it's a non-init dataclass field populated solely from `RESEND_API_KEY` / `QUO_API_KEY` (legacy `OPENPHONE_API_KEY` still honored). A stale `api_key:` left in `config.yaml` warns to stderr and is ignored instead of crashing config load (the loader now filters channel yaml to the dataclass's init fields).
- **pi providers:** the key is read from the process environment via the var named by `pi.providers.<name>.env_var` — `pi.providers.*.api_key` in yaml is ignored with a warning. The `tmux set-environment` injection mechanism is unchanged (pi can't read the dotenv file itself); the `tmux show-environment` visibility trade-off is now documented.
- **Error messages** (email, quo, cloud STT) all point at `~/.agentwire/.env` + the doc page — no more "set the env var" hand-waving.
- **`agentwire doctor`:** new secrets section — for each configured feature (email, quo, each pi provider; cloud STT already had its own check) it reports whether the expected env var is present. Names only, never values.

### Docs
- **New: [`docs/wiki/security/secrets.md`](https://github.com/dotdevdotdev/agentwire-dev/blob/mission-285-secrets-env/docs/wiki/security/secrets.md)** — the single reference: what loads the file (`load_dotenv` on every entry point), chmod 600, per-feature var table (incl. `PYPI_TOKEN` folklore made official), the `api_key_env` indirection pattern from #280 as the model for new integrations, and the **never-`source`-it warning** (dotenv values may contain unquoted `&`; scripts should use `grep '^VAR=' | cut -d= -f2-`).
- Swept quickstart, channels dev guide, pi page, stt-cloud, `agentwire-config` + `agentwire-pi` skills, INDEX.md (new Security section), and CLAUDE.md's config-layout table to point at it.

## Verification
- `uv run --extra dev pytest`: **1436 passed**, 1 failed — `test_terminal_registers_client_in_session`, verified pre-existing on the base commit via `git stash` (websocket `local_disconnected` frame, unrelated).
- New/updated tests: env-only key reads, `TypeError` on explicit `api_key=` kwarg, stale-yaml-key-ignored-with-warning (channels + pi), missing-env-key-skips-injection.
- `grep -r api_key docs/` shows no instruction to paste a key into config.yaml; no docs tell users to export keys in shell profiles.

Built by [dotdev.dev](https://dotdev.dev)