### PR TITLE
Truthful voice status + verified delivery (#441, #444)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -1448,25 +1448,6 @@ def _describe_probe_error(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
-def _check_tts_health(
-    url: str, timeout: int = 2
-) -> tuple[bool, list[str] | None, str | None]:
-    """Check if TTS server is responding at URL.
-
-    Returns:
-        (is_healthy, voices_list or None, error_cause or None)
-    """
-
-    try:
-        req = urllib.request.urlopen(f"{url}/voices", timeout=timeout)
-        voices = json.loads(req.read().decode())
-        if isinstance(voices, list):
-            return True, voices, None
-        return True, None, None
-    except Exception as e:
-        return False, None, _describe_probe_error(e)
-
-
 def cmd_tts_start(args) -> int:
     """Start the Chatterbox TTS server in tmux."""
     from .network import NetworkContext
@@ -1626,185 +1607,39 @@ def cmd_tts_warm(args) -> int:
 
 
 def cmd_tts_status(args) -> int:
-    """Check TTS status (default tier: in-process Kokoro; custom: shim server)."""
-    from .network import NetworkContext
+    """Report whether speech can happen right now and via what path.
+
+    Resolves the ACTIVE tier (default → browser/OS; custom → shim) and only
+    probes a server when the tier actually has one. Flags an orphaned engine
+    server — e.g. a shim still up on the custom-tier port while the tier is
+    'default' (running but unused) (#441).
+    """
+    from .config import load_config as load_config_typed
+    from .voice_status import resolve_tts_status
 
     json_mode = getattr(args, 'json', False)
-    ctx = NetworkContext.from_config()
     session_name = get_tts_session_name()
-    config = load_config()
-    backend = config.get("tts", {}).get("backend", "unknown")
+    st = resolve_tts_status(load_config_typed())
 
-    if backend == "default":
-        # Default tier: Kokoro runs in-process (portal/CLI) — there is no
-        # shim server to probe. Report install + model-cache state.
-        from .tts.local import kokoro_importable
+    if json_mode:
+        payload = {"success": True, **st.to_json()}
+        if st.server_url:
+            payload["session"] = session_name if tmux_session_exists(session_name) else None
+        _output_json(payload)
+        return 0 if st.ready else 1
 
-        importable = kokoro_importable()
-        cached = False
-        if importable:
-            from .tts.engines.kokoro import KokoroEngine
-
-            cached = KokoroEngine.model_files_cached()
-        state = (
-            "ready" if cached
-            else "model not downloaded" if importable
-            else "unavailable (kokoro-onnx not installed; requires Python <3.14)"
-        )
-        if json_mode:
-            _output_json({
-                "success": True,
-                "tier": "default",
-                "engine": "kokoro",
-                "kokoro_installed": importable,
-                "model_cached": cached,
-                "state": state,
-                "backend": backend,
-            })
-        else:
-            print("Default voice tier: Kokoro (in-process)")
-            print(f"  State: {state}")
-            if importable and not cached:
-                print("  Download: run 'agentwire tts warm' to fetch the ~200 MB "
-                      "model now (one-time, cached to ~/.cache/kokoro_onnx/).")
-                print("            Or just start the portal — it downloads in the "
-                      "background and speaks with the OS voice until ready.")
-        return 0
-
-    if ctx.is_local("tts"):
-        url = ctx.get_service_url("tts", use_tunnel=False)
-        if tmux_session_exists(session_name):
-            healthy, voices, error = _check_tts_health(url)
-            if json_mode:
-                _output_json({
-                    "success": True,
-                    "running": True,
-                    "url": url,
-                    "session": session_name,
-                    "healthy": healthy,
-                    "voices": voices or [],
-                    "error": error,
-                    "backend": backend,
-                    "machine": None,
-                })
-            else:
-                print(f"TTS server is running in tmux session '{session_name}'")
-                print(f"  Attach: tmux attach -t {session_name}")
-                if healthy:
-                    if voices:
-                        print(f"  Voices: {', '.join(voices)}")
-                    else:
-                        print(f"  Health: OK ({url})")
-                else:
-                    print(f"  Status: not responding yet — {error}")
-            return 0
-        else:
-            # No local tmux session, but check if TTS is reachable anyway
-            healthy, voices, error = _check_tts_health(url)
-            if healthy:
-                if json_mode:
-                    _output_json({
-                        "success": True,
-                        "running": True,
-                        "url": url,
-                        "healthy": True,
-                        "voices": voices or [],
-                        "backend": backend,
-                        "machine": None,
-                        "external": True,
-                    })
-                else:
-                    print("TTS server is running (external/tunnel)")
-                    if voices:
-                        print(f"  Voices: {', '.join(voices)}")
-                    print(f"  URL: {url}")
-                return 0
-
-            if json_mode:
-                _output_json({
-                    "success": True,
-                    "running": False,
-                    "url": url,
-                    "healthy": False,
-                    "error": error,
-                    "backend": backend,
-                    "machine": None,
-                })
-            else:
-                print("TTS server is not running.")
-                if error:
-                    print(f"  Probe: {error}")
-                print("  Start:  agentwire tts start")
-            return 1
-
-    # TTS runs on another machine - check via health endpoint
-    machine_id = ctx.get_machine_for_service("tts")
-    url = ctx.get_service_url("tts", use_tunnel=True)
-
-    healthy, voices, error = _check_tts_health(url)
-    if healthy:
-        if json_mode:
-            _output_json({
-                "success": True,
-                "running": True,
-                "url": url,
-                "healthy": True,
-                "voices": voices or [],
-                "backend": backend,
-                "machine": machine_id,
-            })
-        else:
-            print(f"TTS server runs on {machine_id}")
-            print("  Status: running")
-            if voices:
-                print(f"  Voices: {', '.join(voices)}")
-            print(f"  URL: {url}")
-        return 0
-    else:
-        # Try direct connection if tunnel might not exist
-        direct_url = ctx.get_service_url("tts", use_tunnel=False)
-        direct_error = None
-        if direct_url != url:
-            healthy, voices, direct_error = _check_tts_health(direct_url)
-            if healthy:
-                if json_mode:
-                    _output_json({
-                        "success": True,
-                        "running": True,
-                        "url": direct_url,
-                        "healthy": True,
-                        "voices": voices or [],
-                        "backend": backend,
-                        "machine": machine_id,
-                        "tunnel_issue": True,
-                    })
-                else:
-                    print(f"TTS server runs on {machine_id}")
-                    print("  Status: running (tunnel not working, direct OK)")
-                    if voices:
-                        print(f"  Voices: {', '.join(voices)}")
-                    print(f"  URL: {direct_url}")
-                    print("  Hint: Run 'agentwire tunnels check' to verify tunnels")
-                return 0
-
-        if json_mode:
-            _output_json({
-                "success": True,
-                "running": False,
-                "url": url,
-                "healthy": False,
-                "error": error,
-                "direct_error": direct_error,
-                "backend": backend,
-                "machine": machine_id,
-            })
-        else:
-            print(f"TTS server runs on {machine_id}")
-            print("  Status: not reachable")
-            print(f"  Checked: {url} — {error}")
-            if direct_url != url:
-                print(f"  Also checked: {direct_url} — {direct_error}")
-        return 1
+    print(f"TTS: {st.tier} tier — {st.path}")
+    print(f"  {'[ok]' if st.ready else '[!!]'} {st.detail}")
+    if st.server_url and tmux_session_exists(session_name):
+        print(f"  Attach: tmux attach -t {session_name}")
+    if not st.ready and st.tier == "custom":
+        print("  Start: agentwire tts start")
+    if st.tier == "default":
+        print("  Warm the in-process model now: agentwire tts warm "
+              "(else the portal downloads it in the background, OS voice until ready)")
+    for w in st.warnings:
+        print(f"  [..] {w}")
+    return 0 if st.ready else 1
 
 
 # === STT Commands ===
@@ -1895,71 +1730,32 @@ def cmd_stt_stop(args) -> int:
 
 
 def cmd_stt_status(args) -> int:
-    """Check STT server status."""
+    """Report the active STT tier's path — only probing a server when the tier
+    actually has one (default-with-Moonshine, custom). Cloud and the browser
+    fallback have no shim to probe (#441)."""
+    from .config import load_config as load_config_typed
+    from .voice_status import resolve_stt_status
+
     json_mode = getattr(args, 'json', False)
     session_name = get_stt_session_name()
-    config = load_config()
-    stt_url = config.get("stt", {}).get("url", "http://localhost:8101")
-
-    # Check health endpoint
-    probe_error = None
-    try:
-        req = urllib.request.Request(f"{stt_url}/health")
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            data = json.loads(resp.read().decode())
-            if json_mode:
-                _output_json({
-                    "success": True,
-                    "running": True,
-                    "url": stt_url,
-                    "healthy": True,
-                    "model": data.get('model', 'unknown'),
-                    "device": data.get('device', 'unknown'),
-                    "session": session_name if tmux_session_exists(session_name) else None,
-                })
-            else:
-                print("STT server is running")
-                print(f"  Model: {data.get('model', 'unknown')}")
-                print(f"  Device: {data.get('device', 'unknown')}")
-                print(f"  URL: {stt_url}")
-                if tmux_session_exists(session_name):
-                    print(f"  Attach: tmux attach -t {session_name}")
-            return 0
-    except Exception as e:
-        probe_error = _describe_probe_error(e)
-
-    if tmux_session_exists(session_name):
-        if json_mode:
-            _output_json({
-                "success": True,
-                "running": True,
-                "url": stt_url,
-                "healthy": False,
-                "error": probe_error,
-                "session": session_name,
-                "starting": True,
-            })
-        else:
-            print(f"STT server is starting in tmux session '{session_name}'")
-            if probe_error:
-                print(f"  Probe: {probe_error}")
-            print(f"  Attach: tmux attach -t {session_name}")
-        return 0
+    st = resolve_stt_status(load_config_typed())
 
     if json_mode:
-        _output_json({
-            "success": True,
-            "running": False,
-            "url": stt_url,
-            "healthy": False,
-            "error": probe_error,
-        })
-    else:
-        print("STT server is not running.")
-        if probe_error:
-            print(f"  Probe: {probe_error}")
+        payload = {"success": True, **st.to_json()}
+        if st.server_url:
+            payload["session"] = session_name if tmux_session_exists(session_name) else None
+        _output_json(payload)
+        return 0 if st.ready else 1
+
+    print(f"STT: {st.tier} tier — {st.path}")
+    print(f"  {'[ok]' if st.ready else '[!!]'} {st.detail}")
+    if st.server_url and tmux_session_exists(session_name):
+        print(f"  Attach: tmux attach -t {session_name}")
+    if not st.ready and st.server_url:
         print("  Start: agentwire stt start")
-    return 1
+    for w in st.warnings:
+        print(f"  [..] {w}")
+    return 0 if st.ready else 1
 
 
 # === Kokoro (default-tier TTS shim) Commands ===
@@ -2415,15 +2211,16 @@ def _infer_session_from_path() -> str | None:
     return None
 
 
-def _check_portal_connections(session: str, portal_url: str) -> tuple[bool, str]:
+def _check_portal_connections(session: str, portal_url: str) -> tuple[bool, str, int]:
     """Check if portal has active browser connections for a session.
 
     Tries session name variants: as-is, with hostname.
 
     Returns:
-        Tuple of (has_connections, actual_session_name)
+        Tuple of (has_connections, actual_session_name, connection_count)
         - has_connections: True if there are connections (audio should go to portal)
         - actual_session_name: The session name that has connections (may include @machine)
+        - connection_count: number of connected browser clients for that session
     """
     import ssl
 
@@ -2448,13 +2245,13 @@ def _check_portal_connections(session: str, portal_url: str) -> tuple[bool, str]
             with urllib.request.urlopen(req, context=ctx, timeout=5) as response:
                 result = json.loads(response.read().decode())
                 if result.get("has_connections", False):
-                    return True, session_name
+                    return True, session_name, int(result.get("connection_count", 0))
 
         except Exception:
             continue
 
     # No connections found in any variant
-    return False, session
+    return False, session, 0
 
 
 def _local_say_os(text: str) -> int:
@@ -2550,11 +2347,15 @@ def _local_say_dispatch(
     instructions: str | None = None,
     language: str = "English",
     stream: bool = False,
-) -> int:
+) -> tuple[int, str]:
     """Local (non-portal) TTS playback, dispatched on the configured tier.
 
     default → in-process Kokoro (OS voice until the model is cached);
     custom → HTTP shim + afplay/aplay; anything else (none) → OS voice.
+
+    Returns (return_code, sink) where sink names the path that actually played
+    ("custom-server", "local-speakers (kokoro)", "os-voice") so callers can
+    report a truthful "did it play" ack instead of a blind "queued" (#444).
     """
     tier = tts_config.get("backend", "default")
 
