### PR TITLE
feat(wiki): ground-truth audit for /wiki lint

### DIFF
--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wiki
+description: "Manage the agentwire LLM Wiki knowledge base. Use when ingesting raw sources, querying accumulated knowledge, or running health checks on the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
+---
+
+# AgentWire Wiki
+
+LLM-maintained knowledge base at `~/.agentwire/wiki/`. Read `~/.agentwire/wiki/CLAUDE.md` for the full schema and conventions.
+
+## Subcommands
+
+### `/wiki ingest`
+
+Process new files in `~/.agentwire/wiki/raw/` into wiki pages.
+
+**Steps:**
+1. List all files in `raw/` that haven't been processed (check for a `.ingested` marker or compare against existing wiki pages)
+2. For each file, read its contents
+3. Identify entities: technologies, patterns, APIs, research topics
+4. For each entity, check if a wiki page already exists in `wiki/<category>/<name>.md`
+   - **Exists**: update the page with new information, bump `last_updated`
+   - **New**: create the page following the schema in CLAUDE.md
+5. Add wikilinks `[[page-name]]` for cross-references between pages
+6. Report what was created/updated
+
+**Do NOT** modify or delete files in `raw/`. They are immutable source material.
+
+### `/wiki query <question>`
+
+Answer a question grounded in wiki content.
+
+**Steps:**
+1. Search `~/.agentwire/wiki/wiki/` for relevant pages (use Grep/Glob)
+2. Read the relevant pages
+3. Synthesize an answer citing specific wiki pages
+4. If the wiki doesn't have enough information, say so clearly — do not hallucinate
+5. If you discover new knowledge while answering, offer to update the relevant wiki pages
+
+### `/wiki lint`
+
+Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase.
+
+**Structural pass — steps:**
+1. Scan all pages in `wiki/` for:
+   - **Stale pages**: `last_updated` older than 90 days
+   - **Orphaned pages**: no other page links to them via `[[wikilink]]`
+   - **Broken wikilinks**: `[[page-name]]` that point to non-existent pages
+   - **Missing frontmatter**: pages without the required YAML frontmatter
+2. Report findings grouped by severity
+3. Do NOT auto-fix — let the user decide what to do
+
+#### Ground-truth audit
+
+The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source.
+
+**Run it** (from a checkout of the agentwire repo — stdlib only, no build/install needed):
+
+```bash
+python -m agentwire.wiki_audit                 # audit ~/.agentwire/wiki/wiki against this repo
+python -m agentwire.wiki_audit --json          # machine-readable findings
+python -m agentwire.wiki_audit --strict        # exit 1 when drift is found (CI)
+python -m agentwire.wiki_audit \
+  --wiki-dir <dir> --repo-dir <repo>           # point at a different wiki / codebase
+```
+
+Each finding is reported as `wiki_file:line  [kind] claim  → reason`, so you can jump straight to the stale line.
+
+**What it checks (precision over recall — it would rather miss a stale claim than cry wolf on a true one):**
+
+| Kind | Claim it verifies | How |
+|------|-------------------|-----|
+| `subcommand` | `` `agentwire <cmd>` `` in a code span | `<cmd>` must be a registered `add_parser("<cmd>")` |
+| `flag` | `--flag` inside an `agentwire …` command span | must be a declared `add_argument("--flag")` |
+| `path` | repo-relative paths under `agentwire/ docs/ scripts/ tests/ examples/ .claude/ .github/` | must exist on disk |
+| `symbol` | `` `module.symbol` `` where `agentwire/<module>.py` exists | `symbol` must be defined in that module |
+| `config-key` | dotted key near a config-file mention | every segment must be a field on a `@dataclass` in `config.py` |
+
+Scoping that keeps it quiet: flags/subcommands are only read inside code spans (bare prose mentioning `agentwire` or a flag isn't a claim); paths under the wiki's own `wiki/`/`raw/` trees and `~`/absolute paths are ignored; common method calls (`config.get`), filenames (`__main__.py`), and version strings (`agentwire v1.35.1`) are not mistaken for claims.
+
+**Act on it:** treat each finding as "a human renamed/removed/moved something and the wiki didn't follow." Confirm against the code, then update the wiki page (or, if the page is a deliberate historical record — e.g. a retrospective on removed code — leave it and note that in the page). As with the structural pass, the audit **never auto-fixes**.
+
+## Guidelines
+
+- Always read `~/.agentwire/wiki/CLAUDE.md` first for the current schema
+- One page per entity — check before creating duplicates
+- Practical over theoretical — "how we use it" and "what broke" over textbook definitions
+- Include code snippets, commands, config examples
+- Date your updates in frontmatter `last_updated`
+- Cite sources (URLs, commit hashes, issue numbers)

--- a/agentwire/wiki_audit.py
+++ b/agentwire/wiki_audit.py
@@ -1,0 +1,361 @@
+"""Ground-truth audit for the LLM-maintained wiki.
+
+The wiki at ``~/.agentwire/wiki/`` (Karpathy LLM-wiki pattern) accrues concrete
+claims about the agentwire codebase — ``agentwire`` subcommands and flags, repo
+file paths, config keys, qualified Python symbols — that nothing ever verifies.
+An auto-maintained knowledge layer that's never checked rots into
+confident-but-wrong, which is worse than no wiki at all.
+
+This module extracts the *checkable* assertions from wiki markdown and verifies
+each against the actual codebase, flagging the ones that no longer resolve. It
+is the engine behind the ``/wiki lint`` skill's ground-truth audit.
+
+Design notes:
+- **Precision over recall.** A noisy audit is worse than none, so every category
+  is scoped tightly (flags only inside ``agentwire`` command spans, paths only
+  under known repo roots, symbols/config-keys disambiguated by context). We would
+  rather miss a stale claim than cry wolf on a true one.
+- **Stdlib only.** Runs as ``python -m agentwire.wiki_audit`` straight from a
+  source checkout with no agentwire build/install.
+- **Never auto-fixes.** Matches the existing lint stance — report ``file:line``,
+  let the human decide.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+DEFAULT_WIKI_DIR = Path.home() / ".agentwire" / "wiki" / "wiki"
+
+# Repo-relative roots we treat as "this is a path claim about the codebase".
+# Deliberately excludes the wiki's own ``wiki/`` and ``raw/`` trees and anything
+# absolute or under ``~`` (runtime/home paths aren't codebase claims).
+REPO_PATH_ROOTS = ("agentwire", "docs", "scripts", "tests", "examples", ".claude", ".github")
+
+# ``agentwire <subcommand>`` — the token right after the binary name.
+_RE_SUBCOMMAND = re.compile(r"\bagentwire\s+([a-z][a-z0-9-]*)")
+# A long flag, e.g. ``--dev`` / ``--dry-run``.
+_RE_FLAG = re.compile(r"--[a-z][a-z0-9-]+")
+# An inline code span: `like this`.
+_RE_INLINE_CODE = re.compile(r"`([^`]+)`")
+# A dotted lowercase identifier chain, e.g. ``stt.backend`` or
+# ``prompt_router.prompt_is_empty``. Used for both config-key and symbol claims.
+_RE_DOTTED = re.compile(r"(?<![\w.])([a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)+)")
+# A repo-relative path under one of REPO_PATH_ROOTS. Negative lookbehind keeps us
+# from matching ``agentwire/server.py`` inside a URL like ``github.com/x/agentwire/...``.
+_RE_REPO_PATH = re.compile(
+    r"(?<![\w/.-])("
+    + "|".join(r.replace(".", r"\.") for r in REPO_PATH_ROOTS)
+    + r")(/[A-Za-z0-9_.\-]+)+"
+)
+# Shell separators that end one command and start another within a code span.
+_RE_SHELL_SEP = re.compile(r"&&|\|\||[|;]")
+# Config-key claims appear near a mention of a config file.
+_RE_CONFIG_CONTEXT = re.compile(r"config\.yaml|\.agentwire\.yml|scheduler\.yaml|\byaml\b|\bconfig\b", re.I)
+
+# File extensions — a dotted token ending in one of these is a filename, not a symbol.
+_EXTENSIONS = frozenset(
+    "py js ts mjs md yaml yml json toml cfg ini txt sh html css scss png jpg jpeg "
+    "gif svg sql lock env log".split()
+)
+# Module-position words that are really local variables / stdlib modules, not an
+# agentwire module — suppresses ``config.get`` / ``args.foo`` style false positives.
+_COMMON_VARS = frozenset(
+    "config self cls args kwargs ctx data result results response resp req request "
+    "err error ex os re sys json io idx item items obj val value payload msg event "
+    "node path paths line text src out ret cfg env db conn cur row rows doc app "
+    "client session task parser ns logger log".split()
+)
+# Symbol-position words that are common method/attribute names on arbitrary objects.
+_COMMON_METHODS = frozenset(
+    "get set pop append extend items keys values update format join split rsplit "
+    "strip lstrip rstrip replace startswith endswith read write close open group "
+    "groups match search sub findall finditer dumps loads dump load add remove "
+    "count index lower upper title encode decode copy sort reverse name value text "
+    "json status_code content exists is_dir is_file parent stem suffix parts resolve".split()
+)
+
+
+@dataclass
+class Finding:
+    """One wiki claim that does not resolve against the codebase."""
+
+    wiki_file: str  # path relative to the wiki dir
+    line: int  # 1-based
+    kind: str  # subcommand | flag | path | symbol | config-key
+    claim: str  # the offending token
+    reason: str  # why it failed to resolve
+    text: str  # the source line (stripped)
+
+
+@dataclass
+class CodebaseIndex:
+    """Everything we can cheaply pre-compute about the repo, built once."""
+
+    repo_dir: Path
+    subcommands: set[str] = field(default_factory=set)
+    flags: set[str] = field(default_factory=set)
+    config_fields: set[str] = field(default_factory=set)
+    modules: dict[str, Path] = field(default_factory=dict)  # top-level agentwire module name -> file
+
+    def path_exists(self, rel: str) -> bool:
+        return (self.repo_dir / rel).exists()
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _python_sources(repo_dir: Path):
+    pkg = repo_dir / "agentwire"
+    root = pkg if pkg.is_dir() else repo_dir
+    for p in sorted(root.rglob("*.py")):
+        if "node_modules" in p.parts:
+            continue
+        yield p
+
+
+def _collect_dataclass_fields(config_src: str) -> set[str]:
+    """Flat set of every field name declared in any ``@dataclass`` in config.py.
+
+    A flat membership set (rather than a strict nested path) is intentional: it
+    covers both section names (``stt``, held as a field on the parent dataclass)
+    and leaf keys (``backend``), and it keeps the check robust to refactors that
+    move a field between nesting levels. We trade some recall (won't catch a key
+    nested under the wrong section) for near-zero false positives.
+    """
+    fields: set[str] = set()
+    try:
+        tree = ast.parse(config_src)
+    except SyntaxError:
+        return fields
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        is_dataclass = any(
+            (isinstance(d, ast.Name) and d.id == "dataclass")
+            or (isinstance(d, ast.Attribute) and d.attr == "dataclass")
+            or (isinstance(d, ast.Call) and (
+                (isinstance(d.func, ast.Name) and d.func.id == "dataclass")
+                or (isinstance(d.func, ast.Attribute) and d.func.attr == "dataclass")
+            ))
+            for d in node.decorator_list
+        )
+        if not is_dataclass:
+            continue
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                fields.add(stmt.target.id)
+    return fields
+
+
+def build_codebase_index(repo_dir: Path) -> CodebaseIndex:
+    """Pre-compute the valid subcommands / flags / config fields / modules."""
+    idx = CodebaseIndex(repo_dir=repo_dir)
+    idx.flags.add("--help")  # argparse-provided, never declared explicitly
+
+    for src_path in _python_sources(repo_dir):
+        src = _read(src_path)
+        for m in re.finditer(r"""add_parser\(\s*["']([a-z][\w-]*)["']""", src):
+            idx.subcommands.add(m.group(1))
+        for m in re.finditer(r"""add_argument\(\s*["'](--[a-z][\w-]*)["']""", src):
+            idx.flags.add(m.group(1))
+
+    # Top-level agentwire modules (for symbol routing): agentwire/<name>.py
+    pkg = repo_dir / "agentwire"
+    if pkg.is_dir():
+        for p in pkg.glob("*.py"):
+            if p.stem != "__init__":
+                idx.modules[p.stem] = p
+
+    config_py = pkg / "config.py"
+    if config_py.exists():
+        idx.config_fields = _collect_dataclass_fields(_read(config_py))
+
+    return idx
+
+
+def _code_spans(line: str, in_fence: bool):
+    """Yield the code portions of a line.
+
+    Inside a fenced block the whole line is code; otherwise only inline
+    ``backtick`` spans count. Flag/symbol/config claims are only trusted inside
+    code, which is where they actually appear — this is the main false-positive
+    guard against prose that merely mentions a flag.
+    """
+    if in_fence:
+        yield line
+    else:
+        for m in _RE_INLINE_CODE.finditer(line):
+            yield m.group(1)
+
+
+def _strip_path(token: str) -> str:
+    token = token.split("#", 1)[0]  # drop ``...md#anchor``
+    return token.rstrip("/.,:;)\"'")
+
+
+def _audit_line(
+    idx: CodebaseIndex,
+    rel_file: str,
+    lineno: int,
+    line: str,
+    in_fence: bool,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    text = line.strip()
+    spans = list(_code_spans(line, in_fence))
+
+    # --- subcommands + flags: only from code spans, scoped to the `agentwire ...`
+    # command. Bare prose is excluded on purpose — outside code, "agentwire" is
+    # just the product name followed by an ordinary English word, not a command.
+    for span in spans:
+        i = span.find("agentwire")
+        if i == -1:
+            continue
+        cmd = _RE_SHELL_SEP.split(span[i:])[0]  # stop at && | ; etc.
+        sm = _RE_SUBCOMMAND.match(cmd)
+        # ``.`` right after the token means it's a version/sentence, not a command
+        # (``agentwire v1.35.1``), so don't treat it as a subcommand claim.
+        if sm and cmd[sm.end():sm.end() + 1] != "." and sm.group(1) not in idx.subcommands:
+            findings.append(Finding(rel_file, lineno, "subcommand", f"agentwire {sm.group(1)}",
+                                    "no such subcommand (no add_parser)", text))
+        for fm in _RE_FLAG.finditer(cmd):
+            flag = fm.group(0)
+            if flag not in idx.flags:
+                findings.append(Finding(rel_file, lineno, "flag", flag,
+                                        "no such agentwire flag (no add_argument)", text))
+
+    # --- repo paths: scan the full line, anchored to known repo roots
+    for pm in _RE_REPO_PATH.finditer(line):
+        raw = _strip_path(pm.group(0))
+        if not raw or "<" in raw or ">" in raw or "*" in raw:
+            continue
+        if not idx.path_exists(raw):
+            findings.append(Finding(rel_file, lineno, "path", raw,
+                                    "path does not exist in repo", text))
+
+    # --- dotted tokens (code spans only): route to config-key OR symbol check
+    config_context = bool(_RE_CONFIG_CONTEXT.search(line))
+    seen_dotted: set[str] = set()
+    for span in spans:
+        for dm in _RE_DOTTED.finditer(span):
+            dotted = dm.group(1)
+            if dotted in seen_dotted:
+                continue
+            seen_dotted.add(dotted)
+            head, _, _ = dotted.partition(".")
+            segments = dotted.split(".")
+
+            if segments[-1] in _EXTENSIONS:
+                continue  # ``__main__.py`` / ``config.yaml`` — a filename, not a claim
+            if config_context and head in idx.config_fields:
+                bad = [s for s in segments if s not in idx.config_fields]
+                if bad:
+                    findings.append(Finding(rel_file, lineno, "config-key", dotted,
+                                            f"unknown config field(s): {', '.join(bad)}", text))
+            elif (
+                head in idx.modules
+                and len(segments) == 2
+                and head not in _COMMON_VARS
+                and segments[1] not in _COMMON_METHODS
+            ):
+                symbol = segments[1]
+                if not _symbol_defined(idx.modules[head], symbol):
+                    findings.append(Finding(rel_file, lineno, "symbol", dotted,
+                                            f"{symbol} not defined in agentwire/{head}.py", text))
+
+    return findings
+
+
+def _symbol_defined(module_path: Path, symbol: str) -> bool:
+    src = _read(module_path)
+    pat = re.compile(
+        rf"\bdef\s+{re.escape(symbol)}\b|\bclass\s+{re.escape(symbol)}\b|^\s*{re.escape(symbol)}\s*[:=]",
+        re.M,
+    )
+    return bool(pat.search(src))
+
+
+def audit_text(idx: CodebaseIndex, rel_file: str, content: str) -> list[Finding]:
+    """Audit a single wiki document's text. Exposed for testing."""
+    findings: list[Finding] = []
+    in_fence = False
+    for i, line in enumerate(content.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        findings.extend(_audit_line(idx, rel_file, i, line, in_fence))
+    return findings
+
+
+def audit(wiki_dir: Path, repo_dir: Path) -> list[Finding]:
+    """Audit every markdown page under ``wiki_dir`` against ``repo_dir``."""
+    idx = build_codebase_index(repo_dir)
+    findings: list[Finding] = []
+    for md in sorted(wiki_dir.rglob("*.md")):
+        rel = str(md.relative_to(wiki_dir))
+        findings.extend(audit_text(idx, rel, _read(md)))
+    return findings
+
+
+def _default_repo_dir() -> Path:
+    # agentwire/wiki_audit.py -> parents[1] is the repo root.
+    return Path(__file__).resolve().parents[1]
+
+
+def _format_text(findings: list[Finding]) -> str:
+    if not findings:
+        return "✓ Wiki ground-truth audit: no drift found."
+    out: list[str] = [f"Wiki ground-truth audit: {len(findings)} drift finding(s)\n"]
+    by_file: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_file.setdefault(f.wiki_file, []).append(f)
+    for wiki_file in sorted(by_file):
+        out.append(f"\n{wiki_file}")
+        for f in sorted(by_file[wiki_file], key=lambda x: x.line):
+            out.append(f"  {wiki_file}:{f.line}  [{f.kind}] {f.claim}")
+            out.append(f"      → {f.reason}")
+    out.append("\nThese are claims that no longer resolve. Review and update the wiki — nothing was auto-fixed.")
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m agentwire.wiki_audit",
+        description="Verify concrete claims in the LLM wiki against the actual codebase.",
+    )
+    parser.add_argument("--wiki-dir", type=Path, default=DEFAULT_WIKI_DIR,
+                        help=f"Wiki pages directory (default: {DEFAULT_WIKI_DIR})")
+    parser.add_argument("--repo-dir", type=Path, default=_default_repo_dir(),
+                        help="Codebase to verify against (default: this repo)")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit 1 when drift is found (for CI); default exits 0")
+    args = parser.parse_args(argv)
+
+    if not args.wiki_dir.is_dir():
+        print(f"wiki dir not found: {args.wiki_dir}", file=sys.stderr)
+        return 2
+
+    findings = audit(args.wiki_dir, args.repo_dir)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], indent=2))
+    else:
+        print(_format_text(findings))
+
+    return 1 if (findings and args.strict) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_wiki_audit.py
+++ b/tests/unit/test_wiki_audit.py
@@ -1,0 +1,187 @@
+"""Unit tests for the wiki ground-truth audit (agentwire/wiki_audit.py).
+
+Each test builds a tiny fake repo + wiki text in tmp_path so the extractors and
+verifiers are exercised in isolation, then asserts on the precise findings. The
+final test reproduces the issue's end-to-end check: rename a flag in a wiki page
+and confirm the audit flags exactly that line and nothing else.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from agentwire.wiki_audit import audit, audit_text, build_codebase_index, main
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal agentwire-shaped repo: known subcommands, flags, config, modules."""
+    pkg = tmp_path / "agentwire"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "__main__.py").write_text(
+        'sub.add_parser("portal")\n'
+        'sub.add_parser("new")\n'
+        'p.add_argument("--dev")\n'
+        'p.add_argument("--json")\n'
+    )
+    (pkg / "config.py").write_text(
+        "from dataclasses import dataclass\n\n"
+        "@dataclass\n"
+        "class STTConfig:\n"
+        '    backend: str = "default"\n\n'
+        "@dataclass\n"
+        "class Config:\n"
+        "    stt: STTConfig = None\n"
+    )
+    (pkg / "prompt_router.py").write_text("def prompt_is_empty():\n    return True\n")
+    (pkg / "server.py").write_text("# real file for path-existence checks\n")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "real.md").write_text("real\n")
+    return tmp_path
+
+
+@pytest.fixture
+def idx(repo: Path):
+    return build_codebase_index(repo)
+
+
+def _kinds(findings):
+    return [(f.kind, f.claim) for f in findings]
+
+
+# --- index construction -----------------------------------------------------
+
+def test_index_collects_vocabulary(idx):
+    assert {"portal", "new"} <= idx.subcommands
+    assert {"--dev", "--json", "--help"} <= idx.flags
+    assert {"stt", "backend"} <= idx.config_fields
+    assert "prompt_router" in idx.modules and "server" in idx.modules
+
+
+# --- flags ------------------------------------------------------------------
+
+def test_valid_flag_not_flagged(idx):
+    assert audit_text(idx, "p.md", "Run `agentwire portal start --dev`.") == []
+
+
+def test_unknown_flag_flagged(idx):
+    findings = audit_text(idx, "p.md", "Run `agentwire portal start --devmode`.")
+    assert _kinds(findings) == [("flag", "--devmode")]
+
+
+def test_flag_only_scoped_to_agentwire_command(idx):
+    # A non-agentwire tool's flag in the same doc must not be attributed to agentwire.
+    assert audit_text(idx, "p.md", "Pi uses `pi --provider zai` and `--disallowedTools`.") == []
+
+
+def test_flag_ignored_in_bare_prose(idx):
+    # Only code spans count; prose mentioning --dev is not a claim.
+    assert audit_text(idx, "p.md", "the --devmode flag is gone") == []
+
+
+# --- subcommands ------------------------------------------------------------
+
+def test_valid_subcommand_not_flagged(idx):
+    assert audit_text(idx, "p.md", "`agentwire new -s proj/branch`") == []
+
+
+def test_removed_subcommand_flagged(idx):
+    findings = audit_text(idx, "p.md", "Use `agentwire brave search`.")
+    assert ("subcommand", "agentwire brave") in _kinds(findings)
+
+
+def test_subcommand_ignored_in_prose(idx):
+    # "agentwire" as the product name + an English word is not a command.
+    assert audit_text(idx, "p.md", "The agentwire project would benefit from this.") == []
+
+
+def test_version_string_not_a_subcommand(idx):
+    assert audit_text(idx, "p.md", 'Render `"agentwire v1.35.1"` verbatim.') == []
+
+
+# --- paths ------------------------------------------------------------------
+
+def test_existing_path_not_flagged(idx):
+    assert audit_text(idx, "p.md", "See `agentwire/server.py` and `docs/real.md`.") == []
+
+
+def test_missing_path_flagged(idx):
+    findings = audit_text(idx, "p.md", "See `agentwire/sdk/client.py`.")
+    assert _kinds(findings) == [("path", "agentwire/sdk/client.py")]
+
+
+def test_placeholder_path_skipped(idx):
+    assert audit_text(idx, "p.md", "Edit `agentwire/<module>.py` or `static/js/*`.") == []
+
+
+def test_non_repo_paths_ignored(idx):
+    # Home/runtime paths and the wiki's own tree are not codebase claims.
+    assert audit_text(idx, "p.md", "Lives at `~/.agentwire/wiki/foo.md` and `/usr/bin/pi`.") == []
+
+
+# --- symbols ----------------------------------------------------------------
+
+def test_defined_symbol_not_flagged(idx):
+    assert audit_text(idx, "p.md", "`prompt_router.prompt_is_empty` guards delivery.") == []
+
+
+def test_undefined_symbol_flagged(idx):
+    findings = audit_text(idx, "p.md", "`prompt_router.is_blank` is checked.")
+    assert _kinds(findings) == [("symbol", "prompt_router.is_blank")]
+
+
+def test_common_method_call_not_flagged(idx):
+    # config.get(...) is a method on a variable, not agentwire.config.get.
+    assert audit_text(idx, "p.md", "We call `config.get('stt')` here.") == []
+
+
+def test_filename_not_treated_as_symbol(idx):
+    assert audit_text(idx, "p.md", "Edit `server.py` and `__main__.py`.") == []
+
+
+# --- config keys ------------------------------------------------------------
+
+def test_valid_config_key_not_flagged(idx):
+    assert audit_text(idx, "p.md", "Set `stt.backend` in config.yaml.") == []
+
+
+def test_unknown_config_key_flagged(idx):
+    findings = audit_text(idx, "p.md", "Set `stt.engdrive` in config.yaml.")
+    assert _kinds(findings) == [("config-key", "stt.engdrive")]
+
+
+def test_config_key_needs_config_context(idx):
+    # Without a config-file mention, a dotted token isn't treated as a config key.
+    assert audit_text(idx, "p.md", "The value `stt.engdrive` appears.") == []
+
+
+# --- end-to-end (issue verification) ----------------------------------------
+
+def test_rename_a_flag_flags_exactly_that_line(repo: Path, tmp_path: Path):
+    wiki = tmp_path / "wiki"
+    (wiki / "patterns").mkdir(parents=True)
+    # One stale line (renamed flag) among otherwise-correct claims.
+    (wiki / "patterns" / "dev.md").write_text(
+        "# Dev\n\n"
+        "Normal restart: `agentwire portal restart --dev`.\n"
+        "After a change: `agentwire portal start --devmode`.\n"  # stale: --dev was renamed
+        "Paths like `agentwire/server.py` still resolve.\n"
+    )
+    findings = audit(wiki, repo)
+    assert len(findings) == 1
+    f = findings[0]
+    assert (f.kind, f.claim, f.line) == ("flag", "--devmode", 4)
+    assert f.wiki_file == "patterns/dev.md"
+
+
+def test_main_strict_exit_code(repo: Path, tmp_path: Path, capsys):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "ok.md").write_text("All good: `agentwire portal start --dev`.\n")
+    (wiki / "bad.md").write_text("Stale: `agentwire brave`.\n")
+
+    assert main(["--wiki-dir", str(wiki), "--repo-dir", str(repo)]) == 0  # informational
+    assert main(["--wiki-dir", str(wiki), "--repo-dir", str(repo), "--strict"]) == 1
+    out = capsys.readouterr().out
+    assert "agentwire brave" in out


