### PR TITLE
docs: accuracy sweep — fix stale references after v1.38.0

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -13,11 +13,11 @@ The portal uses a left sidebar with a floating tab handle instead of hover hotzo
 - **Tab handle**: floating 20×40px button on left edge, rides sidebar when open, chevron flips direction
 - **Header**: connection status dot, session count, clock, pin toggle
 - **Open Windows section**: lists currently-open windows (drag to reorder, click to focus, × to close). Persisted in `localStorage['taskbar-state']` — restores on refresh.
-- **Accordion sections**: Sessions, Services, Machines, Projects, Artifacts, Scheduler, Workflows, Safety, Config. Click header to expand/collapse. Data fetched on first expand.
+- **Accordion sections**: Sessions, Services, Machines, Projects, Artifacts, Scheduler, Safety, Config. Click header to expand/collapse. Data fetched on first expand.
 - **Footer**: global PTT button, voice indicator
 
 **Session grouping:** Sessions are split into two accordion sections based on the name:
-- **Services**: infrastructure sessions. The built-in allowlist in `sessions-section.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`) is merged at load time with config-defined custom services fetched from `/api/services/custom` (driven by `services.custom` in `config.yaml`). When the fetch resolves, `notifyListeners()` re-renders so flagged sessions hop into this column.
+- **Services**: infrastructure sessions. The built-in allowlist in `service-classification.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`) is merged at load time with config-defined custom services fetched from `/api/services/custom` (driven by `services.custom` in `config.yaml`). When the fetch resolves, `notifyListeners()` re-renders so flagged sessions hop into this column.
 - **Sessions**: everything else (working sessions, worktrees, remote sessions)
 
 Both share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -162,11 +162,12 @@ up|down`) — the MCP surface is read-only introspection.
 | `agentwire overnight priority id n` | `overnight_priority(item_id="...", priority=N)` |
 | `agentwire overnight report` | `overnight_report()` |
 
-## Desktop/Portal UI (10 tools)
+## Desktop/Portal UI (12 tools)
 
 | Action | MCP Tool |
 |--------|----------|
 | List open windows | `desktop_windows_list()` |
+| Preview windows in a collage overlay | `desktop_collage()` |
 | Open session window | `desktop_open_session(session="...", mode="monitor")` |
 | Open panel | `desktop_open_panel(panel_type="sessions")` |
 | Open artifact window (URL/file) | `desktop_open_artifact(url="...", title="...")` |
@@ -178,7 +179,7 @@ up|down`) — the MCP surface is read-only introspection.
 | Minimize all | `desktop_minimize_all()` |
 | Multi-window layout | `desktop_layout(windows=[{id: "...", zone: "left"}])` |
 
-**~85 tools total** (sessions, panes, voice, tasks, channels, scheduler, overnight queue, desktop UI, handoffs). When to use CLI vs MCP:
+**~98 tools total** (sessions, panes, voice, tasks, channels, scheduler, overnight queue, desktop UI, handoffs). When to use CLI vs MCP:
 - **MCP tools** — Agents in sessions (orchestrators, workers)
 - **CLI commands** — Humans, shell scripts, automation outside of agent sessions
 

--- a/.claude/skills/agentwire-pi/SKILL.md
+++ b/.claude/skills/agentwire-pi/SKILL.md
@@ -162,9 +162,9 @@ Role tool names are translated Claude CamelCase → pi lowercase, then filtered 
 | `Edit` | `edit` |
 | `Write` | `write` |
 | `Grep` | `grep` |
-| `Glob` / `LS` | `find` / `ls` |
+| `LS` | `ls` |
 
