### PR TITLE
fix(delivery): no re-paste on verify miss + honest say toast ack

### DIFF
--- a/.agents/skills/agentwire-cli/SKILL.md
+++ b/.agents/skills/agentwire-cli/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: agentwire-cli
+description: Full `agentwire` CLI command reference — session/pane management, portal, TTS/STT, voice, channels (email + quo, outbound-only), machine/tunnel/lock management, projects/history/roles, scheduler, web helper (fetch), safety/diagnostics. Use when running or composing `agentwire ...` shell commands, building automation scripts, or answering "how do I X from the CLI".
+---
+
+# AgentWire CLI Reference
+
+```bash
+# Session management
+agentwire new -s name           # not: tmux new-session
+agentwire new -s name --no-soul # skip the always-injected soul personality role
+agentwire new -s name --first-message "idea"  # deliver first prompt once agent boots
+                                #   (verified paste, local only; failure ≠ command failure)
+agentwire send -s name "prompt" # not: tmux send-keys
+agentwire send -s name --wait-ready --timeout 60 -- "prompt"
+                                # wait for agent boot (banner + screen-stable +
+                                #   trust-prompt auto-accept), verified delivery,
+                                #   exit 1 if unverified; local only
+agentwire send-keys -s name key1 key2  # raw keys with pauses
+agentwire send-keys -s name --pane 2 key  # target a specific pane
+agentwire new -s name --created-by orch  # record creator (prompt-routing parent);
+                                #   default: calling tmux session; '' opts out
+agentwire output -s name        # not: tmux capture-pane
+agentwire info -s name          # session metadata (cwd, panes) as JSON
+agentwire kill -s name          # not: tmux kill-session
+agentwire list                  # not: tmux list-sessions
+agentwire recreate -s name      # destroy and recreate with fresh worktree
+agentwire worktree name         # new branch + worktree + STANDALONE session
+                                #   "worktree session" ALWAYS means this command — never
+                                #   `spawn --branch` (that makes a pane). Defaults to the
+                                #   bypass posture (autonomous); override with --posture.
+                                #   The worktree-session etiquette role is intrinsic to
+                                #   the verb (isolation, no rebuild/restart, verify
+                                #   in-worktree, draft PR + notify-back) — first prompts
+                                #   only need the task itself
+                                #   Base branch (default mode): --base wins, else config
+                                #   worktree.default_base, else the repo's actual default
+                                #   branch (origin/HEAD, fallback current) — no hardcoded 'main'.
+                                #   --project defaults to the git root of cwd (monorepo-safe:
+                                #   many sessions can target one repo from different branches).
+                                #   config worktree.naming can template the NEW branch name.
+agentwire worktree name -b develop  # from specific base branch
+agentwire worktree name -c      # from repo's current branch
+agentwire worktree name -e      # checkout existing branch (no new branch)
+agentwire worktree name --ref v2.0  # detached at tag/commit
+agentwire worktree --list       # list this repo's worktree sessions (registry); --all = every repo
+agentwire worktree --remove name  # kill session + remove worktree + unregister (cleanup/recovery)
+agentwire worktree --prune      # drop registry entries whose worktree is gone + git worktree prune
+agentwire fork -s name          # fork session into new worktree
+agentwire fork -s name -t project/branch --commit abc123  # fork from specific commit
+
+# Pane commands (worker PANES inside the current session — NOT worktree
+# sessions; for parallel autonomous work use `agentwire worktree` above)
+agentwire spawn --roles worker  # spawn worker pane
+agentwire spawn --branch name   # worker pane on an isolated worktree (still a pane)
+agentwire send --pane 1 "task"  # send to pane
+agentwire output --pane 1       # read pane output
+agentwire kill --pane 1         # kill pane
+agentwire jump --pane 1         # focus pane
+agentwire split -s name         # add terminal pane(s)
+agentwire detach -s name        # move pane to its own session
+agentwire resize -s name        # resize window to fit largest client
+
+# Boot everything
+agentwire up                    # boot all services (portal, TTS, STT, scheduler,
+                                #   custom) then start/attach the dev session
+agentwire up --no-tts --no-stt  # skip optional voice services
+agentwire up --dev              # run portal from source (uv run)
+
+# Portal management
+agentwire portal start          # start in tmux
+agentwire portal stop           # stop portal
+agentwire portal restart        # stop + start
+agentwire portal status         # check health
+agentwire portal token          # print the auth token (devices enter it once)
+agentwire portal token --rotate # generate a new token (re-enter on devices)
+
+# Scratch pad (shared notes — portal drawer Alt+N; file: ~/.agentwire/scratchpad.json)
+agentwire scratchpad list       # list notes (newest first)
+agentwire scratchpad add "text" --source mysession  # add a note (drawer refreshes live)
+agentwire scratchpad remove <id> # delete a note
+agentwire scratchpad clear      # delete all notes
+
+# Custom services (registered long-running sessions — services.custom in config;
+# autostart on portal launch, health-checked + restarted by the portal watchdog)
+agentwire services list         # registry: autostart/restart/healthcheck per service
+agentwire services status       # run healthchecks now (exit 1 if something's down)
+agentwire services status name  # one service
+agentwire services up <name>    # start (also clears 'down' state)
+agentwire services up --all     # start all autostart services (skips downed)
+agentwire services down <name>  # stop AND keep stopped (watchdog won't respawn)
+
+# TTS/STT servers
+agentwire tts start|stop|status # TTS server management
+agentwire stt start|stop|status # STT server management (host shim on :8101)
+agentwire stt start             # engine from stt.engine (auto|moonshine|whisper); moonshine = fast CPU
+agentwire stt start --backend moonshine --model moonshine/base --port 8101  # ad-hoc overrides
+
+# Voice
+agentwire say "text"            # speak (auto-routes to browser or local)
+agentwire say -s name "text"    # speak to specific session
+agentwire notify-parent "text"   # notify parent session (worker→orchestrator)
+agentwire notify-parent --to name "text" # notify specific session
+agentwire notify-parent --raw --to name "text"  # verbatim, no [NOTIFY ...] prefix
+                                # (delivery is safety-gated: refuses targets showing a
+                                #  live dialog / bare shells / parked sessions, verified paste)
+
+# Prompt routing (interactive prompts → parent session; see wiki sessions/prompt-routing.md)
+agentwire prompts status        # pending prompt markers
+agentwire prompts tick          # run one sweep now (watchdog does this every 60s)
+agentwire prompts answer -s name --pane 0 --expect <hash> 2  # guarded answer:
+                                #   re-detects + hash-compares before sending keys —
+                                #   NEVER answer dialogs with raw send-keys
+agentwire prompts clear -s name --pane 1  # drop a marker
+
+# Polite messaging (non-interrupting agent-to-agent inbox; see wiki sessions/messaging.md)
+agentwire msg send --to name "text"          # queue a message (delivers when their box is clear)
+agentwire msg send --to name --kind done "PR #312 drafted"  # kinds: note|done|request|escalation
+agentwire msg send --to @all "team update"   # broadcast to live agent sessions except sender
+agentwire msg inbox -s name                  # peek pending (does not drain)
+agentwire msg dead -s name                   # list dropped (dead-lettered) msgs + reason/timestamp
+agentwire msg flush -s name                  # attempt a drain now (still gated on empty box + safe target)
+                                # `msg` NEVER clobbers a human's draft — unlike `send`, which
+                                # pastes + Enter immediately. Use `send` only to forcibly drive a session now.
+
+agentwire listen start|stop|cancel  # host voice recording (needs stt.backend: custom + the :8101 shim)
+agentwire listen stop -s name   # transcribe + send to a tmux session (default)
+agentwire listen stop --type    # transcribe + type at cursor (Hammerspoon paste)
+agentwire listen stop --stdout  # transcribe + print raw transcript to stdout, no paste/send
+                                #   (scripting hook — Hammerspoon etc. capture $())
+
+# Voice cloning
+agentwire voiceclone start      # start recording voice sample
+agentwire voiceclone stop name  # stop and save as voice clone
+agentwire voiceclone list       # list available voices
+agentwire voiceclone delete name # delete a voice clone
+
+# Artifact windows (agent visual canvas)
+agentwire open <url> --title "T"  # open URL or local file as artifact window
+agentwire open dashboard.html     # open from ~/.agentwire/artifacts/
+
+# Channels (outbound notification integrations — email + quo)
+agentwire channels list         # list all registered channels
+agentwire channels list --json  # JSON output
+
+# Email (send-only channel)
+agentwire email --to addr --subject "Subject" --body "Body"
+agentwire email --body "msg" # uses default_to from config
+agentwire email --attach file.pdf --body "See attached"
+
+# Quo SMS (send-only channel, no deps)
+agentwire quo --body "msg" --to "+1234567890"
+
+# Machine management
+agentwire machine list
+agentwire machine add <id> --host <host> --user <user>
+agentwire machine remove <id>
+
+# SSH tunnels (for remote services)
+agentwire tunnels up            # create all required tunnels
+agentwire tunnels down          # tear down all tunnels
+agentwire tunnels status        # show tunnel health
+agentwire tunnels check         # verify tunnels are working
+
+# Lock management (for scheduled tasks)
+agentwire lock list             # list all locks
+agentwire lock clean            # remove stale locks
+agentwire lock remove <session> # force-remove a specific lock
+
+# Project discovery
+agentwire projects list         # discover projects from projects_dir
+agentwire projects list --json  # JSON output for scripting
+agentwire projects create name              # mkdir + minimal .agentwire.yml (Codex-bypass)
+                                            # (in git repos, .agentwire.yml is auto-added to
+                                            #  .gitignore — personal config, keep it untracked)
+agentwire projects create name --git-init   # also run `git init`
+agentwire projects create name --from URL   # git clone URL instead of mkdir
+
+# Session history
+agentwire history list          # list conversation history
+agentwire history show <id>     # show session details
+agentwire history resume <id>   # resume session (always forks)
+
+# Shareable conversation handoffs (issue #157)
+agentwire handoff init [--title hint]      # create bundle dir + pre-filled ai-handoff.md template
+agentwire handoff render <bundle-dir>      # render show-the-story.html from ai-handoff.md
+agentwire handoff list                     # list past bundles
+# Inside a Codex session, prefer the /handoff slash command — it walks the
+# agent through filling the template using full conversation context (free, no
+# fresh LLM call). Outputs land in ~/.agentwire/artifacts/handoff-<slug>/.
+
+# Roles management
+agentwire roles list            # list available roles
+agentwire roles show <name>     # show role details
+
+# Scheduled workloads
+agentwire ensure -s name --task task  # run named task reliably
+agentwire task list [session]         # list tasks for session/project
+agentwire task show session/task      # show task definition
+agentwire task validate session/task  # validate task syntax
+
+# URL fetch (helper usable from any session, including pi)
+agentwire fetch <url>                 # fetch a page via Jina Reader (markdown, JS-rendered)
+agentwire fetch <url> --limit 4000    # cap chars (default 8000, 0 = no limit)
+
+# Safety & diagnostics
+agentwire safety check "cmd"    # test if command would be blocked
+agentwire safety status         # show pattern counts and recent blocks
+agentwire safety logs           # query audit logs
+agentwire safety install        # install damage control hooks
+agentwire hooks install         # install permission hook (Codex only)
+agentwire hooks uninstall       # remove permission hook (Codex only)
+agentwire hooks status          # check hook installation status
+agentwire network status        # complete network health check
+agentwire doctor                # auto-diagnose and fix issues
+agentwire doctor --voice        # only the push-to-talk path: mic, STT shim, portal/tunnel, tmux+PTT (pass/fail + fix)
+
+# Notifications
+agentwire notify event          # notify portal of state changes (session/pane events)
+
+# MCP Server
+agentwire mcp                   # expose agentwire as MCP server
+
+# Scheduler
+agentwire scheduler start|serve|stop|status # manage scheduler daemon
+agentwire scheduler board                   # show task board with overdue scores
+agentwire scheduler live                    # show live scheduler state
+agentwire scheduler events                  # show recent scheduler events
+agentwire scheduler history                 # show recent run history
+agentwire scheduler run task                # force-run a task now
+agentwire scheduler enable|disable task     # enable/disable a task
+agentwire scheduler report [--since 8h] [--artifact]  # generate morning report HTML
+agentwire scheduler dashboard               # open scheduler dashboard
+
+# Usage-limit recovery (deterministic watchdog, see docs/wiki/usage-limit-recovery.md)
+agentwire limits tick           # one watchdog pass: sweep panes, resume what's due
+agentwire limits status         # show sessions parked on usage limits
+agentwire limits resume -s name [--force]  # manually resume a parked session now
+agentwire limits install        # install + load the launchd watchdog (60s tick)
+agentwire limits uninstall      # unload + remove the watchdog
+
+# Setup & Development
+agentwire init                  # interactive setup wizard
+agentwire generate-certs        # generate SSL certificates
+agentwire up                    # boot all services + dev session (see "Boot everything")
+agentwire dev                   # start/attach to dev session ONLY (no services)
+agentwire rebuild               # clear uv cache and reinstall
+agentwire uninstall             # uninstall the tool
+```
+
+`agentwire dev` only spawns the `agentwire` agent session — it does NOT start
+the portal or any service. Use `agentwire up` after a reboot to bring up the
+full stack. `up` brings up portal → TTS → STT → autostart custom services, then
+runs `dev`; the scheduler rides along via the portal's `scheduler.autostart`.
+TTS is skipped for `none`/`runpod` backends; STT is skipped without `stt.url`.
+
+Session formats: `name`, `project/branch` (worktree), `name@machine` (remote)
+Pane targeting: `--pane N` auto-detects session from `$TMUX_PANE`
+
+For CLI details: `agentwire --help` or `agentwire <cmd> --help`