@@ -2562,14 +2363,15 @@ def _local_say_dispatch(
         from .network import NetworkContext
         ctx = NetworkContext.from_config()
         tts_url = ctx.get_service_url("tts", use_tunnel=True)
-        return _local_say(
+        rc = _local_say(
             text, voice, exaggeration, cfg_weight, tts_url,
             backend=backend, instructions=instructions, language=language, stream=stream
         )
+        return rc, "custom-server"
 
     if tier == "default" and _local_say_kokoro(text, voice) == 0:
-        return 0
-    return _local_say_os(text)
+        return 0, "local-speakers (kokoro)"
+    return _local_say_os(text), "os-voice"
 
 
 def cmd_say(args) -> int:
@@ -2587,10 +2389,10 @@ def cmd_say(args) -> int:
     - Use --no-auto-notify to disable worker->orchestrator notification
     """
     text = " ".join(args.text) if args.text else ""
+    json_mode = getattr(args, 'json', False)
 
     if not text:
-        print("Usage: agentwire say <text>", file=sys.stderr)
-        return 1
+        return _output_result(False, json_mode, "Usage: agentwire say <text>")
 
     config = load_config()
     tts_config = config.get("tts", {})
@@ -2619,28 +2421,40 @@ def cmd_say(args) -> int:
     if display:
         _post_desktop_notification(display, session=session, priority="high")
 
+    def _say_result(rc: int, sink: str, clients: int = 0) -> int:
+        """Report which sink actually received the audio (#444): browser
+        (played by N connected clients), local speakers / OS voice, or a
+        failed dispatch — instead of a blind "queued"."""
+        if json_mode:
+            _output_json({"success": rc == 0, "sink": sink if rc == 0 else None,
+                          "clients": clients, "session": session,
+                          "error": None if rc == 0 else f"playback failed via {sink}"})
+        return rc
+
     # Try portal first if we have a session
     # Portal handles chunking internally (sequential generation + broadcast)
     if session:
         portal_url = _get_portal_url()
-        has_connections, actual_session = _check_portal_connections(session, portal_url)
+        has_connections, actual_session, clients = _check_portal_connections(session, portal_url)
 
         if has_connections:
-            return _remote_say(text, actual_session, portal_url)
+            rc = _remote_say(text, actual_session, portal_url)
+            return _say_result(rc, "browser", clients)
 
     # No portal connections — chunk locally for better TTS quality
     from .utils.chunker import chunk_text
     chunks = chunk_text(text)
 
+    last_sink = "os-voice"
     for chunk in chunks:
-        result = _local_say_dispatch(
+        result, last_sink = _local_say_dispatch(
             chunk, voice, exaggeration, cfg_weight, tts_config,
             backend=backend, instructions=instructions, language=language, stream=stream
         )
         if result != 0:
-            return result
+            return _say_result(result, last_sink)
 
-    return 0
+    return _say_result(0, last_sink)
 
 
 def cmd_notify_parent(args) -> int:
@@ -2662,10 +2476,10 @@ def cmd_notify_parent(args) -> int:
         agentwire notify --to agentwire "Build finished"
     """
     text = " ".join(args.text) if args.text else ""
+    json_mode = getattr(args, 'json', False)
 
     if not text:
-        print("Usage: agentwire notify <message>", file=sys.stderr)
-        return 1
+        return _output_result(False, json_mode, "Usage: agentwire notify-parent <message>")
 
     target_session = getattr(args, 'to', None)
     current_session = pane_manager.get_current_session()
@@ -2690,13 +2504,13 @@ def cmd_notify_parent(args) -> int:
 
     if target_session:
         if target_session == current_session and current_pane == 0:
-            print("Cannot notify own pane", file=sys.stderr)
-            return 1
+            return _output_result(False, json_mode, "Cannot notify own pane")
     elif current_pane is not None and current_pane > 0 and current_session:
         target_session = current_session
     else:
-        print("No target session (set 'parent' in .agentwire.yml or use --to)", file=sys.stderr)
-        return 1
+        return _output_result(
+            False, json_mode,
+            "No target session (set 'parent' in .agentwire.yml or use --to)")
 
     # safe_deliver refuses targets where a paste could do damage (live
     # dialog on screen, bare shell, parked session) and verifies the paste
@@ -2704,6 +2518,14 @@ def cmd_notify_parent(args) -> int:
     from agentwire import prompt_router
 
     delivered, reason = prompt_router.safe_deliver(target_session, 0, notification)
+    if json_mode:
+        _output_json({
+            "success": delivered,
+            "target": target_session,
+            "delivered": delivered,
+            "reason": reason if not delivered else None,
+        })
+        return 0 if delivered else 1
     if not delivered:
         print(f"Notification not delivered to {target_session}: {reason}", file=sys.stderr)
         return 1
@@ -3240,7 +3062,8 @@ def cmd_notify(args) -> int:
 
         if result.get("success"):
             if json_mode:
-                _output_json({"success": True, "event": event, "session": session})
+                _output_json({"success": True, "event": event, "session": session,
+                              "clients": result.get("clients", 0)})
             return 0
         else:
             return _output_result(False, json_mode, result.get("error", "Unknown error"))
@@ -3265,6 +3088,7 @@ def cmd_send(args) -> int:
     prompt = " ".join(args.prompt) if args.prompt else ""
     json_mode = getattr(args, 'json', False)
     wait_ready = getattr(args, 'wait_ready', False)
+    verify = getattr(args, 'verify', False)
 
     if wait_ready and pane_index is not None:
         return _output_result(False, json_mode, "--wait-ready targets a session's pane 0; it can't be combined with --pane")
@@ -3276,6 +3100,21 @@ def cmd_send(args) -> int:
 
         try:
             target_session = session_full or pane_manager.get_current_session()
+            if verify:
+                # Confirm the paste actually landed in the pane (a paste into a
+                # busy/booting pane can vanish silently). Report verified vs not.
+                from agentwire.session_ready import send_verified
+
+                ok = send_verified(target_session, prompt, pane_index=pane_index)
+                if json_mode:
+                    _output_json({
+                        "success": True, "pane": pane_index, "session": target_session,
+                        "verified": ok,
+                        "message": "Prompt sent (verified)" if ok else "Prompt sent but delivery could not be verified",
+                    })
+                else:
+                    print(f"Sent to pane {pane_index}" + ("" if ok else " (delivery NOT verified)"))
+                return 0
             pane_manager.send_to_pane(session_full, pane_index, prompt)
             if json_mode:
                 _output_json({
@@ -3351,7 +3190,12 @@ def cmd_send(args) -> int:
             return 1
 
         if json_mode:
-            print(json.dumps({"success": True, "session": session_full, "machine": machine_id, "message": "Prompt sent"}))
+            # Delivery can't be verified across SSH (no pane capture) — say so
+            # honestly rather than implying confirmation.
+            out = {"success": True, "session": session_full, "machine": machine_id, "message": "Prompt sent"}
+            if verify:
+                out["verified"] = None  # unverifiable: remote session
+            print(json.dumps(out))
         else:
             print(f"Sent to {session_full}")
         return 0
@@ -3387,6 +3231,21 @@ def cmd_send(args) -> int:
             print(json.dumps({"success": True, "session": session_full, "machine": None, "verified": True, "message": "Prompt sent"}))
         else:
             print(f"Sent to {session} (verified)")
+        return 0
+
+    if verify:
+        # Same delivery verification as --wait-ready, but without waiting for a
+        # fresh-boot banner — for an already-running session, just confirm the
+        # paste landed and report verified vs unconfirmed.
+        from agentwire.session_ready import send_verified
+
+        ok = send_verified(session, prompt)
+        if json_mode:
+            print(json.dumps({"success": True, "session": session_full, "machine": None,
+                              "verified": ok,
+                              "message": "Prompt sent" if ok else "Prompt sent but delivery could not be verified"}))
+        else:
+            print(f"Sent to {session}" + (" (verified)" if ok else " (delivery NOT verified)"))
         return 0
 
     # Delegate paste + Enter handling to the shared pane_manager helper so
@@ -6986,15 +6845,30 @@ def cmd_network_status(args) -> int:
     print("\nServices")
     print("-" * 60)
 
-    # Default-tier TTS has no service to health-check
-    tts_config = load_config().get("tts", {})
-    tts_backend = tts_config.get("backend", "default")
+    # Resolve the ACTIVE voice tier for each subsystem and only health-check a
+    # server when that tier actually uses one. A tier with no server (default
+    # TTS, cloud/browser-fallback STT) reports its path, not a phantom probe —
+    # and an orphaned engine server (up but unused by the tier) is flagged.
+    from .config import load_config as load_config_typed
+    from .voice_status import resolve_stt_status, resolve_tts_status
 
-    for service_name in ["portal", "tts"]:
-        if service_name == "tts" and tts_backend != "custom":
-            print(f"  {'Tts':<16}{'browser/OS voice':<18}[ok] default tier")
-            continue
+    typed_cfg = load_config_typed()
+    for resolver in (resolve_tts_status, resolve_stt_status):
+        vs = resolver(typed_cfg)
+        label = vs.subsystem.upper()
+        loc = vs.server_url if vs.server_url else f"{vs.tier} tier"
+        if vs.ready:
+            mark, note = "[ok]", (vs.path if not vs.server_url else "running")
+        else:
+            mark, note = "[!!]", vs.detail
+            issues.append({"type": "service_down", "service": vs.subsystem,
+                            "location": loc, "error": vs.detail})
+        print(f"  {label:<16}{loc:<18}{mark} {note}")
+        for w in vs.warnings:
+            print(f"  {'':<16}{'':<18}[..] {w}")
+            issues.append({"type": "voice_orphan", "service": vs.subsystem, "warning": w})
 
+    for service_name in ["portal"]:
         service_config = getattr(ctx.config.services, service_name, None)
         if service_config is None:
             continue
@@ -11178,6 +11052,7 @@ def main() -> int:
     say_parser.add_argument("--notify", type=str, metavar="SESSION", help="Also notify this session (sends message as input)")
     say_parser.add_argument("--no-auto-notify", action="store_true", help="Disable auto-notify to pane 0 when in worker pane")
     say_parser.add_argument("--display", type=str, metavar="TEXT", help="Also show the human a desktop toast with this (different) text — the asymmetric brief in one call")
+    say_parser.add_argument("--json", action="store_true", help="Output the sink ack as JSON (which path played: browser/local/os)")
     say_parser.set_defaults(func=cmd_say)
 
     # === notify command (worker→parent) ===
@@ -11187,6 +11062,7 @@ def main() -> int:
     notify_cmd_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     notify_cmd_parser.add_argument("--raw", action="store_true",
                                    help="Send the message verbatim (no [NOTIFY from ...] prefix)")
+    notify_cmd_parser.add_argument("--json", action="store_true", help="Output as JSON")
     notify_cmd_parser.set_defaults(func=cmd_notify_parent)
 
     # === open command (artifact windows) ===
@@ -11275,6 +11151,9 @@ def main() -> int:
     send_parser.add_argument("prompt", nargs="*", help="Prompt to send")
     send_parser.add_argument("--wait-ready", dest="wait_ready", action="store_true",
                              help="Wait for the agent to be ready, then verify delivery (local sessions only)")
+    send_parser.add_argument("--verify", action="store_true",
+                             help="Confirm the message actually landed in the pane (local only); "
+                                  "report verified vs unconfirmed instead of blind success")
     send_parser.add_argument("--timeout", type=float, default=30.0,
                              help="Readiness wait timeout in seconds (with --wait-ready, default: 30)")
     send_parser.add_argument("--json", action="store_true", help="Output as JSON")

--- a/agentwire/doctor_voice.py
+++ b/agentwire/doctor_voice.py
@@ -187,60 +187,40 @@ def check_mic() -> StageResult:
 def check_stt(config: Any) -> StageResult:
     """Stage 2 — the STT process behind transcription.
 
-    Default tier = the portal-managed Moonshine ``:8101`` shim (#383); custom
-    tier = a user/remote shim at ``stt.url``; cloud tier = an OpenAI-compatible
-    API keyed from the environment.
+    Delegates tier resolution to :mod:`agentwire.voice_status` (the SSOT that
+    every status surface shares): cloud tier checks the API key, default tier
+    probes the Moonshine ``:8101`` shim or reports the browser fallback, custom
+    tier probes the configured shim. Only a tier that actually has a server is
+    probed (#441).
     """
+    from .voice_status import resolve_stt_status
+
     name = "STT process"
-    stt = getattr(config, "stt", None)
-    backend = getattr(stt, "backend", "default") if stt is not None else "default"
+    st = resolve_stt_status(config)
 
-    if backend == "cloud":
-        import os
-        cloud = getattr(stt, "cloud", None) or {}
-        key_env = cloud.get("api_key_env", "OPENAI_API_KEY")
-        if os.environ.get(key_env):
-            return StageResult(name, "ok", f"cloud tier ({key_env} is set)")
-        return StageResult(
-            name, "fail", f"cloud tier but {key_env} is not set",
-            fixes=[f"Add {key_env}=... to ~/.agentwire/.env (docs/wiki/security/secrets.md)"],
-        )
+    # A tier with no probed server: cloud is a real working path (green when
+    # its key is set, red when missing); the default-tier browser fallback is
+    # neutral info (works, but isn't host-checkable).
+    if not st.server_url:
+        if st.tier == "cloud":
+            if st.ready:
+                return StageResult(name, "ok", f"cloud tier — {st.detail}")
+            return StageResult(
+                name, "fail", f"cloud tier — {st.detail}",
+                fixes=["Add the API key to ~/.agentwire/.env (docs/wiki/security/secrets.md)"],
+            )
+        return StageResult(name, "info", f"{st.path} — {st.detail}")
 
-    from .stt import DEFAULT_STT_URL, moonshine_importable
+    if st.ready:
+        return StageResult(name, "ok", st.detail)
 
-    if backend == "default" and not moonshine_importable():
-        # py3.14+ or base install without the moonshine extra — push-to-talk
-        # transcribes in the browser via SpeechRecognition. Works, no shim.
-        return StageResult(
-            name, "info",
-            "browser SpeechRecognition fallback (Moonshine not installed for "
-            "this Python — no host shim to run)",
-        )
-
-    url = getattr(stt, "url", None) or DEFAULT_STT_URL
-    reachable, payload = _http_health(url)
-    if reachable and (payload or {}).get("status") == "ok":
-        # /health "model" may be a nested {backend, model, load_time} dict or a
-        # bare string depending on the shim — surface the human-readable name.
-        model = (payload or {}).get("model", "unknown")
-        if isinstance(model, dict):
-            model = model.get("model", "unknown")
-        return StageResult(name, "ok", f"{backend} tier shim healthy at {url} (model {model})")
-
-    if backend == "default":
-        fixes = [
-            "The portal auto-starts it; if it isn't running: agentwire stt start",
-            "If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'",
-        ]
-    else:
-        fixes = [
-            "agentwire stt start",
-            "If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'",
-        ]
+    fixes = ["agentwire stt start",
+             "If it won't boot: uv pip install --python .venv/bin/python -e '.[stt]'"]
+    if st.tier == "default":
+        fixes[0] = "The portal auto-starts it; if it isn't running: agentwire stt start"
     return StageResult(
         name, "fail",
-        f"{backend}-tier shim not responding at {url} — push-to-talk will fail "
-        "(or fall back to browser speech) until it's back",
+        f"{st.detail} — push-to-talk will fail (or fall back to browser speech) until it's back",
         fixes=fixes,
     )
 

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -174,6 +174,25 @@ def run_agentwire_cmd(
         return {"success": False, "error": str(e)}
 
 
+def _delivery_result(data: dict, where: str) -> str:
+    """Honest delivery report for send/notify tools (#444).
+
+    The CLI confirms a paste actually landed in the pane (``--verify``) and
+    returns ``verified``: True (landed), False (sent but not seen — likely a
+    busy/booting pane that dropped it), or None (remote — unverifiable across
+    SSH). Surface that instead of a blind "sent".
+    """
+    verified = data.get("verified")
+    if verified is True:
+        return f"Message delivered {where} (verified in pane)."
+    if verified is False:
+        return (f"Message sent {where} but delivery could NOT be verified — it may "
+                f"have been dropped (busy/booting pane). Check the pane or resend.")
+    if verified is None and "verified" in data:
+        return f"Message sent {where} (remote session — delivery can't be verified across SSH)."
+    return f"Message sent {where}."
+
+
 def _mcp_result(data: dict, on_success: str, operation: str = "complete operation") -> str:
     """Standard success/error string for a thin MCP wrapper over run_agentwire_cmd.
 
@@ -384,11 +403,11 @@ def session_send(session: str, message: str) -> str:
             f"session_send(session=\"{caller}\", message=\"<your reply>\")]\n"
             f"{message}"
         )
-    args = ["send", "-s", session, message]
+    args = ["send", "-s", session, "--verify", message]
     data = run_agentwire_cmd(args)
-    if data.get("success"):
-        return f"Message sent to session '{session}'."
-    return f"Failed to send message: {data.get('error', 'Unknown error')}"
+    if not data.get("success"):
+        return f"Failed to send message: {data.get('error', 'Unknown error')}"
+    return _delivery_result(data, f"to session '{session}'")
 
 
 @mcp.tool()
@@ -905,14 +924,14 @@ def pane_send(pane: int, message: str, session: str | None = None) -> str:
     Returns:
         Success message or error description.
     """
-    args = ["send", "--pane", str(pane), message]
+    args = ["send", "--pane", str(pane), "--verify", message]
     if session:
         args.extend(["-s", session])
 
     data = run_agentwire_cmd(args)
-    if data.get("success"):
-        return f"Message sent to pane {pane}."
-    return f"Failed to send to pane: {data.get('error', 'Unknown error')}"
+    if not data.get("success"):
+        return f"Failed to send to pane: {data.get('error', 'Unknown error')}"
+    return _delivery_result(data, f"to pane {pane}")
 
 
 @mcp.tool()
@@ -1136,15 +1155,23 @@ def say(text: str, session: str | None = None, voice: str | None = None, display
         args.extend(["--display", display])
     args.append(text)
 
-    # Say command doesn't return JSON, run without --json
-    data = run_agentwire_cmd(args, json_output=False)
-    if data.get("success"):
-        from .utils.chunker import chunk_text
-        chunks = chunk_text(text)
-        if len(chunks) > 1:
-            return f"Queued speech ({len(chunks)} chunks)."
-        return "Queued speech."
-    return f"Failed to speak: {data.get('error', 'Unknown error')}"
+    data = run_agentwire_cmd(args, timeout=120)
+    if not data.get("success"):
+        return f"Failed to speak: {data.get('error', 'Unknown error')}"
+
+    # Sink ack (#444): report which path actually played, not a blind "queued".
+    sink = data.get("sink")
+    toast = " Toast shown." if display else ""
+    if sink == "browser":
+        n = data.get("clients", 0)
+        return f"Spoken to {n} connected browser client{'s' if n != 1 else ''}.{toast}"
+    if sink == "local-speakers (kokoro)":
+        return f"Spoken on local speakers (in-process Kokoro).{toast}"
+    if sink == "custom-server":
+        return f"Spoken via custom TTS shim on local speakers.{toast}"
+    if sink == "os-voice":
+        return f"Spoken via the OS voice (no browser connected).{toast}"
+    return f"Speech dispatched.{toast}"
 
 
 @mcp.tool()
@@ -1167,8 +1194,12 @@ def notify_parent(text: str, session: str | None = None) -> str:
         args.extend(["--to", session])
     args.append(text)
 
-    return _mcp_result(run_agentwire_cmd(args, json_output=False),
-                       "Notification sent to parent.", "notify parent")
+    data = run_agentwire_cmd(args)
+    target = data.get("target", session or "parent")
+    if data.get("delivered"):
+        return f"Notification delivered to {target} (verified)."
+    reason = data.get("reason") or data.get("error") or "unknown reason"
+    return f"Notification NOT delivered to {target}: {reason}"
 
 
 
@@ -1375,37 +1406,55 @@ def portal_status() -> str:
     return f"Failed to check portal status: {data.get('error', 'Unknown error')}"
 
 
+def _format_voice_status(kind: str, data: dict) -> str:
+    """Render a voice_status resolver payload (from `tts/stt status --json`).
+
+    Answers "can I X right now, and via what path" instead of probing a server
+    the active tier may never use. Surfaces orphaned engine servers (running
+    but unused by the tier).
+    """
+    if not data.get("success"):
+        return f"Failed to check {kind} status: {data.get('error', 'Unknown error')}"
+    tier = data.get("tier", "unknown")
+    path = data.get("path", "?")
+    ready = data.get("ready", False)
+    detail = data.get("detail", "")
+    head = "ready" if ready else "NOT ready"
+    lines = [f"{kind} [{tier} tier] — {head}: {path}"]
+    if detail:
+        lines.append(f"  {detail}")
+    for w in data.get("warnings") or []:
+        lines.append(f"  ⚠ {w}")
+    return "\n".join(lines)
+
+
 @mcp.tool()
 def tts_status() -> str:
-    """Check TTS server status.
+    """Can I speak right now, and through what path?
+
+    Reports the ACTIVE TTS tier (default → browser portal when connected, else
+    OS voice; custom → shim) — not a probe of a configured-but-unused server.
+    Flags an orphaned engine server (e.g. a shim still up on the custom port
+    while the tier is 'default').
 
     Returns:
-        TTS server status and configuration.
+        Active TTS path, readiness, and any orphan warnings.
     """
-    data = run_agentwire_cmd(["tts", "status"])
-    if data.get("success"):
-        running = data.get("running", False)
-        backend = data.get("backend", "unknown")
-        if running:
-            return f"TTS server is running (backend: {backend})"
-        return f"TTS server is not running. Backend configured: {backend}"
-    return f"Failed to check TTS status: {data.get('error', 'Unknown error')}"
+    return _format_voice_status("TTS", run_agentwire_cmd(["tts", "status"]))
 
 
 @mcp.tool()
 def stt_status() -> str:
-    """Check STT server status.
+    """Can I hear (transcribe) right now, and through what path?
+
+    Reports the ACTIVE STT tier (default → Moonshine :8101 shim or browser
+    fallback; cloud → API key; custom → shim) — only probing a server when the
+    tier actually has one.
 
     Returns:
-        STT server status and configuration.
+        Active STT path, readiness, and any warnings.
     """
-    data = run_agentwire_cmd(["stt", "status"])
-    if data.get("success"):
-        running = data.get("running", False)
-        if running:
-            return "STT server is running."
-        return "STT server is not running."
-    return f"Failed to check STT status: {data.get('error', 'Unknown error')}"
+    return _format_voice_status("STT", run_agentwire_cmd(["stt", "status"]))
 
 
 # =============================================================================
@@ -2562,7 +2611,9 @@ def email_send(
 
     data = run_agentwire_cmd(args, json_output=False)
     if data.get("success"):
-        return "Email sent."
+        # Accepted by Resend ≠ delivered to the inbox — the provider boundary is
+        # a genuine async one, so don't claim more than acceptance (#444).
+        return "Email accepted by provider (Resend)."
     return f"Failed to send email: {data.get('error', 'Unknown error')}"
 
 
@@ -2583,7 +2634,9 @@ def quo_send(body: str, to: str | None = None) -> str:
 
     data = run_agentwire_cmd(args, json_output=False)
     if data.get("success"):
-        return "Quo SMS sent."
+        # Accepted by OpenPhone ≠ delivered to the handset — async provider
+        # boundary, so claim only acceptance (#444).
+        return "SMS accepted by provider (Quo/OpenPhone)."
     return f"Failed to send Quo SMS: {data.get('error', 'Unknown error')}"
 
 
@@ -2606,8 +2659,14 @@ def notify_event(event: str, session: str | None = None) -> str:
     if session:
         args.extend(["-s", session])
 
-    return _mcp_result(run_agentwire_cmd(args),
-                       f"Event '{event}' broadcast to the portal.", "broadcast event")
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to broadcast event: {data.get('error', 'Unknown error')}"
+    # Lifecycle events are ephemeral — report whether any dashboard saw it (#444).
+    n = data.get("clients", 0)
+    if n > 0:
+        return f"Event '{event}' broadcast to {n} dashboard client{'s' if n != 1 else ''}."
+    return f"Event '{event}' had no listeners — no dashboard connected (nothing saw it)."
 
 
 # =============================================================================
@@ -3162,9 +3221,15 @@ def notify_user(text: str, session: str | None = None, priority: str = "normal")
     if session:
         body["session"] = session
     data = _portal_request("POST", "/api/desktop/notification", body)
-    if data.get("success"):
-        return f"Notification posted (id: {data.get('id')})."
-    return f"Failed to post notification: {data.get('error', 'Unknown error')}"
+    if not data.get("success"):
+        return f"Failed to post notification: {data.get('error', 'Unknown error')}"
+    # Honest delivery: how many dashboards saw it live (#444). The toast is
+    # persisted and restored on next load, so 0 clients ≠ lost.
+    n = data.get("clients", 0)
+    if n > 0:
+        return f"Toast shown to {n} connected client{'s' if n != 1 else ''} (id: {data.get('id')})."
+    return (f"Toast queued (id: {data.get('id')}) — no portal open right now; "
+            f"it will appear on next load.")
 
 
 # =============================================================================

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1339,9 +1339,13 @@ class AgentWireServer:
 
         self.active_notifications[notification_id] = notification
 
+        clients = len(self.dashboard_clients)
         await self.broadcast_dashboard("notification", notification)
 
-        return web.json_response({"success": True, "id": notification_id})
+        # Report how many dashboards saw it live. 0 isn't a failure — the toast
+        # is persisted in active_notifications and restored on the next page
+        # load — but the caller deserves to know nobody is watching right now.
+        return web.json_response({"success": True, "id": notification_id, "clients": clients})
 
     async def api_desktop_notification_dismiss(self, request):
         """POST /api/desktop/notification/dismiss — dismiss a notification."""
@@ -5581,7 +5585,10 @@ projects:
                 # Generic event - just broadcast it
                 await self.broadcast_dashboard(event, data)
 
-            return web.json_response({"success": True})
+            # Report how many dashboards received the broadcast. A lifecycle
+            # event is ephemeral (not persisted), so 0 clients means nobody saw
+            # it — the caller should know that, not get a blind "broadcast" (#444).
+            return web.json_response({"success": True, "clients": len(self.dashboard_clients)})
 
         except Exception as e:
             logger.error(f"Notify API failed: {e}")

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -12,17 +12,17 @@ through here.
 import time
 
 
-def send_to_session(session: str, message: str) -> None:
-    """Inject a message into a session's pane 0."""
+def send_to_session(session: str, message: str, pane_index: int = 0) -> None:
+    """Inject a message into a session's pane (pane 0 by default)."""
     from agentwire import pane_manager
 
-    pane_manager.send_to_target(f"{session}.0", message, enter=True)
+    pane_manager.send_to_target(f"{session}.{pane_index}", message, enter=True)
 
 
-def capture_session(session: str, lines: int = 60) -> str:
+def capture_session(session: str, lines: int = 60, pane_index: int = 0) -> str:
     from agentwire import pane_manager
 
-    return pane_manager.capture_pane(session, 0, lines=lines)
+    return pane_manager.capture_pane(session, pane_index, lines=lines)
 
 
 def wait_for_session_ready(
@@ -123,18 +123,21 @@ def send_verified(
     marker: str | None = None,
     retries: int = 1,
     settle: float = 2.0,
+    pane_index: int = 0,
 ) -> bool:
     """Send a message and verify it actually landed in the pane.
 
     After sending, confirm the message is visible in the pane — via
     *marker* if given (council's explicit-marker pattern), otherwise via
     :func:`message_visible` on the message itself. Retry once if not.
+
+    *pane_index* targets a worker pane (1+) instead of the session's pane 0.
     """
     for _ in range(retries + 1):
-        send_to_session(session, message)
+        send_to_session(session, message, pane_index=pane_index)
         time.sleep(settle)
         try:
-            capture = capture_session(session)
+            capture = capture_session(session, pane_index=pane_index)
             if marker is not None:
                 if marker in capture:
                     return True

--- a/agentwire/voice_status.py
+++ b/agentwire/voice_status.py
@@ -1,0 +1,243 @@
+"""Active-tier voice status — the single source of truth for "can I speak /
+hear right now, and through what path?".
+
+Every status surface (``agentwire tts/stt status``, ``agentwire network``,
+``agentwire doctor --voice``, and the MCP ``tts_status``/``stt_status`` tools)
+resolves voice health through here so they all answer the same question the
+same way.
+
+The bug this fixes (#441): the old surfaces probed the **configured engine
+server** regardless of the **active tier**, so they'd report "TTS not running"
+while default-tier voice was working fine through the browser/OS, and they'd
+probe the ``:8101`` STT shim even for the ``cloud`` tier (which has no shim).
+The rule encoded here:
+
+* resolve the **active tier** first,
+* describe the path *that tier actually uses*,
+* only probe a server when the tier actually has one
+  (TTS ``custom``; STT ``custom`` and ``default`` when Moonshine is importable),
+* flag an **orphaned** engine server (e.g. a TTS shim up on the custom-tier
+  port while the tier is ``default`` — running but unused).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class VoiceStatus:
+    """Resolved status of one voice subsystem (TTS or STT).
+
+    ``ready`` answers the headline question — can this subsystem do its job
+    right now over its active path. ``server_url`` is set only when the tier
+    actually depends on a probed server. ``warnings`` carries non-fatal
+    observations, most importantly an orphaned engine server (running but
+    unused by the active tier).
+    """
+
+    subsystem: str          # "tts" | "stt"
+    tier: str               # tts: default|custom ; stt: default|cloud|custom
+    path: str               # human-readable description of the active path
+    ready: bool             # can it work right now over that path?
+    detail: str             # one-line explanation of the readiness state
+    server_url: str | None = None   # set only when a server is part of the path
+    server_probed: bool = False     # did we actually probe a server?
+    warnings: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "subsystem": self.subsystem,
+            "tier": self.tier,
+            "path": self.path,
+            "ready": self.ready,
+            "detail": self.detail,
+            "server_url": self.server_url,
+            "server_probed": self.server_probed,
+            "warnings": self.warnings,
+        }
+
+
+def _describe_probe_error(exc: Exception) -> str:
+    """Concise cause for a failed health probe (mirrors __main__'s helper)."""
+    if isinstance(exc, (socket.timeout, TimeoutError)):
+        return "timed out (no response)"
+    if isinstance(exc, json.JSONDecodeError):
+        return "responded but returned invalid JSON"
+    if isinstance(exc, urllib.error.HTTPError):
+        return f"HTTP {exc.code} {exc.reason}"
+    if isinstance(exc, urllib.error.URLError):
+        reason = exc.reason
+        if isinstance(reason, (socket.timeout, TimeoutError)):
+            return "timed out (no response)"
+        if isinstance(reason, ConnectionRefusedError):
+            return "connection refused (not listening)"
+        if isinstance(reason, socket.gaierror):
+            return f"DNS resolution failed ({reason})"
+        return f"unreachable ({reason})"
+    if isinstance(exc, ConnectionRefusedError):
+        return "connection refused (not listening)"
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _probe(url: str, endpoint: str = "/health", timeout: float = 2.0) -> tuple[bool, str | None]:
+    """GET ``{url}{endpoint}``. Returns (reachable, error_cause).
+
+    Accepts self-signed certs (the portal/remote shims may use HTTPS).
+    """
+    import ssl
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        req = urllib.request.Request(f"{url.rstrip('/')}{endpoint}")
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx):
+            return True, None
+    except Exception as e:  # noqa: BLE001 — any failure means "not reachable"
+        return False, _describe_probe_error(e)
+
+
+def _load_typed_config(config: Any | None):
+    if config is not None:
+        return config
+    from .config import load_config
+    return load_config()
+
+
+# === TTS ===================================================================
+
+
+def _tts_service_url() -> str | None:
+    """The TTS shim location (NetworkContext ``tts`` service, default ``:8100``).
+
+    This is the URL the ``custom`` tier actually POSTs to (matching ``say`` and
+    ``_local_say_dispatch``). Under the ``default`` tier nothing routes here, so
+    a server answering on it is an orphan.
+    """
+    try:
+        from .network import NetworkContext
+        return NetworkContext.from_config().get_service_url("tts", use_tunnel=True)
+    except Exception:
+        return None
+
+
+def resolve_tts_status(config: Any | None = None, *, probe: bool = True) -> VoiceStatus:
+    """Resolve the active TTS path.
+
+    ``default`` tier routes audio to the browser portal when a client is
+    connected, otherwise the OS voice (in-process Kokoro on local speakers once
+    the model is cached, robotic OS ``say``/``espeak`` until then) — there is no
+    server to probe, but a TTS shim left running on the custom-tier port is
+    flagged as orphaned. ``custom`` tier POSTs to the configured shim, which is
+    probed.
+    """
+    cfg = _load_typed_config(config)
+    tier = getattr(getattr(cfg, "tts", None), "backend", "default")
+
+    if tier == "custom":
+        url = _tts_service_url() or getattr(cfg.tts, "url", None)
+        if not url:
+            return VoiceStatus(
+                "tts", "custom", "custom shim (no url configured)", False,
+                "tts.backend is 'custom' but no shim URL could be resolved",
+            )
+        ready, err = (_probe(url, endpoint="/voices") if probe else (True, None))
+        return VoiceStatus(
+            "tts", "custom", f"custom shim at {url}", ready,
+            f"shim healthy at {url}" if ready else f"shim not responding at {url} — {err}",
+            server_url=url, server_probed=probe,
+        )
+
+    # default tier — browser/OS, no shim in the path.
+    warnings: list[str] = []
+    try:
+        from .tts.local import kokoro_importable
+        importable = kokoro_importable()
+    except Exception:
+        importable = False
+    cached = False
+    if importable:
+        try:
+            from .tts.engines.kokoro import KokoroEngine
+            cached = KokoroEngine.model_files_cached()
+        except Exception:
+            cached = False
+
+    if cached:
+        kokoro_state = "in-process Kokoro ready (local speakers when no browser)"
+    elif importable:
+        kokoro_state = "in-process Kokoro installed, model not downloaded (OS voice until cached)"
+    else:
+        kokoro_state = "in-process Kokoro unavailable (needs Python <3.14) — OS voice"
+
+    # Orphan check: a TTS engine server answering on the custom-tier port is
+    # unused under the default tier.
+    if probe:
+        orphan_url = _tts_service_url()
+        if orphan_url:
+            up, _ = _probe(orphan_url, endpoint="/voices")
+            if up:
+                warnings.append(
+                    f"a TTS engine server is up at {orphan_url} but the active tier "
+                    f"is 'default' — it is unused (default routes to browser/OS)."
+                )
+
+    return VoiceStatus(
+        "tts", "default",
+        "browser portal when a client is connected, otherwise OS voice",
+        True,
+        f"default tier: {kokoro_state}",
+        warnings=warnings,
+    )
+
+
+# === STT ===================================================================
+
+
+def resolve_stt_status(config: Any | None = None, *, probe: bool = True) -> VoiceStatus:
+    """Resolve the active STT path.
+
+    ``cloud`` uploads audio to an OpenAI-compatible API server-side — no shim,
+    so readiness is "is the API key set". ``default`` transcribes via the
+    portal-managed Moonshine ``:8101`` shim when Moonshine is importable, else
+    falls back to in-browser SpeechRecognition (no host shim to probe).
+    ``custom`` uploads to the configured shim, which is probed.
+    """
+    cfg = _load_typed_config(config)
+    stt = getattr(cfg, "stt", None)
+    tier = getattr(stt, "backend", "default") if stt is not None else "default"
+
+    if tier == "cloud":
+        cloud = getattr(stt, "cloud", None) or {}
+        key_env = cloud.get("api_key_env", "OPENAI_API_KEY")
+        ready = bool(os.environ.get(key_env))
+        return VoiceStatus(
+            "stt", "cloud", "cloud API (portal uploads audio server-side)", ready,
+            f"{key_env} is set" if ready else f"{key_env} is NOT set in ~/.agentwire/.env",
+        )
+
+    from .stt import DEFAULT_STT_URL, moonshine_importable
+
+    if tier == "default" and not moonshine_importable():
+        # py3.14+ or base install — push-to-talk transcribes in the browser.
+        return VoiceStatus(
+            "stt", "default", "browser SpeechRecognition fallback", True,
+            "Moonshine not installed for this Python — no host shim to run",
+        )
+
+    url = getattr(stt, "url", None) or DEFAULT_STT_URL
+    ready, err = (_probe(url) if probe else (True, None))
+    label = "Moonshine shim" if tier == "default" else "custom shim"
+    return VoiceStatus(
+        "stt", tier, f"{label} at {url}", ready,
+        f"{tier}-tier shim healthy at {url}" if ready
+        else f"{tier}-tier shim not responding at {url} — {err}",
+        server_url=url, server_probed=probe,
+    )

--- a/tests/unit/test_doctor_voice.py
+++ b/tests/unit/test_doctor_voice.py
@@ -71,7 +71,8 @@ def test_mic_info_when_enumeration_unparseable(monkeypatch):
 
 
 def test_stt_default_fails_when_shim_down(monkeypatch):
-    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (False, None))
+    import agentwire.voice_status as vs
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "connection refused"))
     import agentwire.stt as stt_mod
     monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
     r = dv.check_stt(_cfg())
@@ -81,15 +82,14 @@ def test_stt_default_fails_when_shim_down(monkeypatch):
 
 
 def test_stt_default_ok_when_shim_healthy(monkeypatch):
-    monkeypatch.setattr(
-        dv, "_http_health",
-        lambda url, timeout=2.0: (True, {"status": "ok", "model": {"model": "moonshine/base"}}),
-    )
+    import agentwire.voice_status as vs
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
     import agentwire.stt as stt_mod
     monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
     r = dv.check_stt(_cfg())
     assert r.status == "ok"
-    assert "moonshine/base" in r.detail
+    assert "healthy" in r.detail
+    assert "8101" in r.detail
 
 
 def test_stt_default_info_when_moonshine_absent(monkeypatch):
@@ -101,7 +101,8 @@ def test_stt_default_info_when_moonshine_absent(monkeypatch):
 
 
 def test_stt_custom_fails_when_shim_down(monkeypatch):
-    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (False, None))
+    import agentwire.voice_status as vs
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "connection refused"))
     r = dv.check_stt(_cfg(backend="custom", url="http://localhost:9"))
     assert r.failed
     assert "custom" in r.detail
@@ -195,13 +196,12 @@ def test_only_stt_red_when_shim_down(monkeypatch):
     monkeypatch.setattr(dv.shutil, "which", lambda n: "/usr/bin/tmux")
     monkeypatch.setattr(dv, "_tmux_server_running", lambda: True)
 
-    # STT shim down (dead), portal up.
-    def fake_health(url, timeout=2.0):
-        if "8101" in url or ":9" in url:
-            return (False, None)
-        return (True, {"status": "ok"})
+    # STT shim down (dead) — resolver probes via voice_status._probe.
+    import agentwire.voice_status as vs
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "connection refused"))
 
-    monkeypatch.setattr(dv, "_http_health", fake_health)
+    # Portal up — check_portal still uses dv._http_health.
+    monkeypatch.setattr(dv, "_http_health", lambda url, timeout=2.0: (True, {"status": "ok"}))
     cfg = _cfg()
     cfg.portal = SimpleNamespace(url="http://localhost:8765")  # up per fake_health
 

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -56,9 +56,11 @@ class TestSessionTools:
     @patch("agentwire.mcp_server.get_caller_session", return_value="orchestrator")
     def test_session_send_cross_session(self, mock_caller, mock_cmd):
         from agentwire.mcp_server import session_send
-        mock_cmd.return_value = _success()
+        mock_cmd.return_value = _success(verified=True)
         session_send(session="worker", message="do task")
-        sent_msg = mock_cmd.call_args[0][0][3]  # args[3] = message
+        args = mock_cmd.call_args[0][0]
+        assert args[:4] == ["send", "-s", "worker", "--verify"]
+        sent_msg = args[4]  # message follows --verify
         assert '[MESSAGE FROM SESSION "orchestrator"' in sent_msg
         assert 'session_send(session="orchestrator"' in sent_msg
 
@@ -66,10 +68,11 @@ class TestSessionTools:
     @patch("agentwire.mcp_server.get_caller_session", return_value=None)
     def test_session_send_no_caller(self, mock_caller, mock_cmd):
         from agentwire.mcp_server import session_send
-        mock_cmd.return_value = _success()
-        session_send(session="target", message="hello")
-        sent_msg = mock_cmd.call_args[0][0][3]
-        assert sent_msg == "hello"
+        mock_cmd.return_value = _success(verified=True)
+        result = session_send(session="target", message="hello")
+        args = mock_cmd.call_args[0][0]
+        assert args == ["send", "-s", "target", "--verify", "hello"]
+        assert "verified" in result.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -81,18 +84,18 @@ class TestPaneTools:
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_pane_send_with_session(self, mock_cmd):
         from agentwire.mcp_server import pane_send
-        mock_cmd.return_value = _success()
+        mock_cmd.return_value = _success(verified=True)
         pane_send(pane=1, message="task", session="my-session")
         args = mock_cmd.call_args[0][0]
-        assert args == ["send", "--pane", "1", "task", "-s", "my-session"]
+        assert args == ["send", "--pane", "1", "--verify", "task", "-s", "my-session"]
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_pane_send_without_session(self, mock_cmd):
         from agentwire.mcp_server import pane_send
-        mock_cmd.return_value = _success()
+        mock_cmd.return_value = _success(verified=True)
         pane_send(pane=0, message="hi")
         args = mock_cmd.call_args[0][0]
-        assert args == ["send", "--pane", "0", "hi"]
+        assert args == ["send", "--pane", "0", "--verify", "hi"]
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_pane_output_success(self, mock_cmd):
@@ -117,26 +120,30 @@ class TestPaneTools:
 class TestVoiceTools:
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_notify_with_target(self, mock_cmd):
-        from agentwire.mcp_server import notify
-        mock_cmd.return_value = _success()
-        notify(text="hey", to="main")
+        from agentwire.mcp_server import notify_parent
+        mock_cmd.return_value = _success(delivered=True, target="main")
+        result = notify_parent(text="hey", session="main")
         args = mock_cmd.call_args[0][0]
         assert args == ["notify-parent", "--to", "main", "hey"]
+        assert "delivered" in result.lower()
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_notify_without_target(self, mock_cmd):
-        from agentwire.mcp_server import notify
-        mock_cmd.return_value = _success()
-        notify(text="hey")
+        from agentwire.mcp_server import notify_parent
+        mock_cmd.return_value = _success(delivered=True, target="parent")
+        notify_parent(text="hey")
         args = mock_cmd.call_args[0][0]
         assert args == ["notify-parent", "hey"]
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
-    def test_notify_failure(self, mock_cmd):
-        from agentwire.mcp_server import notify
-        mock_cmd.return_value = _failure("no portal")
-        result = notify(text="hey")
-        assert "Failed" in result
+    def test_notify_not_delivered(self, mock_cmd):
+        from agentwire.mcp_server import notify_parent
+        # safe_deliver refused (e.g. parked session) — surfaced, not hidden.
+        mock_cmd.return_value = {"success": False, "delivered": False,
+                                 "target": "main", "reason": "session is parked"}
+        result = notify_parent(text="hey", session="main")
+        assert "NOT delivered" in result
+        assert "parked" in result
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +273,8 @@ class TestEmailTool:
         result = email_send(body="hi", to="a@b.com", subject="test")
         args = mock_cmd.call_args[0][0]
         assert args == ["email", "--body", "hi", "--to", "a@b.com", "--subject", "test"]
-        assert "sent" in result.lower()
+        # Honest async boundary: accepted by provider, not "delivered" (#444).
+        assert "accepted by provider" in result.lower()
 
     @patch("agentwire.mcp_server.run_agentwire_cmd")
     def test_email_send_minimal(self, mock_cmd):

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -445,6 +445,33 @@ class TestApiNotify:
         resp = await client.post("/api/notify", json={"session": "test"})
         assert resp.status == 400
 
+    async def test_generic_event_reports_client_count(self, portal_client):
+        """#444: a broadcast reports how many dashboards received it, so the
+        caller knows whether anything actually saw the ephemeral event."""
+        client, server = portal_client
+        server.dashboard_clients = {object(), object()}
+        server.broadcast_dashboard = AsyncMock()
+        resp = await client.post("/api/notify", json={"event": "agent_progress"})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["success"] is True
+        assert data["clients"] == 2
+
+
+class TestApiDesktopNotification:
+    async def test_toast_reports_client_count(self, portal_client):
+        """#444: posting a toast reports how many dashboards saw it live (the
+        toast is persisted, so 0 isn't a failure — but the caller is told)."""
+        client, server = portal_client
+        server.dashboard_clients = {object()}
+        server.broadcast_dashboard = AsyncMock()
+        resp = await client.post("/api/desktop/notification", json={"text": "hi"})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["success"] is True
+        assert data["clients"] == 1
+        assert "id" in data
+
 
 # ---------------------------------------------------------------------------
 # Security middleware: Origin validation (CSRF guard)

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -104,27 +104,27 @@ class TestSendVerified:
 
     def test_marker_mode_confirms(self, monkeypatch):
         self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m: None)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
         monkeypatch.setattr(
             session_ready, "capture_session",
-            lambda s, lines=60: "...[COUNCIL PROMPT #1]...")
+            lambda s, lines=60, pane_index=0: "...[COUNCIL PROMPT #1]...")
         assert session_ready.send_verified("s", "msg", "[COUNCIL PROMPT #1]")
 
     def test_marker_mode_retries_then_fails(self, monkeypatch):
         self._quiet(monkeypatch)
         sends = []
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m: sends.append(s))
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: sends.append(s))
         monkeypatch.setattr(
-            session_ready, "capture_session", lambda s, lines=60: "no marker here")
+            session_ready, "capture_session", lambda s, lines=60, pane_index=0: "no marker here")
         assert not session_ready.send_verified("s", "msg", "[COUNCIL PROMPT #1]")
         assert len(sends) == 2  # initial + one retry
 
     def test_markerless_uses_message_visible(self, monkeypatch):
         self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m: None)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
         monkeypatch.setattr(
             session_ready, "capture_session",
-            lambda s, lines=60: "❯ build a voice diary app")
+            lambda s, lines=60, pane_index=0: "❯ build a voice diary app")
         assert session_ready.send_verified("s", "build a voice diary app")
 
     def test_markerless_confirms_on_retry(self, monkeypatch):
