### PR TITLE
Real feedback for sidebar actions — toasts, button states, no silent swallows

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -725,6 +725,53 @@ body {
     font-style: italic;
 }
 
+/* --- Action feedback (toast.js) --- */
+.toast-container {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 100000; /* above sidebar, drawers, WinBoxes, and modals */
+    pointer-events: none;
+    max-width: min(360px, calc(100vw - 32px));
+}
+
+.toast {
+    pointer-events: auto;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-left-width: 3px;
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.4;
+    padding: 10px 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity var(--sidebar-transition), transform var(--sidebar-transition);
+    word-break: break-word;
+}
+
+.toast-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.toast-success { border-left-color: var(--accent); }
+.toast-error { border-left-color: var(--error); }
+.toast-info { border-left-color: var(--text-muted); }
+
+/* In-flight trigger buttons (withButtonBusy) */
+.sidebar-list-item-btn.is-busy,
+.sidebar-form-btn.is-busy {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .sidebar-config-item {
     display: flex;
     gap: 8px;

--- a/agentwire/static/js/artifact-window.js
+++ b/agentwire/static/js/artifact-window.js
@@ -8,6 +8,12 @@
 import { apiFetch, getToken } from './api.js';
 import { desktop } from './desktop-manager.js';
 
+// If the iframe's `load` event hasn't fired by now, treat it as stuck and flip
+// the spinner to the error state. The native `error` event doesn't fire for
+// many failure shapes (blank response, hung connection), so the spinner would
+// otherwise spin forever (issue #17).
+const ARTIFACT_LOAD_TIMEOUT_MS = 15000;
+
 export class ArtifactWindow {
     /**
      * @param {Object} options
@@ -30,6 +36,7 @@ export class ArtifactWindow {
         this.iframe = null;
         this.isOpen = false;
         this._objectUrl = null; // blob URL for token-authed artifact loads
+        this._loadTimer = null; // stuck-spinner watchdog
     }
 
     /**
@@ -52,6 +59,8 @@ export class ArtifactWindow {
      */
     close() {
         if (!this.isOpen) return;
+
+        this._clearLoadTimeout();
 
         // Remove iframe to stop any running scripts
         if (this.iframe) {
@@ -95,11 +104,52 @@ export class ArtifactWindow {
      */
     reload() {
         if (this.iframe) {
+            this._resetLoadingUI();
+            this._armLoadTimeout();
             this._setIframeSrc();
         }
     }
 
     // Private methods
+
+    _content() {
+        return this.winbox ? this.winbox.body.querySelector('.artifact-window-content') : null;
+    }
+
+    _clearLoadTimeout() {
+        if (this._loadTimer) {
+            clearTimeout(this._loadTimer);
+            this._loadTimer = null;
+        }
+    }
+
+    _armLoadTimeout() {
+        this._clearLoadTimeout();
+        this._loadTimer = setTimeout(() => {
+            this._loadTimer = null;
+            this._showLoadError(`Timed out loading: ${this.url}`);
+        }, ARTIFACT_LOAD_TIMEOUT_MS);
+    }
+
+    _resetLoadingUI() {
+        const content = this._content();
+        if (!content) return;
+        content.querySelector('.artifact-loading')?.classList.remove('hidden');
+        content.querySelector('.artifact-error')?.classList.add('hidden');
+    }
+
+    _showLoadError(message) {
+        this._clearLoadTimeout();
+        const content = this._content();
+        if (!content) return;
+        content.querySelector('.artifact-loading')?.classList.add('hidden');
+        const errorEl = content.querySelector('.artifact-error');
+        if (errorEl) {
+            errorEl.classList.remove('hidden');
+            const msgEl = errorEl.querySelector('.artifact-error-message');
+            if (msgEl) msgEl.textContent = message;
+        }
+    }
 
     _createContainer() {
         const container = document.createElement('div');
@@ -228,19 +278,16 @@ export class ArtifactWindow {
         }
 
         this.iframe.addEventListener('load', () => {
+            this._clearLoadTimeout();
             if (loadingEl) loadingEl.classList.add('hidden');
             if (errorEl) errorEl.classList.add('hidden');
         });
 
         this.iframe.addEventListener('error', () => {
-            if (loadingEl) loadingEl.classList.add('hidden');
-            if (errorEl) {
-                errorEl.classList.remove('hidden');
-                errorEl.querySelector('.artifact-error-message').textContent =
-                    `Failed to load: ${this.url}`;
-            }
+            this._showLoadError(`Failed to load: ${this.url}`);
         });
 
+        this._armLoadTimeout();
         this._setIframeSrc();
         content.insertBefore(this.iframe, content.firstChild);
     }

--- a/agentwire/static/js/sidebar/artifacts-section.js
+++ b/agentwire/static/js/sidebar/artifacts-section.js
@@ -1,5 +1,6 @@
 
 import { apiFetch } from '../api.js';
+import { toastSuccess, toastError, withButtonBusy, errorFromResponse } from '../toast.js';
 export const artifactsSection = {
     title: 'Artifacts',
     async mount(body) { await this.refresh(body); },
@@ -8,22 +9,25 @@ export const artifactsSection = {
             const res = await apiFetch('/api/artifacts');
             const items = await res.json();
             if (!items.length) {
-                body.innerHTML = '<div class="sidebar-empty">No artifacts</div>';
-                return;
+                body.innerHTML = '<div class="sidebar-empty">No artifacts yet</div>';
+            } else {
+                body.innerHTML = items.map(a => {
+                    const size = a.size < 1024 ? `${a.size}B` : `${(a.size / 1024).toFixed(1)}K`;
+                    return `<div class="sidebar-list-item" data-name="${a.name}">
+                        <span class="sidebar-list-item-title">${a.name}</span>
+                        <span class="sidebar-list-item-meta">${size}</span>
+                        <button class="sidebar-list-item-btn" data-action="open" title="Open">↗</button>
+                        <button class="sidebar-list-item-btn sidebar-list-item-btn-danger" data-action="delete" title="Delete">×</button>
+                    </div>`;
+                }).join('');
             }
-            body.innerHTML = items.map(a => {
-                const size = a.size < 1024 ? `${a.size}B` : `${(a.size / 1024).toFixed(1)}K`;
-                return `<div class="sidebar-list-item" data-name="${a.name}">
-                    <span class="sidebar-list-item-title">${a.name}</span>
-                    <span class="sidebar-list-item-meta">${size}</span>
-                    <button class="sidebar-list-item-btn" data-action="open" title="Open">↗</button>
-                    <button class="sidebar-list-item-btn sidebar-list-item-btn-danger" data-action="delete" title="Delete">×</button>
-                </div>`;
-            }).join('');
-            body.addEventListener('click', (e) => this._handleClick(e, body), { once: false });
         } catch (e) {
             body.innerHTML = '<div class="sidebar-empty">Failed to load artifacts</div>';
         }
+        // Idempotent assignment = single delegated handler. The old
+        // addEventListener-every-refresh stacked listeners, so each click fired
+        // N times (issue #17 double-firing handler).
+        body.onclick = (e) => this._handleClick(e, body);
     },
     async _handleClick(e, body) {
         const btn = e.target.closest('[data-action]');
@@ -35,10 +39,16 @@ export const artifactsSection = {
             const { openArtifactWindow } = await import('../desktop.js');
             openArtifactWindow(name, name);
         } else if (btn.dataset.action === 'delete') {
-            try {
-                await apiFetch(`/api/artifacts/${encodeURIComponent(name)}`, { method: 'DELETE' });
-                await this.refresh(body);
-            } catch (e) { console.warn('Failed to delete artifact', e); }
+            await withButtonBusy(btn, async () => {
+                try {
+                    const res = await apiFetch(`/api/artifacts/${encodeURIComponent(name)}`, { method: 'DELETE' });
+                    if (!res.ok) throw new Error(await errorFromResponse(res));
+                    toastSuccess(`Deleted ${name}`);
+                    await this.refresh(body);
+                } catch (err) {
+                    toastError(`Failed to delete ${name}: ${err.message}`);
+                }
+            });
         }
     },
 };

--- a/agentwire/static/js/sidebar/machines-section.js
+++ b/agentwire/static/js/sidebar/machines-section.js
@@ -1,5 +1,6 @@
 
 import { apiFetch } from '../api.js';
+import { toastSuccess, toastError, withButtonBusy, errorFromResponse } from '../toast.js';
 export const machinesSection = {
     title: 'Machines',
     autoRefreshMs: 10000,
@@ -37,19 +38,24 @@ export const machinesSection = {
         if (!item) return;
         const machineId = item.dataset.machine;
         if (btn.dataset.action === 'new-session') {
-            try {
-                const machine = machineId === 'local' ? null : machineId;
-                const res = await apiFetch('/api/create', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ machine }),
-                });
-                if (res.ok) {
+            await withButtonBusy(btn, async () => {
+                try {
+                    const machine = machineId === 'local' ? null : machineId;
+                    const res = await apiFetch('/api/create', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ machine }),
+                    });
+                    if (!res.ok) throw new Error(await errorFromResponse(res));
                     const data = await res.json();
+                    const sessionName = data.session || data.name;
+                    toastSuccess(`Created ${sessionName}`);
                     const { openSessionTerminal } = await import('../desktop.js');
-                    openSessionTerminal(data.session || data.name, 'terminal', machine);
+                    openSessionTerminal(sessionName, 'terminal', machine);
+                } catch (err) {
+                    toastError(`Failed to create session: ${err.message}`);
                 }
-            } catch (e) { console.warn('Failed to create session', e); }
+            });
         }
     },
 };

