### PR TITLE
fix(desktop): swipe-to-cycle over an unfocused terminal (touch-action)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -146,6 +146,20 @@ body {
     touch-action: pan-y;
 }
 
+/* Window content must also opt into pan-y. WebKit/iPadOS resolves touch-action
+   on the directly-touched element rather than reliably intersecting with the
+   ancestor, so an xterm terminal / Monitor <pre> left at the default `auto`
+   lets the browser claim horizontal swipes — that's why swipe-to-cycle only
+   fired once the terminal was focused. Forcing pan-y here hands every
+   horizontal drag over a window to JS regardless of focus. */
+.wb-body,
+.xterm,
+.xterm-viewport,
+.xterm-screen,
+.session-output {
+    touch-action: pan-y;
+}
+
 .desktop-wallpaper {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
Follow-up to #415. The swipe-to-cycle gesture only worked **after tapping the terminal to focus it**; just looking at an unfocused window, a swipe did nothing.

**Cause:** `.desktop-area` was `touch-action: pan-y`, but the window content — `.wb-body`, `.xterm`, `.xterm-viewport`, `.xterm-screen` — was left at the default `auto`. WebKit/iPadOS resolves `touch-action` on the **directly-touched element** rather than reliably intersecting with ancestors, so the browser claimed horizontal swipes over the unfocused terminal before our capture handler could act on them. Focusing the terminal changed xterm's own touch handling, which is why a tap appeared to "fix" it.

**Fix (CSS only):** force `touch-action: pan-y` on `.wb-body`, `.xterm`, `.xterm-viewport`, `.xterm-screen`, and `.session-output` (Monitor mode) so a horizontal drag over any window always reaches the swipe handler, focused or not. Vertical scroll stays native.

Verified the computed `touch-action` is now `pan-y` on all terminal elements.

Built by [dotdev.dev](https://dotdev.dev)