### PR TITLE
feat(portal): auto-dismiss a session's idle toasts when you tab into it

### DIFF
--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -589,6 +589,9 @@ export function openSessionTerminal(session, mode, machine = null) {
             // Voice follows the focused tab — mirror this session to the
             // active-session shadow file so ⌥Space (Hammerspoon) targets it.
             postActiveSession(session);
+            // Tabbing into a session clears its idle/worker toasts — the user
+            // has seen it, so leaving the notification up is just noise.
+            notificationsPanel.dismissForSession(session);
         }
     });
 

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -63,6 +63,7 @@ class NotificationsPanel {
         const toast = document.createElement('div');
         toast.className = `notification-toast${priority === 'high' ? ' high' : ''}`;
         toast.dataset.id = id;
+        toast.dataset.session = session || '';
 
         const timeStr = this._formatTime(timestamp);
 
@@ -108,6 +109,24 @@ class NotificationsPanel {
             toast.remove();
         }
         this.toasts.delete(id);
+    }
+
+    /**
+     * Auto-dismiss every outstanding toast tied to a given session — called
+     * when the user tabs into that session's window, so a notification they've
+     * clearly seen stops being noise. Toasts for other sessions are untouched.
+     * Routes through _dismissToast so the dismissal is persisted server-side and
+     * won't reappear on reload.
+     *
+     * @param {string} session
+     */
+    dismissForSession(session) {
+        if (!session) return;
+        for (const [id, toast] of this.toasts) {
+            if (toast.dataset.session === session) {
+                this._dismissToast(id);
+            }
+        }
     }
 
     async _dismissToast(id) {


### PR DESCRIPTION
## What

When the user focuses (tabs into) a session in the portal, any outstanding idle/worker toast notifications for that session auto-dismiss. They've clearly seen it, so leaving it up is noise. Toasts for **other** sessions stay up.

## How

- **`static/js/notifications-panel.js`** — stamp each toast with `dataset.session` and add `dismissForSession(session)`. It iterates outstanding toasts and dismisses only those whose session matches exactly, routing through the existing `_dismissToast(id)` so the dismissal is animated **and** persisted server-side (`/api/desktop/notification/dismiss`) — it won't reappear on reload/restore.
- **`static/js/desktop.js`** — call `notificationsPanel.dismissForSession(session)` from the session-window `onFocus` callback, alongside the existing taskbar-active + voice-follow side-effects. The callback fires on focus, maximize, and restore, so tabbing into a session clears its toasts.

No new events or state — reuses the existing focus callback and dismiss path. Match is on the bare session name, which is what both the notification (`server.py` `api_desktop_notification`, and the idle path at `__main__.py:1906`) and `openSessionWindow` carry.

## Verification

- Logic-tested in isolation: session-scoped match, safe Map mutation during iteration, no-op on empty session, other sessions' toasts retained.
- Manual (per issue): trigger an idle notification for session A → focus A's window → toast clears; with a toast up for session B while focused on A, B's toast stays up.

Closes #402

Built by [dotdev.dev](https://dotdev.dev)