### PR TITLE
fix(sessions): route recreate/fork through resolve_roles so etiquette survives (#311)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -4728,8 +4728,20 @@ def cmd_recreate(args) -> int:
             # Fall back to agent-bypass
             session_type_str = f"{agent_type}-bypass"
 
+        # Inject the kind's intrinsic etiquette — a remote project/branch
+        # recreate is still a worktree-session and must carry the safety
+        # contract. The remote project_config isn't readable here, so we
+        # resolve from the derived kind alone; the bundled etiquette roles
+        # resolve locally and are baked into the agent command.
+        kind = derive_session_kind(bool(branch))
+        role_names = resolve_roles(kind)
+        role_names = inject_soul(role_names, load_config())
+        roles = None
+        if role_names:
+            roles, _ = load_roles(role_names)
+
         # Build agent command using the standard function
-        agent = build_agent_command(session_type_str)
+        agent = build_agent_command(session_type_str, roles)
         agent.env.update(parse_env_args(getattr(args, 'env', None)))
         agent_cmd = agent.command
         env_flags = _build_tmux_env_flags_shell(agent.env)
@@ -4825,7 +4837,14 @@ def cmd_recreate(args) -> int:
         # Default to agent-bypass based on detected agent
         session_type_str = f"{agent_type}-bypass"
 
-    role_names = list(project_config.roles) if project_config and project_config.roles else []
+    # Route through resolve_roles with a derived kind so the recreated session
+    # carries its kind's intrinsic etiquette — recreating a project/branch
+    # (worktree) session re-injects the worktree-session safety contract
+    # (isolation / verify / draft-PR / notify), which a raw project_config.roles
+    # copy would silently drop. Same contract as cmd_new/cmd_worktree.
+    kind = derive_session_kind(bool(branch))
+    project_roles = list(project_config.roles) if project_config and project_config.roles else None
+    role_names = resolve_roles(kind, project_roles=project_roles)
     role_names = inject_soul(role_names, load_config())
     roles = None
     if role_names:
@@ -5289,7 +5308,13 @@ def cmd_fork(args) -> int:
             # Default to agent-bypass based on detected agent
             session_type_str = f"{agent_type}-bypass"
 
-        role_names = list(source_config.roles) if source_config and source_config.roles else []
+        # The fork target is a worktree (project/branch) → worktree-session
+        # kind, so resolve_roles stacks the non-overridable safety etiquette
+        # under the source's roles instead of copying them raw (which dropped
+        # the kind's intrinsic contract). Kind derived from the target name.
+        kind = derive_session_kind(bool(target_branch))
+        project_roles = list(source_config.roles) if source_config and source_config.roles else None
+        role_names = resolve_roles(kind, project_roles=project_roles)
         role_names = inject_soul(role_names, load_config())
         roles = None
         if role_names:
@@ -5381,7 +5406,12 @@ def cmd_fork(args) -> int:
             # Default to agent-bypass based on detected agent
             session_type_str = f"{agent_type}-bypass"
 
-        role_names = list(source_project_config.roles) if source_project_config and source_project_config.roles else []
+        # Non-worktree fork: target has no branch → orchestrator kind (a
+        # replaceable persona), so source roles take precedence as usual.
+        # Routed through resolve_roles for one consistent precedence path.
+        kind = derive_session_kind(bool(target_branch))
+        project_roles = list(source_project_config.roles) if source_project_config and source_project_config.roles else None
+        role_names = resolve_roles(kind, project_roles=project_roles)
         role_names = inject_soul(role_names, load_config())
         roles = None
         if role_names:
@@ -5547,7 +5577,12 @@ def cmd_fork(args) -> int:
         # Default to agent-bypass based on detected agent
         session_type_str = f"{agent_type}-bypass"
 
-    role_names = list(source_config.roles) if source_config and source_config.roles else []
+    # Worktree fork: target is project/branch → worktree-session kind, so
+    # resolve_roles stacks the non-overridable isolation/verify/draft-PR/notify
+    # etiquette under the source's roles. Kind derived from the target name.
+    kind = derive_session_kind(bool(target_branch))
+    project_roles = list(source_config.roles) if source_config and source_config.roles else None
+    role_names = resolve_roles(kind, project_roles=project_roles)
     role_names = inject_soul(role_names, load_config())
     roles = None
     if role_names:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -229,3 +229,199 @@ class TestCmdNewFirstMessage:
         assert cmd_new(args) == 1
         payload = json.loads(capsys.readouterr().out.strip())
         assert "local-only" in payload["error"]
+
+
+# --- cmd_recreate / cmd_fork route through resolve_roles (#311) ---
+#
+# Both commands used to copy `project_config.roles` raw, bypassing
+# resolve_roles + the #309/#310 kind-derivation — so a recreated worktree
+# session silently lost its non-overridable worktree-session etiquette
+# (isolation / verify / draft-PR / notify). These capture the role list each
+# command hands to load_roles and assert the kind's intrinsic etiquette is
+# present (or, for the orchestrator persona, replaceable).
+
+class _RoleCapture:
+    """Holds the role_names captured from a mocked load_roles call."""
+
+    def __init__(self):
+        self.role_names = None
+
+
+def _patch_role_pipeline(monkeypatch, projects_dir, project_config_roles):
+    """Mock out tmux/git/worktree side effects and capture resolved roles.
+
+    Returns the capture object whose .role_names is the list cmd_recreate /
+    cmd_fork pass to load_roles (i.e. resolve_roles + inject_soul output).
+    """
+    from types import SimpleNamespace
+    import agentwire.__main__ as mod
+
+    cap = _RoleCapture()
+
+    cfg = None
+    if project_config_roles is not None:
+        cfg = SimpleNamespace(
+            type=SimpleNamespace(value="claude-bypass"),
+            roles=project_config_roles,
+        )
+
+    monkeypatch.setattr(mod, "load_config", lambda: {
+        "projects": {"dir": str(projects_dir), "worktrees": {"suffix": "-worktrees"}},
+    })
+    monkeypatch.setattr(mod, "load_project_config", lambda p: cfg)
+    monkeypatch.setattr(mod, "detect_default_agent_type", lambda: "claude")
+    monkeypatch.setattr(mod, "build_agent_command", lambda *a, **k: mod.AgentCommand(command=""))
+
+    def fake_ensure_worktree(base, branch, wt, **kw):
+        Path(wt).mkdir(parents=True, exist_ok=True)
+        return True
+
+    monkeypatch.setattr(mod, "ensure_worktree", fake_ensure_worktree)
+
+    def fake_load_roles(role_names, path):
+        cap.role_names = list(role_names)
+        return [], []
+
+    monkeypatch.setattr(mod, "load_roles", fake_load_roles)
+    monkeypatch.setattr(mod.time, "sleep", lambda *a, **k: None)
+    return cap
+
+
+def _fake_run(source_session=None, cwd=None):
+    """Command-aware tmux/git stub.
+
+    has-session: source exists (rc 0), everything else absent (rc 1) so
+    recreate skips its kill path and a non-worktree fork sees its target free.
+    """
+    def run(cmd, *a, **k):
+        joined = " ".join(str(x) for x in (cmd if isinstance(cmd, list) else [cmd]))
+        if "has-session" in joined:
+            if source_session and source_session in joined:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=1, stdout="", stderr="")
+        if "display-message" in joined:
+            if "pane_current_path" in joined:
+                return MagicMock(returncode=0, stdout=f"{cwd or ''}\n", stderr="")
+            return MagicMock(returncode=0, stdout="0\n", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+    return run
+
+
+class TestRecreateRoutesThroughResolveRoles:
+    def test_worktree_recreate_reinjects_etiquette_even_without_saved_roles(
+        self, monkeypatch, tmp_path
+    ):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=None)
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(
+            session="proj/feature", json=True, type="claude-bypass", env=None,
+        )
+        assert mod.cmd_recreate(args) == 0
+        # The whole point: a project/branch recreate is a worktree-session, so
+        # the safety contract is present even though nothing was saved.
+        assert cap.role_names[0] == "worktree-session"
+        assert "soul" in cap.role_names
+
+    def test_worktree_recreate_stacks_saved_roles_under_etiquette(
+        self, monkeypatch, tmp_path
+    ):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=["domain"])
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(
+            session="proj/feature", json=True, type="claude-bypass", env=None,
+        )
+        assert mod.cmd_recreate(args) == 0
+        # Non-overridable: etiquette first, saved role stacks, never replaces.
+        assert cap.role_names[0] == "worktree-session"
+        assert "domain" in cap.role_names
+
+    def test_plain_recreate_is_orchestrator_replaceable(self, monkeypatch, tmp_path):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=["custom"])
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(session="proj", json=True, type="claude-bypass", env=None)
+        assert mod.cmd_recreate(args) == 0
+        # Persona kind: saved roles REPLACE the orchestrator default.
+        assert "orchestrator" not in cap.role_names
+        assert "custom" in cap.role_names
+
+    def test_plain_recreate_zero_config_is_orchestrator(self, monkeypatch, tmp_path):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=None)
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(session="proj", json=True, type="claude-bypass", env=None)
+        assert mod.cmd_recreate(args) == 0
+        assert cap.role_names[0] == "orchestrator"
+
+
+class TestForkRoutesThroughResolveRoles:
+    def test_worktree_fork_injects_worktree_session_etiquette(self, monkeypatch, tmp_path):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)  # source_path (no source branch)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=None)
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(
+            source="proj", target="proj/feat", json=True, type="claude-bypass",
+            env=None, commit=None,
+        )
+        assert mod.cmd_fork(args) == 0
+        # Fork target is a worktree → worktree-session etiquette, intrinsic.
+        assert cap.role_names[0] == "worktree-session"
+
+    def test_worktree_fork_stacks_source_roles_under_etiquette(self, monkeypatch, tmp_path):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        (projects / "proj").mkdir(parents=True)
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=["domain"])
+        monkeypatch.setattr(mod.subprocess, "run", _fake_run())
+
+        args = argparse.Namespace(
+            source="proj", target="proj/feat", json=True, type="claude-bypass",
+            env=None, commit=None,
+        )
+        assert mod.cmd_fork(args) == 0
+        assert cap.role_names[0] == "worktree-session"
+        assert "domain" in cap.role_names
+
+    def test_non_worktree_fork_is_orchestrator_replaceable(self, monkeypatch, tmp_path):
+        import agentwire.__main__ as mod
+
+        projects = tmp_path / "projects"
+        projects.mkdir(parents=True)
+        src_cwd = tmp_path / "src_cwd"
+        src_cwd.mkdir()
+        cap = _patch_role_pipeline(monkeypatch, projects, project_config_roles=["custom"])
+        monkeypatch.setattr(
+            mod.subprocess, "run", _fake_run(source_session="ctxa", cwd=src_cwd)
+        )
+
+        args = argparse.Namespace(
+            source="ctxa", target="ctxb", json=True, type="claude-bypass",
+            env=None, commit=None,
+        )
+        assert mod.cmd_fork(args) == 0
+        # Same-dir fork has no branch → orchestrator persona; source roles win.
+        assert "orchestrator" not in cap.role_names
+        assert "custom" in cap.role_names


