### PR TITLE
docs: Briefing Mode feature page + Phase 3 surface refresh

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -43,7 +43,9 @@ agentwire worktree name -b develop  # from specific base branch
 agentwire worktree name -c      # from repo's current branch
 agentwire worktree name -e      # checkout existing branch (no new branch)
 agentwire worktree name --ref v2.0  # detached at tag/commit
-agentwire worktree --list       # list this repo's worktree sessions (registry); --all = every repo
+agentwire worktree name --prompt "task"  # spawn AND seed the first message in one call (verified delivery)
+agentwire worktree --list       # list this repo's worktree sessions + read-only git status; --all = every repo
+agentwire worktree --status name  # read-only git status (dirty/ahead/behind/pushed) for one worktree
 agentwire worktree --remove name  # kill session + remove worktree + unregister (cleanup/recovery)
 agentwire worktree --prune      # drop registry entries whose worktree is gone + git worktree prune
 agentwire fork -s name          # fork session into new worktree
@@ -99,6 +101,7 @@ agentwire stt start --backend moonshine --model moonshine/base --port 8101  # ad
 # Voice
 agentwire say "text"            # speak (auto-routes to browser or local)
 agentwire say -s name "text"    # speak to specific session
+agentwire say "spoken" --display "richer card"  # speak AND show a desktop toast with different text (one call)
 agentwire notify-parent "text"   # notify parent session (worker→orchestrator)
 agentwire notify-parent --to name "text" # notify specific session
 agentwire notify-parent --raw --to name "text"  # verbatim, no [NOTIFY ...] prefix
@@ -115,11 +118,17 @@ agentwire prompts clear -s name --pane 1  # drop a marker
 
 # Polite messaging (non-interrupting agent-to-agent inbox; see wiki sessions/messaging.md)
 agentwire msg send --to name "text"          # queue a message (delivers when their box is clear)
-agentwire msg send --to name --kind done "PR #312 drafted"  # kinds: note|done|request|escalation
+agentwire msg send --to name --kind done "PR #312 drafted"  # kinds: note|done|request|escalation|ingest
+agentwire msg send --to name --kind ingest --ref "/path/report.md" "topic"  # PASSIVE: never auto-delivered, pull-only
 agentwire msg send --to @all "team update"   # broadcast to live agent sessions except sender
-agentwire msg inbox -s name                  # peek pending (does not drain)
+agentwire msg inbox -s name                  # peek pending + passive (does not drain/consume)
+agentwire msg pull -s name                   # read + REMOVE passive (ingest) messages — the voluntary pull
 agentwire msg dead -s name                   # list dropped (dead-lettered) msgs + reason/timestamp
 agentwire msg flush -s name                  # attempt a drain now (still gated on empty box + safe target)
+
+# Research dropbox (Briefing Mode)
+agentwire research dir -s name               # print the dropbox path (~/.agentwire/research/<session>/)
+agentwire research ensure -s name            # create + print the dropbox path
                                 # `msg` NEVER clobbers a human's draft — unlike `send`, which
                                 # pastes + Enter immediately. Use `send` only to forcibly drive a session now.
 
@@ -215,8 +224,10 @@ agentwire network status        # complete network health check
 agentwire doctor                # auto-diagnose and fix issues
 agentwire doctor --voice        # only the push-to-talk path: mic, STT shim, portal/tunnel, tmux+PTT (pass/fail + fix)
 
