### PR TITLE
docs(roles): weave polite `agentwire msg` into the standing role briefings

### DIFF
--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -15,10 +15,14 @@ Sessions are tmux sessions running AI agents. You can create, message, and monit
 |------|-------------|
 | `sessions_list()` | List all active sessions |
 | `session_create(name)` | Create a new session |
-| `session_send(session, message)` | Send a prompt to a session |
+| `session_send(session, message)` | Send a prompt to a session **now** (pastes + Enter immediately) |
+| `msg_send(to, text, kind)` | **Polite** peer message — queued, injected only when their box is empty |
+| `msg_inbox(session)` | Peek a session's pending polite messages |
 | `session_output(session, lines)` | Read session output |
 | `session_info(session)` | Get session metadata |
 | `session_kill(session)` | Kill a session |
+
+**Polite vs forceful.** Prefer `msg_send` for routine peer updates that must not interrupt — "PR drafted", "picking up the footer". It drops the message into a file inbox and the watchdog injects it only when the recipient's input box is empty (≤60s), so it **never clobbers a human's half-typed draft**. Reach for `session_send` **only** when you must drive a session right now — it pastes + Enter immediately, overwriting any uncommitted draft. `kind` ∈ note|done|request|escalation; `to="@all"` broadcasts to live agent sessions except you.
 
 ## Panes (Workers)
 

--- a/agentwire/roles/council-member.md
+++ b/agentwire/roles/council-member.md
@@ -44,4 +44,4 @@ The full prompt text is also on disk at
   lenses are covered. Short and direct — one sharp paragraph beats three
   balanced ones.
 - **Never address the user or other souls directly.** No `session_send`, no
-  `notify`. The inbox is your only output channel.
+  `agentwire msg`, no `notify`. The council inbox is your only output channel.

--- a/agentwire/roles/orchestrator.md
+++ b/agentwire/roles/orchestrator.md
@@ -80,6 +80,7 @@ Make email better.
 
 - **Speak updates** via `say()` if voice is enabled
 - **Notify parent** via `notify()` if you have a parent session
+- **Ping siblings/workers politely** via `msg_send(to, text, kind)` for routine peer updates — it queues into a file inbox and injects only when their box is empty (≤60s), so it never clobbers a draft. Reserve `session_send` for when you must drive a session right now. Workers may also report back this way, so check `msg_inbox()` for anything pending.
 - **Escalate to user** via `email_send()` / `quo_send()` for cross-device push when voice isn't enough
 - **Be concise** — status updates, not novels
 

--- a/agentwire/roles/worker.md
+++ b/agentwire/roles/worker.md
@@ -14,6 +14,7 @@ You're a worker pane executing a task for the parent session. Work autonomously,
 - **No questions** — make your best judgment call
 - **Stay focused** — complete the assigned task, don't go off on tangents
 - **Commit your work** — if the task involves code changes
+- **Report back politely** — if you need to ping the parent before your exit summary (status, a blocker), use `agentwire msg send --to <parent> --kind note "..."` (or `--kind done`). `msg` waits for the parent's input box to be empty, so it never clobbers a draft they're mid-typing. Reserve `session_send` for when something genuinely can't wait.
 
 ## Exit Summary
 

--- a/agentwire/roles/worktree-mission.md
+++ b/agentwire/roles/worktree-mission.md
@@ -24,6 +24,12 @@ When the task is done:
 1. Commit with a clear message, following any commit-footer conventions from your global instructions.
 2. Push the branch: `git push -u origin {{branch}}`.
 3. Open a DRAFT pull request to `{{base_branch}}`. If the work tracks a GitHub issue, include `Closes #<issue>` in the PR body. The PR description is the breadcrumb: what was built, decisions locked in, surprises, verification results.
