### PR TITLE
feat(stt): make moonshine the default — bundled + portal-owned in-process (#374)

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -77,9 +77,12 @@ tts:
   timeout: 60
 
 stt:
-  backend: "default"  # TIER (where transcription happens): default (browser speech
-                      # recognition) | cloud (portal → hosted OpenAI-compatible
-                      # transcription API, no shim daemon) | custom (self-hosted shim at url)
+  backend: "default"  # TIER (where transcription happens): default (portal-owned
+                      # in-process Moonshine — bundled, auto-downloads on first boot,
+                      # no setup; falls back to browser SpeechRecognition while it
+                      # warms up or on py3.14+) | cloud (portal → hosted OpenAI-
+                      # compatible transcription API, no shim daemon) | custom
+                      # (self-hosted shim at url)
   engine: "auto"      # ENGINE (which model the self-hosted shim loads): auto | moonshine |
                       # whisper. Orthogonal to backend — used only by `agentwire stt start/serve`.
                       # `{backend: custom, engine: whisper}` = boot shim AND run faster-whisper.

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6544,7 +6544,8 @@ def cmd_up(args) -> int:
         stt_args = Namespace(port=None, host=None, model=None, backend=None)
         cmd_stt_start(stt_args)
     else:
-        print("  STT skipped (default tier — browser speech recognition).")
+        print("  STT skipped (default tier — portal-owned Moonshine, "
+              "auto-downloads on first boot; no service needed).")
 
     # Custom services (same shared path as portal-launch autostart)
     from . import services as services_mod

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -190,11 +190,14 @@ class TTSConfig:
 class STTConfig:
     """Speech-to-text configuration.
 
-    Three tiers: ``default`` transcribes in the browser (Chrome
-    SpeechRecognition); ``cloud`` uploads audio to the portal, which POSTs
-    it to any OpenAI-compatible transcription API (no extra daemon, key
-    from env, server-side only); ``custom`` uploads audio to any HTTP shim
-    implementing the contract (docs/wiki/voice/shim-contract.md).
+    Three tiers: ``default`` transcribes on the host via the portal-owned
+    in-process Moonshine engine (bundled, auto-downloads on first boot — the
+    STT mirror of the default-tier Kokoro voice), falling back to browser
+    SpeechRecognition while the model warms up or when it can't load (py3.14+);
+    ``cloud`` uploads audio to the portal, which POSTs it to any
+    OpenAI-compatible transcription API (no extra daemon, key from env,
+    server-side only); ``custom`` uploads audio to any HTTP shim implementing
+    the contract (docs/wiki/voice/shim-contract.md).
     """
 
     backend: str = "default"  # TIER: default | cloud | custom (portal/host selector)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -188,6 +188,11 @@ class AgentWireServer:
         # tts.backend == "default".
         from .tts.local import LocalKokoro
         self.kokoro = LocalKokoro()
+        # Default-tier in-process Moonshine STT — the STT mirror of kokoro.
+        # Constructed unconditionally (cheap, no I/O); run_server starts the
+        # warm-up only when stt.backend == "default".
+        from .stt import LocalMoonshine
+        self.moonshine = LocalMoonshine()
         # Origin + token enforcement. The middleware is a pure function of
         # config — run_server() resolves the token file into
         # config.server.auth_token before constructing the server.
@@ -340,7 +345,7 @@ class AgentWireServer:
         from .agents import get_agent_backend
         from .stt import get_stt_backend
 
-        self.stt = get_stt_backend(self.config)
+        self.stt = get_stt_backend(self.config, moonshine=self.moonshine)
         self.agent = get_agent_backend(config_dict)
 
         # Create HTTP session for TTS server calls
@@ -354,6 +359,31 @@ class AgentWireServer:
         if self._http_session:
             await self._http_session.close()
         await self.kokoro.close()
+        await self.moonshine.close()
+
+    async def _on_moonshine_state_change(self, moonshine) -> None:
+        """Moonshine warm-up progress → invalidate voice-status cache + toast.
+
+        Mirrors ``_on_kokoro_state_change``. The toast is replaced in place
+        (keyed on session "moonshine-stt") so the download reads as one
+        updating notification, not a stream."""
+        self._voice_status_cache = None
+        if moonshine.state == "downloading":
+            await self._post_toast(
+                "Downloading Moonshine STT model… (one-time, ~200 MB)",
+                session="moonshine-stt", priority="normal", id_prefix="moonshine")
+        elif moonshine.state == "loading":
+            await self._post_toast(
+                "Loading Moonshine STT model…",
+                session="moonshine-stt", priority="normal", id_prefix="moonshine")
+        elif moonshine.state == "ready":
+            await self._post_toast(
+                "Host STT ready — Moonshine now transcribes your voice",
+                session="moonshine-stt", priority="normal", id_prefix="moonshine")
+        elif moonshine.state == "failed":
+            await self._post_toast(
+                f"Moonshine STT setup failed ({moonshine.error}) — using browser speech fallback",
+                session="moonshine-stt", priority="high", id_prefix="moonshine")
 
     async def _on_kokoro_state_change(self, kokoro) -> None:
         """Kokoro warm-up progress → invalidate voice-status cache + toast.
@@ -743,8 +773,19 @@ class AgentWireServer:
         stt_cfg, tts_cfg = self.config.stt, self.config.tts
 
         stt: dict = {"backend": stt_cfg.backend, "url": stt_cfg.url, "available": True}
+        # server_transcribe drives the frontend's browser-vs-upload choice: true
+        # → MediaRecorder POST /transcribe, false → browser SpeechRecognition.
+        stt["server_transcribe"] = stt_cfg.backend in ("cloud", "custom")
         if stt_cfg.backend == "custom":
             stt["available"] = await self._probe_shim(stt_cfg.url, "/health") is not None
+        elif stt_cfg.backend == "default":
+            # In-process Moonshine warm-up state (mirror of kokoro). The client
+            # only uploads once the host model is ready; until then it keeps
+            # using browser speech recognition.
+            stt["moonshine"] = {"state": self.moonshine.state, "percent": self.moonshine.percent}
+            if self.moonshine.error:
+                stt["moonshine"]["error"] = self.moonshine.error
+            stt["server_transcribe"] = self.moonshine.ready
 
         tts: dict = {"backend": tts_cfg.backend, "url": tts_cfg.url, "available": True}
         if tts_cfg.backend == "default":
@@ -772,7 +813,9 @@ class AgentWireServer:
             "stt": stt,
             "tts": tts,
             "corrections": stt_cfg.corrections,
-            "instant_mode": stt_cfg.backend == "default" and tts_cfg.backend == "default",
+            # Instant (zero-round-trip browser) mode only holds while STT stays
+            # browser-side; once host Moonshine takes over, audio uploads.
+            "instant_mode": not stt["server_transcribe"] and tts_cfg.backend == "default",
         }
         self._voice_status_cache = (now, status)
         return web.json_response(status)
@@ -5419,6 +5462,12 @@ async def run_server(config: Config):
     # ready. Cleaned up via close_backends().
     if config.tts.backend == "default":
         server.kokoro.start(server._on_kokoro_state_change)
+
+    # Warm up the default-tier Moonshine STT: background model download
+    # (one-time ~200 MB) + ONNX load. Browser SpeechRecognition covers input
+    # until ready; on py3.14+ (no package) it stays the browser path.
+    if config.stt.backend == "default":
+        server.moonshine.start(server._on_moonshine_state_change)
 
     # Cleanup old uploads on startup
     await server.cleanup_old_uploads()

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -822,8 +822,9 @@ function setupGlobalPtt() {
 }
 
 function usesBrowserStt() {
-    // cloud and custom tiers upload audio to the portal's /transcribe
-    return !['cloud', 'custom'].includes(desktop.voiceStatus?.stt?.backend);
+    // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio to
+    // the portal's /transcribe; otherwise recognition happens in the browser.
+    return !browserStt.serverTranscribes(desktop.voiceStatus);
 }
 
 let globalSttCancelled = false;

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -371,7 +371,9 @@ function setupPtt() {
 }
 
 function usesBrowserStt() {
-    return !['cloud', 'custom'].includes(voiceStatus?.stt?.backend);
+    // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio to
+    // /transcribe; otherwise recognition happens in the browser.
+    return !browserStt.serverTranscribes(voiceStatus);
 }
 
 function setPttState(state) {

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -1144,8 +1144,9 @@ export class SessionWindow {
     }
 
     _usesBrowserStt() {
-        // cloud and custom tiers upload audio to the portal's /transcribe
-        return !['cloud', 'custom'].includes(desktop.voiceStatus?.stt?.backend);
+        // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio
+        // to /transcribe; otherwise recognition happens in the browser.
+        return !browserStt.serverTranscribes(desktop.voiceStatus);
     }
 
     async _startRecording() {

--- a/agentwire/static/js/voice/browser-stt.js
+++ b/agentwire/static/js/voice/browser-stt.js
@@ -14,6 +14,17 @@ export function isSupported() {
     return Boolean(SR);
 }
 
+/**
+ * Whether the server transcribes (upload audio to /transcribe) vs. the browser
+ * (SpeechRecognition). The portal decides per /api/voice-status: true for the
+ * cloud/custom tiers, and for the default tier once in-process Moonshine is
+ * ready. Until then the default tier stays browser-side.
+ * @param {Object} voiceStatus - parsed /api/voice-status payload
+ */
+export function serverTranscribes(voiceStatus) {
+    return Boolean(voiceStatus?.stt?.server_transcribe);
+}
+
 let activeRecognition = null;
 
 /**

--- a/agentwire/stt/__init__.py
+++ b/agentwire/stt/__init__.py
@@ -6,28 +6,33 @@ from typing import Any
 
 from .base import NoSTT, STTBackend
 from .cloud import DEFAULT_API_KEY_ENV, DEFAULT_BASE_URL, DEFAULT_MODEL, CloudSTTBackend
+from .local import LocalMoonshine, LocalMoonshineBackend, moonshine_importable
 from .server_backend import STTServerBackend
 
 __all__ = [
     "CloudSTTBackend",
+    "LocalMoonshine",
+    "LocalMoonshineBackend",
     "NoSTT",
     "STTBackend",
     "STTServerBackend",
     "get_stt_backend",
+    "moonshine_importable",
 ]
 
 logger = logging.getLogger(__name__)
 
 
-def get_stt_backend(config: Any) -> STTBackend:
+def get_stt_backend(config: Any, moonshine: LocalMoonshine | None = None) -> STTBackend:
     """Get STT backend based on configuration.
 
-    Three tiers: ``stt.backend: custom`` → HTTP shim at ``stt.url``;
+    Four resolutions: ``stt.backend: custom`` → HTTP shim at ``stt.url``;
     ``stt.backend: cloud`` → OpenAI-compatible transcription API called
     directly from the portal (settings under ``stt.cloud``, key from the
     env var named by ``stt.cloud.api_key_env``); ``stt.backend: default``
-    → NoSTT sentinel (the portal transcribes in the browser, so the
-    server has no transcription role).
+    → in-process Moonshine when the portal owns a ``LocalMoonshine`` and the
+    package is importable (host transcription via ``/transcribe``), else the
+    NoSTT sentinel (browser SpeechRecognition, no server transcription role).
     """
     stt_config = getattr(config, "stt", None)
     backend = getattr(stt_config, "backend", "default") if stt_config is not None else "default"
@@ -62,6 +67,10 @@ def get_stt_backend(config: Any) -> STTBackend:
             timeout=getattr(stt_config, "timeout", 30),
             language=cloud.get("language", ""),
         )
+
+    if moonshine is not None and moonshine_importable():
+        logger.info("STT backend: in-process moonshine (default tier, host transcription)")
+        return LocalMoonshineBackend(moonshine)
 
     logger.info("STT backend: default (browser speech recognition)")
     return NoSTT()

--- a/agentwire/stt/local.py
+++ b/agentwire/stt/local.py
@@ -1,0 +1,187 @@
+"""In-process Moonshine for the default STT tier.
+
+The portal owns one LocalMoonshine instance — the STT mirror of
+``tts/local.py``'s LocalKokoro. When ``stt.backend: default``, a background
+task pulls the Moonshine ONNX weights from HuggingFace (~200 MB, one-time)
+and loads the model; until it's ready the portal keeps falling back to
+browser SpeechRecognition. The ``custom`` shim tier never touches this module.
+
+States:
+    absent       model files not downloaded, warm-up not started
+    downloading  background download in progress
+    loading      files present, ONNX session loading
+    ready        transcribe() available
+    failed       download or load error (browser fallback stays active)
+    unavailable  useful-moonshine-onnx not importable (py3.14+, ...) — terminal
+"""
+
+import asyncio
+import importlib.util
+import logging
+import os
+import wave
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from .base import STTBackend
+
+logger = logging.getLogger(__name__)
+
+# Default Moonshine variant. moonshine/base balances speed and accuracy on
+# CPU; moonshine/tiny is faster/lighter. Operator override via MOONSHINE_MODEL
+# mirrors the standalone shim (stt_server.py).
+DEFAULT_MOONSHINE_MODEL = os.environ.get("MOONSHINE_MODEL", "moonshine/base")
+
+_HF_REPO = "UsefulSensors/moonshine"
+_ONNX_FILES = ("encoder_model", "decoder_model_merged")
+
+
+def moonshine_importable() -> bool:
+    """True if useful-moonshine-onnx is installed (base install, py<3.14)."""
+    return importlib.util.find_spec("moonshine_onnx") is not None
+
+
+def _model_files_cached(model_name: str) -> bool:
+    """True if both ONNX weight files are already in the HuggingFace cache."""
+    from huggingface_hub import try_to_load_from_cache
+
+    short = model_name.split("/")[-1]
+    return all(
+        isinstance(
+            try_to_load_from_cache(
+                _HF_REPO, f"onnx/merged/{short}/float/{name}.onnx"
+            ),
+            str,
+        )
+        for name in _ONNX_FILES
+    )
+
+
+class LocalMoonshine:
+    """Owns the default-tier Moonshine engine lifecycle for the portal."""
+
+    def __init__(self, model_name: str = DEFAULT_MOONSHINE_MODEL) -> None:
+        self.model_name = model_name
+        self.state = "absent"
+        self.percent = 0
+        self.error: str | None = None
+        self._model = None
+        self._task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+        self._on_change: Callable[["LocalMoonshine"], Awaitable[None]] | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.state == "ready"
+
+    def start(
+        self, on_change: Callable[["LocalMoonshine"], Awaitable[None]] | None = None
+    ) -> None:
+        """Kick off the background download+load task (idempotent)."""
+        if self._task is not None or self.state in ("ready", "unavailable"):
+            return
+        self._on_change = on_change
+        if not moonshine_importable():
+            self.state = "unavailable"
+            self.error = "useful-moonshine-onnx not installed (requires Python <3.14)"
+            logger.warning(f"Moonshine default STT unavailable: {self.error}")
+            return
+        self._task = asyncio.get_running_loop().create_task(self._warm_up())
+
+    async def _notify(self) -> None:
+        if self._on_change:
+            try:
+                await self._on_change(self)
+            except Exception as e:
+                logger.warning(f"Moonshine state-change callback failed: {e}")
+
+    async def _set_state(self, state: str, percent: int | None = None) -> None:
+        changed = state != self.state or (percent is not None and percent != self.percent)
+        self.state = state
+        if percent is not None:
+            self.percent = percent
+        if changed:
+            await self._notify()
+
+    async def _warm_up(self) -> None:
+        try:
+            if not await asyncio.to_thread(_model_files_cached, self.model_name):
+                logger.info("Moonshine: downloading model files (~200 MB, one-time)...")
+                await self._set_state("downloading", 0)
+            else:
+                await self._set_state("loading", 100)
+            # MoonshineOnnxModel construction pulls weights from HF (if missing)
+            # and loads the ONNX sessions — both happen here in one thread hop.
+            self._model = await asyncio.to_thread(self._load_model)
+            await self._set_state("ready")
+            logger.info(f"Moonshine default STT ready ({self.model_name})")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.error = str(e)
+            logger.error(f"Moonshine warm-up failed: {e}")
+            await self._set_state("failed")
+
+    def _load_model(self):
+        from moonshine_onnx import MoonshineOnnxModel
+
+        return MoonshineOnnxModel(model_name=self.model_name)
+
+    async def transcribe(self, audio_path: Path) -> str | None:
+        """Transcribe a 16 kHz mono PCM16 WAV file to text.
+
+        Serialized with a lock — one ONNX session, one transcription at a time.
+        Returns None if the engine isn't ready or the clip is too short.
+        """
+        if not self.ready:
+            return None
+        async with self._lock:
+            return await asyncio.to_thread(self._transcribe_sync, str(audio_path))
+
+    def _transcribe_sync(self, audio_path: str) -> str | None:
+        import numpy as np
+        from moonshine_onnx import transcribe as moonshine_transcribe
+
+        with wave.open(audio_path, "rb") as wav:
+            channels = wav.getnchannels()
+            frames = wav.readframes(wav.getnframes())
+        samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        if channels > 1:
+            samples = samples.reshape(-1, channels).mean(axis=1)
+        # Moonshine rejects clips outside 0.1s–64s; the portal feeds 16 kHz audio.
+        if samples.size < 1600:
+            return None
+        # moonshine_transcribe's load_audio() adds the [batch] dim — pass 1-D.
+        texts = moonshine_transcribe(samples, self._model)
+        if isinstance(texts, (list, tuple)):
+            return " ".join(t.strip() for t in texts).strip()
+        return str(texts).strip()
+
+    async def close(self) -> None:
+        """Cancel the warm-up task and drop the model."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        self._model = None
+
+
+class LocalMoonshineBackend(STTBackend):
+    """STTBackend adapter that delegates to the portal's LocalMoonshine.
+
+    Returned by ``get_stt_backend`` for the default tier when Moonshine is
+    importable, so ``/transcribe`` transcribes on the host instead of 501-ing.
+    """
+
+    def __init__(self, moonshine: LocalMoonshine) -> None:
+        self._moonshine = moonshine
+
+    @property
+    def name(self) -> str:
+        return "moonshine"
+
+    async def transcribe(self, audio_path: Path) -> str | None:
+        return await self._moonshine.transcribe(audio_path)

--- a/docs/wiki/voice/stt-self-hosted.md
+++ b/docs/wiki/voice/stt-self-hosted.md
@@ -2,13 +2,41 @@
 
 > Living document. Update this, don't create new versions.
 
-AgentWire ships a local STT server (`agentwire stt start`) that the portal calls when you push-to-talk. The browser captures `audio/webm;codecs=opus`, the portal decodes it to 16 kHz mono PCM16 in-process via PyAV, then hands the WAV to the STT backend.
+**Moonshine is the default STT — bundled and portal-owned, zero setup.** A fresh
+`pip install agentwire` + `agentwire portal start` gives you working host
+transcription with no extra install and no `agentwire stt start`. The portal owns
+one in-process Moonshine ONNX engine (the STT mirror of the default-tier Kokoro
+voice): on first boot it downloads the model (~200 MB, one-time) in the
+background; until it's ready, push-to-talk falls back to browser
+SpeechRecognition, then silently switches to host transcription once the model
+loads. This is the `stt.backend: default` tier and needs no config.
 
-## Backends
+When you push-to-talk, the browser captures `audio/webm;codecs=opus`, the portal
+decodes it to 16 kHz mono PCM16 in-process via PyAV, then hands the WAV to the STT
+backend.
 
-| Backend | Model | Where it runs | Notes |
+## Default tier: portal-owned in-process Moonshine
+
+| | Detail |
+|---|---|
+| Package | `useful-moonshine-onnx` — in the **base** install (`pyproject.toml` `dependencies[]`), CPU ONNX, torch-free, alongside `kokoro-onnx`. |
+| Lifecycle | `agentwire/stt/local.py` `LocalMoonshine` — `absent → downloading → loading → ready` (mirrors `tts/local.py` `LocalKokoro`). The portal constructs `self.moonshine` and calls `.start()` on boot when `stt.backend: default`. |
+| Model | `moonshine/base` by default (`MOONSHINE_MODEL=moonshine/tiny` env for the faster/lighter variant), cached in `~/.cache/huggingface/`. |
+| Fallback | py3.14+ (no onnxruntime wheel) or any load failure → browser SpeechRecognition, exactly as before. Nothing to configure. |
+| Client switch | `/api/voice-status` reports `stt.server_transcribe` — `false` while warming up (browser), `true` once ready (the client uploads to `/transcribe`). |
+
+There is **no separate service** for the default tier — the model lives in the
+portal process, like Kokoro. `agentwire stt start` (below) is only for the
+`custom` shim tier and for `agentwire listen` (host CLI recording).
+
+## Shim engines (`custom` tier / `agentwire listen`)
+
+The standalone shim (`agentwire stt start`) loads one of these engines. Moonshine
+ships in the base install; the others need the `[stt]` extra.
+
+| Engine | Model | Where it runs | Notes |
 |---------|-------|---------------|-------|
-| `moonshine` (default on Mac) | `moonshine/tiny` or `moonshine/base` (ONNX) | CPU | Fastest on Apple Silicon — no torch, no GPU. |
+| `moonshine` (default, bundled) | `moonshine/tiny` or `moonshine/base` (ONNX) | CPU | Fastest on Apple Silicon — no torch, no GPU. Same engine the portal owns in-process on the default tier. |
 | `faster-whisper` | `tiny` → `large-v3` | CPU or CUDA | Higher accuracy, slower cold start. |
 | `openai-whisper` | `tiny` → `large` | CPU or CUDA | Fallback when neither of the above is installed. |
 
@@ -27,12 +55,16 @@ no shim process needed).
 
 Backend selection logic lives in `agentwire/stt/engine.py` (FastAPI-free, unit-tested in `tests/unit/test_stt_engine.py`); `stt_server.py` is the HTTP wrapper.
 