### PR DESCRIPTION
## What

Extends `/wiki lint` with a **ground-truth audit**: it extracts concrete, checkable claims from the LLM-maintained wiki (`~/.agentwire/wiki/wiki/**.md`) and verifies each against the actual codebase, flagging drift at `file:line`.

The wiki accrues claims — `agentwire` subcommands/flags, repo paths, config keys, qualified Python symbols — that nothing ever verifies. Run against the live wiki today it surfaces **52 genuine stale claims** (e.g. `agentwire brave` and `agentwire repl` commands, removed `agentwire/sdk/*` and `agentwire/repl/*` paths) with **zero false positives**.

## How

New stdlib-only module `agentwire/wiki_audit.py` — runs as `python -m agentwire.wiki_audit` straight from a checkout, no build/install:

```bash
python -m agentwire.wiki_audit            # audit the wiki against this repo
python -m agentwire.wiki_audit --json     # machine-readable
python -m agentwire.wiki_audit --strict   # exit 1 on drift (CI)
```

| Kind | Verified against |
|------|------------------|
| `subcommand` | `add_parser("…")` names |
| `flag` | `add_argument("--…")` literals |
| `path` | existence under `agentwire/ docs/ scripts/ tests/ examples/ .claude/ .github/` |
| `symbol` | `module.symbol` defined in `agentwire/<module>.py` |
| `config-key` | fields on a `@dataclass` in `config.py` (AST-introspected) |

**Precision over recall** — a noisy audit is worse than none. Flags/subcommands are read only inside code spans (bare prose isn't a claim); the wiki's own `wiki/`/`raw/` trees and `~`/absolute paths are ignored; common method calls (`config.get`), filenames (`__main__.py`), and version strings (`agentwire v1.35.1`) aren't mistaken for claims. Never auto-fixes — matches the existing lint stance.

The `/wiki lint` skill gains a "Ground-truth audit" section. The skill itself was only ever a global file; it's now brought in-repo under `.claude/skills/wiki/` so it's version-controlled alongside the `agentwire-*` skills.

## Verification

- `tests/unit/test_wiki_audit.py` — 22 tests across every category, scoping guards, and false-positive cases. Full unit suite stays green (1393 passed).
- Issue's end-to-end check, against real repo vocabulary: a wiki page using `--dev` is clean; rename it to `--develop` on one line → the audit flags **exactly that line** and nothing else.

Closes #400

Built by [dotdev.dev](https://dotdev.dev)