### PR TITLE
Unattended/scheduled-agent action guardrail (fail-closed ask tier)

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -93,7 +93,21 @@ tasks:
 
     # Context inheritance
     starting_session: ctx-loaded  # Fork Claude context from this session before running
+
+    # Unattended safety (scheduler, no human present)
+    unattended_allow:             # damage-control rule ids this task may run unattended,
+      - tooldef.terraform-apply-planned-changes-to-infrastructure  # extends the global default
 ```
+
+**`unattended_allow`** (per-task): when the scheduler dispatches a task headless
+(`AGENTWIRE_UNATTENDED=1`), the damage-control hook resolves `ask`-tier commands
+by **failing closed** — block + email the owner — unless the matched rule id is
+on the allowlist. The default allowlist lets a task work and open a PR
+(`git.add`/`git.commit`/`git.push`/`gh.pr-create`); list extra rule ids here to
+permit a normally-gated action (deploy, DB write, outbound email) for **this task
+only**. Blocked actions name the exact rule id (in the email and `agentwire safety
+logs`) so widening is copy-paste. Hard blocks (`rm -rf`, `git push --force`) and
+interactive sessions are unaffected. See `docs/wiki/internals/damage-control.md`.
 
 **Built-in variables:**
 - `{{ date }}`, `{{ time }}`, `{{ datetime }}` - Current date/time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Per-project config lives in `.agentwire.yml` at the project root — **keep it g
 - **worker panes** spawn within the orchestrator's session (visible dashboard)
 - **Pane 0** = orchestrator, **panes 1+** = workers
 - **Damage-control hooks** block dangerous ops (`rm -rf`, `git push --force`, etc.)
+- **Unattended guardrail** — scheduler dispatches are marked `AGENTWIRE_UNATTENDED=1`; the hook resolves `ask`-tier commands by failing closed (block + email owner) unless on the `unattended_allow` list. See [`docs/wiki/internals/damage-control.md`](docs/wiki/internals/damage-control.md).
 - **Smart TTS routing** — audio goes to browser if connected, local speakers if not
 
 ### Worker Pane Lifecycle

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -103,6 +103,31 @@ class AgentCommand:
     env: dict[str, str] = field(default_factory=dict)  # Secrets to inject via tmux set-environment (keeps keys out of `ps`)
 
 
+_UNATTENDED_ENV_KEYS = ("AGENTWIRE_UNATTENDED", "AGENTWIRE_UNATTENDED_ALLOW")
+
+
+def _with_unattended_env(env: dict[str, str]) -> dict[str, str]:
+    """Propagate the unattended marker into a session being created.
+
+    The scheduler is the single place that decides a dispatch is unattended —
+    it seeds ``AGENTWIRE_UNATTENDED[=1]`` (and any per-task
+    ``AGENTWIRE_UNATTENDED_ALLOW``) into the dispatch subprocess environment.
+    Every session-creation path funnels its env through here on the way to
+    ``tmux new-session -e K=V``, so the marker lands in the new session BEFORE
+    the agent launches and the damage-control hook can read it. A child session
+    an unattended agent spawns inherits the marker too (defense in depth).
+
+    No leak into interactive sessions: a human's ``agentwire new`` has no such
+    var in its environment, so nothing is propagated.
+    """
+    merged = dict(env)
+    for key in _UNATTENDED_ENV_KEYS:
+        val = os.environ.get(key)
+        if val and key not in merged:
+            merged[key] = val
+    return merged
+
+
 def _build_tmux_env_flags(env: dict[str, str]) -> list[str]:
     """Build `-e KEY=VAL` flag pairs for `tmux new-session`.
 
@@ -114,16 +139,17 @@ def _build_tmux_env_flags(env: dict[str, str]) -> list[str]:
     the var — and the agent command runs in that initial shell.
     """
     flags: list[str] = []
-    for key, value in env.items():
+    for key, value in _with_unattended_env(env).items():
         flags.extend(["-e", f"{key}={value}"])
     return flags
 
 
 def _build_tmux_env_flags_shell(env: dict[str, str]) -> str:
     """Shell-quoted `-e 'K=V' …` fragment for inlining via SSH. Trailing space when non-empty."""
-    if not env:
+    merged = _with_unattended_env(env)
+    if not merged:
         return ""
-    parts = [f"-e {shlex.quote(f'{k}={v}')}" for k, v in env.items()]
+    parts = [f"-e {shlex.quote(f'{k}={v}')}" for k, v in merged.items()]
     return " ".join(parts) + " "
 
 
@@ -6830,6 +6856,15 @@ def cmd_safety_status(args) -> int:
     return cli_safety.safety_status_cmd()
 
 
+def cmd_safety_notify_unattended_block(args) -> int:
+    """CLI command: agentwire safety notify-unattended-block (hook-invoked)"""
+    return cli_safety.safety_notify_unattended_block_cmd(
+        getattr(args, "reason", "") or "",
+        getattr(args, "rule_id", "") or "",
+        getattr(args, "command", "") or "",
+    )
+
+
 def cmd_safety_logs(args) -> int:
     """CLI command: agentwire safety logs"""
     tail = getattr(args, 'tail', None)
@@ -11356,6 +11391,16 @@ def main() -> int:
         "status", help="Show safety status and pattern counts"
     )
     safety_status.set_defaults(func=cmd_safety_status)
+
+    # safety notify-unattended-block (hook-invoked, not for humans)
+    safety_notify = safety_subparsers.add_parser(
+        "notify-unattended-block",
+        help="Email the owner that an unattended action was blocked (hook-internal)",
+    )
+    safety_notify.add_argument("--reason", default="", help="Why the command was blocked")
+    safety_notify.add_argument("--rule-id", dest="rule_id", default="", help="Matched rule id")
+    safety_notify.add_argument("--command", default="", help="The blocked command")
+    safety_notify.set_defaults(func=cmd_safety_notify_unattended_block)
 
     # safety logs
     safety_logs = safety_subparsers.add_parser(

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -8,6 +8,7 @@ stay in sync.
 """
 
 import json
+import os
 import shutil
 import sys
 from datetime import datetime
@@ -340,6 +341,48 @@ def safety_status_cmd() -> int:
     """CLI command: ``agentwire safety status``."""
     print(format_safety_status(get_safety_status()))
     return 0
+
+
+def safety_notify_unattended_block_cmd(
+    reason: str, rule_id: str, command: str
+) -> int:
+    """CLI command: ``agentwire safety notify-unattended-block``.
+
+    Invoked fire-and-forget by the bash damage-control hook when an
+    unattended (scheduler) run hits an ``ask``-tier command that isn't on the
+    allowlist. Emails the owner via the shared Resend wiring so the blocked
+    action surfaces immediately instead of silently disappearing.
+    """
+    session = os.environ.get("AGENTWIRE_SESSION_NAME") or os.environ.get(
+        "AGENTWIRE_SESSION_ID", "unknown"
+    )
+    cwd = os.environ.get("PWD", "")
+    subject = f"[agentwire] Unattended action blocked: {reason[:80]}"
+    body = (
+        f"An unattended (scheduled) agent attempted an action that requires "
+        f"human confirmation, so it was **blocked** (fail-closed).\n\n"
+        f"- **Session:** {session}\n"
+        f"- **Working dir:** {cwd or 'unknown'}\n"
+        f"- **Rule:** {rule_id or 'unknown'}\n"
+        f"- **Reason:** {reason}\n"
+        f"- **Command:** `{command}`\n"
+        f"- **When:** {datetime.now().isoformat(timespec='seconds')}\n\n"
+        f"Nothing was executed. To permit this specific action for the task in "
+        f"future, add rule id `{rule_id}` to that task's `unattended_allow` in "
+        f"its `.agentwire.yml` (or to `safety.unattended_allow` globally)."
+    )
+    try:
+        from agentwire.channels.email import send_email
+
+        result = send_email(subject=subject, body=body)
+        if getattr(result, "success", False):
+            return 0
+        print(f"notify-unattended-block: email failed: "
+              f"{getattr(result, 'error', 'unknown')}", file=sys.stderr)
+        return 1
+    except Exception as e:  # email not configured, etc. — never crash the notifier
+        print(f"notify-unattended-block: {e}", file=sys.stderr)
+        return 1
 
 
 def safety_logs_cmd(

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -400,11 +400,18 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                 regex = _cmd_to_regex(cmd_str)
                 if not regex:
                     continue
-                patterns.append({
+                entry = {
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
-                })
+                }
+                # An explicit ``id:`` on the tooldef command yields a stable
+                # rule ID (e.g. ``git.push``) that survives description edits —
+                # needed so ``safety.unattended_allow`` can name it reliably.
+                # Without one, ``_assign_rule_id`` derives a slug from the reason.
+                if cmd_def.get("id"):
+                    entry["id"] = str(cmd_def["id"])
+                patterns.append(entry)
         except Exception:
             continue
     return patterns
@@ -480,20 +487,76 @@ def load_config(
     return merged
 
 
+# ============================================================================
+# UNATTENDED (NO-HUMAN-PRESENT) RESOLUTION
+# ============================================================================
+#
+# The damage-control hook classifies commands into allow / block / ask. The
+# ``ask`` tier only means something when a human is present to confirm. Under
+# the scheduler (cron, nobody watching) sessions run with
+# ``--dangerously-skip-permissions``, so historically ``ask`` resolved to a
+# SILENT allow — an unsupervised agent could deploy / drop a table / force-push.
+#
+# When a session is marked unattended (``AGENTWIRE_UNATTENDED=1``, stamped at
+# dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
+# block + notify the owner, UNLESS the matched rule's stable ID is on the
+# allowlist. The allowlist is the union of:
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
+#      irreversible or outward-facing),
+#   2. ``safety.unattended_allow`` from global / project config,
+#   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
+#      extension the scheduler stamps from a task's ``unattended_allow``.
+#
+# Hard ``block`` rules (rm -rf, git push --force, …) are unaffected — they fire
+# regardless. Interactive bypass sessions (no ``AGENTWIRE_UNATTENDED``) are
+# unaffected too — their ``ask`` still resolves the old way.
+
+DEFAULT_UNATTENDED_ALLOW = {
+    "git.add",       # stage files
+    "git.add-u",     # stage tracked changes
+    "git.commit",    # commit
+    "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
+    "gh.pr-create",  # open a PR — the human-reviewed gate
+}
+
+
+def is_unattended() -> bool:
+    """True when this session was dispatched with no human present (scheduler)."""
+    return os.environ.get("AGENTWIRE_UNATTENDED") == "1"
+
+
+def resolve_unattended_allow(config: Dict[str, Any]) -> set:
+    """Effective unattended allowlist: defaults ∪ config ∪ per-task env extension."""
+    allow = set(DEFAULT_UNATTENDED_ALLOW)
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    for rid in safety_cfg.get("unattended_allow", []) or []:
+        if rid:
+            allow.add(str(rid))
+    env_allow = os.environ.get("AGENTWIRE_UNATTENDED_ALLOW", "")
+    for rid in env_allow.split(","):
+        rid = rid.strip()
+        if rid:
+            allow.add(rid)
+    return allow
+
+
 def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve the effective ``safety`` block from global + nearest project config.
 
-    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
-    overrides global; ``disabled_rules`` are merged (set-union).
+    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
+    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
+    ``unattended_allow`` are merged (set-union).
     """
     enabled = True
     disabled_rules: List[str] = []
+    unattended_allow: List[str] = []
     project_enabled: Optional[bool] = None
     if not yaml:
-        return {"enabled": enabled, "disabled_rules": disabled_rules}
+        return {"enabled": enabled, "disabled_rules": disabled_rules,
+                "unattended_allow": unattended_allow}
 
     if global_config_path is None:
         global_config_path = Path.home() / ".agentwire" / "config.yaml"
@@ -508,6 +571,9 @@ def load_safety_config(
                 rules = safety.get("disabled_rules", [])
                 if isinstance(rules, list):
                     disabled_rules.extend(str(r) for r in rules if r)
+                allow = safety.get("unattended_allow", [])
+                if isinstance(allow, list):
+                    unattended_allow.extend(str(a) for a in allow if a)
     except Exception:
         pass
 
@@ -527,6 +593,9 @@ def load_safety_config(
                     prules = psafety.get("disabled_rules", [])
                     if isinstance(prules, list):
                         disabled_rules.extend(str(r) for r in prules if r)
+                    pallow = psafety.get("unattended_allow", [])
+                    if isinstance(pallow, list):
+                        unattended_allow.extend(str(a) for a in pallow if a)
             except Exception:
                 pass
             break
@@ -538,7 +607,11 @@ def load_safety_config(
     if project_enabled is not None:
         enabled = project_enabled
 
-    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+    return {
+        "enabled": enabled,
+        "disabled_rules": sorted(set(disabled_rules)),
+        "unattended_allow": sorted(set(unattended_allow)),
+    }
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -747,6 +820,31 @@ def _resolve_tooldefs_dir():
     return bundled if bundled.exists() else None
 
 
+def _notify_unattended_block(command: str, reason: str, rule_id: str | None) -> None:
+    """Fire-and-forget: email the owner that an unattended action was blocked.
+
+    The hook is a PEP 723 script (pyyaml-only) and can't import the agentwire
+    package, so it shells out to the installed CLI, which emails via the same
+    Resend wiring usage-limit recovery uses. Detached + non-blocking so SMTP
+    never sits on the hook's hot path; failures are swallowed (the block has
+    already fired and is audit-logged regardless).
+    """
+    import subprocess
+    try:
+        subprocess.Popen(
+            ["agentwire", "safety", "notify-unattended-block",
+             "--reason", reason or "",
+             "--rule-id", rule_id or "",
+             "--command", command[:500]],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
 def main() -> None:
     config = load_config(_resolve_rules_dir(), _resolve_tooldefs_dir())
     config["safety"] = load_safety_config()
@@ -788,6 +886,28 @@ def main() -> None:
             log_blocked("Bash", command, reason)
         print(f"SECURITY: Blocked: {reason}", file=sys.stderr)
         print(f"Command: {command[:100]}{'...' if len(command) > 100 else ''}", file=sys.stderr)
+        sys.exit(2)
+    elif decision == "ask" and is_unattended():
+        # No human present (scheduler dispatch). The interactive confirm is
+        # meaningless, so fail closed: BLOCK + notify the owner, unless the
+        # matched rule is explicitly on the unattended allowlist.
+        rule_id = result.get("id")
+        allow = resolve_unattended_allow(config)
+        if rule_id and rule_id in allow:
+            log_allowed("Bash", command, user_approved=False)
+            sys.exit(0)
+        try:
+            log_blocked("Bash", command, f"unattended: {reason}",
+                        pattern=result.get("pattern"), rule_id=rule_id)
+        except TypeError:
+            log_blocked("Bash", command, f"unattended: {reason}")
+        _notify_unattended_block(command, reason, rule_id)
+        print(f"SECURITY: Blocked (unattended — no human to confirm): {reason}", file=sys.stderr)
+        print(f"Command: {command[:100]}{'...' if len(command) > 100 else ''}", file=sys.stderr)
+        if rule_id:
+            print(f"To permit this for an unattended task, add rule id "
+                  f"'{rule_id}' to its .agentwire.yml task `unattended_allow`.",
+                  file=sys.stderr)
         sys.exit(2)
     elif decision == "ask" and permission_mode not in bypass_modes:
         log_asked("Bash", command, reason)

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -396,11 +396,18 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                 regex = _cmd_to_regex(cmd_str)
                 if not regex:
                     continue
-                patterns.append({
+                entry = {
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
-                })
+                }
+                # An explicit ``id:`` on the tooldef command yields a stable
+                # rule ID (e.g. ``git.push``) that survives description edits —
+                # needed so ``safety.unattended_allow`` can name it reliably.
+                # Without one, ``_assign_rule_id`` derives a slug from the reason.
+                if cmd_def.get("id"):
+                    entry["id"] = str(cmd_def["id"])
+                patterns.append(entry)
         except Exception:
             continue
     return patterns
@@ -476,20 +483,76 @@ def load_config(
     return merged
 
 
+# ============================================================================
+# UNATTENDED (NO-HUMAN-PRESENT) RESOLUTION
+# ============================================================================
+#
+# The damage-control hook classifies commands into allow / block / ask. The
+# ``ask`` tier only means something when a human is present to confirm. Under
+# the scheduler (cron, nobody watching) sessions run with
+# ``--dangerously-skip-permissions``, so historically ``ask`` resolved to a
+# SILENT allow — an unsupervised agent could deploy / drop a table / force-push.
+#
+# When a session is marked unattended (``AGENTWIRE_UNATTENDED=1``, stamped at
+# dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
+# block + notify the owner, UNLESS the matched rule's stable ID is on the
+# allowlist. The allowlist is the union of:
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
+#      irreversible or outward-facing),
+#   2. ``safety.unattended_allow`` from global / project config,
+#   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
+#      extension the scheduler stamps from a task's ``unattended_allow``.
+#
+# Hard ``block`` rules (rm -rf, git push --force, …) are unaffected — they fire
+# regardless. Interactive bypass sessions (no ``AGENTWIRE_UNATTENDED``) are
+# unaffected too — their ``ask`` still resolves the old way.
+
+DEFAULT_UNATTENDED_ALLOW = {
+    "git.add",       # stage files
+    "git.add-u",     # stage tracked changes
+    "git.commit",    # commit
+    "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
+    "gh.pr-create",  # open a PR — the human-reviewed gate
+}
+
+
+def is_unattended() -> bool:
+    """True when this session was dispatched with no human present (scheduler)."""
+    return os.environ.get("AGENTWIRE_UNATTENDED") == "1"
+
+
+def resolve_unattended_allow(config: Dict[str, Any]) -> set:
+    """Effective unattended allowlist: defaults ∪ config ∪ per-task env extension."""
+    allow = set(DEFAULT_UNATTENDED_ALLOW)
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    for rid in safety_cfg.get("unattended_allow", []) or []:
+        if rid:
+            allow.add(str(rid))
+    env_allow = os.environ.get("AGENTWIRE_UNATTENDED_ALLOW", "")
+    for rid in env_allow.split(","):
+        rid = rid.strip()
+        if rid:
+            allow.add(rid)
+    return allow
+
+
 def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve the effective ``safety`` block from global + nearest project config.
 
-    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
-    overrides global; ``disabled_rules`` are merged (set-union).
+    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
+    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
+    ``unattended_allow`` are merged (set-union).
     """
     enabled = True
     disabled_rules: List[str] = []
+    unattended_allow: List[str] = []
     project_enabled: Optional[bool] = None
     if not yaml:
-        return {"enabled": enabled, "disabled_rules": disabled_rules}
+        return {"enabled": enabled, "disabled_rules": disabled_rules,
+                "unattended_allow": unattended_allow}
 
     if global_config_path is None:
         global_config_path = Path.home() / ".agentwire" / "config.yaml"
@@ -504,6 +567,9 @@ def load_safety_config(
                 rules = safety.get("disabled_rules", [])
                 if isinstance(rules, list):
                     disabled_rules.extend(str(r) for r in rules if r)
+                allow = safety.get("unattended_allow", [])
+                if isinstance(allow, list):
+                    unattended_allow.extend(str(a) for a in allow if a)
     except Exception:
         pass
 
@@ -523,6 +589,9 @@ def load_safety_config(
                     prules = psafety.get("disabled_rules", [])
                     if isinstance(prules, list):
                         disabled_rules.extend(str(r) for r in prules if r)
+                    pallow = psafety.get("unattended_allow", [])
+                    if isinstance(pallow, list):
+                        unattended_allow.extend(str(a) for a in pallow if a)
             except Exception:
                 pass
             break
@@ -534,7 +603,11 @@ def load_safety_config(
     if project_enabled is not None:
         enabled = project_enabled
 
-    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+    return {
+        "enabled": enabled,
+        "disabled_rules": sorted(set(disabled_rules)),
+        "unattended_allow": sorted(set(unattended_allow)),
+    }
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -395,11 +395,18 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                 regex = _cmd_to_regex(cmd_str)
                 if not regex:
                     continue
-                patterns.append({
+                entry = {
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
-                })
+                }
+                # An explicit ``id:`` on the tooldef command yields a stable
+                # rule ID (e.g. ``git.push``) that survives description edits —
+                # needed so ``safety.unattended_allow`` can name it reliably.
+                # Without one, ``_assign_rule_id`` derives a slug from the reason.
+                if cmd_def.get("id"):
+                    entry["id"] = str(cmd_def["id"])
+                patterns.append(entry)
         except Exception:
             continue
     return patterns
@@ -475,20 +482,76 @@ def load_config(
     return merged
 
 
+# ============================================================================
+# UNATTENDED (NO-HUMAN-PRESENT) RESOLUTION
+# ============================================================================
+#
+# The damage-control hook classifies commands into allow / block / ask. The
+# ``ask`` tier only means something when a human is present to confirm. Under
+# the scheduler (cron, nobody watching) sessions run with
+# ``--dangerously-skip-permissions``, so historically ``ask`` resolved to a
+# SILENT allow — an unsupervised agent could deploy / drop a table / force-push.
+#
+# When a session is marked unattended (``AGENTWIRE_UNATTENDED=1``, stamped at
+# dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
+# block + notify the owner, UNLESS the matched rule's stable ID is on the
+# allowlist. The allowlist is the union of:
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
+#      irreversible or outward-facing),
+#   2. ``safety.unattended_allow`` from global / project config,
+#   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
+#      extension the scheduler stamps from a task's ``unattended_allow``.
+#
+# Hard ``block`` rules (rm -rf, git push --force, …) are unaffected — they fire
+# regardless. Interactive bypass sessions (no ``AGENTWIRE_UNATTENDED``) are
+# unaffected too — their ``ask`` still resolves the old way.
+
+DEFAULT_UNATTENDED_ALLOW = {
+    "git.add",       # stage files
+    "git.add-u",     # stage tracked changes
+    "git.commit",    # commit
+    "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
+    "gh.pr-create",  # open a PR — the human-reviewed gate
+}
+
+
+def is_unattended() -> bool:
+    """True when this session was dispatched with no human present (scheduler)."""
+    return os.environ.get("AGENTWIRE_UNATTENDED") == "1"
+
+
+def resolve_unattended_allow(config: Dict[str, Any]) -> set:
+    """Effective unattended allowlist: defaults ∪ config ∪ per-task env extension."""
+    allow = set(DEFAULT_UNATTENDED_ALLOW)
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    for rid in safety_cfg.get("unattended_allow", []) or []:
+        if rid:
+            allow.add(str(rid))
+    env_allow = os.environ.get("AGENTWIRE_UNATTENDED_ALLOW", "")
+    for rid in env_allow.split(","):
+        rid = rid.strip()
+        if rid:
+            allow.add(rid)
+    return allow
+
+
 def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve the effective ``safety`` block from global + nearest project config.
 
-    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
-    overrides global; ``disabled_rules`` are merged (set-union).
+    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
+    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
+    ``unattended_allow`` are merged (set-union).
     """
     enabled = True
     disabled_rules: List[str] = []
+    unattended_allow: List[str] = []
     project_enabled: Optional[bool] = None
     if not yaml:
-        return {"enabled": enabled, "disabled_rules": disabled_rules}
+        return {"enabled": enabled, "disabled_rules": disabled_rules,
+                "unattended_allow": unattended_allow}
 
     if global_config_path is None:
         global_config_path = Path.home() / ".agentwire" / "config.yaml"
@@ -503,6 +566,9 @@ def load_safety_config(
                 rules = safety.get("disabled_rules", [])
                 if isinstance(rules, list):
                     disabled_rules.extend(str(r) for r in rules if r)
+                allow = safety.get("unattended_allow", [])
+                if isinstance(allow, list):
+                    unattended_allow.extend(str(a) for a in allow if a)
     except Exception:
         pass
 
@@ -522,6 +588,9 @@ def load_safety_config(
                     prules = psafety.get("disabled_rules", [])
                     if isinstance(prules, list):
                         disabled_rules.extend(str(r) for r in prules if r)
+                    pallow = psafety.get("unattended_allow", [])
+                    if isinstance(pallow, list):
+                        unattended_allow.extend(str(a) for a in pallow if a)
             except Exception:
                 pass
             break
@@ -533,7 +602,11 @@ def load_safety_config(
     if project_enabled is not None:
         enabled = project_enabled
 
-    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+    return {
+        "enabled": enabled,
+        "disabled_rules": sorted(set(disabled_rules)),
+        "unattended_allow": sorted(set(unattended_allow)),
+    }
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -364,11 +364,18 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                 regex = _cmd_to_regex(cmd_str)
                 if not regex:
                     continue
-                patterns.append({
+                entry = {
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
-                })
+                }
+                # An explicit ``id:`` on the tooldef command yields a stable
+                # rule ID (e.g. ``git.push``) that survives description edits —
+                # needed so ``safety.unattended_allow`` can name it reliably.
+                # Without one, ``_assign_rule_id`` derives a slug from the reason.
+                if cmd_def.get("id"):
+                    entry["id"] = str(cmd_def["id"])
+                patterns.append(entry)
         except Exception:
             continue
     return patterns
@@ -444,20 +451,76 @@ def load_config(
     return merged
 
 
+# ============================================================================
+# UNATTENDED (NO-HUMAN-PRESENT) RESOLUTION
+# ============================================================================
+#
+# The damage-control hook classifies commands into allow / block / ask. The
+# ``ask`` tier only means something when a human is present to confirm. Under
+# the scheduler (cron, nobody watching) sessions run with
+# ``--dangerously-skip-permissions``, so historically ``ask`` resolved to a
+# SILENT allow — an unsupervised agent could deploy / drop a table / force-push.
+#
+# When a session is marked unattended (``AGENTWIRE_UNATTENDED=1``, stamped at
+# dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
+# block + notify the owner, UNLESS the matched rule's stable ID is on the
+# allowlist. The allowlist is the union of:
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
+#      irreversible or outward-facing),
+#   2. ``safety.unattended_allow`` from global / project config,
+#   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
+#      extension the scheduler stamps from a task's ``unattended_allow``.
+#
+# Hard ``block`` rules (rm -rf, git push --force, …) are unaffected — they fire
+# regardless. Interactive bypass sessions (no ``AGENTWIRE_UNATTENDED``) are
+# unaffected too — their ``ask`` still resolves the old way.
+
+DEFAULT_UNATTENDED_ALLOW = {
+    "git.add",       # stage files
+    "git.add-u",     # stage tracked changes
+    "git.commit",    # commit
+    "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
+    "gh.pr-create",  # open a PR — the human-reviewed gate
+}
+
+
+def is_unattended() -> bool:
+    """True when this session was dispatched with no human present (scheduler)."""
+    return os.environ.get("AGENTWIRE_UNATTENDED") == "1"
+
+
+def resolve_unattended_allow(config: Dict[str, Any]) -> set:
+    """Effective unattended allowlist: defaults ∪ config ∪ per-task env extension."""
+    allow = set(DEFAULT_UNATTENDED_ALLOW)
+    safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
+    for rid in safety_cfg.get("unattended_allow", []) or []:
+        if rid:
+            allow.add(str(rid))
+    env_allow = os.environ.get("AGENTWIRE_UNATTENDED_ALLOW", "")
+    for rid in env_allow.split(","):
+        rid = rid.strip()
+        if rid:
+            allow.add(rid)
+    return allow
+
+
 def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resolve the effective ``safety`` block from global + nearest project config.
 
-    Returns ``{enabled: bool, disabled_rules: list[str]}``. Project ``.agentwire.yml``
-    overrides global; ``disabled_rules`` are merged (set-union).
+    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
+    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
+    ``unattended_allow`` are merged (set-union).
     """
     enabled = True
     disabled_rules: List[str] = []
+    unattended_allow: List[str] = []
     project_enabled: Optional[bool] = None
     if not yaml:
-        return {"enabled": enabled, "disabled_rules": disabled_rules}
+        return {"enabled": enabled, "disabled_rules": disabled_rules,
+                "unattended_allow": unattended_allow}
 
     if global_config_path is None:
         global_config_path = Path.home() / ".agentwire" / "config.yaml"
@@ -472,6 +535,9 @@ def load_safety_config(
                 rules = safety.get("disabled_rules", [])
                 if isinstance(rules, list):
                     disabled_rules.extend(str(r) for r in rules if r)
+                allow = safety.get("unattended_allow", [])
+                if isinstance(allow, list):
+                    unattended_allow.extend(str(a) for a in allow if a)
     except Exception:
         pass
 
@@ -491,6 +557,9 @@ def load_safety_config(
                     prules = psafety.get("disabled_rules", [])
                     if isinstance(prules, list):
                         disabled_rules.extend(str(r) for r in prules if r)
+                    pallow = psafety.get("unattended_allow", [])
+                    if isinstance(pallow, list):
+                        unattended_allow.extend(str(a) for a in pallow if a)
             except Exception:
                 pass
             break
@@ -502,7 +571,11 @@ def load_safety_config(
     if project_enabled is not None:
         enabled = project_enabled
 
-    return {"enabled": enabled, "disabled_rules": sorted(set(disabled_rules))}
+    return {
+        "enabled": enabled,
+        "disabled_rules": sorted(set(disabled_rules)),
+        "unattended_allow": sorted(set(unattended_allow)),
+    }
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -1052,7 +1052,9 @@ def _pre_create_session(task: SchedulerTask) -> None:
     if task.model:
         cmd.extend(["--model", task.model])
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=_sched_config().session_create_timeout)
+    result = subprocess.run(cmd, capture_output=True, text=True,
+                            timeout=_sched_config().session_create_timeout,
+                            env=_unattended_env(task))
     if result.returncode == 0:
         print(f"[{_ts()}] Pre-created session: {task.session} (type={task.type or 'default'}, model={task.model or 'default'})")
     else:
@@ -1284,14 +1286,39 @@ def _dispatch_ensure_task(board: Board, task: SchedulerTask, existing_state: Tas
     return _dispatch_inplace_task(board, task, existing_state)
 
 
-def _run_ensure(cmd: list[str]) -> tuple[int, "subprocess.CompletedProcess | None", int]:
+def _unattended_env(task: SchedulerTask) -> dict[str, str]:
+    """Env overlay marking a headless dispatch as unattended (no human present).
+
+    THE single chokepoint where the scheduler declares a run unattended. Every
+    dispatch gets ``AGENTWIRE_UNATTENDED=1``; if the project task defines
+    ``unattended_allow`` (its per-task extension to the global allowlist), those
+    rule ids are passed via ``AGENTWIRE_UNATTENDED_ALLOW``. This overlay is the
+    subprocess ``env=`` for the ensure/new dispatch calls; ``agentwire``'s
+    ``_build_tmux_env_flags`` funnels both vars into the new tmux session before
+    the agent launches, where the damage-control hook reads them. Interactive
+    sessions never go through here, so the marker can't leak into them.
+    """
+    env = dict(os.environ)
+    env["AGENTWIRE_UNATTENDED"] = "1"
+    try:
+        from .tasks import load_task
+        tc = load_task(Path(task.project), task.task)
+        extra = getattr(tc, "unattended_allow", None)
+        if extra:
+            env["AGENTWIRE_UNATTENDED_ALLOW"] = ",".join(str(x) for x in extra if x)
+    except Exception:
+        pass
+    return env
+
+
+def _run_ensure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[int, "subprocess.CompletedProcess | None", int]:
     """Run an `agentwire ensure` subprocess; return (exit_code, result, duration_s)."""
     start_time = time.time()
     result = None
     try:
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, start_new_session=True,
+            text=True, start_new_session=True, env=env,
         )
         stdout, stderr = proc.communicate()
         exit_code = proc.returncode
@@ -1358,7 +1385,7 @@ def _dispatch_inplace_task(board: Board, task: SchedulerTask, existing_state: Ta
         # No type/role overrides — kill stale session so ensure creates fresh
         _kill_session(task.session)
 
-    exit_code, result, duration = _run_ensure(cmd)
+    exit_code, result, duration = _run_ensure(cmd, env=_unattended_env(task))
     status = _EXIT_TO_STATUS.get(exit_code, "failed")
 
     # On lock conflict, don't update last_run so task remains eligible
@@ -1427,11 +1454,13 @@ def _dispatch_worktree_task(board: Board, task: SchedulerTask, existing_state: T
     if task.model:
         new_cmd += ["--model", task.model]
 
+    unattended_env = _unattended_env(task)
     worktree_path = ""
     new_res = None
     try:
         new_res = subprocess.run(new_cmd, capture_output=True, text=True,
-                                 timeout=cfg.session_create_timeout)
+                                 timeout=cfg.session_create_timeout,
+                                 env=unattended_env)
         if new_res.returncode == 0:
             worktree_path = (json.loads(new_res.stdout) or {}).get("path", "")
     except Exception:
@@ -1454,7 +1483,7 @@ def _dispatch_worktree_task(board: Board, task: SchedulerTask, existing_state: T
         "agentwire", "ensure", "-s", wt_session, "--task", task.task,
         "--project", worktree_path, "--json",
     ]
-    exit_code, result, duration = _run_ensure(cmd)
+    exit_code, result, duration = _run_ensure(cmd, env=unattended_env)
     status = _EXIT_TO_STATUS.get(exit_code, "failed")
 
     if exit_code == _EXIT_LOCK_CONFLICT:

--- a/agentwire/tasks.py
+++ b/agentwire/tasks.py
@@ -105,6 +105,12 @@ class TaskConfig:
     starting_session: str | None = None  # Fork Claude context from this session before running
     role: str | None = None              # Role override for this task
 
+    # Unattended (no-human) safety: damage-control rule ids this scheduled task
+    # is permitted to run when the dispatch is unattended, EXTENDING the global
+    # default allowlist (safety.unattended_allow / DEFAULT_UNATTENDED_ALLOW).
+    # Anything ask-tier and off the merged list is blocked + owner-notified.
+    unattended_allow: list[str] = field(default_factory=list)
+
 
 def parse_pre_command(name: str, config: str | dict) -> PreCommand:
     """Parse a pre-command from config.
@@ -202,6 +208,11 @@ def parse_task_config(name: str, config: dict, default_shell: str | None = None)
         pr_draft=config.get("pr_draft", True),
         starting_session=config.get("starting_session"),
         role=config.get("role"),
+        unattended_allow=(
+            list(config.get("unattended_allow", []))
+            if isinstance(config.get("unattended_allow"), list)
+            else []
+        ),
     )
 
 

--- a/agentwire/tooldefs/gh.yaml
+++ b/agentwire/tooldefs/gh.yaml
@@ -50,6 +50,7 @@ commands:
   - cmd: "gh pr create"
     access: write
     description: Create a pull request
+    id: gh.pr-create
 
   - cmd: "gh pr merge [<pr>]"
     access: write

--- a/agentwire/tooldefs/git.yaml
+++ b/agentwire/tooldefs/git.yaml
@@ -41,14 +41,17 @@ commands:
   - cmd: "git add <file>"
     access: write
     description: Stage file for commit
+    id: git.add
 
   - cmd: "git add -u"
     access: write
     description: Stage all tracked file changes (deletions + modifications)
+    id: git.add-u
 
   - cmd: "git commit -m '<message>'"
     access: write
     description: Create a commit
+    id: git.commit
 
   - cmd: "git stash"
     access: write
@@ -87,6 +90,7 @@ commands:
   - cmd: "git push"
     access: write
     description: Push commits to remote
+    id: git.push
 
   - cmd: "git push --force-with-lease"
     access: write

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -185,12 +185,76 @@ Per-project paths are relative to the project root and resolved to absolute path
 
 **Precedence**:
 1. Hard-blocked `bashToolPatterns` (no `bypassable` flag) — always blocked, NEVER bypassed
-2. Ask patterns (`ask: true`) — always prompt for confirmation
+2. Ask patterns (`ask: true`) — prompt for confirmation when a human is present; **fail closed when unattended** (see below)
 3. Bypassable `bashToolPatterns` (`bypassable: true`) — check allowlist for required operation
 4. `allowedPaths` (global + per-project merged) — if target matches with correct operation, skip path checks
 5. `zeroAccessPaths` — block (unless allowlisted with `read`)
 6. `readOnlyPaths` — block modifications (unless allowlisted with specific operation)
 7. `noDeletePaths` — block deletions (unless allowlisted with `delete`)
+
+---
+
+## Unattended (no-human-present) guardrail
+
+The `ask` tier only means something when a human is there to confirm. The
+scheduler dispatches agents headless (cron, nobody watching) with
+`--dangerously-skip-permissions`, so historically an `ask`-tier command
+resolved to a **silent allow** — an unsupervised agent could deploy, drop a
+table, or delete a remote branch with no one seeing it until after the fact.
+
+When a session is marked **unattended**, the bash hook resolves `ask` by
+**failing closed**: it **blocks** the command and **emails the owner**, unless
+the matched rule's stable ID is on the unattended allowlist.
+
+**How a session is marked unattended.** The scheduler is the single chokepoint:
+on every headless dispatch it seeds `AGENTWIRE_UNATTENDED=1` (and any per-task
+`AGENTWIRE_UNATTENDED_ALLOW`) into the dispatch subprocess environment
+(`scheduler._unattended_env`). Session creation funnels that marker into the new
+tmux session via `tmux new-session -e K=V` (`__main__._with_unattended_env`), so
+it lands before the agent launches and the hook can read it. Interactive
+sessions never pass through that chokepoint, so the marker can't leak into a
+human's session — even though interactive sessions use the same
+`--dangerously-skip-permissions` posture. A child session an unattended agent
+spawns inherits the marker (defense in depth).
+
+**What's unaffected.** Hard `block` rules (`rm -rf`, `git push --force`, DB
+drops) fire regardless — they never depended on a human. Interactive `bypass`
+sessions resolve `ask` exactly as before. The kill switch still wins: with
+`safety.enabled: false`, nothing is checked, so the unattended gate is inert too
+(enable safety for scheduled projects to engage it).
+
+**The allowlist** (union of three sources):
+
+| Source | Where | Scope |
+|--------|-------|-------|
+| `DEFAULT_UNATTENDED_ALLOW` | `safety/_core.py` | Built-in: `git.add`, `git.add-u`, `git.commit`, `git.push`, `gh.pr-create` — work + open a PR, nothing irreversible or outward-facing |
+| `safety.unattended_allow` | `config.yaml` / project `.agentwire.yml` | Global / per-project extension (list of rule ids) |
+| `unattended_allow` | per-task in `.agentwire.yml` | Per-task extension — the pressure-relief valve: widen for one task instead of loosening the global default |
+
+Allowlisting is **by rule ID**, not command text — so `git.push` (plain push)
+is allowed while `git push --force` (hard block) and `git push --delete`
+(distinct `ask` rule `git.deletes-remote-branch`) are not. Tooldef commands the
+allowlist references carry an explicit `id:` so the ID is stable across
+description edits.
+
+When a command is blocked, the owner email and `agentwire safety logs` name the
+exact rule id, so widening is copy-paste: add that id to the task's
+`unattended_allow`.
+
+```yaml
+# project .agentwire.yml — let ONE scheduled task run terraform apply unattended
+tasks:
+  infra-drift:
+    prompt: reconcile infra drift and apply
+    unattended_allow:
+      - tooldef.terraform-apply-planned-changes-to-infrastructure
+```
+
+> **Coverage note:** the guardrail makes the `ask` tier fail closed. A
+> destructive command that isn't classified as `ask`/`block` at all (e.g. some
+> cloud-deploy or outbound-email verbs not yet in the rules) is unaffected and
+> remains a separate rules-coverage task — the moment such a verb is classified
+> `ask`, this guardrail blocks it unattended for free.
 
 ---
 

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -237,6 +237,95 @@ class TestBashHookSubprocess:
         assert "Invalid JSON" in proc.stderr or "Error" in proc.stderr
 
 
+class TestUnattendedAllowlist:
+    """Pure-function tests for the unattended (no-human) ask resolution (#401)."""
+
+    def test_is_unattended_reads_env(self, bash_hook, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED", raising=False)
+        assert bash_hook.is_unattended() is False
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED", "1")
+        assert bash_hook.is_unattended() is True
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED", "0")
+        assert bash_hook.is_unattended() is False
+
+    def test_default_allowlist_covers_work_and_pr(self, bash_hook, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED_ALLOW", raising=False)
+        allow = bash_hook.resolve_unattended_allow({"safety": {}})
+        # work + open a PR, nothing irreversible/outward
+        assert {"git.add", "git.commit", "git.push", "gh.pr-create"} <= allow
+        assert "gh.pr-merge" not in allow
+
+    def test_config_extends_default(self, bash_hook, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED_ALLOW", raising=False)
+        allow = bash_hook.resolve_unattended_allow(
+            {"safety": {"unattended_allow": ["custom.rule"]}}
+        )
+        assert "custom.rule" in allow
+        assert "git.commit" in allow  # default still present
+
+    def test_env_extension_merges(self, bash_hook, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED_ALLOW", "task.rule-a, task.rule-b")
+        allow = bash_hook.resolve_unattended_allow({"safety": {}})
+        assert {"task.rule-a", "task.rule-b"} <= allow
+
+
+class TestUnattendedSubprocess:
+    """End-to-end exit codes for the unattended ask resolution (#401)."""
+
+    HOOK = HOOKS_DIR / "bash-tool-damage-control.py"
+
+    def _run(self, command, unattended, permission_mode="bypassPermissions",
+             allow_env=None):
+        env = {
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": "/tmp",  # no ~/.agentwire/config.yaml → safety enabled (default)
+        }
+        if unattended:
+            env["AGENTWIRE_UNATTENDED"] = "1"
+        if allow_env:
+            env["AGENTWIRE_UNATTENDED_ALLOW"] = allow_env
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "permission_mode": permission_mode,
+        }
+        return subprocess.run(
+            [sys.executable, str(self.HOOK)],
+            input=json.dumps(payload),
+            capture_output=True, text=True, env=env, timeout=15,
+        )
+
+    def test_ask_tier_blocks_when_unattended(self):
+        # gh pr merge is ask-tier and NOT on the allowlist → fail closed
+        proc = self._run("gh pr merge 5", unattended=True)
+        assert proc.returncode == 2
+        assert "unattended" in proc.stderr.lower()
+
+    def test_allowlisted_proceeds_when_unattended(self):
+        # git commit is on the default allowlist → proceeds
+        proc = self._run("git commit -m 'x'", unattended=True)
+        assert proc.returncode == 0
+
+    def test_hard_block_still_fires_when_unattended(self):
+        # git push --force is hard-block tier → blocked regardless
+        proc = self._run("git push --force", unattended=True)
+        assert proc.returncode == 2
+
+    def test_interactive_bypass_unchanged(self):
+        # Same ask-tier command with no unattended marker → allow (legacy bypass)
+        proc = self._run("gh pr merge 5", unattended=False,
+                         permission_mode="bypassPermissions")
+        assert proc.returncode == 0
+
+    def test_per_task_env_extension_allows(self):
+        # Extending the allowlist via the per-task env var lets it proceed
+        proc = self._run(
+            "gh pr merge 5", unattended=True,
+            allow_env="tooldef.github-cli-merge-a-pull-request",
+        )
+        assert proc.returncode == 0
+
+
 # ---------------------------------------------------------------------------
 # edit-tool-damage-control.py & write-tool-damage-control.py
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -519,7 +519,7 @@ class TestPersistentSessionDispatch:
         monkeypatch.setattr(agentwire.locking, "remove_stale_lock", lambda s: None)
         monkeypatch.setattr(scheduler, "_kill_session", lambda s: killed.append(s))
         monkeypatch.setattr(scheduler, "_pre_create_session", lambda t: precreated.append(t.session))
-        monkeypatch.setattr(scheduler, "_run_ensure", lambda cmd: (0, None, 1))
+        monkeypatch.setattr(scheduler, "_run_ensure", lambda cmd, env=None: (0, None, 1))
         monkeypatch.setattr(scheduler, "_parse_ensure_summary", lambda t, r: ("ok", [], []))
         monkeypatch.setattr(scheduler, "_log_event", lambda *a, **k: None)
         monkeypatch.setattr(scheduler, "_notify_portal", lambda *a, **k: None)


### PR DESCRIPTION
Closes #401

## What & why

The damage-control hook classifies bash commands into **allow / block / ask**. The `ask` tier only means something when a human is present to confirm. The scheduler dispatches agents **headless** (cron, nobody watching) with `--dangerously-skip-permissions`, so an `ask`-tier command — a deploy, a DB write, `gh pr merge`, `git push --delete` — resolved to a **silent allow** and executed unsupervised.

This is **not** a parallel safety system — it's an improvement to the existing hook: teach the `ask` tier to resolve **safely** when no human is watching. Hard blocks and interactive behavior are untouched.

## How it works

**1. Mark unattended at a single scheduler chokepoint.** `scheduler._unattended_env(task)` seeds `AGENTWIRE_UNATTENDED=1` (+ per-task `AGENTWIRE_UNATTENDED_ALLOW`) into the dispatch subprocess env on **every** headless dispatch (inplace, pre-create, worktree). `__main__._with_unattended_env` funnels the marker into the new tmux session via `tmux new-session -e K=V`, so it's present **before** the agent launches and the hook can read it.

**2. Fail closed.** When `AGENTWIRE_UNATTENDED=1`, the bash hook resolves an `ask` verdict by **blocking** the command and **emailing the owner** (reusing the Resend wiring usage-limit recovery uses) — unless the matched rule's stable id is on the allowlist.

**3. Allowlist by rule id** (union of three sources):
| Source | Where | Scope |
|---|---|---|
| `DEFAULT_UNATTENDED_ALLOW` | `safety/_core.py` | `git.add`, `git.add-u`, `git.commit`, `git.push`, `gh.pr-create` — work + open a PR, nothing irreversible/outward |
| `safety.unattended_allow` | `config.yaml` / project `.agentwire.yml` | global / per-project extension |
| `unattended_allow` | per-task in `.agentwire.yml` | per-task pressure-relief valve |

By **rule id**, not command text — so `git.push` (plain) is allowed while `git push --force` (hard block) and `git push --delete` (distinct `ask` rule `git.deletes-remote-branch`) are not. Referenced tooldef commands carry an explicit `id:` so the id is stable across description edits.

## Owner rulings honored
- **(a) Fail-closed allowlist** (not dry-run).
- **(b) Default allowlist:** git commit / push (non-force) / staging, `gh pr create`, plus file edits and agentwire MCP tools (neither passes through the bash `ask` tier, so inherently permitted). Deploys, DB writes, outbound email, force-push, `rm`, `~/.agentwire` secrets → block/notify.
- **Per-task extension** via `.agentwire.yml` task `unattended_allow`, merges with the global default.
- **Single chokepoint, no interactive leak** — verified (below).

## Verification
All at the runtime boundary (real hook process, real rules, real env marker, real exit codes):
- `gh pr merge` (ask, not allowlisted) + `AGENTWIRE_UNATTENDED=1` → **exit 2 (blocked)**, "unattended" in stderr, notify fired.
- `git commit` / plain `git push` (allowlisted) under unattended → **exit 0 (proceeds)**.
- `git push --force` (hard block) under unattended → **exit 2** (unchanged).
- `gh pr merge` under interactive `bypassPermissions` (no marker) → **exit 0** (legacy behavior unchanged).
- Per-task `AGENTWIRE_UNATTENDED_ALLOW` extension → blocked command now proceeds.
- **No leak:** `_build_tmux_env_flags({})` emits the `-e AGENTWIRE_UNATTENDED=1` flag only when the marker is in the process env; absent for a normal interactive `agentwire new`.
- Per-task `unattended_allow` in `.agentwire.yml` flows through `_unattended_env` into the dispatch env.
- Full unit suite green (1380 passed).

> **Note for the owner:** this machine's global `~/.agentwire/config.yaml` has `safety.enabled: false`, which disables **all** damage control (the kill switch) — so the guardrail is inert until safety is enabled for scheduled projects (globally or per-project). Separately, some destructive verbs (e.g. certain cloud-deploy / outbound-email commands) aren't classified `ask`/`block` at all today — a rules-coverage gap orthogonal to this PR; the guardrail blocks them automatically the moment they're classified `ask`.

## Files
- `safety/_core.py` — `DEFAULT_UNATTENDED_ALLOW`, `is_unattended`, `resolve_unattended_allow`; `load_safety_config` returns `unattended_allow`; tooldef loader honors explicit `id:`. Hooks regenerated (sync test green).
- `bash-tool-damage-control.py` — unattended `ask` branch + fire-and-forget owner-notify.
- `__main__.py` — `_with_unattended_env` propagation; `agentwire safety notify-unattended-block` CLI.
- `scheduler.py` — `_unattended_env` chokepoint threaded through all dispatch subprocesses.
- `tasks.py` — per-task `unattended_allow`.
- `tooldefs/{git,gh}.yaml` — stable ids. Docs: `docs/wiki/internals/damage-control.md`, project-config skill, CLAUDE.md.

Built by [dotdev.dev](https://dotdev.dev)