### PR TITLE
feat(stt): listen stop --stdout + moonshine host STT docs (#368)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -92,7 +92,9 @@ agentwire services down <name>  # stop AND keep stopped (watchdog won't respawn)
 
 # TTS/STT servers
 agentwire tts start|stop|status # TTS server management
-agentwire stt start|stop|status # STT server management
+agentwire stt start|stop|status # STT server management (host shim on :8101)
+agentwire stt start             # engine from stt.engine (auto|moonshine|whisper); moonshine = fast CPU
+agentwire stt start --backend moonshine --model moonshine/base --port 8101  # ad-hoc overrides
 
 # Voice
 agentwire say "text"            # speak (auto-routes to browser or local)
@@ -121,7 +123,11 @@ agentwire msg flush -s name                  # attempt a drain now (still gated 
                                 # `msg` NEVER clobbers a human's draft — unlike `send`, which
                                 # pastes + Enter immediately. Use `send` only to forcibly drive a session now.
 
-agentwire listen start|stop|cancel  # voice recording
+agentwire listen start|stop|cancel  # host voice recording (needs stt.backend: custom + the :8101 shim)
+agentwire listen stop -s name   # transcribe + send to a tmux session (default)
+agentwire listen stop --type    # transcribe + type at cursor (Hammerspoon paste)
+agentwire listen stop --stdout  # transcribe + print raw transcript to stdout, no paste/send
+                                #   (scripting hook — Hammerspoon etc. capture $())
 
 # Voice cloning
 agentwire voiceclone start      # start recording voice sample

--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -83,7 +83,9 @@ stt:
   engine: "auto"      # ENGINE (which model the self-hosted shim loads): auto | moonshine |
                       # whisper. Orthogonal to backend — used only by `agentwire stt start/serve`.
                       # `{backend: custom, engine: whisper}` = boot shim AND run faster-whisper.
-  url: "http://localhost:8101"  # custom tier only — shim endpoint
+  moonshine_model: "moonshine/base"  # moonshine engine only — ONNX model id (moonshine/tiny | moonshine/base)
+  model: "base"       # whisper engine only — faster-whisper/openai-whisper model (tiny → large-v3)
+  url: "http://localhost:8101"  # custom tier only — shim endpoint (also the `agentwire stt` port)
   cloud:  # cloud tier only — all fields optional, defaults shown
     base_url: "https://api.openai.com/v1"  # any OpenAI-compatible endpoint (Groq, Mistral, speaches, ...)
     model: "gpt-4o-mini-transcribe"

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6609,7 +6609,9 @@ def cmd_listen_stop(args) -> int:
     from .listen import stop_recording
     session = args.session or "agentwire"
     type_at_cursor = getattr(args, 'type', False)
-    return stop_recording(session, voice_prompt=not args.no_prompt, type_at_cursor=type_at_cursor)
+    transcribe_only = getattr(args, 'stdout', False)
+    return stop_recording(session, voice_prompt=not args.no_prompt,
+                          type_at_cursor=type_at_cursor, transcribe_only=transcribe_only)
 
 
 def cmd_listen_cancel(args) -> int:
@@ -11093,6 +11095,7 @@ def main() -> int:
     listen_stop.add_argument("--session", "-s", type=str, help="Target session")
     listen_stop.add_argument("--no-prompt", action="store_true")
     listen_stop.add_argument("--type", action="store_true", help="Type at cursor instead of sending to session")
+    listen_stop.add_argument("--stdout", action="store_true", help="Print the raw transcript to stdout (no paste, no tmux send)")
     listen_stop.set_defaults(func=cmd_listen_stop)
 
     # listen cancel

--- a/agentwire/listen.py
+++ b/agentwire/listen.py
@@ -205,13 +205,16 @@ def start_recording() -> int:
     return 0
 
 
-def stop_recording(session: str, voice_prompt: bool = True, type_at_cursor: bool = False) -> int:
+def stop_recording(session: str, voice_prompt: bool = True, type_at_cursor: bool = False,
+                   transcribe_only: bool = False) -> int:
     """Stop recording, transcribe, and send to session or type at cursor.
 
     Args:
-        session: Target tmux session (ignored if type_at_cursor=True)
-        voice_prompt: Prepend voice prompt hint (ignored if type_at_cursor=True)
+        session: Target tmux session (ignored if type_at_cursor/transcribe_only)
+        voice_prompt: Prepend voice prompt hint (ignored if type_at_cursor/transcribe_only)
         type_at_cursor: If True, type text at cursor instead of sending to session
+        transcribe_only: If True, print the raw transcript to stdout and return,
+            without typing at cursor or sending to a tmux session
     """
     log("stop_recording called")
 
@@ -299,6 +302,16 @@ def stop_recording(session: str, voice_prompt: bool = True, type_at_cursor: bool
         return 1
 
     log(f"Transcribed: {text}")
+
+    if transcribe_only:
+        # Print the raw transcript to stdout for scripting (e.g. Hammerspoon),
+        # no pasting and no tmux send. stdout carries only the transcript;
+        # log() goes to the debug file and notify()/beep() are out-of-band.
+        beep("done")
+        notify(f"Transcribed: {text[:30]}...")
+        print(text)
+        AUDIO_FILE.unlink(missing_ok=True)
+        return 0
 
     if type_at_cursor:
         # Type at cursor using Hammerspoon

--- a/docs/wiki/voice/stt-self-hosted.md
+++ b/docs/wiki/voice/stt-self-hosted.md
@@ -12,7 +12,14 @@ AgentWire ships a local STT server (`agentwire stt start`) that the portal calls
 | `faster-whisper` | `tiny` → `large-v3` | CPU or CUDA | Higher accuracy, slower cold start. |
 | `openai-whisper` | `tiny` → `large` | CPU or CUDA | Fallback when neither of the above is installed. |
 
-Pick an engine via the config key `stt.engine: auto|moonshine|whisper` (default `auto` — moonshine first, whisper fallback). This is **orthogonal to `stt.backend`**, which is the portal *tier* (`default|cloud|custom`): the tier decides *where* transcription happens, the engine decides *which model* the self-hosted shim loads. So `stt: {backend: custom, engine: whisper}` boots the shim **and** runs faster-whisper. Equivalent overrides for ad-hoc use: `STT_BACKEND=moonshine|whisper` env or `agentwire stt start --backend ...`. Model name via `MOONSHINE_MODEL=...` or `WHISPER_MODEL=...`.
+Pick an engine via the config key `stt.engine: auto|moonshine|whisper` (default `auto` — moonshine first, whisper fallback). This is **orthogonal to `stt.backend`**, which is the portal *tier* (`default|cloud|custom`): the tier decides *where* transcription happens, the engine decides *which model* the self-hosted shim loads. So `stt: {backend: custom, engine: moonshine}` boots the host shim on `:8101` **and** runs Moonshine ONNX; swap `engine: whisper` to run faster-whisper instead. Equivalent overrides for ad-hoc use: `STT_BACKEND=moonshine|whisper` env or `agentwire stt start --backend ...`.
+
+Model name comes from the engine-specific config key:
+
+- **moonshine** → `stt.moonshine_model` (default `moonshine/base`; `moonshine/tiny` is faster, slightly less accurate). Env/flag override: `MOONSHINE_MODEL=...` or `agentwire stt start --model ...`.
+- **whisper** → `stt.model` (default `base`, `tiny` → `large-v3`). Env override: `WHISPER_MODEL=...`.
+
+`agentwire stt start` reads these and env-passes them to the server, which always listens on `:8101` (`--port` to override). The host shim is what `agentwire listen` records into — see [Host recording](#host-recording-agentwire-listen) below.
 
 Don't want to run local models at all? That's not a shim concern — use the
 portal's [`stt.backend: cloud` tier](stt-cloud.md) (hosted transcription API,
@@ -101,6 +108,35 @@ for i in 1 2 3 4 5; do
   /usr/bin/time -p curl -s -F "audio=@/tmp/tone.webm" http://localhost:8765/transcribe > /dev/null
 done
 ```
+
+## Host recording (`agentwire listen`)
+
+The portal records in the browser, but `agentwire listen` records **on the host**
+(via `ffmpeg`) and POSTs the audio straight to the `:8101` shim — so it requires
+`stt.backend: custom` and a reachable `stt.url` (default `http://localhost:8101`).
+The default tier transcribes in the browser and is unreachable from the CLI, so
+`listen` refuses to run without the custom shim.
+
+```bash
+agentwire listen start        # begin recording (ffmpeg)
+agentwire listen stop         # stop, transcribe, send to a tmux session (default "agentwire")
+agentwire listen cancel       # abandon the recording
+agentwire listen              # no subcommand = toggle (start if idle, stop if recording)
+```
+
+`listen stop` has three mutually exclusive output modes:
+
+| Flag | What it does with the transcript |
+|------|----------------------------------|
+| *(none)* | `agentwire send` it to the target tmux session (`-s`, default `agentwire`). |
+| `--type` | Type it at the cursor via Hammerspoon (clipboard paste + Enter). |
+| `--stdout` | Print the **raw transcript to stdout** and exit `0` — no paste, no tmux send. |
+
+`--stdout` is the scripting hook: stdout carries only the transcript (debug logging
+goes to the listen debug file; beeps/notifications are out-of-band), so a wrapper can
+capture it with `text=$(agentwire listen stop --stdout)`. This is what a Hammerspoon
+binding uses to grab a transcript without committing to paste-at-cursor. It's a
+**stop-only** flag — the no-subcommand toggle always sends to the session.
 
 ## Sidebar: CoreML execution provider is a net loss on moonshine_onnx
 


### PR DESCRIPTION
Closes #368

## Breadcrumb

Two parts from #368.

**Part 3 — `agentwire listen stop --stdout` (net-new code).** Added a third `transcribe_only` branch in `stop_recording` (`agentwire/listen.py`), right after the `Transcribed:` log line and *before* the `type_at_cursor` dispatch: it prints the raw transcript to stdout and returns `0` — no Hammerspoon paste, no `agentwire send` to tmux. stdout carries only the transcript (`log()` → debug file, `beep`/`notify` are out-of-band), so a wrapper can `text=$(agentwire listen stop --stdout)`. Wired `--stdout` through `cmd_listen_stop` and the `listen stop` parser in `__main__.py`. It inherits the existing `stt.backend: custom` + `stt.url` (:8101) requirement.

  **Toggle decision:** stop-only. The no-subcommand toggle (`cmd_listen_toggle`) is a single-hotkey start/stop with nowhere to surface stdout; `--stdout` is an explicit `listen stop` scripting flag. #369's Hammerspoon ref will call `listen stop --stdout` directly — that's the dependency this lands.

**Part 1 — moonshine host STT docs.** The `stt.backend`/`stt.engine` split from #365/#373 already merged, so selection is documented via `stt.engine: moonshine` (the tier `stt.backend` decides *where*, the engine decides *which model* the :8101 shim loads), **not** the `--backend moonshine` workaround. Documented `stt.moonshine_model` (default `moonshine/base`) — it was previously documented nowhere. Updated `docs/wiki/voice/stt-self-hosted.md` (engine→model key mapping + new "Host recording (`agentwire listen`)" section), `agentwire-cli` skill (stt/listen commands incl. `--stdout`), and `agentwire-config` skill (`moonshine_model`/`model` keys).

## Verified in-worktree

- `uv run agentwire listen stop --help` lists `--stdout`.
- `python ast.parse` clean on both edited modules.
- `pytest tests/unit/test_stt_engine.py tests/unit/test_stt_backend.py` → 16 passed.
- No shared services rebuilt/restarted; build happened in a local `.venv`.

Follow-ups from #368 left out of scope (tracked there): launchd service for :8101, `/health` 2s probe flake.

Built by [dotdev.dev](https://dotdev.dev)