### PR TITLE
feat(voice): PTT auto-send toggle — skip transcript review (#364)

### DIFF
--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -30,6 +30,7 @@ import { armDeadKeySuppressor, disarmDeadKeySuppressor } from './dead-key-suppre
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import * as browserStt from './voice/browser-stt.js';
 import { voicePromptWrap } from './voice/prompt.js';
+import { isAutoSend } from './voice/autosend-prefs.js';
 import { initAnnouncements } from './announcement-modal.js';
 
 // State - track open windows
@@ -843,7 +844,9 @@ async function startGlobalRecording() {
         const ok = browserStt.start({
             onFinal: (text) => {
                 updateGlobalPttState('idle');
-                if (!globalSttCancelled && text) showGlobalTranscript(text);
+                if (globalSttCancelled || !text) return;
+                if (isAutoSend()) sendGlobalVoiceText(text);
+                else showGlobalTranscript(text);
             },
             onError: () => updateGlobalPttState('idle'),
         }, desktop.voiceStatus?.corrections || {});

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -18,6 +18,7 @@ import { isService, loadCustomServices } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 import * as browserTts from './voice/browser-tts.js';
 import { voicePromptWrap } from './voice/prompt.js';
+import { isAutoSend } from './voice/autosend-prefs.js';
 
 const SESSION_KEY = 'agentwire_mobile_session';
 
@@ -403,7 +404,9 @@ async function startRecording() {
         const ok = browserStt.start({
             onFinal: (text) => {
                 setPttState('idle');
-                if (!sttCancelled && text) showEditBar(text);
+                if (sttCancelled || !text) return;
+                if (isAutoSend()) sendText(text);
+                else showEditBar(text);
             },
             onError: (err) => {
                 setStatus(`Speech recognition failed: ${err}`, true);
@@ -469,8 +472,10 @@ async function transcribeUpload(blob) {
         const data = await res.json();
         if (data.error) throw new Error(data.error);
         const text = data.text?.trim();
-        if (text) showEditBar(text);
-        else setStatus('No speech detected', true);
+        if (text) {
+            if (isAutoSend()) sendText(text);
+            else showEditBar(text);
+        } else setStatus('No speech detected', true);
     } catch (err) {
         console.error('[Mobile] Transcription failed:', err);
         setStatus(err.message || 'Transcription failed', true);

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -15,6 +15,7 @@ import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
 import { ansiToHtml } from './utils/ansi.js';
 import * as browserStt from './voice/browser-stt.js';
 import { voicePromptWrap } from './voice/prompt.js';
+import { isAutoSend } from './voice/autosend-prefs.js';
 
 const NARROW_VIEWPORT = '(max-width: 768px)';
 function pickTerminalFontSize() {
@@ -1161,7 +1162,9 @@ export class SessionWindow {
             const ok = browserStt.start({
                 onFinal: (text) => {
                     this._setPTTState('idle');
-                    if (!this._sttCancelled && text) this._showTranscriptBar(text);
+                    if (this._sttCancelled || !text) return;
+                    if (isAutoSend()) this._sendVoiceText(text);
+                    else this._showTranscriptBar(text);
                 },
                 onError: (err) => {
                     this._updateStatus('error', `Speech recognition failed: ${err}`);

--- a/agentwire/static/js/sidebar/config-section.js
+++ b/agentwire/static/js/sidebar/config-section.js
@@ -7,6 +7,7 @@ import {
 import {
     getPermission, isMuted, setMuted, enableNotifications,
 } from '../notification-prefs.js';
+import { isAutoSend, setAutoSend, AUTOSEND_EVENT } from '../voice/autosend-prefs.js';
 
 function renderDisplayPrefs() {
     const current = getTerminalFontSize();
@@ -72,6 +73,38 @@ function bindNotificationPrefs(body) {
     wire();
 }
 
+function renderAutoSendPref() {
+    const on = isAutoSend();
+    return `<div class="sidebar-display-prefs" data-autosend-block>
+        <div class="sidebar-display-row">
+            <label class="sidebar-config-key">Voice auto-send</label>
+            <label class="sidebar-notif-mute"><input type="checkbox" data-action="voice-autosend"${on ? ' checked' : ''}/> ${on ? 'on' : 'off'}</label>
+        </div>
+        <div class="sidebar-display-row">
+            <span class="sidebar-display-hint">Skip transcript review — send on release</span>
+        </div>
+    </div>`;
+}
+
+function bindAutoSendPref(body) {
+    const repaint = () => {
+        const block = body.querySelector('[data-autosend-block]');
+        if (!block) return;
+        const tmp = document.createElement('div');
+        tmp.innerHTML = renderAutoSendPref();
+        block.replaceWith(tmp.firstElementChild);
+        wire();
+    };
+    function wire() {
+        body.querySelector('[data-action="voice-autosend"]')?.addEventListener('change', (e) => {
+            setAutoSend(e.target.checked);
+        });
+    }
+    wire();
+    window.addEventListener(AUTOSEND_EVENT, repaint);
+    body._autoSendRepaint = repaint;
+}
+
 function bindDisplayPrefs(body) {
     const slider = body.querySelector('#termFontSize');
     const valueEl = body.querySelector('[data-display="size"]');
@@ -106,13 +139,15 @@ export const configSection = {
                 else if (typeof value === 'object') display = `<code>${JSON.stringify(value)}</code>`;
                 return `<div class="sidebar-config-item"><span class="sidebar-config-key">${key}</span><span class="sidebar-config-val">${display}</span></div>`;
             }).join('');
-            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + itemHtml;
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + itemHtml;
             bindDisplayPrefs(body);
             bindNotificationPrefs(body);
+            bindAutoSendPref(body);
         } catch (e) {
-            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + '<div class="sidebar-empty">Failed to load config</div>';
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + '<div class="sidebar-empty">Failed to load config</div>';
             bindDisplayPrefs(body);
             bindNotificationPrefs(body);
+            bindAutoSendPref(body);
         }
     },
 };

--- a/agentwire/static/js/voice/autosend-prefs.js
+++ b/agentwire/static/js/voice/autosend-prefs.js
@@ -1,0 +1,25 @@
+/**
+ * Push-to-talk auto-send preference — frontend-only, per-browser.
+ *
+ * When off (default), a final transcript drops into the edit-before-send bar
+ * and the user confirms with Enter/➤. When on, the transcript is sent
+ * immediately on release, skipping the bar.
+ *
+ * Persisted in localStorage so it survives reloads and is independent per
+ * device (mobile vs desktop), which a single server config could not do.
+ * Changing it dispatches `voice-autosend-change` on window so the Config
+ * sidebar (and anything else) can repaint.
+ */
+
+const AUTOSEND_KEY = 'aw-voice-autosend';
+export const AUTOSEND_EVENT = 'voice-autosend-change';
+
+export function isAutoSend() {
+    return localStorage.getItem(AUTOSEND_KEY) === '1';
+}
+
+export function setAutoSend(on) {
+    if (on) localStorage.setItem(AUTOSEND_KEY, '1');
+    else localStorage.removeItem(AUTOSEND_KEY);
+    window.dispatchEvent(new CustomEvent(AUTOSEND_EVENT));
+}


### PR DESCRIPTION
## Summary

Adds a portal UI toggle for push-to-talk **auto-send**: when on, a final transcript is sent immediately on release, skipping the edit-before-send bar. Default stays review-before-send.

## Breadcrumb

- **New pref module** `static/js/voice/autosend-prefs.js` — mirrors `notification-prefs.js`: `isAutoSend()`/`setAutoSend(on)` over `localStorage['aw-voice-autosend']` (default off), dispatches `AUTOSEND_EVENT` on change. Per-browser so it reaches mobile + desktop independently.
- **Config sidebar** `static/js/sidebar/config-section.js` — `renderAutoSendPref()` (checkbox `data-action="voice-autosend"`, hint "Skip transcript review — send on release") + `bindAutoSendPref()` (change→`setAutoSend`, repaint on `AUTOSEND_EVENT`); included after the notification block.
- **Gated the send in all three PTT consumers** (browser-STT `onFinal`), with the `sttCancelled`/empty-transcript guards kept *ahead* of the gate so a cancelled/empty transcript never auto-sends:
  - `desktop.js` → `isAutoSend() ? sendGlobalVoiceText(text) : showGlobalTranscript(text)`
  - `session-window.js` → `isAutoSend() ? this._sendVoiceText(text) : this._showTranscriptBar(text)`
  - `mobile.js` → `isAutoSend() ? sendText(text) : showEditBar(text)`
- **Mobile cloud parity**: mobile reviews on every tier today, so `transcribeUpload` honors the toggle too (desktop/session cloud already auto-send).

## Verification (in-worktree; shared portal not rebuilt/restarted)

- `node --check` passes on all 5 files.
- Isolated behavioral test of `autosend-prefs.js` (localStorage shim): default off, persists `'1'`, removes key when off, dispatches a change event each set — all pass.
- Live click-path verification (Config toggle persists + repaints, all three surfaces auto-send when on / show bar when off) deferred to post-merge since it needs the shared portal restarted.

Closes #364

Built by [dotdev.dev](https://dotdev.dev)