-# Notifications
-agentwire notify event          # notify portal of state changes (session/pane events)
+# Notifications (the notify-* family, by target)
+agentwire notify-event EVENT    # broadcast a portal lifecycle event (session/pane); usually called by tmux hooks
+agentwire notify-parent "text"  # text up to your parent/orchestrator session
+agentwire notify-user "text"    # desktop toast for the human (safe markdown: bold, [links](url), line breaks)
 
 # MCP Server
 agentwire mcp                   # expose agentwire as MCP server

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -14,8 +14,10 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire list` | `sessions_list()` |
 | `agentwire new -s name` | `session_create(name="...")` |
 | `agentwire send -s name "msg"` | `session_send(session="...", message="...")` |
-| `agentwire msg send --to name "msg"` | `msg_send(to="...", text="...", kind="note")` |
+| `agentwire msg send --to name "msg"` | `msg_send(to="...", text="...", kind="note", ref="")` |
 | `agentwire msg inbox -s name` | `msg_inbox(session="...")` |
+| `agentwire msg pull -s name` | `msg_pull(session="...")` |
+| `agentwire msg flush -s name` | `msg_flush(session="...")` |
 | `agentwire msg dead -s name` | `msg_dead(session="...")` |
 | `agentwire output -s name` | `session_output(session="...")` |
 | `agentwire info -s name` | `session_info(session="...")` |
@@ -25,7 +27,9 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 | `agentwire fork -s name -t project/branch` | `session_fork(session="...", target="...")` |
 | `agentwire fork -s name -t project/branch --commit abc` | `session_fork(session="...", target="...", commit="abc")` |
 
-**`session_send` vs `msg_send`:** `session_send` pastes + Enter **immediately** — and clobbers a human's half-typed draft if the box is occupied. Use it only when you must forcibly drive a session *now*. `msg_send` is the polite path: it queues a typed message into a file inbox and the watchdog injects it only when the recipient's box is empty and the pane is safe (≤60s). For routine peer updates ("PR drafted", "picking up the footer"), prefer `msg_send`. `kind` ∈ note|done|request|escalation; `to="@all"` broadcasts to live agent sessions except you. See wiki sessions/messaging.md.
+**`session_send` vs `msg_send`:** `session_send` pastes + Enter **immediately** — and clobbers a human's half-typed draft if the box is occupied. Use it only when you must forcibly drive a session *now*. `msg_send` is the polite path: it queues a typed message into a file inbox and the watchdog injects it only when the recipient's box is empty and the pane is safe (≤60s). For routine peer updates ("PR drafted", "picking up the footer"), prefer `msg_send`. `kind` ∈ note|done|request|escalation|**ingest**; `to="@all"` broadcasts to live agent sessions except you. See wiki sessions/messaging.md.
+
+**Passive `ingest` messages (Briefing Mode):** `kind="ingest"` is **never auto-delivered** — it lands silently and waits until the recipient calls `msg_pull()`. Use it for "output ready" awareness signals that must NOT drive the recipient into a turn. Pair with `ref="<path>"` so the pointer is machine-readable. `msg_flush` forces a (still-gated) drain of the *driving* queue; it never touches passive messages.
 
 **Note:** `session_create` (via `agentwire new`) records the calling session as the new session's creator — interactive prompts (permission/plan/AskUserQuestion) in the child then route back to you as `[PROMPT from ...]` messages. Answer them with `agentwire prompts answer -s <session> --expect <hash> <key>` via Bash (guarded compare-and-send), NEVER with raw `session_send_keys` — a late keystroke races the portal and can type into the child's input or abort its turn.
 
@@ -47,8 +51,10 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 
 | CLI Command | MCP Tool |
 |-------------|----------|
-| `agentwire say "text"` | `say(text="...")` |
-| `agentwire notify-parent "text"` | `notify(text="...", to="...")` |
+| `agentwire say "text"` | `say(text="...", display="...")` |
+| `agentwire notify-parent "text"` | `notify_parent(text="...", session="...")` |
+| `agentwire notify-user "text"` | `notify_user(text="...", session="...", priority="normal")` |
+| `agentwire notify-event EVENT` | `notify_event(event="...", session="...")` |
 | `agentwire listen start` | `listen_start()` |
 | `agentwire listen stop` | `listen_stop()` |
 | `agentwire listen cancel` | `listen_cancel()` |
@@ -101,7 +107,7 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 
 | CLI Command | MCP Tool |
 |-------------|----------|
-| `agentwire notify event` | `session_notify(event="...")` |
+| `agentwire notify-event EVENT` | `notify_event(event="...")` |
 | `agentwire tunnels up` | `tunnels_up()` |
 | `agentwire tunnels down` | `tunnels_down()` |
 | `agentwire tunnels status` | `tunnels_status()` |
@@ -162,7 +168,7 @@ up|down`) — the MCP surface is read-only introspection.
 | Open panel | `desktop_open_panel(panel_type="sessions")` |
 | Open artifact window (URL/file) | `desktop_open_artifact(url="...", title="...")` |
 | Write HTML + open as artifact | `desktop_write_artifact(filename="...", html_content="...", title="...")` |
