### PR TITLE
feat(worktree): finish the worktree-session orchestration primitive (#307)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -33,10 +33,19 @@ agentwire worktree name         # new branch + worktree + STANDALONE session
                                 #   the verb (isolation, no rebuild/restart, verify
                                 #   in-worktree, draft PR + notify-back) — first prompts
                                 #   only need the task itself
+                                #   Base branch (default mode): --base wins, else config
+                                #   worktree.default_base, else the repo's actual default
+                                #   branch (origin/HEAD, fallback current) — no hardcoded 'main'.
+                                #   --project defaults to the git root of cwd (monorepo-safe:
+                                #   many sessions can target one repo from different branches).
+                                #   config worktree.naming can template the NEW branch name.
 agentwire worktree name -b develop  # from specific base branch
 agentwire worktree name -c      # from repo's current branch
 agentwire worktree name -e      # checkout existing branch (no new branch)
 agentwire worktree name --ref v2.0  # detached at tag/commit
+agentwire worktree --list       # list this repo's worktree sessions (registry); --all = every repo
+agentwire worktree --remove name  # kill session + remove worktree + unregister (cleanup/recovery)
+agentwire worktree --prune      # drop registry entries whose worktree is gone + git worktree prune
 agentwire fork -s name          # fork session into new worktree
 agentwire fork -s name -t project/branch --commit abc123  # fork from specific commit
 

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -202,10 +202,20 @@ usage_limit:             # Usage-limit recovery watchdog (docs/wiki/usage-limit-
   enabled: true          # Master switch for dialog detection/parking (default: true)
   exclude_sessions: []   # Session names never auto-parked (gates NEW parks only)
 
-worktree:
-  worktree_dir: ~/worktrees       # Where worktrees are created
-  default_base: main              # Default base branch
-  default_project: ~/projects/my-repo  # Default git repo
+worktree:                         # `agentwire worktree <name>` orchestration (WorktreeConfig).
+                                  # Distinct from projects.worktrees above (the legacy
+                                  # project/branch layout). `quicktask:` is a legacy alias for
+                                  # this key — prefer `worktree:`.
+  worktree_dir: ~/worktrees       # Where worktrees are created (one dir per session)
+  default_base: develop           # Base branch new worktrees fork from. OMIT to derive from
+                                  # the repo's actual default branch (origin/HEAD, fallback to
+                                  # current branch) — no hardcoded 'main'. --base always wins.
+  default_project: ~/projects/my-repo  # Repo used when --project is omitted AND cwd isn't in a
+                                  # git repo. Otherwise --project / the git root of cwd is used.
+  naming: "{user}/{slug}"         # Optional branch-name template for NEW branches. Placeholders:
+                                  # {name} (verbatim), {slug} (slugified), {user} (OS login).
+                                  # Omit → branch == name verbatim. Only the git branch is
+                                  # templated; the tmux session name stays {project}-{name}.
 
 overnight:
   window_start: "22:00"        # Start of overnight work window

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -54,6 +54,7 @@ from .worktree import (
     git_root,
     default_base_branch,
     apply_naming,
+    is_valid_branch_name,
 )
 from . import worktree_registry
 
@@ -4962,8 +4963,16 @@ def cmd_worktree(args) -> int:
 
     # If worktree already exists, reattach (and heal the registry entry).
     if worktree_path.exists():
+        # --ref is a detached ref, not a branch → record null. --existing
+        # checks out a real branch (name). Default mode → the templated branch.
+        if ref:
+            reattach_branch = None
+        elif use_existing:
+            reattach_branch = name
+        else:
+            reattach_branch = templated_branch
         worktree_registry.register(
-            project_path, branch=templated_branch if not (ref or use_existing) else name,
+            project_path, branch=reattach_branch,
             session=session_name, base=default_base,
             worktree_path=worktree_path,
         )
@@ -4990,8 +4999,12 @@ def cmd_worktree(args) -> int:
         new_branch = None
         mode_label = f"existing branch {name}"
     else:
-        # Default mode: new branch from base
-        if getattr(args, 'current', False):
+        # Default mode: new branch from base.
+        # Precedence: explicit --base > --current > config default > repo-derived.
+        explicit_base = getattr(args, 'base', None)
+        if explicit_base:
+            base_branch = explicit_base
+        elif getattr(args, 'current', False):
             result = subprocess.run(
                 ["git", "-C", str(project_path), "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True, text=True,
@@ -4999,10 +5012,24 @@ def cmd_worktree(args) -> int:
             if result.returncode != 0 or not result.stdout.strip():
                 return _output_result(False, json_mode, f"Failed to detect current branch in {project_path}")
             base_branch = result.stdout.strip()
+        elif wt_config.default_base:
+            base_branch = wt_config.default_base
         else:
-            base_branch = default_base or default_base_branch(project_path)
+            base_branch = default_base_branch(project_path)
         git_ref = f"origin/{base_branch}"
         new_branch = templated_branch
+
+        # Validate the generated branch name BEFORE touching the working tree,
+        # so a bad name (spaces, '..', leading '-', from the verbatim default
+        # or a naming template) fails cleanly instead of leaving an orphaned
+        # detached worktree on disk after `git worktree add` succeeds.
+        if not is_valid_branch_name(new_branch, project_path):
+            via = f" (from naming template '{wt_config.naming}')" if wt_config.naming else ""
+            return _output_result(
+                False, json_mode,
+                f"Invalid git branch name '{new_branch}'{via}: not a valid ref. "
+                f"Use a name without spaces, '..', or a leading '-', or set worktree.naming.",
+            )
         mode_label = f"new branch {new_branch} from {git_ref}"
 
         # Fetch the base branch
@@ -5036,6 +5063,14 @@ def cmd_worktree(args) -> int:
             capture_output=True, text=True,
         )
         if branch_result.returncode != 0:
+            # Don't leave an orphaned detached worktree behind (belt-and-braces;
+            # is_valid_branch_name above should already have caught bad names).
+            remove_worktree(project_path, worktree_path)
+            if worktree_path.exists():
+                subprocess.run(
+                    ["git", "-C", str(project_path), "worktree", "remove", str(worktree_path), "--force"],
+                    capture_output=True,
+                )
             return _output_result(False, json_mode, f"Failed to create branch '{new_branch}': {branch_result.stderr.strip()}")
 
     # Record the branch↔session association in the local registry.
@@ -11118,7 +11153,7 @@ def main() -> int:
     wt_parser = subparsers.add_parser("worktree", help="Create a git worktree + session in one command")
     wt_parser.add_argument("name", nargs="?", help="Name (becomes branch name in default mode, session suffix always)")
     wt_parser.add_argument("--base", "-b", help="Base branch to fork from (default: config worktree.default_base, else the repo's origin/HEAD default branch)")
-    wt_parser.add_argument("--current", "-c", action="store_true", help="Fork from the repo's current branch instead of --base")
+    wt_parser.add_argument("--current", "-c", action="store_true", help="Fork from the repo's current branch (used when --base is not given)")
     wt_parser.add_argument("--existing", "-e", action="store_true", help="Checkout an existing branch (no new branch created)")
     wt_parser.add_argument("--ref", help="Detach at a specific ref (tag, commit, branch)")
     wt_parser.add_argument("--project", "-p", help="Path to git repo (default: config worktree.default_project, else the git root of cwd)")

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -47,7 +47,15 @@ from .roles import (
     merge_roles,
     resolve_roles,
 )
-from .worktree import ensure_worktree, parse_session_name, remove_worktree
+from .worktree import (
+    ensure_worktree,
+    parse_session_name,
+    remove_worktree,
+    git_root,
+    default_base_branch,
+    apply_naming,
+)
+from . import worktree_registry
 
 # Default config directory
 CONFIG_DIR = Path.home() / ".agentwire"
@@ -4884,30 +4892,56 @@ def cmd_worktree(args) -> int:
     they never replace it.
     """
     json_mode = getattr(args, 'json', False)
-    name = args.name
+    name = getattr(args, 'name', None)
     use_existing = getattr(args, 'existing', False)
     ref = getattr(args, 'ref', None)
+
+    from .config import load_config as load_config_typed
+    wt_config = load_config_typed().worktree
+
+    # Resolve the repo: explicit --project → config default → git root of cwd
+    # (so a worktree session can be spawned from any subdir of a monorepo).
+    project_arg = getattr(args, 'project', None)
+    if project_arg:
+        project_base = Path(project_arg).expanduser().resolve()
+    elif wt_config.default_project:
+        project_base = Path(wt_config.default_project).expanduser().resolve()
+    else:
+        project_base = Path(os.getcwd())
+    project_path = git_root(project_base) or project_base
+
+    worktree_dir = wt_config.worktree_dir
+
+    # Registry management flags (name is optional for these).
+    if getattr(args, 'list', False):
+        return _worktree_list(args, project_path, json_mode)
+    if getattr(args, 'prune', False):
+        return _worktree_prune(args, project_path, json_mode)
+    if getattr(args, 'remove', False):
+        return _worktree_remove(args, project_path, worktree_dir, json_mode)
+
+    if not name:
+        return _output_result(False, json_mode, "Usage: agentwire worktree <name> (or --list / --remove <name> / --prune)")
 
     if not _check_tmux_installed():
         return _output_result(False, json_mode, "tmux is required but not installed")
 
-    config = load_config()
-    wt_config = config.get("worktree", config.get("quicktask", {}))
-
-    # Resolve project repo path
-    project_arg = getattr(args, 'project', None)
-    project_path = Path(
-        project_arg or wt_config.get("default_project") or os.getcwd()
-    ).expanduser().resolve()
     if not (project_path / ".git").exists():
         return _output_result(False, json_mode, f"Not a git repo: {project_path}")
 
-    worktree_dir = Path(wt_config.get("worktree_dir", "~/worktrees")).expanduser().resolve()
     project_name = project_path.name
-    session_name = f"{project_name}-{name}"
+    # Session/worktree-dir key stays the raw CLI name made tmux-safe; the git
+    # branch may be templated separately via worktree.naming.
+    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+    session_name = f"{project_name}-{safe_name}"
     worktree_path = worktree_dir / session_name
 
-    default_base = getattr(args, 'base', None) or wt_config.get("default_base", "main")
+    # --base wins; else config default; else the repo's actual default branch
+    # (origin/HEAD, not a hardcoded 'main'). --current handled per-mode below.
+    default_base = getattr(args, 'base', None) or wt_config.default_base
+
+    # The branch created in default mode honors the naming template.
+    templated_branch = apply_naming(wt_config.naming, name)
 
     def _launch_session():
         # kind="worktree-session" → worktree-session etiquette is injected
@@ -4926,8 +4960,13 @@ def cmd_worktree(args) -> int:
             'env': getattr(args, 'env', None),
         })())
 
-    # If worktree already exists, reattach
+    # If worktree already exists, reattach (and heal the registry entry).
     if worktree_path.exists():
+        worktree_registry.register(
+            project_path, branch=templated_branch if not (ref or use_existing) else name,
+            session=session_name, base=default_base,
+            worktree_path=worktree_path,
+        )
         if json_mode:
             _output_json({"success": True, "session": session_name, "path": str(worktree_path), "reattached": True})
         else:
@@ -4939,6 +4978,7 @@ def cmd_worktree(args) -> int:
         return 0
 
     # Resolve the git ref to create the worktree from
+    base_branch = None
     if ref:
         # --ref mode: detached at a specific ref (tag, commit, branch)
         git_ref = ref
@@ -4960,10 +5000,10 @@ def cmd_worktree(args) -> int:
                 return _output_result(False, json_mode, f"Failed to detect current branch in {project_path}")
             base_branch = result.stdout.strip()
         else:
-            base_branch = default_base
+            base_branch = default_base or default_base_branch(project_path)
         git_ref = f"origin/{base_branch}"
-        new_branch = name
-        mode_label = f"new branch {name} from {git_ref}"
+        new_branch = templated_branch
+        mode_label = f"new branch {new_branch} from {git_ref}"
 
         # Fetch the base branch
         if not json_mode:
@@ -4998,6 +5038,15 @@ def cmd_worktree(args) -> int:
         if branch_result.returncode != 0:
             return _output_result(False, json_mode, f"Failed to create branch '{new_branch}': {branch_result.stderr.strip()}")
 
+    # Record the branch↔session association in the local registry.
+    worktree_registry.register(
+        project_path,
+        branch=new_branch if new_branch else (name if use_existing else None),
+        session=session_name,
+        base=base_branch,
+        worktree_path=worktree_path,
+    )
+
     if json_mode:
         _output_json({
             "success": True, "session": session_name, "path": str(worktree_path),
@@ -5008,6 +5057,104 @@ def cmd_worktree(args) -> int:
         print(f"Mode: {mode_label}")
 
     return _launch_session()
+
+
+def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
+    """List worktree-session registry entries (--list)."""
+    show_all = getattr(args, 'all', False)
+    if show_all:
+        rows = worktree_registry.all_entries()
+    else:
+        rows = [dict(e, project=str(project_path)) for e in worktree_registry.entries(project_path)]
+
+    for r in rows:
+        r["alive"] = tmux_session_exists(r.get("session", ""))
+        r["exists"] = Path(r.get("worktree_path", "")).exists()
+
+    if json_mode:
+        _output_json({"success": True, "entries": rows})
+        return 0
+
+    if not rows:
+        scope = "any repo" if show_all else str(project_path)
+        print(f"No worktree sessions registered for {scope}.")
+        return 0
+
+    for r in rows:
+        live = "live" if r["alive"] else ("orphan" if r["exists"] else "stale")
+        print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}")
+        print(f"      {r.get('worktree_path')}")
+    return 0
+
+
+def _worktree_prune(args, project_path: Path, json_mode: bool) -> int:
+    """Drop registry entries whose worktree path is gone; git worktree prune."""
+    removed = []
+    for e in worktree_registry.entries(project_path):
+        if not Path(e.get("worktree_path", "")).exists():
+            worktree_registry.unregister(project_path, session=e.get("session"))
+            removed.append(e.get("session"))
+    subprocess.run(["git", "-C", str(project_path), "worktree", "prune"],
+                   capture_output=True)
+    if json_mode:
+        _output_json({"success": True, "pruned": removed})
+    else:
+        if removed:
+            print(f"Pruned {len(removed)} stale registry entr{'y' if len(removed) == 1 else 'ies'}: {', '.join(removed)}")
+        else:
+            print("Nothing to prune.")
+    return 0
+
+
+def _worktree_remove(args, project_path: Path, worktree_dir: Path, json_mode: bool) -> int:
+    """Cleanup/recovery: kill the session, remove the worktree, unregister."""
+    name = getattr(args, 'name', None)
+    if not name:
+        return _output_result(False, json_mode, "Usage: agentwire worktree --remove <name|session>")
+
+    project_name = project_path.name
+    candidates = {name, f"{project_name}-{name}"}
+    entry = None
+    for e in worktree_registry.entries(project_path):
+        if e.get("session") in candidates or e.get("branch") == name or Path(e.get("worktree_path", "")).name in candidates:
+            entry = e
+            break
+
+    if entry:
+        session_name = entry.get("session")
+        worktree_path = Path(entry.get("worktree_path"))
+    else:
+        # Not in registry — fall back to the conventional layout so recovery
+        # still works on hand-created or pre-registry worktrees.
+        safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+        session_name = name if name.startswith(f"{project_name}-") else f"{project_name}-{safe_name}"
+        worktree_path = worktree_dir / session_name
+
+    # Kill the tmux session if it's alive.
+    killed = False
+    if tmux_session_exists(session_name):
+        subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
+        killed = True
+
+    # Remove the git worktree (force), then sweep any leftover dir.
+    removed = remove_worktree(project_path, worktree_path)
+    if not removed and worktree_path.exists():
+        subprocess.run(
+            ["git", "-C", str(project_path), "worktree", "remove", str(worktree_path), "--force"],
+            capture_output=True,
+        )
+        removed = not worktree_path.exists()
+
+    worktree_registry.unregister(project_path, session=session_name, worktree_path=worktree_path)
+
+    if json_mode:
+        _output_json({"success": True, "session": session_name, "path": str(worktree_path),
+                      "killed": killed, "worktree_removed": removed})
+    else:
+        print(f"Removed worktree session '{session_name}'"
+              + (" (killed live session)" if killed else "")
+              + (f"; worktree {worktree_path} removed" if removed else f"; worktree {worktree_path} left in place"))
+    return 0
 
 
 def cmd_fork(args) -> int:
@@ -10969,12 +11116,16 @@ def main() -> int:
 
     # === worktree command ===
     wt_parser = subparsers.add_parser("worktree", help="Create a git worktree + session in one command")
-    wt_parser.add_argument("name", help="Name (becomes branch name in default mode, session suffix always)")
-    wt_parser.add_argument("--base", "-b", help="Base branch to fork from (default: from config or 'main')")
+    wt_parser.add_argument("name", nargs="?", help="Name (becomes branch name in default mode, session suffix always)")
+    wt_parser.add_argument("--base", "-b", help="Base branch to fork from (default: config worktree.default_base, else the repo's origin/HEAD default branch)")
     wt_parser.add_argument("--current", "-c", action="store_true", help="Fork from the repo's current branch instead of --base")
     wt_parser.add_argument("--existing", "-e", action="store_true", help="Checkout an existing branch (no new branch created)")
     wt_parser.add_argument("--ref", help="Detach at a specific ref (tag, commit, branch)")
-    wt_parser.add_argument("--project", "-p", help="Path to git repo (default: from config or cwd)")
+    wt_parser.add_argument("--project", "-p", help="Path to git repo (default: config worktree.default_project, else the git root of cwd)")
+    wt_parser.add_argument("--list", action="store_true", help="List registered worktree sessions for this repo (--all for every repo)")
+    wt_parser.add_argument("--remove", action="store_true", help="Kill the session, remove the worktree, and unregister (cleanup/recovery)")
+    wt_parser.add_argument("--prune", action="store_true", help="Drop registry entries whose worktree is gone + git worktree prune")
+    wt_parser.add_argument("--all", action="store_true", help="With --list: include worktree sessions across every repo")
     _add_posture_harness_flags(wt_parser)
     wt_parser.add_argument("--type", help="Legacy fused session type / intent preset (accepted, not primary)")
     wt_parser.add_argument("--roles", help="Comma-separated roles, STACKED on top of the always-present worktree-session etiquette")

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -98,6 +98,43 @@ class ProjectsConfig:
         self.dir = _expand_path(self.dir) or Path.home() / "projects"
 
 
+@dataclass
+class WorktreeConfig:
+    """Standalone worktree-session orchestration (`worktree:` config key).
+
+    Governs `agentwire worktree <name>` — the first-class primitive for
+    spawning an isolated branch+worktree+session for one unit of work.
+
+    Distinct from ``projects.worktrees`` (:class:`WorktreesConfig`), which
+    governs the legacy ``project/branch`` session layout under
+    ``~/projects/<project>-worktrees/``. This one drives the dedicated
+    ``agentwire worktree`` command and its branch↔session registry.
+
+    Fields:
+        default_base: Base branch new worktrees fork from. ``None`` means
+            "ask the repo" — resolved from ``origin/HEAD`` (falling back to
+            the current branch). ``--base`` always overrides.
+        default_project: Repo path used when ``--project`` is omitted and
+            cwd is not inside a git repo. ``None`` → infer from cwd's git
+            root, else cwd.
+        worktree_dir: Where worktrees live (one dir per session).
+        naming: Optional branch-name template applied in default (new-branch)
+            mode, e.g. ``"{user}/{slug}"`` or ``"feature-{slug}"``.
+            Placeholders: ``{name}`` (raw), ``{slug}`` (slugified),
+            ``{user}`` (OS user). ``None`` → branch == name verbatim.
+    """
+
+    default_base: str | None = None
+    default_project: str | None = None
+    worktree_dir: Path = field(default_factory=lambda: Path.home() / "worktrees")
+    naming: str | None = None
+
+    def __post_init__(self):
+        self.worktree_dir = _expand_path(self.worktree_dir) or Path.home() / "worktrees"
+        if self.default_project:
+            self.default_project = str(_expand_path(self.default_project))
+
+
 _VOICE_BACKENDS = ("default", "custom")
 
 _VOICE_BACKEND_MIGRATION_HINT = (
@@ -429,6 +466,7 @@ class Config:
 
     server: ServerConfig = field(default_factory=ServerConfig)
     projects: ProjectsConfig = field(default_factory=ProjectsConfig)
+    worktree: WorktreeConfig = field(default_factory=WorktreeConfig)
     tts: TTSConfig = field(default_factory=TTSConfig)
     stt: STTConfig = field(default_factory=STTConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
@@ -542,6 +580,16 @@ def _dict_to_config(data: dict) -> Config:
         dir=projects_data.get("dir", "~/projects"),
         worktrees=worktrees,
         extra=projects_data.get("extra", []),
+    )
+
+    # Worktree-session orchestration (`worktree:` key). `quicktask:` is a
+    # documented legacy alias — the canonical key is `worktree:`.
+    worktree_data = data.get("worktree", data.get("quicktask", {})) or {}
+    worktree = WorktreeConfig(
+        default_base=worktree_data.get("default_base"),
+        default_project=worktree_data.get("default_project"),
+        worktree_dir=worktree_data.get("worktree_dir", "~/worktrees"),
+        naming=worktree_data.get("naming"),
     )
 
     # TTS
@@ -764,6 +812,7 @@ def _dict_to_config(data: dict) -> Config:
         server=server,
         session=session,
         projects=projects,
+        worktree=worktree,
         tts=tts,
         stt=stt,
         agent=agent,

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -7,8 +7,84 @@ Session naming convention:
 - "project/branch@machine" -> remote worktree session
 """
 
+import getpass
+import re
 import subprocess
 from pathlib import Path
+
+
+def git_root(path: Path) -> Path | None:
+    """Return the top-level git directory containing ``path``, or None.
+
+    Walks up via ``git rev-parse --show-toplevel`` so a worktree session can
+    be spawned from any subdirectory of a (mono)repo and still target the
+    repo root. Returns the main repo root, not a linked-worktree root.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True,
+    )
+    out = result.stdout.strip()
+    if result.returncode == 0 and out:
+        return Path(out)
+    return None
+
+
+def default_base_branch(project_path: Path) -> str:
+    """Resolve a repo's default base branch (no hardcoded 'main').
+
+    Order:
+        1. ``origin/HEAD`` symbolic ref (the remote's default branch) —
+           e.g. a monorepo defaulting to ``develop``.
+        2. The repo's current branch (when origin/HEAD isn't set locally;
+           run ``git remote set-head origin -a`` to populate it).
+        3. ``"main"`` as a last resort.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(project_path), "symbolic-ref", "--quiet",
+         "refs/remotes/origin/HEAD"],
+        capture_output=True, text=True,
+    )
+    ref = result.stdout.strip()
+    if result.returncode == 0 and ref:
+        return ref.rsplit("/", 1)[-1]
+
+    result = subprocess.run(
+        ["git", "-C", str(project_path), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True,
+    )
+    cur = result.stdout.strip()
+    if result.returncode == 0 and cur and cur != "HEAD":
+        return cur
+
+    return "main"
+
+
+def slugify(name: str) -> str:
+    """Lowercase, hyphen-separated, filesystem/branch-safe slug of ``name``."""
+    s = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return s or "wt"
+
+
+class _SafeFormatDict(dict):
+    """format_map helper: leave unknown ``{placeholders}`` literal."""
+
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def apply_naming(template: str | None, name: str) -> str:
+    """Apply a branch-naming template to a CLI name.
+
+    Placeholders: ``{name}`` (verbatim), ``{slug}`` (slugified),
+    ``{user}`` (OS login). ``None``/empty template → ``name`` verbatim.
+    Unknown placeholders are left literal rather than raising.
+    """
+    if not template:
+        return name
+    return template.format_map(_SafeFormatDict(
+        name=name, slug=slugify(name), user=getpass.getuser(),
+    ))
 
 
 def parse_session_name(name: str) -> tuple[str, str | None, str | None]:

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -60,6 +60,25 @@ def default_base_branch(project_path: Path) -> str:
     return "main"
 
 
+def is_valid_branch_name(name: str, project_path: Path | None = None) -> bool:
+    """True if ``name`` is a valid git branch name.
+
+    Uses ``git check-ref-format --branch`` (the authority) plus cheap
+    guards for cases git would mis-parse (leading dash → looks like a flag)
+    or that aren't usable as a worktree branch. Guards against a templated
+    or verbatim name with spaces / ``..`` / leading ``-`` reaching
+    ``git checkout -b`` and failing *after* the worktree is already on disk.
+    """
+    if not name or name.startswith("-") or name.endswith("/") or name.endswith(".lock"):
+        return False
+    cwd = str(project_path) if project_path else None
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", name],
+        capture_output=True, text=True, cwd=cwd,
+    )
+    return result.returncode == 0
+
+
 def slugify(name: str) -> str:
     """Lowercase, hyphen-separated, filesystem/branch-safe slug of ``name``."""
     s = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")

