### PR TITLE
feat(council): first-class citizen — Cmd+K front door, question-first ask, durable thread archive

### DIFF
--- a/agentwire/council/state.py
+++ b/agentwire/council/state.py
@@ -69,6 +69,11 @@ def sitting_path(name: str) -> Path:
     return council_dir(name) / "sitting.json"
 
 
+def archive_path(name: str) -> Path:
+    """Preserved record of a dismissed sitting (kept so threads stay browsable)."""
+    return council_dir(name) / "archive.json"
+
+
 def workspace_dir(name: str) -> Path:
     return council_dir(name) / "workspace"
 
@@ -195,11 +200,60 @@ def write_sitting(name: str, sitting: Sitting) -> None:
 
 
 def clear_sitting(name: str) -> None:
-    """End the sitting. Prompt history under ``prompts/`` is kept."""
+    """End the sitting. A thread that deliberated something is preserved to
+    ``archive.json`` (so it stays browsable/re-askable from the UI), and the
+    ``prompts/`` history is kept; only the live ``sitting.json`` is removed."""
+    sitting = read_sitting(name)
+    if sitting is not None and prompts_dir(name).is_dir():
+        data = sitting.to_dict()
+        data["dismissed_at"] = now_iso()
+        try:
+            _atomic_write(archive_path(name), data)
+        except OSError:
+            pass
     try:
         sitting_path(name).unlink()
     except FileNotFoundError:
         pass
+
+
+def read_archive_dict(name: str) -> dict | None:
+    """Raw archive record (incl. ``dismissed_at``), or None if not archived."""
+    path = archive_path(name)
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def read_archived(name: str) -> Sitting | None:
+    """The preserved record of a dismissed sitting as a ``Sitting``, or None."""
+    data = read_archive_dict(name)
+    return Sitting.from_dict(data) if data is not None else None
+
+
+def _has_rounds(name: str) -> bool:
+    pdir = prompts_dir(name)
+    if not pdir.is_dir():
+        return False
+    return any(p.is_dir() and p.name.isdigit() for p in pdir.iterdir())
+
+
+def list_archive() -> list[str]:
+    """Dismissed threads: have prompt history but no live ``sitting.json``."""
+    if not COUNCIL_ROOT.is_dir():
+        return []
+    out = []
+    for child in COUNCIL_ROOT.iterdir():
+        if not child.is_dir() or (child / "sitting.json").exists():
+            continue  # absent or still live
+        if _has_rounds(child.name):
+            out.append(child.name)
+    return out
 
 
 def allocate_prompt_id(name: str) -> int:

--- a/agentwire/council/view.py
+++ b/agentwire/council/view.py
@@ -143,13 +143,31 @@ def snapshot(
     the sitting ``name``; the per-prompt ``meta.json.roster`` (falling back to
     the sitting roster) fixes both soul order and grid size — nothing is
     hardcoded to a roster of six.
+
+    The thread artifact outlives the compute: a dismissed sitting (no live
+    ``sitting.json``) is still a fully readable thread, derived from the
+    preserved ``archive.json`` or, failing that, reconstructed from the
+    ``prompts/`` tree. ``archived`` flags which case the caller is looking at.
     """
     sitting = state.read_sitting(name)
+    archived = sitting is None
     if sitting is None:
-        return None
+        sitting = state.read_archived(name)
+    if sitting is None:
+        if not available_prompt_ids(name):
+            return None
+        sitting = state.Sitting(
+            orchestrator=state.orchestrator_for(name),
+            roster=[],
+            sessions={},
+            started_at="",
+        )
 
+    # available_prompt_ids (disk-derived) works for live and archived alike —
+    # the sitting.json prompt counter is gone once dismissed.
     if prompt_id is None:
-        prompt_id = state.latest_prompt_id(name)
+        ids = available_prompt_ids(name)
+        prompt_id = ids[-1] if ids else None
 
     dead_souls = dead_souls or set()
 
@@ -178,6 +196,7 @@ def snapshot(
         "tiles": tiles,
         "total": len(tiles),
         "final": final,
+        "archived": archived,
     }
 
 

--- a/agentwire/roles/council-member.md
+++ b/agentwire/roles/council-member.md
@@ -32,6 +32,23 @@ The full prompt text is also on disk — the `[COUNCIL PROMPT #N]` message gives
 the exact path (under `~/.agentwire/council/<council>/prompts/<NNNN>/prompt.md`)
 if the message was truncated.
 
+## Memory — consult past deliberations
+
+Earlier rounds and earlier sittings are on disk; a take grounded in what this
+council already concluded beats one argued from scratch. Before answering a
+question that echoes past work, read the history:
+
+- **This sitting's earlier rounds** — `~/.agentwire/council/<council>/prompts/`
+  holds every round (`NNNN/prompt.md` + `replies/<soul>.*.md`). Skim them so you
+  don't re-litigate a settled point or contradict your own prior take.
+- **Other councils' threads (incl. archived/dismissed)** — sibling directories
+  under `~/.agentwire/council/<other>/prompts/` are durable thread artifacts that
+  outlive their sessions. When a decision was made elsewhere, cite it.
+
+Keep it cheap: a quick `ls`/read of the relevant `prompts/` dir, not an
+exhaustive trawl. When a past round changes your answer, say so in your take
+(e.g. "consistent with round 2's call to …") so the orchestrator can attribute it.
+
 ## Rules
 
 - **Passing is expected and free.** If your lens has nothing real to add, pass.

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -308,6 +308,7 @@ class AgentWireServer:
         self.app.router.add_get("/api/scheduler/output", self.api_scheduler_session_output)
         # Council seating board: live sittings + per-prompt snapshot
         self.app.router.add_get("/api/council/sittings", self.api_council_sittings)
+        self.app.router.add_get("/api/council/archive", self.api_council_archive)
         self.app.router.add_get("/api/council/live", self.api_council_live)
         self.app.router.add_get("/api/council/status", self.api_council_status)
         self.app.router.add_post("/api/council/start", self.api_council_start)
@@ -5007,6 +5008,48 @@ projects:
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
+    async def api_council_archive(self, request: web.Request) -> web.Response:
+        """GET /api/council/archive - Dismissed threads, newest first.
+
+        Each entry: ``{name, rounds, last_prompt_text, dismissed_at, cwd}`` —
+        enough for the sidebar to list past deliberations; the board reads the
+        full thread via ``/api/council/live?sitting=<name>``.
+        """
+        try:
+            from .council import state as council_state
+            from .council import inbox as council_inbox
+            from .council import view as council_view
+
+            out = []
+            for name in council_state.list_archive():
+                ids = council_view.available_prompt_ids(name)
+                last_text = ""
+                if ids:
+                    last_text = self._read_text_safe(
+                        council_inbox.prompt_dir(name, ids[-1]) / "prompt.md"
+                    )
+                rec = council_state.read_archive_dict(name) or {}
+                out.append(
+                    {
+                        "name": name,
+                        "rounds": len(ids),
+                        "last_prompt_text": last_text,
+                        "dismissed_at": rec.get("dismissed_at", ""),
+                        "cwd": rec.get("cwd", ""),
+                    }
+                )
+            out.sort(key=lambda e: e.get("dismissed_at", ""), reverse=True)
+            return web.json_response({"archive": out})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    @staticmethod
+    def _read_text_safe(path) -> str:
+        try:
+            return path.read_text()
+        except OSError:
+            return ""
+
     async def api_council_live(self, request: web.Request) -> web.Response:
         """GET /api/council/live - Board snapshot for a sitting (mirrors
         /api/scheduler/live).
@@ -5033,20 +5076,20 @@ projects:
                         {"running": False, "sittings": live}, status=409
                     )
 
-            sitting = council_state.read_sitting(name)
-            if sitting is None:
+            # A dismissed thread has no live sitting.json but is still a fully
+            # readable artifact (archive.json + prompts/). Only 404 when there
+            # is genuinely nothing on disk.
+            live = council_state.read_sitting(name)
+            prompt_id_raw = request.query.get("prompt_id")
+            prompt_id = int(prompt_id_raw) if prompt_id_raw else None
+            dead = await self._council_dead_souls(live) if live else set()
+            snap = council_view.snapshot(name, prompt_id, dead_souls=dead)
+            if snap is None:
                 return web.json_response(
                     {"running": False, "sittings": council_state.list_sittings()},
                     status=404,
                 )