--- a/agentwire/static/js/sidebar/projects-section.js
+++ b/agentwire/static/js/sidebar/projects-section.js
@@ -1,5 +1,6 @@
 import { apiFetch } from '../api.js';
 import { normalizeMachine, sameMachine } from '../session-id.js';
+import { toastSuccess, toastError, withButtonBusy } from '../toast.js';
 
 export const projectsSection = {
     title: 'Projects',
@@ -82,7 +83,7 @@ export const projectsSection = {
         }
 
         if (action === 'start' && name) {
-            await this._startProjectSession({ name, path, machine });
+            await withButtonBusy(btn, () => this._startProjectSession({ name, path, machine }));
         }
     },
 
@@ -127,12 +128,13 @@ export const projectsSection = {
             const err = data.error || '';
             // If a race made the session appear, that's fine — just open it.
             if (!res.ok || (err && !/already exists/i.test(err))) {
-                console.warn('Failed to start session from project:', err || `HTTP ${res.status}`);
+                toastError(`Failed to start ${name}: ${err || `HTTP ${res.status}`}`);
                 return;
             }
+            toastSuccess(`Started ${name}`);
             open(data.session || data.name || name);
         } catch (e) {
-            console.warn('Failed to start session from project', e);
+            toastError(`Failed to start ${name}: ${e.message}`);
         }
     },
 };