-4. Report back to your creator: `{{notify_back}}`
+4. Report back to your creator with a **polite, non-interrupting** message — so you never clobber a draft they're half-way through typing:
+
+   ```
+   agentwire msg send --to {{creator}} --kind done "{{session}}: <one-liner + PR URL>"
+   ```
+
+   `agentwire msg` queues the message and delivers it only when your creator's input box is empty; `notify-parent` / `session_send` paste + Enter **immediately** and overwrite any uncommitted draft. Reserve the forceful path (`{{notify_back}}`) for something that genuinely can't wait.
 
 Do not merge the PR yourself — your creator or a reviewer handles merge and worktree cleanup.

--- a/docs/wiki/sessions/prompt-routing.md
+++ b/docs/wiki/sessions/prompt-routing.md
@@ -123,3 +123,5 @@ prompt_router:
 
 - [Usage-limit recovery](../usage-limit-recovery.md) — same watchdog, runs
   first each tick.
+- [Polite messaging](messaging.md) — `agentwire msg` drains on the same
+  watchdog tick, after this prompt-routing sweep.


### PR DESCRIPTION
Closes #301

## What

The polite `agentwire msg` channel shipped in #299 (CLI, MCP tools, skills, wiki) — but **no bundled role mentioned it**, so agents were never *told* to prefer it over `session_send`. Roles are the push-surface; skills/docs are pull. This weaves `msg` into the role briefings and audits the #299 discovery surfaces for drift.

## Role edits

- **`worktree-mission.md`** (the auto-injected worker briefing) — *highest-value change*. Workers now report back with:
  ```
  agentwire msg send --to {{creator}} --kind done "{{session}}: <one-liner + PR URL>"
  ```
  This directly fixes the reported collision: a worker reporting via `session_send` while the owner is mid-draft mangles both into one prompt. `msg` injects only when the creator's input box is empty. `notify-parent`/`session_send` reserved for "genuinely can't wait."
- **`agentwire.md`** — `msg_send` / `msg_inbox` rows added to the Sessions tool table + a **"polite vs forceful"** note.
- **`worker.md`** — mirror: if a worker pings the parent before its exit summary, use `msg` not `session_send`.
- **`orchestrator.md`** — mirror in the Communication section; orchestrators told workers may report back via the inbox (check `msg_inbox()`).
- **`council-member.md`** — souls now explicitly forbidden from `agentwire msg` too (they reply only via the council file inbox), alongside the existing `session_send`/`notify` ban.

## Audit of #299 surfaces (verified, not assumed)

| Surface | Status |
|---|---|
| `agentwire-cli` skill | ✅ present, correct (polite-vs-forceful, `@all`, kinds) |
| `agentwire-mcp-tools` skill | ✅ present, correct |
| MCP docstrings (`mcp_server.py` `msg_send`/`msg_inbox`) | ✅ steer to polite path, name `session_send` as forceful |
| `CLAUDE.md` Key Patterns | ✅ "Polite Messaging" section present, links to wiki |
| `docs/wiki/sessions/messaging.md` | ✅ exists, in INDEX, links to council/prompt-routing/usage-limit |
| **Drift fixed** | `prompt-routing.md` "Related" had no back-link to messaging.md → added (cross-link now bidirectional) |

## SSOT wording

One canonical framing reused everywhere: *polite `msg` (queued, injected only when the box is empty, never clobbers a draft) vs forceful `session_send` (pastes + Enter immediately).*

## Out of scope
- No `msg` behavior/code change (shipped in #299). Content-only.

## Verification
- Rendered `worktree-mission.md` against the real template vars (`creator`, `session`, `notify_back` — all in `mission_vars`): step 4 now reads the polite path, **0 unresolved placeholders**.
- `grep msg agentwire/roles/*.md` confirms all five roles carry the guidance.
- ⚠️ Live `agentwire roles show worktree-mission` reflects the *installed* tool, not this worktree's source — it will pick up these edits after merge + `agentwire rebuild`. Verified against source instead (per worktree isolation: no rebuild in-worktree).

Built by [dotdev.dev](https://dotdev.dev)