-
-            prompt_id_raw = request.query.get("prompt_id")
-            prompt_id = int(prompt_id_raw) if prompt_id_raw else None
-            dead = await self._council_dead_souls(sitting)
-            snap = council_view.snapshot(name, prompt_id, dead_souls=dead)
-            if snap is None:
-                return web.json_response({"running": False}, status=404)
-            snap["running"] = True
+            snap["running"] = live is not None
             snap["sittings"] = council_state.list_sittings()
             return web.json_response(snap)
         except Exception as e:

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -1608,6 +1608,13 @@ body {
     border-color: var(--accent);
 }
 
+.cmdk-council-note {
+    margin: 8px 2px 0;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--text-dim, var(--muted-foreground, #94a3b8));
+}
+
 .cmdk-idea-mic {
     position: absolute;
     top: 6px;
@@ -5961,4 +5968,19 @@ body.sidebar-pinned .sidebar-tab {
 }
 .council-section-item:hover { background: var(--hover); }
 .council-section-name { font-weight: 600; font-size: 13px; }
-.council-section-count { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.council-section-count { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.council-section-item--open { border-style: dashed; }
+.council-section-subhead {
+    margin: 10px 2px 2px; font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--text-muted);
+}
+.council-section-item--archived { flex-wrap: wrap; opacity: 0.85; }
+.council-section-item--archived:hover { opacity: 1; }
+.council-section-snip {
+    flex-basis: 100%; font-size: 11px; color: var(--text-muted); font-weight: 400;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.council-archived-tag {
+    font-size: 9px; font-weight: 700; letter-spacing: 0.1em; padding: 2px 6px; border-radius: 4px;
+    background: rgba(255,255,255,0.06); color: var(--text-muted); border: 1px solid var(--chrome-border);
+}

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -1,8 +1,9 @@
 /**
  * Command Palette — unified Cmd/Ctrl+K launcher for quick create/open actions.
  *
- * Cmd/Ctrl+K opens straight into the idea-first capture (Esc reaches the root
- * menu). Root view actions:
+ * Cmd/Ctrl+K opens the root list with "Ask council" selected by default (Esc
+ * closes). Root view actions:
+ *   - Ask council   → open the council board to seat/ask a question
  *   - New idea      → idea (typed or dictated) + derived name → create project
  *                     → spawn session → idea delivered as the agent's first
  *                     message → open (you watch it land live)
@@ -16,7 +17,7 @@
 
 import { apiFetch } from './api.js';
 import { normalizeMachine, sameMachine } from './session-id.js';
-import { isService } from './service-classification.js';
+import { isService, isCouncil } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 
 const PILL_TYPES = ['feat', 'fix', 'chore', 'refactor', 'docs'];
@@ -33,6 +34,11 @@ let currentView = 'root';        // 'root' | 'new-idea' | 'new-session' | 'workt
 let prefillProject = '';
 
 const COMMANDS = [
+    { id: 'ask-council', icon: '🏛', label: 'Ask council', keywords: 'council ask question deliberate lenses brainstorm advice decide soul', run: async () => {
+        closeCommandPalette();
+        const { openCouncilWindow } = await import('./desktop.js');
+        openCouncilWindow(null);
+    } },
     { id: 'new-idea', icon: '💡', label: 'New idea', keywords: 'idea create new project repo clone git init build start', run: () => setView('new-idea') },
     { id: 'new-session', icon: '▶', label: 'New session', keywords: 'create new session start spawn run project', run: () => setView('new-session') },
     { id: 'worktree', icon: '⎇', label: 'New worktree', keywords: 'worktree branch quicktask task feat fix base', run: () => setView('worktree') },
@@ -123,7 +129,7 @@ async function loadSessions() {
             if (!names.has(s.name)) out.push(s);
         }
     } catch (e) { /* ignore */ }
-    sessionsCache = out.filter((s) => !isService(s.name || ''));
+    sessionsCache = out.filter((s) => !isService(s.name || '') && !isCouncil(s.name || ''));
     return sessionsCache;
 }
 

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -34,11 +34,7 @@ let currentView = 'root';        // 'root' | 'new-idea' | 'new-session' | 'workt
 let prefillProject = '';
 
 const COMMANDS = [
-    { id: 'ask-council', icon: '🏛', label: 'Ask council', keywords: 'council ask question deliberate lenses brainstorm advice decide soul', run: async () => {
-        closeCommandPalette();
-        const { openCouncilWindow } = await import('./desktop.js');
-        openCouncilWindow(null);
-    } },
+    { id: 'ask-council', icon: '🏛', label: 'Ask council', keywords: 'council ask question deliberate lenses brainstorm advice decide soul', run: () => setView('ask-council') },
     { id: 'new-idea', icon: '💡', label: 'New idea', keywords: 'idea create new project repo clone git init build start', run: () => setView('new-idea') },
     { id: 'new-session', icon: '▶', label: 'New session', keywords: 'create new session start spawn run project', run: () => setView('new-session') },
     { id: 'worktree', icon: '⎇', label: 'New worktree', keywords: 'worktree branch quicktask task feat fix base', run: () => setView('worktree') },
@@ -578,6 +574,85 @@ function bindWorktreeForm(form) {
 }
 
 // ---------------------------------------------------------------------------
+// Ask council — question-first front door (seat-if-needed → ask → watch board)
+// ---------------------------------------------------------------------------
+
+function askCouncilFormHtml() {
+    return `
+        <div class="quicktask-error" data-error hidden></div>
+        <div class="quicktask-progress" data-progress hidden></div>
+        <form class="quicktask-form" data-form="ask-council">
+            <label class="quicktask-field">
+                <span class="quicktask-label">Ask the council</span>
+                <textarea name="prompt" class="cmdk-idea-input" rows="4"
+                    placeholder="A question or decision to put to the lenses…"
+                    autocomplete="off" spellcheck="false"></textarea>
+            </label>
+            <p class="cmdk-council-note">One model, six lenses — structured self-critique, not a panel of experts. Seats a council if none is live (~6 sessions).</p>
+            <div class="quicktask-footer">
+                <button type="button" class="quicktask-btn-cancel" data-action="back">Back</button>
+                <button type="submit" class="quicktask-btn-submit">Convene &amp; ask</button>
+            </div>
+        </form>`;
+}
+
+function bindAskCouncilForm(form) {
+    const input = form.querySelector('textarea[name="prompt"]');
+    // Enter submits; Shift+Enter for a newline.
+    input?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); }
+        e.stopPropagation();  // don't leak to global shortcuts
+    });
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const prompt = input.value.trim();
+        if (!prompt) { input.focus(); return; }
+        await submitAskCouncil(prompt);
+    });
+}
+
+/** Resolve a sitting (seat one if none live), fan the prompt out, open the board.
+ *  Fire-and-forget: we don't wait for the takes — the board fills them live. */
+async function submitAskCouncil(prompt) {
+    showProgress('Convening the council…');
+    try {
+        let sitting = null;
+        const sres = await apiFetch('/api/council/sittings');
+        const live = (sres.ok ? (await sres.json()).sittings : []) || [];
+        if (live.length === 1) {
+            sitting = live[0];
+        } else if (live.length === 0) {
+            showProgress('Seating the council…');
+            const st = await apiFetch('/api/council/start', { method: 'POST' });
+            const sd = await st.json().catch(() => ({}));
+            if (!st.ok) { showError(sd.error || 'Could not seat the council.'); return; }
+            sitting = sd.council || null;
+        } else {
+            // Several live — let the user pick which chamber in the board.
+            closeCommandPalette();
+            const { openCouncilWindow } = await import('./desktop.js');
+            openCouncilWindow(null);
+            return;
+        }
+        showProgress('Asking the council…');
+        const body = { prompt };
+        if (sitting) body.sitting = sitting;
+        const ares = await apiFetch('/api/council/ask', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const adata = await ares.json().catch(() => ({}));
+        if (!ares.ok) { showError(adata.error || 'Could not ask the council.'); return; }
+        closeCommandPalette();
+        const { openCouncilWindow } = await import('./desktop.js');
+        openCouncilWindow(sitting || adata.council || null);
+    } catch (err) {
+        showError(err?.message || 'Network error');
+    }
+}
+
+// ---------------------------------------------------------------------------
 // List views (root + open-session)
 // ---------------------------------------------------------------------------
 
@@ -656,10 +731,14 @@ function renderView() {
     if (currentView === 'new-idea') {
         footer.textContent = '↵ create & run · ⇧↵ newline · esc back';
         body.innerHTML = newIdeaFormHtml();
+    } else if (currentView === 'ask-council') {
+        footer.textContent = '↵ convene & ask · ⇧↵ newline · esc back';
+        body.innerHTML = askCouncilFormHtml();
     } else if (currentView === 'new-session') body.innerHTML = newSessionFormHtml();
     else if (currentView === 'worktree') body.innerHTML = worktreeFormHtml();
     const form = body.querySelector('.quicktask-form');
     if (currentView === 'new-idea') bindNewIdeaForm(form);
+    else if (currentView === 'ask-council') bindAskCouncilForm(form);
     else if (currentView === 'new-session') bindNewSessionForm(form);
     else if (currentView === 'worktree') bindWorktreeForm(form);
 }

--- a/agentwire/static/js/council-window.js
+++ b/agentwire/static/js/council-window.js
@@ -44,6 +44,8 @@ const state = {
     roundTexts: {},       // prompt_id -> question text, cached as rounds are visited
     liveness: {},         // soul -> bool (lens session alive — from /status)
     seated: false,        // is a sitting present at all
+    archived: false,      // viewing a dismissed thread (no live sessions)
+    running: true,        // a live sitting backs the view
     busy: false,          // a seat/ask/dismiss POST is in flight
 };
 
@@ -157,6 +159,8 @@ async function loadSnapshot(sitting, promptId) {
 function applySnapshot(snap) {
     state.sitting = snap.sitting;
     state.seated = true;
+    state.archived = !!snap.archived;       // dismissed thread, no live sessions
+    state.running = snap.running !== false;  // live sitting present
     state.promptId = snap.prompt_id;
     state.promptIds = snap.prompt_ids || [];
     state.latestPromptId = state.promptIds.length
@@ -295,6 +299,15 @@ function seatControlHtml() {
                 ${state.busy ? 'Seating…' : 'Seat the council'}
             </button>`;
     }
+    if (state.archived) {
+        // Dismissed thread: read-only, no live sessions to dismiss. Re-asking
+        // (from the ask row) re-seats the same roster under the same name.
+        return `
+            <span class="council-seat-summary council-seat-summary--archived">
+                <span class="council-counter">${esc(counterText())}</span>
+                <span class="council-archived-tag">ARCHIVED</span>
+            </span>`;
+    }
     return `
         <span class="council-seat-summary"><span class="council-seat-led"></span><span class="council-counter">${esc(counterText())}</span></span>
         <button class="council-btn council-btn--ghost" data-action="dismiss" ${state.busy ? 'disabled' : ''}>Dismiss</button>`;
@@ -355,12 +368,18 @@ function roundsCrumbHtml() {
 /** The header ASK row — re-prompt the seated sitting; compact input + button. */
 function askHtml() {
     if (!state.seated || !state.sitting) return '';
+    const placeholder = state.archived
+        ? 'Re-ask this thread — re-seats the same lenses…'
+        : 'Ask the council, or add context…';
+    const label = state.busy
+        ? (state.archived ? 'Re-seating…' : 'Asking…')
+        : (state.archived ? 'Re-seat &amp; ask →' : 'Ask the council →');
     return `
         <div class="council-ask">
             <div class="council-ask-row">
-                <textarea class="council-ask-input" rows="1" placeholder="Ask the council, or add context…" ${state.busy ? 'disabled' : ''}></textarea>
+                <textarea class="council-ask-input" rows="1" placeholder="${esc(placeholder)}" ${state.busy ? 'disabled' : ''}></textarea>
                 <button class="council-btn council-btn--primary council-btn--compact" data-action="ask" ${state.busy ? 'disabled' : ''}>
-                    ${state.busy ? 'Asking…' : 'Ask the council →'}
+                    ${label}
                 </button>
             </div>
             <div class="council-ask-err" data-slot="ask-err"></div>
@@ -651,10 +670,33 @@ async function askCouncil(input) {
     if (!prompt) { input.focus(); return; }
     state.busy = true;
     const btn = container?.querySelector('[data-action="ask"]');
-    if (btn) { btn.disabled = true; btn.textContent = 'Asking…'; }
+    const reseating = state.archived || !state.running;
+    if (btn) { btn.disabled = true; btn.textContent = reseating ? 'Re-seating…' : 'Asking…'; }
     input.disabled = true;
     setAskError('');
     try {
+        // Archived thread → re-seat the same roster under the same name first,
+        // so the fan-out has live lens sessions to land in.
+        if (reseating) {
+            const startBody = { sitting: state.sitting };
+            if (state.roster.length) startBody.roster = state.roster.join(',');
+            const sres = await apiFetch('/api/council/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(startBody),
+            });
+            const sdata = await sres.json().catch(() => ({}));
+            if (!sres.ok) {
+                state.busy = false;
+                if (btn) { btn.disabled = false; }
+                input.disabled = false;
+                setAskError(sdata.error || 'Could not re-seat the council.');
+                return;
+            }
+            state.archived = false;
+            state.running = true;
+            if (btn) btn.textContent = 'Asking…';
+        }
         const res = await apiFetch('/api/council/ask', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -879,12 +879,13 @@ function setupGlobalPtt() {
             e.preventDefault();
             startGlobalRecording();
         }
-        // Cmd/Ctrl + K opens the command palette straight into idea capture
-        // (Esc reaches the root menu). xterm.js uses a hidden textarea for
-        // terminal input, so we don't skip on tag — Cmd+K is always intercepted.
+        // Cmd/Ctrl + K opens the command palette on the root list, with
+        // "Ask council" as the default selection. xterm.js uses a hidden
+        // textarea for terminal input, so we don't skip on tag — Cmd+K is
+        // always intercepted.
         if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
             e.preventDefault();
-            if (!isCommandPaletteOpen()) openCommandPalette({ view: 'new-idea' });
+            if (!isCommandPaletteOpen()) openCommandPalette();
         }
     });
     document.addEventListener('keyup', (e) => {

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -14,7 +14,7 @@
  */
 
 import { apiFetch, wsProtocols } from './api.js';
-import { isService, loadCustomServices } from './service-classification.js';
+import { isService, isCouncil, loadCustomServices } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 import * as browserTts from './voice/browser-tts.js';
 import { voicePromptWrap } from './voice/prompt.js';
@@ -143,7 +143,8 @@ function setTab(tab, { render = true } = {}) {
 
 function renderSessions() {
     els.sessionList.innerHTML = '';
-    const visible = sessions.filter(s => isService(s.name || '') === (activeTab === 'services'));
+    // Council sessions have no home on mobile yet — keep them out of both tabs.
+    const visible = sessions.filter(s => !isCouncil(s.name || '') && isService(s.name || '') === (activeTab === 'services'));
     if (visible.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'mobile-empty';

--- a/agentwire/static/js/service-classification.js
+++ b/agentwire/static/js/service-classification.js
@@ -17,6 +17,15 @@ const SERVICE_SESSIONS = new Set([
 
 export function isService(name) { return SERVICE_SESSIONS.has(name); }
 
+// Council sessions are a third category — neither a service nor a working
+// session. A sitting is `agentwire-council-<name>` (orchestrator) plus
+// `council-<name>-<lens>` (souls); they belong to the Council section, not the
+// regular Sessions list. Namespace-prefix match (the namespace is reserved).
+export function isCouncil(name) {
+    const n = String(name || '');
+    return n.startsWith('agentwire-council-') || n.startsWith('council-');
+}
+
 // Merge config-defined custom services (services.custom in config.yaml) into
 // the built-in allowlist. Idempotent — concurrent callers share one fetch.
 // Resolves true if any names were added, so callers can re-render.

--- a/agentwire/static/js/sidebar/council-section.js
+++ b/agentwire/static/js/sidebar/council-section.js
@@ -1,8 +1,11 @@
 /**
- * Council sidebar section — lists live sittings and opens the board window.
+ * Council sidebar section — live sittings + an archive of past threads.
  *
- * The board itself (grid, deltas, reader) lives in council-window.js; this is
- * just the launcher + a compact "N of M in" status line per live sitting.
+ * Live sittings show a compact "N of M in" status; archived threads (dismissed
+ * but preserved on disk) list under an Archive subhead and reopen the board
+ * read-only, where they can be re-asked (which re-seats the same roster). The
+ * board itself (grid, deltas, reader) lives in council-window.js; this is the
+ * launcher + index.
  */
 
 import { apiFetch } from '../api.js';
@@ -14,10 +17,17 @@ function esc(s) {
     })[c]);
 }
 
+/** First line of a question, clamped — the thread's at-a-glance label. */
+function snippet(text, max = 60) {
+    const line = String(text || '').trim().split('\n')[0];
+    return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
 export const councilSection = {
     title: 'Council',
     _body: null,
     _sittings: [],
+    _archive: [],
 
     async mount(body) {
         this._body = body;
@@ -35,6 +45,13 @@ export const councilSection = {
         } catch {
             this._sittings = [];
         }
+        try {
+            const res = await apiFetch('/api/council/archive');
+            const data = res.ok ? await res.json() : { archive: [] };
+            this._archive = data.archive || [];
+        } catch {
+            this._archive = [];
+        }
         // Per-sitting live counts (best-effort; ignore failures).
         const counts = {};
         await Promise.all(this._sittings.map(async (name) => {
@@ -50,36 +67,44 @@ export const councilSection = {
     },
 
     _render(body, counts) {
-        if (!this._sittings.length) {
-            // No live sitting — still offer the workspace so it can be seated there.
-            body.innerHTML = `
-                <div class="council-section-list">
-                    <button class="council-section-item" data-open-empty="1">
-                        <span class="council-section-name">Open council</span>
-                        <span class="council-section-count">seat &amp; ask</span>
-                    </button>
-                </div>`;
-            body.querySelector('[data-open-empty]')?.addEventListener('click', async () => {
-                const { openCouncilWindow } = await import('../desktop.js');
-                openCouncilWindow(null);
-            });
-            return;
-        }
+        const liveHtml = this._sittings.map((name) => {
+            const c = counts[name];
+            const meta = c
+                ? `<span class="council-section-count">${c.final} of ${c.total} in</span>`
+                : '';
+            return `
+                <button class="council-section-item" data-sitting="${esc(name)}">
+                    <span class="council-section-name">${esc(name)}</span>
+                    ${meta}
+                </button>`;
+        }).join('');
+
+        const archiveHtml = this._archive.length ? `
+            <div class="council-section-subhead">Archive</div>
+            ${this._archive.map((a) => `
+                <button class="council-section-item council-section-item--archived" data-sitting="${esc(a.name)}" title="${esc(snippet(a.last_prompt_text, 200))}">
+                    <span class="council-section-name">${esc(a.name)}</span>
+                    <span class="council-section-snip">${esc(snippet(a.last_prompt_text))}</span>
+                    <span class="council-section-count">${a.rounds} round${a.rounds === 1 ? '' : 's'}</span>
+                </button>`).join('')}
+        ` : '';
+
+        // Always offer the workspace launcher (seat/ask a fresh council there).
         body.innerHTML = `
             <div class="council-section-list">
-                ${this._sittings.map((name) => {
-                    const c = counts[name];
-                    const meta = c
-                        ? `<span class="council-section-count">${c.final} of ${c.total} in</span>`
-                        : '';
-                    return `
-                        <button class="council-section-item" data-sitting="${esc(name)}">
-                            <span class="council-section-name">${esc(name)}</span>
-                            ${meta}
-                        </button>`;
-                }).join('')}
+                <button class="council-section-item council-section-item--open" data-open-empty="1">
+                    <span class="council-section-name">Open council</span>
+                    <span class="council-section-count">seat &amp; ask</span>
+                </button>
+                ${liveHtml}
+                ${archiveHtml}
             </div>`;
-        body.querySelectorAll('.council-section-item').forEach((btn) => {
+
+        body.querySelector('[data-open-empty]')?.addEventListener('click', async () => {
+            const { openCouncilWindow } = await import('../desktop.js');
+            openCouncilWindow(null);
+        });
+        body.querySelectorAll('.council-section-item[data-sitting]').forEach((btn) => {
             btn.addEventListener('click', async () => {
                 const { openCouncilWindow } = await import('../desktop.js');
                 openCouncilWindow(btn.dataset.sitting);

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -1,7 +1,7 @@
 import { apiFetch } from '../api.js';
 import { desktop } from '../desktop-manager.js';
 import { buildSessionId, normalizeMachine } from '../session-id.js';
-import { isService, loadCustomServices } from '../service-classification.js';
+import { isService, isCouncil, loadCustomServices } from '../service-classification.js';
 import { toastSuccess, toastError } from '../toast.js';
 
 // Shared state across sessions and services sections
@@ -285,7 +285,8 @@ export const sessionsSection = {
     },
 
     _render(body) {
-        const work = allSessions.filter(s => !isService(s.name || ''));
+        // Council souls/orchestrators live in the Council section, not here.
+        const work = allSessions.filter(s => !isService(s.name || '') && !isCouncil(s.name || ''));
         let html = this._renderForm();
         if (!work.length && !this._formType) {
             html += '<div class="sidebar-empty">No sessions</div>';


### PR DESCRIPTION
Makes the Council a first-class citizen — implements Phases 1–3 of #408. The render contract from the deliberation (cards-primary tiles, round history, reader) already shipped in #404/#405; this PR adds the **front doors** and **durable thread archive** that were missing.

## Phase 1 — Cmd+K front door + declutter
- Cmd+K opens the **root list** with **🏛 Ask council** default-selected (was: jumped into New idea).
- `isCouncil()` added to the classification SSOT; council soul/orchestrator sessions filtered out of the Sessions list (sidebar, palette, mobile).

## Phase 2 — question-first ask
- "Ask council" opens an ask textarea → seats a council if none live → fans out → opens the board to watch (fire-and-forget). Honest framing: "one model, six lenses — structured self-critique, not a panel of experts."

## Phase 3 — threads as durable artifacts
- Dismiss preserves the sitting to `archive.json` (+ `dismissed_at`); `prompts/` already persisted. `view.snapshot()` serves archived threads (live → archive → reconstruct from disk), prompt ids derived from disk.
- `GET /api/council/archive` lists past threads; `/api/council/live` serves them read-only instead of 404.
- Sidebar lists live sittings + an **Archive**; reopening shows an **ARCHIVED** board with verdicts read from disk and a **Re-seat & ask** action (re-asking re-seats the same roster under the same name).
- `council-member` role learns to consult past rounds/threads on disk — the council can build on its own history.

## Verified in-browser
Cmd+K → list with Ask council selected (not the ask screen); ask view renders; archive lists the real `agentwire-dev` thread (7 rounds); reopening shows ARCHIVED + lens verdicts + Re-seat & ask. Python compiles; `node --check` clean.

## Deferred (tracked in #408, Phase 4)
SPLIT/ALIGNED dissent band + synthesis-as-derived-header — these need **new protocol** (per-lens stance + a persisted synthesis). A band that can't actually detect dissent would be the false-confidence `conscience` warned against, and the council's own verdict was to gate synthesis-quality work behind real usage. Flagged, not cowboyed.

Closes #408

Built by [dotdev.dev](https://dotdev.dev)
