### PR TITLE
feat(worktree): teardown + read-only git status across CLI, MCP, portal

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -51,6 +51,7 @@ from .worktree import (
     ensure_worktree,
     parse_session_name,
     remove_worktree,
+    worktree_status,
     git_root,
     default_base_branch,
     apply_naming,
@@ -5157,6 +5158,8 @@ def cmd_worktree(args) -> int:
         return _worktree_list(args, project_path, json_mode)
     if getattr(args, 'prune', False):
         return _worktree_prune(args, project_path, json_mode)
+    if getattr(args, 'status', False):
+        return _worktree_status(args, project_path, worktree_dir, json_mode)
     if getattr(args, 'remove', False):
         return _worktree_remove(args, project_path, worktree_dir, json_mode)
 
@@ -5344,6 +5347,10 @@ def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
     for r in rows:
         r["alive"] = tmux_session_exists(r.get("session", ""))
         r["exists"] = Path(r.get("worktree_path", "")).exists()
+        # Fold in read-only git status so the portal can badge the whole list
+        # without N round-trips. Local git only (no network) — cheap per entry.
+        if r["exists"]:
+            r["git"] = worktree_status(Path(r.get("worktree_path", "")))
 
     if json_mode:
         _output_json({"success": True, "entries": rows})
@@ -5356,8 +5363,66 @@ def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
 
     for r in rows:
         live = "live" if r["alive"] else ("orphan" if r["exists"] else "stale")
-        print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}")
+        print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}  {_git_badge(r.get('git'))}")
         print(f"      {r.get('worktree_path')}")
+    return 0
+
+
+def _git_badge(git: dict | None) -> str:
+    """One-line human summary of a worktree's git status (dirty/ahead/behind)."""
+    if not git or not git.get("exists"):
+        return ""
+    parts = []
+    if git.get("dirty"):
+        parts.append(f"dirty(+{git['staged']}/~{git['unstaged']}/?{git['untracked']})")
+    else:
+        parts.append("clean")
+    if not git.get("upstream"):
+        parts.append("no-upstream")
+    else:
+        if git.get("ahead"):
+            parts.append(f"↑{git['ahead']}")
+        if git.get("behind"):
+            parts.append(f"↓{git['behind']}")
+        if git.get("pushed") and not git.get("ahead"):
+            parts.append("pushed")
+    return " ".join(parts)
+
+
+def _worktree_status(args, project_path: Path, worktree_dir: Path, json_mode: bool) -> int:
+    """Read-only git status for one worktree session (--status). Never mutates."""
+    name = getattr(args, 'name', None)
+    if not name:
+        return _output_result(False, json_mode, "Usage: agentwire worktree --status <name|session>")
+
+    project_name = project_path.name
+    candidates = {name, f"{project_name}-{name}"}
+    entry = None
+    for e in worktree_registry.entries(project_path):
+        if e.get("session") in candidates or e.get("branch") == name or Path(e.get("worktree_path", "")).name in candidates:
+            entry = e
+            break
+
+    if entry:
+        session_name = entry.get("session")
+        worktree_path = Path(entry.get("worktree_path"))
+    else:
+        safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+        session_name = name if name.startswith(f"{project_name}-") else f"{project_name}-{safe_name}"
+        worktree_path = worktree_dir / session_name
+
+    git = worktree_status(worktree_path)
+
+    if json_mode:
+        _output_json({"success": True, "session": session_name,
+                      "worktree_path": str(worktree_path),
+                      "alive": tmux_session_exists(session_name), **git})
+        return 0
+
+    if not git.get("exists"):
+        print(f"Worktree path missing: {worktree_path}")
+        return 0
+    print(f"{session_name}  branch={git.get('branch')}  {_git_badge(git)}")
     return 0
 
 
@@ -11281,6 +11346,7 @@ def main() -> int:
     wt_parser.add_argument("--ref", help="Detach at a specific ref (tag, commit, branch)")
     wt_parser.add_argument("--project", "-p", help="Path to git repo (default: config worktree.default_project, else the git root of cwd)")
     wt_parser.add_argument("--list", action="store_true", help="List registered worktree sessions for this repo (--all for every repo)")
