### PR TITLE
ci: hermetic pytest gate on every PR + push to main (#323)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,35 @@
+# Pytest CI gate (#323).
+#
+# 1,191+ test functions exist in the repo; before this workflow none ran in CI,
+# so `main` could (and did, #249) go red unnoticed. This runs the suite on every
+# PR and every push to main and is the whole win: a trustworthy green/red signal.
+#
+# Hermetic by design — the runner has no live tmux session or portal, so tests
+# that spawn a real tmux binary (the WS-connect and speak-fanout PTY paths) are
+# marked `requires_tmux` and deselected here. They still run locally where tmux
+# is on PATH. Per the council guardrail we do NOT chase coverage % or block PRs
+# on flaky/tmux-dependent tests.
+name: pytest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest (hermetic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Run test suite (tmux-dependent tests deselected)
+        run: uv run --no-sync pytest -q -m "not requires_tmux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,10 @@ markers = [
     "slow: marks tests as slow",
     "integration: requires subprocess mocking",
     "e2e: end-to-end portal tests",
+    # Spawns a real tmux binary (WS connect / speak paths PTY-pipe through tmux).
+    # Deselected in the hermetic CI gate via `-m 'not requires_tmux'` (#323);
+    # still runs locally where tmux is on PATH.
+    "requires_tmux: spawns a real tmux process; deselected in hermetic CI (#323)",
 ]
 asyncio_mode = "auto"
 

--- a/tests/integration/test_server_websockets.py
+++ b/tests/integration/test_server_websockets.py
@@ -71,6 +71,7 @@ async def _recv_json(ws, timeout=2.0):
 
 @pytest.mark.integration
 class TestSessionWebSocket:
+    @pytest.mark.requires_tmux
     async def test_connect_sends_initial_output(self, portal_client):
         client, server = portal_client
         server.agent.get_output.return_value = "hello world"
@@ -79,6 +80,7 @@ class TestSessionWebSocket:
             assert msg["type"] == "output"
             assert msg["data"] == "hello world"
 
+    @pytest.mark.requires_tmux
     async def test_connect_registers_client(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/sess-a") as ws:
@@ -86,6 +88,7 @@ class TestSessionWebSocket:
             assert "sess-a" in server.active_sessions
             assert len(server.active_sessions["sess-a"].clients) == 1
 
+    @pytest.mark.requires_tmux
     async def test_disconnect_removes_client(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/sess-b") as ws:
@@ -95,6 +98,7 @@ class TestSessionWebSocket:
         await asyncio.sleep(0.05)
         assert len(server.active_sessions["sess-b"].clients) == 0
 
+    @pytest.mark.requires_tmux
     async def test_multiple_clients_share_session(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/multi") as ws1:
@@ -103,6 +107,7 @@ class TestSessionWebSocket:
                 await _recv_json(ws2)
                 assert len(server.active_sessions["multi"].clients) == 2
 
+    @pytest.mark.requires_tmux
     async def test_recording_started_locks_session(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/locked") as ws1:
@@ -116,6 +121,7 @@ class TestSessionWebSocket:
                 # Session is now locked by ws1's client_id.
                 assert server.active_sessions["locked"].locked_by is not None
 
+    @pytest.mark.requires_tmux
     async def test_lock_released_on_owner_disconnect(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/release") as ws1:
@@ -127,6 +133,7 @@ class TestSessionWebSocket:
         await asyncio.sleep(0.05)
         assert server.active_sessions["release"].locked_by is None
 
+    @pytest.mark.requires_tmux
     async def test_invalid_json_keeps_connection_alive(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/sess-json") as ws:
@@ -137,6 +144,7 @@ class TestSessionWebSocket:
             # No reply expected for resize. Confirm session still tracked.
             assert "sess-json" in server.active_sessions
 
+    @pytest.mark.requires_tmux
     async def test_resize_message_accepted(self, portal_client):
         client, server = portal_client
         async with client.ws_connect("/ws/sess-resize") as ws:
@@ -179,6 +187,7 @@ class TestTerminalWebSocket:
             # Could be CLOSE or CLOSED — both are acceptable termination signals.
             assert msg.type.name in {"CLOSE", "CLOSED", "CLOSING"}
 
+    @pytest.mark.requires_tmux
     async def test_terminal_registers_client_in_session(self, portal_client):
         client, server = portal_client
         # tmux subprocess spawn will fail in test env; we just verify that
@@ -363,6 +372,7 @@ class TestWebSocketSecurity:
             )
         assert exc.value.status == 401
 
+    @pytest.mark.requires_tmux
     async def test_ws_with_token_connects_and_echoes_protocol(
         self, portal_client_with_token
     ):
@@ -374,6 +384,7 @@ class TestWebSocketSecurity:
             msg = await _recv_json(ws)
             assert msg["type"] == "output"
 
+    @pytest.mark.requires_tmux
     async def test_ws_bearer_header_also_accepted(self, portal_client_with_token):
         """Non-browser WS clients can use a plain Authorization header."""
         client, _ = portal_client_with_token
@@ -396,6 +407,7 @@ class TestWebSocketSecurity:
             )
         assert exc.value.status == 403
 
+    @pytest.mark.requires_tmux
     async def test_terminal_ws_with_token_and_query_params(
         self, portal_client_with_token
     ):
@@ -411,6 +423,7 @@ class TestWebSocketSecurity:
                 pass
         assert "local-session" in server.active_sessions
 
+    @pytest.mark.requires_tmux
     async def test_ws_no_token_configured_open(self, portal_client):
         """Loopback default: no token configured, WS connects as before."""
         client, _ = portal_client

--- a/tests/integration/test_server_websockets.py
+++ b/tests/integration/test_server_websockets.py
@@ -232,6 +232,9 @@ class TestTerminalWebSocket:
 
 
 @pytest.mark.integration
+# Every test here connects a real session WS, which PTY-pipes through a real
+# tmux binary; deselected in the hermetic CI gate via `-m 'not requires_tmux'` (#323).
+@pytest.mark.requires_tmux
 class TestReconnectAndTranscriptResumption:
     async def test_reconnect_resends_transcript(self, portal_client):
         client, server = portal_client

--- a/tests/unit/test_server_async.py
+++ b/tests/unit/test_server_async.py
@@ -218,6 +218,9 @@ def _client(name="c1"):
     return MagicMock(name=name)
 
 
+# Speak fanout reaches session-notify, which PTY-pipes through a real tmux
+# binary; deselected in the hermetic CI gate via `-m 'not requires_tmux'` (#323).
+@pytest.mark.requires_tmux
 class TestSpeakDefaultTier:
     """server.config defaults to tts.backend == 'default' (empty config)."""
 


### PR DESCRIPTION
## What

Adds `.github/workflows/pytest.yml` — a pytest CI gate running on every PR and every push to `main`. The repo has **1,392 tests** and none ran in CI before this; `main` could (and did, #249) go red unnoticed.

The job: `uv sync --extra dev` → `uv run pytest -q -m "not requires_tmux"` on `ubuntu-latest`.

## Hermeticity

The runner has no live tmux session or portal. **19 tests spawn a real `tmux` binary** on the WS-connect and speak-fanout PTY paths — they pass locally (tmux on PATH) but can't be relied on in a bare runner. Per the council guardrail ("don't block PRs on flaky/tmux-dependent tests"):

- Registered a `requires_tmux` marker in `pyproject.toml`.
- Marked exactly those 19 tests (precisely — hermetic auth-rejection / error-path tests in the same classes stay in the gate).
- CI deselects them with `-m "not requires_tmux"`. Local `pytest` still runs everything.

## Starts green

The issue's "2 known failures (#249)" were **already fixed** in #250, and the order-dependent missions test was removed with the missions feature (#306) — confirmed by running the suite first. So no quarantine was needed for those; the only hermeticity work was the tmux marker.

Verified by running the full suite with tmux removed from PATH (simulating the bare runner):

```
1373 passed, 19 deselected, 0 failed
```

## Out of scope (deliberate)

No coverage-summary comment. The directive was explicit: don't chase coverage %; the green/red signal is the whole win. A coverage-comment step also needs PR-write perms and is its own flaky surface — easy to add later in its own PR if wanted.

Closes #323

Built by [dotdev.dev](https://dotdev.dev)