### PR TITLE
fix(stt): split tier (stt.backend) from engine (stt.engine) selector

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -77,9 +77,12 @@ tts:
   timeout: 60
 
 stt:
-  backend: "default"  # tier: default (browser speech recognition) | cloud (portal → hosted
-                      # OpenAI-compatible transcription API, no shim daemon) | custom
-                      # (self-hosted shim at url)
+  backend: "default"  # TIER (where transcription happens): default (browser speech
+                      # recognition) | cloud (portal → hosted OpenAI-compatible
+                      # transcription API, no shim daemon) | custom (self-hosted shim at url)
+  engine: "auto"      # ENGINE (which model the self-hosted shim loads): auto | moonshine |
+                      # whisper. Orthogonal to backend — used only by `agentwire stt start/serve`.
+                      # `{backend: custom, engine: whisper}` = boot shim AND run faster-whisper.
   url: "http://localhost:8101"  # custom tier only — shim endpoint
   cloud:  # cloud tier only — all fields optional, defaults shown
     base_url: "https://api.openai.com/v1"  # any OpenAI-compatible endpoint (Groq, Mistral, speaches, ...)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -1790,7 +1790,7 @@ def cmd_stt_start(args) -> int:
     config = load_config()
     stt_config = config.get("stt", {})
     model = args.model or stt_config.get("model", "base")
-    backend = getattr(args, 'backend', None) or stt_config.get("backend", "auto")
+    backend = getattr(args, 'backend', None) or stt_config.get("engine", "auto")
     moonshine_model = stt_config.get("moonshine_model", "moonshine/base")
 
     # Find agentwire source directory (for running from source venv)
@@ -1830,7 +1830,7 @@ def cmd_stt_serve(args) -> int:
     config = load_config()
     stt_config = config.get("stt", {})
     model = args.model or stt_config.get("model", "base")