--- a/.agents/skills/agentwire-config/SKILL.md
+++ b/.agents/skills/agentwire-config/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: agentwire-config
+description: Reference for `~/.agentwire/config.yaml` — main config structure including server/portal/SSL, projects, TTS/STT, agent, dev, services, executables, pi (binary/system_prompt/extra_env/providers), uploads/artifacts/wiki, channels (email + quo, outbound-only), scheduler, worktree, session defaults. Use when editing or debugging agentwire config, setting up TTS/STT backends, configuring pi providers, or explaining config fields to the user.
+---
+
+# AgentWire Config (`~/.agentwire/config.yaml`)
+
+## Layout of `~/.agentwire/`
+
+| File | Purpose |
+|------|---------|
+| `config.yaml` | Main config (see structure below) |
+| `machines.json` | Remote machines registry |
+| `scripts/` | Machine-specific helper scripts (TTS management, startup, etc.) |
+| `voices/` | Custom TTS voice samples |
+| `uploads/` | Uploaded images for cross-machine sharing |
+| `artifacts/` | Agent-generated HTML for artifact windows |
+| `wiki/` | LLM-maintained knowledge base (Karpathy LLM Wiki pattern) |
+| `logs/` | Audit logs for damage-control |
+
+Per-session config (type, roles, voice) lives in `.agentwire.yml` in each project directory (see `agentwire-project-config` skill).
+
+## Machine Scripts (`~/.agentwire/scripts/`)
+
+Each machine has a `~/.agentwire/scripts/` directory for machine-specific helper scripts (TTS management, startup hooks, service wrappers, etc.). This is the standard location — agents should look here first and put new scripts here.
+
+Scripts in `~/bin/` should symlink to `~/.agentwire/scripts/` so they're callable from PATH but the source of truth is in one place.
+
+These scripts are **not** managed by agentwire — they're local to each machine and not version controlled. They exist because different machines have different roles (GPU server runs TTS, Mac runs the portal, etc.) and need different glue scripts.
+
+## config.yaml Structure
+
+```yaml
+server:
+  host: "127.0.0.1"  # default; "0.0.0.0" allows LAN/phone access and requires the auth token (see SECURITY.md)
+  port: 8765
+  activity_threshold_seconds: 3  # Seconds before session considered idle
+  ssl:
+    cert: "~/.agentwire/cert.pem"
+    key: "~/.agentwire/key.pem"
+  # Auth token: unset = use ~/.agentwire/portal.token (auto-generated on first
+  # non-loopback start; print/rotate with `agentwire portal token [--rotate]`).
+  # Set a string to override the file; "" disables auth (loopback binds only —
+  # the portal refuses to start on 0.0.0.0 with auth disabled).
+  # auth_token: ""
+  # Extra browser origins allowed on state-changing requests (exact
+  # scheme://host[:port]). The portal's own origin and localhost always pass.
+  # Needed when fronting with Cloudflare Tunnel:
+  allowed_origins: []  # e.g. ["https://portal.example.com"]
+
+projects:
+  dir: "~/projects"
+  worktrees:
+    enabled: true
+    suffix: "-worktrees"
+    auto_create_branch: true
+    copy_files: [".env", ".agentwire.yml"]   # gitignored files seeded into each new worktree
+                           # (git worktree add only checks out tracked files,
+                           #  so .env/secrets/local config don't carry over —
+                           #  add ".env.local", ".envrc", etc. as needed).
+                           # Keep .agentwire.yml gitignored: a TRACKED copy means
+                           # worktree runs use the committed version (HEAD) and
+                           # silently ignore live edits — see agentwire-project-config skill.
+
+tts:
+  backend: "default"  # tier: default (in-process Kokoro, zero setup — ~200MB model
+                      # auto-downloads on first portal start; speechSynthesis covers
+                      # the wait) | custom (self-hosted shim at url)
+  url: "http://localhost:8100"  # custom tier only — shim endpoint
+  default_voice: "dotdev"
+  voices_dir: "~/.agentwire/voices"  # Custom voice samples for cloning
+  instructions: ""  # free-text prompt passed through to the shim
+  options:  # opaque JSON passed to the shim; the bundled shim reads:
+    backend: kokoro  # engine: kokoro | chatterbox | chatterbox-streaming | qwen-base-0.6b | qwen-base-1.7b | qwen-custom | qwen-design | zonos-transformer | zonos-hybrid
+  exaggeration: 0.5  # Voice expressiveness (0-1, Chatterbox)
+  cfg_weight: 0.5  # CFG weight (0-1, Chatterbox)
+  timeout: 60
+
+stt:
+  backend: "default"  # TIER (where transcription happens): default (portal-owned
+                      # in-process Moonshine — bundled, auto-downloads on first boot,
+                      # no setup; falls back to browser SpeechRecognition while it
+                      # warms up or on py3.14+) | cloud (portal → hosted OpenAI-
+                      # compatible transcription API, no shim daemon) | custom
+                      # (self-hosted shim at url)
+  engine: "auto"      # ENGINE (which model the self-hosted shim loads): auto | moonshine |
+                      # whisper. Orthogonal to backend — used only by `agentwire stt start/serve`.
+                      # `{backend: custom, engine: whisper}` = boot shim AND run faster-whisper.
+  moonshine_model: "moonshine/base"  # moonshine engine only — ONNX model id (moonshine/tiny | moonshine/base)
+  model: "base"       # whisper engine only — faster-whisper/openai-whisper model (tiny → large-v3)
+  url: "http://localhost:8101"  # custom tier only — shim endpoint (also the `agentwire stt` port)
+  cloud:  # cloud tier only — all fields optional, defaults shown
+    base_url: "https://api.openai.com/v1"  # any OpenAI-compatible endpoint (Groq, Mistral, speaches, ...)
+    model: "gpt-4o-mini-transcribe"
+    api_key_env: "OPENAI_API_KEY"  # NAME of the env var holding the key — the key itself
+                                   # never lives in config and never reaches the browser;
+                                   # portal refuses to start if the var is unset
+    language: ""  # optional ISO-639-1 hint
+  timeout: 30
+  silence_prepend_ms: 0  # prepend silence if your backend clips the first syllable
+  instructions: ""  # free-text hint passed through to the shim
+  options: {}  # opaque JSON passed to the shim (language hints, vocab biasing, ...)
+  corrections: {}  # post-transcription find/replace, e.g. {"agent wire": "agentwire"}
+
+agent:
+  command: "Codex --dangerously-skip-permissions"
+
+dev:
+  source_dir: "~/projects/agentwire-dev"  # agentwire source for TTS/STT venv
+
+services:  # Where services run (for multi-machine setups)
+  portal:
+    machine: null  # null = local
+    port: 8765
+    session_name: "agentwire-portal"  # tmux session name
+  tts:
+    machine: "gpu-server"  # or null for local
+    port: 8100
+    session_name: "agentwire-tts"
+  stt:
+    session_name: "agentwire-stt"
+  custom:  # User-defined service sessions — autostart on portal launch AND
+           #   `agentwire up`, health-checked by the portal watchdog, shown in
+           #   the portal's Services column. Manage with `agentwire services ...`.
+           #   The notifications bridge is a built-in registry entry (override
+           #   by defining a service with its name).
+    - name: "agent-brain"          # tmux session name (required)
+      project: "~/projects/brain"  # project dir; defaults to dev source dir
+      autostart: true              # boot on portal launch / `agentwire up` (default true)
+      roles: "brain"               # optional; overrides project .agentwire.yml
+      type: "Codex-bypass"        # optional; session type override
+      restart: on-failure          # never | on-failure | always (watchdog respawn
+                                   #   with 30s..10m exponential backoff; default on-failure;
+                                   #   `agentwire services down` always sticks)
+      healthcheck:                 # optional; defaults to tmux_session/60s
+        kind: tmux_session         # tmux_session | http | command
+        url: "http://..."          # for http (2xx = healthy)
+        command: "curl -sf ..."    # for command (exit 0 = healthy)
+        interval: 60               # seconds between watchdog checks
+    - "simple-service"             # string shorthand = name only, all defaults
+
+executables:  # Override executable paths (optional, auto-detected by default)
+  ffmpeg: "/opt/homebrew/bin/ffmpeg"
+  whisperkit-cli: "/opt/homebrew/bin/whisperkit-cli"
+  hs: "/opt/homebrew/bin/hs"
+  agentwire: "~/.local/bin/agentwire"
+
+pi:  # Pi coding agent — drives all `pi-<provider>` session types. See `agentwire-pi` skill.
+  binary: "pi"  # path override if pi isn't on PATH (e.g., nvm-installed)
+
+  # Appended via --append-system-prompt to every non-restricted pi-* session.
+  # Use to teach pi about local helpers — agentwire fetch, etc.
+  system_prompt: |
+    ## Fetching URLs
+    Use `agentwire fetch <url>` to fetch a page as clean markdown (Jina Reader).
+
+  # Env vars injected into every pi-* session, in addition to the provider key.
+  # Values are stored in plaintext here — non-secrets only. Secrets belong in
+  # ~/.agentwire/.env (docs/wiki/security/secrets.md).
+  extra_env:
+    MY_SERVICE_URL: "https://internal.example.com"
+
+  # Per-provider config. Session type `pi-<name>` resolves the provider here.
+  # Adding a new provider is config-only — no code changes needed. For non-built-in
+  # providers (e.g. DeepSeek), also register them in `~/.pi/agent/models.json`.
+  # env_var is the NAME of the env var holding the key — the key itself lives
+  # in ~/.agentwire/.env (e.g. ZAI_API_KEY=...), never here.
+  providers:
+    zai:
+      env_var: ZAI_API_KEY
+      default_model: glm-5.1
+    deepseek:
+      env_var: DEEPSEEK_API_KEY
+      default_model: deepseek-chat
+
+uploads:
+  dir: "~/.agentwire/uploads"
+  max_size_mb: 10
+  cleanup_days: 7
+
+artifacts:
+  dir: "~/.agentwire/artifacts"
+  max_size_mb: 10
+
+wiki:
+  dir: "~/.agentwire/wiki"           # Wiki vault location
+
+portal:
+  url: "https://localhost:8765"
+
+channels:  # Outbound-only notifications. Only email + quo ship.
+  # Keys are env-only: RESEND_API_KEY / QUO_API_KEY in ~/.agentwire/.env
+  # (docs/wiki/security/secrets.md) — never in config.yaml.
+  email:
+    from_address: "Echo <echo@yourdomain.com>"
+    default_to: "user@example.com"
+    banner_image_url: "https://yourdomain.com/images/banner.png"
+    echo_image_url: "https://yourdomain.com/images/echo.png"
+    echo_small_url: "https://yourdomain.com/images/echo-small.png"
+    logo_image_url: "https://yourdomain.com/images/logo.png"
+  quo:
+    from_number: "+1234567890"  # E.164 or phone number ID (PNxxx)
+    default_to: "+0987654321"
+
+scheduler:
+  autostart: true        # Start the scheduler daemon when the portal boots (default: true)
+  dispatch_cooldown: 60  # Seconds between task dispatches (default: 60)
+
+usage_limit:             # Usage-limit recovery watchdog (docs/wiki/usage-limit-recovery.md)
+  enabled: true          # Master switch for dialog detection/parking (default: true)
+  exclude_sessions: []   # Session names never auto-parked (gates NEW parks only)
+
+worktree:                         # `agentwire worktree <name>` orchestration (WorktreeConfig).
+                                  # Distinct from projects.worktrees above (the legacy
+                                  # project/branch layout). `quicktask:` is a legacy alias for
+                                  # this key — prefer `worktree:`.
+  worktree_dir: ~/worktrees       # Where worktrees are created (one dir per session)
+  default_base: develop           # Base branch new worktrees fork from. OMIT to derive from
+                                  # the repo's actual default branch (origin/HEAD, fallback to
+                                  # current branch) — no hardcoded 'main'. --base always wins.
+  default_project: ~/projects/my-repo  # Repo used when --project is omitted AND cwd isn't in a
+                                  # git repo. Otherwise --project / the git root of cwd is used.
+  naming: "{user}/{slug}"         # Optional branch-name template for NEW branches. Placeholders:
+                                  # {name} (verbatim), {slug} (slugified), {user} (OS login).
+                                  # Omit → branch == name verbatim. Only the git branch is
+                                  # templated; the tmux session name stays {project}-{name}.
+
+session:
+  # No global default-role: a session's etiquette is derived from its spawn
+  # verb (new → orchestrator, worktree → worktree-session, spawn → worker),
+  # then any --roles / .agentwire.yml roles: replace it. See resolve_roles.
+  inject_soul: true          # Append the bundled 'soul' personality role to every human-facing
+                             # session (appended last for recency weight). Headless roles
+                             # (worker, task-runner, notifications) and soul/soul-* sessions
+                             # are excluded automatically; per-session opt-out: --no-soul on new/dev
+```

