### PR TITLE
feat(scheduler): surface why a task failed + stop silent fail-open gate errors

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -9706,6 +9706,7 @@ def cmd_scheduler_status(args) -> int:
         format_interval,
         load_board,
         pick_next_task,
+        read_events,
     )
 
     json_mode = getattr(args, 'json', False)
@@ -9727,6 +9728,7 @@ def cmd_scheduler_status(args) -> int:
     task_count = len(board.tasks)
     enabled_count = sum(1 for t in board.tasks.values() if t.enabled)
     next_task, wait_seconds = pick_next_task(board)
+    recent_activity = _recent_activity(read_events(tail=60), limit=5)
 
     result = {
         "running": running,
@@ -9735,6 +9737,7 @@ def cmd_scheduler_status(args) -> int:
         "enabled_count": enabled_count,
         "next_task": next_task,
         "next_in_seconds": round(wait_seconds, 1),
+        "recent_activity": recent_activity,
     }
 
     if json_mode:
@@ -9754,7 +9757,50 @@ def cmd_scheduler_status(args) -> int:
     else:
         print("Next: nothing due")
 
+    if recent_activity:
+        print("\nRecent activity:")
+        for item in recent_activity:
+            print(f"  {item['when']:<16} {item['task']:<24} {item['detail']}")
+
     return 0
+
+
+def _recent_activity(events: list[dict], limit: int = 5) -> list[dict]:
+    """Distill the event stream into a short 'what just happened' list.
+
+    Keeps the outcome-bearing events (completed/failed/gate-error) so a
+    glance at `scheduler status` shows recent results — including the
+    fail-open gate errors that used to vanish entirely.
+    """
+    keep = {"task_completed", "task_failed", "gate_error"}
+    out: list[dict] = []
+    for evt in reversed(events):
+        etype = evt.get("event")
+        if etype not in keep:
+            continue
+        ts = evt.get("ts", "")
+        try:
+            when = datetime.datetime.fromisoformat(ts).strftime("%m-%d %H:%M")
+        except (ValueError, TypeError):
+            when = ts[:16] if ts else "?"
+        if etype == "task_completed":
+            status = evt.get("status", "?")
+            summary = evt.get("summary", "")
+            detail = f"{status}" + (f" — {summary}" if summary else "")
+        elif etype == "task_failed":
+            detail = "failed — " + (evt.get("summary") or evt.get("reason") or "?")
+        else:  # gate_error
+            detail = f"[gate-error] {evt.get('gate_type', '?')}: {evt.get('reason', '?')}"
+        if len(detail) > 80:
+            detail = detail[:79] + "…"
+        out.append({"when": when, "task": evt.get("task", "?"), "detail": detail})
+        if len(out) >= limit:
+            break
+    return out
+
+
+# Statuses whose last_summary is worth surfacing as a "why" line on the board.
+_BAD_STATUSES = {"failed", "incomplete", "timeout", "lock_conflict", "usage_limit"}
 
 
 def cmd_scheduler_board(args) -> int:
@@ -9830,6 +9876,18 @@ def cmd_scheduler_board(args) -> int:
                 f"{status_str:<12} "
                 f"{r['overdue_str']}"
             )
+
+            # Surface WHY: a gate-eval error (fail-open, would otherwise be
+            # invisible) takes precedence; else the summary behind a bad status.
+            detail = ""
+            if r.get("last_gate_error"):
+                detail = f"[gate-error] {r['last_gate_error']}"
+            elif status_str in _BAD_STATUSES and r.get("last_summary"):
+                detail = r["last_summary"]
+            if detail:
+                if len(detail) > 96:
+                    detail = detail[:95] + "…"
+                print(f"  {'':<30} ↳ {detail}")
 
         print()
 
@@ -10179,6 +10237,10 @@ def cmd_scheduler_events(args) -> int:
         elif event_type == "task_skipped":
             reason = evt.get("reason", "?")
             print(f"{ts_str}  {event_type:<22} {task_name:<24} reason: {reason}")
+        elif event_type == "gate_error":
+            gate_type = evt.get("gate_type", "?")
+            reason = evt.get("reason", "?")
+            print(f"{ts_str}  {event_type:<22} {task_name:<24} {gate_type}: {reason} (failed open)")
         elif event_type == "scheduler_sleeping":
             next_task = evt.get("next_task", "?")
             sleep_s = evt.get("sleep_seconds", 0)

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -104,6 +104,7 @@ class TaskState:
     last_duration: int = 0
     run_count: int = 0
     last_summary: str = ""