-    backend = getattr(args, 'backend', None) or stt_config.get("backend", "auto")
+    backend = getattr(args, 'backend', None) or stt_config.get("engine", "auto")
     moonshine_model = stt_config.get("moonshine_model", "moonshine/base")
 
     os.environ["WHISPER_MODEL"] = model

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -197,7 +197,11 @@ class STTConfig:
     implementing the contract (docs/wiki/voice/shim-contract.md).
     """
 
-    backend: str = "default"  # default | cloud | custom
+    backend: str = "default"  # TIER: default | cloud | custom (portal/host selector)
+    # ENGINE: auto | moonshine | whisper — which model the self-hosted STT
+    # shim loads (engine.py). Orthogonal to `backend`: the tier picks *where*
+    # transcription happens, the engine picks *which model* the custom shim runs.
+    engine: str = "auto"
     url: str | None = None  # shim URL (required for custom backend)
     timeout: int = 30
     # cloud tier settings — any provider speaking the OpenAI transcription
@@ -222,6 +226,11 @@ class STTConfig:
         _validate_voice_backend(
             "stt", self.backend, self.url, allowed=("default", "cloud", "custom")
         )
+        allowed_engines = ("auto", "moonshine", "whisper")
+        if self.engine not in allowed_engines:
+            raise ValueError(
+                f"stt.engine must be one of {allowed_engines}, got '{self.engine}'"
+            )
 
 
 @dataclass
@@ -573,6 +582,7 @@ def _dict_to_config(data: dict) -> Config:
     stt_data = data.get("stt", {})
     stt = STTConfig(
         backend=stt_data.get("backend", "default"),
+        engine=stt_data.get("engine", "auto"),
         url=stt_data.get("url"),
         timeout=stt_data.get("timeout", 30),
         cloud=stt_data.get("cloud") or {},

--- a/docs/wiki/voice/stt-self-hosted.md
+++ b/docs/wiki/voice/stt-self-hosted.md
@@ -12,7 +12,7 @@ AgentWire ships a local STT server (`agentwire stt start`) that the portal calls
 | `faster-whisper` | `tiny` → `large-v3` | CPU or CUDA | Higher accuracy, slower cold start. |
 | `openai-whisper` | `tiny` → `large` | CPU or CUDA | Fallback when neither of the above is installed. |
 
-Pick a backend via `STT_BACKEND=moonshine|whisper` (or `agentwire stt start --backend ...`). Model name via `MOONSHINE_MODEL=...` or `WHISPER_MODEL=...`.
+Pick an engine via the config key `stt.engine: auto|moonshine|whisper` (default `auto` — moonshine first, whisper fallback). This is **orthogonal to `stt.backend`**, which is the portal *tier* (`default|cloud|custom`): the tier decides *where* transcription happens, the engine decides *which model* the self-hosted shim loads. So `stt: {backend: custom, engine: whisper}` boots the shim **and** runs faster-whisper. Equivalent overrides for ad-hoc use: `STT_BACKEND=moonshine|whisper` env or `agentwire stt start --backend ...`. Model name via `MOONSHINE_MODEL=...` or `WHISPER_MODEL=...`.
 
 Don't want to run local models at all? That's not a shim concern — use the
 portal's [`stt.backend: cloud` tier](stt-cloud.md) (hosted transcription API,

--- a/tests/unit/test_stt_engine.py
+++ b/tests/unit/test_stt_engine.py
@@ -82,6 +82,54 @@ class TestBackendSelection:
         assert info["backend"] == "moonshine"
 
 
+class TestEngineConfigFlow:
+    """The `stt.engine` tier-orthogonal selector reaches load_backend.
+
+    Regression for the overloaded `stt.backend` (#365): the tier value
+    `custom` must never be what the engine sees — the engine reads
+    `stt.engine`, so `{backend: custom, engine: whisper}` forces whisper.
+    """
+
+    def test_engine_config_forces_whisper(self, monkeypatch):
+        from agentwire.config import _dict_to_config
+
+        cfg = _dict_to_config(
+            {"stt": {"backend": "custom", "url": "http://shim", "engine": "whisper"}}
+        )
+        assert cfg.stt.backend == "custom"  # tier — shim boots
+        assert cfg.stt.engine == "whisper"  # engine — model selector
+
+        # The engine value (not the tier) drives load_backend.
+        sentinel = object()
+        monkeypatch.setattr(
+            engine,
+            "_load_faster_whisper",
+            lambda m, d: (sentinel, {"backend": "faster-whisper", "model": m, "device": d}),
+        )
+
+        # moonshine must NOT be consulted when whisper is forced
+        def fail(*a, **k):
+            raise AssertionError("moonshine should not load when engine=whisper")
+
+        monkeypatch.setattr(engine, "_load_moonshine", fail)
+
+        model, info = engine.load_backend(backend=cfg.stt.engine)
+        assert model is sentinel
+        assert info["backend"] == "faster-whisper"
+
+    def test_engine_defaults_to_auto(self):
+        from agentwire.config import _dict_to_config
+
+        cfg = _dict_to_config({"stt": {"backend": "custom", "url": "http://shim"}})
+        assert cfg.stt.engine == "auto"
+
+    def test_invalid_engine_rejected(self):
+        from agentwire.config import _dict_to_config
+
+        with pytest.raises(ValueError, match="stt.engine"):
+            _dict_to_config({"stt": {"engine": "custom"}})
+
+
 class TestTranscribe:
     def test_transcribe_without_backend_raises(self):
         with pytest.raises(RuntimeError, match="not loaded"):


### PR DESCRIPTION
## What & why

`stt.backend` was overloaded across two layers, masked by a silent fallback:

- **Tier** (`default|cloud|custom`) — the portal/host selector. Correct, validated, referenced across ~10 Python + 4 JS + 6 doc sites.
- **Engine** (`auto|moonshine|whisper`) — the STT-server model selector, read off the *same* key by `cmd_stt_start`/`cmd_stt_serve`.

The value-sets are disjoint. `backend: custom` satisfied the tier, then exported `STT_BACKEND=custom` into the engine, where `load_backend("custom")` hit the `Unknown STT_BACKEND 'custom', falling back to auto` path. It landed on a sane engine *by accident*, and an operator could not select whisper through config.

## Change

- **`config.py`**: add `engine: str = "auto"` to `STTConfig`; parse in `_dict_to_config` (`engine=stt_data.get("engine","auto")`); validate against `(auto, moonshine, whisper)` in `__post_init__`.
- **`__main__.py`**: `cmd_stt_start`/`cmd_stt_serve` read `stt.engine` (was `stt.backend`). `STT_BACKEND=custom` is never emitted.
- **`engine.py`**: unchanged — keeps the soft coerce-to-auto as defense-in-depth for the raw env path (so the existing `test_unknown_backend_coerced_to_auto` stays green).
- **Docs/skill**: `stt-self-hosted.md` + `agentwire-config/SKILL.md` now document tier vs engine. `architecture.md` / `troubleshooting.md` had no "backend selects the engine" phrasing — left as-is.
- **Test**: new `TestEngineConfigFlow` asserts `{backend: custom, engine: whisper}` forces faster-whisper through `load_backend`, defaults to `auto`, and rejects an invalid engine.

**Must-NOT-change tier sites** (`listen.py`, `start`/`doctor`, `stt/__init__.py`, `server.py`, frontend JS, `mcp_server.py`) intentionally untouched. CLI `--backend` flag and `STT_BACKEND` env name kept (already engine vocabulary).

#368 and #369 depend on this engine/tier split landing cleanly.

## Verification (in-worktree, no rebuild/restart)

- `tests/unit/test_stt_engine.py` — 12 passed (9 original + 3 new).
- `test_stt_backend.py`, `test_stt_cloud.py`, `test_config.py` — all green (76 total).
- Confirmed `_dict_to_config({stt:{backend:custom,url:...,engine:whisper}})` → `backend=custom`, `engine=whisper`.

Closes #365

Built by [dotdev.dev](https://dotdev.dev)