--- a/.agents/skills/agentwire-desktop-ui/SKILL.md
+++ b/.agents/skills/agentwire-desktop-ui/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agentwire-desktop-ui
+description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`), window collage (preview overlay — NEVER mutate real WinBox windows). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
+---
+
+# Portal Desktop UI Patterns
+
+## Left Sidebar (click-toggle tab handle)
+
+The portal uses a left sidebar with a floating tab handle instead of hover hotzone. A small tab (›) peeks from the left edge — click to slide sidebar open, click again to close. Click outside or press Escape to dismiss. Pin to keep visible (reflows desktop area).
+
+**Structure:**
+- **Tab handle**: floating 20×40px button on left edge, rides sidebar when open, chevron flips direction
+- **Header**: connection status dot, session count, clock, pin toggle
+- **Open Windows section**: lists currently-open windows (drag to reorder, click to focus, × to close). Persisted in `localStorage['taskbar-state']` — restores on refresh.
+- **Accordion sections**: Sessions, Services, Machines, Projects, Artifacts, Scheduler, Safety, Config. Click header to expand/collapse. Data fetched on first expand.
+- **Footer**: global PTT button, voice indicator
+
+**Session grouping:** Sessions are split into two accordion sections based on the name:
+- **Services**: infrastructure sessions. The built-in allowlist in `service-classification.js` (`agentwire-portal`, `agentwire-tts`, `agentwire-stt`, `agentwire-scheduler`, `agentwire-notifications`) is merged at load time with config-defined custom services fetched from `/api/services/custom` (driven by `services.custom` in `config.yaml`). When the fetch resolves, `notifyListeners()` re-renders so flagged sessions hop into this column.
+- **Sessions**: everything else (working sessions, worktrees, remote sessions)
+
+Both share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).
+
+**Keyboard:** Tab cycles forward through open windows, Shift+Tab cycles backward. Works inside terminals (captured on `window` in capture phase before xterm).
+
+**Files:** `static/js/sidebar.js` (shell + click-toggle), `static/js/sidebar/<name>-section.js` (per-section modules), `static/css/desktop.css` (sidebar-* classes).
+
+## Command Palette & Idea-First Capture
+
+`Cmd/Ctrl+K` opens the command palette (`static/js/command-palette.js`) **straight into the `new-idea` view** — Esc reaches the root menu (New idea / New session / New worktree / Open session / Window collage). The full-width 💡 **New idea** sidebar button (between header and sections) and the Projects section `+` route to the same view.
+
+**New-idea flow (issue #253):** idea textarea (Enter submits, Shift+Enter newline, 🎤 dictation via `voice/browser-stt.js`) → kebab-case project name derived client-side (`deriveProjectName`, stopword-stripped; stops auto-updating once the user edits it) → submit POSTs `/api/projects/create` then `/api/create` with `first_message` → window opens immediately while the idea is delivered to the booting agent in the background (server calls `agentwire send --wait-ready`; failure posts a toast). There is no name-first modal anymore — `new-project-modal.js` was deleted.
+
+## Session Window Modes
+
+| Mode | Element | Use Case |
+|------|---------|----------|
+| **Monitor** | `<pre>` with ANSI-to-HTML | Read-only output viewing, polls `tmux capture-pane` |
+| **Terminal** | xterm.js | Interactive terminal, attaches via `tmux attach` |
+
+**Important:** Monitor mode must use a simple `<pre>` element, NOT xterm.js. xterm.js requires precise container dimensions for its fit addon to work correctly. Since monitor mode just displays captured text output, a `<pre>` element with `white-space: pre-wrap` and ANSI-to-HTML conversion is simpler and more reliable.
+
+**Per-session PTT** lives in the WinBox titlebar (next to the activity indicator), not as a floating button.
+
+## Window Collage (Mission Control)
+
+F3 or Alt/Option+` / `desktop_collage` MCP / command palette → grid of live previews of every open window; click a tile to focus, Esc to exit.
+
+**The one rule: tiles are overlay-local previews — NEVER mutate the real WinBox windows.** Session tiles stream pane content over a second monitor WS (`/ws/{sessionId}`, rendered via shared `utils/ansi.js`); artifact tiles are cloned iframes. Real windows are never moved/resized/transformed/un-minimized, so exit has nothing to restore.
+
+Why this is load-bearing (each broke a previous implementation — full autopsy in `docs/wiki/internals/window-collage.md`):
+- Faking `winbox.min` corrupts WinBox's internal min-stack → later minimizes re-lay windows out as 250×35px bars, with duplicate entries compounding per cycle.
+- WinBox animates geometry over 300ms → `getBoundingClientRect` right after a write returns mid-transition garbage.
+- Resizing a terminal window fires ResizeObserver → `fitAddon.fit()` + PTY resize per frame → resizes the real tmux session and corrupts the xterm WebGL layer (transparent windows).
+- `registerWindow`/`setActiveWindow` auto-minimize all others (single-window mode) → any window event mid-overlay fights manual layouts.
+
+**Z-index landscape:** WinBox windows (inline, grows from 10) < collage overlay (1400) < toasts (1500) < modals (2000) < command palette (3000) < sidebar (9001) < tile drag overlay (99999).
+
+## Artifact Windows
+
+Agents can display HTML content in sandboxed iframe windows on the portal desktop.
+
+**Agent workflow (MCP):**
+```python
+# Write HTML and open in one step
+desktop_write_artifact(filename="dashboard.html", html_content="<h1>Hello</h1>", title="Dashboard")
+
+# Or open an existing file or external URL
+desktop_open_artifact(url="dashboard.html", title="Dashboard")
+desktop_open_artifact(url="https://example.com", title="External")
+```
+
+**Files served from:** `~/.agentwire/artifacts/` via `/artifacts/` route.
+
+**Sandboxing:** Local files get `allow-scripts allow-same-origin`. External URLs get `allow-scripts allow-forms allow-popups` (no same-origin).