-| Post toast notification | `portal_notify(text="...", session="...", priority="normal")` |
+| Post toast to the human | `notify_user(text="...", session="...", priority="normal")` (safe markdown: bold, [links](url), line breaks) |
 | Close window | `desktop_close_window(window_id="...")` |
 | Focus window | `desktop_focus_window(window_id="...")` |
 | Tile window | `desktop_tile_window(window_id="...", zone="left")` |
@@ -173,4 +179,6 @@ up|down`) — the MCP surface is read-only introspection.
 - **MCP tools** — Agents in sessions (orchestrators, workers)
 - **CLI commands** — Humans, shell scripts, automation outside of agent sessions
 
-**Note:** MCP tools don't support git worktree creation. Workers spawned via `pane_spawn` share the orchestrator's working directory. For isolated commits with worktrees, use the CLI `agentwire spawn --branch <name>` directly.
+**Worktree lifecycle (MCP):** `worktree_create(name, project_dir, roles, base, prompt)` spawns a worktree session (new branch + checkout + tmux session, optionally seeded with `prompt`); `worktree_status` / `worktree_list` (read-only git status), `worktree_remove` (teardown: kill + remove + unregister), `worktree_prune` (GC stale entries). Worker *panes* via `pane_spawn` still share the orchestrator's working dir — use those for quick subtasks, worktree sessions for isolated parallel work.
+
+**Briefing Mode** (asymmetric-verbosity orchestration): an `anchor` (terse, human-facing) fans out `correspondent` worktrees (verbose researchers) via `worktree_create(roles="correspondent")`; they file reports into `research_dir()` (`~/.agentwire/research/<session>/`) and drop a passive `msg_send(kind="ingest", ref="<path>")` pointer; the anchor `msg_pull()`s on the human's cue and briefs with `say(text=..., display=...)` (voice + toast, different content). See wiki briefing-mode.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,10 @@ Interactive prompts (permission, plan-approval, AskUserQuestion) hitting a child
 
 Multi-soul orchestrator sitting, **namespaced by `<name>`** so independent councils run concurrently: `agentwire-council-<name>` fans prompts out to lens sessions (`council-<name>-brain`, `council-<name>-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/<name>/prompts/`; the orchestrator collects and synthesizes with attribution. Targeting: `--name` → cwd-repo-slug if it matches a live sitting → sole live sitting → else error+list; every command echoes which sitting it hit. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...` (incl. `council list`), 6 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).
 