@@ -132,10 +132,10 @@ class TestSendVerified:
         sends = []
         captures = ["", "❯ my idea text"]
 
-        def fake_capture(s, lines=60):
+        def fake_capture(s, lines=60, pane_index=0):
             return captures[min(len(sends) - 1, 1)]
 
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m: sends.append(s))
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: sends.append(s))
         monkeypatch.setattr(session_ready, "capture_session", fake_capture)
         assert session_ready.send_verified("s", "my idea text")
         assert len(sends) == 2
@@ -143,12 +143,22 @@ class TestSendVerified:
     def test_capture_exception_counts_as_miss(self, monkeypatch):
         self._quiet(monkeypatch)
 
-        def boom(s, lines=60):
+        def boom(s, lines=60, pane_index=0):
             raise RuntimeError("gone")
 
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m: None)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
         monkeypatch.setattr(session_ready, "capture_session", boom)
         assert not session_ready.send_verified("s", "msg")
+
+    def test_pane_index_threads_through(self, monkeypatch):
+        self._quiet(monkeypatch)
+        seen = {}
+        monkeypatch.setattr(session_ready, "send_to_session",
+                            lambda s, m, pane_index=0: seen.update(send=pane_index))
+        monkeypatch.setattr(session_ready, "capture_session",
+                            lambda s, lines=60, pane_index=0: seen.update(cap=pane_index) or "❯ hi there")
+        assert session_ready.send_verified("s", "hi there", pane_index=2)
+        assert seen == {"send": 2, "cap": 2}
 
 
 class TestCouncilDelegation:

