### PR TITLE
feat(doctor): voice-loop preflight — pass/fail per push-to-talk stage (#389)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -213,6 +213,7 @@ agentwire hooks uninstall       # remove permission hook (Claude Code only)
 agentwire hooks status          # check hook installation status
 agentwire network status        # complete network health check
 agentwire doctor                # auto-diagnose and fix issues
+agentwire doctor --voice        # only the push-to-talk path: mic, STT shim, portal/tunnel, tmux+PTT (pass/fail + fix)
 
 # Notifications
 agentwire notify event          # notify portal of state changes (session/pane events)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6854,6 +6854,29 @@ def cmd_safety_tooldefs_show(args) -> int:
     return cli_safety.safety_tooldefs_show_cmd(args.tool)
 
 
+def _render_voice_loop_section(config, ctx) -> int:
+    """Print the voice-loop (push-to-talk) preflight. Returns failures found.
+
+    Read-only pass/fail per stage with an actionable fix line when red — the
+    existing infra sections keep the auto-fix prompts.
+    """
+    from .doctor_voice import run_voice_loop_checks
+
+    print("\nChecking voice loop (push-to-talk)...")
+    failures = 0
+    for stage in run_voice_loop_checks(config, ctx):
+        if stage.status == "ok":
+            print(f"  [ok] {stage.name}: {stage.detail}")
+        elif stage.status == "info":
+            print(f"  [..] {stage.name}: {stage.detail}")
+        else:
+            print(f"  [!!] {stage.name}: {stage.detail}")
+            for fix in stage.fixes:
+                print(f"       Fix: {fix}")
+            failures += 1
+    return failures
+
+
 def cmd_doctor(args) -> int:
     """Auto-diagnose and fix common issues."""
     from .network import NetworkContext
@@ -6862,12 +6885,34 @@ def cmd_doctor(args) -> int:
 
     dry_run = getattr(args, 'dry_run', False)
     auto_confirm = getattr(args, 'yes', False)
+    voice_only = getattr(args, 'voice', False)
 
     print("AgentWire Doctor")
     print("=" * 60)
 
     issues_found = 0
     issues_fixed = 0
+
+    # --voice: run ONLY the end-to-end push-to-talk preflight (fast, no SSH
+    # waits) — for tight first-run / break-a-dependency verification loops.
+    if voice_only:
+        try:
+            from .config import load_config as load_config_typed
+            config = load_config_typed()
+        except Exception as e:
+            print(f"\n  [!!] Config file error: {e}")
+            print("     Run: agentwire init")
+            return 1
+        try:
+            ctx = NetworkContext.from_config()
+        except Exception:
+            ctx = None
+        issues_found = _render_voice_loop_section(config, ctx)
+        print()
+        print("-" * 60)
+        print("Voice loop ready!" if issues_found == 0
+              else f"Voice loop: {issues_found} stage(s) need attention")
+        return 0 if issues_found == 0 else 1
 
     # 1. Check Python version
     print("\nChecking Python version...")
@@ -7158,34 +7203,12 @@ def cmd_doctor(args) -> int:
             else:
                 print(f"     -> Service is remote, start it on {service_config.machine}")
 
-    # 8b. Check STT shim. STT isn't a `services.*` entry — it's configured via
-    # `stt.url`, so the loop above can't see it. Without this check, a crashed
-    # STT shim is invisible and every custom-tier push-to-talk fails at request
-    # time. Probe it explicitly. (Default tier transcribes in the browser — no
-    # service to check.)
-    stt_cfg = getattr(ctx.config, "stt", None)
-    if getattr(stt_cfg, "backend", "default") == "custom":
-        from agentwire.stt.server_backend import STTServerBackend
-
-        stt_url = stt_cfg.url
-        if STTServerBackend.is_available(stt_url):
-            print(f"  [ok] Stt: responding on {stt_url}")
-        else:
-            print(f"  [!!] Stt: not responding on {stt_url}")
-            print("       Custom-tier push-to-talk will fail until it's back.")
-            print("       Fix: agentwire stt start")
-            print("       If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'")
-            issues_found += 1
-    elif getattr(stt_cfg, "backend", "default") == "cloud":
-        cloud_cfg = getattr(stt_cfg, "cloud", None) or {}
-        key_env = cloud_cfg.get("api_key_env", "OPENAI_API_KEY")
-        if os.environ.get(key_env):
-            print(f"  [ok] Stt: cloud tier ({key_env} is set)")
-        else:
-            print(f"  [!!] Stt: cloud tier but {key_env} is not set")
-            print("       The portal will refuse to start until the key is in its environment.")
-            print("       Fix: add the key to ~/.agentwire/.env (docs/wiki/security/secrets.md)")
-            issues_found += 1
+    # 8b. Voice loop (push-to-talk) — walk the live PTT path end to end and
+    # report each stage pass/fail with a fix line when red: mic/audio capture,
+    # the STT shim (incl. the default-tier Moonshine :8101 shim, invisible to
+    # the services loop), portal/tunnel reachability, and tmux+PTT wiring. This
+    # subsumes the old standalone STT probe — the STT stage covers all tiers.
+    issues_found += _render_voice_loop_section(config, ctx)
 
     # 8c. Secrets — for each configured feature that needs a key, report
     # whether its env var is present. Names only, never values. Keys live in
@@ -11405,6 +11428,10 @@ def main() -> int:
     doctor_parser.add_argument(
         "-y", "--yes", action="store_true",
         help="Auto-confirm all fixes without prompting"
+    )
+    doctor_parser.add_argument(
+        "--voice", action="store_true",
+        help="Run only the voice loop (push-to-talk) preflight — fast, no SSH waits"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
 

--- a/agentwire/doctor_voice.py
+++ b/agentwire/doctor_voice.py
@@ -1,0 +1,383 @@
+"""Voice-loop preflight checks for ``agentwire doctor``.
+
+Walks the live push-to-talk path end to end and reports each stage as
+pass/fail with a single actionable fix line when red — so a broken first
+session fails *loudly with a next step* instead of seeming dead.
+
+There are two PTT paths and these checks cover what the CLI can honestly
+inspect across both:
+
+* **Browser PTT** (any device → portal → STT shim → tmux session): the mic
+  is the browser's ``getUserMedia`` (granted in-browser, not host-checkable),
+  but the portal, STT shim, and tmux last-leg all run on this host.
+* **Host PTT** (macOS Hammerspoon ⌥Space → ``agentwire listen`` → host mic →
+  custom STT shim → tmux session): the host mic, the Hammerspoon binding, and
+  tmux are all locally inspectable.
+
+Logic lives here as pure functions returning :class:`StageResult` so each
+stage is unit-testable in isolation; ``cmd_doctor`` only renders them.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class StageResult:
+    """One voice-loop stage outcome.
+
+    ``status`` is ``"ok"`` (green, working), ``"fail"`` (red, a real
+    prerequisite for the configured path is down — counts as an issue), or
+    ``"info"`` (neutral — not applicable / not host-checkable, never an issue).
+    ``fixes`` are printed only when the stage is red.
+    """
+
+    name: str
+    status: str  # "ok" | "fail" | "info"
+    detail: str
+    fixes: list[str] = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "fail"
+
+
+def _http_health(url: str, timeout: float = 2.0) -> tuple[bool, dict | None]:
+    """GET ``{url}/health`` and parse JSON. Returns (reachable, payload).
+
+    Accepts self-signed certs — the portal's HTTPS uses one, and rejecting it
+    would falsely report a live portal as down.
+    """
+    import ssl
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        req = urllib.request.Request(f"{url.rstrip('/')}/health")
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            try:
+                return True, json.loads(resp.read().decode())
+            except (ValueError, UnicodeDecodeError):
+                return True, None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False, None
+
+
+# === Stage 1: mic / audio capture =========================================
+
+
+def _find_ffmpeg() -> str | None:
+    """Locate ffmpeg the same way the host PTT path does — delegating to the
+    canonical resolver in ``agentwire.listen`` (config ``executables.ffmpeg`` →
+    PATH → Homebrew fallbacks). Returns the path, or None if not found."""
+    from .listen import _find_executable
+
+    resolved = _find_executable("ffmpeg", ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"])
+    # _find_executable returns the bare name as a last resort; treat that
+    # (and any non-existent path) as "not found".
+    if resolved and (Path(resolved).exists() or shutil.which(resolved)):
+        return resolved
+    return None
+
+
+def _avfoundation_audio_devices(ffmpeg: str) -> list[str] | None:
+    """List macOS AVFoundation audio input device names.
+
+    ffmpeg prints the device table to stderr and exits non-zero (no output
+    file) — that's expected. Returns the names, or None if the table couldn't
+    be parsed at all. An empty list means the mic permission is denied or no
+    input device is present.
+    """
+    try:
+        proc = subprocess.run(
+            [ffmpeg, "-hide_banner", "-f", "avfoundation",
+             "-list_devices", "true", "-i", ""],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+    out = proc.stderr
+    if "audio devices:" not in out:
+        return None
+    # Lines look like: [AVFoundation indev @ 0x..] [0] PD200X Podcast Microphone
+    devices: list[str] = []
+    in_audio = False
+    for line in out.splitlines():
+        if "audio devices:" in line:
+            in_audio = True
+            continue
+        if in_audio:
+            if "video devices:" in line:
+                in_audio = False
+                continue
+            m = re.search(r"\]\s*\[(\d+)\]\s*(.+?)\s*$", line)
+            if m:
+                devices.append(m.group(2))
+    return devices
+
+
+def check_mic() -> StageResult:
+    """Stage 1 — host audio-capture prerequisites.
+
+    Checks ffmpeg (needed by the host PTT path and server-side wav handling)
+    and, on macOS, that at least one AVFoundation audio input device is
+    visible. Zero devices means the mic permission is revoked or no input
+    exists. The browser PTT mic is granted in-browser per device and is not
+    host-checkable — noted, never failed.
+    """
+    name = "Mic / audio capture"
+    ffmpeg = _find_ffmpeg()
+    if not ffmpeg:
+        return StageResult(
+            name, "fail", "ffmpeg not found (host capture + wav handling need it)",
+            fixes=[
+                "macOS: brew install ffmpeg",
+                "Ubuntu: sudo apt install ffmpeg",
+            ],
+        )
+
+    if platform.system() == "Darwin":
+        devices = _avfoundation_audio_devices(ffmpeg)
+        if devices is None:
+            return StageResult(
+                name, "info",
+                f"ffmpeg present ({ffmpeg}); could not enumerate AVFoundation "
+                "input devices — browser PTT mic is granted in-browser",
+            )
+        if not devices:
+            return StageResult(
+                name, "fail",
+                "no audio input device visible (mic permission denied or none attached)",
+                fixes=[
+                    "Grant the mic: System Settings → Privacy & Security → "
+                    "Microphone → enable your terminal app, then re-run",
+                    "Or pick a device explicitly: set audio.input_device in "
+                    "~/.agentwire/config.yaml",
+                ],
+            )
+        return StageResult(
+            name, "ok",
+            f"{len(devices)} input device(s): {', '.join(devices)} "
+            "(browser PTT mic is granted in-browser per device)",
+        )
+
+    # Non-macOS: ffmpeg is the checkable prerequisite; device permissions live
+    # in the browser (browser PTT) or PulseAudio (host PTT).
+    return StageResult(
+        name, "ok",
+        f"ffmpeg present ({ffmpeg}); browser PTT mic is granted in-browser per device",
+    )
+
+
+# === Stage 2: STT process ==================================================
+
+
+def check_stt(config: Any) -> StageResult:
+    """Stage 2 — the STT process behind transcription.
+
+    Default tier = the portal-managed Moonshine ``:8101`` shim (#383); custom
+    tier = a user/remote shim at ``stt.url``; cloud tier = an OpenAI-compatible
+    API keyed from the environment.
+    """
+    name = "STT process"
+    stt = getattr(config, "stt", None)
+    backend = getattr(stt, "backend", "default") if stt is not None else "default"
+
+    if backend == "cloud":
+        import os
+        cloud = getattr(stt, "cloud", None) or {}
+        key_env = cloud.get("api_key_env", "OPENAI_API_KEY")
+        if os.environ.get(key_env):
+            return StageResult(name, "ok", f"cloud tier ({key_env} is set)")
+        return StageResult(
+            name, "fail", f"cloud tier but {key_env} is not set",
+            fixes=[f"Add {key_env}=... to ~/.agentwire/.env (docs/wiki/security/secrets.md)"],
+        )
+
+    from .stt import DEFAULT_STT_URL, moonshine_importable
+
+    if backend == "default" and not moonshine_importable():
+        # py3.14+ or base install without the moonshine extra — push-to-talk
+        # transcribes in the browser via SpeechRecognition. Works, no shim.
+        return StageResult(
+            name, "info",
+            "browser SpeechRecognition fallback (Moonshine not installed for "
+            "this Python — no host shim to run)",
+        )
+
+    url = getattr(stt, "url", None) or DEFAULT_STT_URL
+    reachable, payload = _http_health(url)
+    if reachable and (payload or {}).get("status") == "ok":
+        # /health "model" may be a nested {backend, model, load_time} dict or a
+        # bare string depending on the shim — surface the human-readable name.
+        model = (payload or {}).get("model", "unknown")
+        if isinstance(model, dict):
+            model = model.get("model", "unknown")
+        return StageResult(name, "ok", f"{backend} tier shim healthy at {url} (model {model})")
+
+    if backend == "default":
+        fixes = [
+            "The portal auto-starts it; if it isn't running: agentwire stt start",
+            "If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'",
+        ]
+    else:
+        fixes = [
+            "agentwire stt start",
+            "If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'",
+        ]
+    return StageResult(
+        name, "fail",
+        f"{backend}-tier shim not responding at {url} — push-to-talk will fail "
+        "(or fall back to browser speech) until it's back",
+        fixes=fixes,
+    )
+
+
+# === Stage 3: tunnel / portal reachability =================================
+
+
+def check_portal(config: Any, ctx: Any = None) -> StageResult:
+    """Stage 3 — the portal the phone/browser talks to, and any reverse
+    tunnel a remote device routes through to reach it."""
+    name = "Tunnel / portal reachability"
+
+    portal_cfg = getattr(config, "portal", None)
+    portal_url = getattr(portal_cfg, "url", None) if portal_cfg else None
+    if not portal_url:
+        # Mirror _default_portal_url: https only when ssl cert+key exist.
+        import os
+        ssl = getattr(getattr(config, "server", None), "ssl", None)
+        cert = getattr(ssl, "cert", None) if ssl else None
+        key = getattr(ssl, "key", None) if ssl else None
+        https = bool(
+            cert and key
+            and Path(os.path.expanduser(cert)).exists()
+            and Path(os.path.expanduser(key)).exists()
+        )
+        portal_url = f"{'https' if https else 'http'}://localhost:8765"
+
+    reachable, _ = _http_health(portal_url, timeout=3.0)
+    if not reachable:
+        return StageResult(
+            name, "fail", f"portal not responding on {portal_url}",
+            fixes=[
+                "agentwire portal start        # or: agentwire portal start --dev",
+                "Then re-run: agentwire doctor --voice",
+            ],
+        )
+
+    # Portal is up. If remote machines route in over reverse tunnels, a down
+    # tunnel breaks the loop for that device — surface it on this stage.
+    down: list[str] = []
+    if ctx is not None:
+        try:
+            from .tunnels import TunnelManager
+            tm = TunnelManager()
+            for spec in ctx.get_required_tunnels():
+                status = tm.check_tunnel(spec)
+                if status.status != "up":
+                    down.append(
+                        f"localhost:{spec.local_port} → "
+                        f"{spec.remote_machine}:{spec.remote_port}"
+                    )
+        except Exception:
+            pass
+
+    if down:
+        return StageResult(
+            name, "fail",
+            f"portal up on {portal_url}, but {len(down)} required tunnel(s) down: "
+            + "; ".join(down),
+            fixes=["agentwire tunnels up"],
+        )
+    return StageResult(name, "ok", f"portal responding on {portal_url}")
+
+
+# === Stage 4: tmux wiring + PTT binding ====================================
+
+
+def _tmux_server_running() -> bool:
+    """True if a tmux server is up (it can list sessions, even if zero)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "list-sessions"], capture_output=True, text=True, timeout=5
+        )
+        # rc 0 with sessions, or rc 1 "no server running" — both mean reachable
+        # tmux binary; only a missing binary (OSError) is fatal here.
+        return proc.returncode == 0 or "no server" not in proc.stderr.lower()
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _hammerspoon_ptt_bound() -> bool | None:
+    """macOS host PTT binding: does ~/.hammerspoon/init.lua wire up
+    ``agentwire listen``? Returns True/False, or None if the file is absent."""
+    init = Path.home() / ".hammerspoon" / "init.lua"
+    if not init.exists():
+        return None
+    try:
+        text = init.read_text(errors="ignore")
+    except OSError:
+        return None
+    return "listen" in text and "agentwire" in text
+
+
+def check_tmux_ptt(config: Any) -> StageResult:
+    """Stage 4 — tmux delivers the transcript's keystrokes to the session
+    (the loop's last leg), plus the host ⌥Space PTT binding on macOS."""
+    name = "tmux wiring + PTT binding"
+
+    if not shutil.which("tmux"):
+        return StageResult(
+            name, "fail", "tmux not found — no way to deliver voice to a session",
+            fixes=["macOS: brew install tmux", "Ubuntu: sudo apt install tmux"],
+        )
+    if not _tmux_server_running():
+        return StageResult(
+            name, "info",
+            "tmux installed; no server running yet (start a session: agentwire new)",
+        )
+
+    # macOS host-PTT binding is informational — browser PTT works without it.
+    if platform.system() == "Darwin":
+        bound = _hammerspoon_ptt_bound()
+        if bound is True:
+            return StageResult(
+                name, "ok",
+                "tmux server reachable; Hammerspoon ⌥Space PTT binding present",
+            )
+        if bound is False:
+            return StageResult(
+                name, "info",
+                "tmux server reachable; ~/.hammerspoon/init.lua exists but has no "
+                "agentwire-listen binding — browser PTT still works",
+            )
+        return StageResult(
+            name, "ok",
+            "tmux server reachable (host ⌥Space PTT is optional: see "
+            "examples/hammerspoon-ptt/; browser PTT needs no binding)",
+        )
+
+    return StageResult(name, "ok", "tmux server reachable")
+
+
+def run_voice_loop_checks(config: Any, ctx: Any = None) -> list[StageResult]:
+    """Run all four voice-loop stages in PTT order."""
+    return [
+        check_mic(),
+        check_stt(config),
+        check_portal(config, ctx),
+        check_tmux_ptt(config),
+    ]

--- a/docs/wiki/internals/troubleshooting.md
+++ b/docs/wiki/internals/troubleshooting.md
@@ -18,9 +18,28 @@ agentwire doctor --dry-run
 # Auto-fix everything without prompts
 agentwire doctor --yes
 
+# Walk ONLY the push-to-talk path (fast, no SSH waits): mic, STT shim,
+# portal/tunnel, tmux+PTT — each pass/fail with a fix line when red
+agentwire doctor --voice
+
 # Check network/service health
 agentwire network status
 ```
+
+### Voice doesn't work / push-to-talk seems dead
+
+`agentwire doctor --voice` walks the live voice loop end to end and tells you
+which link is broken with a next step:
+
+| Stage | Red means | Fix |
+|-------|-----------|-----|
+| **Mic / audio capture** | ffmpeg missing, or (macOS) no input device — mic permission revoked | Grant the mic in System Settings → Privacy → Microphone, or `brew install ffmpeg` |
+| **STT process** | the Moonshine `:8101` shim (default tier) or your custom shim isn't responding | `agentwire stt start` (the portal also auto-starts the default shim) |
+| **Tunnel / portal reachability** | the portal isn't up, or a required reverse tunnel is down | `agentwire portal start` / `agentwire tunnels up` |
+| **tmux wiring + PTT binding** | tmux is missing (no way to deliver keystrokes); host ⌥Space binding absent (informational) | `brew install tmux`; for host PTT copy `examples/hammerspoon-ptt/init.lua` |
+
+Break one dependency and exactly that stage goes red while the others stay
+green — so the broken link is always obvious.
 
 ---
 

--- a/tests/unit/test_doctor_voice.py
+++ b/tests/unit/test_doctor_voice.py
@@ -1,0 +1,213 @@
+"""Voice-loop preflight stage checks (agentwire/doctor_voice.py).
+
+Each stage is exercised in isolation, proving the issue's verification
+contract: break one dependency and EXACTLY that stage goes red while the
+others stay green — without disrupting the live :8101 shim / :8765 portal.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import doctor_voice as dv
+
+
+def _cfg(**stt):
+    """A config-shaped object with an stt section."""
+    stt_fields = {"backend": "default", "url": None, "cloud": {}, **stt}
+    return SimpleNamespace(
+        stt=SimpleNamespace(**stt_fields),
+        portal=SimpleNamespace(url="http://localhost:9"),  # dead by default
+        server=SimpleNamespace(ssl=SimpleNamespace(cert=None, key=None)),
+    )
+
+
+# === Stage 1: mic / audio capture =========================================
+
+
+def test_mic_fails_when_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: None)
+    r = dv.check_mic()
+    assert r.failed
+    assert "ffmpeg" in r.detail
+    assert any("install ffmpeg" in f for f in r.fixes)
+
+
+def test_mic_fails_when_no_input_device(monkeypatch):
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(dv.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dv, "_avfoundation_audio_devices", lambda f: [])
+    r = dv.check_mic()
+    assert r.failed
+    assert "mic permission denied" in r.detail
+    assert any("Microphone" in f for f in r.fixes)
+
+
+def test_mic_ok_with_devices(monkeypatch):
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(dv.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dv, "_avfoundation_audio_devices", lambda f: ["Built-in Mic"])
+    r = dv.check_mic()
+    assert r.status == "ok"
+    assert "Built-in Mic" in r.detail
+
+
+def test_mic_ok_on_linux_with_ffmpeg(monkeypatch):
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(dv.platform, "system", lambda: "Linux")
+    r = dv.check_mic()
+    assert r.status == "ok"
+
+
+def test_mic_info_when_enumeration_unparseable(monkeypatch):
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(dv.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dv, "_avfoundation_audio_devices", lambda f: None)
+    r = dv.check_mic()
+    assert r.status == "info"
+
+
+# === Stage 2: STT process ==================================================
+
+
+def test_stt_default_fails_when_shim_down(monkeypatch):
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (False, None))
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    r = dv.check_stt(_cfg())
+    assert r.failed
+    assert "not responding" in r.detail
+    assert any("agentwire stt start" in f for f in r.fixes)
+
+
+def test_stt_default_ok_when_shim_healthy(monkeypatch):
+    monkeypatch.setattr(
+        dv, "_http_health",
+        lambda url, timeout=2.0: (True, {"status": "ok", "model": {"model": "moonshine/base"}}),
+    )
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    r = dv.check_stt(_cfg())
+    assert r.status == "ok"
+    assert "moonshine/base" in r.detail
+
+
+def test_stt_default_info_when_moonshine_absent(monkeypatch):
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: False)
+    r = dv.check_stt(_cfg())
+    assert r.status == "info"
+    assert "browser" in r.detail.lower()
+
+
+def test_stt_custom_fails_when_shim_down(monkeypatch):
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (False, None))
+    r = dv.check_stt(_cfg(backend="custom", url="http://localhost:9"))
+    assert r.failed
+    assert "custom" in r.detail
+
+
+def test_stt_cloud_fails_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    r = dv.check_stt(_cfg(backend="cloud"))
+    assert r.failed
+    assert "OPENAI_API_KEY" in r.detail
+
+
+def test_stt_cloud_ok_with_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    r = dv.check_stt(_cfg(backend="cloud"))
+    assert r.status == "ok"
+
+
+# === Stage 3: tunnel / portal reachability =================================
+
+
+def test_portal_fails_when_down(monkeypatch):
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (False, None))
+    r = dv.check_portal(_cfg())
+    assert r.failed
+    assert "not responding" in r.detail
+    assert any("agentwire portal start" in f for f in r.fixes)
+
+
+def test_portal_ok_when_up_no_tunnels(monkeypatch):
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (True, {"status": "ok"}))
+    r = dv.check_portal(_cfg(), ctx=None)
+    assert r.status == "ok"
+
+
+def test_portal_fails_when_tunnel_down(monkeypatch):
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (True, {"status": "ok"}))
+
+    spec = SimpleNamespace(local_port=8765, remote_machine="pc", remote_port=8765)
+    ctx = SimpleNamespace(get_required_tunnels=lambda: [spec])
+
+    class _TM:
+        def check_tunnel(self, s):
+            return SimpleNamespace(status="down")
+
+    import agentwire.tunnels as tunnels_mod
+    monkeypatch.setattr(tunnels_mod, "TunnelManager", _TM)
+    r = dv.check_portal(_cfg(), ctx=ctx)
+    assert r.failed
+    assert "tunnel" in r.detail.lower()
+    assert any("tunnels up" in f for f in r.fixes)
+
+
+# === Stage 4: tmux wiring + PTT binding ====================================
+
+
+def test_tmux_fails_when_binary_missing(monkeypatch):
+    monkeypatch.setattr(dv.shutil, "which", lambda n: None)
+    r = dv.check_tmux_ptt(_cfg())
+    assert r.failed
+    assert "tmux" in r.detail
+
+
+def test_tmux_info_when_no_server(monkeypatch):
+    monkeypatch.setattr(dv.shutil, "which", lambda n: "/usr/bin/tmux")
+    monkeypatch.setattr(dv, "_tmux_server_running", lambda: False)
+    r = dv.check_tmux_ptt(_cfg())
+    assert r.status == "info"
+
+
+def test_tmux_ok_with_hammerspoon_binding(monkeypatch):
+    monkeypatch.setattr(dv.shutil, "which", lambda n: "/usr/bin/tmux")
+    monkeypatch.setattr(dv, "_tmux_server_running", lambda: True)
+    monkeypatch.setattr(dv.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(dv, "_hammerspoon_ptt_bound", lambda: True)
+    r = dv.check_tmux_ptt(_cfg())
+    assert r.status == "ok"
+    assert "PTT binding present" in r.detail
+
+
+# === Integration: exactly one stage red ===================================
+
+
+def test_only_stt_red_when_shim_down(monkeypatch):
+    """The headline verification: kill STT, only stage 2 goes red."""
+    monkeypatch.setattr(dv, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(dv.platform, "system", lambda: "Linux")  # skip device enum
+
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    monkeypatch.setattr(dv.shutil, "which", lambda n: "/usr/bin/tmux")
+    monkeypatch.setattr(dv, "_tmux_server_running", lambda: True)
+
+    # STT shim down (dead), portal up.
+    def fake_health(url, timeout=2.0):
+        if "8101" in url or ":9" in url:
+            return (False, None)
+        return (True, {"status": "ok"})
+
+    monkeypatch.setattr(dv, "_http_health", fake_health)
+    cfg = _cfg()
+    cfg.portal = SimpleNamespace(url="http://localhost:8765")  # up per fake_health
+
+    results = dv.run_voice_loop_checks(cfg, ctx=None)
+    by_name = {r.name: r for r in results}
+    assert by_name["STT process"].failed
+    assert not by_name["Mic / audio capture"].failed
+    assert not by_name["Tunnel / portal reachability"].failed
+    assert not by_name["tmux wiring + PTT binding"].failed


### PR DESCRIPTION
Closes #389

## What

Extends `agentwire doctor` with a cohesive **voice loop (push-to-talk)** preflight that walks the live PTT path end to end and reports each stage **pass/fail + one actionable fix line when red** — so a broken first session fails loudly with a next step instead of seeming dead.

Before, `doctor` was a flat component sweep and the **default-tier Moonshine `:8101` shim from #383 was invisible** (STT was only probed for custom/cloud). A broken first session read as a wall of unrelated `[ok]`s.

## Stages

Mapped to what the CLI can honestly inspect across the browser-PTT and host-PTT paths:

1. **Mic / audio capture** — locate ffmpeg (reusing `listen._find_executable`); on macOS enumerate AVFoundation audio input devices. 0 devices = mic permission revoked → red. Browser mic is granted in-browser (not host-checkable) — stated, never failed.
2. **STT process** — `default` → probe the `:8101` shim `/health` (the #383 gap; self-signed cert OK); `custom` → `stt.url`; `cloud` → key env. Moonshine-not-importable (py3.14) → browser-fallback info, not a failure.
3. **Tunnel / portal reachability** — portal `/health` + any required reverse tunnel.
4. **tmux wiring + PTT binding** — tmux last-leg (delivers keystrokes) + macOS Hammerspoon ⌥Space binding (informational).

## Design

- Logic in a new **unit-testable** module `agentwire/doctor_voice.py` (pure functions → `StageResult`); `cmd_doctor` only renders.
- New **`agentwire doctor --voice`** runs ONLY this section (fast, no SSH waits) for tight verification loops.
- Old standalone STT probe (8b) removed — stage 2 subsumes it across all tiers.

## Verification

- **Live `agentwire doctor --voice`** on this machine: all 4 stages green.
- **18 unit tests** (`tests/unit/test_doctor_voice.py`) cover every red/green/info path, including the headline contract: *kill STT → exactly that stage red, others green*. The `:8101` shim / `:8765` portal are the live system's, so the break-each-dependency checks are exercised by construction (dead ports, fake configs, monkeypatched device enum) rather than disrupting live services — matched by a real-renderer demo of the red STT path with fix lines.
- Adjacent suites (`test_cli_commands`, `test_config`) green.

Docs: `docs/wiki/internals/troubleshooting.md` (new voice table) + `agentwire-cli` skill.

Built by [dotdev.dev](https://dotdev.dev)