### PR TITLE
Cheap transport hardening: SSH ControlMaster multiplexing + Tailscale mesh docs (#300)

### DIFF
--- a/agentwire/agents/tmux.py
+++ b/agentwire/agents/tmux.py
@@ -9,6 +9,7 @@ import subprocess
 from pathlib import Path
 
 from .base import AgentBackend
+from ..ssh import ssh_base_opts
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +135,7 @@ class TmuxAgent(AgentBackend):
         port = machine.get("port")
         ssh_cmd = [
             "ssh",
+            *ssh_base_opts(),
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=5",
         ]

--- a/agentwire/history.py
+++ b/agentwire/history.py
@@ -11,6 +11,7 @@ Supports both local and remote machines via SSH for distributed setups.
 import json
 from pathlib import Path
 
+from .ssh import ssh_base_opts
 from .utils.file_io import load_json
 from .utils.paths import agentwire_dir
 from .utils.subprocess import run_command
@@ -124,7 +125,7 @@ def _run_ssh_command(machine: dict, command: str, timeout: int = 10) -> tuple[bo
         ssh_target = host
 
     # Build SSH command with connection timeout
-    ssh_cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+    ssh_cmd = ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
     if port:
         ssh_cmd.extend(["-p", str(port)])
     ssh_cmd.extend([ssh_target, command])

--- a/agentwire/projects.py
+++ b/agentwire/projects.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import yaml
 
 from .config import get_config
+from .ssh import ssh_base_opts
 
 # Default config directory
 CONFIG_DIR = Path.home() / ".agentwire"
@@ -77,7 +78,7 @@ def _run_ssh_command(machine: dict, command: str, timeout: int = 10) -> tuple[bo
         ssh_target = host
 
     # Build SSH command with connection timeout
-    ssh_cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+    ssh_cmd = ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
     if port:
         ssh_cmd.extend(["-p", str(port)])
     ssh_cmd.extend([ssh_target, command])

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -45,6 +45,7 @@ from .security import (
     resolve_auth_token,
     validate_startup_security,
 )
+from .ssh import ssh_base_opts
 from .worktree import parse_session_name
 
 __version__ = "1.3.0"
@@ -70,7 +71,7 @@ async def unpin_tmux_window(session_name: str, ssh_target: str | None = None) ->
     cmd = ["tmux", "set-option", "-w", "-t", session_name, "-u", "window-size"]
     if ssh_target:
         proc = await asyncio.create_subprocess_exec(
-            "ssh", ssh_target, shlex.join(cmd),
+            "ssh", *ssh_base_opts(), ssh_target, shlex.join(cmd),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
         )
@@ -571,7 +572,7 @@ class AgentWireServer:
             try:
                 cmd = f"tmux display-message -t {shlex.quote(session_name)} -p '#{{pane_current_path}}'"
                 result = subprocess.run(
-                    ["ssh", "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
+                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
                     capture_output=True,
                     text=True,
                     timeout=5,
@@ -629,7 +630,7 @@ class AgentWireServer:
             try:
                 yaml_path = f"{cwd}/.agentwire.yml"
                 result = subprocess.run(
-                    ["ssh", "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, f"cat {shlex.quote(yaml_path)}"],
+                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, f"cat {shlex.quote(yaml_path)}"],
                     capture_output=True,
                     text=True,
                     timeout=5,
@@ -686,7 +687,7 @@ class AgentWireServer:
                 encoded = base64.b64encode(yaml_content.encode()).decode()
                 cmd = f"echo {shlex.quote(encoded)} | base64 -d > {shlex.quote(yaml_path)}"
                 result = subprocess.run(
-                    ["ssh", "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
+                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
                     capture_output=True,
                     text=True,
                     timeout=5,
@@ -860,7 +861,7 @@ class AgentWireServer:
 
         try:
             proc = await asyncio.create_subprocess_exec(
-                "ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
+                "ssh", *ssh_base_opts(), "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
                 ssh_target, command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -1929,7 +1930,7 @@ class AgentWireServer:
 
                 # Remote session via SSH with PTY allocation
                 # Use accept-new to accept new host keys but reject changed ones (MITM protection)
-                cmd = ["ssh", "-t", "-o", "StrictHostKeyChecking=accept-new", ssh_target, "tmux", "attach", "-t", session_name]
+                cmd = ["ssh", "-t", *ssh_base_opts(), "-o", "StrictHostKeyChecking=accept-new", ssh_target, "tmux", "attach", "-t", session_name]
                 logger.info(f"[Terminal] Attaching to {session_name}: {' '.join(cmd)}")
 
                 # Create PTY for SSH too (ssh -t needs local PTY)
@@ -2707,7 +2708,7 @@ class AgentWireServer:
                 remote_cmd = " ".join(shlex.quote(a) for a in local_argv)
                 result = await asyncio.to_thread(
                     subprocess.run,
-                    ["ssh", machine, remote_cmd],
+                    ["ssh", *ssh_base_opts(), machine, remote_cmd],
                     capture_output=True,
                     text=True,
                     timeout=30,
@@ -3283,7 +3284,7 @@ class AgentWireServer:
                 # DNS failed, try connecting via SSH to get the remote IP
                 try:
                     proc = await asyncio.create_subprocess_exec(
-                        "ssh", "-o", "ConnectTimeout=2", "-o", "StrictHostKeyChecking=no",
+                        "ssh", *ssh_base_opts(), "-o", "ConnectTimeout=2", "-o", "StrictHostKeyChecking=no",
                         hostname, "hostname -I 2>/dev/null || ip addr show | grep 'inet ' | grep -v '127.0.0.1' | head -1 | awk '{print $2}' | cut -d/ -f1",
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.DEVNULL
@@ -3318,7 +3319,7 @@ class AgentWireServer:
         try:
             proc = await asyncio.wait_for(
                 asyncio.create_subprocess_exec(
-                    "ssh", "-o", f"ConnectTimeout={connect_timeout}", "-o", "BatchMode=yes",
+                    "ssh", *ssh_base_opts(), "-o", f"ConnectTimeout={connect_timeout}", "-o", "BatchMode=yes",
                     ssh_target, "echo ok",
                     stdout=asyncio.subprocess.DEVNULL,
                     stderr=asyncio.subprocess.DEVNULL,

--- a/agentwire/ssh.py
+++ b/agentwire/ssh.py
@@ -1,0 +1,100 @@
+"""Shared SSH connection options — single source of truth for every ssh call.
+
+ControlMaster multiplexing: the first ssh to a target opens a master connection
+and parks its control socket under ``~/.ssh/sockets/``; subsequent ssh
+invocations to the same ``user@host:port`` ride that socket and skip the TCP +
+auth handshake entirely (~90-140ms on loopback, 300-500ms over a VPN — measured
+in #297). ``ControlPersist`` keeps the idle master alive for a window after the
+last client exits so a *burst* of remote ops pays the handshake once.
+
+Degrades gracefully by design:
+- Socket dir missing → we create it on demand (``ensure_socket_dir``).
+- Master gone / never started → ssh just opens a fresh connection (the cost we
+  pay today on every call anyway).
+- Master wedged → ``ServerAliveInterval`` evicts it instead of hanging forever.
+
+This mirrors Ansible's default (ControlMaster on out of the box), so the failure
+modes are well-trodden.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+# How long an idle master lingers after its last client exits. A burst of
+# commands within this window reuses the socket; after it the master self-exits,
+# which is also how stale sockets clean themselves up.
+CONTROL_PERSIST_SECONDS = 600
+
+# One control socket per target. ``%r@%h-%p`` = remote-user @ host - port, so
+# distinct targets never collide on the same socket. ssh expands these tokens
+# itself; we hand it an absolute path (subprocess does not expand ``~``).
+SSH_SOCKET_DIR = Path.home() / ".ssh" / "sockets"
+
+
+def ensure_socket_dir() -> bool:
+    """Create ``~/.ssh/sockets/`` (0700) on demand. Idempotent; never raises.
+
+    Returns True if the dir exists and is usable afterward, False otherwise.
+
+    Called from :func:`ssh_base_opts` so the dir exists before the first
+    multiplexed connection. The return value matters: ``ControlMaster=auto``
+    with a *missing* ``ControlPath`` directory does NOT degrade — ssh aborts
+    with ``unix_listener: cannot bind`` (exit 255) and the command never runs.
+    So when we can't guarantee the dir, the caller drops multiplexing entirely
+    and falls back to a plain (re-handshaking) connection.
+    """
+    try:
+        SSH_SOCKET_DIR.mkdir(parents=True, exist_ok=True)
+        os.chmod(SSH_SOCKET_DIR, 0o700)
+        return SSH_SOCKET_DIR.is_dir()
+    except OSError:
+        return False
+
+
+def ssh_base_opts() -> list[str]:
+    """Shared ``-o`` flags for every ssh invocation (SSOT).
+
+    Returns ControlMaster multiplexing flags plus keepalives as a flat
+    argv-ready list, meant to be spliced right after the ``"ssh"`` token::
+
+        subprocess.run(["ssh", *ssh_base_opts(), target, command])
+
+    Side effect: ensures the socket dir exists. If it can't be created (read-only
+    home, perms) the ControlMaster flags are *omitted* so ssh connects normally
+    instead of aborting on an unbindable socket path — graceful degradation to
+    today's per-command-handshake behavior. Keepalives are always included.
+    """
+    keepalives = [
+        # Evict a wedged master rather than block forever on a dead socket.
+        "-o", "ServerAliveInterval=60",
+        "-o", "ServerAliveCountMax=3",
+    ]
+    if not ensure_socket_dir():
+        return keepalives
+    control_path = str(SSH_SOCKET_DIR / "%r@%h-%p")
+    return [
+        "-o", "ControlMaster=auto",
+        "-o", f"ControlPath={control_path}",
+        "-o", f"ControlPersist={CONTROL_PERSIST_SECONDS}",
+        *keepalives,
+    ]
+
+
+def ssh_control_exit(ssh_target: str) -> None:
+    """Tear down the master connection for ``ssh_target`` (``ssh -O exit``).
+
+    Best-effort: closes the parked socket so nothing lingers past an explicit
+    teardown (e.g. destroying a tunnel). A no-op if no master exists. Never
+    raises — a failed teardown just means ControlPersist will reap it later.
+    """
+    control_path = str(SSH_SOCKET_DIR / "%r@%h-%p")
+    try:
+        subprocess.run(
+            ["ssh", "-o", f"ControlPath={control_path}", "-O", "exit", ssh_target],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass

--- a/agentwire/tunnels.py
+++ b/agentwire/tunnels.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional
 
 from .network import NetworkContext, TunnelSpec
+from .ssh import ssh_base_opts, ssh_control_exit
 from .utils.paths import agentwire_dir
 from .utils.subprocess import run_command
 
@@ -129,20 +130,17 @@ class TunnelManager:
             )
 
         # Build SSH command
-        # -L local_port:localhost:remote_port - Port forwarding
-        # -N - Don't execute remote command
-        # -f - Go to background
-        # -o ExitOnForwardFailure=yes - Exit if port forward fails
-        # -o ServerAliveInterval=60 - Keep connection alive
-        # -o ServerAliveCountMax=3 - Max missed keepalives
+        # ssh_base_opts() supplies ControlMaster multiplexing + keepalives
+        # (ServerAliveInterval/CountMax). -L local_port:localhost:remote_port
+        # port-forwards; -N runs no remote command; -f backgrounds;
+        # -o ExitOnForwardFailure=yes exits if the forward can't bind.
         cmd = [
             "ssh",
+            *ssh_base_opts(),
             "-L", f"{spec.local_port}:localhost:{spec.remote_port}",
             "-N",
             "-f",
             "-o", "ExitOnForwardFailure=yes",
-            "-o", "ServerAliveInterval=60",
-            "-o", "ServerAliveCountMax=3",
             ssh_target,
         ]
 
@@ -235,6 +233,16 @@ class TunnelManager:
         # Clean up state file
         self._get_state_file(spec).unlink(missing_ok=True)
 
+        # Best-effort: close the multiplexing master for this target so it
+        # doesn't linger past an explicit teardown. A no-op if no master
+        # exists; the next command just re-handshakes if it was shared.
+        try:
+            ssh_target = self._get_ssh_target(spec.remote_machine)
+            if ssh_target:
+                ssh_control_exit(ssh_target)
+        except Exception:
+            pass
+
         return TunnelStatus(spec=spec, status="down")
 
     def ensure_tunnels(self, ctx: Optional[NetworkContext] = None) -> list[TunnelStatus]:
@@ -324,6 +332,7 @@ def test_ssh_connectivity(host: str, user: Optional[str] = None, timeout: int = 
         result = run_command(
             [
                 "ssh",
+                *ssh_base_opts(),
                 "-o", f"ConnectTimeout={timeout}",
                 "-o", "StrictHostKeyChecking=accept-new",
                 "-o", "BatchMode=yes",

--- a/docs/wiki/deployment/remote-machines.md
+++ b/docs/wiki/deployment/remote-machines.md
@@ -136,7 +136,16 @@ Host gpu-server
     IdentityFile ~/.ssh/id_ed25519
 ```
 
-**Tip:** Enable SSH ControlMaster for faster remote operations (reuses connections instead of opening new ones each time). Add to `~/.ssh/config`:
+**SSH ControlMaster connection multiplexing (built in).** AgentWire applies
+ControlMaster flags to **every** `ssh` it spawns (see `agentwire/ssh.py` —
+`ssh_base_opts()`), so the first remote op to a host opens a master connection
+and parks its socket under `~/.ssh/sockets/`; subsequent ops ride that socket
+and skip the handshake (~90–140ms saved on loopback, 300–500ms over a VPN). The
+socket dir is created on demand; if it can't be created the flags are dropped
+and ssh just re-handshakes (no command is lost). Nothing to configure.
+
+To get the same speedup for **your own** interactive `ssh`/`scp`/`rsync` from
+the shell, add the equivalent to `~/.ssh/config`:
 
 ```
 Host *
@@ -144,6 +153,88 @@ Host *
     ControlPath ~/.ssh/sockets/%r@%h-%p
     ControlPersist 600
 ```
+
+Inspect or tear down a master by hand: `ssh -O check <host>` /
+`ssh -O exit <host>`.
+
+---
+
+## Tailscale Mesh Underlay (no inbound port 22)
+
+> Optional. SSH stays the transport — Tailscale is just the network it rides.
+> This buys the "no public inbound port / identity-based / NAT-traversal"
+> security story with **zero application-code change** (see research in
+> `docs/wiki/research/orchestration-transport-alternatives.md`).
+
+Today every managed machine needs reachable SSH — typically public port 22 or a
+hole-punched forward. [Tailscale](https://tailscale.com) (a managed WireGuard
+mesh) gives every machine a stable private `100.x` address on your *tailnet*,
+reachable from any other enrolled machine regardless of NAT, with **no inbound
+port open to the public internet**. Point `machines.json` at the tailnet
+addresses and SSH rides the encrypted mesh.
+
+### Setup (per machine)
+
+1. **Install Tailscale** on the orchestrator and every managed machine:
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   sudo tailscale up            # opens a browser/device-auth link
+   ```
+   macOS: `brew install --cask tailscale` (or the App Store app), then `tailscale up`.
+
+2. **Grab each machine's tailnet address** (stable, survives reboots/IP changes):
+   ```bash
+   tailscale ip -4              # e.g. 100.101.102.103
+   tailscale status            # also shows MagicDNS names like gpu-server.tail-scale.ts.net
+   ```
+
+3. **Point `machines.json` at the tailnet address** (or MagicDNS name) instead
+   of the public IP:
+   ```json
+   {
+     "id": "gpu-server",
+     "host": "100.101.102.103",
+     "user": "ubuntu",
+     "projects_dir": "~/projects"
+   }
+   ```
+   MagicDNS names work too (`"host": "gpu-server.tail-scale.ts.net"`) and read
+   better. Verify: `ssh ubuntu@100.101.102.103 echo ok`.
+
+4. **Close public port 22.** Once every machine reaches the others over the
+   tailnet, drop inbound 22 from the public internet at the firewall / cloud
+   security group / `ufw`:
+   ```bash
+   sudo ufw allow in on tailscale0 to any port 22   # SSH only over the tailnet
+   sudo ufw deny  in            to any port 22       # block public 22
+   ```
+   (Cloud hosts: remove the `0.0.0.0/0 :22` rule from the security group; keep a
+   console/out-of-band path so you can't lock yourself out.)
+
+ControlMaster multiplexing (above) stacks on top — the per-command handshake the
+mesh adds (a few ms WireGuard overhead) is paid once per host, then reused.
+
+### Pairing with the public portal (Cloudflare Tunnel)
+
+These solve two different exposure problems and compose cleanly:
+
+| Concern | Mechanism |
+|---|---|
+| Machine-to-machine SSH (orchestrator ↔ managed boxes) | **Tailscale mesh** — private `100.x`, no public port |
+| Public access to the **portal** (your phone, anywhere) | **Cloudflare Tunnel** — outbound-only, no inbound port (see [`remote-access.md`](remote-access.md)) |
+
+Neither opens an inbound port on a managed machine. The portal is reachable from
+the open internet via the tunnel; SSH between machines never leaves the tailnet.
+
+### Optional later step: Tailscale SSH
+
+[Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh) can terminate the
+SSH connection itself using **tailnet device identity / your SSO**, dropping
+`authorized_keys` management entirely — access is governed by tailnet ACLs
+instead of per-host key files. Enable per node with `tailscale up --ssh` and an
+ACL `ssh` rule. **Not required** for the mesh underlay above (plain `sshd` over
+the tailnet works fine); it's a follow-up if you want to retire key
+distribution.
 
 ---
 

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -1,0 +1,110 @@
+"""Tests for agentwire/ssh.py — the ControlMaster multiplexing SSOT (#300)."""
+
+import subprocess
+
+import pytest
+
+from agentwire import ssh
+
+
+@pytest.fixture
+def socket_dir(tmp_path, monkeypatch):
+    """Point the socket dir at a throwaway path so tests never touch ~/.ssh."""
+    d = tmp_path / "sockets"
+    monkeypatch.setattr(ssh, "SSH_SOCKET_DIR", d)
+    return d
+
+
+def _opt_value(opts, key):
+    """Pull the value of a `-o key=value` flag out of a flat opts list."""
+    for i, tok in enumerate(opts):
+        if tok == "-o" and opts[i + 1].startswith(f"{key}="):
+            return opts[i + 1].split("=", 1)[1]
+    return None
+
+
+def test_ssh_base_opts_has_controlmaster_flags(socket_dir):
+    opts = ssh.ssh_base_opts()
+    assert _opt_value(opts, "ControlMaster") == "auto"
+    assert _opt_value(opts, "ControlPersist") == str(ssh.CONTROL_PERSIST_SECONDS)
+    # ControlPath is per-target via ssh's %r@%h-%p tokens, under our socket dir.
+    control_path = _opt_value(opts, "ControlPath")
+    assert control_path.endswith("%r@%h-%p")
+    assert str(socket_dir) in control_path
+
+
+def test_ssh_base_opts_has_keepalives(socket_dir):
+    """ServerAliveInterval evicts a wedged master instead of hanging."""
+    opts = ssh.ssh_base_opts()
+    assert _opt_value(opts, "ServerAliveInterval") == "60"
+    assert _opt_value(opts, "ServerAliveCountMax") == "3"
+
+
+def test_ssh_base_opts_is_flat_argv(socket_dir):
+    """Result splices straight into an ssh argv: flat list of strings, -o paired."""
+    opts = ssh.ssh_base_opts()
+    assert all(isinstance(tok, str) for tok in opts)
+    # Every -o must be followed by a value token (no dangling flag).
+    for i, tok in enumerate(opts):
+        if tok == "-o":
+            assert i + 1 < len(opts)
+            assert "=" in opts[i + 1]
+
+
+def test_ssh_base_opts_creates_socket_dir_on_demand(socket_dir):
+    assert not socket_dir.exists()
+    ssh.ssh_base_opts()
+    assert socket_dir.exists()
+    # 0700 — control sockets are sensitive.
+    assert (socket_dir.stat().st_mode & 0o777) == 0o700
+
+
+def test_ensure_socket_dir_idempotent(socket_dir):
+    ssh.ensure_socket_dir()
+    ssh.ensure_socket_dir()  # second call must not raise
+    assert socket_dir.is_dir()
+
+
+def test_ensure_socket_dir_never_raises_returns_false(monkeypatch, socket_dir):
+    """A read-only home must degrade gracefully — return False, don't raise."""
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(type(socket_dir), "mkdir", boom)
+    assert ssh.ensure_socket_dir() is False
+
+
+def test_ssh_base_opts_drops_controlmaster_when_dir_unavailable(monkeypatch, socket_dir):
+    """If the socket dir can't be created, omit ControlMaster so ssh still
+    connects (ControlMaster=auto + missing ControlPath dir = exit 255)."""
+    monkeypatch.setattr(ssh, "ensure_socket_dir", lambda: False)
+    opts = ssh.ssh_base_opts()
+    assert _opt_value(opts, "ControlMaster") is None
+    assert _opt_value(opts, "ControlPath") is None
+    # Keepalives still present — graceful fallback, not a total strip.
+    assert _opt_value(opts, "ServerAliveInterval") == "60"
+
+
+def test_ssh_control_exit_invokes_o_exit(socket_dir, monkeypatch):
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(ssh.subprocess, "run", fake_run)
+    ssh.ssh_control_exit("user@host")
+    argv = captured["argv"]
+    assert argv[0] == "ssh"
+    assert "-O" in argv and "exit" in argv
+    assert argv[-1] == "user@host"
+    # Targets the same per-target ControlPath the opts use.
+    assert any(a.startswith("ControlPath=") and a.endswith("%r@%h-%p") for a in argv)
+
+
+def test_ssh_control_exit_never_raises(socket_dir, monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no ssh binary")
+
+    monkeypatch.setattr(ssh.subprocess, "run", boom)
+    ssh.ssh_control_exit("user@host")  # swallowed

--- a/tests/unit/test_terminal_resize.py
+++ b/tests/unit/test_terminal_resize.py
@@ -42,9 +42,12 @@ class TestUnpinTmuxWindow:
             await unpin_tmux_window("myproject/branch", ssh_target="user@host")
 
         args = exec_mock.call_args.args
+        # ssh_base_opts() (ControlMaster multiplexing) is spliced between the
+        # "ssh" token and the target, so assert on the stable head/tail.
         assert args[0] == "ssh"
-        assert args[1] == "user@host"
-        assert args[2] == "tmux set-option -w -t myproject/branch -u window-size"
+        assert "ControlMaster=auto" in args
+        assert args[-2] == "user@host"
+        assert args[-1] == "tmux set-option -w -t myproject/branch -u window-size"
         proc.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -53,7 +56,7 @@ class TestUnpinTmuxWindow:
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as exec_mock:
             await unpin_tmux_window("my project", ssh_target="user@host")
 
-        remote_cmd = exec_mock.call_args.args[2]
+        remote_cmd = exec_mock.call_args.args[-1]
         assert "'my project'" in remote_cmd
 
 


### PR DESCRIPTION
Implements the two "cheap win" hardening steps from research #297. Both keep SSH as the transport — no new daemon, bus, or transport. Closes #300.

## 1. SSH ControlMaster connection multiplexing (the "faster" win)

**SSOT:** new `agentwire/ssh.py` with `ssh_base_opts()` returning the connection-reuse flags:

```
-o ControlMaster=auto
-o ControlPath=~/.ssh/sockets/%r@%h-%p   # absolute, expanded — subprocess doesn't expand ~
-o ControlPersist=600
-o ServerAliveInterval=60 / ServerAliveCountMax=3   # evict a wedged master
```

The first remote op to a host opens a master connection and parks its socket under `~/.ssh/sockets/`; a burst of follow-ups rides that socket and skips the handshake (~90–140ms saved on loopback, 300–500ms over a VPN — measured in #297).

**Every daemon-side ssh call site routed through it:**
- `agents/tmux.py` (`_run_remote`)
- `tunnels.py` — `create_tunnel` (replaced its hardcoded keepalives) + `test_ssh_connectivity`
- `server.py` — path probe, `.agentwire.yml` read/write, run-remote command, interactive `attach -t`, remote `rm`, IP discovery, machine-status check
- `projects.py`, `history.py` (`_run_ssh_command`)

`ssh -G` (config dump, not a connection) was intentionally **not** routed.

**Teardown:** `ssh_control_exit()` (`ssh -O exit`) closes the master on tunnel destroy; stale sockets otherwise self-reap at the `ControlPersist` timeout.

### Graceful degradation — the non-obvious failure mode

`ControlMaster=auto` with a **missing** `ControlPath` directory does **not** degrade — ssh aborts with `unix_listener: cannot bind` (exit 255) and the command never runs. So `ssh_base_opts()` creates the dir on demand, and if it can't (read-only home/perms) it **drops the ControlMaster flags entirely**, falling back to today's per-command-handshake behavior. Keepalives are always kept.

## 2. Tailscale mesh underlay (the "more secure" win) — docs only

Added a followable setup recipe to `docs/wiki/deployment/remote-machines.md`: install Tailscale per machine, put tailnet `100.x`/MagicDNS addresses in `machines.json`, close public port 22 (ufw/security-group). Documents the Cloudflare-Tunnel-for-portal pairing (links the existing `remote-access.md`) and Tailscale SSH as the optional later step to retire `authorized_keys`. Also promoted the now-built-in ControlMaster behavior into the SSH Configuration section.

## Verification (in-worktree, against localhost sshd)

- ✅ **Burst reuse:** 5 commands → one master socket `dotdev@localhost-22`; `ssh -O check` → "Master running"; `ssh_control_exit` removes it.
- ✅ **Missing/unusable socket dir:** opts degrade to `[ServerAliveInterval, ServerAliveCountMax]` only; command returns rc=0.
- ✅ **Stale socket file (dead master):** re-handshakes, command succeeds.
- ✅ **Interactive `ssh -t` attach:** exercised through a real PTY (the same `pty.openpty()` path the portal uses) — marker returned.
- ✅ `tests/unit/test_ssh.py` (9 tests) + updated `test_terminal_resize.py`; **full unit suite: 1419 passed**.
- ✅ `ruff` adds zero new lint errors to touched files.

**Cannot verify in-worktree** (needs the live install / a real second machine): end-to-end portal terminal attach over SSH, and the Tailscale recipe against a real tailnet. The `-t` attach path is verified at the ssh-command level via PTY; the docs recipe is standard Tailscale + ufw.

## Notes for review
- Tunnel `-N -f` forwards now ride/become a ControlMaster. Killing the tunnel PID closes its forward; the `ssh -O exit` on destroy is best-effort and may close a master shared with command multiplexing to the same host (next command just re-handshakes — documented inline).
- CLI-side `__main__.py` ssh calls (human one-off commands) were left un-multiplexed — out of the issue's daemon-hot-path scope; easy follow-up if wanted.

Built by [dotdev.dev](https://dotdev.dev)