### PR TITLE
feat(briefing-mode): Phase 2 — passive ingest messaging + worktree_create/seed

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -5200,6 +5200,7 @@ def cmd_worktree(args) -> int:
             'model': getattr(args, 'model', None),
             'roles': getattr(args, 'roles', None),
             'instructions': None, 'persist': False,
+            'first_message': getattr(args, 'prompt', None),
             'env': getattr(args, 'env', None),
         })())
 
@@ -5218,15 +5219,21 @@ def cmd_worktree(args) -> int:
             session=session_name, base=default_base,
             worktree_path=worktree_path,
         )
-        if json_mode:
-            _output_json({"success": True, "session": session_name, "path": str(worktree_path), "reattached": True})
-        else:
-            print(f"Worktree exists: {worktree_path}")
         if tmux_session_exists(session_name):
+            # Already live. For automation/json, report and return (never paste
+            # into a live session); for a human, attach interactively.
+            if json_mode:
+                _output_json({"success": True, "session": session_name,
+                              "path": str(worktree_path), "reattached": True})
+                return 0
+            print(f"Worktree exists: {worktree_path}")
             subprocess.run(["tmux", "attach-session", "-t", session_name])
-        else:
-            return _launch_session()
-        return 0
+            return 0
+        # Worktree dir exists but no live session → relaunch (cmd_new emits the
+        # single authoritative json; don't print a second block here).
+        if not json_mode:
+            print(f"Worktree exists: {worktree_path}")
+        return _launch_session()
 
     # Resolve the git ref to create the worktree from
     base_branch = None
@@ -5324,12 +5331,10 @@ def cmd_worktree(args) -> int:
         worktree_path=worktree_path,
     )
 
-    if json_mode:
-        _output_json({
-            "success": True, "session": session_name, "path": str(worktree_path),
-            "branch": new_branch, "ref": git_ref, "reattached": False,
-        })
-    else:
+    # cmd_new (via _launch_session) emits the single authoritative json
+    # (session, path, branch, first_message_delivered) — don't print a second
+    # block here or run_agentwire_cmd's json.loads chokes on two objects.
+    if not json_mode:
         print(f"Created worktree: {worktree_path}")
         print(f"Mode: {mode_label}")
 
@@ -11353,6 +11358,7 @@ def main() -> int:
     _add_posture_harness_flags(wt_parser)
     wt_parser.add_argument("--type", help="Legacy fused session type / intent preset (accepted, not primary)")
     wt_parser.add_argument("--roles", help="Comma-separated roles, STACKED on top of the always-present worktree-session etiquette")
+    wt_parser.add_argument("--prompt", help="First message to deliver once the agent is booted/ready (spawn + seed in one step)")
     wt_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
     wt_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
     wt_parser.add_argument("--json", action="store_true", help="Output as JSON")

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -40,7 +40,16 @@ EVENTS_FILE = Path.home() / ".agentwire" / "inbox-events.jsonl"
 
 # Typed message enum, Overstory-inspired — kept deliberately small; this is a
 # mailbox, not a workflow engine.
-KINDS = ("note", "done", "request", "escalation")
+#
+# ``ingest`` is the PASSIVE kind: it is never auto-delivered (the watchdog skips
+# it), so it never drives the recipient into a turn. It lands silently in an
+# ``ingest/`` subdir and waits there until the recipient *voluntarily* pulls it
+# (``msg pull``). This is the "awareness without being driven" primitive —
+# correspondents drop a passive pointer; the anchor pulls on the human's cue.
+KINDS = ("note", "done", "request", "escalation", "ingest")
+
+# Kinds the drain never touches — they route to a subdir and are pull-only.
+PASSIVE_KINDS = ("ingest",)
 
 # Broadcast token: deliver to every live agent session except the sender.
 BROADCAST_TOKEN = "@all"
@@ -50,7 +59,12 @@ BROADCAST_TOKEN = "@all"
 # being permanently busy/typed-in).
 MAX_ATTEMPTS = 40
 
-_RESERVED_DIRS = {"dead", "sent", ".lock"}
+_RESERVED_DIRS = {"dead", "sent", ".lock", "ingest"}
+
+
+def is_passive(kind: str) -> bool:
+    """A passive kind is never auto-delivered — it's pull-only (see KINDS)."""
+    return kind in PASSIVE_KINDS
 
 
 # =============================================================================