+## Briefing Mode
+
+Asymmetric-verbosity orchestration: a terse, human-facing **`anchor`** (persona role; replaces orchestrator) fans out exhaustively-verbose **`correspondent`** worktrees (`worktree_create(roles="correspondent", prompt=…)`; stacks on the worktree-session rail). Correspondents file deep reports into the dropbox (`agentwire research ensure` / `research_dir()` → `~/.agentwire/research/<anchor>/`) and signal **passively** — `msg send --kind ingest --ref <path>` is never auto-delivered, so it never drives the anchor. The anchor stays quiet until the human cues it, then `msg pull`s the pointers, reads the files, and **briefs across two channels in one call**: `say(text="<spoken headline>", display="<richer toast card>")` — different content per channel; the toast (`notify_user`) renders a safe markdown subset. Teardown via `worktree_remove` / `worktree_prune`. The notify-* family is split by target: `notify_user` (human toast), `notify_parent` (your orchestrator), `notify_event` (portal lifecycle). Full reference: [`docs/wiki/briefing-mode.md`](docs/wiki/briefing-mode.md).
+
 ## Reference Skills
 
 Reference detail lives in skills under `.claude/skills/` — invoke as needed:

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -26,8 +26,9 @@ How AgentWire runs AI agents — session types, REPLs, and permission models.
 - **[Window sizing](sessions/window-sizing.md)** — how tmux `window-size` policies interact with the portal (v1.33+ behavior change, healing stuck windows, policy picker)
 - **[Custom services](services.md)** — registered long-running sessions: autostart on portal launch, watchdog health checks + restart with backoff, `agentwire services` CLI
 - **[Council](council.md)** — multi-soul orchestrator sitting: fan a prompt out to lens sessions (brain, conscience, gut, critic, …), collect via file inbox, synthesize with attribution
+- **[Briefing Mode](briefing-mode.md)** — asymmetric-verbosity orchestration: a terse `anchor` fans out verbose `correspondent` worktrees that signal passively (`msg ingest`), then briefs the human across voice + screen (`say(text=, display=)`) on cue. Roles + dropbox + passive-pull + worktree lifecycle quartet
 - **[Prompt routing](sessions/prompt-routing.md)** — permission/plan/AskUserQuestion prompts in a child session route to its parent (hook path + watchdog sweep); guarded `agentwire prompts answer`, no auto-answering
-- **[Polite messaging](sessions/messaging.md)** — `agentwire msg` drops typed messages into a per-session file inbox and injects them only when the input box is empty (`prompt_is_empty`) and the pane is safe; never clobbers a human draft, the way `agentwire send` does. `@all` broadcast, MCP `msg_send`/`msg_inbox`
+- **[Polite messaging](sessions/messaging.md)** — `agentwire msg` drops typed messages into a per-session file inbox and injects them only when the input box is empty (`prompt_is_empty`) and the pane is safe; never clobbers a human draft, the way `agentwire send` does. `@all` broadcast, MCP `msg_send`/`msg_inbox`. Plus the **passive `ingest`** kind (never auto-delivered; pulled with `msg pull`) + typed `ref` pointer — the awareness primitive behind Briefing Mode
 
 ## Communication
 