+    last_gate_error: str = ""     # last gate-eval exception reason (failed open)
     last_gate_commit: str = ""    # HEAD at last dispatch (for gate checks)
     last_dispatch: datetime | None = None  # set BEFORE running (restart safety)
     # Active worktree-PR tracking (set on finalize, cleared by the reaper on
@@ -273,6 +274,7 @@ def load_board() -> Board:
                 last_duration=int(s.get("last_duration", 0)),
                 run_count=int(s.get("run_count", 0)),
                 last_summary=str(s.get("last_summary", "")),
+                last_gate_error=str(s.get("last_gate_error", "")),
                 last_gate_commit=str(s.get("last_gate_commit", "")),
                 last_dispatch=_parse_datetime_field(s.get("last_dispatch")),
                 worktree_branch=str(s.get("worktree_branch", "")),
@@ -305,6 +307,8 @@ def save_board(board: Board) -> None:
         }
         if s.last_summary:
             entry["last_summary"] = s.last_summary
+        if s.last_gate_error:
+            entry["last_gate_error"] = s.last_gate_error
         if s.last_gate_commit:
             entry["last_gate_commit"] = s.last_gate_commit
         if s.last_dispatch:
@@ -507,13 +511,23 @@ Cleared per-task when the task is dispatched (runs) or when
 conditions change (new commits make the gate pass).
 """
 
+_gate_errored: dict[str, str] = {}
+"""Last gate-eval error reason per task (log-spam control + change detection).
+
+Cleared when the gate next evaluates cleanly, so a transient git timeout
+surfaces once rather than on every loop.
+"""
+
 
 def _check_gate(board: Board, task_name: str) -> bool:
     """Return True if task should run, False to skip.
 
     Evaluates gate preconditions defined on the task. Multiple gate keys
-    are AND'd — all must pass. Fails open (returns True) on errors,
-    missing baseline, or no gate defined.
+    are AND'd — all must pass. Fails OPEN (returns True) on errors,
+    missing baseline, or no gate defined — but a gate-eval *exception* is
+    no longer silent: it's logged to the event stream and surfaced on the
+    board as `last_gate_error`, so a git timeout that lets the task run
+    anyway leaves a trail instead of vanishing.
 
     Only logs the first time a task is gated — subsequent checks for the
     same task are silent until the task runs or conditions change.
@@ -522,6 +536,7 @@ def _check_gate(board: Board, task_name: str) -> bool:
     gate = task.gate
     if not gate or not isinstance(gate, dict):
         _gated_tasks.discard(task_name)
+        _clear_gate_error(board, task_name)
         return True
 
     cfg = _sched_config()
@@ -537,6 +552,26 @@ def _check_gate(board: Board, task_name: str) -> bool:
             _gated_tasks.add(task_name)
         return False
 
+    def _gate_error(gate_type: str, exc: Exception):
+        """Record a gate-eval exception, then fail OPEN.
+
+        Deliberately keeps the fail-open behaviour (a closed gate that
+        errored would block every task) but routes the captured reason
+        into the event log + board so the run is no longer UNLOGGED.
+        """
+        reason = " ".join(f"{type(exc).__name__}: {exc}".split())[:200]
+        if _gate_errored.get(task_name) != reason:
+            _gate_errored[task_name] = reason
+            _log_event("gate_error", task=task_name, gate_type=gate_type,
+                       reason=reason)
+            print(f"[{_ts()}] Gate error on {task_name}: {gate_type} "
+                  f"({reason}) — failing open")
+            state.last_gate_error = f"{gate_type}: {reason}"
+            board.state[task_name] = state
+            save_board(board)
+        _gated_tasks.discard(task_name)
+        return True
+
     # git_commit: skip if HEAD unchanged since last run
     if gate.get("git_commit"):
         if not state.last_gate_commit:
@@ -551,9 +586,8 @@ def _check_gate(board: Board, task_name: str) -> bool:
                 current_head = result.stdout.strip()
                 if current_head == state.last_gate_commit:
                     return _gate_skip("git_commit", "no new commits")
-        except Exception:
-            _gated_tasks.discard(task_name)
-            return True  # Fail open
+        except Exception as exc:
+            return _gate_error("git_commit", exc)
 
     # git_diff: skip if no commits touched matching paths
     git_diff_paths = gate.get("git_diff")
@@ -571,9 +605,8 @@ def _check_gate(board: Board, task_name: str) -> bool:
             if result.returncode == 0 and not result.stdout.strip():
                 return _gate_skip("git_diff", f"no changes in {', '.join(git_diff_paths)}",
                                   paths=git_diff_paths)