-## Quick Start
+## Quick Start (custom shim tier)
+
+You only need this for the `custom` tier or `agentwire listen` — the **default
+tier needs no setup** (see above). Moonshine itself is already in the base
+install; the `[stt]` extra adds the shim's FastAPI wrapper + `soundfile` (and
+`faster-whisper` for the higher-accuracy engine).
 
 ```bash
-# 1. Install STT extras
+# 1. Install the shim extras (moonshine is already bundled in the base install)
 uv pip install -e '.[stt]'
-pip install useful-moonshine-onnx soundfile  # for moonshine
 
 # 2. Start the server (defaults to moonshine/base on a Mac)
 agentwire stt start
@@ -40,6 +72,7 @@ agentwire stt start
 # 3. Point the portal at it
 # ~/.agentwire/config.yaml
 stt:
+  backend: custom
   url: "http://localhost:8101"
   timeout: 30
   silence_prepend_ms: 0   # default — see "Latency knobs" below
@@ -169,15 +202,16 @@ tmux capture-pane -pt agentwire-portal -S -200 | grep -i stt   # "Using STT shim
 ```
 
 The portal log line at startup is the tell:
-- `Using STT shim at http://localhost:8101` + `STT backend: STTServerBackend` → good.
-- `STT backend: default (browser speech recognition)` → custom tier isn't configured.
+- `Using STT shim at http://localhost:8101` + `STT backend: STTServerBackend` → good (custom tier wired).
+- `STT backend: in-process moonshine (default tier, host transcription)` → default tier, portal-owned Moonshine (not the shim).
+- `STT backend: default (browser speech recognition)` → default tier with Moonshine unavailable (py3.14+ / failed load) — browser fallback.
 
 **Fix:** install the STT deps into the venv the server actually launches with
 (`.venv/bin/python`), restart the server, then **restart the portal** (it only picks
 the backend at startup):
 
 ```bash
-uv pip install --python .venv/bin/python -e '.[stt]'   # declares moonshine + soundfile + fastapi
+uv pip install --python .venv/bin/python -e '.[stt]'   # shim deps: soundfile + fastapi (moonshine is in the base install)
 agentwire stt stop && agentwire stt start              # wait for "Moonshine ONNX loaded"
 agentwire portal restart --dev                         # re-runs get_stt_backend()
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ dependencies = [
     # in espeakng-loader wheels). Marker is mandatory — kokoro-onnx pins <3.14;
     # on 3.14+ the portal falls back to browser speechSynthesis.
     "kokoro-onnx>=0.4.9; python_version < '3.14'",
+    # Default STT engine: Moonshine ONNX in-process (CPU ONNX, no torch, models
+    # pulled from HuggingFace on first boot). Marker mirrors kokoro — onnxruntime
+    # pins <3.14; on 3.14+ the portal falls back to browser speech recognition.
+    "useful-moonshine-onnx>=20250101; python_version < '3.14'",
     # Used by agentwire.tts.base (TTSRequest); explicit rather than transitive via mcp.
     "pydantic>=2.0.0",
 ]
@@ -49,15 +53,14 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.1.0",
 ]
-# STT server dependencies. Moonshine ONNX is the default backend on Mac
-# (small, fast, CPU-only, no torch) — it MUST be declared here or a fresh venv
-# silently loses the default backend and the portal falls back to a model-less
-# WhisperKit. faster-whisper is the higher-accuracy fallback for `STT_BACKEND=whisper`.
+# STT shim server dependencies. Moonshine (the default engine) ships in the
+# base install — see dependencies[] above — so the standalone `agentwire stt
+# start` shim only needs the FastAPI wrapper plus soundfile for its warm-up.
+# faster-whisper is the higher-accuracy fallback for `stt.engine: whisper`.
 stt = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "python-multipart>=0.0.6",