@@ -112,6 +126,13 @@ def dead_dir(session: str) -> Path:
     return session_dir(session) / "dead"
 
 
+def ingest_dir(session: str) -> Path:
+    """Where passive (``ingest``) messages live — a reserved subdir the drain
+    never walks (it's in ``_RESERVED_DIRS`` and below the top-level glob), so
+    these wait silently until pulled."""
+    return session_dir(session) / "ingest"
+
+
 def _log_event(event: str, **fields) -> None:
     record = {"ts": _now_ms(), "event": event, **fields}
     try:
@@ -164,6 +185,37 @@ def pending_files(session: str) -> list[Path]:
 
 def list_messages(session: str) -> list[Message]:
     return [m for m in (_read_message(f) for f in pending_files(session)) if m]
+
+
+def ingest_files(session: str) -> list[Path]:
+    """A session's queued passive (ingest) message files, oldest first."""
+    idir = ingest_dir(session)
+    if not idir.is_dir():
+        return []
+    return sorted(idir.glob("*.json"))
+
+
+def list_ingest(session: str) -> list[Message]:
+    """Peek passive (ingest) messages without consuming them."""
+    return [m for m in (_read_message(f) for f in ingest_files(session)) if m]
+
+
+def pull_ingest(session: str) -> list[Message]:
+    """Read AND remove all passive (ingest) messages — the voluntary pull.
+
+    The inverse of being pushed: the recipient calls this on its own cadence
+    (e.g. the anchor when the human says "what's ready?"). Returns oldest-first.
+    The watchdog never delivers or dead-letters these, so pulling is the only
+    way they leave the inbox — the durable content lives in the files they
+    point at, not in the message itself.
+    """
+    msgs = list_ingest(session)
+    for m in msgs:
+        if m.path is not None:
+            m.path.unlink(missing_ok=True)
+    if msgs:
+        _log_event("pulled", to=session, count=len(msgs))
+    return msgs
 
 
 def list_dead(session: str) -> list[Message]:
@@ -247,12 +299,15 @@ def enqueue(
             ts=ns // 1_000_000,  # epoch ms (schema), derived from the same clock
             attempts=0,
         )
-        path = session_dir(target) / f"{msg.id}.json"
+        # Passive kinds land in the ingest/ subdir, which the drain never walks
+        # — so they wait silently until the recipient pulls them.
+        base = ingest_dir(target) if is_passive(kind) else session_dir(target)
+        path = base / f"{msg.id}.json"
         msg.path = path
         _write_message(path, msg)
         _log_event(
             "enqueued", id=msg.id, **{"from": sender}, to=target, kind=kind,
-            broadcast=(to == BROADCAST_TOKEN),
+            passive=is_passive(kind), broadcast=(to == BROADCAST_TOKEN),
         )
         written.append(msg)
     return written

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -397,7 +397,11 @@ def msg_send(to: str, text: str, kind: str = "note") -> str:
         to: Recipient session name, or "@all" to broadcast to every live
             agent session except yourself.
         text: The message body.
-        kind: One of note (default), done, request, escalation.
+        kind: One of note (default), done, request, escalation, ingest.
+            `ingest` is PASSIVE — never auto-delivered, so it never drives the
+            recipient into a turn; it waits until they `msg_pull` it. Use it for
+            "output ready to ingest" awareness signals (Briefing Mode): drop a
+            passive pointer to a file the recipient reads on the human's cue.
 
     Returns:
         Confirmation of which sessions were queued, or an error.
@@ -418,13 +422,16 @@ def msg_send(to: str, text: str, kind: str = "note") -> str:
 
 @mcp.tool()
 def msg_inbox(session: str | None = None) -> str:
-    """Peek a session's pending polite messages (does not drain them).
+    """Peek a session's pending + passive messages (does not drain or consume).
+
+    Shows both the driving `pending` messages (auto-delivered when the box
+    clears) and the `passive` ingest messages (which wait until you `msg_pull`).
 
     Args:
         session: Session name (default: the calling session).
 
     Returns:
-        The pending messages, or a note that the inbox is empty.
+        The pending and passive messages, or a note that the inbox is empty.
     """
     args = ["msg", "inbox"]
     if session:
@@ -433,10 +440,47 @@ def msg_inbox(session: str | None = None) -> str:
     if not data.get("success"):
         return f"Failed to read inbox: {data.get('error', 'Unknown error')}"
     pending = data.get("pending") or []
-    if not pending:
+    passive = data.get("passive") or []
+    if not pending and not passive:
         return f"Inbox empty for {data.get('session', session or 'this session')}."
-    lines = [f"{len(pending)} pending for {data.get('session')}:"]
-    for m in pending:
+    lines = []
+    if pending:
+        lines.append(f"{len(pending)} pending for {data.get('session')}:")
+        for m in pending:
+            lines.append(f"  [{m.get('kind')}] from {m.get('from')}: {m.get('text')}")
+    if passive:
+        lines.append(f"{len(passive)} passive (ingest) — call msg_pull to consume:")
+        for m in passive:
+            lines.append(f"  [{m.get('kind')}] from {m.get('from')}: {m.get('text')}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def msg_pull(session: str | None = None) -> str:
+    """Read and REMOVE passive (ingest) awareness messages — the voluntary pull.
+
+    This is the Briefing Mode anchor's move: ingest messages are never pushed to
+    you, so call this on the human's cue ("what's ready?") to collect the
+    "output ready" pointers correspondents dropped. Pulling consumes them; the
+    actual content lives in the files they point at, which you then read.
+
+    Args:
+        session: Session name (default: the calling session).
+
+    Returns:
+        The pulled messages, or a note that there were none.
+    """
+    args = ["msg", "pull"]
+    if session:
+        args += ["-s", session]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to pull messages: {data.get('error', 'Unknown error')}"
+    pulled = data.get("pulled") or []
+    if not pulled:
+        return f"No passive (ingest) messages for {data.get('session', session or 'this session')}."
+    lines = [f"Pulled {len(pulled)} passive message(s):"]
+    for m in pulled:
         lines.append(f"  [{m.get('kind')}] from {m.get('from')}: {m.get('text')}")
     return "\n".join(lines)
 
@@ -542,6 +586,56 @@ def session_kill(session: str) -> str:
     if data.get("success"):
         return f"Session '{session}' terminated."
     return f"Failed to kill session: {data.get('error', 'Unknown error')}"
+
+
+@mcp.tool()
+def worktree_create(
+    name: str,
+    project_dir: str = "",
+    roles: str = "",
+    base: str = "",
+    prompt: str = "",
+) -> str:
+    """Create a worktree session (new branch + checkout + tmux session), optionally seeded.
+
+    The spawn half of the worktree lifecycle (paired with worktree_status /
+    worktree_list / worktree_remove). Creates a branch off origin/<base>, a
+    worktree under ~/worktrees/, and a tmux session running an agent with the
+    worktree-session safety etiquette auto-injected. This is how a Briefing Mode
+    anchor fans out correspondents.
+
+    Args:
+        name: Worktree/branch name (becomes the branch + session suffix).
+        project_dir: Path to the git repo (default: server cwd).
+        roles: Comma-separated roles STACKED on the worktree-session etiquette
+            (e.g. "correspondent"). Never replaces the safety rail.
+        base: Base branch to fork from (default: the repo's origin/HEAD).
+        prompt: Optional first message — delivered once the agent is booted and
+            ready (verified paste). Lets you spawn AND seed the task in one call
+            instead of a separate session_send.
+
+    Returns:
+        Success message with the session name + worktree path, or an error.
+    """
+    args = ["worktree", name]
+    if project_dir:
+        args += ["-p", project_dir]
+    if roles:
+        args += ["--roles", roles]
+    if base:
+        args += ["--base", base]
+    if prompt:
+        args += ["--prompt", prompt]
+    # Seeding waits for agent boot (~up to 60s); give the CLI room to finish.
+    data = run_agentwire_cmd(args, timeout=90)
+    if not data.get("success"):
+        return f"Failed to create worktree: {data.get('error', 'Unknown error')}"
+    session = data.get("session", name)
+    path = data.get("path", "")
+    seeded = " (seeded)" if prompt and data.get("first_message_delivered") else ""
+    if data.get("reattached"):
+        return f"Reattached to existing worktree session '{session}' at {path}."
+    return f"Created worktree session '{session}'{seeded} at {path}."
 
 
 @mcp.tool()

--- a/agentwire/msg_cli.py
+++ b/agentwire/msg_cli.py
@@ -6,13 +6,18 @@ the recipient's file inbox and the watchdog injects it only when the input box
 is empty and the pane is a safe target — so a worker reporting back never
 clobbers a half-typed human draft.
 
-    agentwire msg send --to <session|@all> [--kind note|done|request|escalation] <text>
-    agentwire msg inbox [-s <session>]      # peek pending (does not drain)
+    agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest] <text>
+    agentwire msg inbox [-s <session>]      # peek pending + passive (does not drain/consume)
+    agentwire msg pull  [-s <session>]      # read + REMOVE passive (ingest) messages
     agentwire msg dead  [-s <session>]      # list dropped (dead-lettered) msgs
     agentwire msg flush [-s <session>]      # attempt a drain now (still gated)
 
 The drain also rides ``agentwire limits tick`` every 60s, so messages flow
 without anyone running ``flush``.
+
+The ``ingest`` kind is **passive**: never auto-delivered (the watchdog skips
+it), so it never drives the recipient. It waits until the recipient pulls it
+with ``msg pull`` — the "awareness without being driven" primitive.
 """
 
 from __future__ import annotations
@@ -81,20 +86,59 @@ def cmd_msg_inbox(args) -> int:
         return 1
 
     messages = inbox.list_messages(session)
+    passive = inbox.list_ingest(session)
     if getattr(args, "json", False):
         print(json.dumps({
             "success": True,
             "session": session,
             "pending": [m.to_dict() for m in messages],
+            "passive": [m.to_dict() for m in passive],
         }))
         return 0
 
-    if not messages:
+    if not messages and not passive:
         print(f"Inbox empty for {session}")
         return 0
-    print(f"{len(messages)} pending for {session}:")
-    for m in messages:
-        print(f"  [{m.kind}] from {m.sender} (attempts={m.attempts}): {m.text}")
+    if messages:
+        print(f"{len(messages)} pending for {session}:")
+        for m in messages:
+            print(f"  [{m.kind}] from {m.sender} (attempts={m.attempts}): {m.text}")
+    if passive:
+        print(f"{len(passive)} passive (ingest) for {session} — pull to consume:")
+        for m in passive:
+            print(f"  [{m.kind}] from {m.sender}: {m.text}")
+    return 0
+
+
+def cmd_msg_pull(args) -> int:
+    """Read and REMOVE passive (ingest) messages — the voluntary pull.
+
+    This is how an anchor ingests awareness signals on the human's cue: the
+    watchdog never delivers ingest messages, so pulling is the only way they
+    leave the inbox. The content they point at lives in files, not the message.
+    """
+    session = getattr(args, "session", None) or _current_session()
+    if not session:
+        print("No session (use -s or run inside a session)")
+        if getattr(args, "json", False):
+            print(json.dumps({"success": False, "error": "no session"}))
+        return 1
+
+    pulled = inbox.pull_ingest(session)
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "success": True,
+            "session": session,
+            "pulled": [m.to_dict() for m in pulled],
+        }))
+        return 0
+
+    if not pulled:
+        print(f"No passive (ingest) messages for {session}")
+        return 0
+    print(f"Pulled {len(pulled)} passive message(s) for {session}:")
+    for m in pulled:
+        print(f"  [{m.kind}] from {m.sender}: {m.text}")
     return 0
 
 