--- a/tests/unit/test_tts_local.py
+++ b/tests/unit/test_tts_local.py
@@ -251,20 +251,21 @@ class TestLocalSayDispatch:
     def test_default_tier_prefers_kokoro(self):
         with patch("agentwire.__main__._local_say_kokoro", return_value=0) as kokoro, \
              patch("agentwire.__main__._local_say_os") as os_say:
-            assert self._dispatch({"backend": "default"}) == 0
+            # Returns (return_code, sink) — the sink names the path that played.
+            assert self._dispatch({"backend": "default"}) == (0, "local-speakers (kokoro)")
         kokoro.assert_called_once()
         os_say.assert_not_called()
 
     def test_default_tier_falls_back_to_os_voice(self):
         with patch("agentwire.__main__._local_say_kokoro", return_value=1), \
              patch("agentwire.__main__._local_say_os", return_value=0) as os_say:
-            assert self._dispatch({"backend": "default"}) == 0
+            assert self._dispatch({"backend": "default"}) == (0, "os-voice")
         os_say.assert_called_once()
 
     def test_backend_none_never_synthesizes(self):
         with patch("agentwire.__main__._local_say_kokoro") as kokoro, \
              patch("agentwire.__main__._local_say_os", return_value=0) as os_say:
-            assert self._dispatch({"backend": "none"}) == 0
+            assert self._dispatch({"backend": "none"}) == (0, "os-voice")
         kokoro.assert_not_called()
         os_say.assert_called_once()
 
