### PR TITLE
feat(council): live seating board (core — Phases 0–2 of #403)

### DIFF
--- a/agentwire/council/inbox.py
+++ b/agentwire/council/inbox.py
@@ -23,6 +23,8 @@ frontmatter parsing. A soul's initial round is complete once it has any of
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -31,6 +33,29 @@ from pathlib import Path
 from agentwire.council import state
 
 KINDS = ("take", "ack", "pass")
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write text atomically: temp file in the same dir, then ``os.replace``.
+
+    The council board polls ``replies/`` from the portal; a plain ``write_text``
+    leaves a window where a reader can see a half-written verdict. ``os.replace``
+    is atomic on the same filesystem, so a reader sees either the old file (or
+    nothing) or the complete new one — never a partial. This is the real
+    anti-flicker guarantee for the UI.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 @dataclass
@@ -71,13 +96,13 @@ def create_prompt(name: str, prompt_id: int, text: str, roster: list[str]) -> Pa
     replies.mkdir(parents=True, exist_ok=True)
     for stale in replies.glob("*.md"):
         stale.unlink()
-    (pdir / "prompt.md").write_text(text)
+    _atomic_write_text(pdir / "prompt.md", text)
     meta = {
         "id": prompt_id,
         "created_at": state.now_iso(),
         "roster": list(roster),
     }
-    (pdir / "meta.json").write_text(json.dumps(meta, indent=2))
+    _atomic_write_text(pdir / "meta.json", json.dumps(meta, indent=2))
     return pdir
 
 
@@ -116,7 +141,7 @@ def write_reply(
 
     if _initial_reply(name, prompt_id, soul) is None:
         path = rdir / f"{soul}.{kind}.md"
-        path.write_text(text)
+        _atomic_write_text(path, text)
         return path, False
 
     if kind != "take":
@@ -128,7 +153,7 @@ def write_reply(
     while (rdir / f"{soul}.followup-{n}.md").exists():
         n += 1
     path = rdir / f"{soul}.followup-{n}.md"
-    path.write_text(text)
+    _atomic_write_text(path, text)
     return path, True
 
 

--- a/agentwire/council/view.py
+++ b/agentwire/council/view.py
@@ -1,0 +1,193 @@
+"""Read-only board view of a sitting — the portal's council visualization.
+
+Pure derivation from on-disk state (``sitting.json`` + ``prompts/NNNN/`` files);
+no tmux, no mutation. The portal's ``/api/council/*`` endpoints and the
+``council_update`` WebSocket deltas both render through here so the live fill
+and the snapshot can never disagree.
+
+The tile state machine is keyed by **soul**, not by file — a soul files at most
+one initial ``take|ack|pass`` and then any number of ``followup-N`` takes
+(the ack-then-research path). The derivation collapses all of a soul's files
+into one tile:
+
+    pending → acked (working…) → answered (latest take) | passed
+
+with precedence **take > pass > ack > pending**: a terminal take/pass must never
+be repainted by a late ack, and the highest-numbered followup take is the final
+verdict.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from agentwire.council import inbox, state
+
+# status enum the frontend styles by class. ``stalled`` is a pending soul whose
+# lens session has died — only the caller (which can see tmux) can know that, so
+# it's supplied via ``dead_souls`` rather than derived from files.
+STATUS_PENDING = "pending"
+STATUS_ACKED = "acked"
+STATUS_ANSWERED = "answered"
+STATUS_PASSED = "passed"
+STATUS_STALLED = "stalled"
+
+_FOLLOWUP_RE = re.compile(r"^followup-(\d+)$")
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text()
+    except OSError:
+        return ""
+
+
+def _mtime_iso(path: Path) -> str:
+    from datetime import datetime, timezone
+
+    try:
+        return datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).isoformat()
+    except OSError:
+        return ""
+
+
+def derive_tile(
+    name: str, prompt_id: int, soul: str, *, dead: bool = False
+) -> dict:
+    """Collapse one soul's filed replies into a single board tile.
+
+    Returns ``{soul, status, kind, verdict, filed_at}``. ``kind`` is the kind of
+    the *final* verdict (``take|pass|ack`` or ``None`` while pending); ``verdict``
+    is its full text (the UI clamps for display and expands on click).
+    """
+    rdir = inbox.replies_dir(name, prompt_id)
+
+    take_path = rdir / f"{soul}.take.md"
+    ack_path = rdir / f"{soul}.ack.md"
+    pass_path = rdir / f"{soul}.pass.md"
+
+    # Highest-numbered followup take wins as the final verdict.
+    latest_followup: Path | None = None
+    latest_n = 0
+    if rdir.is_dir():
+        for path in rdir.glob(f"{soul}.followup-*.md"):
+            # filename is "<soul>.followup-N.md"; recover the marker after soul.
+            marker = path.name[len(soul) + 1 : -3]  # strip "<soul>." and ".md"
+            m = _FOLLOWUP_RE.match(marker)
+            if not m:
+                continue
+            n = int(m.group(1))
+            if n > latest_n:
+                latest_n = n
+                latest_followup = path
+
+    # Precedence take > pass > ack > pending.
+    if latest_followup is not None:
+        return {
+            "soul": soul,
+            "status": STATUS_ANSWERED,
+            "kind": "take",
+            "verdict": _read(latest_followup),
+            "filed_at": _mtime_iso(latest_followup),
+        }
+    if take_path.exists():
+        return {
+            "soul": soul,
+            "status": STATUS_ANSWERED,
+            "kind": "take",
+            "verdict": _read(take_path),
+            "filed_at": _mtime_iso(take_path),
+        }
+    if pass_path.exists():
+        return {
+            "soul": soul,
+            "status": STATUS_PASSED,
+            "kind": "pass",
+            "verdict": _read(pass_path),
+            "filed_at": _mtime_iso(pass_path),
+        }
+    if ack_path.exists():
+        return {
+            "soul": soul,
+            "status": STATUS_ACKED,
+            "kind": "ack",
+            "verdict": _read(ack_path),
+            "filed_at": _mtime_iso(ack_path),
+        }
+    return {
+        "soul": soul,
+        "status": STATUS_STALLED if dead else STATUS_PENDING,
+        "kind": None,
+        "verdict": "",
+        "filed_at": "",
+    }
+
+
+def _is_final(status: str) -> bool:
+    """The completion counter ("N of M in") counts only terminal states."""
+    return status in (STATUS_ANSWERED, STATUS_PASSED)
+
+
+def snapshot(
+    name: str,
+    prompt_id: int | None = None,
+    *,
+    dead_souls: set[str] | None = None,
+) -> dict | None:
+    """Full board state for a sitting at a given prompt (latest by default).
+
+    Returns ``None`` if the sitting has no state on disk. The view is keyed on
+    the sitting ``name``; the per-prompt ``meta.json.roster`` (falling back to
+    the sitting roster) fixes both soul order and grid size — nothing is
+    hardcoded to a roster of six.
+    """
+    sitting = state.read_sitting(name)
+    if sitting is None:
+        return None
+
+    if prompt_id is None:
+        prompt_id = state.latest_prompt_id(name)
+
+    dead_souls = dead_souls or set()
+
+    meta = inbox.read_meta(name, prompt_id) if prompt_id else {}
+    roster = meta.get("roster") or list(sitting.roster)
+
+    prompt_text = ""
+    if prompt_id:
+        prompt_text = _read(inbox.prompt_dir(name, prompt_id) / "prompt.md")
+
+    tiles = [
+        derive_tile(name, prompt_id, soul, dead=soul in dead_souls)
+        for soul in roster
+    ] if prompt_id else []
+
+    final = sum(1 for t in tiles if _is_final(t["status"]))
+
+    return {
+        "sitting": name,
+        "orchestrator": sitting.orchestrator,
+        "roster": list(roster),
+        "prompt_id": prompt_id,
+        "prompt_ids": available_prompt_ids(name),
+        "prompt_text": prompt_text,
+        "created_at": meta.get("created_at", ""),
+        "tiles": tiles,
+        "total": len(tiles),
+        "final": final,
+    }
+
+
+def available_prompt_ids(name: str) -> list[int]:
+    """Every prompt id with a dir on disk, ascending (drives the round selector)."""
+    pdir = state.prompts_dir(name)
+    if not pdir.is_dir():
+        return []
+    ids = []
+    for child in pdir.iterdir():
+        if child.is_dir() and child.name.isdigit():
+            ids.append(int(child.name))
+    return sorted(ids)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -306,6 +306,9 @@ class AgentWireServer:
         self.app.router.add_post("/api/scheduler/start", self.api_scheduler_start)
         self.app.router.add_post("/api/scheduler/stop", self.api_scheduler_stop)
         self.app.router.add_get("/api/scheduler/output", self.api_scheduler_session_output)
+        # Council seating board: live sittings + per-prompt snapshot
+        self.app.router.add_get("/api/council/sittings", self.api_council_sittings)
+        self.app.router.add_get("/api/council/live", self.api_council_live)
         # Artifact windows: upload and serve agent-generated HTML
         self.app.router.add_post("/api/artifacts/upload", self.api_artifacts_upload)
         self.app.router.add_get("/api/artifacts", self.api_artifacts_list)
@@ -4972,6 +4975,141 @@ projects:
         await proc.wait()
         return proc.returncode == 0
 
+    async def _council_dead_souls(self, sitting) -> set:
+        """Roster souls whose lens tmux session is gone (→ stalled, not pending).
+
+        One ``tmux list-sessions`` off the event loop; council sessions are
+        local so the ``@machine`` suffix is stripped before matching.
+        """
+        if not sitting or not sitting.sessions:
+            return set()
+        try:
+            loop = asyncio.get_event_loop()
+            live_raw = await loop.run_in_executor(None, self.agent.list_sessions)
+        except Exception:
+            return set()
+        live = {s.split("@")[0] for s in live_raw}
+        return {
+            soul
+            for soul, sess in sitting.sessions.items()
+            if sess.split("@")[0] not in live
+        }
+
+    async def api_council_sittings(self, request: web.Request) -> web.Response:
+        """GET /api/council/sittings - Names of every live council sitting."""
+        try:
+            from .council import state as council_state
+            return web.json_response({"sittings": council_state.list_sittings()})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_council_live(self, request: web.Request) -> web.Response:
+        """GET /api/council/live - Board snapshot for a sitting (mirrors
+        /api/scheduler/live).
+
+        Query: ``sitting`` (defaults to the sole live sitting), ``prompt_id``
+        (defaults to the latest). 404 when the named sitting has no state.
+        """
+        try:
+            from .council import state as council_state
+            from .council import view as council_view
+
+            name = request.query.get("sitting")
+            if not name:
+                live = council_state.list_sittings()
+                if len(live) == 1:
+                    name = live[0]
+                elif not live:
+                    return web.json_response(
+                        {"running": False, "sittings": []}, status=404
+                    )
+                else:
+                    # Ambiguous — let the client pick from the list.
+                    return web.json_response(
+                        {"running": False, "sittings": live}, status=409
+                    )
+
+            sitting = council_state.read_sitting(name)
+            if sitting is None:
+                return web.json_response(
+                    {"running": False, "sittings": council_state.list_sittings()},
+                    status=404,
+                )
+
+            prompt_id_raw = request.query.get("prompt_id")
+            prompt_id = int(prompt_id_raw) if prompt_id_raw else None
+            dead = await self._council_dead_souls(sitting)
+            snap = council_view.snapshot(name, prompt_id, dead_souls=dead)
+            if snap is None:
+                return web.json_response({"running": False}, status=404)
+            snap["running"] = True
+            snap["sittings"] = council_state.list_sittings()
+            return web.json_response(snap)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def council_watch_loop(self):
+        """Poll live sittings' latest ``replies/`` dir and push ``council_update``
+        deltas over the dashboard WS.
+
+        A filesystem ``rename`` watch would be tighter, but a ~1.5s poll needs no
+        new dependency and the producer-side atomic write (``inbox.py``) is what
+        actually guarantees a reader never sees a half-written verdict. Each delta
+        carries the fully-derived tile for the one soul that changed, so the
+        browser swaps a single tile with no re-fetch and no flicker. A new prompt
+        round emits ``{reset: True}`` so the board refetches its snapshot.
+        """
+        from .council import inbox, state as council_state, view as council_view
+
+        seen: dict[str, dict] = {}  # name -> {prompt_id, files: {name: mtime}}
+        logger.info("[Council] Board watcher started")
+        while True:
+            try:
+                if self.dashboard_clients:
+                    live = set(council_state.list_sittings())
+                    for stale in [n for n in seen if n not in live]:
+                        seen.pop(stale, None)
+                    for name in live:
+                        await self._council_tick(name, seen, inbox, council_state, council_view)
+            except asyncio.CancelledError:
+                logger.info("[Council] Board watcher stopped")
+                raise
+            except Exception as e:
+                logger.debug(f"[Council] watch tick failed: {e}")
+            await asyncio.sleep(1.5)
+
+    async def _council_tick(self, name, seen, inbox, council_state, council_view):
+        pid = council_state.latest_prompt_id(name)
+        if pid is None:
+            return
+        prev = seen.get(name)
+        if prev is None or prev.get("prompt_id") != pid:
+            # New prompt round — clear stale tile state, tell the board to refetch.
+            seen[name] = {"prompt_id": pid, "files": {}}
+            prev = seen[name]
+            await self.broadcast_dashboard(
+                "council_update", {"sitting": name, "prompt_id": pid, "reset": True}
+            )
+        rdir = inbox.replies_dir(name, pid)
+        current: dict[str, float] = {}
+        if rdir.is_dir():
+            for p in rdir.glob("*.md"):
+                try:
+                    current[p.name] = p.stat().st_mtime
+                except OSError:
+                    pass
+        changed_souls = {
+            fname.split(".", 1)[0]
+            for fname, mt in current.items()
+            if prev["files"].get(fname) != mt
+        }
+        for soul in changed_souls:
+            tile = council_view.derive_tile(name, pid, soul)
+            await self.broadcast_dashboard(
+                "council_update", {"sitting": name, "prompt_id": pid, "tile": tile}
+            )
+        seen[name] = {"prompt_id": pid, "files": current}
+
     async def api_scheduler_events(self, request: web.Request) -> web.Response:
         """GET /api/scheduler/events - Recent scheduler events."""
         try:
@@ -5531,6 +5669,9 @@ async def run_server(config: Config):
     # Watchdog: healthcheck registered services, notify + restart per policy
     watchdog_task = asyncio.create_task(server.service_watchdog_loop())
 
+    # Council board: poll live sittings' replies and push council_update deltas
+    council_task = asyncio.create_task(server.council_watch_loop())
+
     # Sessions are now fetched dynamically from tmux + .agentwire.yml
     # No cache to rebuild or periodically refresh
 
@@ -5561,7 +5702,7 @@ async def run_server(config: Config):
         while True:
             await asyncio.sleep(3600)
     finally:
-        for task in (monitor_task, idle_nag_task, autostart_task, watchdog_task):
+        for task in (monitor_task, idle_nag_task, autostart_task, watchdog_task, council_task):
             task.cancel()
             try:
                 await task

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5631,304 +5631,249 @@ body.sidebar-pinned .sidebar-tab {
     }
 }
 
+
 /* ============================================================
-   Council seating board (issue #403, Phases 0–2 — CORE)
-   Functional, roster-driven grid. Every tile state keys off a
-   status-enum class (council-tile--{pending,acked,answered,
-   passed,stalled}) so the designer pass can restyle by class
-   without touching council-window.js. Status colors are scoped
-   vars — override these to re-skin.
+   Council seating board (issue #403) — Phase 3 designer styling.
+   Ports the approved hi-fi reference (council-design-reference.html)
+   onto the real council window. All selectors are council-namespaced
+   to coexist in the shared desktop.css; every tile treatment keys off
+   a single status class (.council-tile--{pending,acked,answered,
+   passed,stalled}). State colors flow through scoped --council-* alias
+   vars (mapped to existing portal tokens) — override an alias to re-skin
+   without touching council-window.js.
    ============================================================ */
 .council-window .wb-body {
     background: var(--background);
     color: var(--text);
 }
 .council-window-mount {
-    height: 100%;
     position: relative;
-    --council-pending: var(--text-muted);
-    --council-acked: var(--orb-generating);
-    --council-answered: var(--accent);
-    --council-passed: #64748b;
-    --council-stalled: var(--error);
-}
-.council-board {
-    display: flex;
-    flex-direction: column;
     height: 100%;
-    box-sizing: border-box;
-    padding: 16px;
-    gap: 14px;
-    overflow: hidden;
-}
-.council-board--empty {
-    align-items: center;
-    justify-content: center;
-}
-.council-empty {
-    color: var(--text-muted);
-    font-size: 14px;
-}
-.council-empty-picker {
-    margin-bottom: 12px;
-}
-
-/* Header: sitting + counter + selectors */
-.council-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-.council-header-left,
-.council-header-right {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-.council-sitting-name {
-    font-weight: 600;
-    font-size: 15px;
-    color: var(--accent);
-}
-.council-counter {
-    font-variant-numeric: tabular-nums;
-    font-size: 13px;
-    color: var(--text-muted);
-    white-space: nowrap;
-}
-.council-round-select,
-.council-sitting-select {
-    background: var(--chrome);
-    color: var(--text);
-    border: 1px solid var(--chrome-border);
-    border-radius: 6px;
-    padding: 3px 6px;
-    font-size: 12px;
-}
-
-/* Centered question */
-.council-question {
-    text-align: center;
-    font-size: 16px;
-    line-height: 1.4;
-    color: var(--text);
-    padding: 4px 8px;
-    max-width: 760px;
-    margin: 0 auto;
-}
-.council-question-empty {
-    color: var(--text-muted);
-    font-style: italic;
-}
-.council-history-badge {
-    display: inline-block;
-    margin-left: 8px;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--neon-blue);
-    border: 1px solid var(--neon-blue-subtle);
-    border-radius: 4px;
-    padding: 1px 5px;
-    vertical-align: middle;
-}
-
-/* Roster-driven responsive grid — reflows to roster size, never hardcoded */
-.council-grid {
-    flex: 1;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    grid-auto-rows: minmax(120px, auto);
-    gap: 12px;
     overflow-y: auto;
-    align-content: start;
+    background: var(--background);
+    color: var(--text);
+    /* status-enum aliases — the designer restyle surface */
+    --council-pending: var(--neon-blue);
+    --council-acked: var(--orb-listening);
+    --council-answered: var(--accent);
+    --council-passed: var(--text-muted);
+    --council-stalled: var(--error);
+    /* fonts: progressive-enhancement webfonts with solid fallbacks */
+    --council-font-serif: 'Newsreader', 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Times New Roman', Georgia, serif;
+    --council-font-sans: 'Space Grotesk', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --council-font-mono: 'Space Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-family: var(--council-font-sans);
+    -webkit-font-smoothing: antialiased;
 }
 
-/* Tile */
+/* green glow + vignette layered on the black base (scoped to the window) */
+.council-glow {
+    position: absolute; inset: 0; pointer-events: none; z-index: 0;
+    background: radial-gradient(120% 75% at 50% -10%, rgba(57, 255, 20, 0.14) 0%, rgba(57, 255, 20, 0) 45%);
+}
+.council-vignette {
+    position: absolute; inset: 0; pointer-events: none; z-index: 0;
+    background: radial-gradient(78% 56% at 50% 40%, rgba(0, 0, 0, 0) 42%, rgba(0, 0, 0, 0.6) 100%);
+}
+.council-shell {
+    position: relative; z-index: 1;
+    max-width: 1100px; margin: 0 auto;
+    padding: 26px 32px 48px;
+}
+.council-shell--empty {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    min-height: 60vh; gap: 14px;
+}
+.council-empty { color: var(--text-muted); font-size: 14px; }
+
+/* ---------- HEADER ---------- */
+.council-header {
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
+    padding-bottom: 22px; border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+.council-brand { display: flex; align-items: center; gap: 10px; margin-bottom: 7px; }
+.council-led { width: 9px; height: 9px; border-radius: 2px; background: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
+.council-eyebrow { font-family: var(--council-font-mono); font-size: 12px; letter-spacing: 0.28em; color: #7c8a80; }
+.council-sitting { font-weight: 600; font-size: 20px; color: #eef3ee; letter-spacing: -0.01em; }
+
+.council-header-right { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; justify-content: flex-end; }
+.council-counter-wrap { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
+.council-dots { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; max-width: 220px; justify-content: flex-end; }
+.council-dot-cell { width: 9px; height: 9px; border-radius: 2px; background: rgba(255, 255, 255, 0.13); transition: all 0.4s ease; }
+.council-dot-cell--in { background: var(--accent); box-shadow: 0 0 8px rgba(57, 255, 20, 0.6); }
+.council-dot-cell--work { background: var(--council-acked); box-shadow: 0 0 8px color-mix(in srgb, var(--council-acked) 55%, transparent); }
+.council-dot-cell--bad { background: var(--error); }
+.council-counter { font-family: var(--council-font-mono); font-size: 13px; letter-spacing: 0.1em; color: #9aa69c; transition: color 0.4s; white-space: nowrap; }
+.council-counter--complete { color: var(--accent); text-shadow: 0 0 16px rgba(57, 255, 20, 0.55); }
+.council-counter--pop { animation: councilCounterPop 0.9s ease-out; }
+
+/* ROUND selector */
+.council-selector { position: relative; }
+.council-selector-btn {
+    display: flex; align-items: center; gap: 12px; padding: 9px 13px; border-radius: 10px;
+    background: color-mix(in srgb, var(--neon-blue) 6%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--neon-blue) 30%, transparent);
+    cursor: pointer; user-select: none;
+}
+.council-selector-btn .council-sel-lbl { font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.18em; color: #5fb8d8; }
+.council-selector-btn .council-sel-val { font-weight: 600; font-size: 14px; color: #d7eef7; }
+.council-selector-btn .council-sel-chev { color: #5fb8d8; font-size: 11px; }
+.council-dropdown {
+    position: absolute; top: calc(100% + 8px); right: 0; width: 300px; max-height: 320px; overflow-y: auto;
+    padding: 6px; border-radius: 12px; background: #0c1114;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--neon-blue) 18%, transparent), 0 24px 60px rgba(0, 0, 0, 0.7);
+    z-index: 30; display: none;
+}
+.council-dropdown--open { display: block; }
+.council-round-opt { padding: 11px 12px; border-radius: 8px; cursor: pointer; }
+.council-round-opt--active, .council-round-opt:hover { background: color-mix(in srgb, var(--neon-blue) 8%, transparent); }
+.council-round-opt .council-round-tag { font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.16em; color: #5fb8d8; margin-bottom: 3px; }
+.council-round-opt .council-round-txt { font-size: 13px; color: #cdd6ce; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* ---------- QUESTION ---------- */
+.council-question-wrap { display: flex; justify-content: center; padding: 46px 16px 42px; }
+.council-question { max-width: 860px; text-align: center; }
+.council-kicker { font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.3em; color: #4d8aa0; margin-bottom: 18px; }
+.council-q { font-family: var(--council-font-serif); font-weight: 400; font-size: 34px; line-height: 1.32; color: #eaf3f2; text-wrap: pretty; }
+.council-quote { color: var(--neon-blue); opacity: 0.85; }
+.council-q--empty { color: var(--text-muted); font-style: italic; font-size: 22px; }
+
+/* ---------- PANEL / GRID ---------- */
+.council-panel { position: relative; }
+.council-panel-glow {
+    position: absolute; inset: -30px; pointer-events: none; border-radius: 24px; opacity: 0; z-index: 0;
+    background: radial-gradient(60% 50% at 50% 50%, rgba(57, 255, 20, 0.1), rgba(57, 255, 20, 0) 70%);
+}
+.council-panel-glow--show { animation: councilPanelGlow 1.2s ease-out; }
+.council-grid {
+    position: relative; z-index: 1; display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(290px, 1fr)); gap: 18px; margin: 0 auto;
+}
+.council-grid--trio { max-width: 920px; }
+
+/* ============================================================
+   TILE — whole treatment keys off the single status class.
+   ============================================================ */
 .council-tile {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding: 12px;
-    border-radius: 10px;
-    background: var(--chrome);
-    border: 1px solid var(--chrome-border);
-    border-left: 3px solid var(--council-pending);
-    transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
-    overflow: hidden;
+    position: relative; display: flex; flex-direction: column; gap: 14px;
+    padding: 22px 22px 20px; border-radius: 15px; min-height: 218px;
+    background: var(--chrome); border: 1px solid var(--chrome-border);
+    transition: box-shadow 0.35s ease, transform 0.35s ease, border-color 0.35s ease, background 0.35s ease;
+    -webkit-tap-highlight-color: transparent;
 }
-.council-tile[data-expandable="1"] {
-    cursor: pointer;
+.council-tile-head { display: flex; flex-direction: column; gap: 3px; }
+.council-tile-name { font-weight: 600; font-size: 18px; color: #eef3ee; letter-spacing: -0.01em; }
+.council-tile-role { font-family: var(--council-font-mono); font-size: 11px; color: #67756b; letter-spacing: 0.02em; }
+.council-tile-status { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.council-chip { display: inline-flex; align-items: center; padding: 5px 10px; border-radius: 6px; font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.13em; }
+.council-chip-dot { display: none; width: 6px; height: 6px; border-radius: 50%; margin-right: 7px; background: var(--council-pending); }
+.council-meta { font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--text-muted); }
+.council-tile-body {
+    flex: 1; font-size: 14.5px; line-height: 1.52; color: var(--text);
+    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; text-wrap: pretty;
 }
-.council-tile[data-expandable="1"]:hover {
-    background: var(--hover);
-}
-.council-tile-head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-}
-.council-soul {
-    font-weight: 600;
-    font-size: 13px;
-    color: var(--text);
-}
-.council-chip {
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 2px 7px;
-    border-radius: 999px;
-    border: 1px solid currentColor;
-    white-space: nowrap;
-}
-.council-verdict {
-    font-size: 13px;
-    line-height: 1.45;
-    color: var(--text);
-    /* clamp ~3 lines; full text via click-to-expand */
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-.council-tile-placeholder {
-    font-size: 12px;
-    color: var(--text-muted);
-    font-style: italic;
-}
-.council-timer {
-    font-variant-numeric: tabular-nums;
-    font-style: normal;
-    opacity: 0.8;
-}
+.council-tile-expand { display: none; align-items: center; gap: 6px; font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--accent); }
+.council-tile-expand span { font-size: 13px; }
 
-/* Status-enum styling — designer restyles by these classes */
-.council-tile--pending {
-    border-left-color: var(--council-pending);
-    animation: council-breathe 2.4s ease-in-out infinite;
-}
-.council-tile--pending .council-chip { color: var(--council-pending); }
+/* PENDING — alive, breathing, never frozen */
+.council-tile--pending .council-chip { color: var(--council-pending); background: color-mix(in srgb, var(--council-pending) 10%, transparent); }
+.council-tile--pending .council-chip-dot { display: inline-block; animation: councilPulseDot 1.8s ease-in-out infinite; }
+.council-tile--pending .council-tile-body { display: none; }
 
+/* ACKED — amber in-flight promise */
 .council-tile--acked {
-    border-left-color: var(--council-acked);
+    border-color: color-mix(in srgb, var(--council-acked) 48%, var(--chrome-border));
+    background: color-mix(in srgb, var(--council-acked) 7%, var(--chrome));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--council-acked) 26%, transparent), 0 0 26px color-mix(in srgb, var(--council-acked) 8%, transparent), 0 14px 40px rgba(0, 0, 0, 0.5);
 }
-.council-tile--acked .council-chip { color: var(--council-acked); }
+.council-tile--acked .council-chip { color: var(--council-acked); background: color-mix(in srgb, var(--council-acked) 14%, transparent); }
+.council-tile--acked .council-meta { color: color-mix(in srgb, var(--council-acked) 60%, var(--text-muted)); }
+.council-tile--acked .council-tile-body { color: color-mix(in srgb, var(--council-acked) 55%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
 
+/* ANSWERED — the hero / committed state */
 .council-tile--answered {
-    border-left-color: var(--council-answered);
-}
-.council-tile--answered .council-chip { color: var(--council-answered); }
-
-.council-tile--passed {
-    border-left-color: var(--council-passed);
-    opacity: 0.82;
-}
-.council-tile--passed .council-chip { color: var(--council-passed); }
-
-.council-tile--stalled {
-    border-left-color: var(--council-stalled);
-    border-style: dashed;
-}
-.council-tile--stalled .council-chip { color: var(--council-stalled); }
-
-@keyframes council-breathe {
-    0%, 100% { opacity: 0.62; }
-    50%      { opacity: 1; }
-}
-
-/* The swap settle — a single ~250ms scale/glow when a tile resolves */
-.council-tile--settle {
-    animation: council-settle 260ms ease-out;
-}
-@keyframes council-settle {
-    0%   { transform: scale(0.97); box-shadow: 0 0 0 0 var(--primary-glow); }
-    60%  { transform: scale(1.012); box-shadow: 0 0 18px 2px var(--primary-glow); }
-    100% { transform: scale(1); box-shadow: none; }
-}
-
-/* Sitting-complete flourish */
-.council-board--flourish .council-counter {
-    color: var(--accent);
-    text-shadow: 0 0 8px var(--primary-glow);
-}
-
-/* Reader overlay — full verdict, click-to-expand */
-.council-reader-overlay {
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-    z-index: 10;
-}
-.council-reader {
-    background: var(--chrome);
-    border: 1px solid var(--chrome-border);
-    border-radius: 12px;
-    max-width: 640px;
-    width: 100%;
-    max-height: 80%;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-.council-reader-head {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 12px 14px;
-    border-bottom: 1px solid var(--chrome-border);
-}
-.council-reader-head .council-soul { flex: 0 0 auto; }
-.council-reader-close {
-    margin-left: auto;
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    font-size: 22px;
-    line-height: 1;
     cursor: pointer;
+    border-color: color-mix(in srgb, var(--council-answered) 45%, var(--chrome-border));
+    background: color-mix(in srgb, var(--council-answered) 6%, var(--chrome));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--council-answered) 30%, transparent), 0 0 30px color-mix(in srgb, var(--council-answered) 7%, transparent), 0 16px 46px rgba(0, 0, 0, 0.55);
+}
+.council-tile--answered:hover {
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--council-answered) 50%, transparent), 0 0 40px color-mix(in srgb, var(--council-answered) 12%, transparent), 0 16px 46px rgba(0, 0, 0, 0.55);
+}
+.council-tile--answered .council-chip { color: var(--council-answered); background: color-mix(in srgb, var(--council-answered) 12%, transparent); }
+.council-tile--answered .council-tile-expand { display: flex; }
+
+/* PASSED — honest, respected, present (NOT dead) */
+.council-tile--passed {
+    border-color: color-mix(in srgb, var(--council-passed) 34%, var(--chrome-border));
+    background: color-mix(in srgb, var(--council-passed) 5%, var(--chrome));
+}
+.council-tile--passed .council-chip { color: var(--council-passed); background: color-mix(in srgb, var(--council-passed) 13%, transparent); }
+.council-tile--passed .council-tile-body { color: var(--council-passed); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
+
+/* STALLED — errored, clearly different from a pass */
+.council-tile--stalled {
+    border-color: color-mix(in srgb, var(--council-stalled) 44%, var(--chrome-border));
+    background: color-mix(in srgb, var(--council-stalled) 6%, var(--chrome));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--council-stalled) 24%, transparent), 0 14px 40px rgba(0, 0, 0, 0.45);
+}
+.council-tile--stalled .council-chip { color: var(--council-stalled); background: color-mix(in srgb, var(--council-stalled) 12%, transparent); }
+.council-tile--stalled .council-chip::before { content: "\26A0"; margin-right: 6px; }
+.council-tile--stalled .council-meta { color: color-mix(in srgb, var(--council-stalled) 55%, var(--text-muted)); }
+.council-tile--stalled .council-tile-body { color: color-mix(in srgb, var(--council-stalled) 50%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
+
+/* SWAP — the gavel beat: ~250ms scale-punch + glow settle */
+.council-tile--flip { animation: councilSwapIn 0.52s cubic-bezier(0.2, 0.85, 0.25, 1); }
+
+/* ---------- READER OVERLAY (scoped to the window) ---------- */
+.council-backdrop {
+    position: absolute; inset: 0; z-index: 50; display: none; align-items: center; justify-content: center; padding: 32px;
+    background: rgba(4, 6, 7, 0.74); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+}
+.council-backdrop--open { display: flex; animation: councilBackdropIn 0.2s ease-out; }
+.council-reader {
+    position: relative; width: 100%; max-width: 680px; max-height: 84%; overflow-y: auto; padding: 36px 38px 34px; border-radius: 18px;
+    background: linear-gradient(180deg, #0d130f, #0a0e0c);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 28%, transparent), 0 0 60px color-mix(in srgb, var(--accent) 7%, transparent), 0 40px 100px rgba(0, 0, 0, 0.8);
+    animation: councilOverlayIn 0.26s cubic-bezier(0.2, 0.85, 0.25, 1);
+}
+.council-reader-close {
+    position: absolute; top: 18px; right: 20px; width: 30px; height: 30px; display: flex; align-items: center; justify-content: center;
+    border-radius: 8px; background: rgba(255, 255, 255, 0.05); color: #8a958c; cursor: pointer; font-size: 16px; border: none;
 }
 .council-reader-close:hover { color: var(--text); }
-.council-reader-body {
-    padding: 16px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    font-size: 14px;
-    line-height: 1.55;
-    color: var(--text);
+.council-reader-head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 6px; }
+.council-reader-name { font-weight: 700; font-size: 26px; color: #f0f6f0; letter-spacing: -0.015em; }
+.council-reader-role { font-family: var(--council-font-mono); font-size: 12px; color: #6c7a70; }
+.council-reader-chip {
+    display: inline-flex; align-items: center; padding: 5px 11px; border-radius: 6px; margin-bottom: 24px;
+    font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.14em;
+    color: var(--council-answered); background: color-mix(in srgb, var(--council-answered) 11%, transparent);
+}
+.council-reader-body { font-family: var(--council-font-serif); font-size: 18px; line-height: 1.62; color: #d7e0d7; text-wrap: pretty; white-space: pre-wrap; }
+
+/* ---------- KEYFRAMES ---------- */
+@keyframes councilPulseDot { 0%, 100% { opacity: 0.25; transform: scale(0.78); } 50% { opacity: 1; transform: scale(1); } }
+@keyframes councilSwapIn {
+    0%   { transform: scale(0.965); box-shadow: 0 0 0 1px rgba(57, 255, 20, 0.95), 0 0 64px rgba(57, 255, 20, 0.5), 0 16px 46px rgba(0, 0, 0, 0.55); }
+    45%  { transform: scale(1.03);  box-shadow: 0 0 0 1px rgba(57, 255, 20, 0.7), 0 0 50px rgba(57, 255, 20, 0.32), 0 16px 46px rgba(0, 0, 0, 0.55); }
+    100% { transform: scale(1);     box-shadow: 0 0 0 1px rgba(57, 255, 20, 0.3), 0 0 30px rgba(57, 255, 20, 0.06), 0 16px 46px rgba(0, 0, 0, 0.55); }
+}
+@keyframes councilCounterPop { 0% { transform: scale(1); } 30% { transform: scale(1.14); text-shadow: 0 0 22px rgba(57, 255, 20, 0.9); } 100% { transform: scale(1); } }
+@keyframes councilPanelGlow { 0% { opacity: 0; } 25% { opacity: 1; } 100% { opacity: 0; } }
+@keyframes councilOverlayIn { 0% { opacity: 0; transform: translateY(10px) scale(0.985); } 100% { opacity: 1; transform: none; } }
+@keyframes councilBackdropIn { 0% { opacity: 0; } 100% { opacity: 1; } }
+
+@media (prefers-reduced-motion: reduce) {
+    .council-window-mount * { animation-duration: 0.001ms !important; }
 }
 
-/* Sidebar section launcher */
-.council-section-list {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
+/* ---------- Sidebar section launcher ---------- */
+.council-section-list { display: flex; flex-direction: column; gap: 6px; }
 .council-section-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    width: 100%;
-    text-align: left;
-    background: var(--chrome);
-    border: 1px solid var(--chrome-border);
-    border-radius: 8px;
-    padding: 8px 10px;
-    color: var(--text);
-    cursor: pointer;
+    display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; text-align: left;
+    background: var(--chrome); border: 1px solid var(--chrome-border); border-radius: 8px; padding: 8px 10px; color: var(--text); cursor: pointer;
 }
 .council-section-item:hover { background: var(--hover); }
 .council-section-name { font-weight: 600; font-size: 13px; }
-.council-section-count {
-    font-size: 11px;
-    color: var(--text-muted);
-    font-variant-numeric: tabular-nums;
-}
+.council-section-count { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; }

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5630,3 +5630,305 @@ body.sidebar-pinned .sidebar-tab {
         color: var(--accent);
     }
 }
+
+/* ============================================================
+   Council seating board (issue #403, Phases 0–2 — CORE)
+   Functional, roster-driven grid. Every tile state keys off a
+   status-enum class (council-tile--{pending,acked,answered,
+   passed,stalled}) so the designer pass can restyle by class
+   without touching council-window.js. Status colors are scoped
+   vars — override these to re-skin.
+   ============================================================ */
+.council-window .wb-body {
+    background: var(--background);
+    color: var(--text);
+}
+.council-window-mount {
+    height: 100%;
+    position: relative;
+    --council-pending: var(--text-muted);
+    --council-acked: var(--orb-generating);
+    --council-answered: var(--accent);
+    --council-passed: #64748b;
+    --council-stalled: var(--error);
+}
+.council-board {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    box-sizing: border-box;
+    padding: 16px;
+    gap: 14px;
+    overflow: hidden;
+}
+.council-board--empty {
+    align-items: center;
+    justify-content: center;
+}
+.council-empty {
+    color: var(--text-muted);
+    font-size: 14px;
+}
+.council-empty-picker {
+    margin-bottom: 12px;
+}
+
+/* Header: sitting + counter + selectors */
+.council-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.council-header-left,
+.council-header-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.council-sitting-name {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--accent);
+}
+.council-counter {
+    font-variant-numeric: tabular-nums;
+    font-size: 13px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.council-round-select,
+.council-sitting-select {
+    background: var(--chrome);
+    color: var(--text);
+    border: 1px solid var(--chrome-border);
+    border-radius: 6px;
+    padding: 3px 6px;
+    font-size: 12px;
+}
+
+/* Centered question */
+.council-question {
+    text-align: center;
+    font-size: 16px;
+    line-height: 1.4;
+    color: var(--text);
+    padding: 4px 8px;
+    max-width: 760px;
+    margin: 0 auto;
+}
+.council-question-empty {
+    color: var(--text-muted);
+    font-style: italic;
+}
+.council-history-badge {
+    display: inline-block;
+    margin-left: 8px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--neon-blue);
+    border: 1px solid var(--neon-blue-subtle);
+    border-radius: 4px;
+    padding: 1px 5px;
+    vertical-align: middle;
+}
+
+/* Roster-driven responsive grid — reflows to roster size, never hardcoded */
+.council-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-auto-rows: minmax(120px, auto);
+    gap: 12px;
+    overflow-y: auto;
+    align-content: start;
+}
+
+/* Tile */
+.council-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border-radius: 10px;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-left: 3px solid var(--council-pending);
+    transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+    overflow: hidden;
+}
+.council-tile[data-expandable="1"] {
+    cursor: pointer;
+}
+.council-tile[data-expandable="1"]:hover {
+    background: var(--hover);
+}
+.council-tile-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+.council-soul {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--text);
+}
+.council-chip {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 7px;
+    border-radius: 999px;
+    border: 1px solid currentColor;
+    white-space: nowrap;
+}
+.council-verdict {
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--text);
+    /* clamp ~3 lines; full text via click-to-expand */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.council-tile-placeholder {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+}
+.council-timer {
+    font-variant-numeric: tabular-nums;
+    font-style: normal;
+    opacity: 0.8;
+}
+
+/* Status-enum styling — designer restyles by these classes */
+.council-tile--pending {
+    border-left-color: var(--council-pending);
+    animation: council-breathe 2.4s ease-in-out infinite;
+}
+.council-tile--pending .council-chip { color: var(--council-pending); }
+
+.council-tile--acked {
+    border-left-color: var(--council-acked);
+}
+.council-tile--acked .council-chip { color: var(--council-acked); }
+
+.council-tile--answered {
+    border-left-color: var(--council-answered);
+}
+.council-tile--answered .council-chip { color: var(--council-answered); }
+
+.council-tile--passed {
+    border-left-color: var(--council-passed);
+    opacity: 0.82;
+}
+.council-tile--passed .council-chip { color: var(--council-passed); }
+
+.council-tile--stalled {
+    border-left-color: var(--council-stalled);
+    border-style: dashed;
+}
+.council-tile--stalled .council-chip { color: var(--council-stalled); }
+
+@keyframes council-breathe {
+    0%, 100% { opacity: 0.62; }
+    50%      { opacity: 1; }
+}
+
+/* The swap settle — a single ~250ms scale/glow when a tile resolves */
+.council-tile--settle {
+    animation: council-settle 260ms ease-out;
+}
+@keyframes council-settle {
+    0%   { transform: scale(0.97); box-shadow: 0 0 0 0 var(--primary-glow); }
+    60%  { transform: scale(1.012); box-shadow: 0 0 18px 2px var(--primary-glow); }
+    100% { transform: scale(1); box-shadow: none; }
+}
+
+/* Sitting-complete flourish */
+.council-board--flourish .council-counter {
+    color: var(--accent);
+    text-shadow: 0 0 8px var(--primary-glow);
+}
+
+/* Reader overlay — full verdict, click-to-expand */
+.council-reader-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 10;
+}
+.council-reader {
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 12px;
+    max-width: 640px;
+    width: 100%;
+    max-height: 80%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.council-reader-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--chrome-border);
+}
+.council-reader-head .council-soul { flex: 0 0 auto; }
+.council-reader-close {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+}
+.council-reader-close:hover { color: var(--text); }
+.council-reader-body {
+    padding: 16px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--text);
+}
+
+/* Sidebar section launcher */
+.council-section-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.council-section-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    text-align: left;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--text);
+    cursor: pointer;
+}
+.council-section-item:hover { background: var(--hover); }
+.council-section-name { font-weight: 600; font-size: 13px; }
+.council-section-count {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}

--- a/agentwire/static/js/council-window.js
+++ b/agentwire/static/js/council-window.js
@@ -1,0 +1,387 @@
+/**
+ * Council seating board — a WinBox window that makes a live sitting legible at
+ * a glance: each lens (soul) as a tile, the prompt centered above, every tile
+ * showing only its *filed verdict*. Tiles swap once, cleanly, when a reply
+ * lands (the `council_update` WS delta) — no token streaming, no flicker.
+ *
+ * Data flow:
+ *   - first paint / round switch / reconnect → GET /api/council/live (snapshot)
+ *   - per-reply deltas → desktop 'council_update' { sitting, prompt_id, tile }
+ *     (or { reset:true } when a new round starts → refetch)
+ *
+ * Status enum drives a per-tile class so the designer can restyle by class
+ * without touching this logic:
+ *   pending | acked | answered | passed | stalled
+ *
+ * CORE build (issue #403, Phases 0–2). Phase 3 affordances + final visual
+ * styling are intentionally a thin layer on top of these hooks.
+ */
+
+import { apiFetch } from './api.js';
+import { desktop } from './desktop-manager.js';
+
+let activeWindow = null;
+
+// View state — one board at a time (re-opening focuses the existing window).
+const state = {
+    sitting: null,        // sitting <name> currently shown
+    promptId: null,       // prompt id currently shown
+    latestPromptId: null, // newest round for the sitting (for "live vs history")
+    promptIds: [],        // every round id, ascending (selector)
+    promptText: '',
+    roster: [],           // fixed soul order — never reordered under the user
+    createdAt: '',        // round start (drives the pending elapsed timer)
+    tiles: new Map(),     // soul -> { soul, status, kind, verdict, filed_at }
+    sittings: [],         // every live sitting (for the sitting picker)
+};
+
+let container = null;
+let timerInterval = null;
+
+const STATUS_LABEL = {
+    pending: 'waiting…',
+    acked: 'researching…',
+    answered: 'take',
+    passed: 'passed',
+    stalled: 'no response',
+};
+
+const KIND_LABEL = { take: 'take', ack: 'ack', pass: 'pass' };
+
+const CLAMP_CHARS = 200;
+
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+}
+
+/** Whether a tile counts toward "N of M in" (terminal states only). */
+function isFinal(status) {
+    return status === 'answered' || status === 'passed';
+}
+
+function clampVerdict(text) {
+    const t = String(text || '').trim();
+    if (t.length <= CLAMP_CHARS) return t;
+    return t.slice(0, CLAMP_CHARS).trimEnd() + '…';
+}
+
+function elapsedSince(iso) {
+    if (!iso) return '';
+    const start = Date.parse(iso);
+    if (Number.isNaN(start)) return '';
+    const secs = Math.max(0, Math.floor((Date.now() - start) / 1000));
+    if (secs < 60) return `${secs}s`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    return `${hrs}h ${mins % 60}m`;
+}
+
+// ── Snapshot fetch ──────────────────────────────────────────────────────────
+
+async function loadSnapshot(sitting, promptId) {
+    const params = new URLSearchParams();
+    if (sitting) params.set('sitting', sitting);
+    if (promptId != null) params.set('prompt_id', String(promptId));
+    const qs = params.toString();
+    const res = await apiFetch(`/api/council/live${qs ? `?${qs}` : ''}`);
+    if (res.status === 409) {
+        // Ambiguous — multiple sittings, none chosen. Show the picker.
+        const body = await res.json().catch(() => ({}));
+        state.sittings = body.sittings || [];
+        state.sitting = null;
+        renderEmpty('Multiple council sittings — pick one.');
+        return;
+    }
+    if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        state.sittings = body.sittings || [];
+        state.sitting = null;
+        renderEmpty('No live council sitting.');
+        return;
+    }
+    const snap = await res.json();
+    applySnapshot(snap);
+}
+
+function applySnapshot(snap) {
+    state.sitting = snap.sitting;
+    state.promptId = snap.prompt_id;
+    state.promptIds = snap.prompt_ids || [];
+    state.latestPromptId = state.promptIds.length
+        ? state.promptIds[state.promptIds.length - 1]
+        : snap.prompt_id;
+    state.promptText = snap.prompt_text || '';
+    state.roster = snap.roster || [];
+    state.createdAt = snap.created_at || '';
+    state.sittings = snap.sittings || [];
+    state.tiles = new Map();
+    for (const tile of snap.tiles || []) {
+        state.tiles.set(tile.soul, tile);
+    }
+    render();
+}
+
+// ── Delta handling (the show) ───────────────────────────────────────────────
+
+function onCouncilUpdate(msg) {
+    if (!activeWindow) return;
+    if (msg.sitting !== state.sitting) return;
+    // Deltas only apply to the round we're actually viewing — history is static.
+    const viewingLatest = state.promptId === state.latestPromptId;
+
+    if (msg.reset) {
+        // New round started. If the board is following live, jump to it.
+        if (viewingLatest || state.promptId == null) {
+            loadSnapshot(state.sitting, null);
+        } else {
+            // Viewing history — just refresh the round list so the selector
+            // shows the new round without yanking the user off their page.
+            loadSnapshot(state.sitting, state.promptId);
+        }
+        return;
+    }
+
+    if (!msg.tile) return;
+    if (msg.prompt_id !== state.promptId) return;  // delta for a different round
+
+    const prev = state.tiles.get(msg.tile.soul);
+    state.tiles.set(msg.tile.soul, msg.tile);
+    swapTile(msg.tile, prev);
+}
+
+/** Replace a single tile in place with a settle animation — no full re-render. */
+function swapTile(tile, prev) {
+    const el = container?.querySelector(`[data-soul="${cssEscape(tile.soul)}"]`);
+    if (!el) { render(); return; }
+    el.outerHTML = tileHtml(tile);
+    const fresh = container.querySelector(`[data-soul="${cssEscape(tile.soul)}"]`);
+    if (fresh && (!prev || prev.status !== tile.status)) {
+        fresh.classList.add('council-tile--settle');
+        // eslint-disable-next-line no-unused-expressions
+        fresh.offsetWidth;  // reflow so the animation re-triggers
+    }
+    updateCounter();
+    if (allFinal()) markComplete();
+}
+
+function allFinal() {
+    if (!state.roster.length) return false;
+    return state.roster.every((s) => isFinal(state.tiles.get(s)?.status));
+}
+
+function cssEscape(s) {
+    return String(s).replace(/["\\]/g, '\\$&');
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+function tileHtml(tile) {
+    const status = tile.status || 'pending';
+    const kindChip = tile.kind
+        ? `<span class="council-chip council-chip--${esc(tile.kind)}">${esc(KIND_LABEL[tile.kind] || tile.kind)}</span>`
+        : `<span class="council-chip council-chip--${esc(status)}">${esc(STATUS_LABEL[status] || status)}</span>`;
+
+    let bodyHtml;
+    if (status === 'pending' || status === 'stalled') {
+        const timer = status === 'pending'
+            ? `<span class="council-timer" data-since="${esc(state.createdAt)}">· ${esc(elapsedSince(state.createdAt))}</span>`
+            : '';
+        const note = status === 'stalled' ? 'no response' : 'waiting for a verdict';
+        bodyHtml = `<div class="council-tile-placeholder">${esc(note)} ${timer}</div>`;
+    } else {
+        bodyHtml = `<div class="council-verdict">${esc(clampVerdict(tile.verdict))}</div>`;
+    }
+
+    const expandable = status === 'answered' || status === 'passed' || status === 'acked';
+    return `
+        <div class="council-tile council-tile--${esc(status)}"
+             data-soul="${esc(tile.soul)}"
+             ${expandable ? 'data-expandable="1" role="button" tabindex="0"' : ''}>
+            <div class="council-tile-head">
+                <span class="council-soul">${esc(tile.soul)}</span>
+                ${kindChip}
+            </div>
+            ${bodyHtml}
+        </div>`;
+}
+
+function counterText() {
+    const final = state.roster.filter((s) => isFinal(state.tiles.get(s)?.status)).length;
+    return `${final} of ${state.roster.length} in`;
+}
+
+function roundSelectorHtml() {
+    if (state.promptIds.length <= 1) return '';
+    const opts = state.promptIds
+        .map((id) => {
+            const label = id === state.latestPromptId ? `#${id} (latest)` : `#${id}`;
+            return `<option value="${id}" ${id === state.promptId ? 'selected' : ''}>${label}</option>`;
+        })
+        .join('');
+    return `<select class="council-round-select" data-action="round">${opts}</select>`;
+}
+
+function sittingSelectorHtml() {
+    if (state.sittings.length <= 1) return '';
+    const opts = state.sittings
+        .map((n) => `<option value="${esc(n)}" ${n === state.sitting ? 'selected' : ''}>${esc(n)}</option>`)
+        .join('');
+    return `<select class="council-sitting-select" data-action="sitting">${opts}</select>`;
+}
+
+function render() {
+    if (!container) return;
+    if (!state.sitting) { renderEmpty('No live council sitting.'); return; }
+    const live = state.promptId === state.latestPromptId;
+    container.innerHTML = `
+        <div class="council-board" data-complete="0">
+            <header class="council-header">
+                <div class="council-header-left">
+                    <span class="council-sitting-name">${esc(state.sitting)}</span>
+                    ${sittingSelectorHtml()}
+                </div>
+                <div class="council-header-right">
+                    ${roundSelectorHtml()}
+                    <span class="council-counter">${esc(counterText())}</span>
+                </div>
+            </header>
+            <div class="council-question">
+                ${state.promptText
+                    ? esc(state.promptText)
+                    : '<span class="council-question-empty">No prompt asked yet.</span>'}
+                ${live ? '' : '<span class="council-history-badge">history</span>'}
+            </div>
+            <div class="council-grid">
+                ${state.roster.map((s) => tileHtml(state.tiles.get(s) || { soul: s, status: 'pending' })).join('')}
+            </div>
+        </div>`;
+    bindBoard();
+    startTimer();
+    if (allFinal()) markComplete();
+}
+
+function renderEmpty(message) {
+    if (!container) return;
+    stopTimer();
+    container.innerHTML = `
+        <div class="council-board council-board--empty">
+            ${state.sittings.length > 1 ? `<div class="council-empty-picker">${sittingSelectorHtml()}</div>` : ''}
+            <div class="council-empty">${esc(message)}</div>
+        </div>`;
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
+        loadSnapshot(e.target.value, null);
+    });
+}
+
+function updateCounter() {
+    const el = container?.querySelector('.council-counter');
+    if (el) el.textContent = counterText();
+}
+
+function markComplete() {
+    const board = container?.querySelector('.council-board');
+    if (board && board.dataset.complete !== '1') {
+        board.dataset.complete = '1';
+        board.classList.add('council-board--flourish');
+    }
+}
+
+function bindBoard() {
+    container.querySelector('[data-action="round"]')?.addEventListener('change', (e) => {
+        loadSnapshot(state.sitting, Number(e.target.value));
+    });
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
+        loadSnapshot(e.target.value, null);
+    });
+    container.querySelectorAll('[data-expandable="1"]').forEach((el) => {
+        const open = () => openReader(el.dataset.soul);
+        el.addEventListener('click', open);
+        el.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+        });
+    });
+}
+
+// ── Reader overlay (click-to-expand full verdict) ─────────────────────────────
+
+function openReader(soul) {
+    const tile = state.tiles.get(soul);
+    if (!tile || !tile.verdict) return;
+    const overlay = document.createElement('div');
+    overlay.className = 'council-reader-overlay';
+    overlay.innerHTML = `
+        <div class="council-reader" role="dialog" aria-label="${esc(soul)} verdict">
+            <div class="council-reader-head">
+                <span class="council-soul">${esc(soul)}</span>
+                <span class="council-chip council-chip--${esc(tile.kind || tile.status)}">${esc(KIND_LABEL[tile.kind] || STATUS_LABEL[tile.status] || tile.status)}</span>
+                <button class="council-reader-close" aria-label="Close">×</button>
+            </div>
+            <div class="council-reader-body">${esc(tile.verdict)}</div>
+        </div>`;
+    const close = () => overlay.remove();
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+    overlay.querySelector('.council-reader-close')?.addEventListener('click', close);
+    const onKey = (e) => {
+        if (e.key === 'Escape') { close(); document.removeEventListener('keydown', onKey); }
+    };
+    document.addEventListener('keydown', onKey);
+    container.appendChild(overlay);
+}
+
+// ── Pending elapsed timer ─────────────────────────────────────────────────────
+
+function startTimer() {
+    stopTimer();
+    timerInterval = setInterval(() => {
+        if (!container) return;
+        container.querySelectorAll('.council-timer').forEach((el) => {
+            el.textContent = `· ${elapsedSince(el.dataset.since)}`;
+        });
+    }, 1000);
+}
+
+function stopTimer() {
+    if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────────
+
+let listenerBound = false;
+
+export function openCouncilWindow(sitting = null) {
+    if (activeWindow && activeWindow.window) {
+        try {
+            activeWindow.focus();
+            if (sitting && sitting !== state.sitting) loadSnapshot(sitting, null);
+            return;
+        } catch (_) { /* fall through and recreate */ }
+    }
+    container = document.createElement('div');
+    container.className = 'council-window-mount';
+    activeWindow = new WinBox({
+        title: 'Council board',
+        icon: '<span style="font-size:14px">🏛️</span>',
+        mount: container,
+        width: '70%',
+        height: '78%',
+        minwidth: 480,
+        minheight: 360,
+        class: ['council-window'],
+        onclose: () => {
+            stopTimer();
+            activeWindow = null;
+            return false;
+        },
+    });
+
+    if (!listenerBound) {
+        desktop.on('council_update', onCouncilUpdate);
+        listenerBound = true;
+    }
+
+    renderEmpty('Loading…');
+    loadSnapshot(sitting, null);
+}

--- a/agentwire/static/js/council-window.js
+++ b/agentwire/static/js/council-window.js
@@ -4,17 +4,17 @@
  * showing only its *filed verdict*. Tiles swap once, cleanly, when a reply
  * lands (the `council_update` WS delta) — no token streaming, no flicker.
  *
+ * Phase 3 applies the approved hi-fi design (council-design-reference.html):
+ * the whole tile treatment keys off a single status class
+ * `council-tile--{pending,acked,answered,passed,stalled}`, styled in
+ * desktop.css. This module owns the *real* data path and renders that markup —
+ * the mock META/ROSTER/ROUNDS demo harness from the reference is NOT shipped.
+ *
  * Data flow:
  *   - first paint / round switch / reconnect → GET /api/council/live (snapshot)
  *   - per-reply deltas → desktop 'council_update' { sitting, prompt_id, tile }
- *     (or { reset:true } when a new round starts → refetch)
- *
- * Status enum drives a per-tile class so the designer can restyle by class
- * without touching this logic:
- *   pending | acked | answered | passed | stalled
- *
- * CORE build (issue #403, Phases 0–2). Phase 3 affordances + final visual
- * styling are intentionally a thin layer on top of these hooks.
+ *     (or { reset:true } when a new round starts → refetch); the tile that just
+ *     filed gets the `council-tile--flip` swap animation.
  */
 
 import { apiFetch } from './api.js';
@@ -26,29 +26,27 @@ let activeWindow = null;
 const state = {
     sitting: null,        // sitting <name> currently shown
     promptId: null,       // prompt id currently shown
-    latestPromptId: null, // newest round for the sitting (for "live vs history")
+    latestPromptId: null, // newest round for the sitting (live vs history)
     promptIds: [],        // every round id, ascending (selector)
     promptText: '',
     roster: [],           // fixed soul order — never reordered under the user
-    createdAt: '',        // round start (drives the pending elapsed timer)
+    createdAt: '',        // round start (drives the pending/stalled elapsed meta)
     tiles: new Map(),     // soul -> { soul, status, kind, verdict, filed_at }
     sittings: [],         // every live sitting (for the sitting picker)
+    roundTexts: {},       // prompt_id -> question text, cached as rounds are visited
 };
 
 let container = null;
 let timerInterval = null;
 
-const STATUS_LABEL = {
-    pending: 'waiting…',
-    acked: 'researching…',
-    answered: 'take',
-    passed: 'passed',
-    stalled: 'no response',
+// chip copy per status (reference CHIP map)
+const CHIP = {
+    pending: 'DELIBERATING',
+    acked: 'RESEARCHING',
+    answered: 'TAKE',
+    passed: 'PASSED',
+    stalled: 'STALLED',
 };
-
-const KIND_LABEL = { take: 'take', ack: 'ack', pass: 'pass' };
-
-const CLAMP_CHARS = 200;
 
 function esc(s) {
     return String(s ?? '').replace(/[&<>"']/g, (c) => ({
@@ -56,15 +54,31 @@ function esc(s) {
     })[c]);
 }
 
-/** Whether a tile counts toward "N of M in" (terminal states only). */
+/** Whether a tile counts toward "N of M in" — terminal states only (#403). */
 function isFinal(status) {
     return status === 'answered' || status === 'passed';
 }
 
-function clampVerdict(text) {
-    const t = String(text || '').trim();
-    if (t.length <= CLAMP_CHARS) return t;
-    return t.slice(0, CLAMP_CHARS).trimEnd() + '…';
+/** Body copy per status — real verdict where we have one, reference copy else. */
+function bodyFor(tile) {
+    const verdict = String(tile.verdict || '').trim();
+    switch (tile.status) {
+        case 'answered': return verdict;
+        case 'acked': return verdict || 'Filed a holding note — a fuller answer is on the way.';
+        case 'passed': return verdict || 'Nothing to add this round; the others have it covered.';
+        case 'stalled': return 'No response — the soul stalled before filing.';
+        default: return '';
+    }
+}
+
+/** The mono meta line (timer / "will follow up" / "no response"). */
+function metaFor(tile) {
+    switch (tile.status) {
+        case 'pending': return { since: state.createdAt, suffix: '' };
+        case 'stalled': return { since: state.createdAt, suffix: ' · no response' };
+        case 'acked': return { text: 'will follow up' };
+        default: return null;
+    }
 }
 
 function elapsedSince(iso) {
@@ -79,6 +93,30 @@ function elapsedSince(iso) {
     return `${hrs}h ${mins % 60}m`;
 }
 
+function pad2(n) {
+    return String(n).padStart(2, '0');
+}
+
+// ── Webfonts (progressive enhancement — fallback stack holds if blocked) ──────
+
+let fontsInjected = false;
+function ensureFonts() {
+    if (fontsInjected || document.getElementById('council-webfonts')) {
+        fontsInjected = true;
+        return;
+    }
+    fontsInjected = true;
+    const pre1 = document.createElement('link');
+    pre1.rel = 'preconnect'; pre1.href = 'https://fonts.googleapis.com';
+    const pre2 = document.createElement('link');
+    pre2.rel = 'preconnect'; pre2.href = 'https://fonts.gstatic.com'; pre2.crossOrigin = 'anonymous';
+    const css = document.createElement('link');
+    css.id = 'council-webfonts';
+    css.rel = 'stylesheet';
+    css.href = 'https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap';
+    document.head.append(pre1, pre2, css);
+}
+
 // ── Snapshot fetch ──────────────────────────────────────────────────────────
 
 async function loadSnapshot(sitting, promptId) {
@@ -87,23 +125,16 @@ async function loadSnapshot(sitting, promptId) {
     if (promptId != null) params.set('prompt_id', String(promptId));
     const qs = params.toString();
     const res = await apiFetch(`/api/council/live${qs ? `?${qs}` : ''}`);
-    if (res.status === 409) {
-        // Ambiguous — multiple sittings, none chosen. Show the picker.
-        const body = await res.json().catch(() => ({}));
-        state.sittings = body.sittings || [];
-        state.sitting = null;
-        renderEmpty('Multiple council sittings — pick one.');
-        return;
-    }
     if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         state.sittings = body.sittings || [];
         state.sitting = null;
-        renderEmpty('No live council sitting.');
+        renderEmpty(res.status === 409
+            ? 'Multiple council sittings — pick one.'
+            : 'No live council sitting.');
         return;
     }
-    const snap = await res.json();
-    applySnapshot(snap);
+    applySnapshot(await res.json());
 }
 
 function applySnapshot(snap) {
@@ -117,33 +148,24 @@ function applySnapshot(snap) {
     state.roster = snap.roster || [];
     state.createdAt = snap.created_at || '';
     state.sittings = snap.sittings || [];
+    if (snap.prompt_id != null) state.roundTexts[snap.prompt_id] = snap.prompt_text || '';
     state.tiles = new Map();
-    for (const tile of snap.tiles || []) {
-        state.tiles.set(tile.soul, tile);
-    }
+    for (const tile of snap.tiles || []) state.tiles.set(tile.soul, tile);
     render();
 }
 
-// ── Delta handling (the show) ───────────────────────────────────────────────
+// ── Delta handling (the show) ─────────────────────────────────────────────────
 
 function onCouncilUpdate(msg) {
     if (!activeWindow) return;
     if (msg.sitting !== state.sitting) return;
-    // Deltas only apply to the round we're actually viewing — history is static.
     const viewingLatest = state.promptId === state.latestPromptId;
 
     if (msg.reset) {
-        // New round started. If the board is following live, jump to it.
-        if (viewingLatest || state.promptId == null) {
-            loadSnapshot(state.sitting, null);
-        } else {
-            // Viewing history — just refresh the round list so the selector
-            // shows the new round without yanking the user off their page.
-            loadSnapshot(state.sitting, state.promptId);
-        }
+        // New round — follow it if live, else just refresh the round list.
+        loadSnapshot(state.sitting, viewingLatest || state.promptId == null ? null : state.promptId);
         return;
     }
-
     if (!msg.tile) return;
     if (msg.prompt_id !== state.promptId) return;  // delta for a different round
 
@@ -152,19 +174,21 @@ function onCouncilUpdate(msg) {
     swapTile(msg.tile, prev);
 }
 
-/** Replace a single tile in place with a settle animation — no full re-render. */
+/** Replace a single tile in place with the swap animation — no full re-render. */
 function swapTile(tile, prev) {
-    const el = container?.querySelector(`[data-soul="${cssEscape(tile.soul)}"]`);
+    const el = container?.querySelector(`.council-tile[data-soul="${cssEscape(tile.soul)}"]`);
     if (!el) { render(); return; }
     el.outerHTML = tileHtml(tile);
-    const fresh = container.querySelector(`[data-soul="${cssEscape(tile.soul)}"]`);
-    if (fresh && (!prev || prev.status !== tile.status)) {
-        fresh.classList.add('council-tile--settle');
-        // eslint-disable-next-line no-unused-expressions
-        fresh.offsetWidth;  // reflow so the animation re-triggers
+    const fresh = container.querySelector(`.council-tile[data-soul="${cssEscape(tile.soul)}"]`);
+    if (fresh) {
+        bindTile(fresh);
+        if (!prev || prev.status !== tile.status) {
+            fresh.classList.add('council-tile--flip');
+            fresh.addEventListener('animationend', () => fresh.classList.remove('council-tile--flip'), { once: true });
+        }
     }
     updateCounter();
-    if (allFinal()) markComplete();
+    if (allFinal()) flourish();
 }
 
 function allFinal() {
@@ -176,35 +200,34 @@ function cssEscape(s) {
     return String(s).replace(/["\\]/g, '\\$&');
 }
 
-// ── Rendering ────────────────────────────────────────────────────────────────
+// ── Rendering ──────────────────────────────────────────────────────────────────
 
-function tileHtml(tile) {
+function tileHtml(tileOrSoul) {
+    const tile = typeof tileOrSoul === 'string'
+        ? (state.tiles.get(tileOrSoul) || { soul: tileOrSoul, status: 'pending' })
+        : tileOrSoul;
     const status = tile.status || 'pending';
-    const kindChip = tile.kind
-        ? `<span class="council-chip council-chip--${esc(tile.kind)}">${esc(KIND_LABEL[tile.kind] || tile.kind)}</span>`
-        : `<span class="council-chip council-chip--${esc(status)}">${esc(STATUS_LABEL[status] || status)}</span>`;
-
-    let bodyHtml;
-    if (status === 'pending' || status === 'stalled') {
-        const timer = status === 'pending'
-            ? `<span class="council-timer" data-since="${esc(state.createdAt)}">· ${esc(elapsedSince(state.createdAt))}</span>`
-            : '';
-        const note = status === 'stalled' ? 'no response' : 'waiting for a verdict';
-        bodyHtml = `<div class="council-tile-placeholder">${esc(note)} ${timer}</div>`;
-    } else {
-        bodyHtml = `<div class="council-verdict">${esc(clampVerdict(tile.verdict))}</div>`;
+    const meta = metaFor(tile);
+    let metaHtml = '';
+    if (meta) {
+        if (meta.text) {
+            metaHtml = `<span class="council-meta">${esc(meta.text)}</span>`;
+        } else {
+            metaHtml = `<span class="council-meta" data-since="${esc(meta.since)}" data-suffix="${esc(meta.suffix)}">· ${esc(elapsedSince(meta.since))}${esc(meta.suffix)}</span>`;
+        }
     }
-
-    const expandable = status === 'answered' || status === 'passed' || status === 'acked';
+    const body = bodyFor(tile);
     return `
-        <div class="council-tile council-tile--${esc(status)}"
-             data-soul="${esc(tile.soul)}"
-             ${expandable ? 'data-expandable="1" role="button" tabindex="0"' : ''}>
+        <div class="council-tile council-tile--${esc(status)}" data-soul="${esc(tile.soul)}">
             <div class="council-tile-head">
-                <span class="council-soul">${esc(tile.soul)}</span>
-                ${kindChip}
+                <div class="council-tile-name">${esc(tile.soul)}</div>
             </div>
-            ${bodyHtml}
+            <div class="council-tile-status">
+                <span class="council-chip"><span class="council-chip-dot"></span>${esc(CHIP[status] || status)}</span>
+                ${metaHtml}
+            </div>
+            <div class="council-tile-body">${esc(body)}</div>
+            <div class="council-tile-expand">Read full verdict <span>→</span></div>
         </div>`;
 }
 
@@ -213,95 +236,172 @@ function counterText() {
     return `${final} of ${state.roster.length} in`;
 }
 
-function roundSelectorHtml() {
-    if (state.promptIds.length <= 1) return '';
-    const opts = state.promptIds
-        .map((id) => {
-            const label = id === state.latestPromptId ? `#${id} (latest)` : `#${id}`;
-            return `<option value="${id}" ${id === state.promptId ? 'selected' : ''}>${label}</option>`;
-        })
-        .join('');
-    return `<select class="council-round-select" data-action="round">${opts}</select>`;
+function dotsHtml() {
+    return state.roster.map((s) => {
+        const st = state.tiles.get(s)?.status;
+        let cls = 'council-dot-cell';
+        if (st === 'stalled') cls += ' council-dot-cell--bad';
+        else if (isFinal(st)) cls += ' council-dot-cell--in';
+        else if (st === 'acked') cls += ' council-dot-cell--work';
+        return `<div class="${cls}"></div>`;
+    }).join('');
 }
 
-function sittingSelectorHtml() {
-    if (state.sittings.length <= 1) return '';
-    const opts = state.sittings
-        .map((n) => `<option value="${esc(n)}" ${n === state.sitting ? 'selected' : ''}>${esc(n)}</option>`)
-        .join('');
-    return `<select class="council-sitting-select" data-action="sitting">${opts}</select>`;
+function selectorHtml() {
+    if (state.promptIds.length <= 1) return '';
+    const opts = state.promptIds.slice().reverse().map((id) => {
+        const isLatest = id === state.latestPromptId;
+        const tag = `ROUND ${pad2(id)}${isLatest ? ' · LATEST' : ''}`;
+        const txt = state.roundTexts[id] || (isLatest ? 'latest round' : `prompt #${id}`);
+        return `<div class="council-round-opt ${id === state.promptId ? 'council-round-opt--active' : ''}" data-round="${id}">
+            <div class="council-round-tag">${esc(tag)}</div>
+            <div class="council-round-txt">${esc(txt)}</div>
+        </div>`;
+    }).join('');
+    return `
+        <div class="council-selector">
+            <div class="council-selector-btn" data-action="round-toggle">
+                <div>
+                    <div class="council-sel-lbl">ROUND</div>
+                    <div class="council-sel-val">${esc(pad2(state.promptId))}</div>
+                </div>
+                <div class="council-sel-chev">▼</div>
+            </div>
+            <div class="council-dropdown">${opts}</div>
+        </div>`;
+}
+
+function questionHtml() {
+    if (!state.promptText) {
+        return `<div class="council-q council-q--empty">No prompt asked yet.</div>`;
+    }
+    return `<div class="council-q"><span class="council-quote">“</span>${esc(state.promptText)}<span class="council-quote">”</span></div>`;
 }
 
 function render() {
     if (!container) return;
     if (!state.sitting) { renderEmpty('No live council sitting.'); return; }
+    const trio = state.roster.length <= 3 ? ' council-grid--trio' : '';
     const live = state.promptId === state.latestPromptId;
     container.innerHTML = `
-        <div class="council-board" data-complete="0">
-            <header class="council-header">
-                <div class="council-header-left">
-                    <span class="council-sitting-name">${esc(state.sitting)}</span>
-                    ${sittingSelectorHtml()}
+        <div class="council-glow"></div>
+        <div class="council-vignette"></div>
+        <div class="council-shell">
+            <div class="council-header">
+                <div>
+                    <div class="council-brand"><div class="council-led"></div><div class="council-eyebrow">AGENTWIRE · COUNCIL</div></div>
+                    <div class="council-sitting">${esc(state.sitting)}</div>
+                    ${sittingSelectorInline()}
                 </div>
                 <div class="council-header-right">
-                    ${roundSelectorHtml()}
-                    <span class="council-counter">${esc(counterText())}</span>
+                    <div class="council-counter-wrap">
+                        <div class="council-dots">${dotsHtml()}</div>
+                        <div class="council-counter">${esc(counterText())}</div>
+                    </div>
+                    ${selectorHtml()}
                 </div>
-            </header>
-            <div class="council-question">
-                ${state.promptText
-                    ? esc(state.promptText)
-                    : '<span class="council-question-empty">No prompt asked yet.</span>'}
-                ${live ? '' : '<span class="council-history-badge">history</span>'}
             </div>
-            <div class="council-grid">
-                ${state.roster.map((s) => tileHtml(state.tiles.get(s) || { soul: s, status: 'pending' })).join('')}
+            <div class="council-question-wrap">
+                <div class="council-question">
+                    <div class="council-kicker">${live ? 'THE QUESTION BEFORE THE COUNCIL' : 'AN EARLIER ROUND'}</div>
+                    ${questionHtml()}
+                </div>
+            </div>
+            <div class="council-panel">
+                <div class="council-panel-glow"></div>
+                <div class="council-grid${trio}">
+                    ${state.roster.map((s) => tileHtml(s)).join('')}
+                </div>
             </div>
         </div>`;
     bindBoard();
     startTimer();
-    if (allFinal()) markComplete();
+    if (allFinal()) markCompleteStatic();
+}
+
+/** A native <select> to switch sittings when more than one is live. */
+function sittingSelectorInline() {
+    if (state.sittings.length <= 1) return '';
+    const opts = state.sittings
+        .map((n) => `<option value="${esc(n)}" ${n === state.sitting ? 'selected' : ''}>${esc(n)}</option>`)
+        .join('');
+    return `<select class="council-round-select" data-action="sitting" style="margin-top:8px">${opts}</select>`;
 }
 
 function renderEmpty(message) {
     if (!container) return;
     stopTimer();
+    const picker = state.sittings.length > 1
+        ? `<select class="council-round-select" data-action="sitting">${state.sittings.map((n) => `<option value="${esc(n)}">${esc(n)}</option>`).join('')}</select>`
+        : '';
     container.innerHTML = `
-        <div class="council-board council-board--empty">
-            ${state.sittings.length > 1 ? `<div class="council-empty-picker">${sittingSelectorHtml()}</div>` : ''}
+        <div class="council-glow"></div>
+        <div class="council-shell council-shell--empty">
+            ${picker}
             <div class="council-empty">${esc(message)}</div>
         </div>`;
-    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
-        loadSnapshot(e.target.value, null);
-    });
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => loadSnapshot(e.target.value, null));
 }
 
 function updateCounter() {
+    const dots = container?.querySelector('.council-dots');
+    if (dots) dots.innerHTML = dotsHtml();
     const el = container?.querySelector('.council-counter');
     if (el) el.textContent = counterText();
 }
 
-function markComplete() {
-    const board = container?.querySelector('.council-board');
-    if (board && board.dataset.complete !== '1') {
-        board.dataset.complete = '1';
-        board.classList.add('council-board--flourish');
+/** Resting board that's already complete on open — green counter, no pop. */
+function markCompleteStatic() {
+    container?.querySelector('.council-counter')?.classList.add('council-counter--complete');
+}
+
+/** The "sitting complete" flourish — green counter, pop, panel glow. */
+function flourish() {
+    const counter = container?.querySelector('.council-counter');
+    if (counter) {
+        counter.classList.add('council-counter--complete');
+        counter.classList.remove('council-counter--pop');
+        void counter.offsetWidth;
+        counter.classList.add('council-counter--pop');
+    }
+    const glow = container?.querySelector('.council-panel-glow');
+    if (glow) {
+        glow.classList.remove('council-panel-glow--show');
+        void glow.offsetWidth;
+        glow.classList.add('council-panel-glow--show');
     }
 }
 
 function bindBoard() {
-    container.querySelector('[data-action="round"]')?.addEventListener('change', (e) => {
-        loadSnapshot(state.sitting, Number(e.target.value));
-    });
-    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
-        loadSnapshot(e.target.value, null);
-    });
-    container.querySelectorAll('[data-expandable="1"]').forEach((el) => {
-        const open = () => openReader(el.dataset.soul);
-        el.addEventListener('click', open);
-        el.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+    // Round dropdown
+    const selBtn = container.querySelector('[data-action="round-toggle"]');
+    const dropdown = container.querySelector('.council-dropdown');
+    if (selBtn && dropdown) {
+        selBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            dropdown.classList.toggle('council-dropdown--open');
         });
+        dropdown.querySelectorAll('.council-round-opt').forEach((opt) => {
+            opt.addEventListener('click', () => {
+                dropdown.classList.remove('council-dropdown--open');
+                loadSnapshot(state.sitting, Number(opt.dataset.round));
+            });
+        });
+    }
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => loadSnapshot(e.target.value, null));
+    container.querySelectorAll('.council-tile').forEach(bindTile);
+}
+
+function bindTile(el) {
+    const soul = el.dataset.soul;
+    const tile = state.tiles.get(soul);
+    if (!tile || tile.status !== 'answered') return;  // only the hero state opens
+    const open = () => openReader(soul);
+    el.addEventListener('click', open);
+    el.setAttribute('role', 'button');
+    el.setAttribute('tabindex', '0');
+    el.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
     });
 }
 
@@ -310,35 +410,38 @@ function bindBoard() {
 function openReader(soul) {
     const tile = state.tiles.get(soul);
     if (!tile || !tile.verdict) return;
-    const overlay = document.createElement('div');
-    overlay.className = 'council-reader-overlay';
-    overlay.innerHTML = `
+    closeReader();
+    const backdrop = document.createElement('div');
+    backdrop.className = 'council-backdrop council-backdrop--open';
+    backdrop.dataset.councilReader = '1';
+    backdrop.innerHTML = `
         <div class="council-reader" role="dialog" aria-label="${esc(soul)} verdict">
-            <div class="council-reader-head">
-                <span class="council-soul">${esc(soul)}</span>
-                <span class="council-chip council-chip--${esc(tile.kind || tile.status)}">${esc(KIND_LABEL[tile.kind] || STATUS_LABEL[tile.status] || tile.status)}</span>
-                <button class="council-reader-close" aria-label="Close">×</button>
-            </div>
+            <button class="council-reader-close" aria-label="Close">✕</button>
+            <div class="council-reader-head"><div class="council-reader-name">${esc(soul)}</div></div>
+            <div class="council-reader-chip">${esc(CHIP[tile.status] || tile.status)} · FILED</div>
             <div class="council-reader-body">${esc(tile.verdict)}</div>
         </div>`;
-    const close = () => overlay.remove();
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-    overlay.querySelector('.council-reader-close')?.addEventListener('click', close);
-    const onKey = (e) => {
-        if (e.key === 'Escape') { close(); document.removeEventListener('keydown', onKey); }
-    };
+    const close = () => { backdrop.remove(); document.removeEventListener('keydown', onKey); };
+    const onKey = (e) => { if (e.key === 'Escape') close(); };
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) close(); });
+    backdrop.querySelector('.council-reader-close').addEventListener('click', close);
+    backdrop.querySelector('.council-reader').addEventListener('click', (e) => e.stopPropagation());
     document.addEventListener('keydown', onKey);
-    container.appendChild(overlay);
+    container.appendChild(backdrop);
 }
 
-// ── Pending elapsed timer ─────────────────────────────────────────────────────
+function closeReader() {
+    container?.querySelector('[data-council-reader]')?.remove();
+}
+
+// ── Pending/stalled elapsed timer ──────────────────────────────────────────────
 
 function startTimer() {
     stopTimer();
     timerInterval = setInterval(() => {
         if (!container) return;
-        container.querySelectorAll('.council-timer').forEach((el) => {
-            el.textContent = `· ${elapsedSince(el.dataset.since)}`;
+        container.querySelectorAll('.council-meta[data-since]').forEach((el) => {
+            el.textContent = `· ${elapsedSince(el.dataset.since)}${el.dataset.suffix || ''}`;
         });
     }, 1000);
 }
@@ -352,6 +455,7 @@ function stopTimer() {
 let listenerBound = false;
 
 export function openCouncilWindow(sitting = null) {
+    ensureFonts();
     if (activeWindow && activeWindow.window) {
         try {
             activeWindow.focus();
@@ -365,10 +469,10 @@ export function openCouncilWindow(sitting = null) {
         title: 'Council board',
         icon: '<span style="font-size:14px">🏛️</span>',
         mount: container,
-        width: '70%',
-        height: '78%',
+        width: '74%',
+        height: '82%',
         minwidth: 480,
-        minheight: 360,
+        minheight: 380,
         class: ['council-window'],
         onclose: () => {
             stopTimer();
@@ -381,6 +485,11 @@ export function openCouncilWindow(sitting = null) {
         desktop.on('council_update', onCouncilUpdate);
         listenerBound = true;
     }
+
+    // Close the round dropdown on any outside click.
+    document.addEventListener('click', () => {
+        container?.querySelector('.council-dropdown--open')?.classList.remove('council-dropdown--open');
+    });
 
     renderEmpty('Loading…');
     loadSnapshot(sitting, null);

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -357,6 +357,10 @@ class DesktopManager {
                 this.emit('scheduler_state', msg);
                 break;
 
+            case 'council_update':
+                this.emit('council_update', msg);
+                break;
+
             case 'agent_progress':
                 this.emit('agent_progress', msg);
                 break;

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -23,6 +23,7 @@ import { machinesSection } from './sidebar/machines-section.js';
 import { sessionsSection } from './sidebar/sessions-section.js';
 import { projectsSection } from './sidebar/projects-section.js';
 import { schedulerSection } from './sidebar/scheduler-section.js';
+import { councilSection } from './sidebar/council-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { notificationsPanel } from './notifications-panel.js';
 import { scratchpad } from './scratchpad.js';
@@ -83,6 +84,7 @@ async function init() {
     sidebar.addSection('projects', projectsSection);
     sidebar.addSection('artifacts', artifactsSection);
     sidebar.addSection('scheduler', schedulerSection);
+    sidebar.addSection('council', councilSection);
     sidebar.addSection('safety', safetySection);
     sidebar.addSection('config', configSection);
     setupClock();

--- a/agentwire/static/js/sidebar/council-section.js
+++ b/agentwire/static/js/sidebar/council-section.js
@@ -1,0 +1,76 @@
+/**
+ * Council sidebar section — lists live sittings and opens the board window.
+ *
+ * The board itself (grid, deltas, reader) lives in council-window.js; this is
+ * just the launcher + a compact "N of M in" status line per live sitting.
+ */
+
+import { apiFetch } from '../api.js';
+import { desktop } from '../desktop-manager.js';
+import { openCouncilWindow } from '../council-window.js';
+
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+}
+
+export const councilSection = {
+    title: 'Council',
+    _body: null,
+    _sittings: [],
+
+    async mount(body) {
+        this._body = body;
+        // A board delta is a cheap signal that something changed — refresh the
+        // compact counts (debounced by the natural delta cadence).
+        desktop.on('council_update', () => this.refresh(body));
+        await this.refresh(body);
+    },
+
+    async refresh(body) {
+        try {
+            const res = await apiFetch('/api/council/sittings');
+            const data = res.ok ? await res.json() : { sittings: [] };
+            this._sittings = data.sittings || [];
+        } catch {
+            this._sittings = [];
+        }
+        // Per-sitting live counts (best-effort; ignore failures).
+        const counts = {};
+        await Promise.all(this._sittings.map(async (name) => {
+            try {
+                const r = await apiFetch(`/api/council/live?sitting=${encodeURIComponent(name)}`);
+                if (r.ok) {
+                    const s = await r.json();
+                    counts[name] = { final: s.final, total: s.total, prompt: s.prompt_text };
+                }
+            } catch { /* ignore */ }
+        }));
+        this._render(body, counts);
+    },
+
+    _render(body, counts) {
+        if (!this._sittings.length) {
+            body.innerHTML = '<div class="sidebar-empty">No council sittings.</div>';
+            return;
+        }
+        body.innerHTML = `
+            <div class="council-section-list">
+                ${this._sittings.map((name) => {
+                    const c = counts[name];
+                    const meta = c
+                        ? `<span class="council-section-count">${c.final} of ${c.total} in</span>`
+                        : '';
+                    return `
+                        <button class="council-section-item" data-sitting="${esc(name)}">
+                            <span class="council-section-name">${esc(name)}</span>
+                            ${meta}
+                        </button>`;
+                }).join('')}
+            </div>`;
+        body.querySelectorAll('.council-section-item').forEach((btn) => {
+            btn.addEventListener('click', () => openCouncilWindow(btn.dataset.sitting));
+        });
+    },
+};

--- a/tests/integration/test_council_portal.py
+++ b/tests/integration/test_council_portal.py
@@ -1,0 +1,124 @@
+"""Integration tests for the council board portal surface — the read API and
+the watcher delta loop, exercised against a real AgentWireServer app."""
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from agentwire.config import load_config
+from agentwire.council import inbox, state
+from agentwire.server import AgentWireServer
+
+ROSTER = ["brain", "gut", "critic"]
+NAME = "proj"
+
+
+def _make_config(tmp_path):
+    config = load_config(tmp_path / "nonexistent.yaml")
+    config.artifacts = type(config.artifacts)(dir=tmp_path / "artifacts", max_size_mb=10)
+    (tmp_path / "artifacts").mkdir(exist_ok=True)
+    config.server.auth_token = None
+    return config
+
+
+@pytest.fixture(autouse=True)
+def council_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "COUNCIL_ROOT", tmp_path / "council")
+
+
+@pytest.fixture
+def sitting():
+    s = state.Sitting(
+        orchestrator=state.orchestrator_for(NAME),
+        roster=ROSTER,
+        sessions={lens: state.session_for(NAME, lens) for lens in ROSTER},
+        started_at=state.now_iso(),
+        next_prompt_id=1,
+    )
+    state.write_sitting(NAME, s)
+    pid = state.allocate_prompt_id(NAME)
+    inbox.create_prompt(NAME, pid, "Ship it?", ROSTER)
+    return pid
+
+
+@pytest.fixture
+async def client(tmp_path):
+    server = AgentWireServer(_make_config(tmp_path))
+    async with TestClient(TestServer(server.app)) as c:
+        yield c, server
+
+
+class TestCouncilEndpoints:
+    async def test_sittings_lists_live(self, client, sitting):
+        c, _ = client
+        res = await c.get("/api/council/sittings")
+        assert res.status == 200
+        body = await res.json()
+        assert body["sittings"] == [NAME]
+
+    async def test_live_snapshot(self, client, sitting):
+        c, _ = client
+        inbox.write_reply(NAME, sitting, "brain", "take", "yes, ship")
+        inbox.write_reply(NAME, sitting, "gut", "pass", "")
+        res = await c.get("/api/council/live")
+        assert res.status == 200
+        snap = await res.json()
+        assert snap["running"] is True
+        assert snap["sitting"] == NAME
+        assert snap["roster"] == ROSTER
+        assert snap["final"] == 2
+        by_soul = {t["soul"]: t for t in snap["tiles"]}
+        assert by_soul["brain"]["status"] == "answered"
+        assert by_soul["gut"]["status"] == "passed"
+        assert by_soul["critic"]["status"] == "pending"
+
+    async def test_live_404_when_no_sitting(self, client):
+        c, _ = client
+        res = await c.get("/api/council/live?sitting=ghost")
+        assert res.status == 404
+
+    async def test_live_history_round(self, client, sitting):
+        c, _ = client
+        pid2 = state.allocate_prompt_id(NAME)
+        inbox.create_prompt(NAME, pid2, "Round 2?", ROSTER)
+        # Default → latest round.
+        latest = await (await c.get("/api/council/live")).json()
+        assert latest["prompt_id"] == pid2
+        # Explicit older round.
+        old = await (await c.get(f"/api/council/live?prompt_id={sitting}")).json()
+        assert old["prompt_id"] == sitting
+        assert old["prompt_text"] == "Ship it?"
+
+
+class TestCouncilWatcher:
+    async def test_tick_emits_reset_then_tile(self, client, sitting):
+        _, server = client
+        sent = []
+
+        async def fake_broadcast(msg_type, data):
+            sent.append((msg_type, data))
+
+        server.broadcast_dashboard = fake_broadcast
+        server.dashboard_clients.add(object())  # pretend a client is connected
+
+        seen = {}
+        # First tick: new round → reset signal, no tiles yet.
+        await server._council_tick(NAME, seen, inbox, state,
+                                   __import__("agentwire.council.view", fromlist=["x"]))
+        assert ("council_update", {"sitting": NAME, "prompt_id": sitting, "reset": True}) in sent
+
+        # A reply lands; next tick emits exactly that soul's tile.
+        sent.clear()
+        inbox.write_reply(NAME, sitting, "brain", "take", "ship it")
+        await server._council_tick(NAME, seen, inbox, state,
+                                   __import__("agentwire.council.view", fromlist=["x"]))
+        tiles = [d["tile"] for (t, d) in sent if t == "council_update" and "tile" in d]
+        assert len(tiles) == 1
+        assert tiles[0]["soul"] == "brain"
+        assert tiles[0]["status"] == "answered"
+        assert tiles[0]["verdict"] == "ship it"
+
+        # No change → no further deltas (the board rests between events).
+        sent.clear()
+        await server._council_tick(NAME, seen, inbox, state,
+                                   __import__("agentwire.council.view", fromlist=["x"]))
+        assert sent == []

--- a/tests/unit/test_council_view.py
+++ b/tests/unit/test_council_view.py
@@ -1,0 +1,135 @@
+"""Tests for agentwire/council/view.py — the read-only board derivation."""
+
+import pytest
+
+from agentwire.council import inbox, state, view
+
+ROSTER = ["brain", "gut", "critic"]
+NAME = "proj"
+
+
+@pytest.fixture(autouse=True)
+def council_root(tmp_path, monkeypatch):
+    root = tmp_path / "council"
+    monkeypatch.setattr(state, "COUNCIL_ROOT", root)
+    return root
+
+
+@pytest.fixture
+def sitting():
+    s = state.Sitting(
+        orchestrator=state.orchestrator_for(NAME),
+        roster=ROSTER,
+        sessions={lens: state.session_for(NAME, lens) for lens in ROSTER},
+        started_at=state.now_iso(),
+        next_prompt_id=1,
+    )
+    state.write_sitting(NAME, s)
+    return s
+
+
+@pytest.fixture
+def prompt(sitting):
+    pid = state.allocate_prompt_id(NAME)
+    inbox.create_prompt(NAME, pid, "Should we ship X?", ROSTER)
+    return pid
+
+
+class TestDeriveTile:
+    def test_pending(self, prompt):
+        tile = view.derive_tile(NAME, prompt, "brain")
+        assert tile["status"] == view.STATUS_PENDING
+        assert tile["kind"] is None
+        assert tile["verdict"] == ""
+
+    def test_stalled_when_dead(self, prompt):
+        tile = view.derive_tile(NAME, prompt, "brain", dead=True)
+        assert tile["status"] == view.STATUS_STALLED
+
+    def test_take(self, prompt):
+        inbox.write_reply(NAME, prompt, "brain", "take", "ship it")
+        tile = view.derive_tile(NAME, prompt, "brain")
+        assert tile["status"] == view.STATUS_ANSWERED
+        assert tile["kind"] == "take"
+        assert tile["verdict"] == "ship it"
+        assert tile["filed_at"]
+
+    def test_pass(self, prompt):
+        inbox.write_reply(NAME, prompt, "gut", "pass", "nothing to add")
+        tile = view.derive_tile(NAME, prompt, "gut")
+        assert tile["status"] == view.STATUS_PASSED
+        assert tile["kind"] == "pass"
+
+    def test_ack(self, prompt):
+        inbox.write_reply(NAME, prompt, "critic", "ack", "researching…")
+        tile = view.derive_tile(NAME, prompt, "critic")
+        assert tile["status"] == view.STATUS_ACKED
+        assert tile["kind"] == "ack"
+
+    def test_ack_then_followup_resolves_to_take(self, prompt):
+        inbox.write_reply(NAME, prompt, "critic", "ack", "researching…")
+        inbox.write_reply(NAME, prompt, "critic", "take", "here is my take")
+        tile = view.derive_tile(NAME, prompt, "critic")
+        assert tile["status"] == view.STATUS_ANSWERED
+        assert tile["kind"] == "take"
+        assert tile["verdict"] == "here is my take"
+
+    def test_highest_followup_wins(self, prompt):
+        inbox.write_reply(NAME, prompt, "critic", "ack", "researching…")
+        inbox.write_reply(NAME, prompt, "critic", "take", "first take")
+        inbox.write_reply(NAME, prompt, "critic", "take", "second take")
+        tile = view.derive_tile(NAME, prompt, "critic")
+        assert tile["verdict"] == "second take"
+
+    def test_dead_never_repaints_a_filed_take(self, prompt):
+        """A terminal take must survive even if the soul's session has died."""
+        inbox.write_reply(NAME, prompt, "brain", "take", "ship it")
+        tile = view.derive_tile(NAME, prompt, "brain", dead=True)
+        assert tile["status"] == view.STATUS_ANSWERED
+
+
+class TestSnapshot:
+    def test_none_without_sitting(self):
+        assert view.snapshot("nope") is None
+
+    def test_roster_drives_tiles(self, prompt):
+        snap = view.snapshot(NAME)
+        assert snap["sitting"] == NAME
+        assert snap["roster"] == ROSTER
+        assert [t["soul"] for t in snap["tiles"]] == ROSTER
+        assert snap["total"] == 3
+        assert snap["prompt_id"] == prompt
+        assert snap["prompt_text"] == "Should we ship X?"
+
+    def test_counter_counts_only_final_states(self, prompt):
+        inbox.write_reply(NAME, prompt, "brain", "take", "yes")
+        inbox.write_reply(NAME, prompt, "gut", "pass", "")
+        inbox.write_reply(NAME, prompt, "critic", "ack", "later")  # NOT final
+        snap = view.snapshot(NAME)
+        assert snap["final"] == 2
+
+    def test_non_default_roster(self, sitting):
+        """meta.json roster — not a hardcoded 6 — drives the grid."""
+        small = ["brain", "gut"]
+        pid = state.allocate_prompt_id(NAME)
+        inbox.create_prompt(NAME, pid, "Q?", small)
+        snap = view.snapshot(NAME)
+        assert snap["roster"] == small
+        assert snap["total"] == 2
+
+    def test_history_via_prompt_id(self, prompt):
+        # Second round.
+        pid2 = state.allocate_prompt_id(NAME)
+        inbox.create_prompt(NAME, pid2, "Round two?", ROSTER)
+        snap_latest = view.snapshot(NAME)
+        assert snap_latest["prompt_id"] == pid2
+        assert snap_latest["prompt_ids"] == [prompt, pid2]
+        snap_old = view.snapshot(NAME, prompt)
+        assert snap_old["prompt_id"] == prompt
+        assert snap_old["prompt_text"] == "Should we ship X?"
+
+    def test_dead_souls_marked_stalled(self, prompt):
+        snap = view.snapshot(NAME, dead_souls={"brain"})
+        by_soul = {t["soul"]: t for t in snap["tiles"]}
+        assert by_soul["brain"]["status"] == view.STATUS_STALLED
+        assert by_soul["gut"]["status"] == view.STATUS_PENDING


### PR DESCRIPTION
Live portal view of a council sitting: each lens (soul) as a tile, the prompt centered above, every tile showing **only its filed verdict** — swapping once, cleanly, when a reply lands. No token streaming, no flicker.

This is the **CORE** (Phases 0–2 of #403). A designer is producing the visual mockup separately, so this is a clean, functional, roster-driven grid — correct states and data flow over polish — with status-enum CSS classes as the restyle hooks.

## Phase 0 — Producer guarantee (the real anti-flicker)
- `inbox.write_reply` / `create_prompt` now write **atomically** (tmp file + `os.replace`), so a reader never sees a half-written verdict. This — not any UI trick — is what makes the swap clean.
- `server.council_watch_loop`: a ~1.5s poll over each live sitting's latest `replies/` dir broadcasts `council_update` deltas on the **existing** dashboard WS (`broadcast_dashboard`/`dashboard_clients`/`/ws`). Each delta carries the **fully-derived tile** so the browser swaps one tile with no re-fetch. A new prompt round emits `{reset}`. No new dependency.

## Phase 1 — Backend read API
- `council/view.py`: pure snapshot + tile derivation, keyed by **soul, not file**. Status enum `pending|acked|answered|passed|stalled`, precedence **take > pass > ack > pending**, highest-numbered `followup-N` wins as the final verdict. Counter counts **only** terminal states. Roster comes from `meta.json` (never hardcoded to 6).
- `GET /api/council/sittings` + `GET /api/council/live` (mirrors `/api/scheduler/live`): snapshot for a sitting at a prompt — latest by default, `prompt_id` param for history. Pending souls whose lens session is dead → `stalled`.

## Phase 2 — Frontend grid
- `council-window.js`: roster-driven responsive grid, centered question, "N of M in" counter (finals only), round + sitting selectors, per-tile status-enum classes, ~250ms settle on swap, completion flourish, pending elapsed timer, click-to-expand reader overlay. Single clean update on `council_update`.
- `council-section.js` sidebar launcher; `desktop.css` `council-*` hooks scoped by status-enum class.

## Verification
Verified end-to-end in a real portal (sandboxed, alt port, no impact on the running portal): atomic write → watcher → WS delta → single-tile swap → counter tick → completion flourish; reader overlay; all five states render distinct; highest-followup-wins (ack then followup take → resolves to the take). 18 new council tests added; **166 council + portal tests pass**.

## Left for the designer pass (Phase 3, intentional)
- Final visual styling — restyle by the `council-tile--{pending,acked,answered,passed,stalled}` classes and the scoped `--council-*` color vars; no `council-window.js` changes needed.
- Phase 3 affordance polish (richer empty/stall states, flourish choreography). The data + state machine are in place underneath.

Closes #403

Built by [dotdev.dev](https://dotdev.dev)