### PR TITLE
docs: remove Hierarchical Delegation rule from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,6 @@ Voice interface for AI coding agents. Push-to-talk from any device to tmux sessi
 
 **No Backwards Compatibility** - Pre-launch, no customers. Change things completely, no legacy fallbacks.
 
-**Hierarchical Delegation** - Before editing files in OTHER projects (e.g., `~/projects/agentwire-website/`), check `agentwire_sessions_list()`. If a session exists for that project, use `agentwire_session_send()` instead of editing directly. See `~/.claude/rules/delegation.md`.
-
 ## Dev Workflow
 
 `uv tool install` caches builds and ignores source changes.


### PR DESCRIPTION
Removes the **Hierarchical Delegation** rule line near the top of `CLAUDE.md`. It pointed to `~/.claude/rules/delegation.md` — a dangling user-local path not shipped in the repo — and encoded a contributor-personal workflow rather than shippable behavior.

Removed the rule line and its trailing blank line so spacing stays clean. Grepped the repo for other references (`delegation.md`, `Hierarchical Delegation`, `agentwire_session_send`, `agentwire_sessions_list`) — the only hit was this line. No wiki relocation; the issue says drop it.

Docs-only — no rebuild/restart needed.

Closes #385

Built by [dotdev.dev](https://dotdev.dev)