-Unsupported Claude tools (`WebFetch`, `Task`, `TodoWrite`, MCP tools, etc.) are silently filtered. Roles with a `disallowed` list have no effect on pi (only whitelist supported).
+Translation is lowercase-then-filter against pi's supported set `{read, bash, edit, write, grep, find, ls}` (`__main__.py:252`) — there is no name remapping. So `Glob` lowercases to `glob`, which isn't in the set, and is **dropped** (not remapped to `find`). Other unsupported Claude tools (`WebFetch`, `Task`, `TodoWrite`, MCP tools, etc.) are silently filtered the same way. Roles with a `disallowed` list have no effect on pi (only whitelist supported).
 
 ## Limitations vs Claude Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Use dataclasses for configuration (see `agentwire/config.py`):
 ```python
 @dataclass
 class ServerConfig:
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8765
 ```
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ agentwire kill --pane 1           # Kill worker
 
 ```bash
 agentwire say "Hello"             # TTS (auto-routes to browser)
-agentwire alert "Done"            # Text notification (no audio)
+agentwire send -s NAME "Done"     # Inject text into a session
 agentwire listen start/stop       # Voice recording
 agentwire voiceclone list         # Custom voices
 ```

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -31,7 +31,7 @@ Three surfaces, one source of truth.
 ```
 ┌──────────────────────────────┐  ┌──────────────────────────────┐
 │  Humans / scripts            │  │  Agents inside sessions      │
-│    agentwire <cmd>           │  │    MCP tools (87 of them)    │
+│    agentwire <cmd>           │  │    MCP tools (~98 of them)   │
 └─────────────┬────────────────┘  └─────────────┬────────────────┘
               │                                 │
               ▼                                 ▼
@@ -75,9 +75,9 @@ This is why bug fixes land in one place: change the CLI, the portal and MCP tool
 ├── damage-control/          # OPTIONAL user override for security rules
 ├── apps/, artifacts/        # agent-generated UIs and HTML artifacts
 ├── locks/                   # session mutexes (acquired by `agentwire ensure`)
-├── queues/                  # overnight queue items
-├── sessions/                # SDK session transcripts (REPL persistence)
-├── sdk-sessions/            # SDK conversation forks
+├── overnight/               # overnight queue items
+├── sessions/                # per-session metadata.json
+├── usage-limit/             # usage-limit recovery park state
 ├── tasks/                   # ensure-task summary files
 ├── tooldefs/                # tool definitions for damage-control ask-patterns
 ├── tunnels/                 # SSH tunnel state
@@ -151,7 +151,7 @@ Two execution paths for non-interactive work:
                           agentwire ensure
                           (tmux + Claude)
 
-                ┌── ~/.agentwire/queues/  (overnight prepare) ──┐
+                ┌── ~/.agentwire/overnight/  (overnight prepare) ┐
                 │  human prepares interactively → sessionId     │
                 └──────────────┬────────────────────────────────┘
                                ▼

--- a/docs/wiki/deployment/remote-machines.md
+++ b/docs/wiki/deployment/remote-machines.md
@@ -43,7 +43,6 @@ agentwire machine remove <id>
 This:
 - Removes from `machines.json`
 - Kills active SSH tunnel
-- Cleans entries from `rooms.json`
 - Prints reminders for manual cleanup (SSH config, deploy keys, etc.)
 
 ### Portal UI
@@ -282,8 +281,8 @@ ssh my-server
 cd ~/.agentwire/machine
 claude  # gets both global prefs and machine context
 
-# Or spawn via agentwire from the Mac
-agentwire new -s my-server-ops --machine my-server -p ~/.agentwire/machine
+# Or spawn via agentwire from the Mac (remote target is the @machine suffix)
+agentwire new -s my-server-ops@my-server -p ~/.agentwire/machine
 ```
 
 ### What to Put in `~/.agentwire/machine/CLAUDE.md`

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -86,7 +86,7 @@ An SSH or Cloudflare Tunnel that exposes a local agentwire service (TTS server, 
 
 ## V — Voice
 
-A TTS reference WAV (10–30 s) stored in `~/.agentwire/voices/`. Selected per-session via `voice:` in project config or per-call via `--voice`. The `default` voice is used when nothing is specified. → [Self-hosted TTS](tts/tts-self-hosted.md#voices).
+A TTS reference WAV (10–30 s) stored in `~/.agentwire/voices/`. Selected per-session via `voice:` in project config or per-call via `--voice`. The `default` voice is used when nothing is specified. → [Self-hosted TTS](voice/tts-self-hosted.md#voices).
 
 ## W — Worker
 

--- a/docs/wiki/internals/shell-escaping.md
+++ b/docs/wiki/internals/shell-escaping.md
@@ -90,19 +90,20 @@ cmd = f'claude --append-system-prompt "$(<{prompt_file.name})"'
 
 ## Implementation Details
 
-Current implementation in `_build_agent_command_env()` (line 154-162 of `__main__.py`):
+Current implementation in `build_agent_command()` (`__main__.py`, e.g. the Claude path around line 309):
 
 ```python
 if merged.instructions:
-    # Write prompt to temp file and read via $(<file) to handle long prompts
-    # This avoids issues with command line length limits and escaping
-    import tempfile
-    prompt_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
-    prompt_file.write(merged.instructions)
-    prompt_file.close()
-    env["AGENT_SYSTEM_PROMPT_FILE"] = prompt_file.name
-    env["AGENT_SYSTEM_PROMPT_FLAG"] = f'--append-system-prompt "$(<{prompt_file.name})"'
+    # Write to temp file to avoid shell escaping issues
+    # MUST be last flag — multiline content can break subsequent args
+    f = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+    f.write(merged.instructions)
+    f.close()
+    temp_file = f.name
+    parts.append(f'--append-system-prompt "$(<{temp_file})"')
 ```
+
+The temp file path is returned on `AgentCommand.temp_file` so the caller can clean it up after the agent starts. The pi path (around line 264) uses the same `$(<file)` technique with the combined global + role prompt.
 
 ---
 

--- a/docs/wiki/internals/troubleshooting.md
+++ b/docs/wiki/internals/troubleshooting.md
@@ -421,14 +421,15 @@ ls ~/.agentwire/tasks/
 rm ~/.agentwire/tasks/session-name.json
 ```
 
-### `agentwire alert` vs `agentwire say`
+### Text vs voice notifications
 
 | Command | Audio | Use Case |
 |---------|-------|----------|
 | `agentwire say` | Yes (TTS) | User-facing messages, completion announcements |
-| `agentwire alert` | No (text only) | Background notifications, idle status updates |
+| `agentwire msg send` | No (text only) | Polite peer report-back, dropped into the recipient's inbox |
+| `agentwire notify-parent --to` | No (text only) | Worker → orchestrator status, injected as text |
 
-Idle hooks use `alert` to avoid audio spam when multiple panes go idle.
+Idle hooks route text alerts to the orchestrator (no audio) to avoid spam when multiple panes go idle.
 
 ---
 

--- a/docs/wiki/research/orchestration-transport-alternatives.md
+++ b/docs/wiki/research/orchestration-transport-alternatives.md
@@ -1,6 +1,8 @@
 # Orchestration transport alternatives: do we need a non-SSH transport?
 
 > Research note for [#297](https://github.com/dotdevdotdev/agentwire-dev/issues/297). Investigates the "we don't use SSH — we use something faster/more secure" pitch from competing agent-orchestration tools, separates real engineering from marketing, and recommends what (if anything) AgentWire should adopt. **This is a recon report, not a transport rewrite.**
+>
+> **Update (shipped):** cheap win #1 below is now implemented — `agentwire/ssh.py::ssh_base_opts()` supplies `ControlMaster`/`ControlPersist` multiplexing and is wired into every remote call site (`agents/tmux.py`, `tunnels.py`, `server.py`, `projects.py`). The present-tense "no `ControlMaster` anywhere / fresh process per command" baseline below describes the pre-#297 state and is kept for historical context.
 
 ## TL;DR — Recommendation (b): cheap hardening, no transport change
 

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -186,6 +186,7 @@ Environment variables use `${ENV_VAR}` syntax (expanded at runtime).
 | 4 | Pre-phase failure (command failed, `required` empty, `validate` failed, `starting_ref` not found) |
 | 5 | Timeout (hard timeout exceeded) |
 | 6 | Session error (couldn't create or connect) |
+| 7 | Usage limit (`usage_limit` — session parked awaiting reset; scheduler skips dispatch) |
 
 ---
 


### PR DESCRIPTION
Closes #318

Full pass through all documentation, skills, and instructions to fix factual inaccuracies vs current code, surfaced after v1.38.0. Audited with 4 parallel read-only agents cross-checking every claim against the actual codebase (CLI argparse, MCP server, config dataclasses, static JS). The removed-feature sweep (missions, SDK, inbound channels, workflow engine, Brave, OpenCode, claudeGLM, CHANGELOG) came back clean almost everywhere — these are the genuine, code-verified discrepancies that remained.

### Skills
- **agentwire-desktop-ui** — dropped "Workflows" from the accordion-section list (engine removed); allowlist file `sessions-section.js` → `service-classification.js`.
- **agentwire-pi** — `Glob` does not translate to `find`; it's dropped by the lowercase-then-filter against `{read,bash,edit,write,grep,find,ls}`. Only `LS→ls` survives.
- **agentwire-mcp-tools** — Desktop/Portal UI 10→12 tools (+`desktop_collage()`); "~85"→"~98" total.

### Root docs
- **README.md** — removed dead `agentwire alert` (never existed) → `agentwire send`.
- **CONTRIBUTING.md** — `ServerConfig.host` `0.0.0.0` → `127.0.0.1` (matches code + SECURITY.md loopback trust model).

### Wiki
- **architecture.md** — MCP count 87→~98; storage layout: deleted `sdk-sessions/`, `queues/`→`overnight/` (×2), corrected `sessions/` description.
- **glossary.md** — broken `tts/` → `voice/tts-self-hosted.md`.
- **internals/shell-escaping.md** — replaced stale `_build_agent_command_env()`/env-var snippet with the real inline `$(<file)` + `AgentCommand.temp_file` impl.
- **internals/troubleshooting.md** — removed the nonexistent `agentwire alert` table.
- **scheduling/scheduled-workloads.md** — added exit code 7 (`usage_limit`).
- **deployment/remote-machines.md** — removed nonexistent `rooms.json`; `new --machine` (no such flag) → `session@machine` suffix.
- **research/orchestration-transport-alternatives.md** — added a "shipped" banner (ControlMaster multiplexing now in `ssh.py`); recon report otherwise preserved.

Docs-only; no code or tests touched.

Built by [dotdev.dev](https://dotdev.dev)