### PR TITLE
docs(voice): Hammerspoon toggle PTT + voice target-picker reference (#369)

### DIFF
--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -79,6 +79,7 @@ and `custom` (any model behind a small HTTP shim).
 - **[Self-hosted TTS](voice/tts-self-hosted.md)** — the bundled reference shim's engines (Kokoro, Chatterbox, Qwen, Zonos)
 - **[Cloud STT](voice/stt-cloud.md)** — `stt.backend: cloud`, portal → any OpenAI-compatible transcription API, no shim daemon
 - **[Self-hosted STT](voice/stt-self-hosted.md)** — moonshine / faster-whisper reference shim, push-to-talk latency knobs
+- **[Hammerspoon PTT + voice picker](voice/hammerspoon-ptt.md)** — toggle push-to-talk and a voice target-picker that consumes `listen stop --stdout` (reference example)
 
 ## Internals
 

--- a/docs/wiki/communication/hammerspoon.md
+++ b/docs/wiki/communication/hammerspoon.md
@@ -2,6 +2,8 @@
 
 Global hotkeys for voice input on macOS using [Hammerspoon](https://www.hammerspoon.org/). Hold a key to record, release to send — works from any app.
 
+> Want a toggle-based variant (tap to start/stop) with a **voice target-picker** that fuzzy-matches a spoken session name? See [`voice/hammerspoon-ptt.md`](../voice/hammerspoon-ptt.md) and the runnable [`examples/hammerspoon-ptt/`](../../../examples/hammerspoon-ptt/).
+
 ## Prerequisites
 
 1. **Hammerspoon** installed (`brew install --cask hammerspoon`)

--- a/docs/wiki/voice/hammerspoon-ptt.md
+++ b/docs/wiki/voice/hammerspoon-ptt.md
@@ -1,0 +1,34 @@
+# Hammerspoon — toggle PTT + voice target-picker
+
+> Reference example. The runnable config and full setup live in
+> [`examples/hammerspoon-ptt/`](../../../examples/hammerspoon-ptt/) —
+> [`init.lua`](../../../examples/hammerspoon-ptt/init.lua) +
+> [README](../../../examples/hammerspoon-ptt/README.md).
+
+A more capable [Hammerspoon](https://www.hammerspoon.org/) config than the basic hold-to-record setup in [`communication/hammerspoon.md`](../communication/hammerspoon.md). This one is **toggle-based** (tap to start, tap to stop) and adds a **voice target-picker**: say a session name and it fuzzy-matches against your live sessions, then auto-confirms.
+
+It's the canonical consumer of **`agentwire listen stop --stdout`** — the form that prints the raw transcript to stdout (no paste, no tmux send) so an external caller can do its own thing with the text.
+
+## What it does
+
+| Chord | Action | CLI under the hood |
+|-------|--------|--------------------|
+| ⌃⌥⌘ Space | Toggle record → send to target session | `listen start` … `listen stop -s <session>` |
+| ⌃⌥⌘ T | Toggle record → type at cursor | `listen start` … `listen stop --type` |
+| ⌃⌥⌘ S | Toggle record → pick target session by voice | `listen start` … `listen stop --stdout` + `list --sessions --json` |
+
+The picker flow: record a phrase → `listen stop --stdout` captures the transcript → `list --sessions --json` gives the candidates → character-level fuzzy match picks the winner → `hs.chooser:select(row)` auto-confirms it.
+
+## Prerequisites
+
+- `brew install --cask hammerspoon`, AgentWire on PATH, and a **custom STT shim** running (`agentwire stt start`, `stt.backend: custom`). `agentwire listen` records on the host, so it can't use the browser recognizer — see [`stt-self-hosted.md`](stt-self-hosted.md) and [`shim-contract.md`](shim-contract.md).
+
+## The three gotchas
+
+These are the non-obvious bits that the example bakes in as inline comments:
+
+1. **`hs.chooser:choices()` is a setter, not a getter** — calling it with no args clears the list. Keep your own `choices` variable and fuzzy-match against that.
+2. **`hs.chooser:select(row)` fires the completion callback *and* closes the chooser** — use it to auto-confirm the fuzzy winner without a click.
+3. **Character-level fuzzy match (Levenshtein + per-word containment bonus)** — STT turns "agentwire-dev" into "agent wire dev"; a prefix/equality test misses it, so score edit-distance similarity plus a bonus per spoken word contained in the candidate.
+
+Full annotated code and troubleshooting: [`examples/hammerspoon-ptt/`](../../../examples/hammerspoon-ptt/).

--- a/examples/hammerspoon-ptt/README.md
+++ b/examples/hammerspoon-ptt/README.md
@@ -1,0 +1,52 @@
+# Hammerspoon — toggle PTT + voice target-picker
+
+A reference [Hammerspoon](https://www.hammerspoon.org/) config for AgentWire voice input on macOS. Unlike the basic hold-to-record setup ([`docs/wiki/communication/hammerspoon.md`](../../docs/wiki/communication/hammerspoon.md)), this variant is **toggle-based** (tap to start, tap to stop) and adds a **voice target-picker**: say a session name and it fuzzy-matches against your live sessions.
+
+The whole thing is in [`init.lua`](init.lua) — copy it to `~/.hammerspoon/init.lua` (or `require` it) and reload.
+
+## Prerequisites
+
+1. `brew install --cask hammerspoon`
+2. AgentWire on PATH (`~/.local/bin/agentwire`)
+3. A **custom STT shim** running: `agentwire stt start` with `stt.backend: custom` in `~/.agentwire/config.yaml`. The host CLI records on the host, so it can't use the browser-tier recognizer — see [`docs/wiki/voice/stt-self-hosted.md`](../../docs/wiki/voice/stt-self-hosted.md) and [`shim-contract.md`](../../docs/wiki/voice/shim-contract.md).
+4. `hs.ipc` (the `hs` CLI) — the script `require`s it; first load may prompt to install.
+
+## Hotkeys
+
+| Chord | Action |
+|-------|--------|
+| **⌃⌥⌘ Space** | Toggle record → send transcript to the target session |
+| **⌃⌥⌘ T** | Toggle record → type transcript at the cursor (dictation, any app) |
+| **⌃⌥⌘ S** | Toggle record → fuzzy-pick the target session by voice |
+
+Tap once to start recording, tap the **same** key to stop. The hyper chord (`ctrl+alt+cmd`) is collision-free with normal app shortcuts; change `HYPER` at the top of `init.lua` to taste.
+
+## How the voice target-picker works
+
+This is the part that consumes `agentwire listen stop --stdout` — the transcript source merged on `main`:
+
+1. **⌃⌥⌘S** → `agentwire listen start` (alert: "Say a session name…").
+2. **⌃⌥⌘S** again → `agentwire listen stop --stdout`. Unlike `-s <session>` or `--type`, `--stdout` doesn't paste or send anywhere — it prints the raw transcript to stdout, which the script captures.
+3. `agentwire list --sessions --json` → the live session list.
+4. Character-level fuzzy match (below) picks the best-scoring session.
+5. The script opens an `hs.chooser` and **auto-confirms** the winner; if no candidate clears the confidence threshold it leaves the chooser open for you to pick or type.
+
+## The three gotchas (baked into `init.lua`)
+
+These cost real time to rediscover, so they're called out inline in the code:
+
+1. **`hs.chooser:choices()` is a setter, not a getter.** Calling it with no args *clears* the list. Keep your own `choices` table and fuzzy-match against that — only ever pass the list *into* `chooser:choices(choices)`.
+
+2. **`hs.chooser:select(row)` fires the completion callback AND closes the chooser.** That's the mechanism for auto-confirm: compute the best fuzzy row, call `chooser:select(bestRow)`, and the completion callback sets `targetSession` with no click required.
+
+3. **Character-level fuzzy match (Levenshtein + per-word containment bonus).** STT mangles short jargon names — "agentwire-dev" comes back as "agent wire dev". A prefix/equality test misses that. We score `1 − (editDistance / maxLen)` and add `+0.5` for each spoken word contained in the candidate; highest combined score wins. Verified mappings: `agent wire dev → agentwire-dev`, `my project → myproject`, `web site → website`.
+
+## Troubleshooting
+
+| Problem | Check |
+|---------|-------|
+| Alert shows but no transcript | `agentwire stt status`; confirm `stt.backend: custom` |
+| Picker shows "No sessions running" | `agentwire list --sessions` from a normal shell |
+| Wrong session picked | Lower/raise `MATCH_THRESHOLD`; below it the chooser stays open for manual pick |
+| `agentwire: not found` | Fix the `agentwire` path or `PATH` at the top of `init.lua` |
+| Debug the CLI side | `tail -f /tmp/agentwire-listen.log` |

--- a/examples/hammerspoon-ptt/init.lua
+++ b/examples/hammerspoon-ptt/init.lua
@@ -1,0 +1,221 @@
+-- AgentWire — toggle push-to-talk + voice target-picker (Hammerspoon)
+-- ============================================================================
+-- Drop this in ~/.hammerspoon/init.lua (or `require` it from yours) and reload
+-- (Hammerspoon menu > Reload Config, or ⌘⇧R).
+--
+-- What you get:
+--   • Toggle PTT — tap a hotkey to start recording, tap again to stop and
+--     send the transcript to the current target session.
+--   • Toggle dictation — same, but types the transcript at your cursor.
+--   • Voice target-picker — say a session name; the script transcribes it,
+--     fuzzy-matches against your live sessions, and auto-confirms the winner.
+--
+-- It shells out to the agentwire CLI:
+--   agentwire listen start                 -- begin recording (async)
+--   agentwire listen stop -s <session>     -- stop, transcribe, send to session
+--   agentwire listen stop --type           -- stop, transcribe, type at cursor
+--   agentwire listen stop --stdout         -- stop, transcribe, print transcript
+--                                             to stdout (no paste, no tmux send)
+--   agentwire list --sessions --json       -- live session list, as JSON
+--
+-- The `--stdout` form is the key piece: it hands the raw transcript back to
+-- this script so we can fuzzy-match it ourselves instead of sending it
+-- anywhere. Requires `agentwire stt start` running with stt.backend: custom.
+-- ============================================================================
+
+require("hs.ipc")  -- needed for the `hs` CLI; first load may prompt to install
+
+-- ── Config ──────────────────────────────────────────────────────────────────
+-- A roomy PATH so the CLI's child processes (ffmpeg, etc.) resolve when
+-- Hammerspoon launches them outside your login shell.
+local PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+local agentwire = os.getenv("HOME") .. "/.local/bin/agentwire"
+
+local HYPER = {"ctrl", "alt", "cmd"}  -- conflict-free chord for our hotkeys
+local MATCH_THRESHOLD = 0.45          -- min fuzzy score to auto-confirm a pick
+
+local targetSession = "agentwire"     -- default target; resets on config reload
+
+-- ── State ─────────────────────────────────────────────────────────────────
+local recording = false   -- a PTT/dictation capture is in flight
+local modTap              -- forward decl (kept for symmetry / future eventtaps)
+
+-- ── CLI helpers ─────────────────────────────────────────────────────────────
+
+-- Fire-and-forget. Optional onDone() runs when the process exits.
+local function run(args, onDone)
+    local cmd = "PATH=" .. PATH .. " " .. agentwire .. " " .. table.concat(args, " ")
+    hs.task.new("/bin/bash", function()
+        if onDone then onDone() end
+    end, {"-c", cmd}):start()
+end
+
+-- Like run(), but hands stdout (trimmed) back to onDone(stdout).
+local function runCapture(args, onDone)
+    local cmd = "PATH=" .. PATH .. " " .. agentwire .. " " .. table.concat(args, " ")
+    hs.task.new("/bin/bash", function(_, stdout)
+        onDone((stdout or ""):gsub("%s+$", ""))
+    end, {"-c", cmd}):start()
+end
+
+-- ── Fuzzy matching ───────────────────────────────────────────────────────────
+-- STT mangles short, jargon-y session names ("agentwire-dev" → "agent wire dev",
+-- "agent wired f"). A plain equality or prefix test misses those, so we score
+-- character-level similarity (Levenshtein) and add a bonus for each spoken word
+-- that's contained in the candidate. Highest combined score wins.
+
+-- Character-level edit distance. Two rolling rows, O(min) memory.
+local function levenshtein(a, b)
+    local la, lb = #a, #b
+    if la == 0 then return lb end
+    if lb == 0 then return la end
+    local prev, cur = {}, {}
+    for j = 0, lb do prev[j] = j end
+    for i = 1, la do
+        cur[0] = i
+        local ca = a:byte(i)
+        for j = 1, lb do
+            local cost = (ca == b:byte(j)) and 0 or 1
+            cur[j] = math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost)
+        end
+        prev, cur = cur, prev   -- swap; the finished row is now in `prev`
+    end
+    return prev[lb]
+end
+
+-- 0..1 char-level similarity, plus +0.5 per spoken word found in the candidate.
+local function matchScore(query, candidate)
+    query, candidate = query:lower(), candidate:lower()
+    local dist = levenshtein(query, candidate)
+    local maxLen = math.max(#query, #candidate, 1)
+    local sim = 1 - (dist / maxLen)
+
+    local bonus = 0
+    for word in query:gmatch("%S+") do
+        if #word >= 2 and candidate:find(word, 1, true) then
+            bonus = bonus + 0.5
+        end
+    end
+    return sim + bonus
+end
+
+-- ── Voice target-picker ───────────────────────────────────────────────────────
+
+-- Fetch live sessions as JSON and hand the array to onSessions(list).
+local function fetchSessions(onSessions)
+    runCapture({"list", "--sessions", "--json"}, function(stdout)
+        local ok, data = pcall(hs.json.decode, stdout)
+        if ok and data and data.sessions then
+            onSessions(data.sessions)
+        else
+            onSessions({})
+        end
+    end)
+end
+
+-- Build a populated chooser and auto-confirm the best fuzzy match for `heard`.
+local function showPicker(heard, sessions)
+    if #sessions == 0 then
+        hs.alert.show("No sessions running")
+        return
+    end
+
+    -- GOTCHA #1 — hs.chooser:choices() is a SETTER, not a getter.
+    -- Calling chooser:choices() with no args *clears* the list. So we keep our
+    -- own `choices` table and read fuzzy candidates from it, never from the
+    -- chooser. We only ever pass `choices` *into* chooser:choices(choices).
+    local choices = {}
+    for _, s in ipairs(sessions) do
+        choices[#choices + 1] = {
+            text = s.name,
+            subText = (s.type or "session") .. (s.machine and (" @ " .. s.machine) or ""),
+            session = s.name,
+        }
+    end
+
+    local chooser = hs.chooser.new(function(choice)
+        -- nil when the user pressed Esc / clicked away.
+        if choice then
+            targetSession = choice.session
+            hs.alert.show("🎯 Target: " .. targetSession, 1)
+        end
+    end)
+    chooser:choices(choices)                  -- setter call: hand it the list
+    chooser:placeholderText("Heard: " .. heard)
+
+    -- Score every row against our own `choices` var (see GOTCHA #1).
+    local bestRow, bestScore = nil, -1
+    for i, c in ipairs(choices) do
+        local sc = matchScore(heard, c.text)
+        if sc > bestScore then
+            bestRow, bestScore = i, sc
+        end
+    end
+
+    chooser:show()
+
+    -- GOTCHA #2 — chooser:select(row) fires the completion callback AND closes
+    -- the chooser. That's exactly what we want for auto-confirm: select the
+    -- fuzzy winner and the callback above sets targetSession, no click needed.
+    -- Below the confidence threshold we leave the chooser open so the human
+    -- can pick (or type to filter) instead.
+    if bestRow and bestScore >= MATCH_THRESHOLD then
+        chooser:select(bestRow)
+    end
+end
+
+-- Toggle: first tap records, second tap stops + transcribes + opens the picker.
+local pickerArmed = false
+local function voicePickTarget()
+    if not pickerArmed then
+        pickerArmed = true
+        hs.alert.show("🎯 Say a session name…", 0.6)
+        run({"listen", "start"})
+    else
+        pickerArmed = false
+        runCapture({"listen", "stop", "--stdout"}, function(transcript)
+            if transcript == "" then
+                hs.alert.show("No speech detected")
+                return
+            end
+            fetchSessions(function(sessions)
+                showPicker(transcript, sessions)
+            end)
+        end)
+    end
+end
+
+-- ── Toggle PTT (send) and dictation (type) ───────────────────────────────────
+-- Tap to start, tap the SAME key to stop. `recording` guards both so a stray
+-- second hotkey can't double-fire `listen start`.
+
+local function toggleSend()
+    if recording then
+        recording = false
+        hs.alert.show("→ " .. targetSession, 0.6)
+        run({"listen", "stop", "-s", targetSession})
+    else
+        recording = true
+        hs.alert.show("● Recording → " .. targetSession, 0.6)
+        run({"listen", "start"})
+    end
+end
+
+local function toggleType()
+    if recording then
+        recording = false
+        hs.alert.show("⌨︎ Typing…", 0.6)
+        run({"listen", "stop", "--type"})
+    else
+        recording = true
+        hs.alert.show("● Recording (dictate)…", 0.6)
+        run({"listen", "start"})
+    end
+end
+
+-- ── Hotkeys ───────────────────────────────────────────────────────────────────
+hs.hotkey.bind(HYPER, "space", toggleSend)        -- ⌃⌥⌘Space — record → send
+hs.hotkey.bind(HYPER, "t", toggleType)            -- ⌃⌥⌘T     — record → type
+hs.hotkey.bind(HYPER, "s", voicePickTarget)       -- ⌃⌥⌘S     — pick target by voice
+
+hs.alert.show("AgentWire PTT ready → " .. targetSession .. "  (⌃⌥⌘S to retarget)")


### PR DESCRIPTION
Closes #369

Ships the toggle-based push-to-talk + voice target-picker that lived in `~/.hammerspoon/init.lua` (not version-controlled) as a runnable reference example, consuming `agentwire listen stop --stdout` (the transcript source merged to main) so the script does its own thing with the text instead of pasting/sending.

## What's here
- `examples/hammerspoon-ptt/init.lua` — annotated, syntax-checked (`luajit -bl`) config: toggle PTT (⌃⌥⌘Space send / ⌃⌥⌘T type) + voice target-picker (⌃⌥⌘S).
- `examples/hammerspoon-ptt/README.md` — prereqs, hotkeys, picker flow, gotchas, troubleshooting.
- `docs/wiki/voice/hammerspoon-ptt.md` — wiki reference page; wired into `INDEX.md` and cross-linked from the existing basic `communication/hammerspoon.md` (kept as the simpler hold-to-record variant).

## The three gotchas — baked in as inline comments
1. `hs.chooser:choices()` is a **setter**, not a getter — keep the choices list in a var; fuzzy-match against that.
2. `hs.chooser:select(row)` fires the completion callback **and** closes the chooser — used to auto-confirm the fuzzy winner with no click.
3. Character-level fuzzy match (Levenshtein + per-word containment bonus) so STT typos still match. Verified: `agent wire dev → agentwire-dev`, `my project → myproject`, `web site → website`.

## Verification (in-worktree)
- Lua parses clean (`luajit -bl init.lua`).
- Levenshtein + scoring unit-tested against realistic STT mangles — all map to the intended session, all clear the auto-confirm threshold.
- All relative doc links resolve.

Built by [dotdev.dev](https://dotdev.dev)