### PR TITLE
feat(council): workspace window v2 — rail + grid, seat/ask controls

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -309,6 +309,10 @@ class AgentWireServer:
         # Council seating board: live sittings + per-prompt snapshot
         self.app.router.add_get("/api/council/sittings", self.api_council_sittings)
         self.app.router.add_get("/api/council/live", self.api_council_live)
+        self.app.router.add_get("/api/council/status", self.api_council_status)
+        self.app.router.add_post("/api/council/start", self.api_council_start)
+        self.app.router.add_post("/api/council/stop", self.api_council_stop)
+        self.app.router.add_post("/api/council/ask", self.api_council_ask)
         # Artifact windows: upload and serve agent-generated HTML
         self.app.router.add_post("/api/artifacts/upload", self.api_artifacts_upload)
         self.app.router.add_get("/api/artifacts", self.api_artifacts_list)
@@ -5045,6 +5049,115 @@ projects:
             snap["running"] = True
             snap["sittings"] = council_state.list_sittings()
             return web.json_response(snap)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_council_status(self, request: web.Request) -> web.Response:
+        """GET /api/council/status - Per-soul session liveness for a sitting.
+
+        Thin wrapper over ``council status`` (CLI is the SSOT). ``council status``
+        exits 0 even when no sitting matches (``running: false``), so the JSON
+        passes straight through with a 200.
+        """
+        try:
+            args = ["council", "status"]
+            name = request.query.get("sitting")
+            if name:
+                args += ["--name", name]
+            success, result = await self.run_agentwire_cmd(args)
+            return web.json_response(result, status=200 if success else 400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def _council_body(self, request: web.Request) -> dict:
+        """Best-effort JSON body — POSTs from the board may have no body."""
+        if not request.can_read_body:
+            return {}
+        try:
+            data = await request.json()
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    async def api_council_start(self, request: web.Request) -> web.Response:
+        """POST /api/council/start - Seat a council (CLI: ``council start``).
+
+        Body (all optional): ``sitting``/``name`` (default: cwd-repo-slug),
+        ``roster`` (comma-separated lens names). Broadcasts a seating delta so
+        the rail + sidebar go live without a manual refresh.
+        """
+        try:
+            body = await self._council_body(request)
+            args = ["council", "start"]
+            name = body.get("sitting") or body.get("name")
+            roster = body.get("roster")
+            if name:
+                args += ["--name", str(name)]
+            if roster:
+                args += ["--roster", str(roster)]
+            success, result = await self.run_agentwire_cmd(args)
+            if success:
+                seated = result.get("council") or name
+                if seated:
+                    await self.broadcast_dashboard(
+                        "council_update", {"sitting": seated, "seating": True}
+                    )
+                return web.json_response(result)
+            return web.json_response(result, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_council_stop(self, request: web.Request) -> web.Response:
+        """POST /api/council/stop - Dismiss a council (CLI: ``council stop``)."""
+        try:
+            body = await self._council_body(request)
+            args = ["council", "stop"]
+            name = body.get("sitting") or body.get("name")
+            if name:
+                args += ["--name", str(name)]
+            success, result = await self.run_agentwire_cmd(args)
+            if success:
+                stopped = result.get("council") or name
+                if stopped:
+                    await self.broadcast_dashboard(
+                        "council_update", {"sitting": stopped, "stopped": True}
+                    )
+                return web.json_response(result)
+            return web.json_response(result, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def api_council_ask(self, request: web.Request) -> web.Response:
+        """POST /api/council/ask - Fan a new prompt out (CLI: ``council ask``).
+
+        Body: ``{sitting?, prompt}``. The prompt rides after a ``--`` so leading
+        dashes can't be parsed as flags. Broadcasts a reset so the board switches
+        to the new round (the watch loop would catch it within ~1.5s anyway).
+        """
+        try:
+            body = await self._council_body(request)
+            prompt = body.get("prompt")
+            if not prompt or not str(prompt).strip():
+                return web.json_response({"error": "prompt required"}, status=400)
+            args = ["council", "ask"]
+            name = body.get("sitting") or body.get("name")
+            if name:
+                args += ["--name", str(name)]
+            args += ["--", str(prompt)]
+            success, result = await self.run_agentwire_cmd(args)
+            if success:
+                seated = result.get("council") or name
+                if seated:
+                    await self.broadcast_dashboard(
+                        "council_update",
+                        {
+                            "sitting": seated,
+                            "prompt_id": result.get("prompt_id"),
+                            "reset": True,
+                        },
+                    )
+                return web.json_response(result)
+            return web.json_response(result, status=400)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5649,7 +5649,7 @@ body.sidebar-pinned .sidebar-tab {
 .council-window-mount {
     position: relative;
     height: 100%;
-    overflow-y: auto;
+    overflow: hidden;
     background: var(--background);
     color: var(--text);
     /* status-enum aliases — the designer restyle surface */
@@ -5675,6 +5675,7 @@ body.sidebar-pinned .sidebar-tab {
     position: absolute; inset: 0; pointer-events: none; z-index: 0;
     background: radial-gradient(78% 56% at 50% 40%, rgba(0, 0, 0, 0) 42%, rgba(0, 0, 0, 0.6) 100%);
 }
+/* Loading / picker fallback (transient, centered). */
 .council-shell {
     position: relative; z-index: 1;
     max-width: 1100px; margin: 0 auto;
@@ -5682,61 +5683,121 @@ body.sidebar-pinned .sidebar-tab {
 }
 .council-shell--empty {
     display: flex; flex-direction: column; align-items: center; justify-content: center;
-    min-height: 60vh; gap: 14px;
+    min-height: 60vh; gap: 16px;
 }
 .council-empty { color: var(--text-muted); font-size: 14px; }
 
-/* ---------- HEADER ---------- */
-.council-header {
-    display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
-    padding-bottom: 22px; border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+/* ============================================================
+   LAYOUT — left rail (~320px) + wide main grid filling the rest.
+   ============================================================ */
+.council-layout {
+    position: relative; z-index: 1; display: flex; height: 100%;
 }
-.council-brand { display: flex; align-items: center; gap: 10px; margin-bottom: 7px; }
+.council-rail {
+    flex: 0 0 320px; width: 320px; display: flex; flex-direction: column;
+    border-right: 1px solid rgba(255, 255, 255, 0.07);
+    background: color-mix(in srgb, #000 26%, var(--background));
+    overflow: hidden;
+}
+.council-rail-brand {
+    padding: 22px 22px 18px; border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.council-rail-body { flex: 1; overflow-y: auto; padding: 4px 22px 12px; }
+.council-rail-section { padding: 18px 0; border-bottom: 1px solid rgba(255, 255, 255, 0.05); }
+.council-rail-section:last-child { border-bottom: none; }
+.council-rail-label {
+    font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.26em;
+    color: #6c7a70; margin-bottom: 13px;
+}
+.council-brand { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
 .council-led { width: 9px; height: 9px; border-radius: 2px; background: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
-.council-eyebrow { font-family: var(--council-font-mono); font-size: 12px; letter-spacing: 0.28em; color: #7c8a80; }
-.council-sitting { font-weight: 600; font-size: 20px; color: #eef3ee; letter-spacing: -0.01em; }
+.council-eyebrow { font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.26em; color: #7c8a80; }
+.council-sitting { font-weight: 600; font-size: 18px; color: #eef3ee; letter-spacing: -0.01em; word-break: break-word; }
+.council-sitting--link { cursor: pointer; }
+.council-sitting--link:hover { color: var(--accent); }
 
-.council-header-right { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; justify-content: flex-end; }
-.council-counter-wrap { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
-.council-dots { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; max-width: 220px; justify-content: flex-end; }
-.council-dot-cell { width: 9px; height: 9px; border-radius: 2px; background: rgba(255, 255, 255, 0.13); transition: all 0.4s ease; }
-.council-dot-cell--in { background: var(--accent); box-shadow: 0 0 8px rgba(57, 255, 20, 0.6); }
-.council-dot-cell--work { background: var(--council-acked); box-shadow: 0 0 8px color-mix(in srgb, var(--council-acked) 55%, transparent); }
-.council-dot-cell--bad { background: var(--error); }
-.council-counter { font-family: var(--council-font-mono); font-size: 13px; letter-spacing: 0.1em; color: #9aa69c; transition: color 0.4s; white-space: nowrap; }
+.council-counter { font-family: var(--council-font-mono); font-size: 12px; letter-spacing: 0.1em; color: #9aa69c; transition: color 0.4s; white-space: nowrap; }
 .council-counter--complete { color: var(--accent); text-shadow: 0 0 16px rgba(57, 255, 20, 0.55); }
 .council-counter--pop { animation: councilCounterPop 0.9s ease-out; }
 
-/* ROUND selector */
-.council-selector { position: relative; }
-.council-selector-btn {
-    display: flex; align-items: center; gap: 12px; padding: 9px 13px; border-radius: 10px;
-    background: color-mix(in srgb, var(--neon-blue) 6%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--neon-blue) 30%, transparent);
-    cursor: pointer; user-select: none;
+/* ---------- SEATING block ---------- */
+.council-seat-empty { font-size: 13px; color: var(--text-muted); margin-bottom: 12px; }
+.council-seat-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px; }
+.council-seat-summary { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: #dbe6dc; }
+.council-seat-led { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px rgba(57, 255, 20, 0.7); }
+.council-soul-pills { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 12px; }
+.council-soul-pill {
+    display: inline-flex; align-items: center; gap: 6px; padding: 4px 9px; border-radius: 999px;
+    font-size: 11.5px; font-weight: 500; color: #cdd6ce;
+    background: var(--chrome); border: 1px solid var(--chrome-border);
 }
-.council-selector-btn .council-sel-lbl { font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.18em; color: #5fb8d8; }
-.council-selector-btn .council-sel-val { font-weight: 600; font-size: 14px; color: #d7eef7; }
-.council-selector-btn .council-sel-chev { color: #5fb8d8; font-size: 11px; }
-.council-dropdown {
-    position: absolute; top: calc(100% + 8px); right: 0; width: 300px; max-height: 320px; overflow-y: auto;
-    padding: 6px; border-radius: 12px; background: #0c1114;
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--neon-blue) 18%, transparent), 0 24px 60px rgba(0, 0, 0, 0.7);
-    z-index: 30; display: none;
-}
-.council-dropdown--open { display: block; }
-.council-round-opt { padding: 11px 12px; border-radius: 8px; cursor: pointer; }
-.council-round-opt--active, .council-round-opt:hover { background: color-mix(in srgb, var(--neon-blue) 8%, transparent); }
-.council-round-opt .council-round-tag { font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.16em; color: #5fb8d8; margin-bottom: 3px; }
-.council-round-opt .council-round-txt { font-size: 13px; color: #cdd6ce; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.council-soul-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); }
+.council-soul-pill--live .council-soul-dot { background: var(--accent); box-shadow: 0 0 7px rgba(57, 255, 20, 0.6); }
+.council-soul-pill--down { color: var(--text-muted); opacity: 0.7; }
+.council-soul-pill--down .council-soul-dot { background: var(--error); }
+.council-seat-err { margin-top: 10px; font-size: 12px; color: var(--error); line-height: 1.4; }
 
-/* ---------- QUESTION ---------- */
-.council-question-wrap { display: flex; justify-content: center; padding: 46px 16px 42px; }
-.council-question { max-width: 860px; text-align: center; }
-.council-kicker { font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.3em; color: #4d8aa0; margin-bottom: 18px; }
-.council-q { font-family: var(--council-font-serif); font-weight: 400; font-size: 34px; line-height: 1.32; color: #eaf3f2; text-wrap: pretty; }
+/* ---------- Rail buttons ---------- */
+.council-btn {
+    width: 100%; padding: 10px 14px; border-radius: 10px; cursor: pointer;
+    font-family: var(--council-font-sans); font-size: 13px; font-weight: 600; letter-spacing: 0.01em;
+    border: 1px solid transparent; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s;
+}
+.council-btn:disabled { opacity: 0.55; cursor: default; }
+.council-btn--primary {
+    color: #07140a; background: var(--accent);
+    box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 32%, transparent);
+}
+.council-btn--primary:hover:not(:disabled) { box-shadow: 0 0 26px color-mix(in srgb, var(--accent) 50%, transparent); }
+.council-btn--ghost {
+    width: auto; padding: 5px 11px; font-size: 12px; font-weight: 500;
+    color: var(--text-muted); background: transparent; border-color: var(--chrome-border);
+}
+.council-btn--ghost:hover:not(:disabled) { color: var(--error); border-color: color-mix(in srgb, var(--error) 45%, var(--chrome-border)); }
+
+/* ---------- QUESTION (rail heading — shrunk from the v1 hero) ---------- */
+.council-q { font-family: var(--council-font-serif); font-weight: 400; font-size: 21px; line-height: 1.36; color: #eaf3f2; text-wrap: pretty; }
 .council-quote { color: var(--neon-blue); opacity: 0.85; }
-.council-q--empty { color: var(--text-muted); font-style: italic; font-size: 22px; }
+.council-q--empty { color: var(--text-muted); font-style: italic; font-size: 16px; }
+
+/* ---------- ROUNDS list ---------- */
+.council-rounds-list { display: flex; flex-direction: column; gap: 6px; }
+.council-round-item {
+    display: flex; flex-direction: column; gap: 3px; width: 100%; text-align: left;
+    padding: 9px 11px; border-radius: 9px; cursor: pointer;
+    background: transparent; border: 1px solid transparent;
+}
+.council-round-item:hover { background: color-mix(in srgb, var(--neon-blue) 7%, transparent); }
+.council-round-item--active {
+    background: color-mix(in srgb, var(--neon-blue) 9%, transparent);
+    border-color: color-mix(in srgb, var(--neon-blue) 28%, transparent);
+}
+.council-round-tag { font-family: var(--council-font-mono); font-size: 10px; letter-spacing: 0.15em; color: #5fb8d8; }
+.council-round-txt { font-size: 12.5px; color: #cdd6ce; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* ---------- ASK block (pinned to the rail foot) ---------- */
+.council-rail-ask {
+    padding: 16px 22px 18px; border-top: 1px solid rgba(255, 255, 255, 0.07);
+    background: color-mix(in srgb, #000 14%, var(--background));
+}
+.council-ask-input {
+    width: 100%; resize: vertical; min-height: 58px; margin-bottom: 10px;
+    padding: 10px 12px; border-radius: 10px;
+    background: var(--background); color: var(--text);
+    border: 1px solid var(--chrome-border); font-family: var(--council-font-sans); font-size: 13px; line-height: 1.45;
+}
+.council-ask-input:focus { outline: none; border-color: color-mix(in srgb, var(--neon-blue) 55%, var(--chrome-border)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--neon-blue) 30%, transparent); }
+.council-ask-err { margin-top: 9px; font-size: 12px; color: var(--error); line-height: 1.4; }
+.council-ask-err:empty { display: none; }
+
+/* ---------- MAIN (tile grid fills the freed horizontal space) ---------- */
+.council-main { flex: 1; min-width: 0; overflow-y: auto; padding: 30px 34px 48px; }
+.council-main-empty {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    min-height: 70%; gap: 10px; text-align: center; padding: 40px 20px;
+}
+.council-main-empty-title { font-family: var(--council-font-serif); font-size: 26px; color: #cdd8cf; }
+.council-main-empty-sub { font-size: 14px; color: var(--text-muted); max-width: 420px; line-height: 1.5; }
 
 /* ---------- PANEL / GRID ---------- */
 .council-panel { position: relative; }
@@ -5747,9 +5808,9 @@ body.sidebar-pinned .sidebar-tab {
 .council-panel-glow--show { animation: councilPanelGlow 1.2s ease-out; }
 .council-grid {
     position: relative; z-index: 1; display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(290px, 1fr)); gap: 18px; margin: 0 auto;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 18px;
 }
-.council-grid--trio { max-width: 920px; }
+.council-grid--trio { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); max-width: 1100px; }
 
 /* ============================================================
    TILE — whole treatment keys off the single status class.
@@ -5763,19 +5824,30 @@ body.sidebar-pinned .sidebar-tab {
 }
 .council-tile-head { display: flex; flex-direction: column; gap: 3px; }
 .council-tile-name { font-weight: 600; font-size: 18px; color: #eef3ee; letter-spacing: -0.01em; }
+.council-tile-name--link { cursor: pointer; align-self: flex-start; }
+.council-tile-name--link:hover { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
 .council-tile-role { font-family: var(--council-font-mono); font-size: 11px; color: #67756b; letter-spacing: 0.02em; }
 .council-tile-status { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
 .council-chip { display: inline-flex; align-items: center; padding: 5px 10px; border-radius: 6px; font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.13em; }
 .council-chip-dot { display: none; width: 6px; height: 6px; border-radius: 50%; margin-right: 7px; background: var(--council-pending); }
 .council-meta { font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--text-muted); }
 .council-tile-body {
-    flex: 1; font-size: 14.5px; line-height: 1.52; color: var(--text);
-    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; text-wrap: pretty;
+    flex: 1; font-size: 16.5px; line-height: 1.5; color: var(--text);
+    display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden; text-wrap: pretty;
 }
 .council-tile-expand { display: none; align-items: center; gap: 6px; font-family: var(--council-font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--accent); }
 .council-tile-expand span { font-size: 13px; }
 
-/* PENDING — alive, breathing, never frozen */
+/* PENDING — alive, breathing, never frozen. A faint "cooking" sweep rides on
+   top of the breathing dot: ambient liveness only, never faked token streaming. */
+.council-tile--pending { overflow: hidden; }
+.council-tile--pending > * { position: relative; z-index: 1; }
+.council-tile--pending::before {
+    content: ''; position: absolute; inset: 0; z-index: 0; pointer-events: none;
+    background: linear-gradient(115deg, transparent 35%, color-mix(in srgb, var(--council-pending) 13%, transparent) 50%, transparent 65%);
+    background-size: 250% 100%;
+    animation: councilCook 3.4s ease-in-out infinite;
+}
 .council-tile--pending .council-chip { color: var(--council-pending); background: color-mix(in srgb, var(--council-pending) 10%, transparent); }
 .council-tile--pending .council-chip-dot { display: inline-block; animation: councilPulseDot 1.8s ease-in-out infinite; }
 .council-tile--pending .council-tile-body { display: none; }
@@ -5788,7 +5860,7 @@ body.sidebar-pinned .sidebar-tab {
 }
 .council-tile--acked .council-chip { color: var(--council-acked); background: color-mix(in srgb, var(--council-acked) 14%, transparent); }
 .council-tile--acked .council-meta { color: color-mix(in srgb, var(--council-acked) 60%, var(--text-muted)); }
-.council-tile--acked .council-tile-body { color: color-mix(in srgb, var(--council-acked) 55%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
+.council-tile--acked .council-tile-body { color: color-mix(in srgb, var(--council-acked) 55%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 16.5px; }
 
 /* ANSWERED — the hero / committed state */
 .council-tile--answered {
@@ -5809,7 +5881,7 @@ body.sidebar-pinned .sidebar-tab {
     background: color-mix(in srgb, var(--council-passed) 5%, var(--chrome));
 }
 .council-tile--passed .council-chip { color: var(--council-passed); background: color-mix(in srgb, var(--council-passed) 13%, transparent); }
-.council-tile--passed .council-tile-body { color: var(--council-passed); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
+.council-tile--passed .council-tile-body { color: var(--council-passed); font-family: var(--council-font-serif); font-style: italic; font-size: 16.5px; }
 
 /* STALLED — errored, clearly different from a pass */
 .council-tile--stalled {
@@ -5820,7 +5892,7 @@ body.sidebar-pinned .sidebar-tab {
 .council-tile--stalled .council-chip { color: var(--council-stalled); background: color-mix(in srgb, var(--council-stalled) 12%, transparent); }
 .council-tile--stalled .council-chip::before { content: "\26A0"; margin-right: 6px; }
 .council-tile--stalled .council-meta { color: color-mix(in srgb, var(--council-stalled) 55%, var(--text-muted)); }
-.council-tile--stalled .council-tile-body { color: color-mix(in srgb, var(--council-stalled) 50%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 15px; }
+.council-tile--stalled .council-tile-body { color: color-mix(in srgb, var(--council-stalled) 50%, var(--text-muted)); font-family: var(--council-font-serif); font-style: italic; font-size: 16.5px; }
 
 /* SWAP — the gavel beat: ~250ms scale-punch + glow settle */
 .council-tile--flip { animation: councilSwapIn 0.52s cubic-bezier(0.2, 0.85, 0.25, 1); }
@@ -5863,9 +5935,12 @@ body.sidebar-pinned .sidebar-tab {
 @keyframes councilPanelGlow { 0% { opacity: 0; } 25% { opacity: 1; } 100% { opacity: 0; } }
 @keyframes councilOverlayIn { 0% { opacity: 0; transform: translateY(10px) scale(0.985); } 100% { opacity: 1; transform: none; } }
 @keyframes councilBackdropIn { 0% { opacity: 0; } 100% { opacity: 1; } }
+@keyframes councilCook { 0% { background-position: 140% 0; } 100% { background-position: -40% 0; } }
 
 @media (prefers-reduced-motion: reduce) {
     .council-window-mount * { animation-duration: 0.001ms !important; }
+    /* Pseudo-elements aren't matched by the `*` rule above — kill the sweep explicitly. */
+    .council-tile--pending::before { animation: none; display: none; }
 }
 
 /* ---------- Sidebar section launcher ---------- */

--- a/agentwire/static/js/council-window.js
+++ b/agentwire/static/js/council-window.js
@@ -1,26 +1,34 @@
 /**
- * Council seating board — a WinBox window that makes a live sitting legible at
- * a glance: each lens (soul) as a tile, the prompt centered above, every tile
- * showing only its *filed verdict*. Tiles swap once, cleanly, when a reply
- * lands (the `council_update` WS delta) — no token streaming, no flicker.
+ * Council workspace window — a WinBox window that makes a live sitting legible
+ * AND operable: a left rail to seat/dismiss the council, read the question,
+ * switch rounds, and re-prompt; a wide multi-column tile grid filling the rest.
+ * Each lens (soul) is a tile showing only its *filed verdict*; tiles swap once,
+ * cleanly, when a reply lands (the `council_update` WS delta) — no token
+ * streaming, no flicker.
  *
- * Phase 3 applies the approved hi-fi design (council-design-reference.html):
- * the whole tile treatment keys off a single status class
+ * The tile treatment keys off a single status class
  * `council-tile--{pending,acked,answered,passed,stalled}`, styled in
- * desktop.css. This module owns the *real* data path and renders that markup —
- * the mock META/ROSTER/ROUNDS demo harness from the reference is NOT shipped.
+ * desktop.css; state colors flow through the scoped `--council-{state}` alias
+ * vars. This module owns the *real* data path and renders that markup.
+ *
+ * Window behaviour matches a session window: it registers with the desktop
+ * manager (so it opens maximized, joins the open-sessions list, and is
+ * tabbable). The registration wrapper lives in desktop.js (`openCouncilWindow`);
+ * this module exports the `CouncilWindow` class it instantiates.
  *
  * Data flow:
  *   - first paint / round switch / reconnect → GET /api/council/live (snapshot)
+ *   - rail seating/liveness → GET /api/council/status (per-soul session liveness)
  *   - per-reply deltas → desktop 'council_update' { sitting, prompt_id, tile }
- *     (or { reset:true } when a new round starts → refetch); the tile that just
- *     filed gets the `council-tile--flip` swap animation.
+ *     (or { reset:true } on a new round, { seating:true } on seat,
+ *     { stopped:true } on dismiss); the filed tile gets the swap animation.
+ *   - seat/dismiss/ask → POST /api/council/{start,stop,ask}
  */
 
 import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 
-let activeWindow = null;
+export const COUNCIL_WINDOW_ID = 'council-board';
 
 // View state — one board at a time (re-opening focuses the existing window).
 const state = {
@@ -34,9 +42,12 @@ const state = {
     tiles: new Map(),     // soul -> { soul, status, kind, verdict, filed_at }
     sittings: [],         // every live sitting (for the sitting picker)
     roundTexts: {},       // prompt_id -> question text, cached as rounds are visited
+    liveness: {},         // soul -> bool (lens session alive — from /status)
+    seated: false,        // is a sitting present at all
+    busy: false,          // a seat/ask/dismiss POST is in flight
 };
 
-let container = null;
+let container = null;     // the active window's mount (set by CouncilWindow)
 let timerInterval = null;
 
 // chip copy per status (reference CHIP map)
@@ -129,16 +140,23 @@ async function loadSnapshot(sitting, promptId) {
         const body = await res.json().catch(() => ({}));
         state.sittings = body.sittings || [];
         state.sitting = null;
-        renderEmpty(res.status === 409
-            ? 'Multiple council sittings — pick one.'
-            : 'No live council sitting.');
+        state.seated = state.sittings.length > 0;
+        // No sittings at all → the seatable unseated workspace. Ambiguous (409)
+        // or a transient error → a picker / message.
+        if (!state.sittings.length) {
+            render();
+        } else {
+            renderPicker();
+        }
         return;
     }
     applySnapshot(await res.json());
+    loadStatus(state.sitting);  // fire-and-forget — fills the liveness dots
 }
 
 function applySnapshot(snap) {
     state.sitting = snap.sitting;
+    state.seated = true;
     state.promptId = snap.prompt_id;
     state.promptIds = snap.prompt_ids || [];
     state.latestPromptId = state.promptIds.length
@@ -154,10 +172,40 @@ function applySnapshot(snap) {
     render();
 }
 
+/** Per-soul session liveness (the rail's seating dots). Best-effort. */
+async function loadStatus(sitting) {
+    if (!sitting) return;
+    try {
+        const res = await apiFetch(`/api/council/status?sitting=${encodeURIComponent(sitting)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (sitting !== state.sitting) return;  // raced past a round/sitting switch
+        const map = {};
+        for (const s of data.souls || []) map[s.soul] = !!s.alive;
+        state.liveness = map;
+        refreshSeating();
+    } catch { /* ignore */ }
+}
+
 // ── Delta handling (the show) ─────────────────────────────────────────────────
 
 function onCouncilUpdate(msg) {
-    if (!activeWindow) return;
+    if (!container) return;
+
+    // Seat/dismiss events can arrive when we hold no sitting yet (unseated
+    // workspace) — handle them before the per-sitting filter.
+    if (msg.seating) {
+        // A council was just seated; follow it.
+        loadSnapshot(msg.sitting || null, null);
+        return;
+    }
+    if (msg.stopped) {
+        if (!state.sitting || msg.sitting === state.sitting) {
+            loadSnapshot(null, null);  // re-resolve (other sittings may remain)
+        }
+        return;
+    }
+
     if (msg.sitting !== state.sitting) return;
     const viewingLatest = state.promptId === state.latestPromptId;
 
@@ -236,39 +284,52 @@ function counterText() {
     return `${final} of ${state.roster.length} in`;
 }
 
-function dotsHtml() {
+/** Per-soul liveness pills for the rail SEATING block. */
+function soulPillsHtml() {
     return state.roster.map((s) => {
-        const st = state.tiles.get(s)?.status;
-        let cls = 'council-dot-cell';
-        if (st === 'stalled') cls += ' council-dot-cell--bad';
-        else if (isFinal(st)) cls += ' council-dot-cell--in';
-        else if (st === 'acked') cls += ' council-dot-cell--work';
-        return `<div class="${cls}"></div>`;
+        // Liveness is "the session is alive"; default to live until /status
+        // says otherwise (it lands a beat after the snapshot).
+        const alive = state.liveness[s] !== false;
+        const cls = alive ? 'council-soul-pill council-soul-pill--live' : 'council-soul-pill council-soul-pill--down';
+        return `<span class="${cls}"><span class="council-soul-dot"></span>${esc(s)}</span>`;
     }).join('');
 }
 
-function selectorHtml() {
-    if (state.promptIds.length <= 1) return '';
-    const opts = state.promptIds.slice().reverse().map((id) => {
-        const isLatest = id === state.latestPromptId;
-        const tag = `ROUND ${pad2(id)}${isLatest ? ' · LATEST' : ''}`;
-        const txt = state.roundTexts[id] || (isLatest ? 'latest round' : `prompt #${id}`);
-        return `<div class="council-round-opt ${id === state.promptId ? 'council-round-opt--active' : ''}" data-round="${id}">
-            <div class="council-round-tag">${esc(tag)}</div>
-            <div class="council-round-txt">${esc(txt)}</div>
-        </div>`;
-    }).join('');
+function liveCount() {
+    return state.roster.filter((s) => state.liveness[s] !== false).length;
+}
+
+/** The rail SEATING block — seat button (unseated) or roster + dismiss (seated). */
+function seatingHtml() {
+    if (!state.seated || !state.sitting) {
+        return `
+            <div class="council-rail-section">
+                <div class="council-rail-label">SEATING</div>
+                <div class="council-seat-empty">No council seated.</div>
+                <button class="council-btn council-btn--primary" data-action="seat" ${state.busy ? 'disabled' : ''}>
+                    ${state.busy ? 'Seating…' : 'Seat the council'}
+                </button>
+            </div>`;
+    }
+    const total = state.roster.length;
     return `
-        <div class="council-selector">
-            <div class="council-selector-btn" data-action="round-toggle">
-                <div>
-                    <div class="council-sel-lbl">ROUND</div>
-                    <div class="council-sel-val">${esc(pad2(state.promptId))}</div>
-                </div>
-                <div class="council-sel-chev">▼</div>
+        <div class="council-rail-section">
+            <div class="council-rail-label">SEATING</div>
+            <div class="council-seat-head">
+                <span class="council-seat-summary"><span class="council-seat-led"></span>${total} soul${total === 1 ? '' : 's'} seated</span>
+                <button class="council-btn council-btn--ghost" data-action="dismiss" ${state.busy ? 'disabled' : ''}>Dismiss</button>
             </div>
-            <div class="council-dropdown">${opts}</div>
+            <div class="council-soul-pills">${soulPillsHtml()}</div>
+            <div class="council-counter">${esc(counterText())}</div>
         </div>`;
+}
+
+/** Re-render only the seating block (liveness arrives after the snapshot). */
+function refreshSeating() {
+    const slot = container?.querySelector('[data-slot="seating"]');
+    if (!slot) return;
+    slot.innerHTML = seatingHtml();
+    bindSeating();
 }
 
 function questionHtml() {
@@ -278,45 +339,102 @@ function questionHtml() {
     return `<div class="council-q"><span class="council-quote">“</span>${esc(state.promptText)}<span class="council-quote">”</span></div>`;
 }
 
+/** The rail ROUNDS list — clickable, latest first, active highlighted. */
+function roundsHtml() {
+    if (!state.promptIds.length) return '';
+    const items = state.promptIds.slice().reverse().map((id) => {
+        const isLatest = id === state.latestPromptId;
+        const tag = `ROUND ${pad2(id)}${isLatest ? ' · LATEST' : ''}`;
+        const txt = state.roundTexts[id] || (isLatest ? 'latest round' : `prompt #${id}`);
+        return `
+            <button class="council-round-item ${id === state.promptId ? 'council-round-item--active' : ''}" data-round="${id}">
+                <span class="council-round-tag">${esc(tag)}</span>
+                <span class="council-round-txt">${esc(txt)}</span>
+            </button>`;
+    }).join('');
+    return `
+        <div class="council-rail-section">
+            <div class="council-rail-label">ROUNDS</div>
+            <div class="council-rounds-list">${items}</div>
+        </div>`;
+}
+
+/** The rail ASK block — re-prompt the seated sitting without leaving the window. */
+function askHtml() {
+    if (!state.seated || !state.sitting) return '';
+    return `
+        <div class="council-rail-section council-rail-ask">
+            <div class="council-rail-label">ASK</div>
+            <textarea class="council-ask-input" rows="3" placeholder="Ask the council, or add context…" ${state.busy ? 'disabled' : ''}></textarea>
+            <button class="council-btn council-btn--primary" data-action="ask" ${state.busy ? 'disabled' : ''}>
+                ${state.busy ? 'Asking…' : 'Ask the council →'}
+            </button>
+            <div class="council-ask-err" data-slot="ask-err"></div>
+        </div>`;
+}
+
+/** The main-area tile grid (seated + a prompt asked) or a calm empty state. */
+function mainHtml() {
+    if (!state.seated || !state.sitting) {
+        return `
+            <div class="council-main-empty">
+                <div class="council-main-empty-title">The chamber is empty</div>
+                <div class="council-main-empty-sub">Seat the council from the rail to convene the souls.</div>
+            </div>`;
+    }
+    if (!state.promptId || !state.roster.length) {
+        return `
+            <div class="council-main-empty">
+                <div class="council-main-empty-title">The council is seated</div>
+                <div class="council-main-empty-sub">Ask the first question from the rail and the takes will fill in here.</div>
+            </div>`;
+    }
+    const trio = state.roster.length <= 3 ? ' council-grid--trio' : '';
+    return `
+        <div class="council-panel">
+            <div class="council-panel-glow"></div>
+            <div class="council-grid${trio}">
+                ${state.roster.map((s) => tileHtml(s)).join('')}
+            </div>
+        </div>`;
+}
+
+function railHtml() {
+    const live = state.promptId === state.latestPromptId;
+    const sittingLabel = state.sitting || 'No council seated';
+    return `
+        <aside class="council-rail">
+            <div class="council-rail-brand">
+                <div class="council-brand"><div class="council-led"></div><div class="council-eyebrow">AGENTWIRE · COUNCIL</div></div>
+                <div class="council-sitting">${esc(sittingLabel)}</div>
+                ${sittingSelectorInline()}
+            </div>
+            <div class="council-rail-body">
+                <div data-slot="seating">${seatingHtml()}</div>
+                ${state.seated && state.sitting ? `
+                <div class="council-rail-section">
+                    <div class="council-rail-label">${live ? 'THE QUESTION' : 'AN EARLIER ROUND'}</div>
+                    ${questionHtml()}
+                </div>
+                ${roundsHtml()}
+                ` : ''}
+            </div>
+            ${askHtml()}
+        </aside>`;
+}
+
 function render() {
     if (!container) return;
-    if (!state.sitting) { renderEmpty('No live council sitting.'); return; }
-    const trio = state.roster.length <= 3 ? ' council-grid--trio' : '';
-    const live = state.promptId === state.latestPromptId;
     container.innerHTML = `
         <div class="council-glow"></div>
         <div class="council-vignette"></div>
-        <div class="council-shell">
-            <div class="council-header">
-                <div>
-                    <div class="council-brand"><div class="council-led"></div><div class="council-eyebrow">AGENTWIRE · COUNCIL</div></div>
-                    <div class="council-sitting">${esc(state.sitting)}</div>
-                    ${sittingSelectorInline()}
-                </div>
-                <div class="council-header-right">
-                    <div class="council-counter-wrap">
-                        <div class="council-dots">${dotsHtml()}</div>
-                        <div class="council-counter">${esc(counterText())}</div>
-                    </div>
-                    ${selectorHtml()}
-                </div>
-            </div>
-            <div class="council-question-wrap">
-                <div class="council-question">
-                    <div class="council-kicker">${live ? 'THE QUESTION BEFORE THE COUNCIL' : 'AN EARLIER ROUND'}</div>
-                    ${questionHtml()}
-                </div>
-            </div>
-            <div class="council-panel">
-                <div class="council-panel-glow"></div>
-                <div class="council-grid${trio}">
-                    ${state.roster.map((s) => tileHtml(s)).join('')}
-                </div>
-            </div>
+        <div class="council-layout">
+            ${railHtml()}
+            <main class="council-main">${mainHtml()}</main>
         </div>`;
     bindBoard();
     startTimer();
-    if (allFinal()) markCompleteStatic();
+    if (state.seated && allFinal()) markCompleteStatic();
 }
 
 /** A native <select> to switch sittings when more than one is live. */
@@ -325,27 +443,41 @@ function sittingSelectorInline() {
     const opts = state.sittings
         .map((n) => `<option value="${esc(n)}" ${n === state.sitting ? 'selected' : ''}>${esc(n)}</option>`)
         .join('');
-    return `<select class="council-round-select" data-action="sitting" style="margin-top:8px">${opts}</select>`;
+    return `<select class="council-round-select" data-action="sitting" style="margin-top:10px">${opts}</select>`;
 }
 
-function renderEmpty(message) {
+/** Ambiguous (multiple sittings, none picked) or transient — show a picker. */
+function renderPicker() {
     if (!container) return;
     stopTimer();
-    const picker = state.sittings.length > 1
-        ? `<select class="council-round-select" data-action="sitting">${state.sittings.map((n) => `<option value="${esc(n)}">${esc(n)}</option>`).join('')}</select>`
+    const picker = state.sittings.length
+        ? `<select class="council-round-select" data-action="sitting">
+               <option value="" disabled selected>Choose a sitting…</option>
+               ${state.sittings.map((n) => `<option value="${esc(n)}">${esc(n)}</option>`).join('')}
+           </select>`
         : '';
     container.innerHTML = `
         <div class="council-glow"></div>
         <div class="council-shell council-shell--empty">
+            <div class="council-empty">Multiple council sittings are live — pick one.</div>
             ${picker}
+        </div>`;
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
+        if (e.target.value) loadSnapshot(e.target.value, null);
+    });
+}
+
+function renderLoading(message) {
+    if (!container) return;
+    stopTimer();
+    container.innerHTML = `
+        <div class="council-glow"></div>
+        <div class="council-shell council-shell--empty">
             <div class="council-empty">${esc(message)}</div>
         </div>`;
-    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => loadSnapshot(e.target.value, null));
 }
 
 function updateCounter() {
-    const dots = container?.querySelector('.council-dots');
-    if (dots) dots.innerHTML = dotsHtml();
     const el = container?.querySelector('.council-counter');
     if (el) el.textContent = counterText();
 }
@@ -373,27 +505,71 @@ function flourish() {
 }
 
 function bindBoard() {
-    // Round dropdown
-    const selBtn = container.querySelector('[data-action="round-toggle"]');
-    const dropdown = container.querySelector('.council-dropdown');
-    if (selBtn && dropdown) {
-        selBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dropdown.classList.toggle('council-dropdown--open');
-        });
-        dropdown.querySelectorAll('.council-round-opt').forEach((opt) => {
-            opt.addEventListener('click', () => {
-                dropdown.classList.remove('council-dropdown--open');
-                loadSnapshot(state.sitting, Number(opt.dataset.round));
-            });
-        });
+    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => {
+        if (e.target.value) loadSnapshot(e.target.value, null);
+    });
+    // Round list
+    container.querySelectorAll('.council-round-item').forEach((btn) => {
+        btn.addEventListener('click', () => loadSnapshot(state.sitting, Number(btn.dataset.round)));
+    });
+    bindSeating();
+    bindAsk();
+    // Sitting name → focus the orchestrator session.
+    const sit = container.querySelector('.council-sitting');
+    if (sit && state.sitting) {
+        sit.classList.add('council-sitting--link');
+        sit.title = 'Open the orchestrator session';
+        sit.addEventListener('click', openOrchestratorSession);
     }
-    container.querySelector('[data-action="sitting"]')?.addEventListener('change', (e) => loadSnapshot(e.target.value, null));
     container.querySelectorAll('.council-tile').forEach(bindTile);
+}
+
+function bindSeating() {
+    container.querySelector('[data-action="seat"]')?.addEventListener('click', seatCouncil);
+    container.querySelector('[data-action="dismiss"]')?.addEventListener('click', dismissCouncil);
+}
+
+function bindAsk() {
+    const btn = container.querySelector('[data-action="ask"]');
+    const input = container.querySelector('.council-ask-input');
+    if (!btn || !input) return;
+    btn.addEventListener('click', () => askCouncil(input));
+    // Cmd/Ctrl+Enter sends; plain Enter keeps newlines (it's a textarea).
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            askCouncil(input);
+        }
+        e.stopPropagation();  // don't leak keystrokes to global shortcuts
+    });
+}
+
+/**
+ * Souls and the orchestrator are real sessions — jump to them from the board.
+ * Opening a session window flips the desktop to single-window mode (it minimizes
+ * the council window), exactly like clicking any session elsewhere.
+ */
+async function openSoulSession(soul) {
+    if (!state.sitting) return;
+    const { openSessionTerminal } = await import('./desktop.js');
+    openSessionTerminal(`council-${state.sitting}-${soul}`, 'terminal');
+}
+
+async function openOrchestratorSession() {
+    if (!state.sitting) return;
+    const { openSessionTerminal } = await import('./desktop.js');
+    openSessionTerminal(`agentwire-council-${state.sitting}`, 'terminal');
 }
 
 function bindTile(el) {
     const soul = el.dataset.soul;
+    // Soul name → open/focus that soul's session window (any status).
+    const nameEl = el.querySelector('.council-tile-name');
+    if (nameEl) {
+        nameEl.classList.add('council-tile-name--link');
+        nameEl.title = `Open ${soul}'s session`;
+        nameEl.addEventListener('click', (e) => { e.stopPropagation(); openSoulSession(soul); });
+    }
     const tile = state.tiles.get(soul);
     if (!tile || tile.status !== 'answered') return;  // only the hero state opens
     const open = () => openReader(soul);
@@ -403,6 +579,101 @@ function bindTile(el) {
     el.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
     });
+}
+
+// ── Seat / dismiss / ask (the operable rail) ──────────────────────────────────
+
+async function seatCouncil() {
+    if (state.busy) return;
+    state.busy = true;
+    refreshSeating();
+    try {
+        const res = await apiFetch('/api/council/start', { method: 'POST' });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            // Surface the CLI's reason in the seating slot, then recover.
+            state.busy = false;
+            refreshSeating();
+            setSeatError(data.error || 'Could not seat the council.');
+            return;
+        }
+        const seated = data.council;
+        state.busy = false;
+        // The WS seating delta will also fire; loading now makes it feel instant.
+        if (seated) loadSnapshot(seated, null);
+        else loadSnapshot(null, null);
+    } catch (e) {
+        state.busy = false;
+        refreshSeating();
+        setSeatError('Could not reach the portal.');
+    }
+}
+
+function setSeatError(message) {
+    const slot = container?.querySelector('[data-slot="seating"]');
+    if (!slot) return;
+    let err = slot.querySelector('.council-seat-err');
+    if (!err) {
+        err = document.createElement('div');
+        err.className = 'council-seat-err';
+        slot.appendChild(err);
+    }
+    err.textContent = message;
+}
+
+async function dismissCouncil() {
+    if (state.busy || !state.sitting) return;
+    state.busy = true;
+    refreshSeating();
+    const sitting = state.sitting;
+    try {
+        await apiFetch('/api/council/stop', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sitting }),
+        });
+    } catch { /* the WS stopped delta / re-resolve handles the rest */ }
+    state.busy = false;
+    loadSnapshot(null, null);
+}
+
+async function askCouncil(input) {
+    if (state.busy || !state.sitting) return;
+    const prompt = input.value.trim();
+    if (!prompt) { input.focus(); return; }
+    state.busy = true;
+    const btn = container?.querySelector('[data-action="ask"]');
+    if (btn) { btn.disabled = true; btn.textContent = 'Asking…'; }
+    input.disabled = true;
+    setAskError('');
+    try {
+        const res = await apiFetch('/api/council/ask', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sitting: state.sitting, prompt }),
+        });
+        const data = await res.json().catch(() => ({}));
+        state.busy = false;
+        if (!res.ok) {
+            if (btn) { btn.disabled = false; btn.textContent = 'Ask the council →'; }
+            input.disabled = false;
+            setAskError(data.error || 'Could not send the prompt.');
+            return;
+        }
+        input.value = '';
+        // Switch to the freshly-created round; the WS reset would do this too.
+        loadSnapshot(state.sitting, null);
+    } catch (e) {
+        state.busy = false;
+        if (btn) { btn.disabled = false; btn.textContent = 'Ask the council →'; }
+        input.disabled = false;
+        setAskError('Could not reach the portal.');
+    }
+}
+
+function setAskError(message) {
+    const slot = container?.querySelector('[data-slot="ask-err"]');
+    if (slot) slot.textContent = message;
 }
 
 // ── Reader overlay (click-to-expand full verdict) ─────────────────────────────
@@ -450,47 +721,93 @@ function stopTimer() {
     if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
 }
 
-// ── Entry point ────────────────────────────────────────────────────────────────
+// ── Window wrapper ───────────────────────────────────────────────────────────
 
 let listenerBound = false;
 
-export function openCouncilWindow(sitting = null) {
-    ensureFonts();
-    if (activeWindow && activeWindow.window) {
-        try {
-            activeWindow.focus();
-            if (sitting && sitting !== state.sitting) loadSnapshot(sitting, null);
-            return;
-        } catch (_) { /* fall through and recreate */ }
-    }
-    container = document.createElement('div');
-    container.className = 'council-window-mount';
-    activeWindow = new WinBox({
-        title: 'Council board',
-        icon: '<span style="font-size:14px">🏛️</span>',
-        mount: container,
-        width: '74%',
-        height: '82%',
-        minwidth: 480,
-        minheight: 380,
-        class: ['council-window'],
-        onclose: () => {
-            stopTimer();
-            activeWindow = null;
-            return false;
-        },
-    });
-
-    if (!listenerBound) {
-        desktop.on('council_update', onCouncilUpdate);
-        listenerBound = true;
+/**
+ * CouncilWindow — mirrors the SessionWindow/ArtifactWindow surface so desktop.js
+ * can register it (open maximized, taskbar tab, single-window mode). The board
+ * is a module-level singleton (only one sitting is shown at a time), so this is
+ * a thin lifecycle wrapper that owns the WinBox and points `container` at it.
+ */
+export class CouncilWindow {
+    constructor(options = {}) {
+        this.id = COUNCIL_WINDOW_ID;
+        this.title = 'Council';
+        this.root = options.root || document.body;
+        this.sitting = options.sitting || null;
+        this.onCloseCallback = options.onClose || null;
+        this.onFocusCallback = options.onFocus || null;
+        this.winbox = null;
+        this.isOpen = false;
     }
 
-    // Close the round dropdown on any outside click.
-    document.addEventListener('click', () => {
-        container?.querySelector('.council-dropdown--open')?.classList.remove('council-dropdown--open');
-    });
+    open() {
+        if (this.isOpen) { this.focus(); return; }
+        ensureFonts();
+        container = document.createElement('div');
+        container.className = 'council-window-mount';
 
-    renderEmpty('Loading…');
-    loadSnapshot(sitting, null);
+        this.winbox = new WinBox({
+            title: this.title,
+            icon: '<span style="font-size:14px">🏛️</span>',
+            mount: container,
+            root: this.root,
+            width: '100%',
+            height: '100%',
+            minwidth: 480,
+            minheight: 380,
+            class: ['council-window', 'no-full', 'no-resize', 'no-move'],
+            onclose: () => {
+                this.winbox = null;
+                this.close();
+                return false;
+            },
+            onfocus: () => { if (this.onFocusCallback) this.onFocusCallback(this); },
+            onminimize: () => { desktop.emit('window_minimized', { id: this.id }); },
+            onrestore: () => {
+                desktop.emit('window_restored', { id: this.id });
+                if (this.onFocusCallback) this.onFocusCallback(this);
+            },
+        });
+
+        // Always open maximized; registering also flips to single-window mode.
+        this.winbox.maximize();
+        desktop.registerWindow(this.id, this.winbox);
+
+        if (!listenerBound) {
+            desktop.on('council_update', onCouncilUpdate);
+            listenerBound = true;
+        }
+
+        this.isOpen = true;
+        renderLoading('Loading…');
+        loadSnapshot(this.sitting, null);
+    }
+
+    close() {
+        if (!this.isOpen) return;
+        stopTimer();
+        closeReader();
+        if (this.winbox) {
+            const wb = this.winbox;
+            this.winbox = null;
+            wb.close();
+        }
+        desktop.unregisterWindow(this.id);
+        container = null;
+        this.isOpen = false;
+        if (this.onCloseCallback) this.onCloseCallback(this);
+    }
+
+    focus() { if (this.winbox) this.winbox.focus(); }
+    minimize() { if (this.winbox) this.winbox.minimize(); }
+    restore() { if (this.winbox) this.winbox.restore(); }
+    get isMinimized() { return this.winbox ? this.winbox.min : false; }
+
+    /** Switch the board to a different sitting without recreating the window. */
+    showSitting(sitting) {
+        if (sitting && sitting !== state.sitting) loadSnapshot(sitting, null);
+    }
 }

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -13,6 +13,7 @@ import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
+import { CouncilWindow, COUNCIL_WINDOW_ID } from './council-window.js';
 import { sidebar } from './sidebar.js';
 import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
 import { notificationsActive } from './notification-prefs.js';
@@ -37,6 +38,7 @@ import { initAnnouncements } from './announcement-modal.js';
 // State - track open windows
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
 const artifactWindows = new Map();  // artifactId -> ArtifactWindow instance
+let councilWindow = null;  // single CouncilWindow instance (one board at a time)
 
 // Global PTT state
 let globalPttState = 'idle';  // idle | recording | processing
@@ -577,6 +579,50 @@ export function openArtifactWindow(url, title = 'Artifact', artifactId = null) {
     recordTaskbarEntry({ kind: 'artifact', id, url, title });
 }
 
+/**
+ * Open the council workspace window. Registers through the same desktop path as
+ * a session window (single-window maximize + taskbar tab), so it opens
+ * maximized, appears in the open-sessions area, and is tabbable. Only one board
+ * exists at a time — re-opening focuses (and optionally re-targets) it.
+ *
+ * @param {string|null} sitting - Sitting to show (defaults to the sole live one)
+ */
+export function openCouncilWindow(sitting = null) {
+    const id = COUNCIL_WINDOW_ID;
+    if (councilWindow && councilWindow.isOpen) {
+        if (councilWindow.isMinimized) {
+            if (!desktop.isTiled(id)) desktop.minimizeAllExcept(id);
+            councilWindow.restore();
+        } else {
+            councilWindow.focus();
+        }
+        if (sitting) councilWindow.showSitting(sitting);
+        return;
+    }
+
+    // Minimize all other windows before opening new one
+    desktop.minimizeAllExcept(null);
+
+    councilWindow = new CouncilWindow({
+        sitting,
+        root: elements.desktopArea,
+        onClose: () => {
+            councilWindow = null;
+            removeTaskbarButton(id);
+            unrecordTaskbarEntry(id);
+        },
+        onFocus: () => {
+            updateTaskbarActive(id);
+            desktop.setActiveWindow(id);
+            saveTaskbarState();
+        },
+    });
+
+    councilWindow.open();
+    addTaskbarButton(id, councilWindow);
+    recordTaskbarEntry({ kind: 'council', id, sitting });
+}
+
 // Taskbar management — persist open windows + order across page refresh
 const TASKBAR_STATE_KEY = 'taskbar-state';
 const taskbarRecords = new Map(); // id -> { kind, id, ...args }
@@ -584,6 +630,7 @@ let taskbarDragoverBound = false;
 let restoringTaskbar = false;
 
 function _lookupWindowInstance(id) {
+    if (id === COUNCIL_WINDOW_ID && councilWindow) return councilWindow;
     return sessionWindows.get(id) || artifactWindows.get(id) || null;
 }
 
@@ -635,6 +682,8 @@ function _openByRecord(rec) {
         openSessionTerminal(rec.session, rec.mode || 'monitor', rec.machine || null);
     } else if (rec.kind === 'artifact') {
         openArtifactWindow(rec.url, rec.title || 'Artifact', rec.id);
+    } else if (rec.kind === 'council') {
+        openCouncilWindow(rec.sitting || null);
     }
 }
 

--- a/agentwire/static/js/sidebar/council-section.js
+++ b/agentwire/static/js/sidebar/council-section.js
@@ -7,7 +7,6 @@
 
 import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
-import { openCouncilWindow } from '../council-window.js';
 
 function esc(s) {
     return String(s ?? '').replace(/[&<>"']/g, (c) => ({
@@ -52,7 +51,18 @@ export const councilSection = {
 
     _render(body, counts) {
         if (!this._sittings.length) {
-            body.innerHTML = '<div class="sidebar-empty">No council sittings.</div>';
+            // No live sitting — still offer the workspace so it can be seated there.
+            body.innerHTML = `
+                <div class="council-section-list">
+                    <button class="council-section-item" data-open-empty="1">
+                        <span class="council-section-name">Open council</span>
+                        <span class="council-section-count">seat &amp; ask</span>
+                    </button>
+                </div>`;
+            body.querySelector('[data-open-empty]')?.addEventListener('click', async () => {
+                const { openCouncilWindow } = await import('../desktop.js');
+                openCouncilWindow(null);
+            });
             return;
         }
         body.innerHTML = `
@@ -70,7 +80,10 @@ export const councilSection = {
                 }).join('')}
             </div>`;
         body.querySelectorAll('.council-section-item').forEach((btn) => {
-            btn.addEventListener('click', () => openCouncilWindow(btn.dataset.sitting));
+            btn.addEventListener('click', async () => {
+                const { openCouncilWindow } = await import('../desktop.js');
+                openCouncilWindow(btn.dataset.sitting);
+            });
         });
     },
 };


### PR DESCRIPTION
Closes #405

Turns the shipped council board (#403) into a real **workspace**: seat/dismiss the council, see liveness, read verdicts, switch rounds, and re-prompt — all from one window — using the space far better. Keeps the styling DNA (`council-tile--{status}` + `--council-{state}` token contract, glow, single-swap animation, 5 states, reader overlay).

## Phases (all four)

**1 — Backend** (`server.py`, CLI is SSOT — wrapped via `run_agentwire_cmd`, no council logic reimplemented):
- `POST /api/council/start` (optional `roster`/`name`), `POST /api/council/stop`, `POST /api/council/ask {sitting, prompt}`, `GET /api/council/status`.
- Broadcast `council_update` on **seat / dismiss / new-prompt** (not just reply files) so the rail + sidebar stay live.

**2 — Window registration:** `CouncilWindow` registers through the desktop manager like a session window → opens **maximized**, appears in the **open-sessions area**, **tabbable**, and survives taskbar restore (`kind: 'council'`).

**3 — Layout:** killed the centered hero. Left rail (~320px) + wide responsive multi-column grid (`auto-fit minmax`). Question dropped from the 34px hero to a ~21px serif rail heading (neon-blue quotes kept). Tile body bumped 14.5→16.5px, clamp relaxed 3→4 lines.

**4 — Rail controls:** SEATING block (seat button when unseated → soul liveness pills + "N of M in" + Dismiss when seated), THE QUESTION, clickable ROUNDS history (latest default), ASK textarea + button (Cmd/Ctrl+Enter) that POSTs `/api/council/ask` and switches the board to the new round. Calm empty states for unseated / seated-but-no-prompt.

## Folded-in #406 cheap add-ons (per owner request)
- Click a **soul name** → open/focus that soul's session (`council-<sitting>-<lens>`); click the **sitting name** → orchestrator session. Reuses `openSessionTerminal`.
- Ambient **"cooking" sweep** on pending tiles — a faint scanline over the breathing dot, behind `prefers-reduced-motion`. Not faked token streaming; ambient liveness only.

## Out of scope (noted in #405)
- Synthesis / verdict-rollup surface (orchestrator's combined answer) — a natural next rail addition, not this issue.
- Everything else in #406 beyond the two add-ons above remains its own later arc.

## Verification (sandboxed portal on :8799, against the live `agentwire-dev` sitting)
- `GET /status` returns per-soul liveness (6/6 alive). `/ask` + `/stop` validation + the `--`-guarded CLI arg path confirmed with empty/bogus inputs — **the owner's live sitting was never seated/stopped/asked**.
- Window opens maximized, registers as `council-board` in the open-sessions list; grid fans to 4 columns at 1400px.
- Rail renders: 6 souls seated, green liveness pills, "6 of 6 in", Dismiss, question, ASK. Reader overlay still opens.
- Soul-name click opens `council-agentwire-dev-brain`. Pending shimmer applies (`councilCook`). No console errors.
- `pytest tests/integration/test_council_portal.py` → 5 passed.

Built by [dotdev.dev](https://dotdev.dev)