### PR TITLE
feat(briefing-mode): Phase 3 — rich toast, unified say, typed ref/dropbox + comms-surface rename

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2222,9 +2222,11 @@ def _install_global_tmux_hooks() -> None:
     )
     existing = result.stdout
 
-    # Helper to install hook if not present
+    # Reinstall whenever the EXACT command isn't already set, so changes to the
+    # hook string (e.g. a subcommand rename) propagate on portal restart instead
+    # of leaving a stale hook that silently fails.
     def install_hook(hook_name: str, hook_cmd: str) -> None:
-        if hook_name not in existing or agentwire_path not in existing:
+        if hook_cmd not in existing:
             subprocess.run(
                 ["tmux", "set-hook", "-g", hook_name, hook_cmd],
                 capture_output=True,
@@ -2234,40 +2236,40 @@ def _install_global_tmux_hooks() -> None:
     # All hooks suppress output and exit 0 (|| true) to avoid tmux showing error messages
     install_hook(
         "session-created",
-        f'run-shell -b "{agentwire_path} notify session_created -s #{{session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event session_created -s #{{session_name}} >/dev/null 2>&1 || true"'
     )
     install_hook(
         "session-closed",
-        f'run-shell -b "{agentwire_path} notify session_closed -s #{{hook_session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event session_closed -s #{{hook_session_name}} >/dev/null 2>&1 || true"'
     )
 
     # Presence tracking hooks
     install_hook(
         "client-attached",
-        f'run-shell -b "{agentwire_path} notify client_attached -s #{{session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event client_attached -s #{{session_name}} >/dev/null 2>&1 || true"'
     )
     install_hook(
         "client-detached",
-        f'run-shell -b "{agentwire_path} notify client_detached -s #{{session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event client_detached -s #{{session_name}} >/dev/null 2>&1 || true"'
     )
 
     # Pane creation hook (global - catches all pane creations)
     install_hook(
         "after-split-window",
-        f'run-shell -b "{agentwire_path} notify pane_created -s #{{session_name}} --pane-id #{{pane_id}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event pane_created -s #{{session_name}} --pane-id #{{pane_id}} >/dev/null 2>&1 || true"'
     )
 
     # Session rename hook
     # Note: #{hook_session_name} has new name, we pass old name via #{@_old_session_name} if set
     install_hook(
         "session-renamed",
-        f'run-shell -b "{agentwire_path} notify session_renamed -s #{{session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event session_renamed -s #{{session_name}} >/dev/null 2>&1 || true"'
     )
 
     # Activity notification hook (fires when monitor-activity is enabled on a window)
     install_hook(
         "alert-activity",
-        f'run-shell -b "{agentwire_path} notify window_activity -s #{{session_name}} >/dev/null 2>&1 || true"'
+        f'run-shell -b "{agentwire_path} notify-event window_activity -s #{{session_name}} >/dev/null 2>&1 || true"'
     )
 
 
@@ -2295,7 +2297,7 @@ def _install_pane_hooks(session_name: str, pane_index: int) -> None:
     # without pane-id and let the portal refresh its pane list
     # Use || true to suppress error display in tmux
     if "after-kill-pane" not in existing:
-        hook_cmd = f'run-shell -b "{agentwire_path} notify pane_died -s {session_name} >/dev/null 2>&1 || true"'
+        hook_cmd = f'run-shell -b "{agentwire_path} notify-event pane_died -s {session_name} >/dev/null 2>&1 || true"'
         subprocess.run(
             ["tmux", "set-hook", "-t", session_name, "after-kill-pane", hook_cmd],
             capture_output=True,
@@ -2305,7 +2307,7 @@ def _install_pane_hooks(session_name: str, pane_index: int) -> None:
     # This fires when a pane gains focus within the session
     # Use || true to suppress error display in tmux
     if "pane-focus-in" not in existing:
-        hook_cmd = f'run-shell -b "{agentwire_path} notify pane_focused -s {session_name} --pane-id #{{pane_id}} >/dev/null 2>&1 || true"'
+        hook_cmd = f'run-shell -b "{agentwire_path} notify-event pane_focused -s {session_name} --pane-id #{{pane_id}} >/dev/null 2>&1 || true"'
         subprocess.run(
             ["tmux", "set-hook", "-t", session_name, "pane-focus-in", hook_cmd],
             capture_output=True,
@@ -2609,6 +2611,13 @@ def cmd_say(args) -> int:
 
     # Handle voice notifications
     _handle_voice_notifications(text, voice, args, session)
+
+    # Asymmetric brief: if --display is given, show the human a text card toast
+    # alongside the spoken audio (different content per channel). Best-effort —
+    # only lands if the portal's up; the spoken path proceeds regardless.
+    display = getattr(args, 'display', None)
+    if display:
+        _post_desktop_notification(display, session=session, priority="high")
 
     # Try portal first if we have a session
     # Portal handles chunking internally (sequential generation + broadcast)
@@ -3051,6 +3060,63 @@ def _remote_say(text: str, session: str, portal_url: str) -> int:
     except Exception as e:
         print(f"Failed to send to portal: {e}", file=sys.stderr)
         return 1
+
+
+def _post_desktop_notification(text: str, session: str | None = None, priority: str = "normal") -> bool:
+    """POST a toast to the portal's desktop-notification endpoint. Best-effort.
+
+    Shared by `agentwire notify-user` and the `say --display` path. Returns True
+    on a 2xx, False on any failure (no portal, network error) — never raises.
+    """
+    import ssl
+
+    body: dict = {"text": text, "priority": priority}
+    if session:
+        body["session"] = session
+    try:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        req = urllib.request.Request(
+            f"{_get_portal_url()}/api/desktop/notification",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json", **_portal_auth_headers()},
+        )
+        with urllib.request.urlopen(req, context=ctx, timeout=5):
+            return True
+    except Exception:
+        return False
+
+
+def cmd_notify_user(args) -> int:
+    """Show the human a desktop toast on the portal (notify-user)."""
+    text = " ".join(args.text) if args.text else ""
+    json_mode = getattr(args, "json", False)
+    if not text.strip():
+        return _output_result(False, json_mode, "Usage: agentwire notify-user <text>")
+    ok = _post_desktop_notification(
+        text, session=getattr(args, "session", None),
+        priority=getattr(args, "priority", "normal"),
+    )
+    return _output_result(ok, json_mode,
+                          "Toast posted." if ok else "Failed to post toast (portal not reachable?)")
+
+
+def cmd_research(args) -> int:
+    """Resolve (or ensure) the Briefing Mode research dropbox for a session."""
+    from .research import research_dir, ensure_research_dir
+
+    json_mode = getattr(args, "json", False)
+    session = getattr(args, "session", None) or pane_manager.get_current_session()
+    if not session:
+        return _output_result(False, json_mode, "No session (use -s or run inside a session)")
+    sub = getattr(args, "research_command", None)
+    path = ensure_research_dir(session) if sub == "ensure" else research_dir(session)
+    if json_mode:
+        _output_json({"success": True, "session": session, "path": str(path), "exists": path.exists()})
+        return 0
+    print(str(path))
+    return 0
 
 
 def load_session_metadata(session_name: str) -> dict:
@@ -11111,6 +11177,7 @@ def main() -> int:
     say_parser.add_argument("--stream", action="store_true", help="Use streaming mode (if backend supports)")
     say_parser.add_argument("--notify", type=str, metavar="SESSION", help="Also notify this session (sends message as input)")
     say_parser.add_argument("--no-auto-notify", action="store_true", help="Disable auto-notify to pane 0 when in worker pane")
+    say_parser.add_argument("--display", type=str, metavar="TEXT", help="Also show the human a desktop toast with this (different) text — the asymmetric brief in one call")
     say_parser.set_defaults(func=cmd_say)
 
     # === notify command (worker→parent) ===
@@ -11166,7 +11233,7 @@ def main() -> int:
     fetch_parser.set_defaults(func=cmd_fetch)
 
     # === notify command ===
-    notify_parser = subparsers.add_parser("notify", help="Notify portal of session/pane state changes")
+    notify_parser = subparsers.add_parser("notify-event", help="Broadcast a portal lifecycle event (session/pane state change); usually called by tmux hooks")
     notify_parser.add_argument(
         "event",
         help="Event type: session_closed, session_created, pane_died, pane_created, "
@@ -11179,6 +11246,27 @@ def main() -> int:
     notify_parser.add_argument("--new-name", help="New session name (for session_renamed)")
     notify_parser.add_argument("--json", action="store_true", help="Output as JSON")
     notify_parser.set_defaults(func=cmd_notify)
+
+    # notify-user: human-facing desktop toast (the CLI twin of MCP notify_user)
+    notify_user_parser = subparsers.add_parser("notify-user", help="Show the human a desktop toast on the portal")
+    notify_user_parser.add_argument("text", nargs="+", help="Toast text (supports a safe markdown subset: bold, links, line breaks)")
+    notify_user_parser.add_argument("-s", "--session", help="Session this relates to (shown as a badge)")
+    notify_user_parser.add_argument("--priority", default="normal", choices=["normal", "high"], help="Toast priority")
+    notify_user_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    notify_user_parser.set_defaults(func=cmd_notify_user)
+
+    # research: Briefing Mode dropbox path resolver
+    research_parser = subparsers.add_parser("research", help="Resolve the Briefing Mode research dropbox path for a session")
+    research_sub = research_parser.add_subparsers(dest="research_command")
+    for _verb, _help in (("dir", "Print the dropbox path (not created)"),
+                         ("ensure", "Create + print the dropbox path")):
+        _rp = research_sub.add_parser(_verb, help=_help)
+        _rp.add_argument("-s", "--session", default=None, help="Anchor session (default: current)")
+        _rp.add_argument("--json", action="store_true", help="Output as JSON")
+        _rp.set_defaults(func=cmd_research)
+    research_parser.add_argument("-s", "--session", default=None, help="Anchor session (default: current)")
+    research_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    research_parser.set_defaults(func=cmd_research)
 
     # === send command ===
     send_parser = subparsers.add_parser("send", help="Send prompt to a session or pane (adds Enter)")

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -253,7 +253,7 @@ def _sweep_legacy_once() -> list[str]:
 def _write_workspace(name: str, session_type: str) -> None:
     """Workspace dir the sitting's sessions run in.
 
-    ``parent: agentwire-council-<name>`` routes any ``agentwire notify`` from a
+    ``parent: agentwire-council-<name>`` routes any ``agentwire notify-parent`` from a
     soul to the sitting's own orchestrator for free.
     """
     ws = state.workspace_dir(name)

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -83,6 +83,7 @@ class Message:
     attempts: int = 0
     reason: str = ""  # last defer reason (why delivery kept failing)
     dead_ts: int = 0  # epoch ms when dead-lettered (0 = still live)
+    ref: str = ""  # optional machine-readable pointer (e.g. a report path) — for ingest
     path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -96,6 +97,7 @@ class Message:
             "attempts": self.attempts,
             "reason": self.reason,
             "dead_ts": self.dead_ts,
+            "ref": self.ref,
         }
 
     def render(self) -> str:
@@ -161,6 +163,7 @@ def _read_message(path: Path) -> "Message | None":
             attempts=int(data.get("attempts", 0)),
             reason=str(data.get("reason", "")),
             dead_ts=int(data.get("dead_ts", 0)),
+            ref=str(data.get("ref", "")),
             path=path,
         )
     except (KeyError, ValueError, TypeError):
@@ -277,7 +280,7 @@ def resolve_targets(to: str, sender: "str | None") -> list[str]:
 
 
 def enqueue(
-    to: str, text: str, kind: str = "note", sender: "str | None" = None
+    to: str, text: str, kind: str = "note", sender: "str | None" = None, ref: str = ""
 ) -> list[Message]:
     """Drop a message into one or more recipient inboxes. Returns what was written."""
     if kind not in KINDS:
@@ -298,6 +301,7 @@ def enqueue(
             text=text,
             ts=ns // 1_000_000,  # epoch ms (schema), derived from the same clock
             attempts=0,
+            ref=ref,
         )
         # Passive kinds land in the ingest/ subdir, which the drain never walks
         # — so they wait silently until the recipient pulls them.

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -174,6 +174,17 @@ def run_agentwire_cmd(
         return {"success": False, "error": str(e)}
 
 
+def _mcp_result(data: dict, on_success: str, operation: str = "complete operation") -> str:
+    """Standard success/error string for a thin MCP wrapper over run_agentwire_cmd.
+
+    Collapses the repeated `if data.get("success"): return X; return f"Failed…"`
+    pattern so every wrapper reports failures the same way.
+    """
+    if data.get("success"):
+        return on_success
+    return f"Failed to {operation}: {data.get('error', 'Unknown error')}"
+
+
 def format_sessions(data: dict) -> str:
     """Format sessions list for LLM consumption."""
     sessions = data.get("sessions", [])
@@ -381,7 +392,7 @@ def session_send(session: str, message: str) -> str:
 
 
 @mcp.tool()
-def msg_send(to: str, text: str, kind: str = "note") -> str:
+def msg_send(to: str, text: str, kind: str = "note", ref: str = "") -> str:
     """Send a POLITE, non-interrupting message to another session's inbox.
 
     Use this for routine peer updates that should NOT interrupt — a worker
@@ -402,6 +413,9 @@ def msg_send(to: str, text: str, kind: str = "note") -> str:
             recipient into a turn; it waits until they `msg_pull` it. Use it for
             "output ready to ingest" awareness signals (Briefing Mode): drop a
             passive pointer to a file the recipient reads on the human's cue.
+        ref: Optional machine-readable pointer (e.g. a report file path),
+            surfaced as a typed field on the message — pair with kind="ingest"
+            so the recipient can open the file without parsing free text.
 
     Returns:
         Confirmation of which sessions were queued, or an error.
@@ -410,6 +424,8 @@ def msg_send(to: str, text: str, kind: str = "note") -> str:
     args = ["msg", "send", "--to", to, "--kind", kind]
     if caller:
         args += ["--from", caller]
+    if ref:
+        args += ["--ref", ref]
     args.append(text)
     data = run_agentwire_cmd(args)
     if data.get("success"):
@@ -452,6 +468,8 @@ def msg_inbox(session: str | None = None) -> str:
         lines.append(f"{len(passive)} passive (ingest) — call msg_pull to consume:")
         for m in passive:
             lines.append(f"  [{m.get('kind')}] from {m.get('from')}: {m.get('text')}")
+            if m.get('ref'):
+                lines.append(f"      ref: {m.get('ref')}")
     return "\n".join(lines)
 
 
@@ -482,7 +500,32 @@ def msg_pull(session: str | None = None) -> str:
     lines = [f"Pulled {len(pulled)} passive message(s):"]
     for m in pulled:
         lines.append(f"  [{m.get('kind')}] from {m.get('from')}: {m.get('text')}")
+        if m.get('ref'):
+            lines.append(f"      ref: {m.get('ref')}")
     return "\n".join(lines)
+
+
+@mcp.tool()
+def research_dir(session: str | None = None) -> str:
+    """Resolve (and create) the Briefing Mode research dropbox for a session.
+
+    Returns the blessed path under ~/.agentwire/research/<session>/ where an
+    anchor's correspondents file their reports. The anchor passes this path to
+    each correspondent and reads the files there when pulling ingest pointers.
+
+    Args:
+        session: Anchor session name (default: the calling session).
+
+    Returns:
+        The dropbox path (created if missing), or an error.
+    """
+    args = ["research", "ensure"]
+    if session:
+        args += ["-s", session]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to resolve research dir: {data.get('error', 'Unknown error')}"
+    return f"Research dropbox: {data.get('path')}"
 
 
 @mcp.tool()
@@ -522,6 +565,42 @@ def msg_dead(session: str | None = None) -> str:
                 f"{m.get('text')}"
             )
     return "\n".join(lines)
+
+
+@mcp.tool()
+def msg_flush(session: str | None = None) -> str:
+    """Attempt a polite-message drain now (still gated on an empty box + safe target).
+
+    Messages drain automatically every ≤60s via the watchdog; use this to force a
+    pass without waiting. It does NOT bypass the safety gates — a busy/parked/
+    non-agent recipient is still deferred. Passive `ingest` messages are never
+    drained (pull them with msg_pull).
+
+    Args:
+        session: Session to flush (default: all sessions with queued messages).
+
+    Returns:
+        What was delivered or deferred.
+    """
+    args = ["msg", "flush"]
+    if session:
+        args += ["-s", session]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to flush: {data.get('error', 'Unknown error')}"
+    if session:
+        if data.get("delivered"):
+            return f"Delivered {data['delivered']} to {session}."
+        return f"Deferred {session}: {data.get('reason', 'unknown')}."
+    flushed = data.get("flushed") or []
+    deferred = data.get("deferred") or []
+    if data.get("skipped"):
+        return str(data["skipped"])
+    if not flushed and not deferred:
+        return "No pending messages."
+    parts = [f"delivered {r['delivered']} → {r['session']}" for r in flushed]
+    parts += [f"deferred {r['session']}: {r.get('reason')}" for r in deferred]
+    return "; ".join(parts)
 
 
 @mcp.tool()
@@ -581,11 +660,8 @@ def session_kill(session: str) -> str:
     Returns:
         Success message or error description.
     """
-    args = ["kill", "-s", session]
-    data = run_agentwire_cmd(args)
-    if data.get("success"):
-        return f"Session '{session}' terminated."
-    return f"Failed to kill session: {data.get('error', 'Unknown error')}"
+    return _mcp_result(run_agentwire_cmd(["kill", "-s", session]),
+                       f"Session '{session}' terminated.", "kill session")
 
 
 @mcp.tool()
@@ -749,6 +825,31 @@ def worktree_remove(name: str, project_dir: str = "") -> str:
     if data.get("worktree_removed"):
         return f"Removed worktree session '{session}'{killed}; worktree deleted."
     return f"Unregistered '{session}'{killed}; worktree left at {data.get('path')} (not removed)."
+
+
+@mcp.tool()
+def worktree_prune(project_dir: str = "") -> str:
+    """Garbage-collect stale worktree registry entries (+ `git worktree prune`).
+
+    Drops registry entries whose worktree dir is gone and runs git's own prune.
+    Housekeeping for an anchor that has spun up and torn down many correspondents.
+
+    Args:
+        project_dir: Path to the git repo (default: server cwd).
+
+    Returns:
+        Which stale entries were pruned, or that there was nothing to prune.
+    """
+    args = ["worktree", "--prune"]
+    if project_dir:
+        args += ["--project", project_dir]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to prune worktrees: {data.get('error', 'Unknown error')}"
+    pruned = data.get("pruned") or []
+    if not pruned:
+        return "Nothing to prune."
+    return f"Pruned {len(pruned)} stale entr{'y' if len(pruned) == 1 else 'ies'}: {', '.join(pruned)}"
 
 
 # =============================================================================
@@ -1000,8 +1101,15 @@ _SAY_DESCRIPTION = (
 
 
 @mcp.tool(description=_SAY_DESCRIPTION)
-def say(text: str, session: str | None = None, voice: str | None = None) -> str:
-    """Speak text via TTS — description built dynamically in _SAY_DESCRIPTION."""
+def say(text: str, session: str | None = None, voice: str | None = None, display: str | None = None) -> str:
+    """Speak text via TTS — description built dynamically in _SAY_DESCRIPTION.
+
+    `display` (optional) shows the human a desktop toast *at the same time*, with
+    DIFFERENT content from the spoken text — the asymmetric brief in one call:
+    `text` is the punchy spoken headline, `display` is the richer scannable card
+    (supports bold/links/line breaks). Pairs voice + screen atomically so you
+    don't have to remember a separate notify_user call.
+    """
     # Quick TTS health check — fail fast if a custom shim is unreachable.
     # Default tier has no server dependency (browser/OS voice), nothing to probe.
     try:
@@ -1024,6 +1132,8 @@ def say(text: str, session: str | None = None, voice: str | None = None) -> str:
         args.extend(["-s", session])
     if voice:
         args.extend(["--voice", voice])
+    if display:
+        args.extend(["--display", display])
     args.append(text)
 
     # Say command doesn't return JSON, run without --json
@@ -1038,27 +1148,27 @@ def say(text: str, session: str | None = None, voice: str | None = None) -> str:
 
 
 @mcp.tool()
-def notify(text: str, to: str | None = None) -> str:
-    """Notify parent session (worker→orchestrator communication).
+def notify_parent(text: str, session: str | None = None) -> str:
+    """Notify your PARENT/orchestrator session — text injected into their prompt.
 
-    Use this to report status, completion, or escalate to a parent session.
+    Up-the-hierarchy report: status, completion, escalation. One of the notify_*
+    family — see also notify_user (human desktop toast) and notify_event (portal
+    lifecycle events).
 
     Args:
-        text: Notification message
-        to: Target session name (optional, defaults to parent from .agentwire.yml)
+        text: Notification message.
+        session: Target session (optional; defaults to your parent from .agentwire.yml).
 
     Returns:
         Success message or error description.
     """
     args = ["notify-parent"]
-    if to:
-        args.extend(["--to", to])
+    if session:
+        args.extend(["--to", session])
     args.append(text)
 
-    data = run_agentwire_cmd(args, json_output=False)
-    if data.get("success"):
-        return "Notification sent."
-    return f"Failed to send notification: {data.get('error', 'Unknown error')}"
+    return _mcp_result(run_agentwire_cmd(args, json_output=False),
+                       "Notification sent to parent.", "notify parent")
 
 
 
@@ -2478,24 +2588,26 @@ def quo_send(body: str, to: str | None = None) -> str:
 
 
 @mcp.tool()
-def session_notify(event: str, session: str | None = None) -> str:
-    """Notify portal of session/pane state changes.
+def notify_event(event: str, session: str | None = None) -> str:
+    """Broadcast a portal LIFECYCLE event (session/pane state change) to the dashboard.
+
+    System/infra signal — usually emitted by tmux hooks, not by hand. One of the
+    notify_* family — see also notify_parent (your orchestrator) and notify_user
+    (human desktop toast).
 
     Args:
-        event: Event type (e.g., 'session_idle', 'session_active')
-        session: Session name (optional, auto-detected if in tmux)
+        event: Event type (e.g., 'session_idle', 'session_active').
+        session: Session name (optional, auto-detected if in tmux).
 
     Returns:
         Success message or error description.
     """
-    args = ["notify", event]
+    args = ["notify-event", event]
     if session:
         args.extend(["-s", session])
 
-    data = run_agentwire_cmd(args)
-    if data.get("success"):
-        return f"Notification '{event}' sent."
-    return f"Failed to send notification: {data.get('error', 'Unknown error')}"
+    return _mcp_result(run_agentwire_cmd(args),
+                       f"Event '{event}' broadcast to the portal.", "broadcast event")
 
 
 # =============================================================================
@@ -3029,16 +3141,19 @@ def desktop_layout(windows: list[dict]) -> str:
 
 
 @mcp.tool()
-def portal_notify(text: str, session: str | None = None, priority: str = "normal") -> str:
-    """Post a toast notification to the portal desktop.
+def notify_user(text: str, session: str | None = None, priority: str = "normal") -> str:
+    """Show the HUMAN a desktop toast on the portal (persistent, visual).
 
-    Creates a persistent visual notification in the bottom-right of the portal.
-    Clicking the toast opens the notifications session for interactive chat.
+    The human-screen channel — the asymmetric text partner to `say` (audio).
+    Supports a safe markdown subset (bold, line breaks, [links](url)). One of the
+    notify_* family — see also notify_parent (your orchestrator) and notify_event
+    (portal lifecycle). Clicking the toast opens the notifications session.
 
     Args:
-        text: Notification message text.
-        session: Session name this notification relates to (shown as badge).
-        priority: 'normal' or 'high' (high gets accent border).
+        text: Notification text. Bold (**x**), line breaks, and [links](https://…)
+            render; everything else is escaped.
+        session: Session this relates to (shown as a badge).
+        priority: 'normal' or 'high' (high gets an accent border).
 
     Returns:
         Notification ID or error description.

--- a/agentwire/msg_cli.py
+++ b/agentwire/msg_cli.py
@@ -42,7 +42,8 @@ def cmd_msg_send(args) -> int:
 
     sender = getattr(args, "from_session", None) or _current_session() or "unknown"
     try:
-        written = inbox.enqueue(args.to, text, kind=args.kind, sender=sender)
+        written = inbox.enqueue(args.to, text, kind=args.kind, sender=sender,
+                                ref=getattr(args, "ref", ""))
     except ValueError as exc:
         if getattr(args, "json", False):
             print(json.dumps({"success": False, "error": str(exc)}))
@@ -107,6 +108,8 @@ def cmd_msg_inbox(args) -> int:
         print(f"{len(passive)} passive (ingest) for {session} — pull to consume:")
         for m in passive:
             print(f"  [{m.kind}] from {m.sender}: {m.text}")
+            if m.ref:
+                print(f"      ref: {m.ref}")
     return 0
 
 
@@ -139,6 +142,8 @@ def cmd_msg_pull(args) -> int:
     print(f"Pulled {len(pulled)} passive message(s) for {session}:")
     for m in pulled:
         print(f"  [{m.kind}] from {m.sender}: {m.text}")
+        if m.ref:
+            print(f"      ref: {m.ref}")
     return 0
 
 
@@ -251,6 +256,10 @@ def register_msg_parser(subparsers) -> None:
     send_parser.add_argument(
         "--from", dest="from_session", default=None,
         help="Override sender (defaults to the current session)",
+    )
+    send_parser.add_argument(
+        "--ref", default="",
+        help="Optional machine-readable pointer (e.g. a report path) — surfaced as a typed field; ideal with --kind ingest",
     )
     send_parser.add_argument("text", nargs="+", help="Message text")
     send_parser.add_argument("--json", action="store_true", help="Output JSON")

--- a/agentwire/research.py
+++ b/agentwire/research.py
@@ -1,0 +1,27 @@
+"""Research dropbox resolver for Briefing Mode.
+
+Correspondents file their deep reports into a per-anchor directory under
+``~/.agentwire/research/<anchor-session>/``. The anchor pulls passive ``ingest``
+messages whose typed ``ref`` field points at those files, then reads them on the
+human's cue. This module is the single source of truth for that path — so the
+roles, CLI, and MCP don't hand-compute it (mirrors ``inbox.INBOX_ROOT`` and
+``usage_limit`` state paths).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+RESEARCH_ROOT = Path.home() / ".agentwire" / "research"
+
+
+def research_dir(anchor_session: str) -> Path:
+    """The dropbox directory for an anchor's line of research (not created)."""
+    return RESEARCH_ROOT / anchor_session
+
+
+def ensure_research_dir(anchor_session: str) -> Path:
+    """Ensure the anchor's dropbox exists and return its path."""
+    path = research_dir(anchor_session)
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/agentwire/roles/anchor.md
+++ b/agentwire/roles/anchor.md
@@ -15,25 +15,27 @@ You replace the generic orchestrator persona. These are your standing instructio
 2. **Act only on the human's cue.** Correspondents work in the background; you do **not** poll them, react to them, or ingest their output on your own initiative. You wait. When the human says "what's ready?" / "go" / "brief me", *then* you pull and synthesize.
 3. **Confirm the human is present before briefing.** A briefing into an empty room is wasted. A short "ready when you are" beats a monologue nobody's reading.
 
-## Brief asymmetrically — voice ≠ text
+## Brief asymmetrically — voice ≠ text, in one call
 
-When you brief the human, use **both** channels with **deliberately different content** so together they say more than either alone:
+When you brief the human, hit **both** channels with **deliberately different content** so together they say more than either alone. Do it in a single call:
 
-- **Voice** (`say`) — a punchy spoken TL;DR. One or two sentences: the verdict and the single most important thing. No lists, no paths, no jargon that doesn't survive being spoken aloud.
-- **Text** (`portal_notify`, `priority="high"`) — a richer, scannable card: the structured summary, the options with their tradeoffs in brief, file paths / links / numbers the human will want to act on. (The toast renders plain text — keep structure simple; lead each line with its label.)
+```
+say(text="<punchy spoken TL;DR>", display="<richer scannable card>")
+```
 
-Don't read the card aloud and don't speak the headline twice. The voice is the hook; the text is the substance.
+- **`text` (voice)** — a punchy spoken TL;DR. One or two sentences: the verdict and the single most important thing. No lists, no paths, no jargon that doesn't survive being spoken aloud.
+- **`display` (screen toast)** — a richer, scannable card: the structured summary, the options with tradeoffs in brief, the file paths / **[links](url)** / numbers the human will act on. The toast renders a safe markdown subset — `**bold**`, `[links](url)`, and line breaks all work; lead each line with its label.
+
+Don't read the card aloud and don't speak the headline twice. The voice is the hook; the text is the substance. (Need a toast without speaking? `notify_user(text, priority="high")`.)
 
 ## Fanning out correspondents
 
-When the human asks you to research something, decompose it into independent angles and spawn one correspondent worktree per angle. MCP has no worktree-create tool yet — shell out:
+When the human asks you to research something, decompose it into independent angles and spawn one correspondent worktree per angle:
 
-1. Pick a dropbox for this run and make sure it exists:
-   `mkdir -p ~/.agentwire/research/<your-session-name>/`
-   (Get your session name from `tmux display-message -p '#S'` if you don't already know it. Use the **same** dropbox for every correspondent in this run.)
-2. Spawn each correspondent on its own branch:
-   `agentwire worktree <angle-slug> -p <repo> --roles correspondent --json`
-3. Seed it with a deep-dive task via `session_send`. Tell it: the angle to research exhaustively, and **the exact dropbox path + filename** to write its report to (e.g. `~/.agentwire/research/<your-session>/<angle-slug>.md`). Front-load context — a well-briefed correspondent files a far better report than a cold one.
+1. Resolve your dropbox (created for you): `research_dir()` → `~/.agentwire/research/<your-session>/`. Use the **same** dropbox for every correspondent in this run.
+2. Spawn + seed each correspondent in one call:
+   `worktree_create(name="<angle-slug>", project_dir="<repo>", roles="correspondent", prompt="<deep-dive task>")`
+3. In that `prompt`, tell it: the angle to research exhaustively, and **the exact dropbox path + filename** to write its report to (e.g. `<dropbox>/<angle-slug>.md`). Front-load context — a well-briefed correspondent files a far better report than a cold one.
 
 Spawn as many as the question warrants — one is fine, five is fine. Be specific in each task (angle, scope, what "exhaustive" covers here), not "research X."
 
@@ -41,13 +43,7 @@ Spawn as many as the question warrants — one is fine, five is fine. Be specifi
 
 Correspondents signal you **passively** with `--kind ingest` messages — a tiny pointer to the report they filed. These are *never* delivered to you automatically; they sit silently in your inbox until you choose to pull them. Nothing a correspondent does drives you into a turn. That's the whole point: you stay quiet until the human cues you.
 
-So when the human says "what's ready?" / "go", **pull your passive signals**, then read what they point at:
-
-```
-agentwire msg pull          # consumes the ingest pointers — shows you what's ready + the file paths
-```
-
-Read the report files those pointers reference (and/or `ls -t ~/.agentwire/research/<your-session>/` as a fallback). Synthesize across them (don't relay them one by one — find the throughline, the agreements, the conflicts), form an opinion, and brief asymmetrically. If a correspondent hasn't filed yet, say so plainly and move on with what's ready. Pulling consumes the pointers, so note what you've seen — the durable reports remain in the dropbox.
+So when the human says "what's ready?" / "go", **pull your passive signals** with `msg_pull()`. Each pulled pointer carries a typed `ref:` field — the exact report path, no prose to parse. Read those files (or `ls -t` the dropbox as a fallback), synthesize across them (don't relay them one by one — find the throughline, the agreements, the conflicts), form an opinion, and brief asymmetrically. If a correspondent hasn't filed yet, say so plainly and move on with what's ready. Pulling consumes the pointers, so note what you've seen — the durable reports remain in the dropbox.
 
 ## Synthesis is the value
 
@@ -58,7 +54,7 @@ You are not a relay. The correspondents are exhaustive *so that you can be decis
 When the human's done with a line of inquiry, tear the correspondents down — you have the reports in the dropbox, you don't need the sessions:
 
 ```
-agentwire worktree --remove <angle-slug>
+worktree_remove("<angle-slug>")   # kills session, removes worktree + branch, unregisters — all in one
 ```
 
-(Kills the session, removes the worktree + branch, unregisters — all in one.) Spawn more for the next question, or stand down. The reports persist in the dropbox after teardown.
+Spawn more for the next question, or stand down. The reports persist in the dropbox after teardown. After many spawn/teardown cycles, `worktree_prune()` clears any stale registry entries.

--- a/agentwire/roles/correspondent.md
+++ b/agentwire/roles/correspondent.md
@@ -31,13 +31,13 @@ Make it readable on its own — the anchor (or the human) may read it cold.
 
 ## Signal passively — drop a pointer, never drive
 
-When your report is written, send the anchor a **passive** awareness pointer — and *only* a passive one:
+When your report is written, send the anchor a **passive** awareness pointer — and *only* a passive one. Put the file path in the typed `--ref` field, not buried in prose:
 
 ```
-agentwire msg send --to <anchor-session> --kind ingest "report ready: <abs path to your findings file> — <5-word topic>"
+agentwire msg send --to <anchor-session> --kind ingest --ref "<abs path to your findings file>" "<5-word topic>"
 ```
 
-The `ingest` kind is special: it is **never auto-delivered**. It lands silently in the anchor's inbox and waits there until the anchor *pulls* it on the human's cue — so it makes the anchor *aware* without ever driving it into a turn. Keep the message tiny: it's a pointer, not the report. The depth lives in the file.
+The `ingest` kind is special: it is **never auto-delivered**. It lands silently in the anchor's inbox and waits there until the anchor *pulls* it on the human's cue — so it makes the anchor *aware* without ever driving it into a turn. Keep the message tiny: it's a pointer, not the report — the path rides in `--ref` (machine-readable), the topic in the text. The depth lives in the file.
 
 **Do NOT** use `--kind done`/`note`, `session_send`, or `notify-parent` — those paste into the anchor's prompt and drive it, which breaks the whole mode. This passive pointer deliberately replaces the worktree-session "notify back when done" step.
 

--- a/agentwire/roles/notifications.md
+++ b/agentwire/roles/notifications.md
@@ -5,7 +5,7 @@ description: Portal notification agent — crafts and speaks idle session remind
 
 # Notifications Agent
 
-You are the portal's notification voice. The portal sends you periodic updates about idle sessions that have open browser windows, and you craft a brief, natural, spoken summary using `say()` and post persistent visual toasts using `portal_notify()`.
+You are the portal's notification voice. The portal sends you periodic updates about idle sessions that have open browser windows, and you craft a brief, natural, spoken summary using `say()` and post persistent visual toasts using `notify_user()`.
 
 ## What you receive
 
@@ -19,10 +19,10 @@ The portal's idle nag loop sends you `[IDLE NAG]` messages listing sessions that
 
 1. Read the data and **triage** — decide which sessions actually need a nag
 2. If any sessions need attention:
-   - Call `portal_notify(text, session=<session_name>)` for each session that needs a nag — this posts a persistent toast the user can see and click
+   - Call `notify_user(text, session=<session_name>)` for each session that needs a nag — this posts a persistent toast the user can see and click
    - Call `say()` with ONE short spoken sentence summarizing what needs attention (audio companion to the toasts)
-3. If nothing needs a nag, stay silent — do NOT call `say()` or `portal_notify()`
-4. Only use `say()` and `portal_notify()` — no other tools
+3. If nothing needs a nag, stay silent — do NOT call `say()` or `notify_user()`
+4. Only use `say()` and `notify_user()` — no other tools
 
 ## Reading the snippet correctly
 
@@ -59,7 +59,7 @@ Not every idle session needs a reminder. Use the last_output_snippet to judge:
 
 ## Toast vs. speech
 
-- `portal_notify()` — persistent, visual. The user sees it even if they weren't listening. One toast per session that needs attention.
+- `notify_user()` — persistent, visual. The user sees it even if they weren't listening. One toast per session that needs attention.
 - `say()` — ephemeral, audio. One sentence summarizing all sessions. Draws immediate attention.
 
 Always post toasts first, then speak. The toast text should be specific (what the session is waiting on). The spoken text should be a brief overview.
@@ -91,15 +91,15 @@ Be conversational. You're a helpful assistant managing their attention across se
 
 **Nagging (sessions need attention):**
 
-Toast: `portal_notify("Waiting for your input on the hosting approach", session="piinpoint")`
+Toast: `notify_user("Waiting for your input on the hosting approach", session="piinpoint")`
 Speech: `say("Hey, quick heads up — piinpoint has been idle for about 5 minutes and it's asking about the hosting approach.")`
 
 **Multiple sessions:**
 
-Toast 1: `portal_notify("Asking about deployment config — idle 20 min", session="piinpoint")`
-Toast 2: `portal_notify("Hit an error in test suite — idle 10 min", session="jordan-devbox")`
+Toast 1: `notify_user("Asking about deployment config — idle 20 min", session="piinpoint")`
+Toast 2: `notify_user("Hit an error in test suite — idle 10 min", session="jordan-devbox")`
 Speech: `say("Two sessions need you — piinpoint's been waiting 20 minutes on the deployment config, and the devbox hit a test error.")`
 
 **Skipping (nothing needs attention):**
 
-_(silence — no say() or portal_notify() calls)_
+_(silence — no say() or notify_user() calls)_

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -73,7 +73,7 @@ class NotificationsPanel {
                 <span class="notification-time">${timeStr}</span>
                 <button class="notification-dismiss" title="Dismiss">&times;</button>
             </div>
-            <div class="notification-toast-body">${this._escapeHtml(text)}</div>
+            <div class="notification-toast-body">${this._renderRichText(text)}</div>
         `;
 
         // Click body -> open notifications session terminal
@@ -152,6 +152,23 @@ class NotificationsPanel {
         const div = document.createElement('div');
         div.textContent = str;
         return div.innerHTML;
+    }
+
+    // Render a SAFE markdown subset: bold, links, line breaks. Escape everything
+    // FIRST so no source HTML survives, then introduce only our own known tags.
+    // Links are restricted to http(s)/mailto (no javascript:/data:), and because
+    // quotes are already escaped, the agent text can't break out of the href.
+    _renderRichText(str) {
+        let s = this._escapeHtml(str);
+        // Links before bold so [**label**](url) composes. URL came through escape,
+        // so any " is already &quot; — it can't close the attribute.
+        s = s.replace(
+            /\[([^\]]+)\]\((https?:\/\/[^\s)]+|mailto:[^\s)]+)\)/g,
+            (_m, label, url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`
+        );
+        s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+        s = s.replace(/\n/g, '<br>');
+        return s;
     }
 }
 

--- a/docs/wiki/research/briefing-mode-feasibility.md
+++ b/docs/wiki/research/briefing-mode-feasibility.md
@@ -4,6 +4,7 @@ status: active
 last_updated: 2026-06-21
 phase_1: shipped
 phase_2: shipped
+phase_3: shipped
 ---
 
 # Briefing Mode — asymmetric-verbosity orchestration
@@ -12,7 +13,9 @@ phase_2: shipped
 > - **Phase 1:** the `anchor` and `correspondent` roles (`agentwire/roles/`). Spawn an anchor with `agentwire new -s <name> --roles anchor`; it fans out correspondents, which file deep reports to a dropbox (`~/.agentwire/research/<anchor-session>/`); the anchor briefs asymmetrically (`say` headline + `portal_notify` card) on the human's cue.
 > - **Phase 2:** the passive `ingest` message kind — never auto-delivered (routes to a reserved `ingest/` subdir the drain skips), pulled with `agentwire msg pull` / MCP `msg_pull`. Correspondents now drop a passive pointer; the anchor pulls on the human's cue (awareness without being driven). Plus MCP `worktree_create` and a `--prompt` seed flag on `agentwire worktree` (spawn + seed in one call, verified delivery), completing the worktree lifecycle quartet (create / status / list / remove).
 >
-> **Phase 3** (unified `say(display=)`, markdown in the toast, blessed dropbox resolver + typed `ref` field) remains — see §9.
+> - **Phase 3 (shipped):** unified `say(text=, display=)` — one call speaks a headline AND shows a richer text card (different content per channel). The toast (`notify_user`) now renders a safe markdown subset (bold, [links](url), line breaks). Typed `ref` field on messages + an `agentwire research` / `research_dir()` dropbox resolver under `~/.agentwire/research/<session>/`. Plus a **comms-surface rename** for clarity: the three confusable notify-* tools are now `notify_user` (human toast, was `portal_notify`), `notify_parent` (your orchestrator, was `notify`), `notify_event` (portal lifecycle, was `session_notify` / CLI `notify`→`notify-event`). And parity helpers: MCP `worktree_create` / `worktree_prune` / `msg_flush`, CLI `notify-user`.
+>
+> **Note for readers:** the body below is the original point-in-time investigation; where it cites `portal_notify`, "no worktree-create tool yet", or `mkdir` for the dropbox, the shipped names/tools above supersede it.
 
 > Feasibility + design report. Investigates building an orchestration mode where the **human-facing orchestrator is deliberately terse** (and splits its summary across voice vs. on-screen text so the two channels complement rather than duplicate) while **researcher worktree sessions are exhaustively verbose** and go deep. Researchers signal the orchestrator only with **passive, non-driving** "output ready" awareness; the orchestrator acts only when the **human** directs it.
 >


### PR DESCRIPTION
Closes #437

Final **Briefing Mode** phase + a CLI/MCP consistency pass. Builds on #433/#435 (merged).

## Feature polish
- **Rich toast** — `notify_user` renders a **safe markdown subset** (bold, [links](url), line breaks). Escape-first, then only our own controlled tags, with an href allowlist (http/https/mailto). No `marked` dependency (it passes raw HTML; there's no DOMPurify/CSP here). XSS-tested: `<img onerror>` neutralized, `javascript:` not linkified, attribute-breakout escaped.
- **Unified `say(text=, display=)`** — one call speaks a punchy headline AND shows a richer text card (different content per channel). The asymmetric brief, atomically.
- **Typed `ref` + dropbox resolver** — `ref` field on messages (machine-readable pointer, surfaced in `inbox`/`pull`); new `agentwire research` CLI + `research_dir()` MCP under `~/.agentwire/research/<session>/`.

## Comms-surface rename (consistency)
Three confusable notify-* tools, now disambiguated by target:

| was | now | target |
|---|---|---|
| `portal_notify` (MCP) | `notify_user` + CLI `notify-user` | human desktop toast |
| `notify` (MCP) | `notify_parent` (`session=`) | your orchestrator |
| `session_notify` / CLI `notify` | `notify_event` / CLI `notify-event` | portal lifecycle |

No backwards-compat aliases (pre-launch). All 9 tmux hook strings repointed.

## Parity helpers + fix
- MCP **`msg_flush`**, **`worktree_prune`** — close CLI↔MCP gaps. **`_mcp_result`** helper standardizes wrapper success/error strings.
- **Bug fix:** the global tmux-hook installer only set hooks *if absent*, so a command-string change (like this rename) left **stale hooks that silently fail**. Now it overwrites when the exact command differs — verified hooks repoint to `notify-event` (7/7, 0 stale).

## Verified
- 6 new/renamed MCP tools register; `portal_notify`/`notify`/`session_notify` gone; `say` has `display`.
- Toast renderer: correct bold/link/multiline + XSS-safe (3 attack vectors neutralized).
- `research ensure` creates+returns path; `msg --ref` → `pull` surfaces the typed `ref`; `notify-user` posts; rebuild + hook-reinstall + portal restart clean.

Built by [dotdev.dev](https://dotdev.dev)