--- a/docs/wiki/briefing-mode.md
+++ b/docs/wiki/briefing-mode.md
@@ -1,0 +1,80 @@
+# Briefing Mode
+
+> Asymmetric-verbosity orchestration. A terse, human-facing **anchor** fans out exhaustively-verbose **correspondent** worktrees; correspondents go deep and signal passively; the anchor pulls on the human's cue and briefs across two complementary channels (voice + screen). Many-deep-into-one-concise.
+>
+> Design + feasibility history: [`research/briefing-mode-feasibility.md`](research/briefing-mode-feasibility.md).
+
+## The shape
+
+```
+HUMAN ──"research X"──▶ ANCHOR ──worktree_create(roles=correspondent, prompt=…)──▶ N CORRESPONDENTS
+                         │ (terse, never self-driven)                                │ (verbose, isolated)
+HUMAN ◀──say(text,display)── ANCHOR ◀──msg_pull (on human's cue)── inbox ◀──msg ingest(ref)── each files
+                                          reads ref'd report files          (passive, never drives)
+```
+
+The anchor is the calm funnel: pushed only by the human, pulling from correspondents on its own cadence.
+
+## The two roles
+
+| Role | Spawn | Behavior |
+|---|---|---|
+| **`anchor`** | `agentwire new -s <name> --roles anchor` | Replaces the orchestrator persona. Terse with the human; fans out correspondents; **acts only on the human's cue**; briefs asymmetrically; tears down. |
+| **`correspondent`** | `worktree_create(name, roles="correspondent", prompt=…)` (or `agentwire worktree <name> --roles correspondent`) | Stacks on the worktree-session safety rail. Exhaustive; files a report to the dropbox; signals passively. |
+
+`anchor` *replaces* the persona (persona kind); `correspondent` *adds to* the worktree-session etiquette (safety-rail kind) — see [roles](roles.md).
+
+## The two channels (asymmetric brief)
+
+One call hits both, with **deliberately different content**:
+
+```
+say(text="<punchy spoken headline>", display="<richer scannable card>")
+```
+
+- **`text` (voice)** — the verdict + the single most important thing.
+- **`display` (screen toast, via `notify_user`)** — the structured summary with tradeoffs, paths, and **[links](url)**. Renders a safe markdown subset (bold, links, line breaks).
+
+Need a toast without speaking? `notify_user(text, priority="high")`.
+
+## Awareness without being driven
+
+Correspondents never interrupt the anchor. They drop a **passive** pointer:
+
+```
+agentwire msg send --to <anchor> --kind ingest --ref "<report-path>" "<topic>"
+```
+
+`ingest` is never auto-delivered (see [messaging](sessions/messaging.md)). The anchor collects pointers only when the human cues it:
+
+```
+msg_pull()        # consumes the ingest pointers; each carries a typed ref: path
+```
+
+…then reads the referenced report files, synthesizes across them, and briefs. The reports persist in the dropbox after teardown.
+
+## The dropbox
+
+Correspondents file into a per-anchor directory, resolved (and created) by:
+
+```
+agentwire research ensure -s <anchor>     # CLI → ~/.agentwire/research/<anchor>/
+research_dir()                            # MCP, defaults to the calling session
+```
+
+The big report lives here as a file; the `ingest` message only points at it.
+
+## Lifecycle / teardown
+
+```
+worktree_remove("<angle>")   # kill session + remove worktree + branch + unregister, in one
+worktree_prune()             # GC stale registry entries after many spawn/teardown cycles
+```
+
+## Surface added for Briefing Mode
+
+- **MCP:** `worktree_create` / `worktree_status` / `worktree_list` / `worktree_remove` / `worktree_prune`; `msg_pull` / `msg_flush`; `research_dir`; `say(display=)`; `notify_user` / `notify_parent` / `notify_event`.
+- **CLI:** `agentwire worktree --status` / `--prune` / `--prompt`; `agentwire msg pull`; `agentwire research dir|ensure`; `agentwire say --display`; `agentwire notify-user`.
+- **Inbox:** the passive `ingest` kind + typed `ref` field.
+
+Shipped across three phases (#430-group → #433 → #435 → #437).

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -73,6 +73,27 @@ clobbered draft is not.
 | `done` | a worker finished |
 | `request` | asking for something |
 | `escalation` | needs attention |
+| `ingest` | **passive** — awareness only; never auto-delivered (see below) |
+
+An optional `--ref` carries a machine-readable pointer (e.g. a report path)
+alongside the text, surfaced as a typed field rather than parsed out of prose —
+ideal with `ingest`.
+
+## Passive `ingest` — awareness without being driven
+
+Every other kind is *driving*: the watchdog pastes it (and presses Enter) into
+the recipient's prompt the moment their box is empty — which **starts a turn**.
+`ingest` is the exception. It routes to a reserved `ingest/` subdir that the
+drain and watchdog never walk, so it lands **silently** and waits. The recipient
+collects it on their own cadence with `msg pull` (MCP `msg_pull`) — read **and**
+remove. Nothing about an `ingest` message ever drives the recipient.
+
+This is the primitive behind **[Briefing Mode](../briefing-mode.md)**: a
+correspondent drops `msg send --kind ingest --ref <report-path> "<topic>"`; the
+anchor stays quiet until the human says "what's ready?", then `msg pull`s the
+pointers and reads the files. The durable content lives in the referenced file,
+not the message — so `pull` (consume-on-read) is the only way these leave the
+inbox; they are never dead-lettered.
 
 ## Broadcast
 
@@ -83,11 +104,13 @@ skipped automatically because their pane 0 doesn't run an agent.
 ## CLI
 
 ```bash
-agentwire msg send --to <session|@all> [--kind note|done|request|escalation] <text>
+agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest] [--ref <path>] <text>
 agentwire msg send --to agentwire-dev-fix-nav --kind done "PR #312 drafted"
-agentwire msg inbox [-s <session>]   # peek pending (does not drain)
+agentwire msg send --to anchor --kind ingest --ref /path/report.md "auth findings"  # passive
+agentwire msg inbox [-s <session>]   # peek pending + passive (does not drain/consume)
+agentwire msg pull  [-s <session>]   # read + REMOVE passive (ingest) messages
 agentwire msg dead  [-s <session>]   # list dropped (dead-lettered) msgs + why
-agentwire msg flush [-s <session>]   # attempt a drain now (still gated)
+agentwire msg flush [-s <session>]   # attempt a drain now (still gated; never touches passive)
 ```
 
 `msg dead` with `-s` scopes to one session; outside a session it lists every
@@ -99,9 +122,12 @@ the single source of truth; the portal and MCP call it.
 
 ## MCP tools
 
-- `msg_send(to, text, kind="note")` — polite peer update; delivers at the next
-  safe boundary.
-- `msg_inbox(session=None)` — peek pending messages (does not drain).
+- `msg_send(to, text, kind="note", ref="")` — polite peer update; delivers at the
+  next safe boundary. `kind="ingest"` is passive (pull-only); `ref` is a typed
+  pointer.
+- `msg_inbox(session=None)` — peek pending + passive messages (does not consume).
+- `msg_pull(session=None)` — read + remove passive (`ingest`) messages.
+- `msg_flush(session=None)` — force a (still-gated) drain of the driving queue.
 - `msg_dead(session=None)` — list dead-lettered messages with their drop reason
   + timestamp (omit `session` to list every session that has any).
 
@@ -113,7 +139,8 @@ session right now.
 
 | Path | Purpose |
 |---|---|
-| `~/.agentwire/inbox/<session>/*.json` | queued messages (filename = order) |
+| `~/.agentwire/inbox/<session>/*.json` | queued driving messages (filename = order) |
+| `~/.agentwire/inbox/<session>/ingest/` | passive `ingest` messages — pull-only, drain never walks here |
 | `~/.agentwire/inbox/<session>/dead/` | dead-lettered after the attempt cap |
 | `~/.agentwire/inbox/<session>/.lock/` | mkdir-based per-session drain lock |
 | `~/.agentwire/inbox/.tick.lock` | global flock guarding `tick()` |


### PR DESCRIPTION
Closes #439

Documents the now-shipped **Briefing Mode** (Phases 1-3) and refreshes references after the Phase 3 comms-surface rename.

- **New [`docs/wiki/briefing-mode.md`](docs/wiki/briefing-mode.md)** — canonical feature page: the shape, the two roles, the asymmetric brief, passive awareness, the dropbox, lifecycle, and the full CLI/MCP surface added. Linked from the wiki INDEX.
- **`messaging.md`** — passive `ingest` kind (+ why it doesn't drive), `msg pull`, typed `ref`, the `ingest/` state dir, `msg_flush`.
- **Skills** (`agentwire-mcp-tools`, `agentwire-cli`) — fix stale `portal_notify`/`session_notify`/`agentwire notify` → `notify_user`/`notify_event`/`notify-event`; add `worktree_create`/`prune`/`status` + `--prompt`, `msg_pull`/`flush`, `research`, `say --display`; replace the now-false "MCP can't create worktrees" note.
- **CLAUDE.md** — a Briefing Mode section.

Docs-only; the historical feasibility report keeps its point-in-time citations (banner notes the shipped names supersede).

Built by [dotdev.dev](https://dotdev.dev)