@@ -272,7 +273,7 @@ class TestLocalSayDispatch:
         with patch("agentwire.__main__._local_say", return_value=0) as shim, \
              patch("agentwire.__main__._local_say_kokoro") as kokoro, \
              patch("agentwire.__main__._local_say_os") as os_say:
-            assert self._dispatch({"backend": "custom"}) == 0
+            assert self._dispatch({"backend": "custom"}) == (0, "custom-server")
         shim.assert_called_once()
         kokoro.assert_not_called()
         os_say.assert_not_called()

--- a/tests/unit/test_voice_status.py
+++ b/tests/unit/test_voice_status.py
@@ -1,0 +1,104 @@
+"""Tests for the active-tier voice status resolver (#441).
+
+The resolver is the SSOT every status surface shares: resolve the active tier,
+report the path that tier uses, only probe a server when the tier has one, and
+flag an orphaned engine server (running but unused).
+"""
+
+from types import SimpleNamespace
+
+import agentwire.voice_status as vs
+
+
+def _cfg(tts_backend="default", tts_url=None, stt_backend="default",
+         stt_url=None, stt_cloud=None):
+    return SimpleNamespace(
+        tts=SimpleNamespace(backend=tts_backend, url=tts_url),
+        stt=SimpleNamespace(backend=stt_backend, url=stt_url, cloud=stt_cloud or {}),
+    )
+
+
+# === TTS ===================================================================
+
+
+def test_tts_default_ready_and_flags_orphan(monkeypatch):
+    """Default tier is always ready (browser/OS) and flags a shim left running
+    on the custom-tier port — the exact #441 dogfooding scenario."""
+    monkeypatch.setattr(vs, "_tts_service_url", lambda: "http://localhost:8100")
+    # An engine server *is* up on the custom-tier port.
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
+    st = vs.resolve_tts_status(_cfg(tts_backend="default"))
+    assert st.tier == "default"
+    assert st.ready is True
+    assert st.server_url is None  # default tier probes no server in its path
+    assert any("unused" in w for w in st.warnings)
+
+
+def test_tts_default_no_orphan_when_port_empty(monkeypatch):
+    monkeypatch.setattr(vs, "_tts_service_url", lambda: "http://localhost:8100")
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "refused"))
+    st = vs.resolve_tts_status(_cfg(tts_backend="default"))
+    assert st.ready is True
+    assert st.warnings == []
+
+
+def test_tts_default_skips_probe_when_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(vs, "_probe", lambda *a, **k: calls.append(1) or (True, None))
+    st = vs.resolve_tts_status(_cfg(tts_backend="default"), probe=False)
+    assert st.ready is True
+    assert calls == []  # no orphan probe when probing is off
+
+
+def test_tts_custom_probes_shim(monkeypatch):
+    monkeypatch.setattr(vs, "_tts_service_url", lambda: "http://localhost:8100")
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
+    st = vs.resolve_tts_status(_cfg(tts_backend="custom", tts_url="http://localhost:8100"))
+    assert st.tier == "custom"
+    assert st.ready is True
+    assert st.server_url == "http://localhost:8100"
+
+
+def test_tts_custom_down(monkeypatch):
+    monkeypatch.setattr(vs, "_tts_service_url", lambda: "http://localhost:8100")
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "connection refused"))
+    st = vs.resolve_tts_status(_cfg(tts_backend="custom", tts_url="http://localhost:8100"))
+    assert st.ready is False
+    assert "not responding" in st.detail
+
+
+# === STT ===================================================================
+
+
+def test_stt_cloud_ready_with_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    st = vs.resolve_stt_status(_cfg(stt_backend="cloud"))
+    assert st.tier == "cloud"
+    assert st.ready is True
+    assert st.server_url is None  # cloud has no shim to probe
+
+
+def test_stt_cloud_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    st = vs.resolve_stt_status(_cfg(stt_backend="cloud"))
+    assert st.ready is False
+    assert "OPENAI_API_KEY" in st.detail
+
+
+def test_stt_default_browser_fallback(monkeypatch):
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: False)
+    st = vs.resolve_stt_status(_cfg(stt_backend="default"))
+    assert st.ready is True
+    assert st.server_url is None  # browser fallback — no host shim
+    assert "browser" in st.path.lower()
+
+
+def test_stt_default_probes_shim_when_moonshine_present(monkeypatch):
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
+    st = vs.resolve_stt_status(_cfg(stt_backend="default"))
+    assert st.ready is True
+    assert st.server_url is not None
+    assert "8101" in st.server_url


