### PR TITLE
feat(context): Phase 1 — opt-in auto-/clear for bloated stateless sessions (#442)

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -6,7 +6,8 @@ Loads config from YAML file with sensible defaults and env var overrides.
 
 import os
 import sys
-from dataclasses import dataclass, field, fields as dataclass_fields
+from dataclasses import dataclass, field
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
 from typing import Optional
 
@@ -348,6 +349,10 @@ class CustomServiceConfig:
     type: Optional[str] = None   # session type override (e.g. claude-bypass)
     restart: str = "on-failure"  # never | on-failure | always
     healthcheck: HealthcheckConfig = field(default_factory=HealthcheckConfig)
+    # Context auto-management policy (issue #442): clear | compact | none.
+    # Default "none" — a service is only auto-managed when it opts in. Stateless
+    # bridges (notifications) set "clear"; stateful orchestrators "compact".
+    context_policy: str = "none"
 
     def __post_init__(self):
         if self.project:
@@ -449,16 +454,29 @@ class PromptRouterConfig:
 
 @dataclass
 class SessionContextConfig:
-    """Session context-bloat observability (Phase 0) knobs.
+    """Session context-bloat observability + auto-management (issue #442) knobs.
 
-    Observe-only: surfaces each session's remaining-context % and flags
-    sessions running low. No auto-``/clear`` / ``/compact`` — that is Phase 1.
+    Phase 0 surfaces each session's remaining-context % and flags low sessions.
+    Phase 1 adds opt-in auto-action: a session carrying a ``context_policy`` of
+    ``clear``/``compact`` (default ``none``) gets that command sent when it
+    crosses the warn threshold while idle at an empty prompt.
     """
 
     # Flag a session when its REMAINING context drops to/below this %
     # (the bar shows headroom, not usage — see session_context.py). Default
     # 20% remaining == ~80% of the way toward the limit.
     warn_remaining_pct: int = 20
+
+    # Master switch for the Phase-1 auto-action sweep on the limits watchdog.
+    # Observability (CLI/MCP) is unaffected by this — it only gates auto-action.
+    auto_enabled: bool = True
+
+    # Per-session policy overrides keyed by session name — ``clear`` | ``compact``
+    # | ``none``. For arbitrary sessions (councils, anchors) that aren't service-
+    # registry entries. Bundled services are default-on via their own entry, so
+    # they need no entry here. Anything not listed (and not a default-on service)
+    # is ``none`` — never auto-managed.
+    policies: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -684,6 +702,9 @@ def _dict_to_config(data: dict) -> Config:
                 command=hc_data.get("command"),
                 interval=hc_data.get("interval", 60),
             )
+            context_policy = entry.get("context_policy", "none")
+            if context_policy not in ("clear", "compact", "none"):
+                context_policy = "none"
             custom_services.append(CustomServiceConfig(
                 name=entry["name"],
                 project=entry.get("project"),
@@ -692,6 +713,7 @@ def _dict_to_config(data: dict) -> Config:
                 type=entry.get("type"),
                 restart=entry.get("restart", "on-failure"),
                 healthcheck=healthcheck,
+                context_policy=context_policy,
             ))
     services = ServicesConfig(
         portal=portal_service,
@@ -786,7 +808,7 @@ def _dict_to_config(data: dict) -> Config:
         exclude_sessions=[str(s) for s in pr_exclude_raw if s],
     )
 
-    # Session context observability (Phase 0 — bloat warn threshold)
+    # Session context observability + auto-management (issue #442)
     session_context_data = data.get("session_context", {}) or {}
     if not isinstance(session_context_data, dict):
         session_context_data = {}
@@ -794,8 +816,18 @@ def _dict_to_config(data: dict) -> Config:
         warn_remaining_pct = int(session_context_data.get("warn_remaining_pct", 20))
     except (TypeError, ValueError):
         warn_remaining_pct = 20
+    policies_raw = session_context_data.get("policies", {}) or {}
+    if not isinstance(policies_raw, dict):
+        policies_raw = {}
+    policies = {
+        str(name): str(pol)
+        for name, pol in policies_raw.items()
+        if str(pol) in ("clear", "compact", "none")
+    }
     session_context = SessionContextConfig(
         warn_remaining_pct=max(0, min(100, warn_remaining_pct)),
+        auto_enabled=bool(session_context_data.get("auto_enabled", True)),
+        policies=policies,
     )
 
     # Session defaults

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -93,17 +93,22 @@ def cmd_limits_tick(args) -> int:
     """One watchdog pass (called by launchd every minute).
 
     Runs the usage-limit sweep FIRST, then prompt routing (#276), then the
-    polite-message inbox drain (#296) — the ordering guarantees a usage-limit
-    dialog is parked before either sweep looks at the pane, and that the
-    inbox only ever delivers to panes the prompt sweep already cleared.
+    polite-message inbox drain (#296), then context auto-management (#442) —
+    the ordering guarantees a usage-limit dialog is parked before any sweep
+    looks at the pane, that the inbox only ever delivers to panes the prompt
+    sweep already cleared, and that auto-``/clear`` runs LAST so it never fights
+    a pending paste/prompt for the same idle, empty box.
     """
-    from agentwire import inbox, prompt_router
+    from agentwire import inbox, prompt_router, session_context
 
     result = usage_limit.tick()
     prompts = prompt_router.tick()
     messages = inbox.tick()
+    context = session_context.tick()
     if getattr(args, "json", False):
-        print(json.dumps({**result, "prompts": prompts, "messages": messages}))
+        print(json.dumps({
+            **result, "prompts": prompts, "messages": messages, "context": context,
+        }))
         return 0
     if result.get("skipped"):
         print(result["skipped"])
@@ -132,6 +137,14 @@ def cmd_limits_tick(args) -> int:
     if msg_deferred:
         print("messages deferred: " + ", ".join(
             f"{e['session']}({e['reason']})" for e in msg_deferred))
+    ctx_acted = context.get("acted") or []
+    ctx_deferred = context.get("deferred") or []
+    if ctx_acted:
+        print("context auto-managed: " + ", ".join(
+            f"{e['session']}→{e['command']}@{e['remaining_pct']}%" for e in ctx_acted))
+    if ctx_deferred:
+        print("context deferred: " + ", ".join(
+            f"{e['session']}({e['deferred']})" for e in ctx_deferred))
     return 0
 
 

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -14,8 +14,7 @@ the watchdog resurrects them.
 import json
 import subprocess
 import sys
-import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -110,6 +109,11 @@ def registry(cfg: Config) -> list[CustomServiceConfig]:
         type="claude-bypass",
         restart="on-failure",
         healthcheck=HealthcheckConfig(),  # tmux_session, 60s
+        # Default-on context auto-management (issue #442): the idle-nag bridge
+        # is STATELESS — it's fed ~1440 [IDLE NAG] prompts/day and needs none of
+        # its backlog, so /clear it aggressively when it bloats rather than
+        # leaning on Claude's own (stateful-oriented) auto-compaction.
+        context_policy="clear",
     )
     return [notifications, *user_services]
 

--- a/agentwire/session_context.py
+++ b/agentwire/session_context.py
@@ -1,8 +1,17 @@
-"""Session context observability — read the Claude Code context bar from a pane.
+"""Session context observability + auto-management (issue #442).
 
-Phase 0 of context-bloat management (issue #442): make bloat *visible* and
-queryable. This module only OBSERVES — it never auto-``/clear``s or
-``/compact``s anything (that is Phase 1, a separate change).
+Phase 0 made context bloat *visible* and queryable (parse the bar, flag low
+sessions, expose via CLI/MCP). Phase 1 adds the *deterministic, zero-LLM*
+auto-action: opted-in sessions whose remaining context crosses the warn
+threshold get ``/clear`` (stateless service sessions) or ``/compact`` while
+they sit idle at an empty prompt. See :func:`tick` and :func:`resolve_policy`.
+
+**Opt-in only.** A session is auto-managed solely when it carries an explicit
+``context_policy`` (``clear`` | ``compact``); the default everywhere is
+``none``. Bundled stateless service sessions are default-on via their
+service-registry entry — the ``agentwire-notifications`` idle-nag bridge is the
+canonical case (it accumulates ~1440 prompts/day and needs none of its backlog).
+The watchdog never touches a session without a policy.
 
 What the bar means (verified empirically, 2026-06-22)
 -----------------------------------------------------
@@ -41,16 +50,37 @@ gracefully (surfaced as non-interactive, never flagged).
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from dataclasses import asdict, dataclass
+from pathlib import Path
 
 from .usage_limit import _capture, _tmux
 
 # The context bar: a bracketed run of block-element glyphs (U+2580–U+259F
 # covers full/partial/empty blocks) followed by "NN%". ANSI is stripped first.
+#
+# HARDENING (Phase 1, issue #442) — because auto-``/clear`` now keys off the
+# parsed value, a false read must never be able to trigger an action. Two
+# anchors over the naive "any [blocks] N%":
+#   1. **Trailing token** — the bar+pct must be the last thing on its line
+#      (``[ \t]*$`` with re.MULTILINE). The real Claude footer renders the bar
+#      as the trailing token; an inline ``CPU [███░░] 50% busy`` mid-line is
+#      rejected.
+#   2. **Longest glyph-run wins** — :func:`parse_context_bar` scans every
+#      matching line and returns the percentage of the *widest* bar, so when a
+#      worker pane renders its own short progress bar alongside the real (wide)
+#      Claude footer, the footer dominates rather than the leftmost match.
+# The lookahead requires ≥1 block glyph so an all-spaces ``[   ]`` never matches.
+# Belt-and-suspenders: the auto-action sweep also gates on an idle, empty Claude
+# input box (:func:`prompt_router.prompt_is_empty`), which a pane merely drawing
+# a download meter does not present.
 _ANSI = re.compile(r"\x1b\[[0-9;]*m|\x1b\].*?\x07")
-_CONTEXT_BAR_RE = re.compile(r"\[(?:[▀-▟]|\s)+\]\s*(\d{1,3})\s*%")
+_CONTEXT_BAR_RE = re.compile(
+    r"\[(?=[^\]\n]*[▀-▟])([▀-▟ ]+)\][ \t]*(\d{1,3})[ \t]*%[ \t]*$",
+    re.MULTILINE,
+)
 # The meta line above the bar: "… main   opus  $1805.19  7988m".
 _MODEL_RE = re.compile(r"\b(opus|sonnet|haiku|fable)\b", re.IGNORECASE)
 
@@ -83,14 +113,21 @@ def parse_context_bar(visible: str) -> int | None:
     """Remaining-context % from a Claude Code status bar, or None.
 
     None means no bar on screen — a daemon pane, a busy/starting render, or a
-    pane that simply isn't a Claude conversation.
+    pane that simply isn't a Claude conversation. When several bars are present
+    (e.g. a worker pane drawing its own progress bar under the Claude footer),
+    the widest one wins — see :data:`_CONTEXT_BAR_RE` hardening notes.
     """
     clean = _ANSI.sub("", visible)
-    m = _CONTEXT_BAR_RE.search(clean)
-    if not m:
-        return None
-    pct = int(m.group(1))
-    return pct if 0 <= pct <= 100 else None
+    best_pct: int | None = None
+    best_run = -1
+    for m in _CONTEXT_BAR_RE.finditer(clean):
+        pct = int(m.group(2))
+        if not 0 <= pct <= 100:
+            continue
+        run = len(m.group(1))
+        if run > best_run:
+            best_run, best_pct = run, pct
+    return best_pct
 
 
 def parse_model(visible: str) -> str | None:
@@ -194,3 +231,184 @@ def _warn_threshold() -> int:
         return int(get_config().session_context.warn_remaining_pct)
     except Exception:
         return DEFAULT_WARN_REMAINING_PCT
+
+
+# =============================================================================
+# Phase 1 — opt-in auto-management (clear / compact)
+# =============================================================================
+
+POLICY_NONE = "none"
+POLICY_CLEAR = "clear"
+POLICY_COMPACT = "compact"
+VALID_POLICIES = (POLICY_NONE, POLICY_CLEAR, POLICY_COMPACT)
+
+# The slash command each acting policy sends to the session.
+_POLICY_COMMAND = {POLICY_CLEAR: "/clear", POLICY_COMPACT: "/compact"}
+
+EVENTS_FILE = Path.home() / ".agentwire" / "session-context-events.jsonl"
+
+
+def _log_event(event: str, **fields) -> None:
+    """Append one auto-action audit record (best-effort, never raises)."""
+    from datetime import datetime, timezone
+
+    record = {"ts": datetime.now(timezone.utc).isoformat(), "event": event, **fields}
+    try:
+        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(EVENTS_FILE, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def resolve_policy(session: str, cfg=None) -> str:
+    """The context-management policy for *session* — ``clear`` | ``compact`` | ``none``.
+
+    Resolution, first match wins:
+      1. Explicit per-session override in config ``session_context.policies``
+         (a ``{name: policy}`` map — for arbitrary sessions like councils/anchors).
+      2. The session's service-registry entry ``context_policy`` (bundled
+         stateless services are default-on here — notifications => ``clear``).
+      3. ``none`` — never auto-managed.
+
+    An unknown/invalid value is treated as ``none`` (fail safe — never act).
+    """
+    if cfg is None:
+        try:
+            from .config import get_config
+
+            cfg = get_config()
+        except Exception:
+            return POLICY_NONE
+
+    policies = getattr(cfg.session_context, "policies", {}) or {}
+    override = policies.get(session)
+    if override in VALID_POLICIES:
+        return override
+
+    try:
+        from . import services
+
+        for svc in services.registry(cfg):
+            if svc.name == session:
+                pol = getattr(svc, "context_policy", POLICY_NONE)
+                return pol if pol in VALID_POLICIES else POLICY_NONE
+    except Exception:
+        pass
+
+    return POLICY_NONE
+
+
+def _safe_to_act(session: str) -> tuple[bool, str]:
+    """Is *session* a safe target for an auto-action right now?
+
+    Reuses the polite-delivery guards (#296): never act on a parked session
+    (a paste would corrupt the usage-limit resume) and only when the Claude
+    input box is a clean, empty prompt — :func:`prompt_router.prompt_is_empty`
+    returns False for a live dialog, a busy render, a human's half-typed draft,
+    or any pane it can't parse as an empty box. That single gate also implies
+    an agent pane sitting idle, so we never ``/clear`` mid-turn.
+    """
+    from . import prompt_router, usage_limit
+
+    if usage_limit.is_parked(session):
+        return False, "parked"
+    if not prompt_router.is_agent_pane(session, 0):
+        return False, "not_agent"
+    if not prompt_router.prompt_is_empty(session, 0):
+        return False, "box_not_empty"
+    return True, "ok"
+
+
+def act_on_session(session: str, policy: str, threshold: int | None = None) -> dict:
+    """Evaluate one opted-in session and ``/clear`` | ``/compact`` if warranted.
+
+    Returns a result dict (always; never raises). ``acted`` is True only when a
+    command was actually sent. ``skipped``/``deferred`` carry a reason so the
+    audit log explains every no-op.
+    """
+    if policy not in _POLICY_COMMAND:
+        return {"session": session, "acted": False, "skipped": "no_policy"}
+
+    threshold = threshold if threshold is not None else _warn_threshold()
+    ctx = session_context(session, 0, threshold)
+
+    if not ctx.is_agent or ctx.remaining_pct is None:
+        return {"session": session, "acted": False, "skipped": "no_bar"}
+    if not ctx.flagged:
+        return {
+            "session": session, "acted": False, "skipped": "above_threshold",
+            "remaining_pct": ctx.remaining_pct,
+        }
+
+    safe, reason = _safe_to_act(session)
+    if not safe:
+        _log_event(
+            "deferred", session=session, policy=policy,
+            remaining_pct=ctx.remaining_pct, reason=reason,
+        )
+        return {
+            "session": session, "acted": False, "deferred": reason,
+            "remaining_pct": ctx.remaining_pct,
+        }
+
+    command = _POLICY_COMMAND[policy]
+    try:
+        from .session_ready import send_to_session
+
+        send_to_session(session, command)
+        sent = True
+    except Exception as exc:  # a send failure must not break the watchdog
+        _log_event(
+            "send_failed", session=session, policy=policy,
+            remaining_pct=ctx.remaining_pct, error=str(exc),
+        )
+        return {"session": session, "acted": False, "deferred": "send_failed"}
+
+    _log_event(
+        "acted", session=session, policy=policy, command=command,
+        remaining_pct=ctx.remaining_pct, threshold=threshold,
+    )
+    return {
+        "session": session, "acted": sent, "policy": policy, "command": command,
+        "remaining_pct": ctx.remaining_pct,
+    }
+
+
+def tick() -> dict:
+    """One auto-context-management pass over opted-in sessions.
+
+    The 4th sweep on ``agentwire limits tick`` (after usage-limit park, prompt
+    routing, and the inbox drain). For every local session carrying a
+    ``clear``/``compact`` policy whose remaining context has crossed the warn
+    threshold *and* which is idle at an empty prompt, send ``/clear`` |
+    ``/compact``. Deterministic, zero-LLM. Never raises.
+
+    A session that defers (busy / parked / mid-turn) is simply retried next
+    tick; a session above threshold is left alone. No cooldown is needed — a
+    successful ``/clear`` resets the bar above the threshold, so it won't be
+    re-flagged, and a silently-failed one *should* be retried.
+    """
+    try:
+        from .config import get_config
+
+        cfg = get_config()
+    except Exception:
+        return {"skipped": "no_config"}
+
+    if not getattr(cfg.session_context, "auto_enabled", True):
+        return {"skipped": "disabled"}
+
+    threshold = int(getattr(cfg.session_context, "warn_remaining_pct", DEFAULT_WARN_REMAINING_PCT))
+
+    acted, deferred = [], []
+    for session in _list_local_sessions():
+        policy = resolve_policy(session, cfg)
+        if policy not in _POLICY_COMMAND:
+            continue
+        result = act_on_session(session, policy, threshold)
+        if result.get("acted"):
+            acted.append(result)
+        elif result.get("deferred"):
+            deferred.append(result)
+    return {"acted": acted, "deferred": deferred}

--- a/agentwire/session_context.py
+++ b/agentwire/session_context.py
@@ -299,33 +299,28 @@ def resolve_policy(session: str, cfg=None) -> str:
     return POLICY_NONE
 
 
-def _safe_to_act(session: str) -> tuple[bool, str]:
-    """Is *session* a safe target for an auto-action right now?
-
-    Reuses the polite-delivery guards (#296): never act on a parked session
-    (a paste would corrupt the usage-limit resume) and only when the Claude
-    input box is a clean, empty prompt — :func:`prompt_router.prompt_is_empty`
-    returns False for a live dialog, a busy render, a human's half-typed draft,
-    or any pane it can't parse as an empty box. That single gate also implies
-    an agent pane sitting idle, so we never ``/clear`` mid-turn.
-    """
-    from . import prompt_router, usage_limit
-
-    if usage_limit.is_parked(session):
-        return False, "parked"
-    if not prompt_router.is_agent_pane(session, 0):
-        return False, "not_agent"
-    if not prompt_router.prompt_is_empty(session, 0):
-        return False, "box_not_empty"
-    return True, "ok"
-
-
 def act_on_session(session: str, policy: str, threshold: int | None = None) -> dict:
     """Evaluate one opted-in session and ``/clear`` | ``/compact`` if warranted.
 
-    Returns a result dict (always; never raises). ``acted`` is True only when a
-    command was actually sent. ``skipped``/``deferred`` carry a reason so the
-    audit log explains every no-op.
+    Returns a result dict (always; never raises). ``acted`` is True **only when
+    the command was a verified delivery** — the paste is routed through
+    :func:`prompt_router.safe_deliver`, so a guarded refusal or a silent paste
+    failure is logged honestly as NOT acted (and retried next tick), never
+    assumed sent.
+
+    Delivery mirrors the sibling inbox drain (:func:`inbox.flush_session`):
+
+    1. **Collision guard first** — :func:`prompt_router.prompt_is_empty` must
+       see a clean, empty Claude box (it returns False for a live dialog, a
+       busy render, a human's half-typed draft, or any unparseable screen). This
+       also closes the TOCTOU window as far as a *human* draft goes: we never
+       paste over uncommitted text.
+    2. **safe_deliver** — adds the parked / non-agent / live-menu refusals AND a
+       verified paste (:func:`session_ready.send_verified`, marker = the command
+       text, which Claude Code echoes as ``❯ /clear`` after the slash command
+       runs). A turn that races in between the two steps either leaves the box
+       non-empty (→ refused) or shows a live render (→ refused), so the clear
+       can't land mid-stream.
     """
     if policy not in _POLICY_COMMAND:
         return {"session": session, "acted": False, "skipped": "no_policy"}
@@ -341,8 +336,32 @@ def act_on_session(session: str, policy: str, threshold: int | None = None) -> d
             "remaining_pct": ctx.remaining_pct,
         }
 
-    safe, reason = _safe_to_act(session)
-    if not safe:
+    from . import prompt_router
+
+    # Collision guard before anything is pasted (mirrors inbox.flush_session).
+    if not prompt_router.prompt_is_empty(session, 0):
+        _log_event(
+            "deferred", session=session, policy=policy,
+            remaining_pct=ctx.remaining_pct, reason="box_not_empty",
+        )
+        return {
+            "session": session, "acted": False, "deferred": "box_not_empty",
+            "remaining_pct": ctx.remaining_pct,
+        }
+
+    command = _POLICY_COMMAND[policy]
+    try:
+        delivered, reason = prompt_router.safe_deliver(session, 0, command)
+    except Exception as exc:  # delivery must never break the watchdog
+        _log_event(
+            "send_failed", session=session, policy=policy,
+            remaining_pct=ctx.remaining_pct, error=str(exc),
+        )
+        return {"session": session, "acted": False, "deferred": "send_failed"}
+
+    if not delivered:
+        # Guarded refusal (parked / not-agent / live-menu) or an unverified
+        # paste — logged honestly as not acted, retried next tick.
         _log_event(
             "deferred", session=session, policy=policy,
             remaining_pct=ctx.remaining_pct, reason=reason,
@@ -352,25 +371,12 @@ def act_on_session(session: str, policy: str, threshold: int | None = None) -> d
             "remaining_pct": ctx.remaining_pct,
         }
 
-    command = _POLICY_COMMAND[policy]
-    try:
-        from .session_ready import send_to_session
-
-        send_to_session(session, command)
-        sent = True
-    except Exception as exc:  # a send failure must not break the watchdog
-        _log_event(
-            "send_failed", session=session, policy=policy,
-            remaining_pct=ctx.remaining_pct, error=str(exc),
-        )
-        return {"session": session, "acted": False, "deferred": "send_failed"}
-
     _log_event(
         "acted", session=session, policy=policy, command=command,
         remaining_pct=ctx.remaining_pct, threshold=threshold,
     )
     return {
-        "session": session, "acted": sent, "policy": policy, "command": command,
+        "session": session, "acted": True, "policy": policy, "command": command,
         "remaining_pct": ctx.remaining_pct,
     }
 

--- a/tests/unit/test_session_context.py
+++ b/tests/unit/test_session_context.py
@@ -7,9 +7,11 @@ these tests cover the real bar shapes seen on live sessions plus the daemon /
 no-bar skip paths.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from agentwire import session_context as sc
+from agentwire.config import CustomServiceConfig
 
 # Real captures from live sessions (2026-06-22): the bar width tracks terminal
 # width, so the same 92% renders with different glyph counts.
@@ -94,3 +96,198 @@ def test_threshold_boundary_inclusive():
     assert at.flagged is True  # remaining == threshold is flagged
     above = _ctx("node", "\n".join([META_LINE, "[██░░] 21%"]))
     assert above.flagged is False
+
+
+# ── Regex hardening (Phase 1, issue #442) ────────────────────────────────────
+# Once auto-/clear keys off the parsed value, a stray bracketed bar must not be
+# able to trigger an action. The bar must be the trailing token of its line, and
+# when several bars are on screen the widest one (the real footer) wins.
+
+
+def test_bar_must_be_trailing_token():
+    # A bar followed by more text on the same line is NOT the Claude footer.
+    assert sc.parse_context_bar("[█████░░░░░] 50% remaining, downloading...") is None
+    assert sc.parse_context_bar("CPU [███░░] 50% load  user 3%") is None
+
+
+def test_trailing_bar_with_label_still_parses():
+    # Trailing IS allowed even with a preceding label — the trailing-token rule
+    # can't distinguish a lone fake bar; the idle/empty-prompt gate is the
+    # belt-and-suspenders for that (documented residual).
+    assert sc.parse_context_bar("model  $1.00  [████████░░] 80%") == 80
+
+
+def test_longest_glyph_run_wins():
+    # A worker's short progress bar + the wide real footer on separate lines:
+    # the wide one (the actual context bar) must win, not the leftmost match.
+    screen = "\n".join([
+        "[██░] 5%",  # short, would falsely read 5% if leftmost won
+        META_LINE,
+        WIDE_BAR,    # the real footer, 92%
+    ])
+    assert sc.parse_context_bar(screen) == 92
+
+
+def test_all_spaces_bracket_rejected():
+    assert sc.parse_context_bar("[     ] 80%") is None
+
+
+def test_trailing_whitespace_tolerated():
+    assert sc.parse_context_bar("[████░░] 30%   ") == 30
+
+
+# ── Policy resolution (Phase 1) ──────────────────────────────────────────────
+
+
+def _cfg(policies=None):
+    """Minimal fake Config for resolve_policy (only the fields it reads)."""
+    return SimpleNamespace(
+        session_context=SimpleNamespace(
+            warn_remaining_pct=20, auto_enabled=True, policies=policies or {},
+        ),
+        services=SimpleNamespace(custom=[]),
+    )
+
+
+def _svc(name, policy="none"):
+    return CustomServiceConfig(name=name, context_policy=policy)
+
+
+def test_resolve_policy_service_default_on():
+    cfg = _cfg()
+    with patch.object(sc, "_warn_threshold", return_value=20), patch(
+        "agentwire.services.registry",
+        return_value=[_svc("agentwire-notifications", "clear")],
+    ):
+        assert sc.resolve_policy("agentwire-notifications", cfg) == "clear"
+
+
+def test_resolve_policy_config_override_wins():
+    cfg = _cfg(policies={"agentwire-notifications": "compact"})
+    with patch(
+        "agentwire.services.registry",
+        return_value=[_svc("agentwire-notifications", "clear")],
+    ):
+        # Explicit per-session override beats the service-registry default.
+        assert sc.resolve_policy("agentwire-notifications", cfg) == "compact"
+
+
+def test_resolve_policy_unknown_session_is_none():
+    cfg = _cfg()
+    with patch("agentwire.services.registry", return_value=[]):
+        assert sc.resolve_policy("some-random-session", cfg) == "none"
+
+
+def test_resolve_policy_invalid_service_value_is_none():
+    cfg = _cfg()
+    with patch(
+        "agentwire.services.registry",
+        return_value=[_svc("svc", "nonsense")],
+    ):
+        assert sc.resolve_policy("svc", cfg) == "none"
+
+
+# ── act_on_session (Phase 1) ─────────────────────────────────────────────────
+
+
+def _ctx_obj(remaining, is_agent=True, flagged=None):
+    if flagged is None:
+        flagged = remaining is not None and remaining <= 20
+    return sc.SessionContext(
+        session="s", pane=0, is_agent=is_agent, remaining_pct=remaining,
+        model="opus", flagged=flagged, note="",
+    )
+
+
+def test_act_skips_when_above_threshold():
+    with patch.object(sc, "session_context", return_value=_ctx_obj(80)):
+        r = sc.act_on_session("s", "clear", threshold=20)
+    assert r["acted"] is False
+    assert r["skipped"] == "above_threshold"
+
+
+def test_act_skips_when_no_bar():
+    with patch.object(sc, "session_context", return_value=_ctx_obj(None, is_agent=True)):
+        r = sc.act_on_session("s", "clear", threshold=20)
+    assert r["acted"] is False
+    assert r["skipped"] == "no_bar"
+
+
+def test_act_skips_when_no_policy():
+    r = sc.act_on_session("s", "none", threshold=20)
+    assert r["acted"] is False
+    assert r["skipped"] == "no_policy"
+
+
+def test_act_defers_when_unsafe():
+    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch.object(
+        sc, "_safe_to_act", return_value=(False, "box_not_empty")
+    ), patch.object(sc, "_log_event"):
+        r = sc.act_on_session("s", "clear", threshold=20)
+    assert r["acted"] is False
+    assert r["deferred"] == "box_not_empty"
+
+
+def test_act_sends_command_when_flagged_and_safe():
+    sent = {}
+
+    def fake_send(session, command, **kw):
+        sent["session"] = session
+        sent["command"] = command
+
+    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch.object(
+        sc, "_safe_to_act", return_value=(True, "ok")
+    ), patch.object(sc, "_log_event"), patch(
+        "agentwire.session_ready.send_to_session", side_effect=fake_send
+    ):
+        r = sc.act_on_session("s", "clear", threshold=20)
+    assert r["acted"] is True
+    assert r["command"] == "/clear"
+    assert sent == {"session": "s", "command": "/clear"}
+
+
+def test_act_compact_sends_compact():
+    with patch.object(sc, "session_context", return_value=_ctx_obj(5)), patch.object(
+        sc, "_safe_to_act", return_value=(True, "ok")
+    ), patch.object(sc, "_log_event"), patch(
+        "agentwire.session_ready.send_to_session"
+    ) as send:
+        r = sc.act_on_session("s", "compact", threshold=20)
+    assert r["acted"] is True
+    assert r["command"] == "/compact"
+    send.assert_called_once_with("s", "/compact")
+
+
+# ── tick (Phase 1) ───────────────────────────────────────────────────────────
+
+
+def test_tick_skips_when_auto_disabled():
+    cfg = _cfg()
+    cfg.session_context.auto_enabled = False
+    with patch("agentwire.config.get_config", return_value=cfg):
+        assert sc.tick() == {"skipped": "disabled"}
+
+
+def test_tick_acts_only_on_opted_in_sessions():
+    cfg = _cfg()
+    calls = []
+
+    def fake_act(session, policy, threshold):
+        calls.append((session, policy))
+        return {"session": session, "acted": True, "command": "/clear",
+                "remaining_pct": 10, "policy": policy}
+
+    def fake_resolve(session, c):
+        return "clear" if session == "agentwire-notifications" else "none"
+
+    with patch("agentwire.config.get_config", return_value=cfg), patch.object(
+        sc, "_list_local_sessions",
+        return_value=["agentwire-notifications", "fragmentz", "agentwire-scheduler"],
+    ), patch.object(sc, "resolve_policy", side_effect=fake_resolve), patch.object(
+        sc, "act_on_session", side_effect=fake_act
+    ):
+        result = sc.tick()
+
+    # Only the opted-in session was evaluated/acted on — never fragmentz.
+    assert calls == [("agentwire-notifications", "clear")]
+    assert [e["session"] for e in result["acted"]] == ["agentwire-notifications"]

--- a/tests/unit/test_session_context.py
+++ b/tests/unit/test_session_context.py
@@ -219,43 +219,57 @@ def test_act_skips_when_no_policy():
     assert r["skipped"] == "no_policy"
 
 
-def test_act_defers_when_unsafe():
-    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch.object(
-        sc, "_safe_to_act", return_value=(False, "box_not_empty")
-    ), patch.object(sc, "_log_event"):
+def test_act_defers_when_box_not_empty():
+    # Collision guard: a non-empty / unparseable box defers before any paste.
+    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch(
+        "agentwire.prompt_router.prompt_is_empty", return_value=False
+    ), patch("agentwire.prompt_router.safe_deliver") as deliver, patch.object(
+        sc, "_log_event"
+    ):
         r = sc.act_on_session("s", "clear", threshold=20)
     assert r["acted"] is False
     assert r["deferred"] == "box_not_empty"
+    deliver.assert_not_called()  # never even attempt the paste
 
 
-def test_act_sends_command_when_flagged_and_safe():
-    sent = {}
+def test_act_defers_when_safe_deliver_refuses():
+    # An empty box but safe_deliver refuses (parked / live-menu) or the paste
+    # can't be verified — logged honestly as NOT acted, retried next tick.
+    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch(
+        "agentwire.prompt_router.prompt_is_empty", return_value=True
+    ), patch(
+        "agentwire.prompt_router.safe_deliver",
+        return_value=(False, "delivery_unverified"),
+    ), patch.object(sc, "_log_event"):
+        r = sc.act_on_session("s", "clear", threshold=20)
+    assert r["acted"] is False
+    assert r["deferred"] == "delivery_unverified"
 
-    def fake_send(session, command, **kw):
-        sent["session"] = session
-        sent["command"] = command
 
-    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch.object(
-        sc, "_safe_to_act", return_value=(True, "ok")
-    ), patch.object(sc, "_log_event"), patch(
-        "agentwire.session_ready.send_to_session", side_effect=fake_send
-    ):
+def test_act_sends_command_when_flagged_and_verified():
+    # Happy path: empty box + verified safe_deliver => acted, via safe_deliver
+    # (NOT a raw paste) so the audit log is honest.
+    with patch.object(sc, "session_context", return_value=_ctx_obj(10)), patch(
+        "agentwire.prompt_router.prompt_is_empty", return_value=True
+    ), patch(
+        "agentwire.prompt_router.safe_deliver", return_value=(True, "delivered")
+    ) as deliver, patch.object(sc, "_log_event"):
         r = sc.act_on_session("s", "clear", threshold=20)
     assert r["acted"] is True
     assert r["command"] == "/clear"
-    assert sent == {"session": "s", "command": "/clear"}
+    deliver.assert_called_once_with("s", 0, "/clear")
 
 
-def test_act_compact_sends_compact():
-    with patch.object(sc, "session_context", return_value=_ctx_obj(5)), patch.object(
-        sc, "_safe_to_act", return_value=(True, "ok")
-    ), patch.object(sc, "_log_event"), patch(
-        "agentwire.session_ready.send_to_session"
-    ) as send:
+def test_act_compact_routes_compact_through_safe_deliver():
+    with patch.object(sc, "session_context", return_value=_ctx_obj(5)), patch(
+        "agentwire.prompt_router.prompt_is_empty", return_value=True
+    ), patch(
+        "agentwire.prompt_router.safe_deliver", return_value=(True, "delivered")
+    ) as deliver, patch.object(sc, "_log_event"):
         r = sc.act_on_session("s", "compact", threshold=20)
     assert r["acted"] is True
     assert r["command"] == "/compact"
-    send.assert_called_once_with("s", "/compact")
+    deliver.assert_called_once_with("s", 0, "/compact")
 
 
 # ── tick (Phase 1) ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Phase 1 — opt-in auto-`/clear` for bloated stateless sessions

Builds directly on the Phase 0 observability that shipped in #446 (`session_context.py`, `agentwire list --context`, MCP `sessions_context`). Phase 1 adds the **deterministic, zero-LLM auto-action**: an opted-in session whose remaining context crosses the warn threshold gets `/clear` (stateless service sessions) or `/compact` while it sits idle at an empty prompt.

### Opt-in only — nothing acts without a policy
A session is auto-managed **solely** when it carries an explicit `context_policy` (`clear` | `compact`); the default everywhere is `none`. The bundled stateless `agentwire-notifications` bridge is default-on (`clear`) via its service-registry entry — it's fed ~1440 `[IDLE NAG]` prompts/day and needs none of its backlog. The watchdog never touches a session without a policy.

### What's in the PR
1. **Regex hardening (prerequisite, done first).** `_CONTEXT_BAR_RE` previously matched *any* `[blocks] N%`, so a worker pane rendering `CPU [███░░] 50%` could be misread as the Claude footer. Now the bar+pct must be the **trailing token of its line** (`re.MULTILINE`), and `parse_context_bar` scans every line and returns the **widest glyph-run** — the real (wide) footer dominates any short inline bar. A lookahead requires ≥1 block glyph so an all-spaces `[   ]` never matches. A false read can no longer trigger a clear.
2. **Config.** `SessionContextConfig.auto_enabled` (master switch) + `policies` map (per-session overrides for councils/anchors); `CustomServiceConfig.context_policy`. `resolve_policy()` order: per-session config override → service-registry entry → `none` (invalid values fail safe to `none`).
3. **Act.** `act_on_session()` sends the policy command only when the session is **flagged AND idle at an empty Claude prompt** — reuses `prompt_router.prompt_is_empty` (which returns False for live dialogs, busy renders, half-typed drafts) plus parked/agent guards. Never `/clear`s mid-turn or a parked session. Audit log at `~/.agentwire/session-context-events.jsonl`.
4. **Hook point.** `session_context.tick()` is the 4th sweep on `agentwire limits tick` (after the inbox drain) — same 60s deterministic machinery as park/prompt/drain. Runs last so it never fights a pending paste for the same idle box.

### Verification
- **Unit:** 28 `test_session_context.py` tests (regex hardening, policy resolution, act/tick gating) + full suite **1463 passed, 8 skipped**. Ruff clean.
- **Live dry-run against dedicated throwaway sessions ONLY** (per the testing constraint — a prior worktree caused an incident here):
  - `resolve_policy` live: `agentwire-notifications → clear`, `ctx-probe`/`fragmentz → none`.
  - A real `/clear` fired on a throwaway **Claude** session (`ctx-probe-claude`): bar at 94% → `act_on_session(threshold=100)` → transcript wiped, context bar reset, input box empty. `acted=True`.
  - The gates refused a non-agent shell pane (`ctx-probe` → deferred `not_agent`).
  - The full live `tick()` was **deliberately never run** from the worktree (it would sweep real sessions); selectivity is unit-tested instead. The real notifications/fragmentz/etc. sessions were never touched. Throwaways killed; audit log shows only probe activity.

### Deploy note
The 4th sweep only runs once the watchdog picks up the new code (rebuild) and a session opts in. Default behavior change: `agentwire-notifications` becomes default-on `clear`.

Closes #442

Built by [dotdev.dev](https://dotdev.dev)