-        except Exception:
-            _gated_tasks.discard(task_name)
-            return True  # Fail open
+        except Exception as exc:
+            return _gate_error("git_diff", exc)
 
     # command: skip if command exits non-zero
     gate_cmd = gate.get("command")
@@ -586,13 +619,27 @@ def _check_gate(board: Board, task_name: str) -> bool:
             if result.returncode != 0:
                 return _gate_skip("command", f"exit {result.returncode}",
                                   command=gate_cmd)
-        except Exception:
-            _gated_tasks.discard(task_name)
-            return True  # Fail open
+        except Exception as exc:
+            return _gate_error("command", exc)
 
     # Gate passed — clear from gated set so it can be re-reported if gated again later
     _gated_tasks.discard(task_name)
+    _clear_gate_error(board, task_name)
     return True
+
+
+def _clear_gate_error(board: Board, task_name: str) -> None:
+    """Clear a previously-recorded gate error once the gate evaluates cleanly.
+
+    No-op (and no board write) unless this task actually had an error, so
+    the common clean path stays cheap.
+    """
+    state = board.state.get(task_name)
+    had_tracked = _gate_errored.pop(task_name, None) is not None
+    if had_tracked or (state is not None and state.last_gate_error):
+        if state is not None and state.last_gate_error:
+            state.last_gate_error = ""
+            save_board(board)
 
 
 def pick_next_task(board: Board) -> tuple[str | None, float]:
@@ -1595,6 +1642,8 @@ def get_board_display(board: Board) -> list[dict]:
         }
         if state.last_summary:
             row["last_summary"] = state.last_summary
+        if state.last_gate_error:
+            row["last_gate_error"] = state.last_gate_error
         rows.append(row)
 
     # Sort: enabled first, then by overdue (most overdue first)

--- a/tests/integration/test_scheduler_board.py
+++ b/tests/integration/test_scheduler_board.py
@@ -349,6 +349,20 @@ class TestBoardDisplay:
             assert "schedule_str" in row
             assert "interval_str" not in row
 