@@ -212,10 +256,15 @@ def register_msg_parser(subparsers) -> None:
     send_parser.add_argument("--json", action="store_true", help="Output JSON")
     send_parser.set_defaults(func=cmd_msg_send)
 
-    inbox_parser = msg_sub.add_parser("inbox", help="Peek pending messages (no drain)")
+    inbox_parser = msg_sub.add_parser("inbox", help="Peek pending + passive messages (no drain/consume)")
     inbox_parser.add_argument("-s", "--session", default=None, help="Session (default: current)")
     inbox_parser.add_argument("--json", action="store_true", help="Output JSON")
     inbox_parser.set_defaults(func=cmd_msg_inbox)
+
+    pull_parser = msg_sub.add_parser("pull", help="Read + remove passive (ingest) messages")
+    pull_parser.add_argument("-s", "--session", default=None, help="Session (default: current)")
+    pull_parser.add_argument("--json", action="store_true", help="Output JSON")
+    pull_parser.set_defaults(func=cmd_msg_pull)
 
     dead_parser = msg_sub.add_parser(
         "dead", help="List dead-lettered messages (dropped after retries)"

--- a/agentwire/roles/anchor.md
+++ b/agentwire/roles/anchor.md
@@ -39,15 +39,15 @@ Spawn as many as the question warrants — one is fine, five is fine. Be specifi
 
 ## Awareness — pull, don't get pushed
 
-Correspondents signal you **passively**: they write their report to the dropbox and that's it. There is no ping, by design — nothing they do drives you into a turn.
+Correspondents signal you **passively** with `--kind ingest` messages — a tiny pointer to the report they filed. These are *never* delivered to you automatically; they sit silently in your inbox until you choose to pull them. Nothing a correspondent does drives you into a turn. That's the whole point: you stay quiet until the human cues you.
 
-So when the human cues you, **list the dropbox and read what's there**:
+So when the human says "what's ready?" / "go", **pull your passive signals**, then read what they point at:
 
 ```
-ls -t ~/.agentwire/research/<your-session>/
+agentwire msg pull          # consumes the ingest pointers — shows you what's ready + the file paths
 ```
 
-Read the reports that have appeared, synthesize across them (don't relay them one by one — find the throughline, the agreements, the conflicts), form an opinion, and brief asymmetrically. If a correspondent hasn't filed yet, say so plainly and move on with what's ready.
+Read the report files those pointers reference (and/or `ls -t ~/.agentwire/research/<your-session>/` as a fallback). Synthesize across them (don't relay them one by one — find the throughline, the agreements, the conflicts), form an opinion, and brief asymmetrically. If a correspondent hasn't filed yet, say so plainly and move on with what's ready. Pulling consumes the pointers, so note what you've seen — the durable reports remain in the dropbox.
 
 ## Synthesis is the value
 

--- a/agentwire/roles/correspondent.md
+++ b/agentwire/roles/correspondent.md
@@ -29,11 +29,19 @@ date: <YYYY-MM-DD>
 
 Make it readable on its own — the anchor (or the human) may read it cold.
 
-## Signal passively — the file IS the signal
+## Signal passively — drop a pointer, never drive
 
-When your report is written, **you are done. Do not ping the anchor.** No `agentwire msg`, no `session_send`, no `notify-parent` — anything that pastes into the anchor's prompt would *drive* it into a turn, and the anchor must only act on the human's cue. The anchor reads the dropbox when the human says go; your file appearing there is the entire signal.
+When your report is written, send the anchor a **passive** awareness pointer — and *only* a passive one:
 
-This deliberately replaces the worktree-session "notify back when done" step. Write the file, then stop.
+```
+agentwire msg send --to <anchor-session> --kind ingest "report ready: <abs path to your findings file> — <5-word topic>"
+```
+
+The `ingest` kind is special: it is **never auto-delivered**. It lands silently in the anchor's inbox and waits there until the anchor *pulls* it on the human's cue — so it makes the anchor *aware* without ever driving it into a turn. Keep the message tiny: it's a pointer, not the report. The depth lives in the file.
+
+**Do NOT** use `--kind done`/`note`, `session_send`, or `notify-parent` — those paste into the anchor's prompt and drive it, which breaks the whole mode. This passive pointer deliberately replaces the worktree-session "notify back when done" step.
+
+Then you're done — write the file, drop the passive pointer, stop.
 
 ## PRs
 

--- a/docs/wiki/research/briefing-mode-feasibility.md
+++ b/docs/wiki/research/briefing-mode-feasibility.md
@@ -3,11 +3,16 @@ name: Briefing Mode — asymmetric-verbosity orchestration (feasibility)
 status: active
 last_updated: 2026-06-21
 phase_1: shipped
+phase_2: shipped
 ---
 
 # Briefing Mode — asymmetric-verbosity orchestration
 
-> **Status — Phase 1 shipped (2026-06-21):** the `anchor` and `correspondent` roles exist (`agentwire/roles/`). Awareness is via a filesystem dropbox (`~/.agentwire/research/<anchor-session>/`) — non-driving by construction, no inbox changes. Spawn an anchor with `agentwire new -s <name> --roles anchor`; it fans out `agentwire worktree <angle> --roles correspondent`, correspondents file deep reports to the dropbox, the anchor pulls + briefs asymmetrically (`say` headline + `portal_notify` card) on the human's cue, and tears down via `agentwire worktree --remove`. **Phase 2** (the passive `ingest` message kind + `msg pull`, MCP `worktree_create` + a `--prompt` seed flag) and **Phase 3** (unified `say(display=)`, blessed dropbox resolver) remain — see §9.
+> **Status — Phases 1 & 2 shipped (2026-06-21):**
+> - **Phase 1:** the `anchor` and `correspondent` roles (`agentwire/roles/`). Spawn an anchor with `agentwire new -s <name> --roles anchor`; it fans out correspondents, which file deep reports to a dropbox (`~/.agentwire/research/<anchor-session>/`); the anchor briefs asymmetrically (`say` headline + `portal_notify` card) on the human's cue.
+> - **Phase 2:** the passive `ingest` message kind — never auto-delivered (routes to a reserved `ingest/` subdir the drain skips), pulled with `agentwire msg pull` / MCP `msg_pull`. Correspondents now drop a passive pointer; the anchor pulls on the human's cue (awareness without being driven). Plus MCP `worktree_create` and a `--prompt` seed flag on `agentwire worktree` (spawn + seed in one call, verified delivery), completing the worktree lifecycle quartet (create / status / list / remove).
+>
+> **Phase 3** (unified `say(display=)`, markdown in the toast, blessed dropbox resolver + typed `ref` field) remains — see §9.
 
 > Feasibility + design report. Investigates building an orchestration mode where the **human-facing orchestrator is deliberately terse** (and splits its summary across voice vs. on-screen text so the two channels complement rather than duplicate) while **researcher worktree sessions are exhaustively verbose** and go deep. Researchers signal the orchestrator only with **passive, non-driving** "output ready" awareness; the orchestrator acts only when the **human** directs it.
 >


### PR DESCRIPTION
Closes #435

Phase 2 of **Briefing Mode** — the one genuinely new primitive (*awareness without being driven*) plus the plumbing to spawn-and-seed correspondents in one call. Builds on Phase 1 (#433, merged).

## Passive `ingest` messaging (the crux)
Today's `msg` is non-clobbering but it still presses Enter — it *drives* the recipient into a turn, precisely when their box is idle. That's the opposite of what an anchor waiting for the human needs.

- New **`ingest`** kind that is **never auto-delivered**. It routes to a reserved `ingest/` subdir that the top-level glob and `_RESERVED_DIRS` already exclude — so the drain *and* the watchdog skip it with **zero drain-logic changes** ("ls is the protocol").
- **`agentwire msg pull` / MCP `msg_pull`** — read + remove passive messages: the *voluntary* pull, on the human's cue. `msg inbox` / `msg_inbox` now also surface passive messages (without consuming).

## `worktree_create` + seed
- **MCP `worktree_create`** completes the lifecycle quartet (create / status / list / remove from #430).
- **`--prompt` flag** on `agentwire worktree` delivers a first message once the agent is booted, reusing `cmd_new`'s verified `--first-message` path — spawn + seed in one call.
- **Bug fix:** `cmd_worktree` emitted *two* JSON objects in `--json` mode (its own block + `cmd_new`'s), which broke `json.loads`. `cmd_new` is now the single authoritative emitter; reattach paths no longer try to `tmux attach` under `--json`.

## Roles
Correspondent now drops a passive `ingest` pointer (not a driving msg); anchor `msg pull`s on the human's cue. The dropbox still holds the big report; the ingest message is just the lightweight pointer.

## Verified
- Passive invariants: ingest excluded from `list_messages` + `_iter_pending_sessions` (watchdog), `pull` consumes, a mixed session still flushes its driving note.
- CLI `msg send --kind ingest` → `inbox` (shows passive) → `pull` (consumes).
- MCP `msg_pull` + `worktree_create` register.
- `worktree --prompt … --json` emits a **single** JSON with `first_message_delivered: true`; a seeded correspondent replied `SEEDED-OK` end-to-end; teardown clean.

## Not in this PR (Phase 3)
Unified `say(text=, display=)`, markdown/links in the toast, blessed dropbox resolver + typed `ref` field on `Message`.

Built by [dotdev.dev](https://dotdev.dev)