### PR TITLE
fix(council): Escape backs out of the Cmd+K ask-council form

### DIFF
--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -598,10 +598,12 @@ function askCouncilFormHtml() {
 
 function bindAskCouncilForm(form) {
     const input = form.querySelector('textarea[name="prompt"]');
-    // Enter submits; Shift+Enter for a newline.
+    // Enter submits; Shift+Enter for a newline. Escape must bubble to the
+    // palette's overlay handler (goBack), so don't swallow it.
     input?.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') return;
         if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); }
-        e.stopPropagation();  // don't leak to global shortcuts
+        e.stopPropagation();  // keep other keystrokes off global shortcuts
     });
     form.addEventListener('submit', async (e) => {
         e.preventDefault();


### PR DESCRIPTION
The ask-council textarea swallowed Escape (its keydown called `stopPropagation` on every key to keep typing off global shortcuts), so Escape never reached the palette overlay's `goBack` handler. Result: Escape did nothing in the ask-council view, while it worked everywhere else (other form views never stop propagation).

Fix: let Escape bubble; keep `stopPropagation` for the rest.

Verified in-browser: Escape from the ask-council form → back to the list; Escape from the list → closes the palette.

Follow-up to #409 / #408.

Built by [dotdev.dev](https://dotdev.dev)