--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -1,5 +1,6 @@
 import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
+import { toastSuccess, toastError, withButtonBusy, errorFromResponse } from '../toast.js';
 
 const COLLAPSED_KEY = 'scheduler-section-collapsed';
 const DEFAULT_COLLAPSED = ['inactive'];  // first-load: hide the long disabled list
@@ -201,28 +202,48 @@ export const schedulerSection = {
 
         // Daemon start/stop toggle (not tied to a task row).
         if (action === 'scheduler-start' || action === 'scheduler-stop') {
-            btn.disabled = true;
-            try {
-                const path = action === 'scheduler-start' ? '/api/scheduler/start' : '/api/scheduler/stop';
-                await apiFetch(path, { method: 'POST' });
-            } catch (e) { console.warn('Scheduler toggle failed', e); }
-            // Daemon takes a moment to spin up / write its state file.
-            setTimeout(() => this.refresh(body), 1500);
+            const starting = action === 'scheduler-start';
+            await withButtonBusy(btn, async () => {
+                try {
+                    const path = starting ? '/api/scheduler/start' : '/api/scheduler/stop';
+                    const res = await apiFetch(path, { method: 'POST' });
+                    if (!res.ok) throw new Error(await errorFromResponse(res));
+                    toastSuccess(starting ? 'Scheduler started' : 'Scheduler stopped');
+                    // Response-gated refresh — no fixed 1.5s guess. The daemon has
+                    // acknowledged by the time the POST resolves; WS scheduler_state
+                    // events keep it current after that.
+                    await this.refresh(body);
+                } catch (err) {
+                    toastError(`Scheduler ${starting ? 'start' : 'stop'} failed: ${err.message}`);
+                }
+            });
             return;
         }
 
         const item = btn.closest('[data-task]');
         if (!item) return;
         const task = item.dataset.task;
-        try {
-            if (action === 'run') {
-                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });
-            } else if (action === 'enable') {
-                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/enable`, { method: 'POST' });
-            } else if (action === 'disable') {
-                await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/disable`, { method: 'POST' });
+        await withButtonBusy(btn, async () => {
+            try {
+                let res, msg;
+                if (action === 'run') {
+                    res = await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/run`, { method: 'POST' });
+                    msg = `Triggered ${task}`;
+                } else if (action === 'enable') {
+                    res = await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/enable`, { method: 'POST' });
+                    msg = `Enabled ${task}`;
+                } else if (action === 'disable') {
+                    res = await apiFetch(`/api/scheduler/tasks/${encodeURIComponent(task)}/disable`, { method: 'POST' });
+                    msg = `Disabled ${task}`;
+                } else {
+                    return;
+                }
+                if (!res.ok) throw new Error(await errorFromResponse(res));
+                toastSuccess(msg);
+                await this.refresh(body);
+            } catch (err) {
+                toastError(`Task ${action} failed: ${err.message}`);
             }
-            await this.refresh(body);
-        } catch (e) { console.warn('Scheduler action failed', e); }
+        });
     },
 };

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -2,6 +2,7 @@ import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 import { buildSessionId, normalizeMachine } from '../session-id.js';
 import { isService, loadCustomServices } from '../service-classification.js';
