### PR TITLE
feat(context): Phase 0 — session context-bloat observability (#442)

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -210,6 +210,11 @@ usage_limit:             # Usage-limit recovery watchdog (docs/wiki/usage-limit-
   enabled: true          # Master switch for dialog detection/parking (default: true)
   exclude_sessions: []   # Session names never auto-parked (gates NEW parks only)
 
+session_context:         # Context-bloat observability (Phase 0, observe-only — issue #442)
+  warn_remaining_pct: 20 # Flag a session when its REMAINING context drops to/below this %.
+                         # The Claude Code bar shows headroom, not usage, so LOW = bloated.
+                         # Surfaced via `agentwire list --context` and MCP `sessions_context`.
+
 worktree:                         # `agentwire worktree <name>` orchestration (WorktreeConfig).
                                   # Distinct from projects.worktrees above (the legacy
                                   # project/branch layout). `quicktask:` is a legacy alias for

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -7,11 +7,12 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 
 **Agents running in agentwire sessions should use MCP tools instead of CLI commands.** The agentwire MCP server provides tools that wrap CLI functionality. Use these instead of `Bash: agentwire <cmd>`.
 
-## Session Management (11 tools)
+## Session Management (12 tools)
 
 | CLI Command | MCP Tool |
 |-------------|----------|
 | `agentwire list` | `sessions_list()` |
+| `agentwire list --context` | `sessions_context(session="")` — context headroom (remaining %); LOW = bloated. Observe-only (#442). |
 | `agentwire new -s name` | `session_create(name="...")` |
 | `agentwire send -s name "msg"` | `session_send(session="...", message="...")` |
 | `agentwire msg send --to name "msg"` | `msg_send(to="...", text="...", kind="note", ref="")` |

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3418,7 +3418,8 @@ def cmd_list(args) -> int:
     local_only = getattr(args, 'local', False)
     remote_only = getattr(args, 'remote', False)
     machine_filter = getattr(args, 'machine', None)
-    show_sessions = getattr(args, 'sessions', False)
+    show_context = getattr(args, 'context', False)
+    show_sessions = getattr(args, 'sessions', False) or show_context
 
     # Check if we're inside a tmux session
     current_session = pane_manager.get_current_session()
@@ -3483,6 +3484,16 @@ def cmd_list(args) -> int:
                         }
                         if usage_limit_parked(parts[0]):
                             session_info["usage_limit"] = True
+                        if show_context:
+                            from .session_context import session_context as _sctx
+                            ctx = _sctx(parts[0])
+                            session_info["context"] = {
+                                "is_agent": ctx.is_agent,
+                                "remaining_pct": ctx.remaining_pct,
+                                "model": ctx.model,
+                                "flagged": ctx.flagged,
+                                "note": ctx.note,
+                            }
                         local_sessions.append(session_info)
                         all_sessions.append(session_info)
 
@@ -3560,7 +3571,17 @@ def cmd_list(args) -> int:
                 # Remove @machine suffix for display within machine group
                 display_name = s['name'].rsplit('@', 1)[0] if '@' in s['name'] else s['name']
                 parked_marker = " [parked: usage limit]" if s.get("usage_limit") else ""
-                print(f"  {display_name}: {s['windows']} window(s) ({s['path']}){parked_marker}")
+                ctx_marker = ""
+                if show_context:
+                    ctx = s.get("context")
+                    if ctx is None:
+                        ctx_marker = "  ctx=remote(n/a)"
+                    elif ctx.get("remaining_pct") is None:
+                        ctx_marker = "  ctx=— (daemon/non-agent)" if not ctx.get("is_agent") else "  ctx=? (no bar)"
+                    else:
+                        flag = " ⚠ LOW" if ctx.get("flagged") else ""
+                        ctx_marker = f"  ctx={ctx['remaining_pct']}% left{flag}"
+                print(f"  {display_name}: {s['windows']} window(s) ({s['path']}){parked_marker}{ctx_marker}")
         else:
             print("  (no sessions)")
         print()
@@ -11297,6 +11318,9 @@ def main() -> int:
     list_parser.add_argument("--remote", action="store_true", help="Only show remote sessions")
     list_parser.add_argument("--machine", help="Filter by specific machine ID")
     list_parser.add_argument("--sessions", action="store_true", help="Show sessions instead of panes")
+    list_parser.add_argument("--context", action="store_true",
+                             help="Annotate each session with its Claude Code context headroom "
+                                  "(remaining %); flags sessions running low (implies --sessions)")
     list_parser.set_defaults(func=cmd_list)
 
     new_parser = subparsers.add_parser("new", help="Create new Claude Code session")

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -448,6 +448,20 @@ class PromptRouterConfig:
 
 
 @dataclass
+class SessionContextConfig:
+    """Session context-bloat observability (Phase 0) knobs.
+
+    Observe-only: surfaces each session's remaining-context % and flags
+    sessions running low. No auto-``/clear`` / ``/compact`` — that is Phase 1.
+    """
+
+    # Flag a session when its REMAINING context drops to/below this %
+    # (the bar shows headroom, not usage — see session_context.py). Default
+    # 20% remaining == ~80% of the way toward the limit.
+    warn_remaining_pct: int = 20
+
+
+@dataclass
 class Config:
     """Root configuration for AgentWire."""
 
@@ -468,6 +482,7 @@ class Config:
     safety: SafetyConfig = field(default_factory=SafetyConfig)
     usage_limit: UsageLimitConfig = field(default_factory=UsageLimitConfig)
     prompt_router: PromptRouterConfig = field(default_factory=PromptRouterConfig)
+    session_context: SessionContextConfig = field(default_factory=SessionContextConfig)
     channels: dict = field(default_factory=dict)
 
 
@@ -771,6 +786,18 @@ def _dict_to_config(data: dict) -> Config:
         exclude_sessions=[str(s) for s in pr_exclude_raw if s],
     )
 