--- a/agentwire/worktree_registry.py
+++ b/agentwire/worktree_registry.py
@@ -1,0 +1,138 @@
+"""Local branch↔session registry for worktree sessions.
+
+agentwire-owned **local state** — never provider data. It records which
+worktree sessions exist for a repo so the `agentwire worktree` command can
+list, clean up, and recover them robustly when 4–5 branches are in flight
+at once (inference from the `{project}-{branch}` session name alone is
+fragile at that scale).
+
+Layout: one JSON file per repo under ``~/.agentwire/worktrees/``, keyed by
+the repo's absolute path. Each file holds a list of entries:
+
+    {
+      "project": "/Users/me/projects/monorepo",
+      "entries": [
+        {"branch": "fix-bug", "session": "monorepo-fix-bug",
+         "base": "develop", "worktree_path": "/Users/me/worktrees/monorepo-fix-bug",
+         "created_at": "2026-06-14T10:30:00-04:00"}
+      ]
+    }
+
+Files are plain JSON and **hand-editable** — delete a stale entry by hand,
+or run ``agentwire worktree --prune`` to drop entries whose worktree path
+no longer exists.
+"""
+
+import datetime
+import json
+from pathlib import Path
+
+REGISTRY_DIR = Path.home() / ".agentwire" / "worktrees"
+
+
+def _repo_key(project_path: Path) -> str:
+    """Stable, filesystem-safe key from a repo's absolute path."""
+    p = str(Path(project_path).expanduser().resolve())
+    return p.strip("/").replace("/", "_").replace(" ", "_") or "root"
+
+
+def registry_file(project_path: Path) -> Path:
+    """Path to the registry JSON for a given repo."""
+    return REGISTRY_DIR / f"{_repo_key(project_path)}.json"
+
+
+def _load(path: Path) -> dict:
+    if not path.exists():
+        return {"project": None, "entries": []}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {"project": None, "entries": []}
+        data.setdefault("entries", [])
+        if not isinstance(data["entries"], list):
+            data["entries"] = []
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"project": None, "entries": []}
+
+
+def _save(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def register(
+    project_path: Path,
+    *,
+    branch: str | None,
+    session: str,
+    base: str | None,
+    worktree_path: Path,
+    created_at: str | None = None,
+) -> dict:
+    """Record (or replace) a worktree session. Idempotent per session/path."""
+    path = registry_file(project_path)
+    data = _load(path)
+    data["project"] = str(Path(project_path).expanduser().resolve())
+    if created_at is None:
+        created_at = datetime.datetime.now().astimezone().isoformat(timespec="seconds")
+    entry = {
+        "branch": branch,
+        "session": session,
+        "base": base,
+        "worktree_path": str(worktree_path),
+        "created_at": created_at,
+    }
+    # Drop any prior entry for the same session or worktree path, then append.
+    data["entries"] = [
+        e for e in data["entries"]
+        if e.get("session") != session
+        and e.get("worktree_path") != str(worktree_path)
+    ]
+    data["entries"].append(entry)
+    _save(path, data)
+    return entry
+
+
+def entries(project_path: Path) -> list[dict]:
+    """All recorded entries for a repo (oldest first)."""
+    return _load(registry_file(project_path)).get("entries", [])
+
+
+def unregister(
+    project_path: Path,
+    *,
+    session: str | None = None,
+    branch: str | None = None,
+    worktree_path: Path | str | None = None,
+) -> int:
+    """Remove matching entries. Returns the number removed."""
+    path = registry_file(project_path)
+    data = _load(path)
+    wt = str(worktree_path) if worktree_path is not None else None
+    before = len(data["entries"])
+
+    def matches(e: dict) -> bool:
+        return (
+            (session is not None and e.get("session") == session)
+            or (branch is not None and e.get("branch") == branch)
+            or (wt is not None and e.get("worktree_path") == wt)
+        )
+
+    data["entries"] = [e for e in data["entries"] if not matches(e)]
+    _save(path, data)
+    return before - len(data["entries"])
+
+
+def all_entries() -> list[dict]:
+    """Every entry across every repo, each tagged with its ``project`` path."""
+    out: list[dict] = []
+    if not REGISTRY_DIR.exists():
+        return out
+    for f in sorted(REGISTRY_DIR.glob("*.json")):
+        data = _load(f)
+        for e in data.get("entries", []):
+            e = dict(e)
+            e.setdefault("project", data.get("project"))
+            out.append(e)
+    return out

--- a/agentwire/worktree_registry.py
+++ b/agentwire/worktree_registry.py
@@ -23,8 +23,12 @@ or run ``agentwire worktree --prune`` to drop entries whose worktree path
 no longer exists.
 """
 
+import contextlib
 import datetime
+import fcntl
 import json
+import os
+import tempfile
 from pathlib import Path
 
 REGISTRY_DIR = Path.home() / ".agentwire" / "worktrees"
@@ -39,6 +43,28 @@ def _repo_key(project_path: Path) -> str:
 def registry_file(project_path: Path) -> Path:
     """Path to the registry JSON for a given repo."""
     return REGISTRY_DIR / f"{_repo_key(project_path)}.json"
+
+
+@contextlib.contextmanager
+def _locked(path: Path):
+    """Serialize read-modify-write across processes via an flock sidecar.
+
+    Concurrent ``agentwire worktree`` PROCESSES race on the same registry
+    file (load → mutate → save). Without this, parallel dispatch of 4–5
+    worktree sessions would lose all-but-one update. We flock a ``.lock``
+    sibling (held for the whole RMW, not just the write) so writers
+    serialize; pair it with the atomic replace in ``_save`` so a reader
+    never sees a half-written file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def _load(path: Path) -> dict:
@@ -57,8 +83,20 @@ def _load(path: Path) -> dict:
 
 
 def _save(path: Path, data: dict) -> None:
+    """Atomically write the registry (temp file in same dir + os.replace)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2) + "\n")
+    payload = json.dumps(data, indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)  # atomic on POSIX
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def register(
@@ -70,10 +108,12 @@ def register(
     worktree_path: Path,
     created_at: str | None = None,
 ) -> dict:
-    """Record (or replace) a worktree session. Idempotent per session/path."""
+    """Record (or replace) a worktree session. Idempotent per session/path.
+
+    The full read-modify-write is held under an exclusive flock so
+    concurrent registration processes serialize instead of clobbering.
+    """
     path = registry_file(project_path)
-    data = _load(path)
-    data["project"] = str(Path(project_path).expanduser().resolve())
     if created_at is None:
         created_at = datetime.datetime.now().astimezone().isoformat(timespec="seconds")
     entry = {
@@ -83,14 +123,17 @@ def register(
         "worktree_path": str(worktree_path),
         "created_at": created_at,
     }
-    # Drop any prior entry for the same session or worktree path, then append.
-    data["entries"] = [
-        e for e in data["entries"]
-        if e.get("session") != session
-        and e.get("worktree_path") != str(worktree_path)
-    ]
-    data["entries"].append(entry)
-    _save(path, data)
+    with _locked(path):
+        data = _load(path)
+        data["project"] = str(Path(project_path).expanduser().resolve())
+        # Drop any prior entry for the same session or worktree path, then append.
+        data["entries"] = [
+            e for e in data["entries"]
+            if e.get("session") != session
+            and e.get("worktree_path") != str(worktree_path)
+        ]
+        data["entries"].append(entry)
+        _save(path, data)
     return entry
 
 
@@ -108,9 +151,7 @@ def unregister(
 ) -> int:
     """Remove matching entries. Returns the number removed."""
     path = registry_file(project_path)
-    data = _load(path)
     wt = str(worktree_path) if worktree_path is not None else None
-    before = len(data["entries"])
 
     def matches(e: dict) -> bool:
         return (
@@ -119,9 +160,12 @@ def unregister(
             or (wt is not None and e.get("worktree_path") == wt)
         )
 
-    data["entries"] = [e for e in data["entries"] if not matches(e)]
-    _save(path, data)
-    return before - len(data["entries"])
+    with _locked(path):
+        data = _load(path)
+        before = len(data["entries"])
+        data["entries"] = [e for e in data["entries"] if not matches(e)]
+        _save(path, data)
+        return before - len(data["entries"])
 
 
 def all_entries() -> list[dict]:

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -20,6 +20,7 @@ New to AgentWire? Start here:
 
 How AgentWire runs AI agents — session types, REPLs, and permission models.
 
+- **[Worktree sessions](sessions/worktree-sessions.md)** — `agentwire worktree <name>`: isolated branch + worktree + standalone session for one unit of work; repo-derived base branch, naming templates, monorepo support, local branch↔session registry (`--list`/`--remove`/`--prune`)
 - **[claude-code-auto-mode](sessions/claude-code-auto-mode.md)** — Auto mode session type with classifier safety net
 - **[pi](sessions/pi.md)** — Pi coding agent (multi-provider: zai, deepseek, openai, openrouter, …)
 - **[Window sizing](sessions/window-sizing.md)** — how tmux `window-size` policies interact with the portal (v1.33+ behavior change, healing stuck windows, policy picker)

--- a/docs/wiki/sessions/worktree-sessions.md
+++ b/docs/wiki/sessions/worktree-sessions.md
@@ -1,0 +1,71 @@
+# Worktree sessions
+
+> The first-class primitive for "spawn an isolated branch + worktree + session for one unit of work." This is **session orchestration, not project management** — the unit of work is an opaque branch/name; agentwire neither knows nor cares whether it maps to a GitHub issue, a kanban card, or nothing.
+
+```bash
+agentwire worktree fix-bug          # new branch from the repo's default base + standalone session
+```
+
+A worktree session is a **standalone tmux session** (`{project}-{name}`) running on its own git worktree under `worktree_dir` (default `~/worktrees/`). It survives independently of its creator and carries the intrinsic **worktree-session etiquette** (isolation, no live-tool rebuild/restart, in-worktree verification, draft PR + notify-back) — that role is injected by the spawn verb, so first prompts only need the task itself. `--roles` / `.agentwire.yml roles:` **add** to it; they never replace it.
+
+> "Worktree session" **always** means this command — never `agentwire spawn --branch` (that makes a worker *pane* inside the current session). See the [glossary](../glossary.md).
+
+## Base branch — repo-derived, never hardcoded
+
+The branch a new worktree forks from is resolved in this order:
+
+1. `--base/-b <branch>` (explicit, always wins)
+2. `--current/-c` (the repo's currently checked-out branch)
+3. config `worktree.default_base`
+4. **the repo's actual default branch** — `git symbolic-ref refs/remotes/origin/HEAD` (e.g. a monorepo defaulting to `develop`), falling back to the current branch, finally `main`
+
+So `agentwire worktree foo` in a repo whose default is `develop` branches off `origin/develop` with no flags and no config. (If `origin/HEAD` isn't set locally, run `git remote set-head origin -a` once to populate it; until then the current-branch fallback applies.)
+
+## Project — inferred from cwd
+
+`--project/-p` points at the git repo. When omitted, it resolves to config `worktree.default_project`, else the **git root of cwd** — so you can fire a worktree session from any subdirectory of a (mono)repo. Many worktree sessions can target the **same** repo from different branches; each is keyed by `name`.
+
+## Branch naming templates
+
+By default the git branch equals the CLI `name` verbatim. Set `worktree.naming` to honor a shop's branch convention without a wrapper script:
+
+```yaml
+worktree:
+  naming: "{user}/{slug}"     # → "jordan/fix-bug"
+  # or "feature-{slug}", etc.
+```
+
+Placeholders: `{name}` (verbatim), `{slug}` (slugified — lowercased, hyphenated), `{user}` (OS login). Only the **git branch** is templated; the tmux session name stays `{project}-{name}` (made tmux-safe) so session names remain predictable. Unknown placeholders are left literal rather than crashing on a hand-edited config.
+
+## Branch↔session registry
+
+agentwire keeps a small **local, per-repo registry** (one JSON file per repo under `~/.agentwire/worktrees/`, keyed by branch) recording `branch → session, base, worktree path, created-at`. It's populated on spawn and is **agentwire-owned local state — never provider data**. The files are plain JSON and hand-editable.
+
+```bash
+agentwire worktree --list          # this repo's worktree sessions (live / orphan / stale)
+agentwire worktree --list --all    # across every repo
+agentwire worktree --remove name   # kill the session + remove the worktree + unregister
+agentwire worktree --prune         # drop entries whose worktree is gone + `git worktree prune`
+```
+
+`--list` annotates each entry: **live** (tmux session running), **orphan** (worktree on disk, no session), **stale** (registry entry, worktree gone). `--remove` is the cleanup/recovery path; it still works on hand-created worktrees not in the registry by falling back to the conventional `{project}-{name}` layout.
+
+## Config
+
+```yaml
+worktree:                         # `quicktask:` is a legacy alias for this key — prefer `worktree:`
+  worktree_dir: ~/worktrees
+  default_base: develop           # omit → repo-derived (origin/HEAD)
+  default_project: ~/projects/my-repo
+  naming: "{user}/{slug}"
+```
+
+Distinct from `projects.worktrees` (the legacy `project/branch` session layout under `~/projects/<project>-worktrees/`). See the `agentwire-config` skill for the full field reference.
+
+## Other modes
+
+```bash
+agentwire worktree feature/auth --existing   # checkout an existing branch (no new branch)
+agentwire worktree review-v2 --ref v2.0.0     # detached at a tag/commit/branch
+agentwire worktree foo --current              # base off the repo's current branch
+```

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -1,0 +1,185 @@
+"""Integration tests for `agentwire worktree` git mechanics (#307).
+
+Exercises base-branch derivation, naming templates, monorepo project
+inference, and the local branch↔session registry — with the tmux/session
+launch stubbed out so the tests stay hermetic.
+"""
+
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from agentwire import __main__ as m
+from agentwire import worktree_registry as reg
+from agentwire.config import Config, WorktreeConfig
+
+
+def _git(repo, *a):
+    return subprocess.run(["git", "-C", str(repo), *a], capture_output=True, text=True)
+
+
+def _origin_and_clone(tmp_path, default_branch="develop"):
+    """A bare-ish origin (real repo) + a clone whose origin/HEAD → default_branch."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", default_branch)
+    _git(origin, "config", "user.email", "t@t")
+    _git(origin, "config", "user.name", "t")
+    (origin / "README.md").write_text("hi\n")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-qm", "base")
+
+    clone = tmp_path / "clone-repo"
+    subprocess.run(["git", "clone", "-q", str(origin), str(clone)],
+                   capture_output=True, text=True)
+    _git(clone, "config", "user.email", "t@t")
+    _git(clone, "config", "user.name", "t")
+    return origin, clone
+
+
+@pytest.fixture
+def wt_env(tmp_path, monkeypatch):
+    """Isolate registry + stub session launch + capture the cmd_new call."""
+    monkeypatch.setattr(reg, "REGISTRY_DIR", tmp_path / "registry")
+
+    launched = {}
+
+    def fake_cmd_new(ns):
+        launched["args"] = ns
+        return 0
+
+    monkeypatch.setattr(m, "cmd_new", fake_cmd_new)
+    monkeypatch.setattr(m, "_check_tmux_installed", lambda: True)
+    monkeypatch.setattr(m, "tmux_session_exists", lambda *_: False)
+    return launched
+
+
+def _config(worktree_dir, **wt):
+    cfg = Config()
+    cfg.worktree = WorktreeConfig(worktree_dir=worktree_dir, **wt)
+    return cfg
+
+
+def _run(monkeypatch, cfg, **arg_overrides):
+    monkeypatch.setattr(m, "load_config", lambda *a, **k: cfg, raising=False)
+    # cmd_worktree imports the typed loader lazily from agentwire.config.
+    import agentwire.config as config_mod
+    monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: cfg)
+    base = dict(
+        name=None, base=None, current=False, existing=False, ref=None,
+        project=None, list=False, remove=False, prune=False, all=False,
+        json=True, type=None, posture=None, harness=None, model=None,
+        roles=None, env=None,
+    )
+    base.update(arg_overrides)
+    return m.cmd_worktree(Namespace(**base))
+
+
+def test_default_base_is_repo_derived(tmp_path, monkeypatch, wt_env):
+    """No --base, no config default → branches off origin/HEAD (develop)."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+
+    rc = _run(monkeypatch, cfg, name="fix-bug", project=str(clone))
+    assert rc == 0
+
+    wt_path = wt_dir / "clone-repo-fix-bug"
+    assert wt_path.exists()
+    # New branch's parent is origin/develop's tip.
+    base_sha = _git(clone, "rev-parse", "origin/develop").stdout.strip()
+    parent = _git(wt_path, "rev-parse", "HEAD~0").stdout.strip()
+    assert parent == base_sha
+    # Registry recorded it with the derived base.
+    entries = reg.entries(clone.resolve())
+    assert len(entries) == 1
+    assert entries[0]["base"] == "develop"
+    assert entries[0]["session"] == "clone-repo-fix-bug"
+
+
+def test_base_flag_overrides(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    # Add a second branch on origin to base off of.
+    origin = tmp_path / "origin"
+    _git(origin, "branch", "release")
+    _git(clone, "fetch", "-q", "origin")
+
+    wt_dir = tmp_path / "worktrees"
+    rc = _run(monkeypatch, _config(wt_dir), name="hot", base="release", project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve())[0]["base"] == "release"
+
+
+def test_naming_template_applied_to_branch(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir, naming="feature-{slug}")
+
+    rc = _run(monkeypatch, cfg, name="Auth V2", project=str(clone))
+    assert rc == 0
+    # Branch is templated; session/worktree key stays the tmux-safe raw name.
+    wt_path = wt_dir / "clone-repo-Auth-V2"  # spaces → '-' for tmux safety
+    assert wt_path.exists()
+    branch = _git(wt_path, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    assert branch == "feature-auth-v2"
+    assert reg.entries(clone.resolve())[0]["branch"] == "feature-auth-v2"
+
+
+def test_project_inferred_from_cwd_git_root(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    sub = clone / "packages" / "app"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+
+    wt_dir = tmp_path / "worktrees"
+    rc = _run(monkeypatch, _config(wt_dir), name="thing")  # no --project
+    assert rc == 0
+    assert (wt_dir / "clone-repo-thing").exists()
+    assert reg.entries(clone.resolve())[0]["session"] == "clone-repo-thing"
+
+
+def test_monorepo_many_sessions_one_repo(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    for n in ("one", "two", "three"):
+        assert _run(monkeypatch, cfg, name=n, project=str(clone)) == 0
+
+    sessions = {e["session"] for e in reg.entries(clone.resolve())}
+    assert sessions == {"clone-repo-one", "clone-repo-two", "clone-repo-three"}
+    for n in ("one", "two", "three"):
+        assert (wt_dir / f"clone-repo-{n}").exists()
+
+
+def test_remove_cleans_worktree_and_registry(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    assert _run(monkeypatch, cfg, name="kill-me", project=str(clone)) == 0
+    wt_path = wt_dir / "clone-repo-kill-me"
+    assert wt_path.exists()
+
+    rc = _run(monkeypatch, cfg, name="kill-me", project=str(clone), remove=True)
+    assert rc == 0
+    assert not wt_path.exists()
+    assert reg.entries(clone.resolve()) == []
+
+
+def test_prune_drops_stale_entries(tmp_path, monkeypatch, wt_env):
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    assert _run(monkeypatch, cfg, name="gone", project=str(clone)) == 0
+
+    # Simulate an externally-removed worktree.
+    wt_path = wt_dir / "clone-repo-gone"
+    subprocess.run(["git", "-C", str(clone), "worktree", "remove", str(wt_path), "--force"],
+                   capture_output=True)
+    assert not wt_path.exists()
+    assert len(reg.entries(clone.resolve())) == 1  # registry still has it
+
+    rc = _run(monkeypatch, cfg, prune=True, project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve()) == []

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -112,6 +112,36 @@ def test_base_flag_overrides(tmp_path, monkeypatch, wt_env):
     assert reg.entries(clone.resolve())[0]["base"] == "release"
 
 
+def test_invalid_branch_name_fails_clean_no_orphan(tmp_path, monkeypatch, wt_env):
+    """A name with spaces is rejected BEFORE any worktree lands on disk."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+
+    rc = _run(monkeypatch, _config(wt_dir), name="Auth V2", project=str(clone))
+    assert rc != 0
+    # No orphaned worktree, nothing registered, nothing launched.
+    assert not (wt_dir / "clone-repo-Auth-V2").exists()
+    assert reg.entries(clone.resolve()) == []
+    # git agrees there's only the main worktree.
+    wt_list = _git(clone, "worktree", "list").stdout
+    assert "clone-repo-Auth-V2" not in wt_list
+
+
+def test_base_flag_wins_over_current(tmp_path, monkeypatch, wt_env):
+    """--base X --current → --base wins (least-surprising)."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    origin = tmp_path / "origin"
+    _git(origin, "branch", "release")
+    _git(clone, "fetch", "-q", "origin")
+    # Put the clone's current branch somewhere else entirely.
+    _git(clone, "checkout", "-q", "-b", "scratch")
+
+    rc = _run(monkeypatch, _config(wt_dir := tmp_path / "worktrees"),
+              name="hot", base="release", current=True, project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve())[0]["base"] == "release"
+
+
 def test_naming_template_applied_to_branch(tmp_path, monkeypatch, wt_env):
     _, clone = _origin_and_clone(tmp_path, default_branch="develop")
     wt_dir = tmp_path / "worktrees"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -135,6 +135,46 @@ class TestLoadConfig:
         assert config.session.inject_soul is False
 
 
+# --- WorktreeConfig (worktree: orchestration key) ---
+
+class TestWorktreeConfig:
+    def test_defaults(self, tmp_path):
+        config = load_config(tmp_path / "nonexistent.yaml")
+        # No hardcoded 'main' — None means "ask the repo" (origin/HEAD).
+        assert config.worktree.default_base is None
+        assert config.worktree.default_project is None
+        assert config.worktree.naming is None
+        assert config.worktree.worktree_dir.name == "worktrees"
+
+    def test_from_yaml(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump({"worktree": {
+            "default_base": "develop",
+            "naming": "{user}/{slug}",
+            "worktree_dir": "~/wt",
+        }}))
+        config = load_config(path)
+        assert config.worktree.default_base == "develop"
+        assert config.worktree.naming == "{user}/{slug}"
+        assert config.worktree.worktree_dir.name == "wt"
+
+    def test_quicktask_alias(self, tmp_path):
+        # `quicktask:` is the documented legacy alias for `worktree:`.
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump({"quicktask": {"default_base": "trunk"}}))
+        config = load_config(path)
+        assert config.worktree.default_base == "trunk"
+
+    def test_worktree_key_wins_over_alias(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump({
+            "worktree": {"default_base": "main"},
+            "quicktask": {"default_base": "old"},
+        }))
+        config = load_config(path)
+        assert config.worktree.default_base == "main"
+
+
 # --- two-tier voice backends ---
 
 class TestVoiceBackends:

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -11,7 +11,29 @@ from agentwire.worktree import (
     is_git_repo,
     get_project_type,
     ensure_worktree,
+    git_root,
+    default_base_branch,
+    slugify,
+    apply_naming,
 )
+
+
+def _make_repo(tmp_path, name="repo", default_branch="main"):
+    """Init a git repo with one commit on `default_branch`."""
+    repo = tmp_path / name
+    repo.mkdir()
+
+    def git(*a):
+        return subprocess.run(["git", "-C", str(repo), *a],
+                              capture_output=True, text=True)
+
+    git("init", "-q", "-b", default_branch)
+    git("config", "user.email", "t@t")
+    git("config", "user.name", "t")
+    (repo / "README.md").write_text("hi\n")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    return repo, git
 
 
 # --- parse_session_name ---
@@ -81,6 +103,70 @@ class TestGetProjectType:
 
     def test_scratch_without_git(self, tmp_path):
         assert get_project_type(tmp_path) == "scratch"
+
+
+# --- slugify / apply_naming ---
+
+class TestNaming:
+    def test_slugify_basic(self):
+        assert slugify("Fix Bug") == "fix-bug"
+        assert slugify("feature/auth-v2") == "feature-auth-v2"
+        assert slugify("  Hello  World  ") == "hello-world"
+
+    def test_slugify_empty_fallback(self):
+        assert slugify("!!!") == "wt"
+
+    def test_apply_naming_none_is_verbatim(self):
+        assert apply_naming(None, "my-branch") == "my-branch"
+        assert apply_naming("", "my-branch") == "my-branch"
+
+    def test_apply_naming_user_slug_template(self):
+        import getpass
+        out = apply_naming("{user}/{slug}", "Fix Bug")
+        assert out == f"{getpass.getuser()}/fix-bug"
+
+    def test_apply_naming_literal_prefix(self):
+        assert apply_naming("feature-{slug}", "auth") == "feature-auth"
+
+    def test_apply_naming_name_verbatim_placeholder(self):
+        assert apply_naming("wip/{name}", "Keep As Is") == "wip/Keep As Is"
+
+    def test_apply_naming_unknown_placeholder_left_literal(self):
+        # Hand-edited config shouldn't crash on an unsupported placeholder.
+        assert apply_naming("{bogus}-{slug}", "x") == "{bogus}-x"
+
+
+# --- git_root ---
+
+class TestGitRoot:
+    def test_returns_repo_root_from_subdir(self, tmp_path):
+        repo, _ = _make_repo(tmp_path)
+        sub = repo / "packages" / "app"
+        sub.mkdir(parents=True)
+        assert git_root(sub) == repo.resolve()
+
+    def test_none_outside_repo(self, tmp_path):
+        assert git_root(tmp_path) is None
+
+
+# --- default_base_branch (repo-derived, no hardcoded main) ---
+
+class TestDefaultBaseBranch:
+    def test_falls_back_to_current_branch(self, tmp_path):
+        # No origin/HEAD set → uses the repo's current branch.
+        repo, _ = _make_repo(tmp_path, default_branch="develop")
+        assert default_base_branch(repo) == "develop"
+
+    def test_reads_origin_head(self, tmp_path):
+        # A clone with origin/HEAD pointing at the remote's default branch.
+        origin, ogit = _make_repo(tmp_path, name="origin", default_branch="trunk")
+        clone = tmp_path / "clone"
+        subprocess.run(["git", "clone", "-q", str(origin), str(clone)],
+                       capture_output=True, text=True)
+        # Switch the clone off the default so current-branch fallback would differ.
+        subprocess.run(["git", "-C", str(clone), "checkout", "-q", "-b", "side"],
+                       capture_output=True, text=True)
+        assert default_base_branch(clone) == "trunk"
 
 
 # --- ensure_worktree seeding (gitignored files like .env) ---

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -15,6 +15,7 @@ from agentwire.worktree import (
     default_base_branch,
     slugify,
     apply_naming,
+    is_valid_branch_name,
 )
 
 
@@ -134,6 +135,27 @@ class TestNaming:
     def test_apply_naming_unknown_placeholder_left_literal(self):
         # Hand-edited config shouldn't crash on an unsupported placeholder.
         assert apply_naming("{bogus}-{slug}", "x") == "{bogus}-x"
+
+
+# --- is_valid_branch_name ---
+
+class TestValidBranchName:
+    @pytest.mark.parametrize("name", ["fix-bug", "feature/auth", "jordan/fix-bug", "v2.0-rc1"])
+    def test_valid(self, name):
+        assert is_valid_branch_name(name) is True
+
+    @pytest.mark.parametrize("name", [
+        "",            # empty
+        "Auth V2",     # spaces
+        "a..b",        # double dot
+        "-foo",        # leading dash (git would read it as a flag)
+        "foo/",        # trailing slash
+        "foo.lock",    # reserved suffix
+        "foo~bar",     # tilde
+        "foo:bar",     # colon
+    ])
+    def test_invalid(self, name):
+        assert is_valid_branch_name(name) is False
 
 
 # --- git_root ---

--- a/tests/unit/test_worktree_registry.py
+++ b/tests/unit/test_worktree_registry.py
@@ -80,6 +80,61 @@ def test_corrupt_file_is_tolerated(tmp_path):
     assert reg.entries(repo) == []  # degrades, doesn't raise
 
 
+def test_concurrent_registration_threads_all_survive(tmp_path):
+    """N threads registering distinct sessions must not clobber each other."""
+    import threading
+
+    repo = tmp_path / "monorepo"
+    n = 20
+    barrier = threading.Barrier(n)
+
+    def worker(i):
+        barrier.wait()  # maximize contention on the read-modify-write
+        reg.register(repo, branch=f"b{i}", session=f"monorepo-{i}", base="develop",
+                     worktree_path=tmp_path / "wt" / f"monorepo-{i}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    sessions = {e["session"] for e in reg.entries(repo)}
+    assert sessions == {f"monorepo-{i}" for i in range(n)}
+
+
+def test_concurrent_registration_processes_all_survive(tmp_path, monkeypatch):
+    """Cross-PROCESS contention (the real dispatch case) — flock must serialize."""
+    import sys
+    import subprocess as sp
+
+    registry_dir = tmp_path / "wt-registry"
+    repo = tmp_path / "monorepo"
+    wt = tmp_path / "wt"
+    n = 8
+
+    # Each child registers one entry, pointing REGISTRY_DIR at the shared dir.
+    prog = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from agentwire import worktree_registry as reg\n"
+        "reg.REGISTRY_DIR = Path(sys.argv[1])\n"
+        "i = sys.argv[2]\n"
+        "reg.register(Path(sys.argv[3]), branch='b'+i, session='monorepo-'+i, "
+        "base='develop', worktree_path=Path(sys.argv[4])/('monorepo-'+i))\n"
+    )
+    procs = [
+        sp.Popen([sys.executable, "-c", prog, str(registry_dir), str(i), str(repo), str(wt)])
+        for i in range(n)
+    ]
+    for p in procs:
+        assert p.wait() == 0
+
+    monkeypatch.setattr(reg, "REGISTRY_DIR", registry_dir)
+    sessions = {e["session"] for e in reg.entries(repo)}
+    assert sessions == {f"monorepo-{i}" for i in range(n)}
+
+
 def test_file_is_hand_editable_json(tmp_path):
     repo = tmp_path / "repo"
     reg.register(repo, branch="a", session="repo-a", base="main",

--- a/tests/unit/test_worktree_registry.py
+++ b/tests/unit/test_worktree_registry.py
@@ -1,0 +1,90 @@
+"""Tests for agentwire/worktree_registry.py — local branch↔session store."""
+
+from pathlib import Path
+
+import pytest
+
+from agentwire import worktree_registry as reg
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path, monkeypatch):
+    """Point the registry at a throwaway dir for every test."""
+    monkeypatch.setattr(reg, "REGISTRY_DIR", tmp_path / "wt-registry")
+
+
+def test_register_and_entries(tmp_path):
+    repo = tmp_path / "monorepo"
+    reg.register(repo, branch="fix-bug", session="monorepo-fix-bug",
+                 base="develop", worktree_path=tmp_path / "wt" / "monorepo-fix-bug")
+    rows = reg.entries(repo)
+    assert len(rows) == 1
+    e = rows[0]
+    assert e["branch"] == "fix-bug"
+    assert e["session"] == "monorepo-fix-bug"
+    assert e["base"] == "develop"
+    assert e["created_at"]  # stamped
+
+
+def test_register_is_idempotent_per_session(tmp_path):
+    repo = tmp_path / "repo"
+    wt = tmp_path / "wt" / "repo-a"
+    reg.register(repo, branch="a", session="repo-a", base="main", worktree_path=wt)
+    reg.register(repo, branch="a", session="repo-a", base="develop", worktree_path=wt)
+    rows = reg.entries(repo)
+    assert len(rows) == 1
+    assert rows[0]["base"] == "develop"  # replaced, not duplicated
+
+
+def test_many_sessions_one_repo(tmp_path):
+    """Monorepo: several branches of the SAME repo coexist."""
+    repo = tmp_path / "monorepo"
+    for n in ("one", "two", "three"):
+        reg.register(repo, branch=n, session=f"monorepo-{n}", base="develop",
+                     worktree_path=tmp_path / "wt" / f"monorepo-{n}")
+    sessions = {e["session"] for e in reg.entries(repo)}
+    assert sessions == {"monorepo-one", "monorepo-two", "monorepo-three"}
+
+
+def test_unregister_by_session(tmp_path):
+    repo = tmp_path / "repo"
+    reg.register(repo, branch="a", session="repo-a", base="main",
+                 worktree_path=tmp_path / "wt" / "repo-a")
+    reg.register(repo, branch="b", session="repo-b", base="main",
+                 worktree_path=tmp_path / "wt" / "repo-b")
+    removed = reg.unregister(repo, session="repo-a")
+    assert removed == 1
+    assert {e["session"] for e in reg.entries(repo)} == {"repo-b"}
+
+
+def test_all_entries_across_repos(tmp_path):
+    reg.register(tmp_path / "alpha", branch="x", session="alpha-x", base="main",
+                 worktree_path=tmp_path / "wt" / "alpha-x")
+    reg.register(tmp_path / "beta", branch="y", session="beta-y", base="dev",
+                 worktree_path=tmp_path / "wt" / "beta-y")
+    rows = reg.all_entries()
+    assert len(rows) == 2
+    # Each row is tagged with its repo path.
+    assert all(r.get("project") for r in rows)
+
+
+def test_entries_empty_for_unknown_repo(tmp_path):
+    assert reg.entries(tmp_path / "never-seen") == []
+
+
+def test_corrupt_file_is_tolerated(tmp_path):
+    repo = tmp_path / "repo"
+    path = reg.registry_file(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not valid json")
+    assert reg.entries(repo) == []  # degrades, doesn't raise
+
+
+def test_file_is_hand_editable_json(tmp_path):
+    repo = tmp_path / "repo"
+    reg.register(repo, branch="a", session="repo-a", base="main",
+                 worktree_path=tmp_path / "wt" / "repo-a")
+    import json
+    data = json.loads(reg.registry_file(repo).read_text())
+    assert data["entries"][0]["session"] == "repo-a"
+    assert data["project"].endswith("repo")


### PR DESCRIPTION
## Summary

Finishes the **worktree-session** orchestration primitive (`agentwire worktree`) so it's a complete, first-class core thing — the gap every power user (the owner's `quicktask` script being exhibit A) re-invents. Session orchestration, **not** project management: the unit of work is an opaque branch/name. Builds on the #293 flow; the role-rename + etiquette-from-verb work was already landed by #310, so this is the orchestration **mechanics** only.

## What changed

- **Repo-derived default base branch** — drop the hardcoded `'main'`. Default to the repo's actual default branch via `git symbolic-ref refs/remotes/origin/HEAD` (fallback: current branch → `'main'`). `--base` and `worktree.default_base` still override. A monorepo defaulting to `develop` now Just Works with no flags.
- **Typed `WorktreeConfig` dataclass** (`config.py`) — `default_base` / `default_project` / `worktree_dir` / `naming`, replacing the raw untyped `config["worktree"|"quicktask"].get()` dict access. Canonical key is `worktree:`; `quicktask:` kept as a documented alias.
- **Pluggable branch-naming template** — `worktree.naming`, e.g. `{user}/{slug}` or `feature-{slug}` (`{name}`/`{slug}`/`{user}` placeholders). Verbatim stays the default; only the git branch is templated, the tmux session name stays predictable.
- **Monorepo support** — `--project` inferred from the **git root of cwd** when omitted; many worktree sessions can target one repo from different branches cleanly.
- **Local branch↔session registry** (`agentwire/worktree_registry.py`) — `branch → session/base/worktree-path/created-at`, one JSON file per repo under `~/.agentwire/worktrees/`, hand-editable, **agentwire-owned local state (never provider data)**. New surfaces: `worktree --list` (live/orphan/stale, `--all` across repos), `--remove` (kill session + remove worktree + unregister), `--prune` (drop stale entries + `git worktree prune`).

## Docs

`agentwire-config` + `agentwire-cli` skills updated; new `docs/wiki/sessions/worktree-sessions.md` + INDEX entry.

## Verification

- `uv run --extra dev pytest` → **1366 passed, 1 failed**; the single failure is the pre-existing, unrelated `test_server_websockets.py::test_terminal_registers_client_in_session` present on `main` — left as-is per task note.
- New tests: `WorktreeConfig` parsing (+ `quicktask` alias + precedence), repo-derived base (origin/HEAD + current-branch fallback), naming templates, git-root inference, registry CRUD, and an end-to-end `cmd_worktree` integration suite (stubbed session launch) covering base derivation, naming, monorepo many-sessions-one-repo, `--remove` cleanup, and `--prune`.
- `agentwire worktree --help` + `--list` smoke-tested live.

Out of scope (parked per #305): any PM/issue product, provider seam, `agentwire issues` surface, UI.

Closes #307

Built by [dotdev.dev](https://dotdev.dev)
