### PR TITLE
feat(desktop): touch swipe-to-cycle on the desktop route (tablets)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -141,6 +141,9 @@ body {
     position: relative;
     overflow: hidden;
     background: var(--background);
+    /* Tablets: keep vertical pan native (terminal scroll) but hand horizontal
+       drags to JS for swipe-to-cycle instead of browser back/forward nav. */
+    touch-action: pan-y;
 }
 
 .desktop-wallpaper {

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -17,6 +17,7 @@ import { CouncilWindow, COUNCIL_WINDOW_ID } from './council-window.js';
 import { sidebar } from './sidebar.js';
 import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
 import { notificationsActive } from './notification-prefs.js';
+import { attachHorizontalSwipe } from './utils/swipe.js';
 import { configSection } from './sidebar/config-section.js';
 import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
@@ -402,6 +403,16 @@ function setupWindowSwipeCycling() {
         cooldown = true;
         setTimeout(() => { cooldown = false; }, COOLDOWN_MS);
     }, { passive: false });
+
+    // Touch devices (tablets on the desktop route — `/` always serves the
+    // desktop, there's no mobile redirect) don't fire wheel events, so add the
+    // single-finger swipe equivalent. Capture phase so an xterm terminal can't
+    // swallow the gesture; sidebar and the command palette opt out.
+    const surface = document.getElementById('desktopArea') || document;
+    attachHorizontalSwipe(surface, cycleWindow, {
+        capture: true,
+        ignore: (t) => !!(t.closest && t.closest('.sidebar, .cmdk-overlay')),
+    });
 }
 
 /** True if the target sits inside an element that can actually scroll sideways. */

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -14,6 +14,7 @@
  */
 
 import { apiFetch, wsProtocols } from './api.js';
+import { attachHorizontalSwipe } from './utils/swipe.js';
 import { isService, isCouncil, loadCustomServices } from './service-classification.js';
 import * as browserStt from './voice/browser-stt.js';
 import * as browserTts from './voice/browser-tts.js';
@@ -231,64 +232,15 @@ function cycleSession(direction) {
     if (next && next.name !== selectedSession) selectSession(next.name);
 }
 