--- a/.agents/skills/agentwire-mcp-tools/SKILL.md
+++ b/.agents/skills/agentwire-mcp-tools/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: agentwire-mcp-tools
+description: Reference for the `mcp__agentwire__*` MCP tools — session/pane management, voice/TTS, tasks/locks, channels (email + quo, outbound-only), machines/tunnels/network, history/roles/projects, scheduler, desktop UI, notifications. Use when agents inside agentwire sessions need to pick the right MCP tool instead of shelling out to the `agentwire` CLI.
+---
+
+# AgentWire MCP Tools
+
+**Agents running in agentwire sessions should use MCP tools instead of CLI commands.** The agentwire MCP server provides tools that wrap CLI functionality. Use these instead of `Bash: agentwire <cmd>`.
+
+## Session Management (11 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire list` | `sessions_list()` |
+| `agentwire new -s name` | `session_create(name="...")` |
+| `agentwire send -s name "msg"` | `session_send(session="...", message="...")` |
+| `agentwire msg send --to name "msg"` | `msg_send(to="...", text="...", kind="note")` |
+| `agentwire msg inbox -s name` | `msg_inbox(session="...")` |
+| `agentwire msg dead -s name` | `msg_dead(session="...")` |
+| `agentwire output -s name` | `session_output(session="...")` |
+| `agentwire info -s name` | `session_info(session="...")` |
+| `agentwire kill -s name` | `session_kill(session="...")` |
+| `agentwire send-keys -s name key1 key2` | `session_send_keys(session="...", keys=["..."])` |
+| `agentwire recreate -s name` | `session_recreate(session="...")` |
+| `agentwire fork -s name -t project/branch` | `session_fork(session="...", target="...")` |
+| `agentwire fork -s name -t project/branch --commit abc` | `session_fork(session="...", target="...", commit="abc")` |
+
+**`session_send` vs `msg_send`:** `session_send` pastes + Enter **immediately** — and clobbers a human's half-typed draft if the box is occupied. Use it only when you must forcibly drive a session *now*. `msg_send` is the polite path: it queues a typed message into a file inbox and the watchdog injects it only when the recipient's box is empty and the pane is safe (≤60s). For routine peer updates ("PR drafted", "picking up the footer"), prefer `msg_send`. `kind` ∈ note|done|request|escalation; `to="@all"` broadcasts to live agent sessions except you. See wiki sessions/messaging.md.
+
+**Note:** `session_create` (via `agentwire new`) records the calling session as the new session's creator — interactive prompts (permission/plan/AskUserQuestion) in the child then route back to you as `[PROMPT from ...]` messages. Answer them with `agentwire prompts answer -s <session> --expect <hash> <key>` via Bash (guarded compare-and-send), NEVER with raw `session_send_keys` — a late keystroke races the portal and can type into the child's input or abort its turn.
+
+## Pane Management (9 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire spawn --roles worker` | `pane_spawn(roles="worker")` |
+| `agentwire send --pane 1 "msg"` | `pane_send(pane=1, message="...")` |
+| `agentwire output --pane 1` | `pane_output(pane=1)` |
+| `agentwire kill --pane 1` | `pane_kill(pane=1)` |
+| `agentwire list` (in tmux) | `panes_list()` |
+| `agentwire split -n 2` | `pane_split(count=2)` |
+| `agentwire detach --pane 1 -s target` | `pane_detach(session="src", pane=1, target="target")` |
+| `agentwire jump --pane 1` | `pane_jump(pane=1)` |
+| `agentwire resize` | `pane_resize()` |
+
+## Voice & TTS (11 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire say "text"` | `say(text="...")` |
+| `agentwire notify-parent "text"` | `notify(text="...", to="...")` |
+| `agentwire listen start` | `listen_start()` |
+| `agentwire listen stop` | `listen_stop()` |
+| `agentwire listen cancel` | `listen_cancel()` |
+| `agentwire voiceclone start` | `voiceclone_start()` |
+| `agentwire voiceclone stop name` | `voiceclone_stop(name="...")` |
+| `agentwire voiceclone cancel` | `voiceclone_cancel()` |
+| `agentwire voiceclone list` | `voiceclone_list()` |
+| `agentwire voiceclone delete name` | `voiceclone_delete(name="...")` |
+| (portal API) | `transcribe(audio_base64="...", format="webm")` |
+| `agentwire voiceclone list` | `voices_list()` |
+
+## Tasks & Locks (7 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire ensure -s x --task y` | `task_run(session="x", task="y")` |
+| `agentwire task list x` | `task_list(session="x")` |
+| `agentwire task show x/y` | `task_show(session="x", task="y")` |
+| `agentwire task validate x/y` | `task_validate(session="x", task="y")` |
+| `agentwire lock list` | `lock_list()` |
+| `agentwire lock clean` | `lock_clean()` |
+| `agentwire lock remove session` | `lock_remove(session="...")` |
+
+## Operations (12 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire projects list` | `projects_list()` |
+| `agentwire roles list` | `roles_list()` |
+| `agentwire roles show name` | `role_show(name="...")` |
+| `agentwire machine list` | `machines_list()` |
+| `agentwire machine add id --host h --user u` | `machine_add(machine_id="...", host="...", user="...")` |
+| `agentwire machine remove id` | `machine_remove(machine_id="...")` |
+| `agentwire history list` | `history_list()` |
+| `agentwire history show id` | `history_show(session_id="...")` |
+| `agentwire history resume id -p path` | `history_resume(session_id="...", project="...")` |
+| `agentwire handoff init --title hint` | `handoff_init(title="...")` |
+| `agentwire handoff render <bundle-dir>` | `handoff_render(bundle_dir="...", story=True)` |
+| `agentwire handoff list` | `handoff_list()` |
+
+## Channels (outbound-only)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire channels list` | `channels_list()` |
+| `agentwire email --body "..." --to addr` | `email_send(body="...", to="...", attachments=["..."], plain_text=False)` |
+| `agentwire quo --body "..." --to "+1..."` | `quo_send(body="...", to="+1...")` |
+
+## Notifications & Network (5 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire notify event` | `session_notify(event="...")` |
+| `agentwire tunnels up` | `tunnels_up()` |
+| `agentwire tunnels down` | `tunnels_down()` |
+| `agentwire tunnels status` | `tunnels_status()` |
+| `agentwire network status` | `network_status()` |
+
+## Status (3 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire portal status` | `portal_status()` |
+| `agentwire tts status` | `tts_status()` |
+| `agentwire stt status` | `stt_status()` |
+
+## Scratch Pad (2 tools)
+
+The user's shared notes drawer (portal, Alt+N) — server-backed, synced live to
+every connected client. Use `scratchpad_add` when the user says "save this",
+"note that", or "add to my notes".
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire scratchpad add "text" --source s` | `scratchpad_add(text, source)` |
+| `agentwire scratchpad list` | `scratchpad_list()` |
+
+## Custom Services (2 tools)
+
+Registered long-running sessions (`services.custom` in config + the built-in
+notifications bridge). Autostarted on portal launch; health-checked and
+restarted by the portal watchdog. Start/stop is CLI-only (`agentwire services
+up|down`) — the MCP surface is read-only introspection.
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire services list` | `services_list()` |
+| `agentwire services status` | `services_status()` |
+
+## Scheduler (8 tools)
+
+| CLI Command | MCP Tool |
+|-------------|----------|
+| `agentwire scheduler status` | `scheduler_status()` |
+| `agentwire scheduler board` | `scheduler_board()` |
+| `agentwire scheduler live --json` | `scheduler_live()` |
+| `agentwire scheduler events --json` | `scheduler_events(tail=20, task="")` |
+| `agentwire scheduler run task` | `scheduler_run(task="...")` |
+| `agentwire scheduler report --since 8h` | `scheduler_report(since="8h", artifact=False)` |
+| `agentwire scheduler enable task` | `scheduler_enable(task="...")` |
+| `agentwire scheduler disable task` | `scheduler_disable(task="...")` |
+| `agentwire scheduler history` | `scheduler_history(limit=20)` |
+
+## Desktop/Portal UI (12 tools)
+
+| Action | MCP Tool |
+|--------|----------|
+| List open windows | `desktop_windows_list()` |
+| Preview windows in a collage overlay | `desktop_collage()` |
+| Open session window | `desktop_open_session(session="...", mode="monitor")` |
+| Open panel | `desktop_open_panel(panel_type="sessions")` |
+| Open artifact window (URL/file) | `desktop_open_artifact(url="...", title="...")` |
+| Write HTML + open as artifact | `desktop_write_artifact(filename="...", html_content="...", title="...")` |
+| Post toast notification | `portal_notify(text="...", session="...", priority="normal")` |
+| Close window | `desktop_close_window(window_id="...")` |
+| Focus window | `desktop_focus_window(window_id="...")` |
+| Tile window | `desktop_tile_window(window_id="...", zone="left")` |
+| Minimize all | `desktop_minimize_all()` |
+| Multi-window layout | `desktop_layout(windows=[{id: "...", zone: "left"}])` |
+
+**~92 tools total** (sessions, panes, voice, tasks, channels, scheduler, desktop UI, handoffs). When to use CLI vs MCP:
+- **MCP tools** — Agents in sessions (orchestrators, workers)
+- **CLI commands** — Humans, shell scripts, automation outside of agent sessions
+
+**Note:** MCP tools don't support git worktree creation. Workers spawned via `pane_spawn` share the orchestrator's working directory. For isolated commits with worktrees, use the CLI `agentwire spawn --branch <name>` directly.

