### PR TITLE
fix(notifications): toast click routes to subject session (#443)

### DIFF
--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -3147,7 +3147,8 @@ def notify_user(text: str, session: str | None = None, priority: str = "normal")
     The human-screen channel — the asymmetric text partner to `say` (audio).
     Supports a safe markdown subset (bold, line breaks, [links](url)). One of the
     notify_* family — see also notify_parent (your orchestrator) and notify_event
-    (portal lifecycle). Clicking the toast opens the notifications session.
+    (portal lifecycle). Clicking the toast opens the session that generated the
+    notification (the `session` below); a toast with no session is non-clickable.
 
     Args:
         text: Notification text. Bold (**x**), line breaks, and [links](https://…)

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -235,9 +235,13 @@ async function init() {
     // Scratch pad drawer (Alt+N, right-edge handle, selection capture)
     scratchpad.init();
 
-    // Click on a toast -> open the notifications session as interactive terminal
-    document.addEventListener('open-notification-session', () => {
-        openSessionTerminal('agentwire-notifications', 'terminal');
+    // Click on a toast -> open the subject session it's about as interactive terminal.
+    // No subject (e.g. a system-level toast) -> no-op, never fall back to the bridge.
+    document.addEventListener('open-notification-session', (e) => {
+        const session = e.detail && e.detail.session;
+        if (session) {
+            openSessionTerminal(session, 'terminal');
+        }
     });
 
     // Set initial voice indicator state

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -8,7 +8,6 @@
 import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 
-const NOTIFICATIONS_SESSION = 'agentwire-notifications';
 const MAX_TOASTS = 8;
 
 class NotificationsPanel {
@@ -76,10 +75,11 @@ class NotificationsPanel {
             <div class="notification-toast-body">${this._renderRichText(text)}</div>
         `;
 
-        // Click body -> open notifications session terminal
+        // Click body -> open the subject session this notification is about
         toast.querySelector('.notification-toast-body').addEventListener('click', () => {
-            // Import dynamically to avoid circular deps
-            const event = new CustomEvent('open-notification-session');
+            const event = new CustomEvent('open-notification-session', {
+                detail: { session: toast.dataset.session || '' },
+            });
             document.dispatchEvent(event);
         });
 


### PR DESCRIPTION
## Problem

Clicking a notification toast opened the producer session (`agentwire-notifications`) instead of the subject session the notification is *about*. The subject was carried correctly all the way to the frontend (`toast.dataset.session`) — only the final click handler dropped it.

## Fix

- `notifications-panel.js` — the click handler now threads `toast.dataset.session` through the `open-notification-session` CustomEvent `detail`.
- `desktop.js` — the listener opens **that subject session**; with no subject it's a no-op (never falls back to the `agentwire-notifications` bridge).
- `mcp_server.py` — `notify_user` docstring updated to match (opens the session that generated the notification).
- Removed the now-orphaned `NOTIFICATIONS_SESSION` const.

## Verification

Traced the full JS path in-worktree: single dispatch site (notifications-panel.js:81) → single `document` listener (desktop.js:240) → exported `openSessionTerminal` (desktop.js:557). Python + JS syntax-checked clean.

Closes #443

Built by [dotdev.dev](https://dotdev.dev)