-// Horizontal swipe to cycle sessions — the mobile analog of Tab/Shift+Tab.
-//
-// Single-finger by design: on a phone a TWO-finger gesture is claimed by the
-// browser as pinch-zoom / a system gesture before JS sees clean move events, so
-// two-finger swipe-cycling can't be made reliable there (no gesture library
-// fixes that — it's the OS/browser, not us). A one-finger horizontal swipe is
-// the standard mobile gesture and, with `touch-action: pan-y` on the surface
-// (mobile.css), the browser hands us horizontal drags while keeping vertical
-// scroll native. The PTT button and edit bar opt out so press-to-talk and
-// typing are untouched.
+// Single-finger horizontal swipe to cycle sessions — the mobile analog of
+// Tab/Shift+Tab. Shared detector (utils/swipe.js); `touch-action: pan-y` on
+// .mobile-app (mobile.css) keeps vertical scroll native. PTT + edit bar opt out
+// so press-to-talk and typing are untouched.
 function setupSwipeCycling() {
-    let active = false;
-    let startX = 0, startY = 0, curX = 0, curY = 0;
-    let lockedVertical = false;
-    const THRESHOLD = 50;  // px of horizontal travel for a deliberate swipe
-
     const surface = document.querySelector('.mobile-app') || document;
-
-    surface.addEventListener('touchstart', (e) => {
-        // Let press-to-talk and the text input own their own touches.
-        const t = e.target;
-        if (t.closest && (t.closest('#pttButton') || t.closest('#editBar'))) {
-            active = false;
-            return;
-        }
-        active = true;
-        lockedVertical = false;
-        const p = e.touches[0];
-        startX = curX = p.clientX;
-        startY = curY = p.clientY;
-    }, { passive: true });
-
-    surface.addEventListener('touchmove', (e) => {
-        if (!active) return;
-        const p = e.touches[0];
-        curX = p.clientX;
-        curY = p.clientY;
-        const dx = curX - startX;
-        const dy = curY - startY;
-        // First decisive axis wins: vertical → release for native scroll;
-        // horizontal → claim the gesture (block scroll/back-nav under it).
-        if (!lockedVertical && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 12) {
-            lockedVertical = true;
-        }
-        if (!lockedVertical && Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 8) {
-            e.preventDefault();
-        }
-    }, { passive: false });
-
-    surface.addEventListener('touchend', () => {
-        if (!active) return;
-        active = false;
-        if (lockedVertical) return;
-        const dx = curX - startX;
-        const dy = curY - startY;
-        if (Math.abs(dx) < THRESHOLD || Math.abs(dx) <= Math.abs(dy)) return;
-        cycleSession(dx < 0 ? 1 : -1);  // swipe left → next, right → previous
-    }, { passive: true });
+    attachHorizontalSwipe(surface, cycleSession, {
+        ignore: (t) => !!(t.closest && (t.closest('#pttButton') || t.closest('#editBar'))),
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/agentwire/static/js/utils/swipe.js
+++ b/agentwire/static/js/utils/swipe.js
@@ -1,0 +1,68 @@
+/**
+ * Shared horizontal-swipe detector — used by the desktop window cycler and the
+ * mobile session cycler so the two surfaces can't drift apart.
+ *
+ * Single-finger by design: on a touch device a TWO-finger gesture is claimed by
+ * the browser as pinch-zoom / a system gesture before JS sees clean move events,
+ * so two-finger swipe-cycling can't be made reliable (no gesture library fixes
+ * that — it's the OS/browser, not us). Pair this with `touch-action: pan-y` on
+ * the surface so the browser keeps vertical scroll native and hands horizontal
+ * drags to us instead of treating them as scroll / back-forward navigation.
+ *
+ * onSwipe(direction): direction is +1 for a left swipe (→ next), -1 for right
+ * (→ previous), matching Tab / Shift+Tab.
+ *
+ * opts.threshold  px of horizontal travel required (default 50)
+ * opts.ignore(target)  return true to skip a gesture starting on that element
+ * opts.capture  listen in the capture phase (default false) — use it when a
+ *               child (e.g. an xterm terminal) might swallow bubbling touches
+ */
+export function attachHorizontalSwipe(surface, onSwipe, opts = {}) {
+    const threshold = opts.threshold ?? 50;
+    const ignore = opts.ignore || (() => false);
+    const capture = !!opts.capture;
+
+    let active = false;
+    let startX = 0, startY = 0, curX = 0, curY = 0;
+    let lockedVertical = false;
+
+    surface.addEventListener('touchstart', (e) => {
+        // Single finger only; let multi-touch (zoom) and opted-out targets pass.
+        if (e.touches.length !== 1 || (e.target && ignore(e.target))) {
+            active = false;
+            return;
+        }
+        active = true;
+        lockedVertical = false;
+        const p = e.touches[0];
+        startX = curX = p.clientX;
+        startY = curY = p.clientY;
+    }, { passive: true, capture });
+
+    surface.addEventListener('touchmove', (e) => {
+        if (!active) return;
+        const p = e.touches[0];
+        curX = p.clientX;
+        curY = p.clientY;
+        const dx = curX - startX;
+        const dy = curY - startY;
+        // First decisive axis wins: vertical → release for native scroll;
+        // horizontal → claim the gesture (block scroll / back-nav under it).
+        if (!lockedVertical && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 12) {
+            lockedVertical = true;
+        }
+        if (!lockedVertical && Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 8) {
+            e.preventDefault();
+        }
+    }, { passive: false, capture });
+
+    surface.addEventListener('touchend', () => {
+        if (!active) return;
+        active = false;
+        if (lockedVertical) return;
+        const dx = curX - startX;
+        const dy = curY - startY;
+        if (Math.abs(dx) < threshold || Math.abs(dx) <= Math.abs(dy)) return;
+        onSwipe(dx < 0 ? 1 : -1);  // swipe left → next, right → previous
+    }, { passive: true, capture });
+}


### PR DESCRIPTION
Follow-up to #412/#413/#414. `/` (the "regular route") **always serves the desktop page** — there's no UA-based mobile redirect — so a tablet on `/` gets the WinBox desktop, which only had the **trackpad (wheel)** swipe. Touchscreens don't fire wheel events, so swipe-to-cycle did nothing on a tablet at `/`.

- Adds the **single-finger touch swipe** to the desktop route (cycles open windows, left = next / right = previous).
- Extracts the detector into **`utils/swipe.js`**, now shared by desktop (`cycleWindow`) and mobile (`cycleSession`) so the two surfaces can't drift apart.
- **Capture phase** so an xterm terminal can't swallow the gesture; `touch-action: pan-y` on `.desktop-area` keeps terminal vertical scroll native while horizontal drags go to JS (no browser back/forward hijack).
- Sidebar and command palette opt out.

Verified on `/` with dispatched touch events: swipe left → next window, right → previous, vertical drag → no cycle. `node --check` clean on all three files.

Built by [dotdev.dev](https://dotdev.dev)