### PR TITLE
feat(desktop): don't pop the soft keyboard on session open/switch (touch)

### DIFF
--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -22,6 +22,15 @@ function pickTerminalFontSize() {
     return getTerminalFontSize();
 }
 
+// Touch-primary devices (tablets/phones) raise the on-screen keyboard the
+// instant xterm's hidden textarea is focused. Opening or switching to a window
+// shouldn't do that uninvited — the user taps the terminal to type, which
+// focuses xterm and raises the keyboard only when they actually want it. On a
+// mouse/trackpad device we still auto-focus so typing works immediately.
+const TOUCH_PRIMARY = typeof window !== 'undefined'
+    && window.matchMedia
+    && window.matchMedia('(pointer: coarse)').matches;
+
 // Terminal WS reconnect tuning. A transient drop (portal restart, an
 // over-broad bg-process kill, a network blip) should heal silently rather than
 // dump the user onto the manual "Reconnect" wall — the tmux session almost
@@ -116,8 +125,10 @@ export class SessionWindow {
 
         // Focus the terminal so the user can type immediately. Deferred to the
         // next frame so WinBox's maximize animation has settled — focusing
-        // during the transition gets stolen back by the parent.
-        if (this.mode === 'terminal') {
+        // during the transition gets stolen back by the parent. Skipped on
+        // touch devices so opening a session doesn't pop the soft keyboard —
+        // the user taps the terminal to type.
+        if (this.mode === 'terminal' && !TOUCH_PRIMARY) {
             requestAnimationFrame(() => {
                 if (this.terminal) this.terminal.focus();
             });
@@ -239,7 +250,11 @@ export class SessionWindow {
         if (this.winbox) {
             this.winbox.focus();
         }
-        if (this.terminal) {
+        // On touch devices, don't pull focus into the terminal input — that
+        // raises the soft keyboard on every window switch. Bring the window
+        // forward only; tapping the terminal focuses it (and shows the keyboard)
+        // when the user actually wants to type.
+        if (this.terminal && !TOUCH_PRIMARY) {
             this.terminal.focus();
         }
     }


### PR DESCRIPTION
On a tablet, opening or switching to a session auto-focused xterm's hidden textarea, which **raises the soft keyboard every time** — even when you only want to view or swipe between sessions.

Fix: gate the programmatic terminal focus (`open()` and `focus()`) behind a touch-primary check (`matchMedia('(pointer: coarse)')`).
- **Touch devices:** the window comes forward without grabbing the text input. Tapping the terminal focuses it and raises the keyboard **only when you want to type** — exactly the requested behavior (no uninvited keyboard, but still available on demand).
- **Mouse/trackpad:** unchanged — still auto-focuses so typing works immediately.

Verified: on a fine-pointer device the xterm textarea still takes focus after a window switch (desktop typing unaffected). The voice transcript-edit refocus is left as-is (it's tied to a deliberate text-editing action, not open/switch).

Built by [dotdev.dev](https://dotdev.dev)