### PR TITLE
fix(tts): process-isolate default-tier Kokoro via portal-managed shim (#398)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -543,6 +543,12 @@ def get_stt_session_name() -> str:
     return config.get("services", {}).get("stt", {}).get("session_name", "agentwire-stt")
 
 
+def get_kokoro_session_name() -> str:
+    """Get default-tier Kokoro TTS shim tmux session name from config."""
+    config = load_config()
+    return config.get("services", {}).get("kokoro", {}).get("session_name", "agentwire-kokoro")
+
+
 # === Wave 2: Remote Infrastructure Helpers ===
 
 
@@ -1926,6 +1932,148 @@ def cmd_stt_status(args) -> int:
         if probe_error:
             print(f"  Probe: {probe_error}")
         print("  Start: agentwire stt start")
+    return 1
+
+
+# === Kokoro (default-tier TTS shim) Commands ===
+
+def cmd_kokoro_start(args) -> int:
+    """Start the default-tier Kokoro TTS shim in tmux (idempotent).
+
+    Mirrors ``agentwire stt start``: the portal's ``ensure_managed_tts`` calls
+    this on startup, and the early-return on an existing session means a
+    user-started shim is reused with no port clash."""
+    session_name = get_kokoro_session_name()
+
+    if tmux_session_exists(session_name):
+        print(f"Kokoro TTS shim already running in tmux session '{session_name}'")
+        print(f"  Attach: tmux attach -t {session_name}")
+        return 0
+
+    port = args.port or 8102
+    host = args.host or "0.0.0.0"
+
+    # Find agentwire source directory (for running from source venv)
+    source_dir = get_source_dir()
+    if not (source_dir / ".venv" / "bin" / "python").exists():
+        print("Error: Cannot find agentwire source directory with .venv", file=sys.stderr)
+        print(f"Configure dev.source_dir in ~/.agentwire/config.yaml (current: {source_dir})", file=sys.stderr)
+        return 1
+    agentwire_dir = source_dir
+
+    python_path = agentwire_dir / ".venv" / "bin" / "python"
+    cmd = f"cd {agentwire_dir} && KOKORO_PORT={port} KOKORO_HOST={host} {python_path} -m agentwire.tts.kokoro_server"
+
+    subprocess.run([
+        "tmux", "new-session", "-d", "-s", session_name, "-c", str(agentwire_dir)
+    ], check=True)
+
+    subprocess.run([
+        "tmux", "send-keys", "-t", session_name, cmd, "Enter"
+    ], check=True)
+
+    print(f"Kokoro TTS shim starting in tmux session '{session_name}'")
+    print(f"  Port: {port}")
+    print(f"  Attach: tmux attach -t {session_name}")
+    return 0
+
+
+def cmd_kokoro_serve(args) -> int:
+    """Run the Kokoro TTS shim directly (foreground)."""
+    import uvicorn
+
+    port = args.port or 8102
+    host = args.host or "0.0.0.0"
+
+    os.environ["KOKORO_PORT"] = str(port)
+    os.environ["KOKORO_HOST"] = host
+
+    print(f"Starting Kokoro TTS shim on {host}:{port}...")
+    uvicorn.run(
+        "agentwire.tts.kokoro_server:app",
+        host=host,
+        port=port,
+        log_level="info",
+    )
+    return 0
+
+
+def cmd_kokoro_stop(args) -> int:
+    """Stop the Kokoro TTS shim."""
+    session_name = get_kokoro_session_name()
+
+    if not tmux_session_exists(session_name):
+        print("Kokoro TTS shim is not running.")
+        return 1
+
+    subprocess.run(["tmux", "kill-session", "-t", session_name])
+    print("Kokoro TTS shim stopped.")
+    return 0
+
+
+def cmd_kokoro_status(args) -> int:
+    """Check Kokoro TTS shim status."""
+    json_mode = getattr(args, 'json', False)
+    session_name = get_kokoro_session_name()
+    config = load_config()
+    kokoro_url = config.get("tts", {}).get("url") or "http://localhost:8102"
+
+    probe_error = None
+    try:
+        req = urllib.request.Request(f"{kokoro_url}/health")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            data = json.loads(resp.read().decode())
+            if json_mode:
+                _output_json({
+                    "success": True,
+                    "running": True,
+                    "url": kokoro_url,
+                    "healthy": data.get("status") == "ok",
+                    "status": data.get("status", "unknown"),
+                    "percent": data.get("percent", 0),
+                    "session": session_name if tmux_session_exists(session_name) else None,
+                })
+            else:
+                print("Kokoro TTS shim is running")
+                print(f"  State: {data.get('status', 'unknown')} ({data.get('percent', 0)}%)")
+                print(f"  URL: {kokoro_url}")
+                if tmux_session_exists(session_name):
+                    print(f"  Attach: tmux attach -t {session_name}")
+            return 0
+    except Exception as e:
+        probe_error = _describe_probe_error(e)
+
+    if tmux_session_exists(session_name):
+        if json_mode:
+            _output_json({
+                "success": True,
+                "running": True,
+                "url": kokoro_url,
+                "healthy": False,
+                "error": probe_error,
+                "session": session_name,
+                "starting": True,
+            })
+        else:
+            print(f"Kokoro TTS shim is starting in tmux session '{session_name}'")
+            if probe_error:
+                print(f"  Probe: {probe_error}")
+            print(f"  Attach: tmux attach -t {session_name}")
+        return 0
+
+    if json_mode:
+        _output_json({
+            "success": True,
+            "running": False,
+            "url": kokoro_url,
+            "healthy": False,
+            "error": probe_error,
+        })
+    else:
+        print("Kokoro TTS shim is not running.")
+        if probe_error:
+            print(f"  Probe: {probe_error}")
+        print("  Start: agentwire kokoro start")
     return 1
 
 
@@ -10766,6 +10914,33 @@ def main() -> int:
     stt_status = stt_subparsers.add_parser("status", help="Check STT status")
     stt_status.add_argument("--json", action="store_true", help="Output JSON")
     stt_status.set_defaults(func=cmd_stt_status)
+
+    # === kokoro command group (default-tier TTS shim) ===
+    kokoro_parser = subparsers.add_parser(
+        "kokoro", help="Manage the default-tier Kokoro TTS shim (process-isolated)"
+    )
+    kokoro_subparsers = kokoro_parser.add_subparsers(dest="kokoro_command")
+
+    # kokoro start
+    kokoro_start = kokoro_subparsers.add_parser("start", help="Start Kokoro shim in tmux")
+    kokoro_start.add_argument("--port", type=int, help="Server port (default: 8102)")
+    kokoro_start.add_argument("--host", type=str, help="Server host (default: 0.0.0.0)")
+    kokoro_start.set_defaults(func=cmd_kokoro_start)
+
+    # kokoro serve
+    kokoro_serve = kokoro_subparsers.add_parser("serve", help="Run Kokoro shim in foreground")
+    kokoro_serve.add_argument("--port", type=int, help="Server port (default: 8102)")
+    kokoro_serve.add_argument("--host", type=str, help="Server host (default: 0.0.0.0)")
+    kokoro_serve.set_defaults(func=cmd_kokoro_serve)
+
+    # kokoro stop
+    kokoro_stop = kokoro_subparsers.add_parser("stop", help="Stop Kokoro shim")
+    kokoro_stop.set_defaults(func=cmd_kokoro_stop)
+
+    # kokoro status
+    kokoro_status = kokoro_subparsers.add_parser("status", help="Check Kokoro shim status")
+    kokoro_status.add_argument("--json", action="store_true", help="Output JSON")
+    kokoro_status.set_defaults(func=cmd_kokoro_status)
 
     # === quo command ===
     from agentwire.channels.quo import cmd_quo

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -164,13 +164,20 @@ def _validate_voice_backend(
 class TTSConfig:
     """Text-to-speech configuration.
 
-    Two tiers: ``default`` speaks via the browser (speechSynthesis) with an
-    OS-voice fallback when no browser is connected; ``custom`` POSTs to any
-    HTTP shim implementing the contract (docs/wiki/voice/shim-contract.md).
+    Two tiers: ``default`` speaks via Kokoro running in the portal-managed shim
+    **subprocess** (tmux ``agentwire-kokoro``, default ``:8102``) — the portal
+    ensures it's running on startup and talks to it over HTTP, with process
+    isolation keeping the ~200 MB download + ONNX warm-up off the event loop
+    (#398, mirroring the STT shim). Browser speechSynthesis (and an OS-voice
+    fallback when no browser is connected) covers speech while the model loads
+    or when Kokoro can't load (py3.14+). For this tier ``url`` is optional and
+    resolves to ``http://localhost:8102``; if an operator overrides the shim
+    port (``KOKORO_PORT``) or ``url``, the two must agree. ``custom`` POSTs to
+    any HTTP shim implementing the contract (docs/wiki/voice/shim-contract.md).
     """
 
     backend: str = "default"  # default | custom
-    url: str | None = None  # shim URL (required for custom backend)
+    url: str | None = None  # shim URL (required for custom; optional override for default :8102)
     default_voice: str = "default"
     voices_dir: Path = field(default_factory=lambda: Path.home() / ".agentwire" / "voices")
     # Session-default knobs; sent to custom shims inside `options`

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -183,14 +183,11 @@ class AgentWireServer:
         self.stt = None
         self.agent = None
         self._http_session: aiohttp.ClientSession | None = None  # For TTS HTTP calls
-        # Default-tier in-process Kokoro voice. Constructed unconditionally
-        # (cheap, no I/O); run_server starts the warm-up only when
-        # tts.backend == "default".
-        from .tts.local import LocalKokoro
-        self.kokoro = LocalKokoro()
-        # Default-tier Moonshine STT runs in the standalone shim subprocess
-        # (process isolation — see ensure_managed_stt), not in-process. No
-        # object to construct here; run_server ensures the shim post-bind.
+        # Default-tier Kokoro TTS and Moonshine STT both run in standalone shim
+        # subprocesses (process isolation — see ensure_managed_tts /
+        # ensure_managed_stt), not in-process: the GIL-holding warm-up would
+        # wedge this event loop (#382/#398). No object to construct here;
+        # run_server ensures the shims post-bind and the portal talks HTTP.
         # Origin + token enforcement. The middleware is a pure function of
         # config — run_server() resolves the token file into
         # config.server.auth_token before constructing the server.
@@ -365,10 +362,10 @@ class AgentWireServer:
         """Clean up backend resources."""
         if self._http_session:
             await self._http_session.close()
-        await self.kokoro.close()
-        # The default-tier STT shim runs in its own tmux session
-        # (agentwire-stt) — leave it running on portal shutdown; the user may
-        # own it. `agentwire stt stop` is the off switch.
+        # The default-tier TTS (agentwire-kokoro) and STT (agentwire-stt) shims
+        # run in their own tmux sessions — leave them running on portal
+        # shutdown; the user may own them. `agentwire kokoro stop` /
+        # `agentwire stt stop` are the off switches.
 
     async def ensure_managed_stt(self) -> None:
         """Ensure the default-tier Moonshine shim subprocess is running.
@@ -397,28 +394,33 @@ class AgentWireServer:
             # shim's /health and surfaces server_transcribe promptly.
             self._voice_status_cache = None
 
-    async def _on_kokoro_state_change(self, kokoro) -> None:
-        """Kokoro warm-up progress → invalidate voice-status cache + toast.
+    async def ensure_managed_tts(self) -> None:
+        """Ensure the default-tier Kokoro TTS shim subprocess is running.
 
-        The toast is replaced in place (keyed on session "kokoro-voice") so
-        the download reads as one updating notification, not a stream."""
-        self._voice_status_cache = None
-        if kokoro.state == "downloading":
-            await self._post_toast(
-                f"Downloading Kokoro voice model… {kokoro.percent}% (one-time, ~200 MB)",
-                session="kokoro-voice", priority="normal", id_prefix="kokoro")
-        elif kokoro.state == "loading":
-            await self._post_toast(
-                "Loading Kokoro voice model…",
-                session="kokoro-voice", priority="normal", id_prefix="kokoro")
-        elif kokoro.state == "ready":
-            await self._post_toast(
-                "Voice ready — Kokoro is now the portal voice",
-                session="kokoro-voice", priority="normal", id_prefix="kokoro")
-        elif kokoro.state == "failed":
-            await self._post_toast(
-                f"Kokoro voice setup failed ({kokoro.error}) — using browser voice fallback",
-                session="kokoro-voice", priority="high", id_prefix="kokoro")
+        Delegates to the CLI (single source of truth): ``agentwire kokoro start``
+        is idempotent — ``cmd_kokoro_start`` early-returns if the
+        ``agentwire-kokoro`` tmux session already exists, so a user-started shim
+        is reused with no port clash. The ~200 MB download + ONNX warm-up
+        happens in that child process, never on the portal's event loop. Mirrors
+        ``ensure_managed_stt``."""
+        await asyncio.sleep(5)  # let the portal finish binding first
+        try:
+            success, result = await self.run_agentwire_cmd(["kokoro", "start"], json_output=False)
+            if success:
+                await self._post_toast(
+                    "Starting host voice (Kokoro) — browser speech until ready",
+                    session="kokoro-voice", priority="normal", id_prefix="kokoro")
+                logger.info("[TTS] Ensured managed Kokoro shim")
+            else:
+                logger.warning("[TTS] Managed shim start failed: %s", result.get("error"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("[TTS] Managed shim start error: %s", e)
+        finally:
+            # Flip voice-status off the 30s TTL so the next poll re-probes the
+            # shim's /health and surfaces the ready voice promptly.
+            self._voice_status_cache = None
 
     def _tts_envelope_options(self, exaggeration: float, cfg_weight: float) -> dict:
         """Session knobs + config pass-through, merged into the shim `options`."""
@@ -428,6 +430,29 @@ class AgentWireServer:
             **self.config.tts.options,
         }
 
+    def _tts_base_url(self) -> str | None:
+        """Resolve the shim URL for the active TTS tier.
+
+        ``default`` → the portal-managed Kokoro shim (``tts.url`` override or
+        :8102); ``custom`` → the user/remote-managed shim at ``tts.url``. Both
+        speak the same HTTP contract, so synthesis goes through one path."""
+        from .tts import _default_tts_url
+
+        if self.config.tts.backend == "default":
+            return _default_tts_url(self.config.tts)
+        return self.config.tts.url
+
+    async def _kokoro_shim_ready(self) -> bool:
+        """True if the default-tier Kokoro shim's /health reports ``ok``.
+
+        The default tier probes the managed shim before synthesizing; while it
+        downloads/loads (or hasn't spawned) the caller falls back to browser
+        speechSynthesis / OS voice — never blocking on a not-ready engine."""
+        from .tts import _default_tts_url
+
+        health = await self._probe_shim(_default_tts_url(self.config.tts), "/health")
+        return bool(health and health.get("status") == "ok")
+
     async def _tts_generate(
         self,
         text: str,
@@ -435,12 +460,17 @@ class AgentWireServer:
         instructions: str | None = None,
         options: dict | None = None,
     ) -> bytes | None:
-        """Generate TTS audio via the custom shim (contract envelope).
+        """Generate TTS audio via the active-tier shim (contract envelope).
 
         Core fields: text (+ optional voice). `instructions` and `options`
-        pass through verbatim — only the shim interprets them.
+        pass through verbatim — only the shim interprets them. The base URL
+        resolves per tier (default → managed Kokoro shim, custom → `tts.url`).
         """
         if not self._http_session:
+            return None
+
+        base_url = self._tts_base_url()
+        if not base_url:
             return None
 
         payload: dict = {"text": text}
@@ -453,7 +483,7 @@ class AgentWireServer:
 
         try:
             async with self._http_session.post(
-                f"{self.config.tts.url}/tts",
+                f"{base_url}/tts",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=self.config.tts.timeout),
             ) as resp:
@@ -749,7 +779,7 @@ class AgentWireServer:
             voices = await self._tts_get_voices()
             self._voices_cache = (now, voices)
             return voices
-        if self.config.tts.backend == "default" and self.kokoro.ready:
+        if self.config.tts.backend == "default" and await self._kokoro_shim_ready():
             from .tts.engines.kokoro import PRESET_VOICES
 
             return list(PRESET_VOICES)
@@ -803,12 +833,19 @@ class AgentWireServer:
 
         tts: dict = {"backend": tts_cfg.backend, "url": tts_cfg.url, "available": True}
         if tts_cfg.backend == "default":
-            # In-process Kokoro warm-up state; the cache is invalidated on
-            # every state change so transitions surface immediately.
-            tts["kokoro"] = {"state": self.kokoro.state, "percent": self.kokoro.percent}
-            if self.kokoro.error:
-                tts["kokoro"]["error"] = self.kokoro.error
-            if self.kokoro.ready:
+            # Portal-managed Kokoro shim subprocess. Probe its /health for the
+            # warm-up state (mirrors the STT shim); the browser keeps
+            # synthesizing speech until status is "ok", and `available` stays
+            # true because that browser fallback is always there.
+            from .tts import _default_tts_url
+
+            health = await self._probe_shim(_default_tts_url(tts_cfg), "/health")
+            state = health.get("status") if health else "absent"
+            percent = health.get("percent", 0) if health else 0
+            tts["kokoro"] = {"state": state, "percent": percent}
+            if health and health.get("error"):
+                tts["kokoro"]["error"] = health["error"]
+            if state == "ok":
                 from .tts.engines.kokoro import PRESET_VOICES
 
                 tts["voices"] = list(PRESET_VOICES)
@@ -4107,19 +4144,19 @@ projects:
             if not text:
                 return web.json_response({"error": "No text provided"}, status=400)
 
-            # Default tier: Kokoro on local speakers when ready, OS voice
-            # while warming up — no shim, no HTTP round-trip
+            # Default tier: Kokoro shim on local speakers when ready, OS voice
+            # while it warms up (process-isolated — see ensure_managed_tts)
             if self.config.tts.backend == "default":
                 from .utils.speech import strip_speech_tags
 
                 clean = strip_speech_tags(text)
-                if self.kokoro.ready:
+                if await self._kokoro_shim_ready():
                     try:
                         session_config = self._get_session_config(name)
-                        wav, _ = await self.kokoro.synthesize(
+                        wav = await self._tts_generate(
                             clean, voice or session_config.voice
                         )
-                        if await self._play_wav_locally(wav):
+                        if wav and await self._play_wav_locally(wav):
                             return web.json_response(
                                 {"success": True, "tier": "default", "engine": "kokoro"}
                             )
@@ -5558,7 +5595,7 @@ projects:
 
     async def _speak_no_clients_fallback(self, text: str) -> bool:
         """No browser connected: default tier plays on this machine's
-        speakers — Kokoro when ready, OS voice while warming up — so
+        speakers — the Kokoro shim when ready, OS voice while it warms up — so
         notifications stay audible; custom tier returns False (the CLI's
         smart routing handles local playback there)."""
         if self.config.tts.backend != "default":
@@ -5566,10 +5603,10 @@ projects:
         from .utils.speech import strip_speech_tags
 
         clean = strip_speech_tags(text)
-        if self.kokoro.ready:
+        if await self._kokoro_shim_ready():
             try:
-                wav, _ = await self.kokoro.synthesize(clean, self.config.tts.default_voice)
-                if await self._play_wav_locally(wav):
+                wav = await self._tts_generate(clean, self.config.tts.default_voice)
+                if wav and await self._play_wav_locally(wav):
                     return True
             except Exception as e:
                 logger.error(f"Kokoro local playback failed: {e}")
@@ -5649,24 +5686,20 @@ projects:
         for target in broadcast_to:
             await self._broadcast(target, tts_start_msg)
 
-        # Default tier: in-process Kokoro once the model is warmed up. Until
-        # then (and if warm-up failed) browsers synthesize the text themselves
-        # via speechSynthesis — broadcast clean text instead of audio.
+        # Default tier: the managed Kokoro shim once its model is warmed up
+        # (process-isolated — see ensure_managed_tts). Until then (and if
+        # warm-up failed) browsers synthesize the text themselves via
+        # speechSynthesis — broadcast clean text instead of audio.
         if self.config.tts.backend == "default":
             from .utils.speech import strip_speech_tags
 
             clean = strip_speech_tags(text)
 
-            if self.kokoro.ready:
+            if await self._kokoro_shim_ready():
                 voice = session.config.voice or self.config.tts.default_voice
 
                 async def _generate(chunk: str) -> bytes | None:
-                    try:
-                        wav, _ = await self.kokoro.synthesize(chunk, voice)
-                        return wav
-                    except Exception as e:
-                        logger.error(f"[{session_name}] Kokoro synthesis failed: {e}")
-                        return None
+                    return await self._tts_generate(chunk, voice)
 
                 return await self._speak_chunks(session_name, clean, broadcast_to, _generate)
 
@@ -5784,11 +5817,15 @@ async def run_server(config: Config):
     server = AgentWireServer(config)
     await server.init_backends()
 
-    # Warm up the default-tier Kokoro voice: background model download
-    # (one-time ~200 MB) + engine load. speechSynthesis covers speech until
-    # ready. Cleaned up via close_backends().
-    if config.tts.backend == "default":
-        server.kokoro.start(server._on_kokoro_state_change)
+    # Default-tier TTS: ensure the Kokoro shim subprocess is running (process
+    # isolation — the ~200 MB download + ONNX warm-up happens in that child,
+    # never on this event loop). speechSynthesis covers speech until the shim's
+    # /health is ok; on py3.14+ (no package) the spawn is gated off and it
+    # stays the browser path.
+    from .tts import kokoro_importable
+
+    if config.tts.backend == "default" and kokoro_importable():
+        asyncio.create_task(server.ensure_managed_tts())
 
     # Default-tier STT: ensure the Moonshine shim subprocess is running
     # (process isolation — the ~19s ONNX warm-up happens in that child, never

--- a/agentwire/tts/__init__.py
+++ b/agentwire/tts/__init__.py
@@ -1,6 +1,9 @@
 """AgentWire TTS Module - Multi-backend TTS with hot-swapping support"""
 
+from typing import Any
+
 from .base import TTSCapabilities, TTSEngine, TTSRequest, TTSResult
+from .local import kokoro_importable
 from .registry import EngineRegistry, registry
 
 __all__ = [
@@ -10,4 +13,20 @@ __all__ = [
     "TTSResult",
     "EngineRegistry",
     "registry",
+    "kokoro_importable",
+    "DEFAULT_KOKORO_URL",
+    "_default_tts_url",
 ]
+
+# Default-tier Kokoro shim subprocess (tmux ``agentwire-kokoro``). Must agree
+# with the shim's ``KOKORO_PORT`` (default 8102) if an operator overrides it.
+DEFAULT_KOKORO_URL = "http://localhost:8102"
+
+
+def _default_tts_url(tts_config: Any) -> str:
+    """Resolve the default-tier Kokoro shim URL: ``tts.url`` override or :8102.
+
+    Mirror of ``stt._default_stt_url``. The custom tier uses ``tts.url``
+    directly; the default tier falls back to the portal-managed shim port.
+    """
+    return getattr(tts_config, "url", None) or DEFAULT_KOKORO_URL

--- a/agentwire/tts/kokoro_server.py
+++ b/agentwire/tts/kokoro_server.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""AgentWire Kokoro Server — the process-isolated default TTS tier.
+
+The default voice tier runs Kokoro (kokoro-onnx, torch-free, base install) in
+this **standalone shim subprocess** (tmux ``agentwire-kokoro``, ``:8102``),
+which the portal auto-manages via ``ensure_managed_tts``. Process isolation
+keeps the ~200 MB one-time model download and the GIL-holding ONNX warm-up off
+the portal's event loop — the #382 failure mode the STT shim (``:8101``) fixed
+for Moonshine, mirrored here for Kokoro (#398).
+
+The engine lifecycle (download → load → ready, plus serialized synthesis) lives
+in ``LocalKokoro``; this module is the thin HTTP wrapper. The portal talks to
+it over the same shim contract envelope it already uses for the custom tier
+(``/tts`` with ``{text, voice, instructions, options}``); ``/health`` reports
+the warm-up state so the portal keeps browser speechSynthesis as the fallback
+until the model is ready.
+
+Run via:
+    agentwire kokoro start                  # Start in tmux (CPU)
+    agentwire kokoro stop                    # Stop the server
+    agentwire kokoro status                  # Check status
+
+Or run directly:
+    KOKORO_PORT=8102 uvicorn agentwire.tts.kokoro_server:app --host 0.0.0.0 --port 8102
+"""
+
+import io
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+
+from .base import TTSRequest
+from .engines.kokoro import PRESET_VOICES, SUPPORTED_LANGUAGES
+from .local import LocalKokoro
+
+# Configuration via environment (mirrors stt_server's STT_HOST/STT_PORT).
+KOKORO_HOST = os.environ.get("KOKORO_HOST", "0.0.0.0")
+KOKORO_PORT = int(os.environ.get("KOKORO_PORT", "8102"))
+
+# Single engine owned by this process. Constructed at import (cheap, no I/O);
+# the warm-up download+load is kicked off in the lifespan startup.
+kokoro = LocalKokoro()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Kick off the background warm-up on startup.
+
+    ``LocalKokoro.start`` downloads the model files (~200 MB, one-time) and
+    loads the ONNX session in a background task. This holds the GIL — which is
+    exactly why it must run here, in the shim, and not in the portal."""
+    kokoro.start()
+    print(f"Kokoro server starting on {KOKORO_HOST}:{KOKORO_PORT} (warming up)")
+    yield
+    await kokoro.close()
+    print("Shutting down Kokoro server...")
+
+
+app = FastAPI(title="AgentWire Kokoro Server", lifespan=lifespan)
+
+
+@app.post("/tts")
+async def generate_tts(request: TTSRequest):
+    """Generate TTS audio from text.
+
+    Accepts the agentwire shim contract envelope: core ``text``/``voice`` plus
+    opaque ``instructions`` and ``options`` (ignored — Kokoro takes no style
+    knobs). Returns WAV bytes, matching the custom shim's ``/tts``.
+    """
+    if not request.text.strip():
+        raise HTTPException(status_code=400, detail="Text cannot be empty")
+    if not kokoro.ready:
+        raise HTTPException(
+            status_code=503, detail=f"Kokoro not ready (state: {kokoro.state})"
+        )
+
+    try:
+        wav_bytes, _ = await kokoro.synthesize(request.text, request.voice)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return StreamingResponse(
+        io.BytesIO(wav_bytes),
+        media_type="audio/wav",
+        headers={"Content-Disposition": "attachment; filename=speech.wav"},
+    )
+
+
+@app.get("/health")
+async def health():
+    """Health check — surfaces the warm-up state machine.
+
+    ``status`` is ``ok`` once the engine is ready; until then it mirrors
+    ``LocalKokoro.state`` (``absent``/``downloading``/``loading``/``failed``/
+    ``unavailable``) so the portal can keep browser speech as the fallback and
+    render download progress from ``percent``.
+    """
+    status = "ok" if kokoro.ready else kokoro.state
+    body: dict = {"status": status, "engine": "kokoro", "percent": kokoro.percent}
+    if kokoro.error:
+        body["error"] = kokoro.error
+    return body
+
+
+@app.get("/voices")
+async def list_voices():
+    """List the Kokoro preset voices (available once the engine is ready)."""
+    return {"voices": list(PRESET_VOICES) if kokoro.ready else []}
+
+
+@app.get("/capabilities")
+async def capabilities():
+    """Shim contract: capability discovery for agentwire.
+
+    Kokoro is a plain preset-voice engine — no emotion control, no
+    paralinguistic tags — so ``tool_prompt`` is empty unless the operator sets
+    AGENTWIRE_KOKORO_TOOL_PROMPT.
+    """
+    return {
+        "tool_prompt": os.environ.get("AGENTWIRE_KOKORO_TOOL_PROMPT", ""),
+        "voices": list(PRESET_VOICES) if kokoro.ready else [],
+        "engine": "kokoro",
+        "emotion_control": False,
+        "paralinguistic_tags": False,
+        "voice_cloning": False,
+        "languages": SUPPORTED_LANGUAGES,
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host=KOKORO_HOST, port=KOKORO_PORT)

--- a/docs/wiki/voice/tts-self-hosted.md
+++ b/docs/wiki/voice/tts-self-hosted.md
@@ -4,7 +4,7 @@
 
 The bundled TTS server is the **reference implementation of the [shim contract](shim-contract.md)** — multiple engines, each with different capabilities and hardware requirements, all behind one server (`agentwire tts start`) with runtime hot-swap.
 
-> **You don't need this page for a good voice.** `tts.backend: default` already speaks via **Kokoro-82M in-process** — bundled with the base install, CPU-only, auto-downloaded (~200 MB) on first portal start (`agentwire tts warm` pre-downloads it). This page is the `custom` tier: voice cloning, GPU engines, emotion control, or any other model behind the shim contract.
+> **You don't need this page for a good voice.** `tts.backend: default` already speaks via **Kokoro-82M** — bundled with the base install, CPU-only, auto-downloaded (~200 MB) on first portal start (`agentwire tts warm` pre-downloads it). Since #398 the default tier runs Kokoro in a **portal-managed shim subprocess** (tmux `agentwire-kokoro`, `:8102`) rather than in-process — process isolation keeps the GIL-holding ONNX warm-up off the portal event loop, mirroring the STT shim (`:8101`). The portal auto-spawns it on startup; `agentwire kokoro start|stop|status` manage it by hand, and browser speechSynthesis covers speech until its `/health` reports `ok`. This page is the `custom` tier: voice cloning, GPU engines, emotion control, or any other model behind the shim contract.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ curl -X POST http://localhost:8100/engines/zonos-transformer/load
 
 ### Choosing a Backend
 
-- **No GPU / CPU only** → you likely don't need the server at all: the `default` tier runs kokoro in-process. Run `kokoro` behind the shim only when serving TTS to other machines.
+- **No GPU / CPU only** → you likely don't need this server at all: the `default` tier already runs kokoro in its own portal-managed shim (`agentwire-kokoro`, `:8102`). Run `kokoro` behind *this* multi-engine shim only when serving TTS to other machines or hot-swapping engines.
 - **Best voice quality + emotion control** → `zonos-transformer`
 - **Mid-sentence sounds** (laugh, sigh, cough) → `chatterbox` or `chatterbox-streaming`
 - **Multilingual** (10 languages) → `qwen-base-1.7b` or `qwen-custom`

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -723,13 +723,13 @@ class TestVoiceStatus:
     async def test_default_tier_shim_loading(self, portal_client):
         client, server = portal_client
 
-        # Default tier probes the managed shim's /health like custom does.
-        # While the shim loads (or hasn't spawned), /health isn't "ok" →
-        # server_transcribe False, so the client stays on browser speech
-        # recognition and instant mode holds. No `moonshine` key any more.
+        # Default tier probes the managed shims' /health like custom does — STT
+        # at :8101, TTS (Kokoro) at :8102. While they load (or haven't spawned),
+        # /health isn't "ok" → server_transcribe False, so the client stays on
+        # browser speech recognition and instant mode holds. No `moonshine` key.
         async def fake_probe(base_url, path, timeout=1.5):
-            assert base_url == "http://localhost:8101"
-            return {"status": "loading"}
+            assert base_url in ("http://localhost:8101", "http://localhost:8102")
+            return {"status": "loading", "percent": 40}
 
         server._probe_shim = fake_probe
 
@@ -744,6 +744,9 @@ class TestVoiceStatus:
         }
         assert body["tts"]["backend"] == "default"
         assert body["tts"]["available"] is True
+        # Kokoro shim warm-up state surfaced from its /health, no `voices` yet.
+        assert body["tts"]["kokoro"] == {"state": "loading", "percent": 40}
+        assert "voices" not in body["tts"]
         assert body["instant_mode"] is True
         assert body["corrections"] == {}
 
@@ -761,6 +764,9 @@ class TestVoiceStatus:
         assert body["stt"]["server_transcribe"] is False
         assert body["stt"]["available"] is True
         assert body["instant_mode"] is True
+        # TTS shim absent too → kokoro state "absent", browser fallback stands.
+        assert body["tts"]["kokoro"]["state"] == "absent"
+        assert body["tts"]["available"] is True
 
     async def test_default_tier_shim_ok(self, portal_client):
         client, server = portal_client
@@ -777,6 +783,9 @@ class TestVoiceStatus:
         assert body["stt"]["server_transcribe"] is True
         assert "moonshine" not in body["stt"]
         assert body["instant_mode"] is False
+        # Kokoro shim ready → its preset voices are surfaced for the picker.
+        assert body["tts"]["kokoro"]["state"] == "ok"
+        assert body["tts"]["voices"]
 
     async def test_custom_tier_probes_shim(self, portal_client):
         client, server = portal_client
@@ -889,6 +898,55 @@ class TestEnsureManagedStt:
         from agentwire.stt import moonshine_importable
 
         assert moonshine_importable() is True
+
+
+# ---------------------------------------------------------------------------
+# Default-tier managed Kokoro TTS shim lifecycle (ensure_managed_tts)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureManagedTts:
+    async def test_delegates_to_kokoro_start_cli(self, portal_client, monkeypatch):
+        client, server = portal_client
+        # Skip the post-bind settle delay.
+        monkeypatch.setattr("agentwire.server.asyncio.sleep", AsyncMock())
+
+        calls = []
+
+        async def fake_cmd(args, json_output=True):
+            calls.append((args, json_output))
+            return True, {"output": "Kokoro TTS shim starting"}
+
+        server.run_agentwire_cmd = fake_cmd
+        server._voice_status_cache = (12345.0, {"stale": True})
+
+        await server.ensure_managed_tts()
+
+        # Idempotent CLI spawn — reuses cmd_kokoro_start (early-returns if the
+        # agentwire-kokoro tmux session already exists).
+        assert calls == [(["kokoro", "start"], False)]
+        # Cache invalidated so the next voice-status poll re-probes /health.
+        assert server._voice_status_cache is None
+
+    async def test_cli_failure_is_soft(self, portal_client, monkeypatch):
+        client, server = portal_client
+        monkeypatch.setattr("agentwire.server.asyncio.sleep", AsyncMock())
+
+        async def fake_cmd(args, json_output=True):
+            return False, {"error": "boom"}
+
+        server.run_agentwire_cmd = fake_cmd
+        # Must not raise — browser speechSynthesis keeps working.
+        await server.ensure_managed_tts()
+        assert server._voice_status_cache is None
+
+    def test_spawn_gate_is_kokoro_importable(self):
+        # run_server schedules ensure_managed_tts only when
+        # `config.tts.backend == "default" and kokoro_importable()`. This is
+        # the gate it evaluates — proven importable in this (py<3.14) env.
+        from agentwire.tts import kokoro_importable
+
+        assert kokoro_importable() is True
 
     def test_spawn_gate_false_when_not_importable(self, monkeypatch):
         import agentwire.stt as stt_pkg

--- a/tests/unit/test_server_async.py
+++ b/tests/unit/test_server_async.py
@@ -267,8 +267,8 @@ class TestSpeakDefaultTier:
         server._os_say.assert_not_awaited()
 
     async def test_kokoro_ready_broadcasts_audio_not_speak_text(self, server):
-        """Once the in-process Kokoro engine is warm, the default tier sends
-        real WAV audio messages instead of delegating to speechSynthesis."""
+        """Once the managed Kokoro shim is warm (/health ok), the default tier
+        sends real WAV audio messages instead of delegating to speechSynthesis."""
         import numpy as np
 
         from agentwire.tts.audio import pcm_float_to_wav_bytes
@@ -276,9 +276,8 @@ class TestSpeakDefaultTier:
         server._broadcast = AsyncMock()
         server.broadcast_dashboard = AsyncMock()
         wav = pcm_float_to_wav_bytes(np.zeros(2400, dtype=np.float32), 24000)
-        server.kokoro = MagicMock()
-        server.kokoro.ready = True
-        server.kokoro.synthesize = AsyncMock(return_value=(wav, 0.1))
+        server._kokoro_shim_ready = AsyncMock(return_value=True)
+        server._tts_generate = AsyncMock(return_value=wav)
         from agentwire.server import Session
         session = Session(name="dev", config=server._get_session_config("dev"))
         session.clients.add(_client())
@@ -291,16 +290,15 @@ class TestSpeakDefaultTier:
         assert any(m.get("type") == "audio" for m in sent)
         assert not any(m.get("type") == "speak_text" for m in sent)
         # Speech tags stripped before synthesis (kokoro has no tag support)
-        chunk = server.kokoro.synthesize.await_args[0][0]
+        chunk = server._tts_generate.await_args[0][0]
         assert "[laugh]" not in chunk
 
     async def test_kokoro_failure_returns_false_no_speak_text(self, server):
-        """A ready engine that errors mid-synthesis must not crash speak()."""
+        """A ready shim that returns no audio mid-synthesis must not crash speak()."""
         server._broadcast = AsyncMock()
         server.broadcast_dashboard = AsyncMock()
-        server.kokoro = MagicMock()
-        server.kokoro.ready = True
-        server.kokoro.synthesize = AsyncMock(side_effect=RuntimeError("onnx died"))
+        server._kokoro_shim_ready = AsyncMock(return_value=True)
+        server._tts_generate = AsyncMock(return_value=None)
         from agentwire.server import Session
         session = Session(name="dev", config=server._get_session_config("dev"))
         session.clients.add(_client())

--- a/tests/unit/test_tts_local.py
+++ b/tests/unit/test_tts_local.py
@@ -5,11 +5,13 @@ the LocalKokoro state machine, the portal's WAV duration parser, and the CLI
 tier dispatch. No real model files or network involved.
 """
 
+import importlib.util
 import subprocess
 import sys
 import wave
+from contextlib import contextmanager
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -274,6 +276,104 @@ class TestLocalSayDispatch:
         shim.assert_called_once()
         kokoro.assert_not_called()
         os_say.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Process-isolated Kokoro shim server (kokoro_server.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("fastapi") is None,
+    reason="fastapi only ships in the stt/tts extras (the shim runs from the source venv)",
+)
+class TestKokoroServer:
+    """The shim wraps one LocalKokoro and serves the contract envelope.
+
+    The portal talks to this over HTTP so the GIL-holding warm-up runs in a
+    child process, never on the portal event loop (#398)."""
+
+    @contextmanager
+    def _client(self, fake):
+        from fastapi.testclient import TestClient
+
+        from agentwire.tts import kokoro_server
+
+        # Replace the module-level engine with a controllable fake for the whole
+        # test (the patch must outlive lifespan startup, which calls start(),
+        # and every request, which reads the module global). start()/close()
+        # become no-ops on the fake — no real ONNX load.
+        with patch.object(kokoro_server, "kokoro", fake):
+            with TestClient(kokoro_server.app) as client:
+                yield client
+
+    def _fake_kokoro(self, *, ready=False, state="loading", percent=0, error=None):
+        fake = MagicMock()
+        fake.ready = ready
+        fake.state = state
+        fake.percent = percent
+        fake.error = error
+        fake.start = MagicMock()
+        fake.close = AsyncMock()
+        return fake
+
+    def test_health_reports_loading_state(self):
+        fake = self._fake_kokoro(state="downloading", percent=42)
+        with self._client(fake) as c:
+            body = c.get("/health").json()
+        assert body == {"status": "downloading", "engine": "kokoro", "percent": 42}
+
+    def test_health_ok_when_ready(self):
+        fake = self._fake_kokoro(ready=True, state="ready", percent=100)
+        with self._client(fake) as c:
+            body = c.get("/health").json()
+        assert body["status"] == "ok"
+        assert body["percent"] == 100
+
+    def test_health_surfaces_error(self):
+        fake = self._fake_kokoro(state="failed", error="network down")
+        with self._client(fake) as c:
+            body = c.get("/health").json()
+        assert body["status"] == "failed"
+        assert body["error"] == "network down"
+
+    def test_tts_503_until_ready(self):
+        fake = self._fake_kokoro(ready=False, state="loading")
+        with self._client(fake) as c:
+            resp = c.post("/tts", json={"text": "hello"})
+        assert resp.status_code == 503
+
+    def test_tts_400_on_empty_text(self):
+        fake = self._fake_kokoro(ready=True)
+        with self._client(fake) as c:
+            resp = c.post("/tts", json={"text": "   "})
+        assert resp.status_code == 400
+
+    def test_tts_returns_wav_when_ready(self):
+        wav = pcm_float_to_wav_bytes(np.zeros(2400, dtype=np.float32), 24000)
+        fake = self._fake_kokoro(ready=True)
+        fake.synthesize = AsyncMock(return_value=(wav, 0.1))
+        with self._client(fake) as c:
+            resp = c.post("/tts", json={"text": "hello", "voice": "af_bella"})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        assert resp.content[:4] == b"RIFF"
+        # Voice passed through to the engine.
+        assert fake.synthesize.await_args[0] == ("hello", "af_bella")
+
+    def test_voices_empty_until_ready_then_presets(self):
+        with self._client(self._fake_kokoro(ready=False)) as c:
+            assert c.get("/voices").json() == {"voices": []}
+        with self._client(self._fake_kokoro(ready=True)) as c:
+            assert c.get("/voices").json()["voices"] == list(PRESET_VOICES)
+
+    def test_capabilities_shape(self):
+        with self._client(self._fake_kokoro(ready=True)) as c:
+            caps = c.get("/capabilities").json()
+        assert caps["engine"] == "kokoro"
+        assert caps["emotion_control"] is False
+        assert caps["voice_cloning"] is False
+        assert caps["voices"] == list(PRESET_VOICES)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Process-isolate the default-tier Kokoro TTS into a portal-managed shim subprocess, mirroring the #383 STT shim. Closes #398.

The default TTS tier loaded Kokoro (kokoro-onnx) **in-process**: the ~200 MB one-time download + GIL-holding ONNX warm-up can wedge the portal event loop — the exact #382 failure mode (`asyncio.to_thread` doesn't help; the GIL is the bottleneck). #384 was closed not-planned with "mirror #382 shim isolation if load grows" — this does it proactively.

## How

Mirrors the STT shim (`:8101`) one-to-one:

- **`agentwire/tts/kokoro_server.py`** — new lightweight FastAPI shim owning one `LocalKokoro`. `POST /tts` (the same contract envelope the portal already sends the custom shim), `GET /health` (warm-up state + percent), `/voices`, `/capabilities`. `LocalKokoro` moves from portal-owned to shim-owned, unchanged — its GIL-holding warm-up now runs in the child, off the portal loop.
- **`agentwire kokoro start|serve|stop|status`** — idempotent tmux spawn `agentwire-kokoro` on `:8102`, mirroring `agentwire stt`.
- **`server.py`** — drop `self.kokoro` / `_on_kokoro_state_change` / in-process `start()`/`close()`. Add `ensure_managed_tts()` (delegates to `agentwire kokoro start`, idempotent), `_default_tts_url()` (`:8102`), `_tts_base_url()`, `_kokoro_shim_ready()`. The default tier now goes through the existing async `_tts_generate` HTTP path; `speak` / `api_local_tts` / `_speak_no_clients_fallback` probe the shim `/health` and fall back to **browser speechSynthesis / OS voice** until it's ready (fallback preserved). `voice-status` + `_get_voices` probe the shim instead of in-process state. `run_server` schedules `ensure_managed_tts` gated on `kokoro_importable()`.
- The CLI `agentwire say` default path stays in-process — short-lived CLI process, no portal loop to wedge (out of scope).

## Verification

- New shim booted on a test port: `/health` transitions to `ok`, `/voices` + `/capabilities` correct, `POST /tts` returns a valid 24 kHz mono WAV (72 KB) — end-to-end synthesis confirmed.
- Portal side is now **purely async HTTP** (grep confirms zero remaining `self.kokoro` synthesis/warm-up calls) — GIL starvation removed by construction, the #398 requirement.
- `1382` unit tests pass (hermetic gate `1376 passed / 6 deselected`). Added: shim endpoint tests, `TestEnsureManagedTts`, default-tier voice-status shim-probe cases; reworked the in-process `speak` tests to the HTTP path. No new lint.

Built by [dotdev.dev](https://dotdev.dev)
