### PR TITLE
fix(stt): process-isolate default-tier Moonshine via portal-managed shim (#382)

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -190,10 +190,14 @@ class TTSConfig:
 class STTConfig:
     """Speech-to-text configuration.
 
-    Three tiers: ``default`` transcribes on the host via the portal-owned
-    in-process Moonshine engine (bundled, auto-downloads on first boot — the
-    STT mirror of the default-tier Kokoro voice), falling back to browser
-    SpeechRecognition while the model warms up or when it can't load (py3.14+);
+    Three tiers: ``default`` transcribes on the host via Moonshine running in
+    the portal-managed shim **subprocess** (tmux ``agentwire-stt``, default
+    ``:8101``) — the portal ensures it's running on startup and talks to it
+    over HTTP, with process isolation keeping the ~19s ONNX warm-up off the
+    event loop. Browser SpeechRecognition is the fallback while the model
+    loads or when Moonshine can't load (py3.14+). For this tier ``url`` is
+    optional and resolves to ``http://localhost:8101``; if an operator
+    overrides the shim port (``STT_PORT``) or ``url``, the two must agree.
     ``cloud`` uploads audio to the portal, which POSTs it to any
     OpenAI-compatible transcription API (no extra daemon, key from env,
     server-side only); ``custom`` uploads audio to any HTTP shim implementing

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -188,11 +188,9 @@ class AgentWireServer:
         # tts.backend == "default".
         from .tts.local import LocalKokoro
         self.kokoro = LocalKokoro()
-        # Default-tier in-process Moonshine STT — the STT mirror of kokoro.
-        # Constructed unconditionally (cheap, no I/O); run_server starts the
-        # warm-up only when stt.backend == "default".
-        from .stt import LocalMoonshine
-        self.moonshine = LocalMoonshine()
+        # Default-tier Moonshine STT runs in the standalone shim subprocess
+        # (process isolation — see ensure_managed_stt), not in-process. No
+        # object to construct here; run_server ensures the shim post-bind.
         # Origin + token enforcement. The middleware is a pure function of
         # config — run_server() resolves the token file into
         # config.server.auth_token before constructing the server.
@@ -346,7 +344,7 @@ class AgentWireServer:
         from .agents import get_agent_backend
         from .stt import get_stt_backend
 
-        self.stt = get_stt_backend(self.config, moonshine=self.moonshine)
+        self.stt = get_stt_backend(self.config)
         self.agent = get_agent_backend(config_dict)
 
         # Create HTTP session for TTS server calls
@@ -360,31 +358,36 @@ class AgentWireServer:
         if self._http_session:
             await self._http_session.close()
         await self.kokoro.close()
-        await self.moonshine.close()
+        # The default-tier STT shim runs in its own tmux session
+        # (agentwire-stt) — leave it running on portal shutdown; the user may
+        # own it. `agentwire stt stop` is the off switch.
 
-    async def _on_moonshine_state_change(self, moonshine) -> None:
-        """Moonshine warm-up progress → invalidate voice-status cache + toast.
+    async def ensure_managed_stt(self) -> None:
+        """Ensure the default-tier Moonshine shim subprocess is running.
 
-        Mirrors ``_on_kokoro_state_change``. The toast is replaced in place
-        (keyed on session "moonshine-stt") so the download reads as one
-        updating notification, not a stream."""
-        self._voice_status_cache = None
-        if moonshine.state == "downloading":
-            await self._post_toast(
-                "Downloading Moonshine STT model… (one-time, ~200 MB)",
-                session="moonshine-stt", priority="normal", id_prefix="moonshine")
-        elif moonshine.state == "loading":
-            await self._post_toast(
-                "Loading Moonshine STT model…",
-                session="moonshine-stt", priority="normal", id_prefix="moonshine")
-        elif moonshine.state == "ready":
-            await self._post_toast(
-                "Host STT ready — Moonshine now transcribes your voice",
-                session="moonshine-stt", priority="normal", id_prefix="moonshine")
-        elif moonshine.state == "failed":
-            await self._post_toast(
-                f"Moonshine STT setup failed ({moonshine.error}) — using browser speech fallback",
-                session="moonshine-stt", priority="high", id_prefix="moonshine")
+        Delegates to the CLI (single source of truth): ``agentwire stt start``
+        is idempotent — ``cmd_stt_start`` early-returns if the ``agentwire-stt``
+        tmux session already exists, so a user-started shim is reused with no
+        port clash. The ~19s ONNX warm-up happens in that child process, never
+        on the portal's event loop. Mirrors ``autostart_custom_services``."""
+        await asyncio.sleep(5)  # let the portal finish binding first
+        try:
+            success, result = await self.run_agentwire_cmd(["stt", "start"], json_output=False)
+            if success:
+                await self._post_toast(
+                    "Starting host STT (Moonshine) — browser speech until ready",
+                    session="moonshine-stt", priority="normal", id_prefix="moonshine")
+                logger.info("[STT] Ensured managed Moonshine shim")
+            else:
+                logger.warning("[STT] Managed shim start failed: %s", result.get("error"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("[STT] Managed shim start error: %s", e)
+        finally:
+            # Flip voice-status off the 30s TTL so the next poll re-probes the
+            # shim's /health and surfaces server_transcribe promptly.
+            self._voice_status_cache = None
 
     async def _on_kokoro_state_change(self, kokoro) -> None:
         """Kokoro warm-up progress → invalidate voice-status cache + toast.
@@ -780,13 +783,15 @@ class AgentWireServer:
         if stt_cfg.backend == "custom":
             stt["available"] = await self._probe_shim(stt_cfg.url, "/health") is not None
         elif stt_cfg.backend == "default":
-            # In-process Moonshine warm-up state (mirror of kokoro). The client
-            # only uploads once the host model is ready; until then it keeps
-            # using browser speech recognition.
-            stt["moonshine"] = {"state": self.moonshine.state, "percent": self.moonshine.percent}
-            if self.moonshine.error:
-                stt["moonshine"]["error"] = self.moonshine.error
-            stt["server_transcribe"] = self.moonshine.ready
+            # Portal-managed Moonshine shim subprocess. The client only uploads
+            # once the shim's /health is "ok" (model loaded); while it loads or
+            # if the spawn failed, server_transcribe stays false and the client
+            # keeps using browser speech recognition. available stays true —
+            # browser fallback is always there.
+            from .stt import _default_stt_url
+
+            health = await self._probe_shim(_default_stt_url(stt_cfg), "/health")
+            stt["server_transcribe"] = bool(health and health.get("status") == "ok")
 
         tts: dict = {"backend": tts_cfg.backend, "url": tts_cfg.url, "available": True}
         if tts_cfg.backend == "default":
@@ -3768,21 +3773,11 @@ projects:
         shape for Whisper- and Moonshine-class models. Optionally prepends a
         configurable amount of silence (``stt.silence_prepend_ms``, default 0).
 
-        Cloud and custom tiers only — in the default tier, recognition
-        happens in the browser and this endpoint answers 501.
+        All three tiers transcribe server-side: default and custom via an HTTP
+        shim, cloud via a hosted API. If the default-tier shim isn't ready yet
+        the backend raises and this endpoint answers 500 (the client is already
+        using browser speech recognition until /api/voice-status flips).
         """
-        from .stt import NoSTT
-
-        if isinstance(self.stt, NoSTT):
-            return web.json_response(
-                {
-                    "error": "Server-side STT is not configured (stt.backend: default — "
-                    "the portal uses browser speech recognition). Set stt.backend: "
-                    "cloud (hosted transcription API) or custom with a url to enable "
-                    "audio-upload transcription."
-                },
-                status=501,
-            )
         try:
             reader = await request.multipart()
             audio_field = await reader.next()
@@ -5501,11 +5496,15 @@ async def run_server(config: Config):
     if config.tts.backend == "default":
         server.kokoro.start(server._on_kokoro_state_change)
 
-    # Warm up the default-tier Moonshine STT: background model download
-    # (one-time ~200 MB) + ONNX load. Browser SpeechRecognition covers input
-    # until ready; on py3.14+ (no package) it stays the browser path.
-    if config.stt.backend == "default":
-        server.moonshine.start(server._on_moonshine_state_change)
+    # Default-tier STT: ensure the Moonshine shim subprocess is running
+    # (process isolation — the ~19s ONNX warm-up happens in that child, never
+    # on this event loop). Browser SpeechRecognition covers input until the
+    # shim's /health is ok; on py3.14+ (no package) the spawn is gated off and
+    # it stays the browser path.
+    from .stt import moonshine_importable
+
+    if config.stt.backend == "default" and moonshine_importable():
+        asyncio.create_task(server.ensure_managed_stt())
 
     # Cleanup old uploads on startup
     await server.cleanup_old_uploads()

--- a/agentwire/stt/__init__.py
+++ b/agentwire/stt/__init__.py
@@ -4,16 +4,13 @@ import logging
 import os
 from typing import Any
 
-from .base import NoSTT, STTBackend
+from .base import STTBackend
 from .cloud import DEFAULT_API_KEY_ENV, DEFAULT_BASE_URL, DEFAULT_MODEL, CloudSTTBackend
-from .local import LocalMoonshine, LocalMoonshineBackend, moonshine_importable
+from .local import moonshine_importable
 from .server_backend import STTServerBackend
 
 __all__ = [
     "CloudSTTBackend",
-    "LocalMoonshine",
-    "LocalMoonshineBackend",
-    "NoSTT",
     "STTBackend",
     "STTServerBackend",
     "get_stt_backend",
@@ -22,29 +19,32 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_STT_URL = "http://localhost:8101"
 
-def get_stt_backend(config: Any, moonshine: LocalMoonshine | None = None) -> STTBackend:
+
+def _default_stt_url(stt_config: Any) -> str:
+    """Resolve the default-tier shim URL: ``stt.url`` override or :8101.
+
+    Must agree with the shim's ``STT_PORT`` (default 8101) if an operator
+    overrides either side.
+    """
+    return getattr(stt_config, "url", None) or DEFAULT_STT_URL
+
+
+def get_stt_backend(config: Any) -> STTBackend:
     """Get STT backend based on configuration.
 
-    Four resolutions: ``stt.backend: custom`` → HTTP shim at ``stt.url``;
+    Three resolutions: ``stt.backend: custom`` → HTTP shim at ``stt.url``;
     ``stt.backend: cloud`` → OpenAI-compatible transcription API called
     directly from the portal (settings under ``stt.cloud``, key from the
     env var named by ``stt.cloud.api_key_env``); ``stt.backend: default``
-    → in-process Moonshine when the portal owns a ``LocalMoonshine`` and the
-    package is importable (host transcription via ``/transcribe``), else the
-    NoSTT sentinel (browser SpeechRecognition, no server transcription role).
+    → the portal-managed Moonshine shim subprocess at ``_default_stt_url``
+    (same HTTP client as ``custom``; the portal ensures it's running via
+    ``ensure_managed_stt``). Browser SpeechRecognition is the fallback until
+    the shim's ``/health`` reports ``ok``.
     """
     stt_config = getattr(config, "stt", None)
     backend = getattr(stt_config, "backend", "default") if stt_config is not None else "default"
-
-    if backend == "custom":
-        logger.info(f"Using STT shim at {stt_config.url}")
-        return STTServerBackend(
-            url=stt_config.url,
-            timeout=getattr(stt_config, "timeout", 30),
-            instructions=getattr(stt_config, "instructions", ""),
-            options=getattr(stt_config, "options", None),
-        )
 
     if backend == "cloud":
         cloud = getattr(stt_config, "cloud", None) or {}
@@ -68,9 +68,13 @@ def get_stt_backend(config: Any, moonshine: LocalMoonshine | None = None) -> STT
             language=cloud.get("language", ""),
         )
 
-    if moonshine is not None and moonshine_importable():
-        logger.info("STT backend: in-process moonshine (default tier, host transcription)")
-        return LocalMoonshineBackend(moonshine)
-
-    logger.info("STT backend: default (browser speech recognition)")
-    return NoSTT()
+    # default tier → portal-managed shim; custom tier → user/remote-managed
+    # shim. Same HTTP client; only the URL resolution and lifecycle differ.
+    url = _default_stt_url(stt_config) if backend == "default" else stt_config.url
+    logger.info(f"Using STT shim at {url} ({backend} tier)")
+    return STTServerBackend(
+        url=url,
+        timeout=getattr(stt_config, "timeout", 30),
+        instructions=getattr(stt_config, "instructions", ""),
+        options=getattr(stt_config, "options", None),
+    )

--- a/agentwire/stt/base.py
+++ b/agentwire/stt/base.py
@@ -24,19 +24,3 @@ class STTBackend(ABC):
             Transcribed text, or None if transcription failed.
         """
         ...
-
-
-class NoSTT(STTBackend):
-    """Sentinel backend for the default tier.
-
-    Speech recognition happens in the browser (Chrome SpeechRecognition);
-    the server has no transcription role. ``/transcribe`` returns 501 when
-    this backend is active.
-    """
-
-    @property
-    def name(self) -> str:
-        return "none"
-
-    async def transcribe(self, audio_path: Path) -> str | None:
-        return None

--- a/agentwire/stt/local.py
+++ b/agentwire/stt/local.py
@@ -1,187 +1,26 @@
-"""In-process Moonshine for the default STT tier.
+"""Default-tier Moonshine availability probe.
 
-The portal owns one LocalMoonshine instance — the STT mirror of
-``tts/local.py``'s LocalKokoro. When ``stt.backend: default``, a background
-task pulls the Moonshine ONNX weights from HuggingFace (~200 MB, one-time)
-and loads the model; until it's ready the portal keeps falling back to
-browser SpeechRecognition. The ``custom`` shim tier never touches this module.
-
-States:
-    absent       model files not downloaded, warm-up not started
-    downloading  background download in progress
-    loading      files present, ONNX session loading
-    ready        transcribe() available
-    failed       download or load error (browser fallback stays active)
-    unavailable  useful-moonshine-onnx not importable (py3.14+, ...) — terminal
+The default STT tier runs Moonshine in the **standalone shim subprocess**
+(``stt_server.py``, tmux ``agentwire-stt``, ``:8101``), which the portal
+auto-manages via ``ensure_managed_stt``. Process isolation keeps the ~19s
+ONNX warm-up off the portal's event loop. This module no longer loads any
+model in-process — it only exposes the spawn gate (``moonshine_importable``)
+and the default model name shared with the shim.
 """
 
-import asyncio
 import importlib.util
-import logging
 import os
-import wave
-from pathlib import Path
-from typing import Awaitable, Callable
-
-from .base import STTBackend
-
-logger = logging.getLogger(__name__)
 
 # Default Moonshine variant. moonshine/base balances speed and accuracy on
 # CPU; moonshine/tiny is faster/lighter. Operator override via MOONSHINE_MODEL
 # mirrors the standalone shim (stt_server.py).
 DEFAULT_MOONSHINE_MODEL = os.environ.get("MOONSHINE_MODEL", "moonshine/base")
 
-_HF_REPO = "UsefulSensors/moonshine"
-_ONNX_FILES = ("encoder_model", "decoder_model_merged")
-
 
 def moonshine_importable() -> bool:
-    """True if useful-moonshine-onnx is installed (base install, py<3.14)."""
-    return importlib.util.find_spec("moonshine_onnx") is not None
+    """True if useful-moonshine-onnx is installed (base install, py<3.14).
 
-
-def _model_files_cached(model_name: str) -> bool:
-    """True if both ONNX weight files are already in the HuggingFace cache."""
-    from huggingface_hub import try_to_load_from_cache
-
-    short = model_name.split("/")[-1]
-    return all(
-        isinstance(
-            try_to_load_from_cache(
-                _HF_REPO, f"onnx/merged/{short}/float/{name}.onnx"
-            ),
-            str,
-        )
-        for name in _ONNX_FILES
-    )
-
-
-class LocalMoonshine:
-    """Owns the default-tier Moonshine engine lifecycle for the portal."""
-
-    def __init__(self, model_name: str = DEFAULT_MOONSHINE_MODEL) -> None:
-        self.model_name = model_name
-        self.state = "absent"
-        self.percent = 0
-        self.error: str | None = None
-        self._model = None
-        self._task: asyncio.Task | None = None
-        self._lock = asyncio.Lock()
-        self._on_change: Callable[["LocalMoonshine"], Awaitable[None]] | None = None
-
-    @property
-    def ready(self) -> bool:
-        return self.state == "ready"
-
-    def start(
-        self, on_change: Callable[["LocalMoonshine"], Awaitable[None]] | None = None
-    ) -> None:
-        """Kick off the background download+load task (idempotent)."""
-        if self._task is not None or self.state in ("ready", "unavailable"):
-            return
-        self._on_change = on_change
-        if not moonshine_importable():
-            self.state = "unavailable"
-            self.error = "useful-moonshine-onnx not installed (requires Python <3.14)"
-            logger.warning(f"Moonshine default STT unavailable: {self.error}")
-            return
-        self._task = asyncio.get_running_loop().create_task(self._warm_up())
-
-    async def _notify(self) -> None:
-        if self._on_change:
-            try:
-                await self._on_change(self)
-            except Exception as e:
-                logger.warning(f"Moonshine state-change callback failed: {e}")
-
-    async def _set_state(self, state: str, percent: int | None = None) -> None:
-        changed = state != self.state or (percent is not None and percent != self.percent)
-        self.state = state
-        if percent is not None:
-            self.percent = percent
-        if changed:
-            await self._notify()
-
-    async def _warm_up(self) -> None:
-        try:
-            if not await asyncio.to_thread(_model_files_cached, self.model_name):
-                logger.info("Moonshine: downloading model files (~200 MB, one-time)...")
-                await self._set_state("downloading", 0)
-            else:
-                await self._set_state("loading", 100)
-            # MoonshineOnnxModel construction pulls weights from HF (if missing)
-            # and loads the ONNX sessions — both happen here in one thread hop.
-            self._model = await asyncio.to_thread(self._load_model)
-            await self._set_state("ready")
-            logger.info(f"Moonshine default STT ready ({self.model_name})")
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            self.error = str(e)
-            logger.error(f"Moonshine warm-up failed: {e}")
-            await self._set_state("failed")
-
-    def _load_model(self):
-        from moonshine_onnx import MoonshineOnnxModel
-
-        return MoonshineOnnxModel(model_name=self.model_name)
-
-    async def transcribe(self, audio_path: Path) -> str | None:
-        """Transcribe a 16 kHz mono PCM16 WAV file to text.
-
-        Serialized with a lock — one ONNX session, one transcription at a time.
-        Returns None if the engine isn't ready or the clip is too short.
-        """
-        if not self.ready:
-            return None
-        async with self._lock:
-            return await asyncio.to_thread(self._transcribe_sync, str(audio_path))
-
-    def _transcribe_sync(self, audio_path: str) -> str | None:
-        import numpy as np
-        from moonshine_onnx import transcribe as moonshine_transcribe
-
-        with wave.open(audio_path, "rb") as wav:
-            channels = wav.getnchannels()
-            frames = wav.readframes(wav.getnframes())
-        samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
-        if channels > 1:
-            samples = samples.reshape(-1, channels).mean(axis=1)
-        # Moonshine rejects clips outside 0.1s–64s; the portal feeds 16 kHz audio.
-        if samples.size < 1600:
-            return None
-        # moonshine_transcribe's load_audio() adds the [batch] dim — pass 1-D.
-        texts = moonshine_transcribe(samples, self._model)
-        if isinstance(texts, (list, tuple)):
-            return " ".join(t.strip() for t in texts).strip()
-        return str(texts).strip()
-
-    async def close(self) -> None:
-        """Cancel the warm-up task and drop the model."""
-        if self._task is not None:
-            self._task.cancel()
-            try:
-                await self._task
-            except (asyncio.CancelledError, Exception):
-                pass
-            self._task = None
-        self._model = None
-
-
-class LocalMoonshineBackend(STTBackend):
-    """STTBackend adapter that delegates to the portal's LocalMoonshine.
-
-    Returned by ``get_stt_backend`` for the default tier when Moonshine is
-    importable, so ``/transcribe`` transcribes on the host instead of 501-ing.
+    Gates whether the portal bothers spawning the host STT shim for the
+    default tier — on py3.14+ (no package) it stays the browser path.
     """
-
-    def __init__(self, moonshine: LocalMoonshine) -> None:
-        self._moonshine = moonshine
-
-    @property
-    def name(self) -> str:
-        return "moonshine"
-
-    async def transcribe(self, audio_path: Path) -> str | None:
-        return await self._moonshine.transcribe(audio_path)
+    return importlib.util.find_spec("moonshine_onnx") is not None

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -715,48 +715,68 @@ class TestApiRestrictedMode:
 
 
 # ---------------------------------------------------------------------------
-# /transcribe under the default tier
-# ---------------------------------------------------------------------------
-
-
-class TestTranscribeDefaultTier:
-    async def test_transcribe_returns_501_without_custom_stt(self, portal_client):
-        client, server = portal_client
-        # Empty config → stt.backend "default" → NoSTT
-        from agentwire.stt import NoSTT
-        server.stt = NoSTT()
-
-        resp = await client.post("/transcribe", data=b"fakeaudio")
-        assert resp.status == 501
-        body = await resp.json()
-        assert "browser speech recognition" in body["error"]
-
-
-# ---------------------------------------------------------------------------
 # /api/voice-status
 # ---------------------------------------------------------------------------
 
 
 class TestVoiceStatus:
-    async def test_default_tier_shape(self, portal_client):
+    async def test_default_tier_shim_loading(self, portal_client):
         client, server = portal_client
+
+        # Default tier probes the managed shim's /health like custom does.
+        # While the shim loads (or hasn't spawned), /health isn't "ok" →
+        # server_transcribe False, so the client stays on browser speech
+        # recognition and instant mode holds. No `moonshine` key any more.
+        async def fake_probe(base_url, path, timeout=1.5):
+            assert base_url == "http://localhost:8101"
+            return {"status": "loading"}
+
+        server._probe_shim = fake_probe
+
         resp = await client.get("/api/voice-status")
         assert resp.status == 200
         body = await resp.json()
-        # Default tier: in-process Moonshine (mirror of kokoro). Until the
-        # model warms up, server_transcribe is False so the client stays on
-        # browser speech recognition and instant mode holds.
         assert body["stt"] == {
             "backend": "default",
             "url": None,
             "available": True,
             "server_transcribe": False,
-            "moonshine": {"state": "absent", "percent": 0},
         }
         assert body["tts"]["backend"] == "default"
         assert body["tts"]["available"] is True
         assert body["instant_mode"] is True
         assert body["corrections"] == {}
+
+    async def test_default_tier_shim_absent(self, portal_client):
+        client, server = portal_client
+
+        # Shim not spawned / unreachable → probe returns None → fall back.
+        async def fake_probe(base_url, path, timeout=1.5):
+            return None
+
+        server._probe_shim = fake_probe
+
+        resp = await client.get("/api/voice-status")
+        body = await resp.json()
+        assert body["stt"]["server_transcribe"] is False
+        assert body["stt"]["available"] is True
+        assert body["instant_mode"] is True
+
+    async def test_default_tier_shim_ok(self, portal_client):
+        client, server = portal_client
+
+        # Shim /health ok → host transcription takes over: server_transcribe
+        # True and instant mode drops (audio now uploads).
+        async def fake_probe(base_url, path, timeout=1.5):
+            return {"status": "ok"}
+
+        server._probe_shim = fake_probe
+
+        resp = await client.get("/api/voice-status")
+        body = await resp.json()
+        assert body["stt"]["server_transcribe"] is True
+        assert "moonshine" not in body["stt"]
+        assert body["instant_mode"] is False
 
     async def test_custom_tier_probes_shim(self, portal_client):
         client, server = portal_client
@@ -820,6 +840,61 @@ class TestVoiceStatus:
         resp = await client.get("/api/voices")
         assert resp.status == 200
         assert await resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Default-tier managed STT shim lifecycle (ensure_managed_stt)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureManagedStt:
+    async def test_delegates_to_stt_start_cli(self, portal_client, monkeypatch):
+        client, server = portal_client
+        # Skip the post-bind settle delay.
+        monkeypatch.setattr("agentwire.server.asyncio.sleep", AsyncMock())
+
+        calls = []
+
+        async def fake_cmd(args, json_output=True):
+            calls.append((args, json_output))
+            return True, {"output": "STT server starting"}
+
+        server.run_agentwire_cmd = fake_cmd
+        server._voice_status_cache = (12345.0, {"stale": True})
+
+        await server.ensure_managed_stt()
+
+        # Idempotent CLI spawn — reuses cmd_stt_start (early-returns if the
+        # agentwire-stt tmux session already exists).
+        assert calls == [(["stt", "start"], False)]
+        # Cache invalidated so the next voice-status poll re-probes /health.
+        assert server._voice_status_cache is None
+
+    async def test_cli_failure_is_soft(self, portal_client, monkeypatch):
+        client, server = portal_client
+        monkeypatch.setattr("agentwire.server.asyncio.sleep", AsyncMock())
+
+        async def fake_cmd(args, json_output=True):
+            return False, {"error": "boom"}
+
+        server.run_agentwire_cmd = fake_cmd
+        # Must not raise — browser STT keeps working.
+        await server.ensure_managed_stt()
+        assert server._voice_status_cache is None
+
+    def test_spawn_gate_is_moonshine_importable(self):
+        # run_server schedules ensure_managed_stt only when
+        # `config.stt.backend == "default" and moonshine_importable()`. This is
+        # the gate it evaluates — proven importable in this (py<3.14) env.
+        from agentwire.stt import moonshine_importable
+
+        assert moonshine_importable() is True
+
+    def test_spawn_gate_false_when_not_importable(self, monkeypatch):
+        import agentwire.stt as stt_pkg
+
+        monkeypatch.setattr(stt_pkg, "moonshine_importable", lambda: False)
+        assert stt_pkg.moonshine_importable() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_stt_backend.py
+++ b/tests/unit/test_stt_backend.py
@@ -1,10 +1,14 @@
-"""Tests for STT backend selection (two-tier model)."""
+"""Tests for STT backend selection.
 
-import asyncio
-from pathlib import Path
+The default tier no longer loads Moonshine in-process — it auto-manages the
+standalone shim subprocess and talks to it over HTTP. So both ``default`` and
+``custom`` resolve to ``STTServerBackend``; only the URL resolution differs
+(default → :8101 unless ``stt.url`` overrides).
+"""
+
 from types import SimpleNamespace
 
-from agentwire.stt import NoSTT, STTServerBackend, get_stt_backend
+from agentwire.stt import STTServerBackend, _default_stt_url, get_stt_backend
 
 
 def _cfg(backend: str, url: str | None = None, timeout: int = 30):
@@ -12,10 +16,15 @@ def _cfg(backend: str, url: str | None = None, timeout: int = 30):
 
 
 class TestGetSttBackend:
-    def test_default_tier_returns_nostt(self):
+    def test_default_tier_returns_managed_shim_at_8101(self):
         backend = get_stt_backend(_cfg("default"))
-        assert isinstance(backend, NoSTT)
-        assert backend.name == "none"
+        assert isinstance(backend, STTServerBackend)
+        assert backend.url == "http://localhost:8101"
+
+    def test_default_tier_honors_url_override(self):
+        backend = get_stt_backend(_cfg("default", url="http://localhost:9999"))
+        assert isinstance(backend, STTServerBackend)
+        assert backend.url == "http://localhost:9999"
 
     def test_custom_tier_returns_server_backend(self):
         backend = get_stt_backend(_cfg("custom", url="http://localhost:8101", timeout=12))
@@ -23,12 +32,15 @@ class TestGetSttBackend:
         assert backend.url == "http://localhost:8101"
         assert backend.timeout == 12
 
-    def test_config_without_stt_section_is_default(self):
+    def test_config_without_stt_section_is_default_shim(self):
         backend = get_stt_backend(SimpleNamespace())
-        assert isinstance(backend, NoSTT)
+        assert isinstance(backend, STTServerBackend)
+        assert backend.url == "http://localhost:8101"
 
 
-class TestNoSTT:
-    def test_transcribe_returns_none(self):
-        result = asyncio.run(NoSTT().transcribe(Path("/tmp/nonexistent.wav")))
-        assert result is None
+class TestDefaultSttUrl:
+    def test_falls_back_to_8101(self):
+        assert _default_stt_url(SimpleNamespace(url=None)) == "http://localhost:8101"
+
+    def test_override_wins(self):
+        assert _default_stt_url(SimpleNamespace(url="http://host:1234")) == "http://host:1234"

--- a/tests/unit/test_stt_cloud.py
+++ b/tests/unit/test_stt_cloud.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from agentwire.stt import CloudSTTBackend, NoSTT, get_stt_backend
+from agentwire.stt import CloudSTTBackend, STTServerBackend, get_stt_backend
 from agentwire.stt import cloud as cloud_module
 
 
@@ -64,8 +64,10 @@ class TestGetSttBackendCloudTier:
         with pytest.raises(ValueError, match="MY_STT_KEY"):
             get_stt_backend(_cfg("cloud", cloud={"api_key_env": "MY_STT_KEY"}))
 
-    def test_default_tier_still_nostt(self):
-        assert isinstance(get_stt_backend(_cfg("default")), NoSTT)
+    def test_default_tier_is_managed_shim(self):
+        backend = get_stt_backend(_cfg("default"))
+        assert isinstance(backend, STTServerBackend)
+        assert backend.url == "http://localhost:8101"
 
 
 class TestCloudRequest:


### PR DESCRIPTION
Closes #382

## What & why

`stt.backend: default` loaded Moonshine ONNX **inside the portal process**. The ~19s `MoonshineOnnxModel(...)` init holds the GIL, starving the asyncio event loop **despite `asyncio.to_thread`** — HTTP + terminal WebSockets froze, xterm couldn't attach on refresh. Fix: the `default` tier now **auto-manages the standalone shim subprocess** (tmux `agentwire-stt`, `:8101`) and talks to it over HTTP via the existing `STTServerBackend`. Process isolation removes GIL starvation by construction. Pre-launch repo → no backwards compat: the in-process path is deleted, not flagged.

`default` = "auto-managed shim", `custom` = "user/remote-managed shim". Browser SpeechRecognition stays the fallback until the shim's `/health` is `ok`.

## Breadcrumb

- **`stt/local.py`** — deleted `LocalMoonshine` + `LocalMoonshineBackend`; kept `moonshine_importable()` (spawn gate) + `DEFAULT_MOONSHINE_MODEL`.
- **`stt/__init__.py`** — added `_default_stt_url(stt_config)` (→ `stt.url` or `http://localhost:8101`); `get_stt_backend(config)` dropped the `moonshine=` param; `default` returns `STTServerBackend@:8101` (same construction as `custom`).
- **`stt/base.py`** — deleted `NoSTT` (no longer constructed anywhere; the `/transcribe` 501 guard that used it is removed — all three tiers now transcribe server-side).
- **`server.py`** — dropped `self.moonshine`, `_on_moonshine_state_change`, `moonshine.close()`; added `async ensure_managed_stt()` (delegates to `agentwire stt start`, idempotent, invalidates voice-status cache; modeled on `autostart_custom_services`); `run_server` schedules it gated on `config.stt.backend == "default" and moonshine_importable()`; `api_voice_status` default branch now probes the shim `/health` (`server_transcribe = health and status == "ok"`, `available=True`).
- **`config.py`** — `STTConfig` docstring documents the managed shim + the `stt.url`↔`STT_PORT` coupling.
- **No frontend change** — `desktop.js`/`mobile.js`/`browser-stt.js` read only `stt.server_transcribe` + top-level `instant_mode`, both preserved (verified by grep). Granular download-progress toasts dropped (lived in `LocalMoonshine`); one "starting host STT" toast replaces them.

### Edge cases honored
Idempotent reuse of a user-started shim; py3.14/not-importable → no spawn, browser fallback permanent; shim loading → `server_transcribe:false`; shim not killed on portal shutdown (`agentwire stt stop` is the off switch).

## Tests
`tests/unit/` green (1357 passed). Updated `test_stt_backend.py` (default → `STTServerBackend@:8101`), `test_stt_cloud.py` (default-tier assertion), `test_portal_api.py::TestVoiceStatus` (dropped `moonshine` key; added `_probe_shim` None/loading/ok cases driving `server_transcribe` + `instant_mode`); added `TestEnsureManagedStt` (asserts `ensure_managed_stt` calls `["stt","start"]` and the spawn gate is `moonshine_importable()`).

## Verification
In-worktree: `import agentwire` OK + `python -m pytest tests/unit/ -q` → 1357 passed. The #382 responsiveness smoke test (cold model, hammer `GET /` < 1s during warm-up, hold a terminal WS) is for the orchestrator to run post-merge against the shared portal.

## Follow-up
**Kokoro** (`tts/local.py`) shares the same latent GIL risk (in-process `to_thread` load), but loads in ~1–2s so it doesn't trip the loop today. Filed as #384; mirror this isolation only if its load grows or profiling shows >1s loop stalls.

Built by [dotdev.dev](https://dotdev.dev)