+import { toastSuccess, toastError } from '../toast.js';
 
 // Shared state across sessions and services sections
 export const activityStates = new Map();
@@ -110,8 +111,9 @@ async function handleCloseClick(session) {
         // The portal broadcasts sessions_update after the kill; drop the row
         // locally too so the sidebar doesn't wait on the round-trip.
         allSessions = allSessions.filter(s => (s.name || '') !== session);
+        toastSuccess(`Killed ${session}`);
     } catch (err) {
-        console.error(`Failed to kill session ${session}:`, err);
+        toastError(`Failed to kill ${session}: ${err.message}`);
     } finally {
         killingSessions.delete(session);
         notifyListeners();
@@ -265,13 +267,17 @@ export const sessionsSection = {
                     this._render(body);
                     const { openSessionTerminal } = await import('../desktop.js');
                     const sessionName = data.session || data.name || name;
+                    toastSuccess(`Created ${sessionName}`);
                     openSessionTerminal(sessionName, 'terminal');
                 } else {
                     const err = await res.json().catch(() => ({}));
+                    const reason = err.error || `HTTP ${res.status}`;
+                    toastError(`Failed to create ${name}: ${reason}`);
                     btn.textContent = err.error || 'Error';
                     setTimeout(() => { btn.disabled = false; btn.textContent = isWorktree ? 'Create worktree' : 'Create'; }, 2000);
                 }
             } catch (e) {
+                toastError(`Failed to create ${name}: ${e.message}`);
                 btn.textContent = 'Error';
                 setTimeout(() => { btn.disabled = false; btn.textContent = isWorktree ? 'Create worktree' : 'Create'; }, 2000);
             }