### PR DESCRIPTION
## What

`cmd_recreate` and `cmd_fork` built their role lists directly from the saved project/source config + `inject_soul`, **bypassing `resolve_roles()` and the #310 kind-derivation**. Consequences:

- Recreating a `project/branch` (worktree) session **dropped the non-overridable worktree-session safety contract** (isolation / verify / draft-PR / notify).
- Forking didn't preserve a kind's intrinsic etiquette — inconsistent with the "etiquette is always present for the kind" contract.

## Fix

Route every role-building site in both commands through `derive_session_kind(bool(branch)) + resolve_roles()`, exactly like `cmd_new`/`cmd_worktree`:

- A `project/branch` (slash) name → **worktree-session** (safety-rail kind: intrinsic etiquette first, saved/source roles stack on top, non-overridable).
- A plain name → **orchestrator** (persona: saved/source roles **replace** the default, stays replaceable for council/scheduler/task sessions).

Kind is derived from the **target** name for forks, the session name for recreate. Reuses the existing `derive_session_kind` + `resolve_roles` helpers — no duplicated precedence logic.

Sites converted:
- `cmd_recreate` local
- `cmd_recreate` remote — *previously injected **no** roles at all*; now resolves the intrinsic etiquette from the derived kind (bundled etiquette roles resolve locally and bake into the agent command; the remote project config isn't readable here, so only intrinsic etiquette is applied)
- `cmd_fork` remote worktree, local non-worktree, local worktree

Out of scope: `cmd_history_resume` (in-place resume, no project/branch derivation) — left untouched per the issue's recreate+fork scope.

## Tests

New `tests/unit/test_cli_commands.py` classes capture the role list each command hands to `load_roles` (resolve + soul output), with tmux/git/worktree side effects mocked:

- `TestRecreateRoutesThroughResolveRoles` — worktree recreate re-injects `worktree-session` etiquette even with **no saved roles**; saved roles stack under it; plain recreate stays orchestrator-**replaceable**; zero-config plain recreate → orchestrator.
- `TestForkRoutesThroughResolveRoles` — worktree fork injects `worktree-session` etiquette; source roles stack under it; non-worktree fork stays orchestrator-replaceable.

`uv run pytest` → **1390 passed**.

Closes #311

Built by [dotdev.dev](https://dotdev.dev)