### PR DESCRIPTION
Two related honesty fixes, both rooted in `mcp_server.py` and sharing the theme **report the active path / verify the result**.

## #441 — voice status observability

Status tools probed a *configured-but-unused* server instead of the *active tier*'s path. Surfaced live while dogfooding Briefing Mode's `say()` brief: `tts_status` said "not running" while default-tier voice worked fine, and an orphaned kokoro server on `:8100` was invisible to every tool.

- **New `agentwire/voice_status.py`** — the shared resolver (SSOT). Resolves the active tier, reports the path that tier actually uses, only probes a server when the tier has one, and **flags an orphaned engine server** (running but unused by the tier).
- Rewired all surfaces through it: `cmd_tts_status` (path + orphan flag), `cmd_stt_status` (tier-aware — no more unconditional `:8101` probe), `cmd_network_status` (now resolves **both** voice subsystems; previously had no STT check at all), `doctor_voice.check_stt`, and the MCP `tts_status`/`stt_status` tools.
- `tts_status` now answers *"can I speak now and via what path"* (browser-connected vs OS voice) and flags an orphaned engine server.
- Deleted the now-unused `_check_tts_health`.

The orphan check **fired live** during verification — there's a real TTS server up on `:8100` while the tier is `default`, exactly the repro scenario.