-    "useful-moonshine-onnx>=20250101",
     "soundfile>=0.12.0",
     "faster-whisper>=1.0.0",
 ]

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -707,7 +707,16 @@ class TestVoiceStatus:
         resp = await client.get("/api/voice-status")
         assert resp.status == 200
         body = await resp.json()
-        assert body["stt"] == {"backend": "default", "url": None, "available": True}
+        # Default tier: in-process Moonshine (mirror of kokoro). Until the
+        # model warms up, server_transcribe is False so the client stays on
+        # browser speech recognition and instant mode holds.
+        assert body["stt"] == {
+            "backend": "default",
+            "url": None,
+            "available": True,
+            "server_transcribe": False,
+            "moonshine": {"state": "absent", "percent": 0},
+        }
         assert body["tts"]["backend"] == "default"
         assert body["tts"]["available"] is True
         assert body["instant_mode"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "resend" },
+    { name = "useful-moonshine-onnx", marker = "python_full_version < '3.14'" },
 ]
 
 [package.optional-dependencies]
@@ -38,7 +39,6 @@ stt = [
     { name = "faster-whisper" },
     { name = "python-multipart" },
     { name = "soundfile" },
-    { name = "useful-moonshine-onnx" },
     { name = "uvicorn" },
 ]
 tts = [
@@ -83,7 +83,7 @@ requires-dist = [
     { name = "soundfile", marker = "extra == 'stt'", specifier = ">=0.12.0" },
     { name = "torch", marker = "extra == 'tts'", specifier = ">=2.0.0" },
     { name = "torchaudio", marker = "extra == 'tts'", specifier = ">=2.0.0" },
-    { name = "useful-moonshine-onnx", marker = "extra == 'stt'", specifier = ">=20250101" },
+    { name = "useful-moonshine-onnx", marker = "python_full_version < '3.14'", specifier = ">=20250101" },
     { name = "uvicorn", marker = "extra == 'stt'", specifier = ">=0.24.0" },
     { name = "uvicorn", marker = "extra == 'tts'", specifier = ">=0.24.0" },
 ]
@@ -5794,13 +5794,13 @@ name = "useful-moonshine-onnx"
 version = "20251121"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.13.*'" },
+    { name = "huggingface-hub", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "huggingface-hub", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "librosa" },
-    { name = "numba", version = "0.63.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "librosa", marker = "python_full_version < '3.14'" },
+    { name = "numba", version = "0.63.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnxruntime" },
-    { name = "tokenizers", version = "0.20.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.13.*'" },
+    { name = "onnxruntime", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", version = "0.20.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "tokenizers", version = "0.22.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/30/0260a3e61ddf944c7ce0f65fc94e5d7e846bc061e2c255f016093baec8cf/useful_moonshine_onnx-20251121.tar.gz", hash = "sha256:b1fabd5b7b5cd9f4ff22fdacc3cc8f6cee26232032a1ee24b85064070a9784bc", size = 721446, upload-time = "2025-11-21T22:57:11.917Z" }


### PR DESCRIPTION
Makes **moonshine the default STT** — bundled in the base install and owned in-process by the portal — mirroring how kokoro is the default TTS. A fresh `pip install agentwire` + `agentwire portal start` now gives working host STT with zero setup: no `agentwire stt start`, no `[stt]` extra, model auto-downloads on first boot.

## What landed (all three phases)

**Phase 1 — bundle.** `useful-moonshine-onnx>=20250101` moved from `[project.optional-dependencies.stt]` into base `dependencies[]` next to `kokoro-onnx`, with the same `python_version < '3.14'` guard (onnxruntime has no 3.14 wheel). The `[stt]` extra now only carries the shim's FastAPI wrapper + `soundfile` + `faster-whisper` (the heavier whisper engine stays opt-in).

**Phase 2 — portal-owned in-process.** New `agentwire/stt/local.py`:
- `LocalMoonshine` — `absent → downloading → loading → ready` lifecycle, `moonshine_importable()` guard, HF-cache check to skip the "downloading" toast when already cached. Modeled directly on `tts/local.py` `LocalKokoro`.
- `LocalMoonshineBackend` — `STTBackend` adapter delegating to the portal's `LocalMoonshine`.
- `server.py`: constructs `self.moonshine`, warms it up on boot when `stt.backend: default`, closes it on shutdown, and posts warm-up toasts via `_on_moonshine_state_change`.
- `get_stt_backend(config, moonshine=...)` returns the in-process backend for the default tier when moonshine is importable, else `NoSTT` (browser fallback — py3.14+ / load failure).
- `/api/voice-status` exposes `stt.moonshine` state + a `server_transcribe` boolean. The frontend's browser-vs-upload predicate is consolidated into `browserStt.serverTranscribes()` (one helper, used by desktop / session-window / mobile — was three copies keyed on `stt.backend`). `instant_mode` now holds only while STT stays browser-side, so the client uploads to `/transcribe` once the host model is ready and falls back to browser SpeechRecognition while it warms up.

**Phase 3 — docs/UX.** `cmd_up()` default-tier message updated; `docs/wiki/voice/stt-self-hosted.md` (the #368 doc) rewritten around "moonshine is the default, auto-installed" with a dedicated in-process section; `agentwire-config` skill + `STTConfig` docstring updated; troubleshooting log-line tells corrected.

## Verification (in-worktree)

- `import moonshine_onnx` succeeds in the base venv after `uv sync` (no extras).
- Real-speech round-trip through the exact `LocalMoonshine` code path (wave read → numpy → `moonshine_onnx.transcribe`) transcribes correctly; too-short clips guard to `None`; `close()` drops the model.
- Tier selection confirmed: default+moonshine → `LocalMoonshineBackend`, default+None → `NoSTT`.
- `/api/voice-status` flips `server_transcribe` False→True and `instant_mode` True→False when moonshine reaches `ready`.
- 1415 unit + integration tests pass (one voice-status shape test updated for the new payload).

Not rebuilt/restarted (worktree isolation) — the portal boot-time warm-up + frontend upload switch are exercised by the verifications above but want a real `agentwire portal restart --dev` smoke test post-merge.

Closes #374

Built by [dotdev.dev](https://dotdev.dev)