### PR TITLE
feat(council): de-singleton — namespaced concurrent sittings (#357)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Interactive prompts (permission, plan-approval, AskUserQuestion) hitting a child
 
 ## Council
 
-Multi-soul orchestrator sitting: `agentwire-council` fans prompts out to lens sessions (`council-brain`, `council-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/prompts/`; the orchestrator collects and synthesizes with attribution. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...`, 5 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).
+Multi-soul orchestrator sitting, **namespaced by `<name>`** so independent councils run concurrently: `agentwire-council-<name>` fans prompts out to lens sessions (`council-<name>-brain`, `council-<name>-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/<name>/prompts/`; the orchestrator collects and synthesizes with attribution. Targeting: `--name` → cwd-repo-slug if it matches a live sitting → sole live sitting → else error+list; every command echoes which sitting it hit. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...` (incl. `council list`), 6 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).
 
 ## Reference Skills
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11727,9 +11727,16 @@ def main() -> int:
     )
     council_subparsers = council_parser.add_subparsers(dest="council_command")
 
+    # Targeting is shared: --name picks the sitting; absent, the cwd-repo-slug
+    # if it matches a live sitting, else the sole live sitting, else error.
+    _name_help = "Sitting name (default: cwd-repo-slug / sole live sitting)"
+
     # council start
     c_start = council_subparsers.add_parser(
         "start", help="Start a sitting: orchestrator + all soul sessions"
+    )
+    c_start.add_argument(
+        "--name", help="Sitting name (default: cwd-repo-slug)"
     )
     c_start.add_argument(
         "--roster", help="Comma-separated lens names (default: full bundled roster)"
@@ -11746,6 +11753,7 @@ def main() -> int:
     c_stop = council_subparsers.add_parser(
         "stop", help="Kill the sitting's sessions (prompt history kept)"
     )
+    c_stop.add_argument("--name", help=_name_help)
     c_stop.add_argument("--json", action="store_true", help="Output JSON")
     c_stop.set_defaults(func=council_cli.cmd_council_stop)
 
@@ -11753,14 +11761,23 @@ def main() -> int:
     c_status = council_subparsers.add_parser(
         "status", help="Sitting state, session liveness, open prompts"
     )
+    c_status.add_argument("--name", help=_name_help)
     c_status.add_argument("--json", action="store_true", help="Output JSON")
     c_status.set_defaults(func=council_cli.cmd_council_status)
+
+    # council list
+    c_list = council_subparsers.add_parser(
+        "list", help="Every known sitting: name, cwd, age, live sessions, prompts"
+    )
+    c_list.add_argument("--json", action="store_true", help="Output JSON")
+    c_list.set_defaults(func=council_cli.cmd_council_list)
 
     # council ask
     c_ask = council_subparsers.add_parser(
         "ask", help="Fan a prompt out to every soul in the sitting"
     )
     c_ask.add_argument("prompt", nargs="?", help="Prompt text (or --file / stdin)")
+    c_ask.add_argument("--name", help=_name_help)
     c_ask.add_argument("--file", help="Read prompt text from a file")
     c_ask.add_argument("--json", action="store_true", help="Output JSON")
     c_ask.set_defaults(func=council_cli.cmd_council_ask)
@@ -11769,6 +11786,7 @@ def main() -> int:
     c_collect = council_subparsers.add_parser(
         "collect", help="Wait for every soul's take/ack/pass (or timeout)"
     )
+    c_collect.add_argument("--name", help=_name_help)
     c_collect.add_argument("--prompt", type=int, help="Prompt id (default: latest)")
     c_collect.add_argument(
         "--timeout", type=float, default=120, help="Soft timeout in seconds (default: 120)"
@@ -11783,6 +11801,7 @@ def main() -> int:
     c_reply = council_subparsers.add_parser(
         "reply", help="File a soul's reply: --take / --ack / --pass"
     )
+    c_reply.add_argument("--name", help=_name_help)
     c_reply.add_argument("--prompt", type=int, help="Prompt id (default: latest)")
     c_reply.add_argument(
         "--take", action="store_true", help="Substantive take (text required)"

--- a/agentwire/council/__init__.py
+++ b/agentwire/council/__init__.py
@@ -1,13 +1,19 @@
 """The agentwire council — a multi-soul orchestrator session group (#213).
 
-An ``agentwire-council`` orchestrator session fans user prompts out to a
-roster of lens sessions (``council-brain``, ``council-conscience``, …), each
-carrying the shared ``council-member`` protocol role plus its own
-``council-<lens>`` role. Souls reply through a file-based inbox
-(``~/.agentwire/council/prompts/NNNN/replies/``) with exactly one of: a
-substantive **take**, an **ack** (researching, follow-up coming), or a
-**pass** (nothing to add). The orchestrator collects and synthesizes,
-attributed by lens.
+Sittings are **namespaced by ``<name>``** so independent councils run
+concurrently. An ``agentwire-council-<name>`` orchestrator session fans user
+prompts out to a roster of lens sessions (``council-<name>-brain``,
+``council-<name>-conscience``, …), each carrying the shared ``council-member``
+protocol role plus its own ``council-<lens>`` role. Souls reply through a
+file-based inbox (``~/.agentwire/council/<name>/prompts/NNNN/replies/``) with
+exactly one of: a substantive **take**, an **ack** (researching, follow-up
+coming), or a **pass** (nothing to add). The orchestrator collects and
+synthesizes, attributed by lens.
+
+All state for a sitting lives under ``~/.agentwire/council/<name>/``
+(``sitting.json`` + ``workspace/`` + ``prompts/``). The ``<name>`` is the
+source of truth — never recover a name/lens by splitting a session string;
+``sitting.json`` is the SSOT lens→session map.
 
 Modules:
 

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -4,6 +4,15 @@ Argparse wiring lives in ``agentwire/__main__.py``; handlers receive an
 ``argparse.Namespace`` and return an exit code. Every handler supports
 ``--json`` so the MCP layer can shell out and parse structured output.
 
+Sittings are **namespaced by ``<name>``** (``agentwire/council/state.py``), so
+independent councils run concurrently. Targeting, every command:
+
+    explicit ``--name`` → else cwd-repo-slug *if it matches a live sitting*
+    → else the sole live sitting → else error + list candidates.
+
+The system auto-picks only when unambiguous; it refuses (never guesses by
+recency) otherwise, and **every command echoes which sitting it acted on**.
+
 Subcommands:
 
 - ``start``   — spin up the orchestrator + lens soul sessions (a *sitting*)
@@ -12,6 +21,7 @@ Subcommands:
 - ``ask``     — fan a prompt out to every soul (creates the inbox first)
 - ``collect`` — block until every soul has filed take/ack/pass, or timeout
 - ``reply``   — file a soul's reply (souls run this via Bash)
+- ``list``    — every live/known sitting, oldest-first
 """
 
 from __future__ import annotations
@@ -19,7 +29,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-import time
+from datetime import datetime, timezone
 from typing import Any
 
 from agentwire.council import inbox, state
@@ -27,10 +37,27 @@ from agentwire.council import inbox, state
 # --- output helpers -----------------------------------------------------------
 
 
-def _emit(args, payload: dict[str, Any], human: str = "", exit_code: int = 0) -> int:
+def _emit(
+    args,
+    payload: dict[str, Any],
+    human: str = "",
+    exit_code: int = 0,
+    council: str | None = None,
+    echo_suffix: str = "",
+) -> int:
+    """Emit JSON or human output, echoing which sitting was acted on.
+
+    ``council`` is the resolved sitting name — non-negotiable to surface:
+    targeting you can't see is targeting you can't trust.
+    """
+    if council is not None:
+        payload = {"council": council, **payload}
     if getattr(args, "json", False):
         print(json.dumps(payload, indent=2, default=str))
     elif human:
+        if council is not None:
+            suffix = f" {echo_suffix}" if echo_suffix else ""
+            print(f"→ council '{council}'{suffix}")
         print(human)
     return exit_code
 
@@ -64,15 +91,16 @@ def list_live_sessions() -> set[str]:
     return {s.get("name", "") for s in sessions if isinstance(s, dict)} - {""}
 
 
-def create_session(name: str, roles: list[str], session_type: str, model: str | None) -> None:
-    """Create one council session via ``agentwire new`` in the shared workspace.
-
-    Raises ``RuntimeError`` on failure.
+def create_session(
+    name: str, roles: list[str], session_type: str, model: str | None, cwd: str
+) -> None:
+    """Create one council session via ``agentwire new`` in the sitting's
+    workspace. Raises ``RuntimeError`` on failure.
     """
     cmd = [
         "agentwire", "new",
         "-s", name,
-        "-p", str(state.WORKSPACE_DIR),
+        "-p", cwd,
         "--roles", ",".join(roles),
         "--type", session_type,
         "--allow-shared-dir",
@@ -132,18 +160,106 @@ def current_session() -> str | None:
     return pane_manager.get_current_session()
 
 
+# --- targeting / resolution -----------------------------------------------------
+
+
+def live_sitting_names(live: set[str]) -> list[str]:
+    """Names whose orchestrator session is alive in ``live``."""
+    out = []
+    for name in state.list_sittings():
+        sitting = state.read_sitting(name)
+        if sitting is not None and sitting.orchestrator in live:
+            out.append(name)
+    return out
+
+
+def resolve_name(args) -> tuple[str | None, str | None]:
+    """Resolve which sitting an operate-on command targets.
+
+    Returns ``(name, error)``; exactly one is non-None. Order: explicit
+    ``--name`` → cwd-slug if it matches a live sitting → the sole live sitting
+    → else error (0 = none here; N = ambiguous, list the names). Never guesses
+    by recency. Liveness of an explicit ``--name`` is the caller's check.
+    """
+    explicit = getattr(args, "name", None)
+    if explicit:
+        if not state.valid_name(explicit):
+            return None, f"invalid council name: {explicit!r}"
+        return explicit, None
+
+    live_names = live_sitting_names(list_live_sessions())
+    cwd_slug = state.default_name()
+    if cwd_slug in live_names:
+        return cwd_slug, None
+    if len(live_names) == 1:
+        return live_names[0], None
+    if not live_names:
+        return None, "no council for this repo — run 'agentwire council start'"
+    return None, (
+        "multiple councils live — disambiguate with --name: "
+        + ", ".join(sorted(live_names))
+    )
+
+
+# --- first-run legacy zombie sweep ----------------------------------------------
+
+
+def _sweep_legacy_once() -> list[str]:
+    """Tear down the pre-namespace global layout, exactly once.
+
+    Pre-namespace, the council was a singleton: orchestrator ``agentwire-council``,
+    lens sessions ``council-<lens>``, a global ``~/.agentwire/council/sitting.json``
+    + ``workspace/``. After upgrade those panes keep burning tokens invisibly —
+    this exact zombie state has been hit live. Kill them and remove the orphaned
+    global state; ``prompts/`` history is kept. Marker-guarded so it runs once.
+    """
+    marker = state.COUNCIL_ROOT / ".namespaced"
+    if marker.exists():
+        return []
+
+    legacy_sitting = state.COUNCIL_ROOT / "sitting.json"
+    targets: set[str] = {"agentwire-council"}
+    targets.update(f"council-{lens}" for lens in state.DEFAULT_ROSTER)
+    if legacy_sitting.exists():
+        try:
+            data = json.loads(legacy_sitting.read_text())
+            if isinstance(data, dict):
+                targets.update(
+                    v for v in data.get("sessions", {}).values() if isinstance(v, str)
+                )
+                orch = data.get("orchestrator")
+                if isinstance(orch, str):
+                    targets.add(orch)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    live = list_live_sessions()
+    killed = [t for t in sorted(targets) if t and t in live and kill_session(t)]
+
+    for orphan in (legacy_sitting, state.COUNCIL_ROOT / "workspace" / ".agentwire.yml"):
+        try:
+            orphan.unlink()
+        except (FileNotFoundError, OSError):
+            pass
+
+    state.COUNCIL_ROOT.mkdir(parents=True, exist_ok=True)
+    marker.write_text(state.now_iso())
+    return killed
+
+
 # --- workspace ------------------------------------------------------------------
 
 
-def _write_workspace(session_type: str) -> None:
-    """Workspace dir all council sessions run in.
+def _write_workspace(name: str, session_type: str) -> None:
+    """Workspace dir the sitting's sessions run in.
 
-    ``parent: agentwire-council`` routes any ``agentwire notify`` from a soul
-    to the orchestrator for free.
+    ``parent: agentwire-council-<name>`` routes any ``agentwire notify`` from a
+    soul to the sitting's own orchestrator for free.
     """
-    state.WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
-    (state.WORKSPACE_DIR / ".agentwire.yml").write_text(
-        f"type: {session_type}\nparent: {state.ORCHESTRATOR_SESSION}\n"
+    ws = state.workspace_dir(name)
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / ".agentwire.yml").write_text(
+        f"type: {session_type}\nparent: {state.orchestrator_for(name)}\n"
     )
 
 
@@ -151,6 +267,13 @@ def _write_workspace(session_type: str) -> None:
 
 
 def cmd_council_start(args) -> int:
+    _sweep_legacy_once()
+
+    explicit = getattr(args, "name", None)
+    name = explicit or state.default_name()
+    if not state.valid_name(name):
+        return _emit_error(args, f"invalid council name: {name!r}")
+
     roster_arg = getattr(args, "roster", None)
     roster = (
         [r.strip() for r in roster_arg.split(",") if r.strip()]
@@ -161,119 +284,141 @@ def cmd_council_start(args) -> int:
         if not state.valid_lens(lens):
             return _emit_error(args, f"invalid lens name: {lens!r}")
 
-    sitting = state.read_sitting()
-    if sitting is not None:
+    orchestrator = state.orchestrator_for(name)
+
+    existing = state.read_sitting(name)
+    if existing is not None:
         live = list_live_sessions()
-        still_up = [s for s in (*sitting.sessions.values(), sitting.orchestrator) if s in live]
+        still_up = [
+            s for s in (*existing.sessions.values(), existing.orchestrator) if s in live
+        ]
         if still_up and not getattr(args, "force", False):
             return _emit_error(
                 args,
-                f"a council sitting is already active ({', '.join(still_up)}) — "
+                f"council '{name}' is already live ({', '.join(still_up)}) — "
                 "use 'agentwire council stop' or --force",
             )
         # Stale or --force: tear down what's left before restarting.
         for s in still_up:
             kill_session(s)
-        state.clear_sitting()
+        state.clear_sitting(name)
 
     session_type = getattr(args, "type", None) or "claude-bypass"
     model = getattr(args, "model", None)
-    _write_workspace(session_type)
+    _write_workspace(name, session_type)
+    workspace = str(state.workspace_dir(name))
+
+    # Advisory: name the live sittings when seating beyond the first.
+    other_live = live_sitting_names(list_live_sessions())
+    advisory = ""
+    if other_live:
+        all_live = sorted({*other_live, name})
+        advisory = f"{len(all_live)} councils live: {', '.join(all_live)}"
 
     sessions: dict[str, str] = {}
     failed: list[dict] = []
 
     try:
-        create_session(
-            state.ORCHESTRATOR_SESSION, ["council-orchestrator"], session_type, model
-        )
+        create_session(orchestrator, ["council-orchestrator"], session_type, model, workspace)
     except RuntimeError as e:
         return _emit_error(args, f"failed to start orchestrator: {e}")
 
     for lens in roster:
-        name = state.session_for(lens)
+        session = state.session_for(name, lens)
         try:
-            create_session(name, ["council-member", f"council-{lens}"], session_type, model)
-            sessions[lens] = name
+            create_session(
+                session, ["council-member", f"council-{lens}"], session_type, model, workspace
+            )
+            sessions[lens] = session
         except RuntimeError as e:
             failed.append({"soul": lens, "error": str(e)})
 
     # Sessions boot concurrently; wait for each to be input-ready so an
     # immediate `council ask` doesn't paste into a half-booted pane.
-    not_ready = [
-        s
-        for s in (state.ORCHESTRATOR_SESSION, *sessions.values())
-        if not wait_ready(s)
-    ]
+    not_ready = [s for s in (orchestrator, *sessions.values()) if not wait_ready(s)]
 
     state.write_sitting(
+        name,
         state.Sitting(
-            orchestrator=state.ORCHESTRATOR_SESSION,
+            orchestrator=orchestrator,
             roster=[lens for lens in roster if lens in sessions],
             sessions=sessions,
             started_at=state.now_iso(),
+            cwd=workspace,
             session_type=session_type,
-        )
+        ),
     )
 
     payload = {
         "success": not failed and not not_ready,
-        "orchestrator": state.ORCHESTRATOR_SESSION,
+        "orchestrator": orchestrator,
         "sessions": sessions,
         "failed": failed,
         "not_ready": not_ready,
+        "advisory": advisory,
     }
     human = (
-        f"Council sitting started: {state.ORCHESTRATOR_SESSION} + "
+        f"Council sitting started: {orchestrator} + "
         f"{len(sessions)} souls ({', '.join(sessions)})"
     )
+    if advisory:
+        human += f"\n{advisory}"
     if failed:
         human += f"\nfailed: {', '.join(f['soul'] for f in failed)}"
     if not_ready:
         human += f"\nnot ready after wait: {', '.join(not_ready)}"
-    return _emit(args, payload, human, exit_code=0 if payload["success"] else 1)
+    return _emit(args, payload, human, exit_code=0 if payload["success"] else 1, council=name)
 
 
 def cmd_council_stop(args) -> int:
-    sitting = state.read_sitting()
+    _sweep_legacy_once()
+    name, err = resolve_name(args)
+    if err:
+        return _emit_error(args, err)
+    sitting = state.read_sitting(name)
     if sitting is None:
-        return _emit_error(args, "no active council sitting")
+        return _emit_error(args, f"no council sitting '{name}'")
 
     live = list_live_sessions()
     killed: list[str] = []
     not_running: list[str] = []
-    for name in (*sitting.sessions.values(), sitting.orchestrator):
-        if name in live and kill_session(name):
-            killed.append(name)
+    for session in (*sitting.sessions.values(), sitting.orchestrator):
+        if session in live and kill_session(session):
+            killed.append(session)
         else:
-            not_running.append(name)
-    state.clear_sitting()
+            not_running.append(session)
+    state.clear_sitting(name)
 
     payload = {"success": True, "killed": killed, "not_running": not_running}
     return _emit(
         args,
         payload,
-        f"Council sitting stopped ({len(killed)} sessions killed). Prompt history kept.",
+        f"Council '{name}' stopped ({len(killed)} sessions killed). Prompt history kept.",
+        council=name,
     )
 
 
 def cmd_council_status(args) -> int:
-    sitting = state.read_sitting()
+    _sweep_legacy_once()
+    name, err = resolve_name(args)
+    if err:
+        return _emit(args, {"success": True, "running": False, "error": err}, err)
+    sitting = state.read_sitting(name)
     if sitting is None:
         return _emit(
             args,
             {"success": True, "running": False},
-            "No active council sitting.",
+            f"No council sitting '{name}'.",
         )
 
     live = list_live_sessions()
     souls = [
-        {"soul": lens, "session": name, "alive": name in live}
-        for lens, name in sitting.sessions.items()
+        {"soul": lens, "session": session, "alive": session in live}
+        for lens, session in sitting.sessions.items()
     ]
     prompts = []
     for pid in range(1, sitting.next_prompt_id):
-        pending = inbox.pending_souls(pid, sitting.roster)
+        pending = inbox.pending_souls(name, pid, sitting.roster)
         prompts.append(
             {
                 "id": pid,
@@ -293,7 +438,7 @@ def cmd_council_status(args) -> int:
         "prompts": prompts,
     }
     lines = [
-        f"Council sitting (started {sitting.started_at})",
+        f"Council '{name}' (started {sitting.started_at})",
         f"  orchestrator: {sitting.orchestrator} "
         f"[{'alive' if payload['orchestrator_alive'] else 'DOWN'}]",
     ]
@@ -302,7 +447,7 @@ def cmd_council_status(args) -> int:
     for p in prompts:
         status = "complete" if p["complete"] else f"pending: {', '.join(p['pending'])}"
         lines.append(f"  prompt #{p['id']}: {status}")
-    return _emit(args, payload, "\n".join(lines))
+    return _emit(args, payload, "\n".join(lines), council=name)
 
 
 def _prompt_text_from(args) -> str | None:
@@ -322,25 +467,31 @@ def _prompt_text_from(args) -> str | None:
 
 
 def cmd_council_ask(args) -> int:
-    sitting = state.read_sitting()
+    _sweep_legacy_once()
+    name, err = resolve_name(args)
+    if err:
+        return _emit_error(args, err)
+    sitting = state.read_sitting(name)
     if sitting is None:
-        return _emit_error(args, "no active council sitting — run 'agentwire council start'")
+        return _emit_error(args, f"no council sitting '{name}'")
 
     prompt_text = getattr(args, "prompt", None) or _prompt_text_from(args)
     if not prompt_text or not prompt_text.strip():
         return _emit_error(args, "no prompt text (positional, --file, or stdin)")
     prompt_text = prompt_text.strip()
 
-    prompt_id = state.allocate_prompt_id()
-    inbox.create_prompt(prompt_id, prompt_text, sitting.roster)  # inbox before any send
+    prompt_id = state.allocate_prompt_id(name)
+    inbox.create_prompt(name, prompt_id, prompt_text, sitting.roster)  # inbox before any send
 
+    prompt_path = inbox.prompt_dir(name, prompt_id) / "prompt.md"
     message = (
         f"[COUNCIL PROMPT #{prompt_id}]\n"
         f"{prompt_text}\n\n"
         f"Reply through your lens with exactly one of:\n"
-        f'  agentwire council reply --prompt {prompt_id} --take --text "<your take>"\n'
-        f"  agentwire council reply --prompt {prompt_id} --ack\n"
-        f"  agentwire council reply --prompt {prompt_id} --pass"
+        f'  agentwire council reply --name {name} --prompt {prompt_id} --take --text "<your take>"\n'
+        f"  agentwire council reply --name {name} --prompt {prompt_id} --ack\n"
+        f"  agentwire council reply --name {name} --prompt {prompt_id} --pass\n"
+        f"Full prompt on disk: {prompt_path}"
     )
 
     marker = f"[COUNCIL PROMPT #{prompt_id}]"
@@ -368,19 +519,31 @@ def cmd_council_ask(args) -> int:
     human = f"Prompt #{prompt_id} fanned out to {len(sent_to)} souls."
     if failed:
         human += f" Failed: {', '.join(f['soul'] for f in failed)}"
-    return _emit(args, payload, human, exit_code=0 if sent_to else 1)
+    return _emit(
+        args,
+        payload,
+        human,
+        exit_code=0 if sent_to else 1,
+        council=name,
+        echo_suffix=f"(prompt #{prompt_id})",
+    )
 
 
 def cmd_council_collect(args) -> int:
-    sitting = state.read_sitting()
+    _sweep_legacy_once()
+    name, err = resolve_name(args)
+    if err:
+        return _emit_error(args, err)
+    sitting = state.read_sitting(name)
     if sitting is None:
-        return _emit_error(args, "no active council sitting")
+        return _emit_error(args, f"no council sitting '{name}'")
 
-    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id()
+    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id(name)
     if not prompt_id:
         return _emit_error(args, "no prompts asked yet")
 
     result = inbox.collect(
+        name,
         prompt_id,
         sitting.roster,
         timeout=float(getattr(args, "timeout", 120)),
@@ -394,28 +557,44 @@ def cmd_council_collect(args) -> int:
     lines = [f"Prompt #{prompt_id}: {status}"]
     for r in result["replies"]:
         lines.append(f"\n--- {r['soul']} ({r['kind']}) ---\n{r['text']}")
-    return _emit(args, result, "\n".join(lines))
+    return _emit(
+        args, result, "\n".join(lines), council=name, echo_suffix=f"(prompt #{prompt_id})"
+    )
+
+
+def _infer_soul(sitting: state.Sitting, session: str | None) -> str | None:
+    """Recover the lens for a session via the sitting's SSOT map.
+
+    Never ``.split('-')`` a session string — ``sitting.sessions`` is the only
+    authority for the lens→session mapping.
+    """
+    if not session:
+        return None
+    for lens, sess in sitting.sessions.items():
+        if sess == session:
+            return lens
+    return None
 
 
 def cmd_council_reply(args) -> int:
+    _sweep_legacy_once()
     kinds = [k for k in inbox.KINDS if getattr(args, k.replace("-", "_"), False)]
     if len(kinds) != 1:
         return _emit_error(args, "specify exactly one of --take / --ack / --pass")
     kind = kinds[0]
 
-    sitting = state.read_sitting()
+    name, err = resolve_name(args)
+    if err:
+        return _emit_error(args, err)
+    sitting = state.read_sitting(name)
     if sitting is None:
-        return _emit_error(args, "no active council sitting")
+        return _emit_error(args, f"no council sitting '{name}'")
 
-    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id()
+    prompt_id = getattr(args, "prompt", None) or state.latest_prompt_id(name)
     if not prompt_id:
         return _emit_error(args, "no prompts asked yet")
 
-    soul = getattr(args, "soul", None)
-    if not soul:
-        session = current_session()
-        if session and session.startswith("council-"):
-            soul = session[len("council-") :]
+    soul = getattr(args, "soul", None) or _infer_soul(sitting, current_session())
     if not soul:
         return _emit_error(args, "could not infer soul — pass --soul <lens>")
 
@@ -427,7 +606,7 @@ def cmd_council_reply(args) -> int:
         return _emit_error(args, "--take requires text (--text, --file, or stdin)")
 
     try:
-        path, is_followup = inbox.write_reply(prompt_id, soul, kind, text)
+        path, is_followup = inbox.write_reply(name, prompt_id, soul, kind, text)
     except (ValueError, FileNotFoundError) as e:
         return _emit_error(args, str(e))
 
@@ -459,4 +638,56 @@ def cmd_council_reply(args) -> int:
         args,
         payload,
         f"Filed {'follow-up ' if is_followup else ''}{kind} from {soul} on prompt #{prompt_id}.",
+        council=name,
     )
+
+
+def _age(iso: str) -> str:
+    """Compact humanized age (``5m`` / ``2h`` / ``3d``) for the list table."""
+    try:
+        started = datetime.fromisoformat(iso)
+    except (ValueError, TypeError):
+        return "?"
+    secs = int((datetime.now(timezone.utc) - started).total_seconds())
+    if secs < 60:
+        return f"{max(secs, 0)}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h"
+    return f"{secs // 86400}d"
+
+
+def cmd_council_list(args) -> int:
+    _sweep_legacy_once()
+    live = list_live_sessions()
+    rows = []
+    for name in state.list_sittings():
+        sitting = state.read_sitting(name)
+        if sitting is None:
+            continue
+        all_sessions = [*sitting.sessions.values(), sitting.orchestrator]
+        rows.append(
+            {
+                "name": name,
+                "cwd": sitting.cwd,
+                "started_at": sitting.started_at,
+                "live_sessions": sum(1 for s in all_sessions if s in live),
+                "total_sessions": len(all_sessions),
+                "prompts": max(sitting.next_prompt_id - 1, 0),
+            }
+        )
+    rows.sort(key=lambda r: r["started_at"])  # oldest-first
+
+    payload = {"success": True, "councils": rows}
+    if not rows:
+        return _emit(args, payload, "No council sittings.")
+    header = f"{'NAME':<24} {'AGE':>5} {'LIVE':>7} {'PROMPTS':>8}  CWD"
+    lines = [header]
+    for r in rows:
+        live_col = f"{r['live_sessions']}/{r['total_sessions']}"
+        lines.append(
+            f"{r['name']:<24} {_age(r['started_at']):>5} {live_col:>7} "
+            f"{r['prompts']:>8}  {r['cwd']}"
+        )
+    return _emit(args, payload, "\n".join(lines))

--- a/agentwire/council/inbox.py
+++ b/agentwire/council/inbox.py
@@ -1,6 +1,9 @@
 """Per-prompt reply inbox — the council's fan-out/collect protocol.
 
-Layout under ``~/.agentwire/council/prompts/``::
+Every function is scoped to a sitting ``name``; paths resolve through
+``state.prompts_dir(name)`` so concurrent sittings never share an inbox.
+
+Layout under ``~/.agentwire/council/<name>/prompts/``::
 
     0003/
       prompt.md                 # fanned-out prompt text
@@ -48,22 +51,22 @@ class Reply:
         }
 
 
-def prompt_dir(prompt_id: int) -> Path:
-    return state.PROMPTS_DIR / f"{prompt_id:04d}"
+def prompt_dir(name: str, prompt_id: int) -> Path:
+    return state.prompts_dir(name) / f"{prompt_id:04d}"
 
 
-def replies_dir(prompt_id: int) -> Path:
-    return prompt_dir(prompt_id) / "replies"
+def replies_dir(name: str, prompt_id: int) -> Path:
+    return prompt_dir(name, prompt_id) / "replies"
 
 
-def create_prompt(prompt_id: int, text: str, roster: list[str]) -> Path:
+def create_prompt(name: str, prompt_id: int, text: str, roster: list[str]) -> Path:
     """Create the prompt dir + inbox. Must exist before any fan-out send.
 
     Prompt ids restart at 1 each sitting while ``prompts/`` history is kept,
     so a reused id may collide with a previous sitting's dir — stale reply
     files would corrupt the new round's completion check. Clear them.
     """
-    pdir = prompt_dir(prompt_id)
+    pdir = prompt_dir(name, prompt_id)
     replies = pdir / "replies"
     replies.mkdir(parents=True, exist_ok=True)
     for stale in replies.glob("*.md"):
@@ -78,8 +81,8 @@ def create_prompt(prompt_id: int, text: str, roster: list[str]) -> Path:
     return pdir
 
 
-def read_meta(prompt_id: int) -> dict:
-    meta_path = prompt_dir(prompt_id) / "meta.json"
+def read_meta(name: str, prompt_id: int) -> dict:
+    meta_path = prompt_dir(name, prompt_id) / "meta.json"
     try:
         data = json.loads(meta_path.read_text())
     except (FileNotFoundError, json.JSONDecodeError, OSError):
@@ -87,16 +90,18 @@ def read_meta(prompt_id: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def _initial_reply(prompt_id: int, soul: str) -> Path | None:
+def _initial_reply(name: str, prompt_id: int, soul: str) -> Path | None:
     """The soul's initial take/ack/pass file, or None if not yet filed."""
     for kind in KINDS:
-        path = replies_dir(prompt_id) / f"{soul}.{kind}.md"
+        path = replies_dir(name, prompt_id) / f"{soul}.{kind}.md"
         if path.exists():
             return path
     return None
 
 
-def write_reply(prompt_id: int, soul: str, kind: str, text: str) -> tuple[Path, bool]:
+def write_reply(
+    name: str, prompt_id: int, soul: str, kind: str, text: str
+) -> tuple[Path, bool]:
     """File a reply. Returns ``(path, is_followup)``.
 
     First reply from a soul lands as ``<soul>.<kind>.md``. Once an initial
@@ -105,11 +110,11 @@ def write_reply(prompt_id: int, soul: str, kind: str, text: str) -> tuple[Path, 
     """
     if kind not in KINDS:
         raise ValueError(f"invalid reply kind: {kind!r} (expected one of {KINDS})")
-    rdir = replies_dir(prompt_id)
+    rdir = replies_dir(name, prompt_id)
     if not rdir.is_dir():
         raise FileNotFoundError(f"no inbox for council prompt #{prompt_id}")
 
-    if _initial_reply(prompt_id, soul) is None:
+    if _initial_reply(name, prompt_id, soul) is None:
         path = rdir / f"{soul}.{kind}.md"
         path.write_text(text)
         return path, False
@@ -127,9 +132,9 @@ def write_reply(prompt_id: int, soul: str, kind: str, text: str) -> tuple[Path, 
     return path, True
 
 
-def list_replies(prompt_id: int) -> list[Reply]:
+def list_replies(name: str, prompt_id: int) -> list[Reply]:
     """All filed replies for a prompt, initial rounds first, then follow-ups."""
-    rdir = replies_dir(prompt_id)
+    rdir = replies_dir(name, prompt_id)
     if not rdir.is_dir():
         return []
     out: list[Reply] = []
@@ -151,16 +156,17 @@ def list_replies(prompt_id: int) -> list[Reply]:
     return out
 
 
-def pending_souls(prompt_id: int, roster: list[str]) -> list[str]:
+def pending_souls(name: str, prompt_id: int, roster: list[str]) -> list[str]:
     """Roster souls that haven't filed their initial take/ack/pass yet."""
-    return [s for s in roster if _initial_reply(prompt_id, s) is None]
+    return [s for s in roster if _initial_reply(name, prompt_id, s) is None]
 
 
-def initial_round_complete(prompt_id: int, roster: list[str]) -> bool:
-    return not pending_souls(prompt_id, roster)
+def initial_round_complete(name: str, prompt_id: int, roster: list[str]) -> bool:
+    return not pending_souls(name, prompt_id, roster)
 
 
 def collect(
+    name: str,
     prompt_id: int,
     roster: list[str],
     timeout: float = 120.0,
@@ -176,7 +182,7 @@ def collect(
     deadline = time.monotonic() + timeout
     timed_out = False
     while True:
-        pending = pending_souls(prompt_id, roster)
+        pending = pending_souls(name, prompt_id, roster)
         if not pending or not wait:
             break
         if time.monotonic() >= deadline:
@@ -187,6 +193,6 @@ def collect(
         "prompt_id": prompt_id,
         "complete": not pending,
         "timed_out": timed_out,
-        "replies": [r.to_dict() for r in list_replies(prompt_id)],
+        "replies": [r.to_dict() for r in list_replies(name, prompt_id)],
         "pending": pending,
     }

--- a/agentwire/council/state.py
+++ b/agentwire/council/state.py
@@ -1,27 +1,36 @@
-"""Sitting state for the council subsystem.
+"""Sitting state for the council subsystem — namespaced by ``<name>``.
 
 A *sitting* is one ``council start`` → ``council stop`` span: the orchestrator
-session, the roster of lens souls, and a monotonic prompt counter. State is
-small JSON at ``~/.agentwire/council/sitting.json``, written atomically
-(tempfile + ``os.replace``).
+session, the roster of lens souls, and a monotonic prompt counter. Independent
+sittings run concurrently, each isolated under its own name::
+
+    ~/.agentwire/council/<name>/
+      sitting.json        # roster, lens→session map, prompt counter
+      workspace/          # shared cwd all the sitting's sessions run in
+      prompts/NNNN/       # per-prompt inbox (see inbox.py)
+
+The ``<name>`` is identity. Sessions are ``council-<name>-<lens>``; the
+orchestrator is ``agentwire-council-<name>``. **Never** ``.split('-')`` a
+session string to recover name/lens — ``sitting.json`` is the SSOT for the
+lens→session map.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-COUNCIL_DIR = Path.home() / ".agentwire" / "council"
-SITTING_PATH = COUNCIL_DIR / "sitting.json"
-WORKSPACE_DIR = COUNCIL_DIR / "workspace"
-PROMPTS_DIR = COUNCIL_DIR / "prompts"
+# Root holding every namespaced sitting (``<name>/`` subdirs). The only
+# filesystem constant — everything else is derived per name so two sittings
+# never share state.
+COUNCIL_ROOT = Path.home() / ".agentwire" / "council"
 
-ORCHESTRATOR_SESSION = "agentwire-council"
 DEFAULT_ROSTER = [
     "brain",
     "conscience",
@@ -31,8 +40,13 @@ DEFAULT_ROSTER = [
     "devils-advocate",
 ]
 
-# Lens names become session names, role names, and reply filenames.
+# Lens *and* council names become session names, role names, and filenames.
+# Same grammar for both: ``[a-z0-9][a-z0-9-]*`` (tmux-safe — no ``.``/``:``).
 _LENS_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# cwd-derived default names are slugified + capped so ``council-<name>-<lens>``
+# stays a sane tmux session length.
+_NAME_MAX = 24
 
 
 def valid_lens(name: str) -> bool:
@@ -40,9 +54,71 @@ def valid_lens(name: str) -> bool:
     return bool(_LENS_RE.match(name))
 
 
-def session_for(lens: str) -> str:
-    """tmux session name for a lens."""
-    return f"council-{lens}"
+# A council name shares the lens grammar (both flow into session/file names).
+valid_name = valid_lens
+
+
+# --- per-name paths -------------------------------------------------------------
+
+
+def council_dir(name: str) -> Path:
+    return COUNCIL_ROOT / name
+
+
+def sitting_path(name: str) -> Path:
+    return council_dir(name) / "sitting.json"
+
+
+def workspace_dir(name: str) -> Path:
+    return council_dir(name) / "workspace"
+
+
+def prompts_dir(name: str) -> Path:
+    return council_dir(name) / "prompts"
+
+
+def orchestrator_for(name: str) -> str:
+    """tmux session name for a sitting's orchestrator."""
+    return f"agentwire-council-{name}"
+
+
+def session_for(name: str, lens: str) -> str:
+    """tmux session name for a lens within a sitting."""
+    return f"council-{name}-{lens}"
+
+
+def default_name(cwd: Path | None = None) -> str:
+    """Deterministic sitting name seeded by the current directory.
+
+    Derives from the repo/worktree root (so N worktrees of one repo don't
+    collide onto one sitting), slugified with the #307 worktree helper and
+    capped at ``_NAME_MAX``. A short path-hash is appended only when the slug
+    would be truncated, keeping the common case readable while staying a pure
+    function of cwd (re-derivable by every later command from the same dir).
+    """
+    from agentwire import worktree
+
+    base = cwd or Path.cwd()
+    root = worktree.git_root(base) or base
+    slug = worktree.slugify(root.name)
+    if len(slug) <= _NAME_MAX:
+        return slug
+    digest = hashlib.sha1(str(root).encode()).hexdigest()[:6]
+    return f"{slug[: _NAME_MAX - 7].rstrip('-')}-{digest}"
+
+
+def list_sittings() -> list[str]:
+    """Names of every sitting with state on disk (a ``sitting.json``)."""
+    if not COUNCIL_ROOT.is_dir():
+        return []
+    out = []
+    for child in COUNCIL_ROOT.iterdir():
+        if child.is_dir() and (child / "sitting.json").exists():
+            out.append(child.name)
+    return out
+
+
+# --- sitting record -------------------------------------------------------------
 
 
 @dataclass
@@ -51,6 +127,7 @@ class Sitting:
     roster: list[str]
     sessions: dict[str, str]  # lens -> tmux session name
     started_at: str
+    cwd: str = ""  # dir the sitting was started from (for `council list`)
     next_prompt_id: int = 1
     session_type: str = "claude-bypass"
 
@@ -60,6 +137,7 @@ class Sitting:
             "roster": list(self.roster),
             "sessions": dict(self.sessions),
             "started_at": self.started_at,
+            "cwd": self.cwd,
             "next_prompt_id": self.next_prompt_id,
             "session_type": self.session_type,
         }
@@ -67,10 +145,11 @@ class Sitting:
     @classmethod
     def from_dict(cls, d: dict) -> "Sitting":
         return cls(
-            orchestrator=d.get("orchestrator", ORCHESTRATOR_SESSION),
+            orchestrator=d.get("orchestrator", ""),
             roster=list(d.get("roster", [])),
             sessions=dict(d.get("sessions", {})),
             started_at=d.get("started_at", ""),
+            cwd=d.get("cwd", ""),
             next_prompt_id=int(d.get("next_prompt_id", 1)),
             session_type=d.get("session_type", "claude-bypass"),
         )
@@ -96,12 +175,13 @@ def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def read_sitting() -> Sitting | None:
-    """Return the current sitting, or None if no sitting (or corrupt state)."""
-    if not SITTING_PATH.exists():
+def read_sitting(name: str) -> Sitting | None:
+    """Return the named sitting, or None if absent (or corrupt state)."""
+    path = sitting_path(name)
+    if not path.exists():
         return None
     try:
-        with open(SITTING_PATH) as f:
+        with open(path) as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError):
         return None
@@ -110,35 +190,37 @@ def read_sitting() -> Sitting | None:
     return Sitting.from_dict(data)
 
 
-def write_sitting(sitting: Sitting) -> None:
-    _atomic_write(SITTING_PATH, sitting.to_dict())
+def write_sitting(name: str, sitting: Sitting) -> None:
+    _atomic_write(sitting_path(name), sitting.to_dict())
 
 
-def clear_sitting() -> None:
+def clear_sitting(name: str) -> None:
     """End the sitting. Prompt history under ``prompts/`` is kept."""
     try:
-        SITTING_PATH.unlink()
+        sitting_path(name).unlink()
     except FileNotFoundError:
         pass
 
 
-def allocate_prompt_id() -> int:
+def allocate_prompt_id(name: str) -> int:
     """Bump and persist the sitting's prompt counter; return the new id.
 
-    Raises ``RuntimeError`` if no sitting is active.
+    Raises ``RuntimeError`` if the named sitting doesn't exist.
     """
-    sitting = read_sitting()
+    sitting = read_sitting(name)
     if sitting is None:
-        raise RuntimeError("no active council sitting — run 'agentwire council start'")
+        raise RuntimeError(
+            f"no council sitting '{name}' — run 'agentwire council start'"
+        )
     prompt_id = sitting.next_prompt_id
     sitting.next_prompt_id = prompt_id + 1
-    write_sitting(sitting)
+    write_sitting(name, sitting)
     return prompt_id
 
 
-def latest_prompt_id() -> int | None:
+def latest_prompt_id(name: str) -> int | None:
     """The most recently allocated prompt id, or None if none yet."""
-    sitting = read_sitting()
+    sitting = read_sitting(name)
     if sitting is None or sitting.next_prompt_id <= 1:
         return None
     return sitting.next_prompt_id - 1

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2002,16 +2002,24 @@ def scheduler_report(since: str = "8h", artifact: bool = False) -> str:
 # =============================================================================
 
 
+def _council_tag(data: dict) -> str:
+    """A ``[council: <name>]`` echo prefix so every tool surfaces which
+    sitting it acted on (the CLI returns the resolved name as ``council``)."""
+    name = data.get("council")
+    return f"[council: {name}] " if name else ""
+
+
 @mcp.tool()
-def council_start(roster: str = "", model: str = "") -> str:
+def council_start(name: str = "", roster: str = "", model: str = "") -> str:
     """Start a council sitting: orchestrator + one session per lens soul.
 
-    Spins up the ``agentwire-council`` orchestrator and a ``council-<lens>``
-    session per roster lens (default roster: brain, conscience, gut, critic,
-    historian, devils-advocate). Sessions stay warm for follow-up asks until
-    ``council_stop``.
+    Sittings are namespaced — spins up an ``agentwire-council-<name>``
+    orchestrator and ``council-<name>-<lens>`` sessions (default roster:
+    brain, conscience, gut, critic, historian, devils-advocate). Independent
+    sittings run concurrently; sessions stay warm until ``council_stop``.
 
     Args:
+        name: Sitting name (empty = derived from the current repo/dir)
         roster: Comma-separated lens names (empty = full default roster)
         model: Model override for all council sessions
 
@@ -2019,6 +2027,8 @@ def council_start(roster: str = "", model: str = "") -> str:
         Orchestrator + soul session names, or failure details.
     """
     args = ["council", "start"]
+    if name:
+        args += ["--name", name]
     if roster:
         args += ["--roster", roster]
     if model:
@@ -2028,43 +2038,57 @@ def council_start(roster: str = "", model: str = "") -> str:
     if not data.get("success"):
         return f"Failed to start council: {data.get('error') or data}"
     sessions = data.get("sessions", {})
-    lines = [f"Council sitting started: {data.get('orchestrator')}"]
-    lines += [f"  {lens}: {name}" for lens, name in sessions.items()]
+    lines = [f"{_council_tag(data)}Council sitting started: {data.get('orchestrator')}"]
+    if data.get("advisory"):
+        lines.append(f"  ({data['advisory']})")
+    lines += [f"  {lens}: {sname}" for lens, sname in sessions.items()]
     for f in data.get("failed") or []:
         lines.append(f"  ! {f['soul']}: {f['error']}")
     return "\n".join(lines)
 
 
 @mcp.tool()
-def council_stop() -> str:
-    """Stop the council sitting: kill all soul sessions + the orchestrator.
+def council_stop(name: str = "") -> str:
+    """Stop a council sitting: kill all soul sessions + the orchestrator.
 
-    Prompt history under ``~/.agentwire/council/prompts/`` is kept.
+    Prompt history under ``~/.agentwire/council/<name>/prompts/`` is kept.
+
+    Args:
+        name: Sitting name (empty = cwd-repo-slug / sole live sitting)
 
     Returns:
         Which sessions were killed.
     """
-    data = run_agentwire_cmd(["council", "stop"], timeout=60)
+    args = ["council", "stop"]
+    if name:
+        args += ["--name", name]
+    data = run_agentwire_cmd(args, timeout=60)
     if not data.get("success"):
         return f"Failed to stop council: {data.get('error', 'Unknown error')}"
     killed = data.get("killed") or []
-    return f"Council sitting stopped. Killed: {', '.join(killed) or '(none)'}"
+    return f"{_council_tag(data)}Council stopped. Killed: {', '.join(killed) or '(none)'}"
 
 
 @mcp.tool()
-def council_status() -> str:
-    """Show the council sitting: session liveness and per-prompt reply state.
+def council_status(name: str = "") -> str:
+    """Show a council sitting: session liveness and per-prompt reply state.
+
+    Args:
+        name: Sitting name (empty = cwd-repo-slug / sole live sitting)
 
     Returns:
         Roster health and which souls are still pending on open prompts.
     """
-    data = run_agentwire_cmd(["council", "status"])
+    args = ["council", "status"]
+    if name:
+        args += ["--name", name]
+    data = run_agentwire_cmd(args)
     if not data.get("success"):
         return f"Failed to get council status: {data.get('error', 'Unknown error')}"
     if not data.get("running"):
-        return "No active council sitting."
+        return data.get("error") or "No active council sitting."
     lines = [
-        f"Council sitting (started {data.get('started_at')})",
+        f"{_council_tag(data)}Council sitting (started {data.get('started_at')})",
         f"  orchestrator: {data.get('orchestrator')} "
         f"[{'alive' if data.get('orchestrator_alive') else 'DOWN'}]",
     ]
@@ -2077,8 +2101,29 @@ def council_status() -> str:
 
 
 @mcp.tool()
-def council_ask(prompt: str) -> str:
-    """Fan a prompt out to every soul in the council sitting.
+def council_list() -> str:
+    """List every known council sitting, oldest-first.
+
+    Returns:
+        name · cwd · age · live/total sessions · prompts for each sitting —
+        the age column surfaces forgotten token-burning sittings.
+    """
+    data = run_agentwire_cmd(["council", "list"])
+    if not data.get("success"):
+        return f"Failed to list councils: {data.get('error', 'Unknown error')}"
+    councils = data.get("councils") or []
+    if not councils:
+        return "No council sittings."
+    lines = [f"{'NAME':<24} {'LIVE':>7} {'PROMPTS':>8}  CWD"]
+    for c in councils:
+        live = f"{c['live_sessions']}/{c['total_sessions']}"
+        lines.append(f"{c['name']:<24} {live:>7} {c['prompts']:>8}  {c.get('cwd', '')}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def council_ask(prompt: str, name: str = "") -> str:
+    """Fan a prompt out to every soul in a council sitting.
 
     Creates the prompt's reply inbox, then sends the prompt to every live
     lens session. Each soul will file exactly one of: a substantive take, an
@@ -2087,24 +2132,31 @@ def council_ask(prompt: str) -> str:
 
     Args:
         prompt: The question or decision to put before the council
+        name: Sitting name (empty = cwd-repo-slug / sole live sitting)
 
     Returns:
         The prompt id (needed for council_collect) and fan-out result.
     """
-    data = run_agentwire_cmd(["council", "ask", prompt])
+    args = ["council", "ask", prompt]
+    if name:
+        args += ["--name", name]
+    data = run_agentwire_cmd(args)
     if not data.get("success"):
         return f"Failed to ask council: {data.get('error') or data}"
     pid = data.get("prompt_id")
     sent = data.get("sent_to") or []
-    out = f"PROMPT ID: {pid} — fanned out to {len(sent)} souls ({', '.join(sent)})"
+    out = (
+        f"{_council_tag(data)}PROMPT ID: {pid} — fanned out to "
+        f"{len(sent)} souls ({', '.join(sent)})"
+    )
     for f in data.get("failed") or []:
         out += f"\n  ! {f['soul']}: {f['error']}"
     return out
 
 
 @mcp.tool()
-def council_collect(prompt_id: int = 0, timeout: int = 120) -> str:
-    """Collect the council's replies for a prompt (blocks until done/timeout).
+def council_collect(prompt_id: int = 0, timeout: int = 120, name: str = "") -> str:
+    """Collect a council's replies for a prompt (blocks until done/timeout).
 
     Returns as soon as every roster soul has filed a take, ack, or pass — or
     when the soft timeout lapses. Re-collecting a complete prompt returns
@@ -2114,6 +2166,7 @@ def council_collect(prompt_id: int = 0, timeout: int = 120) -> str:
     Args:
         prompt_id: Prompt id from council_ask (0 = latest)
         timeout: Soft timeout in seconds (default 120)
+        name: Sitting name (empty = cwd-repo-slug / sole live sitting)
 
     Returns:
         Every reply attributed by soul, plus any souls still pending.
@@ -2121,12 +2174,14 @@ def council_collect(prompt_id: int = 0, timeout: int = 120) -> str:
     args = ["council", "collect", "--timeout", str(timeout)]
     if prompt_id:
         args += ["--prompt", str(prompt_id)]
+    if name:
+        args += ["--name", name]
     # Pad the subprocess timeout past the blocking collect window.
     data = run_agentwire_cmd(args, timeout=timeout + 15)
     if not data.get("success"):
         return f"Failed to collect: {data.get('error') or data}"
     lines = [
-        f"Prompt #{data.get('prompt_id')}: "
+        f"{_council_tag(data)}Prompt #{data.get('prompt_id')}: "
         + ("complete" if data.get("complete") else f"pending: {', '.join(data.get('pending') or [])}")
     ]
     for r in data.get("replies") or []:

--- a/agentwire/roles/council-member.md
+++ b/agentwire/roles/council-member.md
@@ -12,24 +12,25 @@ through the orchestrator's synthesis.
 
 ## The protocol
 
-You receive prompts as messages tagged `[COUNCIL PROMPT #N]`. For **every**
-prompt, you MUST file exactly one initial reply with the `agentwire council
-reply` CLI (via Bash):
+You receive prompts as messages tagged `[COUNCIL PROMPT #N]`. **Always copy the
+exact `agentwire council reply` command from that message** — it already carries
+the right `--name <council>` and `--prompt N` for your sitting. The shapes are:
 
 ```bash
 # A substantive take through your lens
-agentwire council reply --prompt N --take --text "Your take here"
+agentwire council reply --name <council> --prompt N --take --text "Your take here"
 # (long takes: write a file and use --file path, or pipe via stdin)
 
 # You want to research or think before answering — follow up later
-agentwire council reply --prompt N --ack
+agentwire council reply --name <council> --prompt N --ack
 
 # Nothing valid to add through your lens
-agentwire council reply --prompt N --pass
+agentwire council reply --name <council> --prompt N --pass
 ```
 
-The full prompt text is also on disk at
-`~/.agentwire/council/prompts/<NNNN>/prompt.md` if the message was truncated.
+The full prompt text is also on disk — the `[COUNCIL PROMPT #N]` message gives
+the exact path (under `~/.agentwire/council/<council>/prompts/<NNNN>/prompt.md`)
+if the message was truncated.
 
 ## Rules
 

--- a/docs/wiki/council.md
+++ b/docs/wiki/council.md
@@ -8,14 +8,34 @@
 
 ## Mental model
 
-A **sitting** is one `council start` → `council stop` span. It comprises:
+A **sitting** is one `council start` → `council stop` span, **namespaced by
+`<name>`** so independent councils run concurrently (one per project/decision).
+It comprises:
 
-- The **orchestrator** — the `agentwire-council` session (role
+- The **orchestrator** — the `agentwire-council-<name>` session (role
   `council-orchestrator`). You talk to it; it fans out, collects, and
   synthesizes.
-- The **souls** — one `council-<lens>` session per roster lens, each loading
-  the shared `council-member` protocol role plus its own `council-<lens>`
-  lens role.
+- The **souls** — one `council-<name>-<lens>` session per roster lens, each
+  loading the shared `council-member` protocol role plus its own
+  `council-<lens>` lens role.
+
+### Targeting (which sitting a command hits)
+
+`<name>` is identity — deterministic and inspectable, never a hidden
+active-pointer. Every command resolves the same way and **echoes which sitting
+it acted on** (`→ council 'agentwire-dev' (prompt #3)`):
+
+1. explicit `--name`, else
+2. the **cwd-repo-slug** if it matches a live sitting, else
+3. the **sole** live sitting, else
+4. **error** + the candidate list (0 live → `no council for this repo`; N live
+   and ambiguous → refuse, demand `--name`). Never guesses by recency.
+
+`<name>` is validated by the lens grammar (`[a-z0-9][a-z0-9-]*` — tmux-safe);
+cwd-derived defaults are slugified + capped (~24 chars, short path-hash when
+truncated, derived from repo/worktree root so N worktrees don't collide). The
+lens→session map lives in `sitting.json` — **never** recover a name/lens by
+splitting a session string.
 
 Default roster:
 
@@ -28,14 +48,14 @@ Default roster:
 | `historian` | What we tried before, what worked, what didn't |
 | `devils-advocate` | The strongest opposing case, argued in good faith |
 
-All council sessions run in a shared workspace
-(`~/.agentwire/council/workspace/`) whose `.agentwire.yml` sets
-`parent: agentwire-council`, and none of them receive the standard `soul`
-role — `inject_soul()` skips any session carrying a `council-*` role.
+All of a sitting's sessions run in its own workspace
+(`~/.agentwire/council/<name>/workspace/`) whose `.agentwire.yml` sets
+`parent: agentwire-council-<name>`, and none of them receive the standard
+`soul` role — `inject_soul()` skips any session carrying a `council-*` role.
 
 ## The protocol
 
-Per prompt, on disk under `~/.agentwire/council/prompts/NNNN/`:
+Per prompt, on disk under `~/.agentwire/council/<name>/prompts/NNNN/`:
 
 ```
 prompt.md        # the fanned-out prompt
@@ -56,36 +76,43 @@ follow-up and the CLI itself nudges the orchestrator's pane with a
 `[COUNCIL FOLLOW-UP]` message — delivery doesn't depend on the soul
 remembering to notify.
 
-Sitting state (roster, session names, prompt counter) lives at
-`~/.agentwire/council/sitting.json`. `council stop` clears it but keeps the
-`prompts/` history.
+Sitting state (roster, session names, originating cwd, prompt counter) lives at
+`~/.agentwire/council/<name>/sitting.json`. `council stop` clears it but keeps
+the `prompts/` history.
 
 ## CLI
 
 ```bash
-agentwire council start [--roster brain,gut,...] [--type T] [--model M] [--force]
-agentwire council stop
-agentwire council status
-agentwire council ask "Should we ship X?"      # or --file / stdin
-agentwire council collect [--prompt N] [--timeout 120] [--no-wait]
-agentwire council reply --prompt N --take --text "..."   # souls run this
-agentwire council reply --prompt N --ack
-agentwire council reply --prompt N --pass
+agentwire council start [--name N] [--roster brain,gut,...] [--type T] [--model M] [--force]
+agentwire council list                          # every sitting: name·cwd·age·live·prompts
+agentwire council stop    [--name N]
+agentwire council status  [--name N]
+agentwire council ask     [--name N] "Should we ship X?"   # or --file / stdin
+agentwire council collect [--name N] [--prompt P] [--timeout 120] [--no-wait]
+agentwire council reply   --name N --prompt P --take --text "..."   # souls run this
+agentwire council reply   --name N --prompt P --ack
+agentwire council reply   --name N --prompt P --pass
 ```
 
-All subcommands support `--json`. `reply` infers `--soul` from the current
-tmux session name (`council-gut` → `gut`); `--take` text comes from `--text`,
-`--file`, or stdin.
+`--name` is optional everywhere (resolved per the targeting rules above); the
+fanned-out `[COUNCIL PROMPT #N]` message hands each soul the exact `reply`
+command, `--name` already filled in. `reply` infers `--soul` by reverse-looking
+its session up in `sitting.json` (never by splitting the name); `--take` text
+comes from `--text`, `--file`, or stdin. All subcommands support `--json`.
 
 ## MCP tools (orchestrator-facing)
 
 | Tool | Wraps |
 |------|-------|
-| `council_start(roster, model)` | `council start` |
-| `council_stop()` | `council stop` |
-| `council_status()` | `council status` |
-| `council_ask(prompt)` | `council ask` — returns the prompt id |
-| `council_collect(prompt_id, timeout)` | `council collect` (subprocess timeout padded past the blocking window) |
+| `council_start(name, roster, model)` | `council start` |
+| `council_list()` | `council list` |
+| `council_stop(name)` | `council stop` |
+| `council_status(name)` | `council status` |
+| `council_ask(prompt, name)` | `council ask` — returns the prompt id |
+| `council_collect(prompt_id, timeout, name)` | `council collect` (subprocess timeout padded past the blocking window) |
+
+Every tool takes the optional `name` and echoes `[council: <name>]` so you can
+see which sitting it hit.
 
 `council reply` is deliberately CLI-only — souls invoke it via Bash.
 
@@ -106,8 +133,12 @@ Overriding a bundled lens's content works the same way — a user-level
   souls; check the session is alive and the `[COUNCIL PROMPT #N]` message
   landed in its pane. `collect` returns `timed_out: true` with the pending
   list rather than blocking forever.
-- **Stale sitting after a crash** — `council start --force` tears down
-  whatever is left and starts fresh.
+- **Stale sitting after a crash** — `council start --force` (same `--name`)
+  tears down whatever is left and starts fresh. First run after upgrading from
+  the pre-namespace singleton sweeps any zombie `council-*` / `agentwire-council`
+  panes + orphaned global `sitting.json` automatically.
+- **"multiple councils live" error** — pass `--name`; `council list` shows the
+  candidates (the age column flags forgotten token-burning sittings).
 - **Soul replies rejected** — a soul gets one initial reply per prompt;
   after that only `--take` follow-ups are accepted (a second `--ack`/`--pass`
   errors by design).

--- a/tests/unit/test_council_cli.py
+++ b/tests/unit/test_council_cli.py
@@ -7,15 +7,15 @@ import pytest
 
 from agentwire.council import cli, inbox, state
 
+NAME = "proj"
+
 
 @pytest.fixture(autouse=True)
-def council_dirs(tmp_path, monkeypatch):
-    council = tmp_path / "council"
-    monkeypatch.setattr(state, "COUNCIL_DIR", council)
-    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
-    monkeypatch.setattr(state, "WORKSPACE_DIR", council / "workspace")
-    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
-    return council
+def council_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "COUNCIL_ROOT", tmp_path / "council")
+    # Keep resolution hermetic — no real `git` call for the cwd-slug seed.
+    monkeypatch.setattr(state, "default_name", lambda cwd=None: "nomatch")
+    return tmp_path / "council"
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def mocks(monkeypatch):
     calls = {"created": [], "killed": [], "sent": [], "live": set()}
     monkeypatch.setattr(cli, "list_live_sessions", lambda: set(calls["live"]))
 
-    def create(name, roles, session_type, model):
+    def create(name, roles, session_type, model, cwd):
         calls["created"].append((name, roles, session_type, model))
         calls["live"].add(name)
 
@@ -52,6 +52,7 @@ def mocks(monkeypatch):
 
 def _args(**kw):
     ns = argparse.Namespace()
+    kw.setdefault("name", NAME)
     for k, v in kw.items():
         setattr(ns, k, v)
     return ns
@@ -67,33 +68,41 @@ def _payload(capsys) -> dict:
 
 
 class TestStart:
-    def test_creates_sessions_and_sitting(self, mocks, capsys):
+    def test_creates_namespaced_sessions_and_sitting(self, mocks, capsys):
         assert _start(mocks) == 0
         payload = _payload(capsys)
         assert payload["success"]
+        assert payload["council"] == NAME
         names = [c[0] for c in mocks["created"]]
-        assert names == ["agentwire-council", "council-brain", "council-gut"]
+        assert names == ["agentwire-council-proj", "council-proj-brain", "council-proj-gut"]
         roles = {c[0]: c[1] for c in mocks["created"]}
-        assert roles["agentwire-council"] == ["council-orchestrator"]
-        assert roles["council-brain"] == ["council-member", "council-brain"]
-        sitting = state.read_sitting()
+        assert roles["agentwire-council-proj"] == ["council-orchestrator"]
+        assert roles["council-proj-brain"] == ["council-member", "council-brain"]
+        sitting = state.read_sitting(NAME)
         assert sitting.roster == ["brain", "gut"]
-        assert sitting.sessions == {"brain": "council-brain", "gut": "council-gut"}
+        assert sitting.sessions == {
+            "brain": "council-proj-brain",
+            "gut": "council-proj-gut",
+        }
+        assert sitting.orchestrator == "agentwire-council-proj"
 
     def test_writes_workspace_config(self, mocks, capsys):
         _start(mocks)
-        yml = (state.WORKSPACE_DIR / ".agentwire.yml").read_text()
-        assert "parent: agentwire-council" in yml
+        yml = (state.workspace_dir(NAME) / ".agentwire.yml").read_text()
+        assert "parent: agentwire-council-proj" in yml
 
     def test_default_roster(self, mocks, capsys):
         _start(mocks, roster=None)
-        assert state.read_sitting().roster == state.DEFAULT_ROSTER
+        assert state.read_sitting(NAME).roster == state.DEFAULT_ROSTER
 
     def test_invalid_lens_rejected(self, mocks, capsys):
         assert _start(mocks, roster="brain,../etc") == 1
-        assert state.read_sitting() is None
+        assert state.read_sitting(NAME) is None
 
-    def test_refuses_live_sitting(self, mocks, capsys):
+    def test_invalid_name_rejected(self, mocks, capsys):
+        assert _start(mocks, name="../evil") == 1
+
+    def test_refuses_live_same_name(self, mocks, capsys):
         _start(mocks)
         capsys.readouterr()
         assert _start(mocks) == 1
@@ -104,8 +113,19 @@ class TestStart:
         capsys.readouterr()
         args = _args(roster="brain", type=None, model=None, force=True, json=True)
         assert cli.cmd_council_start(args) == 0
-        assert "agentwire-council" in mocks["killed"]
-        assert state.read_sitting().roster == ["brain"]
+        assert "agentwire-council-proj" in mocks["killed"]
+        assert state.read_sitting(NAME).roster == ["brain"]
+
+    def test_concurrent_sittings_isolated(self, mocks, capsys):
+        assert _start(mocks, name="a") == 0
+        capsys.readouterr()
+        assert _start(mocks, name="b") == 0
+        payload = _payload(capsys)
+        # Advisory names every live sitting when seating beyond the first.
+        assert "councils live" in payload["advisory"]
+        assert set(state.list_sittings()) == {"a", "b"}
+        assert state.read_sitting("a").orchestrator == "agentwire-council-a"
+        assert state.read_sitting("b").orchestrator == "agentwire-council-b"
 
 
 class TestStop:
@@ -114,15 +134,55 @@ class TestStop:
         capsys.readouterr()
         assert cli.cmd_council_stop(_args(json=True)) == 0
         payload = _payload(capsys)
+        assert payload["council"] == NAME
         assert set(payload["killed"]) == {
-            "agentwire-council",
-            "council-brain",
-            "council-gut",
+            "agentwire-council-proj",
+            "council-proj-brain",
+            "council-proj-gut",
         }
-        assert state.read_sitting() is None
+        assert state.read_sitting(NAME) is None
+
+    def test_stop_targets_only_named_sitting(self, mocks, capsys):
+        _start(mocks, name="a")
+        _start(mocks, name="b")
+        capsys.readouterr()
+        assert cli.cmd_council_stop(_args(name="a", json=True)) == 0
+        assert state.read_sitting("a") is None
+        assert state.read_sitting("b") is not None  # survives
+        assert "council-b-brain" not in mocks["killed"]
 
     def test_no_sitting(self, mocks, capsys):
         assert cli.cmd_council_stop(_args(json=True)) == 1
+
+
+class TestResolution:
+    def test_sole_live_autopick(self, mocks, capsys):
+        _start(mocks, name="only")
+        capsys.readouterr()
+        # No --name; cwd-slug ('nomatch') doesn't match, but it's the sole live.
+        assert cli.cmd_council_status(_args(name=None, json=True)) == 0
+        payload = _payload(capsys)
+        assert payload["running"] and payload["council"] == "only"
+
+    def test_ambiguous_refuses_and_lists(self, mocks, capsys):
+        _start(mocks, name="a")
+        _start(mocks, name="b")
+        capsys.readouterr()
+        assert cli.cmd_council_ask(_args(name=None, prompt="x", file=None, json=True)) == 1
+        err = _payload(capsys)["error"]
+        assert "a" in err and "b" in err and "--name" in err
+
+    def test_zero_live_errors(self, mocks, capsys):
+        assert cli.cmd_council_ask(_args(name=None, prompt="x", file=None, json=True)) == 1
+        assert "no council" in _payload(capsys)["error"]
+
+    def test_cwd_slug_match_wins(self, mocks, capsys, monkeypatch):
+        _start(mocks, name="a")
+        _start(mocks, name="repo-slug")
+        capsys.readouterr()
+        monkeypatch.setattr(state, "default_name", lambda cwd=None: "repo-slug")
+        assert cli.cmd_council_status(_args(name=None, json=True)) == 0
+        assert _payload(capsys)["council"] == "repo-slug"
 
 
 class TestStatus:
@@ -133,9 +193,9 @@ class TestStatus:
     def test_liveness_and_prompts(self, mocks, capsys):
         _start(mocks)
         capsys.readouterr()
-        mocks["live"].discard("council-gut")
+        mocks["live"].discard("council-proj-gut")
         cli.cmd_council_ask(_args(prompt="ship it?", file=None, json=True))
-        inbox.write_reply(1, "brain", "take", "yes")
+        inbox.write_reply(NAME, 1, "brain", "take", "yes")
         capsys.readouterr()
 
         cli.cmd_council_status(_args(json=True))
@@ -145,6 +205,24 @@ class TestStatus:
         assert payload["prompts"][0]["pending"] == ["gut"]
 
 
+class TestList:
+    def test_empty(self, mocks, capsys):
+        assert cli.cmd_council_list(_args(json=True)) == 0
+        assert _payload(capsys)["councils"] == []
+
+    def test_lists_sittings_oldest_first(self, mocks, capsys):
+        _start(mocks, name="a")
+        _start(mocks, name="b")
+        capsys.readouterr()
+        assert cli.cmd_council_list(_args(json=True)) == 0
+        rows = _payload(capsys)["councils"]
+        names = [r["name"] for r in rows]
+        assert set(names) == {"a", "b"}
+        # Every session live → live == total.
+        for r in rows:
+            assert r["live_sessions"] == r["total_sessions"]
+
+
 class TestAsk:
     def test_inbox_before_send_and_fanout(self, mocks, capsys, monkeypatch):
         _start(mocks)
@@ -152,7 +230,7 @@ class TestAsk:
 
         def send_checking(session, message, marker, retries=1):
             # The inbox must exist before any soul could conceivably reply.
-            assert inbox.replies_dir(1).is_dir()
+            assert inbox.replies_dir(NAME, 1).is_dir()
             mocks["sent"].append((session, message))
             return True
 
@@ -160,17 +238,19 @@ class TestAsk:
         assert cli.cmd_council_ask(_args(prompt="ship it?", file=None, json=True)) == 0
         payload = _payload(capsys)
         assert payload["prompt_id"] == 1
+        assert payload["council"] == NAME
         assert set(payload["sent_to"]) == {"brain", "gut"}
         sessions = [s for s, _ in mocks["sent"]]
-        assert set(sessions) == {"council-brain", "council-gut"}
+        assert set(sessions) == {"council-proj-brain", "council-proj-gut"}
         msg = mocks["sent"][0][1]
         assert "[COUNCIL PROMPT #1]" in msg
-        assert "council reply --prompt 1" in msg
+        # The fanned reply command carries --name so souls never split sessions.
+        assert "council reply --name proj --prompt 1" in msg
 
     def test_dead_soul_reported(self, mocks, capsys):
         _start(mocks)
         capsys.readouterr()
-        mocks["live"].discard("council-gut")
+        mocks["live"].discard("council-proj-gut")
         cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
         payload = _payload(capsys)
         assert payload["sent_to"] == ["brain"]
@@ -186,9 +266,6 @@ class TestAsk:
         assert all(
             f["error"] == "delivery not confirmed in pane" for f in payload["failed"]
         )
-
-    # send_verified mechanics (retry/marker) are covered in
-    # tests/unit/test_session_ready.py — the implementation moved there.
 
     def test_no_sitting(self, mocks, capsys):
         assert cli.cmd_council_ask(_args(prompt="x", file=None, json=True)) == 1
@@ -209,19 +286,31 @@ class TestCollect:
         assert cli.cmd_council_collect(args) == 0
         payload = _payload(capsys)
         assert payload["prompt_id"] == 1
+        assert payload["council"] == NAME
         assert not payload["complete"]
 
     def test_complete_round(self, mocks, capsys):
         _start(mocks)
         cli.cmd_council_ask(_args(prompt="x", file=None, json=True))
-        inbox.write_reply(1, "brain", "take", "yes")
-        inbox.write_reply(1, "gut", "pass", "")
+        inbox.write_reply(NAME, 1, "brain", "take", "yes")
+        inbox.write_reply(NAME, 1, "gut", "pass", "")
         capsys.readouterr()
         args = _args(prompt=1, timeout=120, no_wait=False, json=True)
         assert cli.cmd_council_collect(args) == 0
         payload = _payload(capsys)
         assert payload["complete"]
         assert {r["kind"] for r in payload["replies"]} == {"take", "pass"}
+
+    def test_collect_targets_named_sitting(self, mocks, capsys):
+        _start(mocks, name="a")
+        _start(mocks, name="b")
+        cli.cmd_council_ask(_args(name="a", prompt="for a", file=None, json=True))
+        inbox.write_reply("a", 1, "brain", "take", "a-take")
+        inbox.write_reply("a", 1, "gut", "pass", "")
+        capsys.readouterr()
+        args = _args(name="a", prompt=1, timeout=1, no_wait=True, json=True)
+        assert cli.cmd_council_collect(args) == 0
+        assert _payload(capsys)["complete"]
 
     def test_no_prompts_yet(self, mocks, capsys):
         _start(mocks)
@@ -251,11 +340,12 @@ class TestReply:
         payload = _payload(capsys)
         assert payload["kind"] == "take"
         assert not payload["followup"]
-        assert inbox.list_replies(1)[0].text == "my take"
+        assert inbox.list_replies(NAME, 1)[0].text == "my take"
 
-    def test_soul_inferred_from_session(self, mocks, capsys, monkeypatch):
+    def test_soul_inferred_from_session_via_ssot(self, mocks, capsys, monkeypatch):
         self._setup(mocks, capsys)
-        monkeypatch.setattr(cli, "current_session", lambda: "council-gut")
+        # Inference reverse-looks-up the SSOT map, never splits the session name.
+        monkeypatch.setattr(cli, "current_session", lambda: "council-proj-gut")
         assert self._reply(pass_=True) == 0
         assert _payload(capsys)["soul"] == "gut"
 
@@ -263,6 +353,13 @@ class TestReply:
         self._setup(mocks, capsys)
         monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
         assert self._reply(take=True, text="x") == 1
+
+    def test_unknown_session_not_split(self, mocks, capsys, monkeypatch):
+        """A session not in the SSOT map yields no soul — never a bad split."""
+        self._setup(mocks, capsys)
+        monkeypatch.setattr(cli, "current_session", lambda: "council-proj-ghost")
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        assert self._reply(pass_=True) == 1
 
     def test_exactly_one_kind(self, mocks, capsys):
         self._setup(mocks, capsys)
@@ -287,7 +384,7 @@ class TestReply:
         nudges = mocks["sent"][sent_before:]
         assert len(nudges) == 1
         session, msg = nudges[0]
-        assert session == "agentwire-council"
+        assert session == "agentwire-council-proj"
         assert "[COUNCIL FOLLOW-UP]" in msg and "brain" in msg
 
     def test_initial_reply_does_not_nudge(self, mocks, capsys):
@@ -295,3 +392,22 @@ class TestReply:
         sent_before = len(mocks["sent"])
         self._reply(take=True, soul="brain", text="x")
         assert len(mocks["sent"]) == sent_before
+
+
+class TestLegacySweep:
+    def test_kills_legacy_singleton_once(self, mocks, capsys, monkeypatch):
+        # A live pre-namespace global sitting + orphaned global state.
+        mocks["live"].update({"agentwire-council", "council-brain"})
+        global_sitting = state.COUNCIL_ROOT / "sitting.json"
+        global_sitting.parent.mkdir(parents=True, exist_ok=True)
+        global_sitting.write_text(
+            json.dumps(
+                {"orchestrator": "agentwire-council", "sessions": {"brain": "council-brain"}}
+            )
+        )
+        killed = cli._sweep_legacy_once()
+        assert "agentwire-council" in killed and "council-brain" in killed
+        assert not global_sitting.exists()
+        assert (state.COUNCIL_ROOT / ".namespaced").exists()
+        # Idempotent — second call is a no-op.
+        assert cli._sweep_legacy_once() == []

--- a/tests/unit/test_council_inbox.py
+++ b/tests/unit/test_council_inbox.py
@@ -5,95 +5,102 @@ import pytest
 from agentwire.council import inbox, state
 
 ROSTER = ["brain", "gut", "critic"]
+NAME = "proj"
 
 
 @pytest.fixture(autouse=True)
-def council_dirs(tmp_path, monkeypatch):
-    council = tmp_path / "council"
-    monkeypatch.setattr(state, "COUNCIL_DIR", council)
-    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
-    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
-    return council
+def council_root(tmp_path, monkeypatch):
+    root = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_ROOT", root)
+    return root
 
 
 @pytest.fixture
 def prompt():
-    inbox.create_prompt(1, "Should we ship X?", ROSTER)
+    inbox.create_prompt(NAME, 1, "Should we ship X?", ROSTER)
     return 1
 
 
 class TestCreatePrompt:
     def test_layout(self, prompt):
-        pdir = inbox.prompt_dir(1)
+        pdir = inbox.prompt_dir(NAME, 1)
         assert pdir.name == "0001"
+        assert pdir == state.prompts_dir(NAME) / "0001"
         assert (pdir / "prompt.md").read_text() == "Should we ship X?"
         assert (pdir / "replies").is_dir()
-        assert inbox.read_meta(1)["roster"] == ROSTER
+        assert inbox.read_meta(NAME, 1)["roster"] == ROSTER
 
     def test_reused_id_clears_stale_replies(self, prompt):
         """Prompt ids restart per sitting; a reused id must not inherit the
         previous sitting's reply files."""
-        inbox.write_reply(1, "brain", "pass", "")
-        inbox.create_prompt(1, "New sitting, same id", ROSTER)
-        assert inbox.list_replies(1) == []
-        assert inbox.pending_souls(1, ROSTER) == ROSTER
+        inbox.write_reply(NAME, 1, "brain", "pass", "")
+        inbox.create_prompt(NAME, 1, "New sitting, same id", ROSTER)
+        assert inbox.list_replies(NAME, 1) == []
+        assert inbox.pending_souls(NAME, 1, ROSTER) == ROSTER
+
+    def test_inboxes_are_per_name(self, prompt):
+        inbox.create_prompt("other", 1, "Different council", ROSTER)
+        inbox.write_reply(NAME, 1, "brain", "take", "in proj")
+        # 'other' sitting's prompt #1 is untouched.
+        assert inbox.list_replies("other", 1) == []
+        assert inbox.pending_souls("other", 1, ROSTER) == ROSTER
 
 
 class TestWriteReply:
     def test_filename_per_kind(self, prompt):
         for soul, kind in [("brain", "take"), ("gut", "pass"), ("critic", "ack")]:
-            path, followup = inbox.write_reply(1, soul, kind, f"{soul} text")
+            path, followup = inbox.write_reply(NAME, 1, soul, kind, f"{soul} text")
             assert path.name == f"{soul}.{kind}.md"
             assert not followup
 
     def test_invalid_kind(self, prompt):
         with pytest.raises(ValueError):
-            inbox.write_reply(1, "brain", "musing", "x")
+            inbox.write_reply(NAME, 1, "brain", "musing", "x")
 
     def test_missing_inbox(self):
         with pytest.raises(FileNotFoundError):
-            inbox.write_reply(99, "brain", "take", "x")
+            inbox.write_reply(NAME, 99, "brain", "take", "x")
 
     def test_followup_numbering(self, prompt):
-        inbox.write_reply(1, "brain", "ack", "")
-        p1, f1 = inbox.write_reply(1, "brain", "take", "found it")
-        p2, f2 = inbox.write_reply(1, "brain", "take", "more")
+        inbox.write_reply(NAME, 1, "brain", "ack", "")
+        p1, f1 = inbox.write_reply(NAME, 1, "brain", "take", "found it")
+        p2, f2 = inbox.write_reply(NAME, 1, "brain", "take", "more")
         assert (p1.name, f1) == ("brain.followup-1.md", True)
         assert (p2.name, f2) == ("brain.followup-2.md", True)
 
     def test_second_initial_rejected(self, prompt):
-        inbox.write_reply(1, "brain", "take", "x")
+        inbox.write_reply(NAME, 1, "brain", "take", "x")
         with pytest.raises(ValueError):
-            inbox.write_reply(1, "brain", "pass", "")
+            inbox.write_reply(NAME, 1, "brain", "pass", "")
         with pytest.raises(ValueError):
-            inbox.write_reply(1, "brain", "ack", "")
+            inbox.write_reply(NAME, 1, "brain", "ack", "")
 
 
 class TestRoundCompletion:
     def test_pending_and_complete(self, prompt):
-        assert inbox.pending_souls(1, ROSTER) == ROSTER
-        inbox.write_reply(1, "brain", "take", "x")
-        inbox.write_reply(1, "gut", "pass", "")
-        assert inbox.pending_souls(1, ROSTER) == ["critic"]
-        assert not inbox.initial_round_complete(1, ROSTER)
-        inbox.write_reply(1, "critic", "ack", "")
-        assert inbox.initial_round_complete(1, ROSTER)
+        assert inbox.pending_souls(NAME, 1, ROSTER) == ROSTER
+        inbox.write_reply(NAME, 1, "brain", "take", "x")
+        inbox.write_reply(NAME, 1, "gut", "pass", "")
+        assert inbox.pending_souls(NAME, 1, ROSTER) == ["critic"]
+        assert not inbox.initial_round_complete(NAME, 1, ROSTER)
+        inbox.write_reply(NAME, 1, "critic", "ack", "")
+        assert inbox.initial_round_complete(NAME, 1, ROSTER)
 
     def test_mixed_kinds_count(self, prompt):
         """take, ack, and pass all complete a soul's initial round."""
-        inbox.write_reply(1, "brain", "take", "x")
-        inbox.write_reply(1, "gut", "ack", "")
-        inbox.write_reply(1, "critic", "pass", "")
-        assert inbox.initial_round_complete(1, ROSTER)
+        inbox.write_reply(NAME, 1, "brain", "take", "x")
+        inbox.write_reply(NAME, 1, "gut", "ack", "")
+        inbox.write_reply(NAME, 1, "critic", "pass", "")
+        assert inbox.initial_round_complete(NAME, 1, ROSTER)
 
 
 class TestListReplies:
     def test_kinds_and_followups(self, prompt):
-        inbox.write_reply(1, "brain", "ack", "researching")
-        inbox.write_reply(1, "gut", "pass", "")
-        inbox.write_reply(1, "critic", "take", "premise is weak")
-        inbox.write_reply(1, "brain", "take", "the follow-up")
-        replies = inbox.list_replies(1)
+        inbox.write_reply(NAME, 1, "brain", "ack", "researching")
+        inbox.write_reply(NAME, 1, "gut", "pass", "")
+        inbox.write_reply(NAME, 1, "critic", "take", "premise is weak")
+        inbox.write_reply(NAME, 1, "brain", "take", "the follow-up")
+        replies = inbox.list_replies(NAME, 1)
         by_kind = {(r.soul, r.kind) for r in replies}
         assert by_kind == {
             ("brain", "ack"),
@@ -105,22 +112,22 @@ class TestListReplies:
         assert replies[-1].kind == "followup"
 
     def test_empty(self, prompt):
-        assert inbox.list_replies(1) == []
+        assert inbox.list_replies(NAME, 1) == []
 
     def test_missing_prompt(self):
-        assert inbox.list_replies(42) == []
+        assert inbox.list_replies(NAME, 42) == []
 
 
 class TestCollect:
     def test_returns_early_when_complete(self, prompt, monkeypatch):
         for soul in ROSTER:
-            inbox.write_reply(1, soul, "pass", "")
+            inbox.write_reply(NAME, 1, soul, "pass", "")
 
         def boom(_):
             raise AssertionError("collect slept despite round being complete")
 
         monkeypatch.setattr(inbox.time, "sleep", boom)
-        result = inbox.collect(1, ROSTER, timeout=120)
+        result = inbox.collect(NAME, 1, ROSTER, timeout=120)
         assert result["complete"]
         assert not result["timed_out"]
         assert result["pending"] == []
@@ -133,8 +140,8 @@ class TestCollect:
             clock["t"] += 10.0
 
         monkeypatch.setattr(inbox.time, "sleep", tick)
-        inbox.write_reply(1, "brain", "take", "x")
-        result = inbox.collect(1, ROSTER, timeout=30)
+        inbox.write_reply(NAME, 1, "brain", "take", "x")
+        result = inbox.collect(NAME, 1, ROSTER, timeout=30)
         assert not result["complete"]
         assert result["timed_out"]
         assert set(result["pending"]) == {"gut", "critic"}
@@ -145,12 +152,12 @@ class TestCollect:
             raise AssertionError("--no-wait must not sleep")
 
         monkeypatch.setattr(inbox.time, "sleep", boom)
-        result = inbox.collect(1, ROSTER, timeout=120, wait=False)
+        result = inbox.collect(NAME, 1, ROSTER, timeout=120, wait=False)
         assert not result["complete"]
         assert not result["timed_out"]
 
     def test_pass_replies_carried(self, prompt):
         for soul in ROSTER:
-            inbox.write_reply(1, soul, "pass", "")
-        result = inbox.collect(1, ROSTER, timeout=1, wait=False)
+            inbox.write_reply(NAME, 1, soul, "pass", "")
+        result = inbox.collect(NAME, 1, ROSTER, timeout=1, wait=False)
         assert {r["kind"] for r in result["replies"]} == {"pass"}

--- a/tests/unit/test_council_state.py
+++ b/tests/unit/test_council_state.py
@@ -1,87 +1,156 @@
-"""Tests for agentwire/council/state.py — sitting lifecycle state."""
+"""Tests for agentwire/council/state.py — namespaced sitting lifecycle."""
 
 import pytest
 
 from agentwire.council import state
 
+NAME = "proj"
+
 
 @pytest.fixture(autouse=True)
-def council_dirs(tmp_path, monkeypatch):
-    """Point all council paths at a temp dir."""
-    council = tmp_path / "council"
-    monkeypatch.setattr(state, "COUNCIL_DIR", council)
-    monkeypatch.setattr(state, "SITTING_PATH", council / "sitting.json")
-    monkeypatch.setattr(state, "WORKSPACE_DIR", council / "workspace")
-    monkeypatch.setattr(state, "PROMPTS_DIR", council / "prompts")
-    return council
+def council_root(tmp_path, monkeypatch):
+    """Point the council root at a temp dir; all per-name paths derive from it."""
+    root = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_ROOT", root)
+    return root
 
 
 def _sitting(**overrides) -> state.Sitting:
     base = dict(
-        orchestrator=state.ORCHESTRATOR_SESSION,
+        orchestrator=state.orchestrator_for(NAME),
         roster=["brain", "gut"],
-        sessions={"brain": "council-brain", "gut": "council-gut"},
+        sessions={
+            "brain": state.session_for(NAME, "brain"),
+            "gut": state.session_for(NAME, "gut"),
+        },
         started_at="2026-06-06T00:00:00+00:00",
     )
     base.update(overrides)
     return state.Sitting(**base)
 
 
+class TestPaths:
+    def test_per_name_layout(self, council_root):
+        assert state.council_dir(NAME) == council_root / NAME
+        assert state.sitting_path(NAME) == council_root / NAME / "sitting.json"
+        assert state.workspace_dir(NAME) == council_root / NAME / "workspace"
+        assert state.prompts_dir(NAME) == council_root / NAME / "prompts"
+
+    def test_session_names(self):
+        assert state.orchestrator_for(NAME) == "agentwire-council-proj"
+        assert state.session_for(NAME, "brain") == "council-proj-brain"
+        assert state.session_for("redesign", "devils-advocate") == (
+            "council-redesign-devils-advocate"
+        )
+
+    def test_two_names_are_isolated(self):
+        assert state.sitting_path("a") != state.sitting_path("b")
+        assert state.session_for("a", "brain") != state.session_for("b", "brain")
+
+
 class TestSitting:
     def test_round_trip(self):
-        state.write_sitting(_sitting())
-        loaded = state.read_sitting()
+        state.write_sitting(NAME, _sitting(cwd="/tmp/proj"))
+        loaded = state.read_sitting(NAME)
         assert loaded is not None
         assert loaded.roster == ["brain", "gut"]
-        assert loaded.sessions["gut"] == "council-gut"
+        assert loaded.sessions["gut"] == "council-proj-gut"
+        assert loaded.cwd == "/tmp/proj"
         assert loaded.next_prompt_id == 1
         assert loaded.session_type == "claude-bypass"
 
     def test_read_missing(self):
-        assert state.read_sitting() is None
+        assert state.read_sitting(NAME) is None
 
     def test_read_corrupt(self):
-        state.SITTING_PATH.parent.mkdir(parents=True)
-        state.SITTING_PATH.write_text("{not json")
-        assert state.read_sitting() is None
+        path = state.sitting_path(NAME)
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json")
+        assert state.read_sitting(NAME) is None
 
     def test_clear(self):
-        state.write_sitting(_sitting())
-        state.clear_sitting()
-        assert state.read_sitting() is None
-        state.clear_sitting()  # idempotent
+        state.write_sitting(NAME, _sitting())
+        state.clear_sitting(NAME)
+        assert state.read_sitting(NAME) is None
+        state.clear_sitting(NAME)  # idempotent
+
+    def test_concurrent_sittings_isolated(self):
+        state.write_sitting("a", _sitting(orchestrator=state.orchestrator_for("a")))
+        state.write_sitting(
+            "b",
+            _sitting(orchestrator=state.orchestrator_for("b"), roster=["critic"]),
+        )
+        assert state.read_sitting("a").roster == ["brain", "gut"]
+        assert state.read_sitting("b").roster == ["critic"]
+        state.clear_sitting("a")
+        assert state.read_sitting("a") is None
+        assert state.read_sitting("b") is not None  # the other survives
+
+
+class TestListSittings:
+    def test_empty(self):
+        assert state.list_sittings() == []
+
+    def test_lists_only_dirs_with_state(self):
+        state.write_sitting("a", _sitting())
+        state.write_sitting("redesign", _sitting())
+        # A stray dir without sitting.json (e.g. an orphaned global workspace)
+        (state.COUNCIL_ROOT / "workspace").mkdir(parents=True)
+        assert set(state.list_sittings()) == {"a", "redesign"}
 
 
 class TestPromptIds:
     def test_allocate_increments_and_persists(self):
-        state.write_sitting(_sitting())
-        assert state.allocate_prompt_id() == 1
-        assert state.allocate_prompt_id() == 2
-        assert state.read_sitting().next_prompt_id == 3
+        state.write_sitting(NAME, _sitting())
+        assert state.allocate_prompt_id(NAME) == 1
+        assert state.allocate_prompt_id(NAME) == 2
+        assert state.read_sitting(NAME).next_prompt_id == 3
 
     def test_allocate_without_sitting_raises(self):
         with pytest.raises(RuntimeError):
-            state.allocate_prompt_id()
+            state.allocate_prompt_id(NAME)
+
+    def test_counters_are_per_name(self):
+        state.write_sitting("a", _sitting())
+        state.write_sitting("b", _sitting())
+        state.allocate_prompt_id("a")
+        state.allocate_prompt_id("a")
+        assert state.latest_prompt_id("a") == 2
+        assert state.latest_prompt_id("b") is None  # untouched
 
     def test_latest_none_before_first_ask(self):
-        state.write_sitting(_sitting())
-        assert state.latest_prompt_id() is None
-
-    def test_latest_after_allocations(self):
-        state.write_sitting(_sitting())
-        state.allocate_prompt_id()
-        state.allocate_prompt_id()
-        assert state.latest_prompt_id() == 2
+        state.write_sitting(NAME, _sitting())
+        assert state.latest_prompt_id(NAME) is None
 
 
-class TestLensValidation:
+class TestNameValidation:
     def test_valid(self):
-        for name in ["brain", "devils-advocate", "x2"]:
+        for name in ["brain", "devils-advocate", "x2", "redesign", "agentwire-dev"]:
+            assert state.valid_name(name)
             assert state.valid_lens(name)
 
     def test_invalid(self):
-        for name in ["", "Brain", "a b", "../etc", "-lead", "a/b"]:
-            assert not state.valid_lens(name)
+        for name in ["", "Brain", "a b", "../etc", "-lead", "a/b", "a.b", "a:b"]:
+            assert not state.valid_name(name)
 
-    def test_session_for(self):
-        assert state.session_for("brain") == "council-brain"
+
+class TestDefaultName:
+    def test_slugifies_dir_basename(self, tmp_path):
+        d = tmp_path / "My Project"
+        d.mkdir()
+        # Not a git repo → git_root returns None, falls back to the dir itself.
+        name = state.default_name(d)
+        assert state.valid_name(name)
+        assert name.startswith("my-project")
+
+    def test_is_capped_and_hashed_when_long(self, tmp_path):
+        long = tmp_path / ("x" * 60)
+        long.mkdir()
+        name = state.default_name(long)
+        assert state.valid_name(name)
+        assert len(name) <= state._NAME_MAX
+
+    def test_deterministic(self, tmp_path):
+        d = tmp_path / "repo"
+        d.mkdir()
+        assert state.default_name(d) == state.default_name(d)


### PR DESCRIPTION
## What

De-singletons the council. It was a **global singleton** — fixed session names (`council-<lens>`, orchestrator `agentwire-council`), one global `sitting.json` + `workspace/` + `prompts/`, and `start` refused a second sitting while one was live. You couldn't seat independent councils for two projects concurrently.

Now every sitting is **namespaced by `<name>`**, so unlimited councils run concurrently, fully isolated.

## Design (per #357 / council R3 consensus)

**Layout** — `~/.agentwire/council/<name>/{sitting.json,workspace,prompts}`. Sessions `council-<name>-<lens>`; orchestrator `agentwire-council-<name>`. Global layout deleted outright (no-backwards-compat, pre-launch).

**Targeting** (every command, echoed): explicit `--name` → cwd-repo-slug *if it matches a live sitting* → the *sole* live sitting → else **error + candidate list**. Never guesses by recency. 0 live → hard error (never auto-starts a 7-pane roster as a side effect); 1 → use it; N ambiguous → refuse + demand `--name`. **Every command echoes which sitting it hit** (`→ council 'name'`).

**Naming** — `<name>` validated by the existing `_LENS_RE`; cwd-derived defaults slugified via the #307 worktree helper, capped ~24 chars, short path-hash appended only when truncated (derived from repo/worktree root so N worktrees don't collide).

**Invariant** — never `.split('-')` a session string to recover name/lens. `sitting.json` is the SSOT lens→session map; `reply` infers its soul by reverse-lookup, and the fanned-out prompt hands each soul the exact `reply` command with `--name` pre-filled.

**Migration** — first-run zombie sweep tears down any pre-namespace `council-*` / `agentwire-council` panes + orphaned global `sitting.json` (this zombie state has been hit live), marker-guarded to run once.

**MCP** — all 5 `council_*` tools mirror the optional `name` param + echo `[council: <name>]`; added `council_list`.

## Landmine handled first

The prompt path was hardcoded outside the CLI. Threaded `<name>` through `roles/council-member.md`, `council/__init__.py`, `inbox.py`, and the MCP refs **before** touching argparse, so souls never read the wrong/empty dir.

## New surface

- `agentwire council list` — issues.sh-style table: name · cwd · age · live/total sessions · prompts, oldest-first (age column surfaces forgotten token-burning sittings).
- `--name` on `start`/`stop`/`status`/`ask`/`collect`/`reply`.

## Verification

- `uv run --extra dev pytest -q -m "not requires_tmux"` → **1399 passed**.
- New tests cover: two `--name` sittings concurrent + isolated; `ask`/`collect` hit the right one; `stop --name` tears down only that sitting; the 0/1/N resolution rule + echo; SSOT soul inference (and refusal on an unmapped session — never a bad split); the legacy zombie sweep; `council list`.
- `ruff check` clean; argparse + MCP wiring smoke-checked.

Closes #357

Built by [dotdev.dev](https://dotdev.dev)