+    wt_parser.add_argument("--status", action="store_true", help="Show read-only git status (dirty/ahead/behind/pushed) for a worktree session")
     wt_parser.add_argument("--remove", action="store_true", help="Kill the session, remove the worktree, and unregister (cleanup/recovery)")
     wt_parser.add_argument("--prune", action="store_true", help="Drop registry entries whose worktree is gone + git worktree prune")
     wt_parser.add_argument("--all", action="store_true", help="With --list: include worktree sessions across every repo")

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -544,6 +544,119 @@ def session_kill(session: str) -> str:
     return f"Failed to kill session: {data.get('error', 'Unknown error')}"
 
 
+@mcp.tool()
+def worktree_list(project_dir: str = "") -> str:
+    """List worktree sessions for a repo, each with read-only git status.
+
+    Use this to see the state of in-flight worktree work before tearing it
+    down — which sessions are alive, and whether each worktree is clean and
+    pushed. Git status is local-only (no network): dirty/ahead/behind/pushed.
+
+    Args:
+        project_dir: Path to the git repo. Defaults to the server's cwd; pass a
+            repo path to scope the list to that project.
+
+    Returns:
+        Formatted list of worktree sessions, or a message if none are registered.
+    """
+    args = ["worktree", "--list"]
+    if project_dir:
+        args += ["--project", project_dir]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to list worktrees: {data.get('error', 'Unknown error')}"
+    entries = data.get("entries", [])
+    if not entries:
+        return "No worktree sessions registered."
+    lines = ["Worktree sessions:"]
+    for e in entries:
+        state = "live" if e.get("alive") else ("orphan" if e.get("exists") else "stale")
+        git = e.get("git") or {}
+        badge = ""
+        if git.get("exists"):
+            bits = ["dirty" if git.get("dirty") else "clean"]
+            if not git.get("upstream"):
+                bits.append("no-upstream")
+            else:
+                if git.get("ahead"):
+                    bits.append(f"ahead {git['ahead']}")
+                if git.get("behind"):
+                    bits.append(f"behind {git['behind']}")
+                if git.get("pushed") and not git.get("ahead"):
+                    bits.append("pushed")
+            badge = f" [{', '.join(bits)}]"
+        lines.append(f"  {e.get('session')} ({state}) branch={e.get('branch')}{badge}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def worktree_status(name: str, project_dir: str = "") -> str:
+    """Read-only git status for one worktree session (no network, no mutation).
+
+    Reports whether the worktree is clean and whether its branch is pushed —
+    use it to confirm the agent finished committing/pushing/PR'ing before you
+    call worktree_remove. This tool NEVER commits, pushes, or otherwise writes.
+
+    Args:
+        name: Worktree session name, branch, or short name.
+        project_dir: Path to the git repo (default: server cwd).
+
+    Returns:
+        Git status summary, or an error description.
+    """
+    args = ["worktree", "--status", name]
+    if project_dir:
+        args += ["--project", project_dir]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to get worktree status: {data.get('error', 'Unknown error')}"
+    if not data.get("exists"):
+        return f"Worktree path missing for '{name}' ({data.get('worktree_path')})."
+    bits = ["dirty" if data.get("dirty") else "clean"]
+    if data.get("dirty"):
+        bits[0] += f" (+{data.get('staged', 0)}/~{data.get('unstaged', 0)}/?{data.get('untracked', 0)})"
+    if not data.get("upstream"):
+        bits.append("no upstream (not pushed)")
+    else:
+        if data.get("ahead"):
+            bits.append(f"ahead {data['ahead']}")
+        if data.get("behind"):
+            bits.append(f"behind {data['behind']}")
+        if data.get("pushed") and not data.get("ahead"):
+            bits.append("pushed")
+    alive = "alive" if data.get("alive") else "no session"
+    return f"{data.get('session')} [{alive}] branch={data.get('branch')}: {', '.join(bits)}"
+
+
+@mcp.tool()
+def worktree_remove(name: str, project_dir: str = "") -> str:
+    """Tear down a worktree session: kill the session, remove the worktree + branch, unregister.
+
+    This is the teardown step. The agent should have already committed, pushed,
+    and opened its PR (confirm with worktree_status first). This kills the tmux
+    session, force-removes the git worktree, and drops the registry entry — it
+    does NOT push or open a PR for you.
+
+    Args:
+        name: Worktree session name, branch, or short name.
+        project_dir: Path to the git repo (default: server cwd).
+
+    Returns:
+        Success message describing what was removed, or an error description.
+    """
+    args = ["worktree", "--remove", name]
+    if project_dir:
+        args += ["--project", project_dir]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to remove worktree: {data.get('error', 'Unknown error')}"
+    session = data.get("session", name)
+    killed = " (killed live session)" if data.get("killed") else ""
+    if data.get("worktree_removed"):
+        return f"Removed worktree session '{session}'{killed}; worktree deleted."
+    return f"Unregistered '{session}'{killed}; worktree left at {data.get('path')} (not removed)."
+
+
 # =============================================================================
 # Pane Management Tools
 # =============================================================================

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -221,6 +221,7 @@ class AgentWireServer:
         self.app.router.add_get("/api/sessions", self.api_sessions)
         self.app.router.add_get("/api/sessions/local", self.api_sessions_local)
         self.app.router.add_get("/api/sessions/remote", self.api_sessions_remote)
+        self.app.router.add_get("/api/worktrees", self.api_worktrees)
         self.app.router.add_get("/api/projects", self.api_projects)
         self.app.router.add_post("/api/projects/create", self.api_projects_create)
         self.app.router.add_post("/api/projects/delete", self.api_projects_delete)
@@ -2495,6 +2496,21 @@ class AgentWireServer:
         except Exception as e:
             logger.error(f"Failed to list sessions: {e}")
             return web.json_response({"machines": []})
+
+    async def api_worktrees(self, request: web.Request) -> web.Response:
+        """List worktree sessions (across all repos) with read-only git status.
+
+        Thin wrapper over `agentwire worktree --list --all --json`; the CLI
+        folds in local-only git status (dirty/ahead/behind/pushed) per entry so
+        the sidebar can badge worktree sessions without per-session round-trips.
+        """
+        try:
+            success, result = await self.run_agentwire_cmd(["worktree", "--list", "--all"])
+            entries = result.get("entries", []) if success else []
+            return web.json_response({"entries": entries})
+        except Exception as e:
+            logger.error(f"Failed to list worktrees: {e}")
+            return web.json_response({"entries": []})
 
     async def api_sessions_local(self, request: web.Request) -> web.Response:
         """Fast endpoint for local sessions only (no SSH checks)."""

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -706,6 +706,33 @@ body {
     flex-wrap: wrap;
 }
 
+/* Worktree git-status badges (dirty/ahead/behind/pushed). Local git only. */
+.sidebar-session-git {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+    padding-left: 14px;
+    flex-wrap: wrap;
+}
+
+.sidebar-git-badge {
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 0 5px;
+    border-radius: 3px;
+    background: var(--chrome-border);
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.sidebar-git-badge.git-clean { color: var(--text-muted); }
+.sidebar-git-badge.git-dirty { background: rgba(251, 146, 60, 0.18); color: #fb923c; }
+.sidebar-git-badge.git-ahead { background: rgba(0, 191, 255, 0.18); color: #00bfff; }
+.sidebar-git-badge.git-behind { background: rgba(251, 146, 60, 0.18); color: #fb923c; }
+.sidebar-git-badge.git-pushed { background: rgba(57, 255, 20, 0.16); color: #39ff14; }
+.sidebar-git-badge.git-unpushed { background: rgba(248, 113, 113, 0.18); color: #f87171; }
+
 /* Session kill button — always visible and occupying its flex slot, so the
    row never reflows on hover. Confirm/killing states restyle in place. */
 .sidebar-session-close {

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -12,6 +12,9 @@ export const activityStates = new Map();
 loadCustomServices().then((changed) => { if (changed) notifyListeners(); });
 
 let allSessions = [];
+// session name → read-only git status ({dirty, ahead, behind, pushed, ...})
+// for worktree sessions, populated from /api/worktrees alongside session fetches.
+const worktreeGit = new Map();
 const listeners = new Set();
 
 // Close-button state: session name → confirm-expiry timer / in-flight kill.
@@ -32,6 +35,28 @@ function renderCloseButton(name) {
         return '<button class="sidebar-list-item-btn sidebar-session-close is-confirm" data-action="close" title="Click again to kill the session">sure?</button>';
     }
     return '<button class="sidebar-list-item-btn sidebar-list-item-btn-danger sidebar-session-close" data-action="close" title="Kill session (graceful /exit, then tmux kill)">✕</button>';
+}
+
+// Compact git-status badges for a worktree session. Returns '' for non-worktree
+// sessions (those absent from the worktree map). Local git only — no PR state.
+function renderGitBadges(name) {
+    const git = worktreeGit.get(name);
+    if (!git || !git.exists) return '';
+    const badges = [];
+    if (git.dirty) {
+        const n = (git.staged || 0) + (git.unstaged || 0) + (git.untracked || 0);
+        badges.push(`<span class="sidebar-git-badge git-dirty" title="${git.staged||0} staged, ${git.unstaged||0} unstaged, ${git.untracked||0} untracked">● dirty${n ? ` ${n}` : ''}</span>`);
+    } else {
+        badges.push('<span class="sidebar-git-badge git-clean" title="Working tree clean">clean</span>');
+    }
+    if (!git.upstream) {
+        badges.push('<span class="sidebar-git-badge git-unpushed" title="No upstream — branch not pushed">unpushed</span>');
+    } else {
+        if (git.ahead) badges.push(`<span class="sidebar-git-badge git-ahead" title="${git.ahead} commit(s) ahead of upstream">↑${git.ahead}</span>`);
+        if (git.behind) badges.push(`<span class="sidebar-git-badge git-behind" title="${git.behind} commit(s) behind upstream">↓${git.behind}</span>`);
+        if (git.pushed && !git.ahead) badges.push('<span class="sidebar-git-badge git-pushed" title="Pushed — upstream up to date">pushed</span>');
+    }
+    return `<div class="sidebar-session-git">${badges.join('')}</div>`;
 }
 
 export function renderCard(s, opts = {}) {
@@ -58,6 +83,7 @@ export function renderCard(s, opts = {}) {
         </div>
         ${path ? `<div class="sidebar-session-row2"><span class="sidebar-session-path">${path}</span></div>` : ''}
         ${tagsHtml ? `<div class="sidebar-session-row3">${tagsHtml}</div>` : ''}
+        ${renderGitBadges(name)}
     </div>`;
 }
 
@@ -151,7 +177,22 @@ function initData() {
     });
 }
 
+// Refresh worktree git status (dirty/ahead/behind/pushed) for badge rendering.
+// Fire-and-forget — failures just leave the badges absent, never block the list.
+async function fetchWorktrees() {
+    try {
+        const res = await apiFetch('/api/worktrees');
+        const data = await res.json();
+        worktreeGit.clear();
+        for (const e of (data.entries || [])) {
+            if (e.session && e.git) worktreeGit.set(e.session, e.git);
+        }
+        notifyListeners();
+    } catch (e) { /* leave badges absent on failure */ }
+}
+
 async function fetchSessions() {
+    fetchWorktrees();
     try {
         const localRes = await apiFetch('/api/sessions/local');
         const localData = await localRes.json();

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -334,6 +334,72 @@ def remove_worktree(project_path: Path, worktree_path: Path) -> bool:
     return result.returncode == 0
 
 
+def worktree_status(worktree_path: Path) -> dict:
+    """Read-only git status for a worktree. Local git only — no network, no gh.
+
+    Reports working-tree cleanliness and ahead/behind vs the upstream as it's
+    known locally (reflects the last fetch — never reaches out to the remote).
+    This is a pure read: it runs no `git add`/`commit`/`push`, by design.
+
+    Returns dict:
+        exists:    bool — the worktree path is present on disk
+        branch:    current branch name, or None if detached
+        dirty:     bool — any staged/unstaged/untracked changes
+        staged/unstaged/untracked: int counts
+        upstream:  upstream ref (e.g. "origin/fix-bug"), or None if unset
+        ahead:     commits on HEAD not on upstream
+        behind:    commits on upstream not on HEAD
+        pushed:    bool — upstream exists and ahead == 0 (work is on the remote)
+    """
+    wt = Path(worktree_path)
+    status = {
+        "exists": False, "branch": None, "dirty": False,
+        "staged": 0, "unstaged": 0, "untracked": 0,
+        "upstream": None, "ahead": 0, "behind": 0, "pushed": False,
+    }
+    if not wt.exists():
+        return status
+    status["exists"] = True
+
+    def _git(*a):
+        return subprocess.run(["git", "-C", str(wt), *a], capture_output=True, text=True)
+
+    # Current branch (None when detached, e.g. --ref worktrees).
+    r = _git("rev-parse", "--abbrev-ref", "HEAD")
+    branch = r.stdout.strip() if r.returncode == 0 else ""
+    status["branch"] = None if branch in ("", "HEAD") else branch
+
+    # Working-tree state via porcelain. Column X = index/staged, Y = worktree.
+    r = _git("status", "--porcelain")
+    if r.returncode == 0:
+        for line in r.stdout.splitlines():
+            if not line:
+                continue
+            xy = line[:2]
+            if xy == "??":
+                status["untracked"] += 1
+                continue
+            if xy[0] not in (" ", "?"):
+                status["staged"] += 1
+            if xy[1] not in (" ", "?"):
+                status["unstaged"] += 1
+        status["dirty"] = bool(status["staged"] or status["unstaged"] or status["untracked"])
+
+    # Upstream + ahead/behind, using the locally-stored remote-tracking ref.
+    up = _git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+    if up.returncode == 0 and up.stdout.strip():
+        status["upstream"] = up.stdout.strip()
+        # --left-right --count "@{upstream}...HEAD" → "<behind>\t<ahead>"
+        cnt = _git("rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+        if cnt.returncode == 0 and cnt.stdout.split():
+            parts = cnt.stdout.split()
+            if len(parts) == 2:
+                status["behind"], status["ahead"] = int(parts[0]), int(parts[1])
+        status["pushed"] = status["ahead"] == 0
+
+    return status
+
+
 def get_project_type(path: Path) -> str:
     """Determine project type based on git status.
 


### PR DESCRIPTION
Closes #430

Makes the full worktree lifecycle drivable from MCP, and gives the portal/MCP read-only git awareness of worktrees. SSOT preserved — every layer routes through the one CLI `worktree` command; portal and MCP stay thin `run_agentwire_cmd` wrappers with no parallel git logic.

## What's new

**CLI (source of truth)**
- `worktree_status(path)` helper — pure read, **local git only** (no network, no `gh`): `branch`, `dirty` (+staged/unstaged/untracked), `upstream`, `ahead`/`behind`, `pushed`.
- `agentwire worktree --status <name> --json`; git status folded into `worktree --list --json` (so the UI badges the whole list in one call).

**MCP** — three thin wrappers (`session_kill` style):
- `worktree_list`, `worktree_status` (read-only, documented as never-writes), `worktree_remove` (teardown: kill session + tmux, force-remove worktree + branch, unregister).
- No write verb — commit/push/PR stays the agent's job by design.

**Portal:** `GET /api/worktrees`. **Frontend:** git badges (dirty/ahead/behind/pushed/unpushed) on worktree session cards, brand-neon colors.

## The chain this enables
1. Agent: `commit` → `push -u` → `gh pr create --draft` → `msg_send(kind=done)`
2. Orchestrator: `worktree_status` to confirm clean + pushed → `worktree_remove` to tear down.

## Verified end-to-end
- Real-flow worktree (detach + `checkout -b`) reads `unpushed` until the agent pushes — confirmed against the actual creation path, not a naive `-b` test.
- Dirty detection, teardown (`worktree_removed: true`), MCP tool registration, and the live portal route returning the git field all check out.

> Note: agents must restart their session to see the new `worktree_*` MCP tools (separate process spawned by Claude Code).

Built by [dotdev.dev](https://dotdev.dev)