### PR TITLE
feat(sidebar): nest child/spawned sessions under their parent (#448)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -3005,6 +3005,30 @@ def _record_session_creator(session_name: str, created_by: str | None, via: str)
     store_session_metadata(session_name, metadata)
 
 
+def _display_parent(session_name: str, path: str = "") -> "str | None":
+    """The session that should visually own this one in the sidebar.
+
+    Display-only relationship (powers sidebar nesting, issue #448) — NOT a
+    lifecycle coupling. Mirrors prompt_router.resolve_parent's precedence for
+    pane-0 sessions, minus the liveness check (the sidebar decides whether to
+    nest based on whether the parent is actually in the list):
+      1. Creator recorded at `agentwire new` time (session metadata).
+      2. `.agentwire.yml` `parent:` field (from the session's path).
+    Returns None for top-level sessions (no recorded parent).
+    """
+    bare = session_name.split("@")[0]
+    creator = load_session_metadata(bare).get("created_by")
+    if isinstance(creator, str) and creator and creator != bare:
+        return creator
+    try:
+        parent = get_parent_from_config(Path(path) if path else None)
+    except Exception:
+        parent = None
+    if parent and parent != bare:
+        return parent
+    return None
+
+
 def cmd_notify(args) -> int:
     """Send a notification to the portal about session/pane state changes.
 
@@ -3347,6 +3371,7 @@ def cmd_list(args) -> int:
                             "machine": None,
                             "type": cfg.get("type"),
                             "roles": cfg.get("roles", []),
+                            "parent": _display_parent(parts[0], path),
                         }
                         if usage_limit_parked(parts[0]):
                             session_info["usage_limit"] = True

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -733,6 +733,47 @@ body {
 .sidebar-git-badge.git-pushed { background: rgba(57, 255, 20, 0.16); color: #39ff14; }
 .sidebar-git-badge.git-unpushed { background: rgba(248, 113, 113, 0.18); color: #f87171; }
 
+/* Nested child/spawned sessions (issue #448) — display-only hierarchy so a
+   worktree/spawned session reads as belonging to its parent, never an unrelated
+   peer. Children are indented under the parent card with a connecting rail. */
+.sidebar-session-group {
+    margin-bottom: 4px;
+}
+
+.sidebar-session-children {
+    margin: 2px 0 2px 10px;
+    padding-left: 10px;
+    border-left: 2px solid var(--chrome-border);
+}
+
+.sidebar-session-children-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    padding: 2px 0 4px;
+}
+
+/* Collapse caret — compact, no border, so it sits flush before the dot. */
+.sidebar-children-toggle {
+    border: none;
+    background: transparent;
+    padding: 0 2px;
+    min-width: 14px;
+    color: var(--text-muted);
+}
+
+/* Child-count badge next to a parent's name (visible even when collapsed). */
+.sidebar-child-count {
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 0 5px;
+    border-radius: 8px;
+    background: var(--chrome-border);
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
 /* Session kill button — always visible and occupying its flex slot, so the
    row never reflows on hover. Confirm/killing states restyle in place. */
 .sidebar-session-close {

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -22,6 +22,11 @@ const listeners = new Set();
 const pendingClose = new Map();
 const killingSessions = new Set();
 
+// Parents whose nested children are collapsed in the sidebar (issue #448).
+// Module-level so collapse state survives the frequent activity re-renders.
+// Default is expanded — the whole point is making the relationship visible.
+const collapsedParents = new Set();
+
 export function getAllSessions() { return allSessions; }
 export function onSessionsChanged(fn) { listeners.add(fn); }
 
@@ -73,10 +78,21 @@ export function renderCard(s, opts = {}) {
     const roles = (s.roles || []).map(r => `<span class="sidebar-tag sidebar-tag-role">${r}</span>`).join('');
     const path = s.path ? s.path.replace(/^\/Users\/[^/]+\//, '~/') : '';
     const tagsHtml = `${tags.join('')}${roles}`;
+    // Collapse caret for parents with nested children (issue #448). The count
+    // badge keeps the relationship legible even when the children are hidden.
+    const childCount = opts.childCount || 0;
+    const caret = childCount
+        ? `<button class="sidebar-list-item-btn sidebar-children-toggle" data-action="toggle-children" title="${opts.collapsed ? 'Show' : 'Hide'} ${childCount} child session${childCount > 1 ? 's' : ''}">${opts.collapsed ? '▸' : '▾'}</button>`
+        : '';
+    const childBadge = childCount
+        ? `<span class="sidebar-child-count" title="${childCount} child session${childCount > 1 ? 's' : ''}">${childCount}</span>`
+        : '';
     return `<div class="sidebar-session-card" data-session="${name}" data-machine="${machine || ''}" data-id="${id}">
         <div class="sidebar-session-row1">
+            ${caret}
             <span class="sidebar-activity-dot ${dotClass}" data-session-dot="${name}"></span>
             <span class="sidebar-session-name">${name}</span>
+            ${childBadge}
             <button class="sidebar-list-item-btn" data-action="connect" title="Connect">▸</button>
             <button class="sidebar-list-item-btn" data-action="monitor" title="Monitor">👁</button>
             ${opts.closable ? renderCloseButton(name) : ''}
@@ -93,6 +109,54 @@ export function updateActivityDot(body, session) {
     dot.className = 'sidebar-activity-dot';
     const state = activityStates.get(session) || 'idle';
     dot.classList.add(state === 'idle' ? 'dot-idle' : state === 'processing' ? 'dot-processing' : state === 'generating' ? 'dot-generating' : 'dot-playing');
+}
+
+// Group sessions into a parent→children forest (issue #448). A session nests
+// under another only when its `parent` (display linkage from the CLI: creator
+// recorded at `agentwire new`, else `.agentwire.yml parent:`) is itself present
+// in the same list. Sessions whose parent is absent render as top-level roots.
+function buildSessionTree(sessions) {
+    const byName = new Map(sessions.map(s => [s.name || '', s]));
+    const childrenOf = new Map();  // parent name → [child sessions]
+    const roots = [];
+    for (const s of sessions) {
+        const parent = s.parent;
+        if (parent && parent !== s.name && byName.has(parent)) {
+            if (!childrenOf.has(parent)) childrenOf.set(parent, []);
+            childrenOf.get(parent).push(s);
+        } else {
+            roots.push(s);
+        }
+    }
+    return { childrenOf, roots };
+}
+
+// Render one session and its nested children (recursive). `visited` guards
+// against pathological parent cycles so a 2-cycle can't loop forever.
+function renderSessionNode(s, childrenOf, visited) {
+    const name = s.name || '';
+    if (visited.has(name)) return '';
+    visited.add(name);
+    const kids = childrenOf.get(name) || [];
+    const collapsed = collapsedParents.has(name);
+    const card = renderCard(s, { closable: true, childCount: kids.length, collapsed });
+    if (!kids.length) return card;
+    const childrenHtml = collapsed ? '' : `<div class="sidebar-session-children">
+        <div class="sidebar-session-children-label">Child sessions</div>
+        ${kids.map(k => renderSessionNode(k, childrenOf, visited)).join('')}
+    </div>`;
+    return `<div class="sidebar-session-group">${card}${childrenHtml}</div>`;
+}
+
+// Full forest render: roots first, then any session orphaned by a cycle.
+function renderSessionForest(sessions) {
+    const { childrenOf, roots } = buildSessionTree(sessions);
+    const visited = new Set();
+    let html = roots.map(s => renderSessionNode(s, childrenOf, visited)).join('');
+    for (const s of sessions) {
+        if (!visited.has(s.name || '')) html += renderSessionNode(s, childrenOf, visited);
+    }
+    return html;
 }
 
 export async function handleSessionClick(e) {
@@ -332,12 +396,22 @@ export const sessionsSection = {
         if (!work.length && !this._formType) {
             html += '<div class="sidebar-empty">No sessions</div>';
         } else {
-            html += work.map(s => renderCard(s, { closable: true })).join('');
+            html += renderSessionForest(work);
         }
         body.innerHTML = html;
         body.onclick = (e) => {
             if (e.target.closest('.sidebar-form')) {
                 this._handleFormClick(e, body);
+                return;
+            }
+            const toggle = e.target.closest('[data-action="toggle-children"]');
+            if (toggle) {
+                const name = toggle.closest('[data-session]')?.dataset.session;
+                if (name) {
+                    if (collapsedParents.has(name)) collapsedParents.delete(name);
+                    else collapsedParents.add(name);
+                    this._render(body);
+                }
                 return;
             }
             handleSessionClick(e);


### PR DESCRIPTION
## What

Makes the parent → child session relationship **legible** in the portal sidebar. Child/spawned sessions (worktree sessions, creator-recorded `agentwire new` children, `.agentwire.yml parent:` sessions) now render **indented + collapsible under their parent's entry** instead of sitting anonymously among unrelated top-level peers.

Motivated by the near-miss in #448: a worktree session spawned from the session being worked in looked like an unrelated sibling, and was almost deleted by mistake.

## How

**Backend (`agentwire/__main__.py`)**
- New `_display_parent(session_name, path)` helper resolves a **display-only** parent: creator recorded at `agentwire new` (session metadata), else `.agentwire.yml parent:`. Mirrors `prompt_router.resolve_parent`'s precedence for pane-0 sessions, **minus the liveness check** — the sidebar decides whether to nest based on whether the parent is actually in the list.
- `cmd_list` now includes a `parent` field on each local session dict. Flows through `/api/sessions/local` (and `/api/sessions`) untouched.

**Frontend (`static/js/sidebar/sessions-section.js`, `static/css/desktop.css`)**
- `buildSessionTree` / `renderSessionForest` group the (already service/council-filtered) session list into a parent→children forest. A session only nests when its `parent` is **present in the same column** — so worktree children nest under their parent in Sessions, but a session whose parent is a Service stays a root.
- Recursive render with a **cycle guard** (a pathological parent-loop can't hang the render). Multi-level nesting works (e.g. `fragmentz/billing-v3-*` → `fragmentz`).
- Collapse caret (▾/▸) + child-count badge on parents; collapse state persists at module level across the frequent activity re-renders. Default is **expanded** (the whole point is visibility).

## Decisions
- **Bucket label = "Child sessions"** (rendered as a small header above each nested group). Explicitly **not** "Worktree" — that term already names the git-worktree tooling/section, per the issue.
- **Display relationship only.** No lifecycle coupling — standalone worktree sessions still survive independently of their parent. This PR only changes how they're *shown*.

## Verification (in-worktree)
Served a dev portal on `:8799` (`--no-tts --no-stt`, non-default port, no collision with the live portal), confirmed:
- `/api/sessions/local` returns `parent` (incl. multi-level: `fragmentz/billing-v3-engine` → `fragmentz` → `agentwire-portal`).
- Sidebar renders `agentwire` with an `11` child badge + "CHILD SESSIONS" group; `fragmentz` with `3` nested `billing-v3-*` children; roots (`meshyai`, `agentwire-kokoro`) flat.
- Collapse caret toggles + persists. No console errors from the change (only a pre-existing unrelated xterm fit-addon warning).

Closes #448

Built by [dotdev.dev](https://dotdev.dev)