### PR TITLE
fix(portal): sidebar tab green pill (#362) + close-button hover reflow (#363)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -684,16 +684,11 @@ body {
     flex-wrap: wrap;
 }
 
-/* Session kill button — hidden until the row is hovered; confirm/killing
-   states stay visible so the second click can't lose its target. */
+/* Session kill button — always visible and occupying its flex slot, so the
+   row never reflows on hover. Confirm/killing states restyle in place. */
 .sidebar-session-close {
-    display: none;
-}
-
-.sidebar-session-card:hover .sidebar-session-close,
-.sidebar-session-close.is-confirm,
-.sidebar-session-close.is-killing {
-    display: inline-block;
+    visibility: visible;
+    opacity: 1;
 }
 
 .sidebar-session-close.is-confirm {
@@ -5620,7 +5615,7 @@ body.sidebar-pinned .sidebar-tab {
     .sidebar-tab {
         opacity: 0.9;
         font-size: 20px;
-        background: var(--accent);
-        color: var(--background);
+        background: var(--chrome);
+        color: var(--accent);
     }
 }


### PR DESCRIPTION
Two small, self-contained portal CSS fixes in `agentwire/static/css/desktop.css` (one file, one PR).

Closes #362
Closes #363

## Breadcrumb

**#362 — sidebar toggle handle solid green pill.** The mobile `@media (max-width:768px)` `.sidebar-tab` block painted the tab's *base* background full `var(--accent)` (`#4ade80`) with `opacity: 0.9`, so at ≤768px it rendered as a solid saturated-green pill at all times (overriding the correct desktop `var(--chrome)` base). Not a hover/active bug — the desktop `:hover` rule was already correct. Fix: changed that block to `background: var(--chrome); color: var(--accent);`, matching the desktop treatment (dark chrome + green chevron).

**#363 — close (✕) button shifts row content on hover.** `.sidebar-session-close` used `display: none` → `display: inline-block` on `:hover`/`.is-confirm`/`.is-killing`. Toggling `display` added/removed the button as a flex item in `.sidebar-session-row1` (`display:flex; gap:6px`); since `.sidebar-session-name` is `flex:1`, the name's right edge jumped on every hover. Fix: removed the `display` hide/reveal toggle and made the button always visible (`visibility: visible; opacity: 1`). It's a flex child with `flex-shrink:0` + padding/border, so it always occupies its slot — zero reflow. `.is-confirm`/`.is-killing` styling blocks unchanged; confirm/kill flow intact.

## Verification (in-worktree)
Inspected the static file directly (no `agentwire rebuild`, no shared-portal restart — worktree isolation):
- `.sidebar-tab` mobile block now `background: var(--chrome); color: var(--accent);` — no opaque `#4ade80` background on `.sidebar-tab` in any state.
- `.sidebar-session-close` no longer references `display`; always laid out, reserving width + 6px gap regardless of hover.

Built by [dotdev.dev](https://dotdev.dev)