+    def test_gate_error_round_trips_and_surfaces(self, board_env):
+        board = load_board()
+        board.state["code-quality"] = TaskState(
+            last_status="complete",
+            last_gate_error="git_commit: TimeoutExpired: timed out after 10s",
+        )
+        save_board(board)
+
+        reloaded = load_board()
+        assert reloaded.state["code-quality"].last_gate_error.startswith("git_commit:")
+
+        row = next(r for r in get_board_display(reloaded) if r["name"] == "code-quality")
+        assert row["last_gate_error"].startswith("git_commit:")
+
 
 class TestSchedulerWorktreeDispatchOptsOutOfPR:
     """The scheduler is the deterministic PR finalizer, so its worktree task

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -9,6 +9,37 @@ import pytest
 import yaml
 
 
+# --- _recent_activity (scheduler status helper) ---
+
+class TestRecentActivity:
+    def test_keeps_outcome_events_newest_first(self):
+        from agentwire.__main__ import _recent_activity
+
+        events = [
+            {"ts": "2026-06-15T10:00:00+00:00", "event": "scheduler_sleeping"},
+            {"ts": "2026-06-15T10:01:00+00:00", "event": "task_completed",
+             "task": "a", "status": "complete", "summary": "ok"},
+            {"ts": "2026-06-15T10:02:00+00:00", "event": "task_started", "task": "b"},
+            {"ts": "2026-06-15T10:03:00+00:00", "event": "gate_error",
+             "task": "b", "gate_type": "git_commit", "reason": "TimeoutExpired"},
+        ]
+        out = _recent_activity(events, limit=5)
+        # Newest first, non-outcome events dropped.
+        assert [i["task"] for i in out] == ["b", "a"]
+        assert out[0]["detail"].startswith("[gate-error] git_commit")
+        assert "complete" in out[1]["detail"]
+
+    def test_respects_limit(self):
+        from agentwire.__main__ import _recent_activity
+
+        events = [
+            {"ts": f"2026-06-15T10:0{i}:00+00:00", "event": "task_completed",
+             "task": f"t{i}", "status": "complete"}
+            for i in range(6)
+        ]
+        assert len(_recent_activity(events, limit=3)) == 3
+
+
 # --- cmd_roles_list ---
 
 class TestCmdRolesList:

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -171,6 +171,78 @@ class TestCheckGate:
         assert _check_gate(board, "t") is False
 
 
+# --- _check_gate: gate-eval errors surface instead of vanishing ---
+
+class TestGateError:
+    """A gate-eval exception (e.g. git timeout) must still fail OPEN, but no
+    longer silently — it's logged to the event stream and recorded on state.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_spam_state(self):
+        import agentwire.scheduler as sched
+        sched._gate_errored.clear()
+        yield
+        sched._gate_errored.clear()
+
+    @pytest.fixture
+    def board(self, tmp_path):
+        from agentwire.scheduler import Board, SchedulerTask, TaskState
+        task = SchedulerTask(name="t", project=str(tmp_path))
+        task.gate = {"git_commit": True}
+        board = Board(tasks={"t": task}, state={"t": TaskState()})
+        board.state["t"].last_gate_commit = "deadbeef"  # force gate to evaluate
+        return board
+
+    def test_timeout_fails_open_and_records(self, board):
+        import subprocess
+        from unittest.mock import patch
+        from agentwire.scheduler import _check_gate
+
+        boom = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        with patch("agentwire.scheduler.subprocess.run", side_effect=boom), \
+             patch("agentwire.scheduler.save_board") as save, \
+             patch("agentwire.scheduler._log_event") as log:
+            assert _check_gate(board, "t") is True  # still fails OPEN
+
+        assert "git_commit" in board.state["t"].last_gate_error
+        assert "TimeoutExpired" in board.state["t"].last_gate_error
+        save.assert_called_once()  # persisted so the board can show it
+        log.assert_called_once()
+        assert log.call_args.args[0] == "gate_error"
+
+    def test_error_logged_once_until_changes(self, board):
+        import subprocess
+        from unittest.mock import patch
+        from agentwire.scheduler import _check_gate
+
+        boom = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        with patch("agentwire.scheduler.subprocess.run", side_effect=boom), \
+             patch("agentwire.scheduler.save_board"), \
+             patch("agentwire.scheduler._log_event") as log:
+            assert _check_gate(board, "t") is True
+            assert _check_gate(board, "t") is True  # same error, no re-log
+        assert log.call_count == 1
+
+    def test_clears_when_gate_recovers(self, board, tmp_path):
+        import subprocess
+        from unittest.mock import patch
+        from agentwire.scheduler import _check_gate
+
+        boom = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        with patch("agentwire.scheduler.subprocess.run", side_effect=boom), \
+             patch("agentwire.scheduler.save_board"), \
+             patch("agentwire.scheduler._log_event"):
+            _check_gate(board, "t")
+        assert board.state["t"].last_gate_error
+
+        # Gate now has no preconditions → clean pass clears the recorded error.
+        board.tasks["t"].gate = {}
+        with patch("agentwire.scheduler.save_board"):
+            assert _check_gate(board, "t") is True
+        assert board.state["t"].last_gate_error == ""
+
+
 # --- _EXIT_TO_STATUS mapping ---
 
 class TestExitCodeMapping:


### PR DESCRIPTION
## What

Three visibility fixes for the scheduler, addressing the real correctness bug in #332: gate-evaluation exceptions **failed open silently** (a git timeout made the gate `return True` and the task ran UNLOGGED), and the board showed `failed` with no reason.

### 1. "Why" line on the board (`__main__.py`)
Each board row can now print an indented `↳` reason line:
- `[gate-error] <reason>` takes precedence (the fail-open case that was invisible), else
- `last_summary` when the status is a bad one (`failed`/`incomplete`/`timeout`/`lock_conflict`/`usage_limit`).

```
  flaky          regular   every 1h   never   failed   +…
                 ↳ [gate-error] git_commit: TimeoutExpired: git timed out after 10s
```

### 2. Gate-eval errors surface instead of vanishing (`scheduler.py`)
The three `except Exception: return True  # Fail open` blocks in `_check_gate` now route through `_gate_error()`, which:
- **keeps failing OPEN** — per the council guardrail, a closed gate that errored would block *every* task,
- logs a `gate_error` event into the existing event stream (the "journal"), and
- records `TaskState.last_gate_error` so the board/status can show it.

Spam-controlled (logged once until the gate next evaluates cleanly, then auto-cleared via `_clear_gate_error`). `gate_error` is also rendered by `scheduler events`.

### 3. "Recent activity" on `scheduler status`
The removed `overnight status` activity line moves here — last 5 outcome-bearing events (completed / failed / gate-error), newest first, in both text and `--json`.

## Tests
`uv run pytest -q -k scheduler` → green. Added coverage for gate-error capture (fail-open + log-once + recover-clears), board round-trip/surfacing of `last_gate_error`, and `_recent_activity`.

Closes #332

Built by [dotdev.dev](https://dotdev.dev)