+    # Session context observability (Phase 0 — bloat warn threshold)
+    session_context_data = data.get("session_context", {}) or {}
+    if not isinstance(session_context_data, dict):
+        session_context_data = {}
+    try:
+        warn_remaining_pct = int(session_context_data.get("warn_remaining_pct", 20))
+    except (TypeError, ValueError):
+        warn_remaining_pct = 20
+    session_context = SessionContextConfig(
+        warn_remaining_pct=max(0, min(100, warn_remaining_pct)),
+    )
+
     # Session defaults
     session_data = data.get("session", {}) or {}
     session = SessionConfig(
@@ -796,6 +823,7 @@ def _dict_to_config(data: dict) -> Config:
         safety=safety,
         usage_limit=usage_limit,
         prompt_router=prompt_router,
+        session_context=session_context,
     )
 
 

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -309,6 +309,77 @@ def sessions_list() -> str:
     return format_sessions(data)
 
 
+def format_session_contexts(data: dict, session_filter: str | None = None) -> str:
+    """Format per-session context headroom for LLM consumption.
+
+    The bar % is context REMAINING (headroom before Claude Code auto-compacts),
+    not usage — so LOW = bloated. Daemons (scheduler/portal/tts/…) have no bar
+    and are reported as non-interactive.
+    """
+    sessions = data.get("sessions", [])
+    if session_filter:
+        sessions = [s for s in sessions if s.get("name", "").split("@")[0] == session_filter]
+        if not sessions:
+            return f"No session named '{session_filter}'."
+    if not sessions:
+        return "No active sessions."
+
+    def sort_key(s):
+        ctx = s.get("context") or {}
+        pct = ctx.get("remaining_pct")
+        return (not ctx.get("is_agent"), pct if pct is not None else 999, s.get("name", ""))
+
+    flagged = []
+    lines = ["Session context (remaining % = headroom; LOW = bloated):"]
+    for s in sorted(sessions, key=sort_key):
+        name = s.get("name", "unknown")
+        ctx = s.get("context")
+        if ctx is None:
+            lines.append(f"  - {name}: (remote — context n/a)")
+            continue
+        pct = ctx.get("remaining_pct")
+        if pct is None:
+            kind = "daemon/non-agent" if not ctx.get("is_agent") else "agent, no bar visible"
+            lines.append(f"  - {name}: — ({kind})")
+            continue
+        model = f" {ctx['model']}" if ctx.get("model") else ""
+        flag = "  ⚠ LOW — running out of context" if ctx.get("flagged") else ""
+        lines.append(f"  - {name}:{model} {pct}% context remaining{flag}")
+        if ctx.get("flagged"):
+            flagged.append(name)
+
+    if flagged:
+        lines.append("")
+        lines.append(f"⚠ {len(flagged)} session(s) low on context: {', '.join(flagged)}")
+        lines.append("(Observe-only — Phase 0. No auto-/clear or /compact is performed.)")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def sessions_context(session: str | None = None) -> str:
+    """Report Claude Code context headroom for sessions (observability only).
+
+    Each interactive session's footer shows a context bar whose percentage is
+    the context REMAINING before Claude Code auto-compacts — so a LOW number
+    means the session is bloated. Daemon sessions (scheduler/portal/tts/stt)
+    run plain processes with no bar and are reported as non-interactive.
+
+    This is Phase 0 of context-bloat management: it makes bloat visible and
+    queryable. It NEVER auto-/clear or /compacts a session.
+
+    Args:
+        session: Optional single session name to report. Omit for all sessions
+            (sorted most-bloated first).
+
+    Returns:
+        Formatted per-session context state, with low sessions flagged.
+    """
+    data = run_agentwire_cmd(["list", "--context"])
+    if not data.get("success"):
+        return f"Failed to read session context: {data.get('error', 'Unknown error')}"
+    return format_session_contexts(data, session_filter=session)
+
+
 @mcp.tool()
 def session_create(
     name: str,

--- a/agentwire/session_context.py
+++ b/agentwire/session_context.py
@@ -1,0 +1,196 @@
+"""Session context observability — read the Claude Code context bar from a pane.
+
+Phase 0 of context-bloat management (issue #442): make bloat *visible* and
+queryable. This module only OBSERVES — it never auto-``/clear``s or
+``/compact``s anything (that is Phase 1, a separate change).
+
+What the bar means (verified empirically, 2026-06-22)
+-----------------------------------------------------
+The Claude Code footer renders a line like::
+
+    [████████████████████████░░░░░] 92%
+
+The percentage is **context REMAINING** — the headroom left before Claude
+Code's own auto-compaction kicks in, NOT the amount consumed. Evidence:
+
+- A fresh session reads high (~94%); the gap from 100% is the baseline
+  system-prompt + tools + CLAUDE.md overhead that every session pays.
+- Driving a live session and watching the number move: it *decreases* as the
+  conversation grows (observed 92% → 91% after loading ~1.4k lines of files
+  into one session's context).
+- It does NOT correlate with age — a 6-day-old service session read 92% while
+  a freshly-created session read 83% — because Claude Code auto-compacts and
+  the number jumps back up afterward. So it is a live, resettable headroom
+  gauge, not a lifetime-usage counter.
+
+Therefore "bloated" == **LOW remaining %**. A session is flagged when its
+remaining context drops to/below the warn threshold (default 20% remaining,
+i.e. ~80% of the way toward the limit — the framing used in #442).
+
+How it is parsed
+----------------
+Straight from ``tmux capture-pane`` text, the same mechanism agentwire already
+uses for usage-limit dialogs (:func:`usage_limit._capture`) and prompt boxes
+(:func:`prompt_router.input_box_content`). No new API into Claude Code.
+
+Daemon sessions (scheduler / portal / tts / stt / kokoro) run plain processes,
+not Claude conversations — they have no bar and nothing to bloat. They are
+detected via the pane's current command (not an agent binary) and skipped
+gracefully (surfaced as non-interactive, never flagged).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+
+from .usage_limit import _capture, _tmux
+
+# The context bar: a bracketed run of block-element glyphs (U+2580–U+259F
+# covers full/partial/empty blocks) followed by "NN%". ANSI is stripped first.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m|\x1b\].*?\x07")
+_CONTEXT_BAR_RE = re.compile(r"\[(?:[▀-▟]|\s)+\]\s*(\d{1,3})\s*%")
+# The meta line above the bar: "… main   opus  $1805.19  7988m".
+_MODEL_RE = re.compile(r"\b(opus|sonnet|haiku|fable)\b", re.IGNORECASE)
+
+# pane_current_command values that mean an interactive agent runs in the pane.
+# Claude Code panes report the node binary or a bare version string
+# (e.g. "2.1.185"); daemons report python3.13 / uv / a bare shell. Mirrors
+# prompt_router._AGENT_COMMAND_RE — kept local to avoid an import cycle risk.
+_AGENT_COMMAND_RE = re.compile(r"^(node|claude|\d+\.\d+\.\d+\S*)$")
+
+DEFAULT_WARN_REMAINING_PCT = 20
+
+
+@dataclass
+class SessionContext:
+    """Context state of a single session's pane."""
+
+    session: str
+    pane: int
+    is_agent: bool  # interactive Claude session (vs daemon / bare shell)
+    remaining_pct: int | None  # % context HEADROOM left; None when no bar
+    model: str | None
+    flagged: bool  # remaining_pct <= warn threshold (agents only)
+    note: str  # human-readable one-liner
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def parse_context_bar(visible: str) -> int | None:
+    """Remaining-context % from a Claude Code status bar, or None.
+
+    None means no bar on screen — a daemon pane, a busy/starting render, or a
+    pane that simply isn't a Claude conversation.
+    """
+    clean = _ANSI.sub("", visible)
+    m = _CONTEXT_BAR_RE.search(clean)
+    if not m:
+        return None
+    pct = int(m.group(1))
+    return pct if 0 <= pct <= 100 else None
+
+
+def parse_model(visible: str) -> str | None:
+    clean = _ANSI.sub("", visible)
+    m = _MODEL_RE.search(clean)
+    return m.group(1).lower() if m else None
+
+
+def _pane_command(session: str, pane: int) -> str:
+    try:
+        result = _tmux(
+            ["display", "-t", f"{session}.{pane}", "-p", "#{pane_current_command}"]
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _is_agent_command(command: str) -> bool:
+    return bool(_AGENT_COMMAND_RE.match(command.strip()))
+
+
+def session_context(
+    session: str, pane: int = 0, warn_threshold: int | None = None
+) -> SessionContext:
+    """Read one session's context state from its pane.
+
+    ``warn_threshold`` is the *remaining* % at/below which the session is
+    flagged (default :data:`DEFAULT_WARN_REMAINING_PCT`). A daemon / non-agent
+    pane is surfaced as ``is_agent=False`` and never flagged.
+    """
+    threshold = warn_threshold if warn_threshold is not None else _warn_threshold()
+    command = _pane_command(session, pane)
+    is_agent = _is_agent_command(command)
+    visible = _capture(f"{session}.{pane}")
+    remaining = parse_context_bar(visible)
+    model = parse_model(visible) if remaining is not None else None
+
+    if remaining is None:
+        flagged = False
+        note = (
+            f"daemon / non-agent ({command or 'unknown'}) — no context bar"
+            if not is_agent
+            else "agent pane but no bar visible (busy render or starting up)"
+        )
+    else:
+        flagged = remaining <= threshold
+        note = f"{remaining}% context remaining" + (
+            f" — LOW (<= {threshold}% warn threshold)" if flagged else ""
+        )
+
+    return SessionContext(
+        session=session,
+        pane=pane,
+        is_agent=is_agent,
+        remaining_pct=remaining,
+        model=model,
+        flagged=flagged,
+        note=note,
+    )
+
+
+def _list_local_sessions() -> list[str]:
+    try:
+        result = _tmux(["list-sessions", "-F", "#{session_name}"])
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [s for s in result.stdout.strip().splitlines() if s]
+
+
+def all_session_contexts(
+    warn_threshold: int | None = None,
+) -> list[SessionContext]:
+    """Context state for every local session (pane 0), sorted bloated-first.
+
+    Pane 0 is the orchestrator / main conversation — the long-lived surface
+    that accumulates. Daemons fall out as ``is_agent=False`` and sort last.
+    """
+    threshold = warn_threshold if warn_threshold is not None else _warn_threshold()
+    contexts = [
+        session_context(name, 0, threshold) for name in _list_local_sessions()
+    ]
+    # Bloated agents first (lowest remaining), then other agents, then daemons.
+    contexts.sort(
+        key=lambda c: (
+            not c.is_agent,
+            c.remaining_pct if c.remaining_pct is not None else 999,
+            c.session,
+        )
+    )
+    return contexts
+
+
+def _warn_threshold() -> int:
+    """The remaining-% warn threshold from config (best-effort default)."""
+    try:
+        from .config import get_config
+
+        return int(get_config().session_context.warn_remaining_pct)
+    except Exception:
+        return DEFAULT_WARN_REMAINING_PCT

--- a/tests/unit/test_session_context.py
+++ b/tests/unit/test_session_context.py
@@ -1,0 +1,96 @@
+"""Tests for session context-bar parsing (issue #442, Phase 0 — observe only).
+
+Locks in the verified semantic: the Claude Code footer bar percentage is
+context REMAINING (headroom before auto-compact), not usage — so a LOW number
+means a bloated session. Parsing is pure string work on captured pane text;
+these tests cover the real bar shapes seen on live sessions plus the daemon /
+no-bar skip paths.
+"""
+
+from unittest.mock import patch
+
+from agentwire import session_context as sc
+
+# Real captures from live sessions (2026-06-22): the bar width tracks terminal
+# width, so the same 92% renders with different glyph counts.
+WIDE_BAR = "  [████████████████████████████████████████████████████████████████████████████████░░░░░░░░] 92%"
+NARROW_BAR = "  [████████████████████████████████████████████████████████████████░░░░░░] 92%"
+LOW_BAR = "  [█████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 12%"
+META_LINE = "  ~/projects/agentwire-dev  main                       opus  $1805.19  7988m"
+
+
+def test_parse_bar_wide_and_narrow_same_pct():
+    assert sc.parse_context_bar(WIDE_BAR) == 92
+    assert sc.parse_context_bar(NARROW_BAR) == 92
+
+
+def test_parse_bar_low():
+    assert sc.parse_context_bar(LOW_BAR) == 12
+
+
+def test_parse_bar_with_ansi():
+    noisy = "\x1b[2m" + WIDE_BAR + "\x1b[0m"
+    assert sc.parse_context_bar(noisy) == 92
+
+
+def test_no_bar_returns_none():
+    assert sc.parse_context_bar("INFO: 127.0.0.1 - GET /health 200 OK") is None
+    assert sc.parse_context_bar("[2026-06-22 07:43:41] Nothing due. Sleeping 0s...") is None
+    assert sc.parse_context_bar("") is None
+
+
+def test_out_of_range_rejected():
+    assert sc.parse_context_bar("[██░░] 150%") is None
+
+
+def test_parse_model():
+    assert sc.parse_model(META_LINE) == "opus"
+    assert sc.parse_model("  main  sonnet  $1.00") == "sonnet"
+    assert sc.parse_model("no model here") is None
+
+
+def _ctx(command: str, pane_text: str):
+    """Build a SessionContext with pane command + capture mocked."""
+    with patch.object(sc, "_pane_command", return_value=command), patch.object(
+        sc, "_capture", return_value=pane_text
+    ):
+        return sc.session_context("s", warn_threshold=20)
+
+
+def test_agent_session_healthy():
+    c = _ctx("node", "\n".join([META_LINE, WIDE_BAR]))
+    assert c.is_agent is True
+    assert c.remaining_pct == 92
+    assert c.model == "opus"
+    assert c.flagged is False
+
+
+def test_agent_session_flagged_when_low():
+    c = _ctx("2.1.185", "\n".join([META_LINE, LOW_BAR]))
+    assert c.is_agent is True
+    assert c.remaining_pct == 12
+    assert c.flagged is True  # 12 <= 20 warn threshold
+    assert "LOW" in c.note
+
+
+def test_daemon_skipped_gracefully():
+    c = _ctx("python3.13", "INFO: GET /health 200 OK")
+    assert c.is_agent is False
+    assert c.remaining_pct is None
+    assert c.flagged is False
+    assert "daemon" in c.note
+
+
+def test_agent_pane_no_bar_visible():
+    c = _ctx("node", "...busy render, no footer yet...")
+    assert c.is_agent is True
+    assert c.remaining_pct is None
+    assert c.flagged is False
+    assert "no bar" in c.note
+
+
+def test_threshold_boundary_inclusive():
+    at = _ctx("node", "\n".join([META_LINE, "[██░░] 20%"]))
+    assert at.flagged is True  # remaining == threshold is flagged
+    above = _ctx("node", "\n".join([META_LINE, "[██░░] 21%"]))
+    assert above.flagged is False


### PR DESCRIPTION
## What

Phase 0 of context-bloat management (#442): make Claude Code context bloat **visible and queryable**. **Observe-only** — this PR takes no action on any session (no `/clear`, no `/compact`). That's Phase 1, a separate PR.

Part of #442, Phase 0 (observability); Phase 1 auto-clear is a follow-up — so the issue stays open.

## Step 1 — what the bar % MEANS (verified empirically, gated everything else)

The Claude Code footer renders `[████░░░] 92%`. The percentage is **context REMAINING** (headroom before Claude Code's own auto-compaction), **not** usage. Evidence gathered against live sessions on 2026-06-22:

- **It decreases as context fills.** Watching my own session over the course of this task: `92% → 91% → 88%` as I loaded files into context. Higher = more headroom.
- **It does not correlate with age** — a 6-day-old service session read **92%** while a freshly-created session read **83%** — because Claude Code auto-compacts and the number jumps back up. So it's a live, *resettable* headroom gauge, not a lifetime counter.
- **A fresh session reads ~94%, not 100%** — the gap is the baseline system-prompt + tools + CLAUDE.md every session pays.

**Therefore "bloated" == LOW remaining %.** A session is flagged when remaining drops to/below the warn threshold (default **20% remaining ≈ 80% toward the limit**, the framing used in the issue). All downstream logic is built on this verified semantic.

## How

Parsed straight from `tmux capture-pane` text — the exact mechanism agentwire already uses for usage-limit dialogs (`usage_limit._capture`) and prompt boxes (`prompt_router.input_box_content`). No new API into Claude Code.

- **`agentwire/session_context.py`** (new) — `parse_context_bar()`, `session_context()`, `all_session_contexts()`. Classifies interactive-Claude vs daemon by the pane's current command; daemons (scheduler/portal/tts/stt/kokoro run `python3.13`/`uv`) have no bar and are skipped gracefully (surfaced as non-interactive, never flagged).
- **Config** — `session_context.warn_remaining_pct` (default 20).
- **CLI** — `agentwire list --context` annotates each session with its headroom (`ctx=88% left`, `ctx=— (daemon/non-agent)`, `⚠ LOW`). JSON output carries a `context` object per session.
- **MCP** — `sessions_context(session="")` — one session or all, sorted most-bloated-first, with a flagged summary.
- **Tests** — 11 unit tests locking the semantic + the daemon/no-bar skip paths.

## Verification (in-worktree, against real sessions)

Proved the skip logic on both a daemon and an interactive session:

```
agentwire-notifications     agent=True  rem=92  model=opus  flagged=False  (interactive)
agentwire-scheduler         agent=False rem=None             flagged=False  daemon / non-agent (python3.13)
agentwire-portal            agent=False rem=None             flagged=False  daemon / non-agent (uv)
agentwire-dev-security...   agent=True  rem=90  model=opus  flagged=False  (interactive)
```

- Flag fires correctly: `notifications @ threshold=95 → flagged=True`.
- `agentwire list --context` and `sessions_context()` both render cleanly (text + JSON).
- Full unit suite: 163 passed; the 1 failure + 4 errors are **pre-existing** (confirmed by stashing this branch's changes — same failures on base; all TTS/portal-API, unrelated to this change).

## Not in scope (Phase 1+)

No auto-action on any session. Portal indicator deferred (CLI + MCP were the must-haves).

Built by [dotdev.dev](https://dotdev.dev)