## #444 — verified delivery (no more blind success)

Send/notify tools returned success the instant they dispatched, with no check it landed — even though `send_verified`/`message_visible` already exist in `session_ready.py`.

- `session_ready.send_verified` gains `pane_index` so worker-pane sends verify too.
- `agentwire send --verify` confirms the paste landed; MCP `session_send`/`pane_send` report **verified vs unconfirmed** (`null` = remote, unverifiable over SSH).
- `notify_parent` routes through `safe_deliver` and surfaces delivered/reason.
- `say` returns a real **sink ack** (browser → N clients / local speakers / OS voice) instead of "Queued speech."
- `notify_user`/`notify_event` report **dashboard client counts** (portal endpoints now return `clients`) instead of a bare "posted"/"broadcast".
- `email_send`/`quo_send` reworded to **"accepted by provider"** (genuine async boundary — acceptance ≠ delivery).

## Verification

- Full unit suite: **1435 passed, 8 skipped**. New `test_voice_status.py` (9 tests) + portal client-count coverage; updated `session_ready`/`doctor_voice`/`mcp`/`tts_local` tests for the new signatures.
- Live in-worktree: `tts/stt status`, `network status` (orphan flag fired on the real `:8100`), `doctor --voice`, `say --json` sink ack, `send --verify` (verified=true to a live session).
- **Not verifiable in-worktree:** the portal-side `clients` field on `/api/notify` + `/api/desktop/notification` only takes effect once the live portal restarts (out of scope for an isolated worktree) — covered by unit tests against a fresh app instance instead.

Closes #441
Closes #444

Built by [dotdev.dev](https://dotdev.dev)