--- a/agentwire/static/js/toast.js
+++ b/agentwire/static/js/toast.js
@@ -1,0 +1,110 @@
+/**
+ * toast.js — shared action-feedback primitives for the portal.
+ *
+ * SSOT for two things every state-changing UI action needs:
+ *   1. toast()           — a transient success/failure/info notification
+ *   2. withButtonBusy()  — disable + busy-mark a trigger button while in flight
+ *   3. errorFromResponse() — best-effort human reason from a failed fetch
+ *
+ * Sidebar sections used to `console.error` silent failures and leave the UI
+ * unchanged, so a click looked like a no-op. Route every action through these
+ * helpers instead: success toast only after the server confirms, failure toast
+ * carrying the reason, button disabled for the duration.
+ */
+
+let _container = null;
+
+function _ensureContainer() {
+    if (_container && document.body.contains(_container)) return _container;
+    _container = document.createElement('div');
+    _container.className = 'toast-container';
+    document.body.appendChild(_container);
+    return _container;
+}
+
+function _dismiss(el) {
+    if (!el || el._dismissing) return;
+    el._dismissing = true;
+    clearTimeout(el._dismissTimer);
+    el.classList.remove('toast-visible');
+    el.addEventListener('transitionend', () => el.remove(), { once: true });
+    // Fallback removal if transitionend never fires (display:none, reduced motion).
+    setTimeout(() => el.remove(), 400);
+}
+
+/**
+ * Show a transient toast in the bottom-right stack. Click to dismiss early.
+ *
+ * @param {string} message
+ * @param {Object} [opts]
+ * @param {'success'|'error'|'info'} [opts.type='info']
+ * @param {number} [opts.duration] - ms before auto-dismiss (errors linger longer)
+ * @returns {HTMLElement}
+ */
+export function toast(message, opts = {}) {
+    const type = opts.type || 'info';
+    const duration = opts.duration ?? (type === 'error' ? 6000 : 3500);
+    const container = _ensureContainer();
+
+    const el = document.createElement('div');
+    el.className = `toast toast-${type}`;
+    el.setAttribute('role', type === 'error' ? 'alert' : 'status');
+    el.textContent = message;
+    el.addEventListener('click', () => _dismiss(el));
+
+    container.appendChild(el);
+    requestAnimationFrame(() => el.classList.add('toast-visible'));
+
+    el._dismissTimer = setTimeout(() => _dismiss(el), duration);
+    return el;
+}
+
+export const toastSuccess = (msg, opts) => toast(msg, { ...opts, type: 'success' });
+export const toastError = (msg, opts) => toast(msg, { ...opts, type: 'error' });
+
+/**
+ * Run an async action with the trigger button disabled + `.is-busy` for the
+ * duration; the button is always restored afterwards (even if the action
+ * re-renders the list out from under it — a detached node is harmless).
+ * Caller owns success/failure messaging based on the result.
+ *
+ * @template T
+ * @param {HTMLButtonElement|null} btn
+ * @param {() => Promise<T>} fn
+ * @param {Object} [opts]
+ * @param {string} [opts.busyText] - temporary textContent while in flight
+ * @returns {Promise<T>}
+ */
+export async function withButtonBusy(btn, fn, opts = {}) {
+    if (!btn) return fn();
+    const prevDisabled = btn.disabled;
+    const hadBusyText = opts.busyText != null;
+    const prevText = hadBusyText ? btn.textContent : null;
+    btn.disabled = true;
+    btn.classList.add('is-busy');
+    if (hadBusyText) btn.textContent = opts.busyText;
+    try {
+        return await fn();
+    } finally {
+        btn.disabled = prevDisabled;
+        btn.classList.remove('is-busy');
+        if (hadBusyText) btn.textContent = prevText;
+    }
+}
+
+/**
+ * Best-effort human-readable error from a failed fetch Response. Portal
+ * endpoints return JSON `{error}` on failure; fall back to the HTTP status.
+ *
+ * @param {Response} res
+ * @returns {Promise<string>}
+ */
+export async function errorFromResponse(res) {
+    try {
+        const data = await res.clone().json();
+        if (data && data.error) return data.error;
+    } catch {
+        // body wasn't JSON
+    }
+    return `HTTP ${res.status}`;
+}


### PR DESCRIPTION
## What

Every state-changing portal sidebar action now surfaces success and failure. Previously most caught the error, `console.error`'d it, and left the UI unchanged — a click looked like a no-op, so users assumed failure and re-clicked.

## Approach

- **One shared SSOT util** — `static/js/toast.js` exports `toast` / `toastSuccess` / `toastError`, `withButtonBusy` (disable + `.is-busy` for the duration, always restored), and `errorFromResponse` (human reason from a failed fetch). Not reinvented per section.
- **Wired the named silent catches:**
  - `artifacts-section.js` — delete
  - `machines-section.js` — new-session
  - `scheduler-section.js` — daemon start/stop + task run/enable/disable
  - `sessions-section.js` — kill + create-form error paths
  - `projects-section.js` — start
- Success toast fires **only after the server confirms**; lists refresh only on confirmed success.
- Replaced the hardcoded **1.5s scheduler refresh** with a response-gated refresh.

## Absorbs #16 / #17

- **Double-firing click handler (#17):** `artifacts-section.js` re-attached a `click` listener via `addEventListener` on every refresh, so a single click fired N times. Switched to a single delegated handler (idempotent `body.onclick`).
- **Artifact load-timeout (#17):** added a watchdog that flips a stuck spinner to the error state when neither the iframe `load` nor `error` event fires.
- **#16 copy/danger styling:** normalized empty-state copy ("No artifacts yet"), toast + busy-button styles added to `desktop.css`; danger button resting style already present.

No sidebar redesign — one helper, wire the catches.

## Verification

- `node --check` passes on all 7 touched JS files.
- Static files only — no rebuild needed; portal serves them on restart.

Closes #331

Built by [dotdev.dev](https://dotdev.dev)