--- a/.agents/skills/agentwire-pi/SKILL.md
+++ b/.agents/skills/agentwire-pi/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: agentwire-pi
+description: Pi coding agent (multi-provider) integration — `pi-<provider>` / `pi-<provider>-restricted` / `pi-<provider>-readonly` session types for any pi provider (zai, deepseek, openai, openrouter, etc.). Install (`npm install -g @mariozechner/pi-coding-agent`), config (`pi.binary`, `pi.system_prompt`, `pi.extra_env`, `pi.providers.<name>.{env_var,default_model}`; keys env-only via `~/.agentwire/.env`), custom providers via `~/.pi/agent/models.json`, tool translation (Codex CamelCase → pi lowercase), system-prompt injection (global + role merged), built-in helper (`agentwire fetch`), limitations vs Codex (no MCP client, no web search, no `--disallowedTools`, no `--resume --fork-session`, no hook integration). Use when setting up pi sessions for any provider, debugging pi tool execution, or explaining when to pick pi-* vs Codex-*.
+---
+
+# pi — Pi Coding Agent (multi-provider)
+
+Pi is a minimal terminal coding agent (MIT licensed, [github.com/badlogic/pi-mono](https://github.com/badlogic/pi-mono)) that supports many model providers via `--provider <name>`. Used for non-Anthropic models so Codex stays pure for Anthropic subscription auth.
+
+Session types follow `pi-<provider>[-restricted|-readonly]`. The provider, env var, and default model are resolved from `pi.providers.<name>` in `~/.agentwire/config.yaml`. New providers can be added by config alone — no code changes.
+
+## Install
+
+```bash
+# One-time
+npm install -g @mariozechner/pi-coding-agent
+
+# Verify
+agentwire doctor    # reports pi version
+pi --version
+```
+
+## Session Creation
+
+```bash
+# Z.AI (closest to Codex-bypass cost-wise)
+agentwire new -s project --type pi-zai -p ~/projects/project
+
+# DeepSeek
+agentwire new -s project --type pi-deepseek -p ~/projects/project
+
+# OpenAI restricted (read+grep+find+bash, no edits)
+agentwire new -s audit --type pi-openai-restricted -p ~/projects/audit
+
+# Override model for any provider
+agentwire new -s fast --type pi-zai --model glm-4.7-flash
+
+# Persist type to .agentwire.yml (opt-in)
+agentwire new -s project --type pi-deepseek --persist
+
+# Add custom env vars (repeatable, injected via tmux set-environment)
+agentwire new -s project --type pi-zai --env DEBUG=1
+```
+
+If `pi.providers.<provider>` is missing from config, session creation fails fast with a clear error:
+
+```
+ValueError: No config for pi provider 'foo'. Add pi.providers.foo to ~/.agentwire/config.yaml
+```
+
+## Variants
+
+| Suffix | Tools | Use Case |
+|--------|-------|----------|
+| (none) | read, bash, edit, write | Full access, closest to Codex-bypass |
+| `-restricted` | read, grep, find, bash | Worker panes — commands allowed, no edits |
+| `-readonly` | read, grep, find | Audit / inspection — pure file inspection |
+
+Pi has no permission system to bypass — variants translate directly to pi's `--tools` whitelist. Restricted/readonly variants are curated contexts: `pi.system_prompt` and role instructions are **skipped**.
+
+## Config
+
+Provider keys live in `~/.agentwire/.env` (docs/wiki/security/secrets.md) — config holds the env var NAME:
+
+```bash
+# ~/.agentwire/.env
+ZAI_API_KEY=...
+DEEPSEEK_API_KEY=...
+```
+
+In `~/.agentwire/config.yaml`:
+
+```yaml
+pi:
+  binary: "pi"  # path override if not on PATH (e.g., nvm-installed)
+
+  # Appended via --append-system-prompt to every non-restricted pi-* session.
+  # Use to teach pi about local helpers — agentwire fetch, etc.
+  system_prompt: |
+    ## Fetching URLs
+    Use `agentwire fetch <url>` to fetch a page as clean markdown.
+
+  # Env vars injected into every pi-* session (in addition to the provider key).
+  # Plaintext in config — non-secrets only; secrets go in ~/.agentwire/.env.
+  extra_env:
+    MY_SERVICE_URL: "https://internal.example.com"
+
+  providers:
+    zai:
+      env_var: ZAI_API_KEY          # NAME of the env var holding the key
+      default_model: glm-5.1
+    deepseek:
+      env_var: DEEPSEEK_API_KEY
+      default_model: deepseek-chat
+    # add more as needed: openai, openrouter, anthropic, ...
+```
+
+The key is read from the process environment (loaded from `~/.agentwire/.env` on every entry point) and flows to the session via `tmux set-environment`, so it never appears in `ps auxwww` or shell history.
+
+## Custom Providers via `~/.pi/agent/models.json`
+
+For providers pi doesn't ship with built-in (e.g. DeepSeek), register them as OpenAI-compatible endpoints:
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "baseUrl": "https://api.deepseek.com/v1",
+      "api": "openai-completions",
+      "apiKey": "sk-...",
+      "models": [
+        { "id": "deepseek-chat" },
+        { "id": "deepseek-reasoner", "reasoning": true }
+      ]
+    }
+  }
+}
+```
+
+Then in `~/.agentwire/config.yaml` (key goes in `~/.agentwire/.env` as `DEEPSEEK_API_KEY=sk-...`):
+
+```yaml
+pi:
+  providers:
+    deepseek:
+      env_var: DEEPSEEK_API_KEY
+      default_model: deepseek-chat
+```
+
+Same pattern works for OpenRouter, Together AI, Groq, or any other OpenAI-compatible API.
+
+## Built-in Helpers in pi Sessions
+
+One CLI helper is automatically taught to pi via `pi.system_prompt`:
+
+| Helper | Purpose |
+|--------|---------|
+| `agentwire fetch <url>` | Fetches a URL via Jina Reader — handles JS-rendered pages, returns clean markdown |
+
+Add new helpers by extending `pi.system_prompt`. Note: pi sessions have **no web search** — WebSearch is Anthropic-server-side and the old CLI search helper was removed in #268. `agentwire fetch` covers direct page pulls only.
+
+## System Prompt Composition
+
+For non-restricted sessions, the temp file passed to `--append-system-prompt` is:
+
+```
+{pi.system_prompt}
+
+{role.instructions if any}
+```
+
+Order matters: global comes first so role-specific instructions can build on it. Empty pieces are dropped — if neither is set, no `--append-system-prompt` flag is added.
+
+## Tool Translation
+
+Role tool names are translated Codex CamelCase → pi lowercase, then filtered to pi's supported set:
+
+| Codex | Pi |
+|--------|-----|
+| `Read` | `read` |
+| `Bash` | `bash` |
+| `Edit` | `edit` |
+| `Write` | `write` |
+| `Grep` | `grep` |
+| `LS` | `ls` |
+
+Translation is lowercase-then-filter against pi's supported set `{read, bash, edit, write, grep, find, ls}` (`__main__.py:252`) — there is no name remapping. So `Glob` lowercases to `glob`, which isn't in the set, and is **dropped** (not remapped to `find`). Other unsupported Codex tools (`WebFetch`, `Task`, `TodoWrite`, MCP tools, etc.) are silently filtered the same way. Roles with a `disallowed` list have no effect on pi (only whitelist supported).
+
+## Limitations vs Codex
+
+- **No MCP client** — pi sessions cannot call agentwire MCP tools. Use Codex for orchestrator sessions that need MCP.
+- **No `--disallowedTools`** — can only whitelist tools.
+- **No session forking** — `--resume --fork-session` isn't supported. Linear resume works via `--session <file> --continue`. Copy the JSONL manually for fork-like behavior.
+- **No hook system integration** — idle-handler, damage-control, and user-prompt-submit hooks don't fire for pi sessions.
+- **Idle detection works** — pi runs under `node`, so existing tmux process detection correctly identifies idle (shell) vs busy (node) states.
+
+## Session Storage
+
+Pi persists every session to `~/.pi/agent/sessions/<cwd-encoded>/<timestamp>_<uuid>.jsonl`. CWD is encoded with `--` separators (e.g., `/Users/dotdev/projects/foo` → `--Users-dotdev-projects-foo--`).
+
+Each JSONL line records one event: model, user message, assistant message with tool calls, tool results. Sessions are recoverable after crashes — extract file writes from `toolCall` events to rebuild generated artifacts.
+
+## Known Gotchas
+
+- **GLM identity hallucination** — GLM models often claim to be Codex (Z.AI trained on Codex outputs). Don't rely on self-reports; verify via the JSONL event stream (`"provider":"zai"`, Z.AI-formatted response IDs).
+- **Pi pre-1.0** — v0.66.1 was the original baseline. Breaking changes possible between minors.
+- **Binary location via nvm** — pi installs at `~/.nvm/versions/node/<ver>/bin/pi`. Set `pi.binary` if not on PATH.
+- **Provider key via tmux set-environment** — keys are injected onto the tmux session with `tmux set-environment -t <session>` at creation time, so they don't appear in `ps auxwww`. Worker panes inherit automatically. If you spawn pi manually outside an agentwire session, you'll need to export the env var yourself.
+
+## Session Type Selection
+
+| Use Case | Type | Notes |
+|----------|------|-------|
+| Human-directed work, full Anthropic | `Codex-bypass` | MCP-aware, hooks fire |
+| Cost-sensitive Z.AI | `pi-zai` | Z.AI subscription / pay-as-you-go |
+| Cost-sensitive DeepSeek | `pi-deepseek` | Cheap, strong on code |
+| Anything OpenAI-compatible | `pi-<provider>` | Add to `pi.providers` + optionally `~/.pi/agent/models.json` |
+| Worker pane (no edits) | `pi-<provider>-restricted` | read+grep+find+bash whitelist |
+| Audit/inspection (read-only) | `pi-<provider>-readonly` | read+grep+find whitelist |
+
+## See Also
+
+- `docs/wiki/sessions/pi.md` — full user guide, compatibility matrix, troubleshooting
+- `agentwire-config` skill — `pi:` config block reference
+- `agentwire-project-config` skill — `.agentwire.yml` session type field

--- a/.agents/skills/agentwire-project-config/SKILL.md
+++ b/.agents/skills/agentwire-project-config/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: agentwire-project-config
+description: Reference for per-project `.agentwire.yml` — session type, roles, voice, parent, shell, safety allowlist; task schema with pre/prompt/post/output/branch-management fields and built-in variables; hierarchical idle notifications with worker summary files and queue processor; role system. Use when configuring a project for agentwire, wiring up scheduled tasks, defining worker/orchestrator relationships, or debugging task execution.
+---
+
+# `.agentwire.yml` Project Config
+
+Each project can have a `.agentwire.yml` in its root directory. This configures session type, roles, voice, and parent for that project.
+
+## Gitignore it (don't commit it)
+
+**`.agentwire.yml` should be gitignored, not committed.** Two reasons:
+
+1. **A tracked copy breaks worktree dispatch subtly.** Worktree-dispatched runs (scheduler tasks, worktree sessions) check out HEAD — if the file is tracked, uncommitted live edits are invisible to the run, which silently executes the stale committed version. The failure mode is confusing: the live file looks right, the run behaves wrong.
+2. **It's personal/live config, not project code.** Voice choices, email recipients, schedules, machine-specific roles — none of that belongs in a repo, especially a public one.
+
+Worktree runs still get the file: `projects.worktrees.copy_files` (default `[".env", ".agentwire.yml"]`) copies gitignored configs from the main checkout into every new worktree as live files — the live file always wins, no drift.
+
+AgentWire enforces this automatically: whenever it writes `.agentwire.yml` into a git repo (`agentwire projects create`, `agentwire new --persist`, portal project settings), it appends the file to the project's `.gitignore` unless it's already ignored — or already *tracked*. A tracked file is left alone: committing is a valid choice for teams that want shared, versioned task definitions, but they're opting into the HEAD-checkout behavior above — worktree runs use the committed version, never live edits. To switch an existing project to the recommended setup: `git rm --cached .agentwire.yml`, add it to `.gitignore`, commit.
+
+**Format is FLAT (no nesting):**
+
+```yaml
+# Session with voice and agentwire awareness
+type: Codex-bypass
+roles:
+  - agentwire
+  - voice
+voice: may
+parent: main  # Notify parent session when idle (optional)
+```
+
+```yaml
+# WRONG - don't nest under "session:"
+session:
+  type: Codex
+  roles: [...]  # This won't be loaded!
+```
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `type` | `Codex-bypass`, `Codex-auto`, `Codex-prompted`, `Codex-restricted`, `pi-<provider>` (e.g. `pi-zai`, `pi-deepseek`), `pi-<provider>-restricted`, `pi-<provider>-readonly` | Session permission level. **Use `Codex-auto` for unattended work** — same capability as `Codex-bypass` but with AI classifier blocking dangerous actions. Requires Team/Enterprise plan. **`pi-*` types** resolve `<provider>` against `pi.providers.<name>` in `~/.agentwire/config.yaml` — see the `agentwire-pi` skill. |
+| `roles` | List of role names | Roles to load (from bundled or `~/.agentwire/roles/`) |
+| `voice` | Voice name | TTS voice for this project |
+| `parent` | Session name | Parent session for hierarchical notifications |
+| `shell` | `/bin/sh`, `/bin/bash`, etc. | Default shell for task commands |
+| `tasks` | Task definitions | Scheduled workload configurations |
+| `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist |
+
+For pi sessions (`pi-*`, e.g. `pi-zai`, `pi-deepseek`), see the `agentwire-pi` skill.
+
+## Task Schema
+
+Tasks are defined in `.agentwire.yml` for use with `agentwire ensure`:
+
+```yaml
+shell: /bin/sh  # Project-level default shell
+
+tasks:
+  morning-briefing:
+    shell: /bin/bash           # Task-level override
+    priority: 10               # Pipeline ordering (lower = higher priority, default: 99)
+    retries: 2                 # Retry on failure (default: 0)
+    retry_delay: 30            # Seconds between retries (default: 30)
+    idle_timeout: 30           # Seconds of idle before completion (default: 30)
+    exit_on_complete: true     # Exit session after completion (default: true)
+    role: task-runner          # Role override for this task (optional)
+    pre:                       # Data gathering (NO {{ }} - these PRODUCE variables)
+      weather: "curl -s wttr.in/?format=3"
+      calendar:
+        cmd: "gcal-cli today --json"
+        required: true         # Fail if empty (default: false)
+        validate: "jq . > /dev/null"  # Validation command
+        timeout: 30            # Command timeout
+    prompt: |                  # Main prompt (supports {{ variables }})
+      Weather: {{ weather }}
+      Calendar: {{ calendar }}
+      Summarize my day.
+    on_task_end: |             # Optional: after system summary
+      Read {{ summary_file }}.
+      If complete, save to ~/briefings/{{ date }}.md
+    post:                      # Commands after completion
+      - "echo 'Status: {{ status }}'"
+    output:
+      capture: 50              # Lines to capture
+      save: ~/logs/{{ task }}.log
+
+    # Branch management (for async agent workflows)
+    starting_ref: main         # Git ref to checkout before task runs
+    work_branch: agent/task    # Branch for agent's work (default: agent/<task>-<date>)
+    pr_target: main            # PR target branch (default: starting_ref)
+    pr_draft: true             # Create as draft PR (default: true)
+
+    # Context inheritance
+    starting_session: ctx-loaded  # Fork Codex context from this session before running
+
+    # Unattended safety (scheduler, no human present)
+    unattended_allow:             # damage-control rule ids this task may run unattended,
+      - tooldef.terraform-apply-planned-changes-to-infrastructure  # extends the global default
+```
+
+**`unattended_allow`** (per-task): when the scheduler dispatches a task headless
+(`AGENTWIRE_UNATTENDED=1`), the damage-control hook resolves `ask`-tier commands
+by **failing closed** — block + email the owner — unless the matched rule id is
+on the allowlist. The default allowlist lets a task work and open a PR
+(`git.add`/`git.commit`/`git.push`/`gh.pr-create`); list extra rule ids here to
+permit a normally-gated action (deploy, DB write, outbound email) for **this task
+only**. Blocked actions name the exact rule id (in the email and `agentwire safety
+logs`) so widening is copy-paste. Hard blocks (`rm -rf`, `git push --force`) and
+interactive sessions are unaffected. See `docs/wiki/internals/damage-control.md`.
+
+**Built-in variables:**
+- `{{ date }}`, `{{ time }}`, `{{ datetime }}` - Current date/time
+- `{{ session }}`, `{{ task }}`, `{{ project_root }}` - Task identity
+- `{{ attempt }}` - Current attempt number (1-based)
+- `{{ status }}`, `{{ summary }}`, `{{ summary_file }}` - After completion
+- `{{ output }}` - Captured session output (in post phase)
+- `{{ work_branch }}`, `{{ pr_url }}` - Branch/PR after branch management (in post phase)
+- `{{ var_name }}` - Pre-command outputs
+
+**Exit codes:** 0=complete, 1=failed, 2=incomplete, 3=lock conflict, 4=pre failure, 5=timeout, 6=session error
+
+## Parent Resolution (prompt routing + notifications)
+
+For prompt routing (#276), a session's parent resolves in this order: **creator recorded at `agentwire new` time** (session metadata, `--created-by` to override) → **`.agentwire.yml` `parent:`** → none. Worker panes always route to pane 0 of their own session. Interactive prompts (permission/plan/AskUserQuestion) hitting a child are texted to that parent; answer only via `agentwire prompts answer` (guarded), never raw send-keys.
+
+## Hierarchical Idle Notifications
+
+When a session goes idle, it notifies up the hierarchy via `agentwire notify-parent` (text-only, no audio):
+
+```
+parent session ← receives "[ALERT from child] ..."
+    ↑ notify-parent --to parent
+child session   ← receives "[ALERT from pane N] ..."
+    ↑ auto-notify pane 0
+worker panes
+```
+
+**Worker summary files:**
+- Workers write summaries to `.agentwire/worker-{pane}.md` before going idle
+- Summaries include: task, status, what worked, what didn't, notes for orchestrator
+- Orchestrators read these files to understand worker results
+
+**Auto-exit (workers auto-kill on idle):**
+- Worker panes (index > 0) automatically exit when idle
+- Use `parent: <session-name>` in `.agentwire.yml` for child → parent notifications
+
+**Queue system files:**
+- `~/.agentwire/queue-processor.sh` - Processes queue with 15s delays between alerts
+- `~/.agentwire/queues/{session}.jsonl` - Per-session notification queues
+
+**Worker idle sequence:**
+1. `session.idle` fires → wait 2s (let agent settle)
+2. Worker writes summary to `.agentwire/worker-{pane}.md`
+3. Queue notification to `{session}.jsonl`
+4. Start queue processor if not running
+5. Worker auto-exits
+
+**Idle notifications** are handled via `~/.Codex/hooks/idle-handler.sh`.
+
+**Creating a project with roles:**
+
+```bash
+# Option 1: Create .agentwire.yml first, then create session
+echo "type: Codex-bypass
+roles:
+  - agentwire
+  - voice" > ~/projects/myproject/.agentwire.yml
+
+agentwire new -s myproject -p ~/projects/myproject
+
+# Option 2: Specify roles on command line, --persist saves to .agentwire.yml
+agentwire new -s myproject -p ~/projects/myproject --roles agentwire,voice --persist
+```
+
+By default, `agentwire new` flags (`--type`, `--roles`) are session-level overrides only and never save to `.agentwire.yml`. Use `--persist` to opt in to saving.
+
+## Role System
+
+Roles define agent behavior and are composable. Mix and match roles in `.agentwire.yml` to configure orchestrators, workers, or specialized agents.
+
+**Available roles:**
+
+| Role | Purpose |
+|------|---------|
+| `agentwire` | Core session/pane/MCP tools awareness |
+| `orchestrator` | Long-lived project orchestrator — plans, delegates, reviews results |
+| `voice` | Voice communication (speak/listen) |
+| `worker` | Receive tasks, execute autonomously, report back |
+| `task-runner` | Scheduled task execution |
+| `worktree-session` | Intrinsic etiquette for `agentwire worktree` sessions (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) — auto-injected by the verb's kind, not configurable |
+| `chatbot` | Conversational personality |
+| `init` | Setup wizard behavior |
+
+Use `agentwire roles list` to see available roles. Roles are bundled in `agentwire/roles/` and can be composed freely in `.agentwire.yml`.

--- a/.agents/skills/agentwire-scheduler/SKILL.md
+++ b/.agents/skills/agentwire-scheduler/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: agentwire-scheduler
+description: Scheduler configuration — task gates (`git_commit`, `git_diff`, `command`), `schedule` field reference (duration vs calendar, `at`/`every`/`after`/`delay`/`cooldown`/`not_before`/`not_after`/`except`), priority/pipeline ordering, one-time/max_runs tasks. Use when adding or debugging scheduled tasks in `~/.agentwire/scheduler.yaml`, or explaining how gating/dispatch works.
+---
+
+# AgentWire Scheduler
+
+## Scheduler Task Gates
+
+Tasks in `~/.agentwire/scheduler.yaml` can define `gate` preconditions to skip execution when changes aren't relevant:
+
+```yaml
+tasks:
+  code-quality:
+    gate:
+      git_commit: true  # Skip if HEAD unchanged since last run
+  doc-drift:
+    gate:
+      git_diff:         # Skip if no commits touched these paths
+        - docs/
+        - agentwire/
+  custom-check:
+    gate:
+      command: "test -f /tmp/ready.flag"  # Skip if command exits non-zero
+```
+
+Gates are evaluated before dispatching and skip the task (zero AI cost) if conditions fail. Multiple gates are AND'd. Gates fail open on errors.
+
+## Worktree + PR Mode (the standard for repo work)
+
+Tasks that touch a git repo run in an **isolated worktree** forked off the latest `base` branch, and their output is proposed back as a **draft PR** — the live project folder is never modified and nothing lands on `main` unreviewed.
+
+```yaml
+tasks:
+  doc-drift:
+    project: ~/projects/agentwire-dev
+    worktree: true       # DEFAULT when project is a git repo
+    base: main           # fork the worktree off latest origin/main
+    pr_target: main      # draft PR base branch (defaults to `base`)
+    pr_draft: true       # open as draft (default)
+  ai-morning-briefing:
+    project: ~/projects/agentwire-dev
+    worktree: false      # research/email task — runs in place, never commits
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `worktree` | auto (`true` if `project` is a git repo) | Run isolated + open a PR. Set `false` for tasks that only email/produce side effects. |
+| `base` | `main` | Branch the worktree forks from (fetched fresh from `origin`). |
+| `pr_target` | `base` | PR base branch. |
+| `pr_draft` | `true` | Open the PR as a draft. |
+
+**Lifecycle:** branch `scheduler-<task>-<timestamp>` → run in worktree → if it produced changes, `git add -A` + commit (`scheduler: <task> — <summary>`) + push + draft PR; if it produced **nothing**, the empty worktree is removed and no PR is opened. The worktree **persists while the PR is open** (so you can spawn a session there during review) and is **reaped automatically when the PR merges or closes** (worktree + branch + session torn down). `worktree: false` tasks run in place and never commit.
+
+**Seeded files:** `git worktree add` only checks out *tracked* files, so gitignored secrets/config (`.env`, `.agentwire.yml`) won't be in a fresh worktree — an agent that needs them to authenticate would fail. The files listed in `projects.worktrees.copy_files` (default `[".env", ".agentwire.yml"]`) are copied from the main repo into every new worktree. They stay gitignored there, so they're never committed.
+
+**Keep `.agentwire.yml` gitignored, not tracked.** Worktree runs check out HEAD — if the project *tracks* `.agentwire.yml`, uncommitted live edits to it are silently invisible to the run, which executes the stale committed version (and `copy_files` won't overwrite a tracked checkout). Gitignored + seeded via `copy_files` means the live file always wins. See the `agentwire-project-config` skill.
+
+## Scheduler Task Scheduling
+
+Each task has a `schedule` field (replaces the old `interval`). The scheduler uses `_compute_next_eligible()` as the single source of truth for when a task becomes eligible.
+
+**`schedule` field reference:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `every` | `str` | `30m`, `2h`, `1d` (duration) or `day`, `weekday`, `weekend`, `monday`..`sunday` (calendar) |
+| `at` | `str` | Target time `"HH:MM"` local. Only with calendar `every` values |
+| `except` | `list[str]` | Days to skip: `["saturday"]` |
+| `after` | `str` | Dependency task name |
+| `delay` | `str` | Wait after dependency: `"1h"`, `"30m"` |
+| `cooldown` | `str` | Min time between runs: `"4h"` |
+| `require_status` | `str` | `"complete"` (default) or `"any"` |
+| `not_before` | `str` | Earliest time of day: `"08:00"` |
+| `not_after` | `str` | Latest time of day: `"22:00"` |
+
+Must have at least `every` OR `after` (or both).
+
+**Examples:**
+```yaml
+# Duration-based interval
+schedule:
+  every: 4h
+
+# Time-anchored daily
+schedule:
+  every: day
+  at: "08:00"
+
+# Dependency with delay
+schedule:
+  after: upstream-task
+  delay: 1h
+  cooldown: 3h
+
+# Weekend exclusion
+schedule:
+  every: 4h
+  except: [saturday, sunday]
+```
+
+**Restart safety:** `last_dispatch` is persisted before running. Tasks dispatched within 2h are considered "in-flight" and won't be re-dispatched after restart.
+
+## Scheduler Task Priority
+
+Tasks sort by `priority` first (lower = runs first), with overdue score as tiebreaker. This ensures pipeline ordering — upstream stages run before downstream when multiple tasks are overdue.
+
+Tasks with default priority (99) sort after all prioritized tasks. Fillers always run after all regular tasks regardless of priority.
+
+## One-Time and Limited Tasks
+
+Tasks can auto-disable after a set number of runs:
+
+```yaml
+tasks:
+  tonight-scaffold:
+    # ...
+    once: true        # Run once, then auto-disable (shorthand for max_runs: 1)
+    schedule:
+      every: 1m       # Run ASAP
+
+  quarterly-report:
+    # ...
+    max_runs: 4       # Run 4 times then auto-disable
+    schedule:
+      every: day
+      at: "09:00"
+```
+
+- `once: true` — shorthand for `max_runs: 1`
+- `max_runs: N` — auto-disables task after N successful dispatches
+- Scheduler logs a `task_disabled` event with `reason: max_runs_reached`
+- Re-enabling a disabled task via `agentwire scheduler enable <name>` resets it

--- a/.agents/skills/wiki/SKILL.md
+++ b/.agents/skills/wiki/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wiki
+description: "Manage the agentwire LLM Wiki knowledge base. Use when ingesting raw sources, querying accumulated knowledge, or running health checks on the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
+---
+
+# AgentWire Wiki
+
+LLM-maintained knowledge base at `~/.agentwire/wiki/`. Read `~/.agentwire/wiki/AGENTS.md` for the full schema and conventions.
+
+## Subcommands
+
+### `/wiki ingest`
+
+Process new files in `~/.agentwire/wiki/raw/` into wiki pages.
+
+**Steps:**
+1. List all files in `raw/` that haven't been processed (check for a `.ingested` marker or compare against existing wiki pages)
+2. For each file, read its contents
+3. Identify entities: technologies, patterns, APIs, research topics
+4. For each entity, check if a wiki page already exists in `wiki/<category>/<name>.md`
+   - **Exists**: update the page with new information, bump `last_updated`
+   - **New**: create the page following the schema in AGENTS.md
+5. Add wikilinks `[[page-name]]` for cross-references between pages
+6. Report what was created/updated
+
+**Do NOT** modify or delete files in `raw/`. They are immutable source material.
+
+### `/wiki query <question>`
+
+Answer a question grounded in wiki content.
+
+**Steps:**
+1. Search `~/.agentwire/wiki/wiki/` for relevant pages (use Grep/Glob)
+2. Read the relevant pages
+3. Synthesize an answer citing specific wiki pages
+4. If the wiki doesn't have enough information, say so clearly — do not hallucinate
+5. If you discover new knowledge while answering, offer to update the relevant wiki pages
+
+### `/wiki lint`
+
+Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase.
+
+**Structural pass — steps:**
+1. Scan all pages in `wiki/` for:
+   - **Stale pages**: `last_updated` older than 90 days
+   - **Orphaned pages**: no other page links to them via `[[wikilink]]`
+   - **Broken wikilinks**: `[[page-name]]` that point to non-existent pages
+   - **Missing frontmatter**: pages without the required YAML frontmatter
+2. Report findings grouped by severity
+3. Do NOT auto-fix — let the user decide what to do
+
+#### Ground-truth audit
+
+The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source.
+
+**Run it** (from a checkout of the agentwire repo — stdlib only, no build/install needed):
+
+```bash
+python -m agentwire.wiki_audit                 # audit ~/.agentwire/wiki/wiki against this repo
+python -m agentwire.wiki_audit --json          # machine-readable findings
+python -m agentwire.wiki_audit --strict        # exit 1 when drift is found (CI)
+python -m agentwire.wiki_audit \
+  --wiki-dir <dir> --repo-dir <repo>           # point at a different wiki / codebase
+```
+
+Each finding is reported as `wiki_file:line  [kind] claim  → reason`, so you can jump straight to the stale line.
+
+**What it checks (precision over recall — it would rather miss a stale claim than cry wolf on a true one):**
+
+| Kind | Claim it verifies | How |
+|------|-------------------|-----|
+| `subcommand` | `` `agentwire <cmd>` `` in a code span | `<cmd>` must be a registered `add_parser("<cmd>")` |
+| `flag` | `--flag` inside an `agentwire …` command span | must be a declared `add_argument("--flag")` |
+| `path` | repo-relative paths under `agentwire/ docs/ scripts/ tests/ examples/ .Codex/ .github/` | must exist on disk |
+| `symbol` | `` `module.symbol` `` where `agentwire/<module>.py` exists | `symbol` must be defined in that module |
+| `config-key` | dotted key near a config-file mention | every segment must be a field on a `@dataclass` in `config.py` |
+
+Scoping that keeps it quiet: flags/subcommands are only read inside code spans (bare prose mentioning `agentwire` or a flag isn't a claim); paths under the wiki's own `wiki/`/`raw/` trees and `~`/absolute paths are ignored; common method calls (`config.get`), filenames (`__main__.py`), and version strings (`agentwire v1.35.1`) are not mistaken for claims.
+
+**Act on it:** treat each finding as "a human renamed/removed/moved something and the wiki didn't follow." Confirm against the code, then update the wiki page (or, if the page is a deliberate historical record — e.g. a retrospective on removed code — leave it and note that in the page). As with the structural pass, the audit **never auto-fixes**.
+
+## Guidelines
+
+- Always read `~/.agentwire/wiki/AGENTS.md` first for the current schema
+- One page per entity — check before creating duplicates
+- Practical over theoretical — "how we use it" and "what broke" over textbook definitions
+- Include code snippets, commands, config examples
+- Date your updates in frontmatter `last_updated`
+- Cite sources (URLs, commit hashes, issue numbers)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# AgentWire
+
+Voice interface for AI coding agents. Push-to-talk from any device to tmux sessions running Codex.
+
+**No Backwards Compatibility** - Pre-launch, no customers. Change things completely, no legacy fallbacks.
+
+## Dev Workflow
+
+`uv tool install` caches builds and ignores source changes.
+
+```bash
+# During development (picks up changes instantly)
+agentwire portal start --dev
+
+# After structural changes (pyproject.toml, new files)
+agentwire rebuild
+
+# After code changes: ALWAYS do both
+agentwire rebuild && agentwire portal restart --dev
+```
+
+Rebuild alone = stale static files. Restart alone = stale Python. The MCP server runs as a separate process started by Codex — session restart required after rebuild to pick up MCP changes.
+
+## CLI is the Single Source of Truth
+
+All session/machine logic lives in CLI commands (`agentwire/__main__.py`). The portal (`agentwire/server.py`) is a thin wrapper that:
+
+1. Calls CLI via `run_agentwire_cmd(["command", "args"])`
+2. Parses JSON output (`--json` flag)
+3. Adds WebSocket/real-time features
+
+**When adding new functionality:**
+1. Implement in CLI first with `--json` output
+2. Portal calls CLI, doesn't duplicate logic
+3. Never bypass CLI with direct tmux/subprocess calls
+
+Full CLI command reference lives in the `agentwire-cli` skill.
+
+## MCP Server (For Agents)
+
+**Agents running in agentwire sessions should use MCP tools instead of CLI commands.**
+
+The `agentwire-mcp-tools` skill has the full reference (sessions, panes, voice, tasks, outbound channels, scheduler, desktop UI, handoffs). Rule of thumb: MCP for agents, CLI for humans/scripts.
+
+**Note:** MCP tools don't support git worktree creation. For worktree-isolated work, use the CLI directly — and pick the right primitive:
+
+| Term | Command | What you get |
+|------|---------|--------------|
+| **Worktree session** | `agentwire worktree <name> -p <repo>` | **Standalone tmux session** named `{project}-<name>`, new branch `<name>` from origin/main, worktree under `~/worktrees/`. Survives independently; report-back via `agentwire notify-parent --to <orchestrator>`. Etiquette (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) is intrinsic — the `worktree-session` role is auto-injected by the verb, so first prompts only need the task. |
+| **Worker pane** | `agentwire spawn --branch <name>` | A **pane inside the current session** (pane 1+), worktree on `<name>`. Inherits the session's dashboard; idle hook reaps it. |
+
+When the owner says "worktree session", they mean the standalone session (`agentwire worktree`), **never** `spawn` panes. Worker panes are for small subtasks watched by the orchestrator; worktree sessions are for parallel autonomous work. The verb sets the posture: `worktree`/`new` default to the bypass posture (full access), `spawn` to restricted — no `--type` needed for the common case.
+
+## Config Layout (`~/.agentwire/`)
+
+| File | Purpose |
+|------|---------|
+| `config.yaml` | Main config (see `agentwire-config` skill) |
+| `.env` | **All API keys/secrets** — the one blessed spot, loaded on every entry point. `chmod 600`. See [`docs/wiki/security/secrets.md`](docs/wiki/security/secrets.md) |
+| `machines.json` | Remote machines registry |
+| `scripts/` | Machine-specific helper scripts (TTS, startup, service wrappers). Local only, not version controlled. `~/bin/` entries should symlink here. |
+| `voices/` | Custom TTS voice samples |
+| `uploads/` | Uploaded images for cross-machine sharing |
+| `artifacts/` | Agent-generated HTML for artifact windows |
+| `wiki/` | LLM-maintained knowledge base (Karpathy LLM Wiki pattern) |
+| `logs/` | Audit logs for damage-control |
+
+Per-project config lives in `.agentwire.yml` at the project root — **keep it gitignored** (personal config; a tracked copy makes worktree-dispatched runs silently use the stale committed version). See `agentwire-project-config` skill for fields and task schema. For pi sessions (zai, deepseek, openai, etc.), see the `agentwire-pi` skill.
+
+## Key Patterns
+
+- **agentwire sessions** coordinate via voice, delegate to workers
+- **worker panes** spawn within the orchestrator's session (visible dashboard)
+- **Pane 0** = orchestrator, **panes 1+** = workers
+- **Damage-control hooks** block dangerous ops (`rm -rf`, `git push --force`, etc.)
+- **Unattended guardrail** — scheduler dispatches are marked `AGENTWIRE_UNATTENDED=1`; the hook resolves `ask`-tier commands by failing closed (block + email owner) unless on the `unattended_allow` list. See [`docs/wiki/internals/damage-control.md`](docs/wiki/internals/damage-control.md).
+- **Smart TTS routing** — audio goes to browser if connected, local speakers if not
+
+### Worker Pane Lifecycle
+
+Workers auto-kill after sending idle notification. The idle hook captures output, sends alert to pane 0, then kills the worker. Manual kill if needed: `agentwire kill --pane 1`.
+
+## Hook Installation
+
+One command installs/refreshes everything agentwire-owned:
+
+```bash
+agentwire hooks install   # permission hook, idle handler, queue processor, slash commands
+agentwire doctor          # verify (flags stale copies, not just missing ones)
+```
+
+Installs (symlinks by default, `--copy` to copy):
+
+| File | Target | Purpose |
+|------|--------|---------|
+| `agentwire-permission.sh` | `~/.Codex/hooks/` | Permission dialogs in portal (registered as `PermissionRequest` hook) |
+| `idle-handler.sh` | `~/.Codex/hooks/` | Worker notifications + scheduled task completion (registered as `Notification` hook) |
+| `queue-processor.sh` | `~/.agentwire/` | Sends queued alerts with 15-second gaps to avoid overwhelming orchestrators |
+
+These files are agentwire-owned: `hooks install` replaces any copy that drifts from the packaged source. Re-run it after `agentwire rebuild` to pick up hook changes.
+
+### Diagnosing Issues
+
+```bash
+agentwire doctor                        # all components
+tail -f /tmp/Codex-hook-debug.log      # hook debug
+tail -f /tmp/queue-processor-debug.log  # queue processor
+```
+
+## Wiki (Knowledge Base)
+
+LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wiki pattern. Research and debugging knowledge compounds across sessions. Use `/wiki ingest`, `/wiki query <question>`, `/wiki lint` skills. **Before researching**: agents check the wiki first. After discovering: agents write it down.
+
+## Handoffs
+
+`/handoff` distills the current conversation into a shareable bundle: `ai-handoff.md` for another LLM and `show-the-story.html` for humans. The agent does the distillation in-context (free); the CLI/MCP renders deterministically. Outputs in `~/.agentwire/artifacts/handoff-<slug>/`. Full reference: [`docs/wiki/communication/handoff.md`](docs/wiki/communication/handoff.md).
+
+## Usage-Limit Recovery
+
+Deterministic (zero-LLM) recovery from the Codex usage-limit dialog: a launchd watchdog (`agentwire limits tick`, 60s) plus ensure's completion poll detect the dialog, park the session (option 1: stop and wait), parse the reset time, email the owner via Resend, and nudge the session to continue after reset. Park state under `~/.agentwire/usage-limit/` guards every surface — ensure exits 7 (`usage_limit`), the scheduler skips dispatch, the idle hook never reaps a parked session. CLI under `agentwire limits ...`. Full reference: [`docs/wiki/usage-limit-recovery.md`](docs/wiki/usage-limit-recovery.md).
+
+## Prompt Routing
+
+Interactive prompts (permission, plan-approval, AskUserQuestion) hitting a child session are routed as text to its parent/orchestrator — hook path for permissions (seconds), pane-sweep riding the limits watchdog for the rest (≤60s). Parent resolution: worker pane → pane 0; else creator recorded at `agentwire new`; else `.agentwire.yml` `parent:`. Answer ONLY with `agentwire prompts answer -s <session> --expect <hash> <key>` (compare-and-send; raw send-keys races the portal). Deliveries are safety-gated (never paste into a live menu, a bare shell, or a parked session). CLI under `agentwire prompts ...`. Full reference: [`docs/wiki/sessions/prompt-routing.md`](docs/wiki/sessions/prompt-routing.md).
+
+## Polite Messaging
+
+`agentwire msg` is the non-interrupting sibling of `agentwire send`. `send`/`session_send` paste into the prompt and press Enter immediately — and **clobber a human's half-typed draft** if the box is occupied. `msg` drops a typed JSON message into a per-recipient file inbox (`~/.agentwire/inbox/<session>/`) and the watchdog injects it **only when the input box is empty** (`prompt_router.prompt_is_empty`) and `safe_deliver` guards pass (not parked, agent pane, no live dialog). Drain rides the limits watchdog (≤60s), coalescing queued messages into one paste; deferred messages bump `attempts` and dead-letter after 40. Typed kinds (`note`/`done`/`request`/`escalation`), `@all` broadcast (live agent sessions minus sender). Dead-lettered messages carry their drop reason + timestamp; `agentwire msg dead [-s <session>]` (MCP `msg_dead`) lists them so the drop is never silent. CLI `agentwire msg send|inbox|dead|flush`, MCP `msg_send`/`msg_inbox`/`msg_dead`. **Use `msg` for routine peer updates; reserve `send`/`session_send` for forcibly driving a session now.** Full reference: [`docs/wiki/sessions/messaging.md`](docs/wiki/sessions/messaging.md).
+
+## Council
+
+Multi-soul orchestrator sitting, **namespaced by `<name>`** so independent councils run concurrently: `agentwire-council-<name>` fans prompts out to lens sessions (`council-<name>-brain`, `council-<name>-conscience`, …), each replying take/ack/pass through a file inbox under `~/.agentwire/council/<name>/prompts/`; the orchestrator collects and synthesizes with attribution. Targeting: `--name` → cwd-repo-slug if it matches a live sitting → sole live sitting → else error+list; every command echoes which sitting it hit. The standard `soul` role self-excludes from any `council-*` session. CLI under `agentwire council ...` (incl. `council list`), 6 MCP `council_*` tools. Full reference: [`docs/wiki/council.md`](docs/wiki/council.md).
+
+## Reference Skills
+
+Reference detail lives in skills under `.Codex/skills/` — invoke as needed:
+
+| Skill | When to use |
+|-------|-------------|
+| `agentwire-cli` | Running or composing any `agentwire ...` shell command |
+| `agentwire-mcp-tools` | Picking the right MCP tool from inside an agent session |
+| `agentwire-config` | Editing `~/.agentwire/config.yaml` (TTS, channels, services, etc.) |
+| `agentwire-project-config` | Editing `.agentwire.yml`, defining tasks, roles, idle notifications |
+| `agentwire-scheduler` | Scheduled task gates/schedule/priority |
+| `agentwire-desktop-ui` | Editing portal static files (sidebar, windows, artifacts) |
+| `agentwire-pi` | Setting up pi sessions (zai, deepseek, openai, etc.) via pi coding agent |
+
+## Docs
+
+- CLI: `agentwire --help` or `agentwire <cmd> --help`
+- **[`docs/wiki/INDEX.md`](docs/wiki/INDEX.md)** — feature reference manual (sessions, communication, scheduling, integrations, deployment, TTS, internals)
+
+## Issue tracking
+
+How work is tracked is a contributor preference, not something agentwire ships — the product imposes no PM mandate. For *this* repo, the convention is GitHub issues as the source of truth, with `Closes #N` in the PR body to link and auto-close. If you keep cross-repo tracking preferences in `~/.Codex/rules/project-tracking.md`, those govern your own workflow and override this. Post-ship reference content (concepts, architecture, troubleshooting) belongs in `docs/wiki/`.

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2418,8 +2418,9 @@ def cmd_say(args) -> int:
     # alongside the spoken audio (different content per channel). Best-effort —
     # only lands if the portal's up; the spoken path proceeds regardless.
     display = getattr(args, 'display', None)
-    if display:
-        _post_desktop_notification(display, session=session, priority="high")
+    # Capture whether the toast actually reached the portal, so the caller can
+    # report it honestly rather than claiming "shown" when the portal is down.
+    toast_ok = _post_desktop_notification(display, session=session, priority="high") if display else None
 
     def _say_result(rc: int, sink: str, clients: int = 0) -> int:
         """Report which sink actually received the audio (#444): browser
@@ -2427,7 +2428,7 @@ def cmd_say(args) -> int:
         failed dispatch — instead of a blind "queued"."""
         if json_mode:
             _output_json({"success": rc == 0, "sink": sink if rc == 0 else None,
-                          "clients": clients, "session": session,
+                          "clients": clients, "session": session, "toast": toast_ok,
                           "error": None if rc == 0 else f"playback failed via {sink}"})
         return rc
 
@@ -3103,9 +3104,13 @@ def cmd_send(args) -> int:
             if verify:
                 # Confirm the paste actually landed in the pane (a paste into a
                 # busy/booting pane can vanish silently). Report verified vs not.
+                # retries=0: send ONCE and report — never re-paste. A streaming
+                # pane can scroll the echo out of the capture window and produce
+                # a false miss; re-pasting there would deliver the instruction
+                # twice, which is worse than a false "not verified" warning.
                 from agentwire.session_ready import send_verified
 
-                ok = send_verified(target_session, prompt, pane_index=pane_index)
+                ok = send_verified(target_session, prompt, pane_index=pane_index, retries=0)
                 if json_mode:
                     _output_json({
                         "success": True, "pane": pane_index, "session": target_session,
@@ -3236,10 +3241,12 @@ def cmd_send(args) -> int:
     if verify:
         # Same delivery verification as --wait-ready, but without waiting for a
         # fresh-boot banner — for an already-running session, just confirm the
-        # paste landed and report verified vs unconfirmed.
+        # paste landed and report verified vs unconfirmed. retries=0: send ONCE
+        # and report — a re-paste on a false miss (a busy session that scrolled
+        # the echo past the capture window) would deliver the message twice.
         from agentwire.session_ready import send_verified
 
-        ok = send_verified(session, prompt)
+        ok = send_verified(session, prompt, retries=0)
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None,
                               "verified": ok,

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -1232,7 +1232,16 @@ def say(text: str, session: str | None = None, voice: str | None = None, display
 
     # Sink ack (#444): report which path actually played, not a blind "queued".
     sink = data.get("sink")
-    toast = " Toast shown." if display else ""
+    # Toast ack: report the toast's real fate, not a blind "shown". `toast` is
+    # True if the portal accepted it, False if the portal was unreachable, None
+    # if no display was requested.
+    toast_ok = data.get("toast")
+    if toast_ok is None:
+        toast = ""
+    elif toast_ok:
+        toast = " Toast posted to the portal."
+    else:
+        toast = " (toast not delivered — portal unreachable)."
     if sink == "browser":
         n = data.get("clients", 0)
         return f"Spoken to {n} connected browser client{'s' if n != 1 else ''}.{toast}"


### PR DESCRIPTION
Follow-up to the #441/#444 merge (PR #447), addressing two findings from the post-merge adversarial review.

## 1. Duplicate-delivery regression on the hot path (the important one)

`session_send` / `pane_send` (MCP) send via `agentwire send --verify`, which called `send_verified` with the default `retries=1` — **re-pasting the entire message** on a verification miss. `message_visible` checks the first 32 chars against a 60-line `capture-pane` taken 2s after send, so a verbose agent streaming output can scroll its own echo out of the window → **false miss → the orchestrated agent receives the instruction twice.** A doubled instruction is worse than the old blind "sent."

Fix: both interactive verify sites in `cmd_send` now pass `retries=0` — send once, report verified/unverified, **never re-paste**. A false "not verified" warning is harmless (the message still landed exactly once); a duplicate paste is not. The `--wait-ready` path (fresh, idle session) and marker-based callers (council) keep their retry — they aren't exposed to the streaming-pane false-miss.

## 2. `say --display` toast claimed success blindly

`say --display` appended `" Toast shown."` unconditionally, ignoring the toast post's result — claiming success even when the portal was unreachable. That's the exact blind-"sent" pattern #444 set out to kill, surviving in the toast half of unified `say`.

Fix: `cmd_say` captures the `_post_desktop_notification` result into the say JSON (`"toast": true/false/null`); the MCP wrapper reports it honestly — **"Toast posted to the portal."** vs **"(toast not delivered — portal unreachable)."**

## Verification
- 1454 unit tests pass (`pytest tests/unit -q`).

The third review finding (greedy context-bar regex in `session_context.py:53`) is tracked under #442 for Phase 1 — it's observe-only, no auto-action, lower blast radius.

Built by [dotdev.dev](https://dotdev.dev)