### PR TITLE
feat(safety): gate unattended-relevant verbs at ask tier (#428)

### DIFF
--- a/agentwire/hooks/damage-control/rules/aws.yaml
+++ b/agentwire/hooks/damage-control/rules/aws.yaml
@@ -33,3 +33,21 @@ bashToolPatterns:
 
   - pattern: '\baws\s+iam\s+delete-user\b'
     reason: aws iam delete-user
+
+  # ---------------------------------------------------------------------------
+  # AWS DEPLOYS (ask: true — ship code/infra, caught in unattended sessions)
+  # ---------------------------------------------------------------------------
+  - pattern: '\baws\s+cloudformation\s+deploy\b'
+    reason: aws cloudformation deploy (ships an infrastructure change)
+    ask: true
+    id: deploy.aws-cloudformation
+
+  - pattern: '\baws\s+lambda\s+update-function-code\b'
+    reason: aws lambda update-function-code (ships new function code)
+    ask: true
+    id: deploy.aws-lambda-update
+
+  - pattern: '\baws\s+ecs\s+update-service\b'
+    reason: aws ecs update-service (ships an ECS deployment)
+    ask: true
+    id: deploy.aws-ecs-update

--- a/agentwire/hooks/damage-control/rules/cloud-hosting.yaml
+++ b/agentwire/hooks/damage-control/rules/cloud-hosting.yaml
@@ -85,3 +85,49 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bnpm\s+unpublish\b'
     reason: npm unpublish (removes package from registry)
+
+  # ---------------------------------------------------------------------------
+  # DEPLOYS (ask: true — outward-facing, caught in unattended sessions)
+  # ---------------------------------------------------------------------------
+  # A deploy ships code to production. The matching `remove`/`destroy` verbs are
+  # hard-blocked above; the deploy verbs themselves were previously `allow`-tier,
+  # so a scheduled agent could ship to prod silently. Classify them `ask`.
+  - pattern: '\bvercel\s+deploy\b'
+    reason: vercel deploy (ships a deployment)
+    ask: true
+    id: deploy.vercel
+
+  - pattern: '\bvercel\s+(-[^\s]*\s+)*--prod\b'
+    reason: vercel --prod (ships a production deployment)
+    ask: true
+    id: deploy.vercel-prod
+
+  - pattern: '\bnetlify\s+deploy\b'
+    reason: netlify deploy (ships a deployment)
+    ask: true
+    id: deploy.netlify
+
+  - pattern: '\b(fly|flyctl)\s+deploy\b'
+    reason: fly deploy (ships a Fly.io deployment)
+    ask: true
+    id: deploy.fly
+
+  - pattern: '\bwrangler\s+(deploy|publish)\b'
+    reason: wrangler deploy (ships a Cloudflare Worker)
+    ask: true
+    id: deploy.wrangler
+
+  - pattern: '\brailway\s+(up|deploy)\b'
+    reason: railway up (ships a Railway deployment)
+    ask: true
+    id: deploy.railway
+
+  - pattern: '\brender\s+deploys?\s+create\b'
+    reason: render deploys create (ships a Render deployment)
+    ask: true
+    id: deploy.render
+
+  - pattern: '\bsupabase\s+functions\s+deploy\b'
+    reason: supabase functions deploy (ships an edge function)
+    ask: true
+    id: deploy.supabase-functions

--- a/agentwire/hooks/damage-control/rules/containers.yaml
+++ b/agentwire/hooks/damage-control/rules/containers.yaml
@@ -34,3 +34,20 @@ bashToolPatterns:
 
   - pattern: '\bhelm\s+uninstall\b'
     reason: helm uninstall (removes release)
+
+  # ---------------------------------------------------------------------------
+  # CONTAINER REGISTRY PUBLISH / WORKLOAD DELETE (ask: true)
+  # ---------------------------------------------------------------------------
+  # `docker push` publishes an image (outward-facing) and a generic
+  # `kubectl delete <resource>` removes a workload. Previously `allow`-tier.
+  # The catastrophic kubectl deletes above are hard-blocked and listed first, so
+  # they still block; this generic ask only catches the narrower deletes.
+  - pattern: '\bdocker\s+(compose\s+)?push\b'
+    reason: docker push (publishes an image to a registry)
+    ask: true
+    id: container.docker-push
+
+  - pattern: '\bkubectl\s+delete\b'
+    reason: kubectl delete (removes a Kubernetes resource)
+    ask: true
+    id: container.kubectl-delete

--- a/agentwire/hooks/damage-control/rules/databases.yaml
+++ b/agentwire/hooks/damage-control/rules/databases.yaml
@@ -23,6 +23,15 @@ bashToolPatterns:
   - pattern: '\bmysqladmin\s+drop\b'
     reason: MySQL drop database
 
+  # Migration tools that DROP/recreate the schema (data loss) — hard block.
+  - pattern: '\bprisma\s+migrate\s+reset\b'
+    reason: prisma migrate reset (drops the database and re-applies migrations)
+    id: db.prisma-reset
+
+  - pattern: '\bflyway\s+clean\b'
+    reason: flyway clean (drops all objects in the schema)
+    id: db.flyway-clean
+
   # ---------------------------------------------------------------------------
   # SQL DESTRUCTIVE OPERATIONS (catastrophic - no WHERE clause)
   # ---------------------------------------------------------------------------
@@ -50,3 +59,89 @@ bashToolPatterns:
   - pattern: '\bDELETE\s+FROM\s+\w+\s+WHERE\b.*\bid\s*='
     reason: SQL DELETE with specific ID
     ask: true
+
+  # ---------------------------------------------------------------------------
+  # SCHEMA MIGRATIONS (ask: true — apply DDL/DML to a database)
+  # ---------------------------------------------------------------------------
+  # A migration mutates a real database and is rarely cleanly reversible. These
+  # were previously `allow`-tier, so a scheduled agent could migrate prod
+  # silently. Classify them `ask`. The schema-dropping variants (prisma migrate
+  # reset, flyway clean) are hard-blocked above. `\b` before each tool name lets
+  # the pattern match through `npx`/`python -m`/`bundle exec` prefixes.
+  - pattern: '\bprisma\s+migrate\s+(deploy|dev)\b'
+    reason: prisma migrate (applies database migrations)
+    ask: true
+    id: db.prisma-migrate
+
+  - pattern: '\bprisma\s+db\s+push\b'
+    reason: prisma db push (pushes schema changes to the database)
+    ask: true
+    id: db.prisma-db-push
+
+  - pattern: '\bsupabase\s+db\s+push\b'
+    reason: supabase db push (applies local migrations to the linked database)
+    ask: true
+    id: db.supabase-db-push
+
+  - pattern: '\bsupabase\s+migration\s+up\b'
+    reason: supabase migration up (applies pending migrations)
+    ask: true
+    id: db.supabase-migration-up
+
+  - pattern: '\balembic\s+(upgrade|downgrade)\b'
+    reason: alembic upgrade/downgrade (applies/reverts SQLAlchemy migrations)
+    ask: true
+    id: db.alembic
+
+  - pattern: '\bmanage\.py\s+migrate\b'
+    reason: Django manage.py migrate (applies database migrations)
+    ask: true
+    id: db.django-migrate
+
+  - pattern: '\b(rails|rake)\s+db:migrate\b'
+    reason: rails db:migrate (applies ActiveRecord migrations)
+    ask: true
+    id: db.rails-migrate
+
+  - pattern: '\bknex\s+migrate:(latest|up|down|rollback)\b'
+    reason: knex migrate (applies/reverts Knex migrations)
+    ask: true
+    id: db.knex-migrate
+
+  - pattern: '\bsequelize\s+db:migrate\b'
+    reason: sequelize db:migrate (applies Sequelize migrations)
+    ask: true
+    id: db.sequelize-migrate
+
+  - pattern: '\bflyway\s+migrate\b'
+    reason: flyway migrate (applies pending migrations)
+    ask: true
+    id: db.flyway-migrate
+
+  - pattern: '\bliquibase\s+update\b'
+    reason: liquibase update (applies pending changesets)
+    ask: true
+    id: db.liquibase-update
+
+  # ---------------------------------------------------------------------------
+  # RAW DML / DDL VIA DB CLIENTS (ask: true)
+  # ---------------------------------------------------------------------------
+  # Catastrophic statements (DROP/TRUNCATE/DELETE-without-WHERE) are hard-blocked
+  # above regardless of client. These catch the remaining write statements only
+  # when an actual DB client is on the command line, so SELECT-only queries stay
+  # `allow`-tier. File-fed scripts (psql -f, mysql < file) can't be introspected
+  # by a regex and remain a residual gap — see the wiki coverage matrix.
+  - pattern: '\bpsql\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
+    reason: psql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
+    ask: true
+    id: db.psql-write
+
+  - pattern: '\b(mysql|mariadb)\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
+    reason: mysql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
+    ask: true
+    id: db.mysql-write
+
+  - pattern: '\bmongosh?\b.*\.(insertOne|insertMany|updateOne|updateMany|deleteOne|deleteMany|replaceOne|bulkWrite)\b'
+    reason: mongosh executing a write operation (insert/update/delete)
+    ask: true
+    id: db.mongosh-write

--- a/agentwire/hooks/damage-control/rules/gcp.yaml
+++ b/agentwire/hooks/damage-control/rules/gcp.yaml
@@ -24,3 +24,18 @@ bashToolPatterns:
 
   - pattern: '\bgcloud\s+iam\s+service-accounts\s+delete\b'
     reason: gcloud iam service-accounts delete
+
+  # ---------------------------------------------------------------------------
+  # GCP DEPLOYS (ask: true — outward-facing, caught in unattended sessions)
+  # ---------------------------------------------------------------------------
+  # `gcloud functions deploy` is already ask-tier via the gcp tooldef; these
+  # cover the other deploy surfaces (Cloud Run, App Engine).
+  - pattern: '\bgcloud\s+run\s+deploy\b'
+    reason: gcloud run deploy (ships a Cloud Run service)
+    ask: true
+    id: deploy.gcloud-run
+
+  - pattern: '\bgcloud\s+app\s+deploy\b'
+    reason: gcloud app deploy (ships an App Engine version)
+    ask: true
+    id: deploy.gcloud-app

--- a/agentwire/hooks/damage-control/rules/infrastructure.yaml
+++ b/agentwire/hooks/damage-control/rules/infrastructure.yaml
@@ -19,3 +19,33 @@ bashToolPatterns:
 
   - pattern: '\bsam\s+delete\b'
     reason: sam delete (deletes SAM application)
+
+  # ---------------------------------------------------------------------------
+  # IaC DEPLOYS (ask: true — provision/ship infra, caught in unattended sessions)
+  # ---------------------------------------------------------------------------
+  # `terraform apply` is already ask-tier via the terraform tooldef; these cover
+  # the other IaC apply verbs that were previously `allow`-tier.
+  - pattern: '\bpulumi\s+up\b'
+    reason: pulumi up (provisions/updates infrastructure)
+    ask: true
+    id: deploy.pulumi-up
+
+  - pattern: '\b(serverless|sls)\s+deploy\b'
+    reason: serverless deploy (ships a Serverless Framework stack)
+    ask: true
+    id: deploy.serverless
+
+  - pattern: '\bsam\s+deploy\b'
+    reason: sam deploy (ships an AWS SAM application)
+    ask: true
+    id: deploy.sam
+
+  - pattern: '\bcdk\s+deploy\b'
+    reason: cdk deploy (ships an AWS CDK stack)
+    ask: true
+    id: deploy.cdk
+
+  - pattern: '\bansible-playbook\b'
+    reason: ansible-playbook (applies configuration to remote hosts)
+    ask: true
+    id: deploy.ansible

--- a/agentwire/hooks/damage-control/rules/outbound.yaml
+++ b/agentwire/hooks/damage-control/rules/outbound.yaml
@@ -1,0 +1,62 @@
+# Outbound communication damage control rules
+#
+# Outward-facing "send" verbs — email, SMS, push. These are irreversible (you
+# can't un-send) and reach real people, so they must NOT sail through an
+# UNATTENDED (scheduler) session silently. They're classified `ask: true`:
+#   - interactive bypass/auto session  → allow (no friction, the common case)
+#   - interactive non-bypass session   → confirm prompt
+#   - UNATTENDED (AGENTWIRE_UNATTENDED) → fail closed: block + email owner,
+#     unless the rule id is on the task's `unattended_allow`.
+#
+# Caveat: agents inside agentwire sessions usually send via MCP tools
+# (`email_send`, `quo_send`) which do NOT pass through this Bash hook. These
+# patterns cover the case where an agent (or a scheduled task's `post:` step)
+# shells out to the CLI. See docs/wiki/internals/damage-control.md.
+
+bashToolPatterns:
+  # ---------------------------------------------------------------------------
+  # AGENTWIRE OUTBOUND CHANNELS (external — email via Resend, SMS via Quo)
+  # ---------------------------------------------------------------------------
+  - pattern: '\bagentwire\s+email\b'
+    reason: agentwire email (sends an external email via Resend)
+    ask: true
+    id: outbound.agentwire-email
+
+  - pattern: '\bagentwire\s+quo\b'
+    reason: agentwire quo (sends an external SMS via Quo/OpenPhone)
+    ask: true
+    id: outbound.agentwire-quo
+
+  # ---------------------------------------------------------------------------
+  # TWILIO (SMS / messaging)
+  # ---------------------------------------------------------------------------
+  - pattern: '\btwilio\s+api[:\w.]*messages[:\w.]*create\b'
+    reason: twilio messages create (sends an SMS/MMS)
+    ask: true
+    id: outbound.twilio-messages
+
+  # ---------------------------------------------------------------------------
+  # AWS messaging (SES email, SNS publish)
+  # ---------------------------------------------------------------------------
+  - pattern: '\baws\s+ses(v2)?\s+send-email\b'
+    reason: aws ses send-email (sends an external email)
+    ask: true
+    id: outbound.aws-ses
+
+  - pattern: '\baws\s+sns\s+publish\b'
+    reason: aws sns publish (sends an SMS/notification)
+    ask: true
+    id: outbound.aws-sns
+
+  # ---------------------------------------------------------------------------
+  # GENERIC MAIL TRANSPORTS
+  # ---------------------------------------------------------------------------
+  - pattern: '\bsendmail\b'
+    reason: sendmail (sends external email)
+    ask: true
+    id: outbound.sendmail
+
+  - pattern: '\b(mail|mailx)\s+(-[^\s]*\s+)*-s\b'
+    reason: mail -s (sends external email)
+    ask: true
+    id: outbound.mail

--- a/agentwire/hooks/damage-control/rules/publish.yaml
+++ b/agentwire/hooks/damage-control/rules/publish.yaml
@@ -1,0 +1,40 @@
+# Package publish damage control rules
+#
+# Publishing to a public registry is irreversible and outward-facing (downstream
+# users pull what you push), so it must be caught in UNATTENDED sessions. All
+# `ask: true` — see outbound.yaml for how `ask` resolves per session mode.
+#
+# Note: `npm publish` and `uv publish` are already `ask`-tier via the write-access
+# tooldef commands (agentwire/tooldefs/{npm,uv}.yaml). These rules cover the
+# registries that have no tooldef.
+
+bashToolPatterns:
+  - pattern: '\bcargo\s+publish\b'
+    reason: cargo publish (publishes a crate to crates.io)
+    ask: true
+    id: publish.cargo
+
+  - pattern: '\bpoetry\s+publish\b'
+    reason: poetry publish (publishes a package to PyPI)
+    ask: true
+    id: publish.poetry
+
+  - pattern: '\btwine\s+upload\b'
+    reason: twine upload (publishes a package to PyPI)
+    ask: true
+    id: publish.twine
+
+  - pattern: '\b(pnpm|yarn)\s+publish\b'
+    reason: pnpm/yarn publish (publishes a package to npm registry)
+    ask: true
+    id: publish.pnpm-yarn
+
+  - pattern: '\bgem\s+push\b'
+    reason: gem push (publishes a gem to RubyGems)
+    ask: true
+    id: publish.gem
+
+  - pattern: '\bmvn\s+(deploy|.*\bdeploy:deploy)\b'
+    reason: mvn deploy (publishes artifacts to a Maven repository)
+    ask: true
+    id: publish.maven

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -54,10 +54,12 @@ agentwire/hooks/damage-control/       # Bundled in package
 └── rules/                            # Pattern files (categorized)
     ├── core.yaml                     # rm, chmod, system-level dangers
     ├── git.yaml                      # force push, reset --hard
-    ├── databases.yaml                # DROP, TRUNCATE
-    ├── containers.yaml               # docker prune, etc.
-    ├── cloud-hosting.yaml, aws.yaml, gcp.yaml, firebase.yaml
+    ├── databases.yaml                # DROP, TRUNCATE, migrations, raw DML
+    ├── containers.yaml               # docker prune/push, kubectl delete
+    ├── cloud-hosting.yaml, aws.yaml, gcp.yaml, firebase.yaml  # incl. deploys
     ├── infrastructure.yaml, remote.yaml
+    ├── outbound.yaml                 # email/SMS send verbs (ask)
+    ├── publish.yaml                  # package-registry publish (ask)
     ├── agentwire.yaml                # tmux/session protections
     └── gws.yaml                      # Google Workspace CLI
 
@@ -75,7 +77,7 @@ Hooks load every `*.yaml` file in the rules directory and merge their pattern li
 
 ## Security Patterns
 
-Patterns live in **categorized YAML files** under `agentwire/hooks/damage-control/rules/` (12 files, one per topic). To override or extend, drop YAML files into `~/.agentwire/damage-control/` — when that directory exists with `*.yaml` files, hooks load from there instead of the bundled rules.
+Patterns live in **categorized YAML files** under `agentwire/hooks/damage-control/rules/` (14 files, one per topic). To override or extend, drop YAML files into `~/.agentwire/damage-control/` — when that directory exists with `*.yaml` files, hooks load from there instead of the bundled rules.
 
 ### Pattern Types
 
@@ -251,10 +253,68 @@ tasks:
 ```
 
 > **Coverage note:** the guardrail makes the `ask` tier fail closed. A
-> destructive command that isn't classified as `ask`/`block` at all (e.g. some
-> cloud-deploy or outbound-email verbs not yet in the rules) is unaffected and
-> remains a separate rules-coverage task — the moment such a verb is classified
-> `ask`, this guardrail blocks it unattended for free.
+> destructive command that isn't classified as `ask`/`block` at all is
+> unaffected and would sail through unattended. The moment such a verb is
+> classified `ask`, this guardrail blocks it unattended for free. The matrix
+> below (the #428 audit) is the record of which high-impact verbs are covered.
+
+### Unattended verb-coverage matrix (#428)
+
+The guardrail is only as strong as the tier assignments for the verbs we most
+want stopped headless. Two mechanisms classify a verb as `ask`:
+
+- **rule** — an `ask: true` `bashToolPattern` in `rules/*.yaml`
+- **tooldef** — an `access: write` command in `tooldefs/*.yaml`, auto-promoted
+  to an `ask` pattern at load time
+
+Both land in the same `ask` tier, so both are caught unattended. `ask` resolves
+per session mode: interactive **bypass/auto** → allow (no friction, the common
+agentwire posture); interactive **non-bypass** → confirm prompt; **unattended**
+→ block + email owner (unless the rule id is allowlisted). Genuinely
+catastrophic, never-reversible verbs are `block` (fire in every mode).
+
+| Verb class | Representative commands | Tier | Where |
+|---|---|---|---|
+| **Deploy — hosting** | `vercel deploy` / `--prod`, `netlify deploy`, `fly deploy`, `wrangler deploy`/`publish`, `railway up`, `render deploys create`, `supabase functions deploy` | ask | `cloud-hosting.yaml` (`deploy.*`) |
+| **Deploy — cloud** | `gcloud run deploy`, `gcloud app deploy` | ask | `gcp.yaml` (`deploy.gcloud-*`) |
+| | `gcloud functions deploy` | ask | gcp tooldef |
+| | `aws cloudformation deploy`, `aws lambda update-function-code`, `aws ecs update-service` | ask | `aws.yaml` (`deploy.aws-*`) |
+| **Deploy — IaC** | `terraform apply` | ask | terraform tooldef |
+| | `pulumi up`, `serverless`/`sls deploy`, `sam deploy`, `cdk deploy`, `ansible-playbook` | ask | `infrastructure.yaml` (`deploy.*`) |
+| **Deploy — containers** | `kubectl apply` | ask | kubectl tooldef |
+| | `docker push`, `docker compose push` | ask | `containers.yaml` (`container.docker-push`) |
+| **Deploy — CI/release** | `gh release create`, `gh workflow run`, `gh pr merge` | ask | gh tooldef |
+| **Outbound comms** | `agentwire email`, `agentwire quo`, `twilio … messages create`, `aws ses send-email`, `aws sns publish`, `sendmail`, `mail -s` | ask | `outbound.yaml` (`outbound.*`) |
+| **DB migrations** | `prisma migrate deploy`/`dev`, `prisma db push`, `supabase db push`, `supabase migration up`, `alembic upgrade`/`downgrade`, `manage.py migrate`, `rails`/`rake db:migrate`, `knex migrate:*`, `sequelize db:migrate`, `flyway migrate`, `liquibase update` | ask | `databases.yaml` (`db.*`) |
+| **DB raw writes** | `psql`/`mysql` executing INSERT/UPDATE/ALTER/CREATE/GRANT, `mongosh` insert/update/delete | ask | `databases.yaml` (`db.psql-write`, `db.mysql-write`, `db.mongosh-write`) |
+| **DB schema-drop** | `prisma migrate reset`, `flyway clean` | **block** | `databases.yaml` (`db.prisma-reset`, `db.flyway-clean`) |
+| **Package publish** | `npm publish`, `uv publish` | ask | npm/uv tooldef |
+| | `cargo`/`poetry`/`pnpm`/`yarn publish`, `twine upload`, `gem push`, `mvn deploy` | ask | `publish.yaml` (`publish.*`) |
+| **Destroy / drop** | `vercel remove`, `gh repo delete`, `terraform destroy`, `DROP DATABASE`, `aws … delete-*`, `git push --force`, `rm -rf` | **block** | various |
+
+**Allowlisting a covered verb for one task** — the block message and owner email
+name the exact rule id, so widening is copy-paste into the task's
+`unattended_allow` (e.g. `deploy.vercel`, `outbound.agentwire-email`,
+`db.prisma-migrate`).
+
+**Residual gaps (intentional / known):**
+
+- **MCP send paths bypass the hook.** Agents in agentwire sessions usually send
+  via MCP tools (`email_send`, `quo_send`), which are *not* Bash/Edit/Write and
+  so never reach this hook. The `outbound.*` rules only catch a shell-out to the
+  CLI. Closing the MCP path needs a guard at the MCP layer, not a rule — out of
+  scope here.
+- **File-fed SQL can't be introspected.** `psql -f migration.sql` /
+  `mysql < dump.sql` carry their statements in a file the regex can't read, so
+  they stay `allow` unless the file path trips a path rule. Catastrophic inline
+  statements (`DROP`/`TRUNCATE`/`DELETE`-without-`WHERE`) are still blocked by
+  the client-agnostic SQL patterns.
+- **Bare implicit-deploy invocations.** `vercel` with no subcommand deploys to
+  preview; matching a bare binary name would false-positive on every read
+  subcommand, so only the explicit `vercel deploy` / `--prod` forms are gated.
+- **Text matching is conservative.** A literal mention inside `echo`/a comment
+  can trip an `ask` (errs safe). This is the same tradeoff every existing rule
+  carries (`DROP DATABASE` in an `echo` also blocks).
 
 ---
 

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -327,6 +327,93 @@ class TestUnattendedSubprocess:
 
 
 # ---------------------------------------------------------------------------
+# Unattended-relevant verb coverage (#428)
+# ---------------------------------------------------------------------------
+#
+# The unattended guardrail only catches the `ask` tier. A high-impact verb left
+# at `allow` (deploy / outbound / DB migration / publish) would sail through a
+# headless scheduler session silently. These tests assert each such verb is at
+# least `ask` (so the guardrail fails it closed unattended) while benign
+# read-only variants stay `allow` (so interactive mode isn't over-blocked).
+
+# Bundled rules + tooldefs evaluated through the real decision ladder.
+_DC_ROOT = Path(__file__).resolve().parent.parent.parent / "agentwire"
+_DC_RULES = _DC_ROOT / "hooks" / "damage-control" / "rules"
+_DC_TOOLDEFS = _DC_ROOT / "tooldefs"
+
+
+@pytest.fixture(scope="module")
+def bundled_config(bash_hook):
+    cfg = bash_hook.load_config(_DC_RULES, _DC_TOOLDEFS)
+    cfg["safety"] = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
+    return cfg
+
+
+class TestUnattendedVerbCoverage:
+    # Verbs that MUST be at least `ask` so the unattended guardrail catches them.
+    ASK_OR_BLOCK = [
+        # deploys
+        "vercel deploy --prod", "vercel --prod", "netlify deploy", "fly deploy",
+        "flyctl deploy", "wrangler deploy", "wrangler publish", "railway up",
+        "supabase functions deploy fn", "gcloud run deploy svc",
+        "gcloud app deploy", "gcloud functions deploy fn", "terraform apply",
+        "pulumi up", "serverless deploy", "sls deploy", "sam deploy",
+        "cdk deploy", "ansible-playbook site.yml",
+        "aws cloudformation deploy --stack-name s",
+        "aws lambda update-function-code --function-name f",
+        "aws ecs update-service --service s", "docker push reg/img",
+        "docker compose push", "kubectl apply -f x.yaml",
+        "gh release create v1", "gh workflow run deploy.yml",
+        # outbound comms
+        "agentwire email --to a@b.com", "agentwire quo --to +1 --body hi",
+        "twilio api:core:messages:create --to +1",
+        "aws ses send-email --to a@b.com", "aws sesv2 send-email --to a@b.com",
+        "aws sns publish --message hi", "sendmail a@b.com", "mail -s subj a@b.com",
+        # db migrations / writes
+        "prisma migrate deploy", "npx prisma migrate deploy", "prisma migrate dev",
+        "prisma db push", "supabase db push", "supabase migration up",
+        "alembic upgrade head", "alembic downgrade -1", "python manage.py migrate",
+        "rails db:migrate", "bundle exec rake db:migrate", "knex migrate:latest",
+        "npx sequelize db:migrate", "flyway migrate", "liquibase update",
+        'psql -c "UPDATE users SET x=1 WHERE id=2"',
+        'psql -c "INSERT INTO t VALUES (1)"',
+        'mysql -e "ALTER TABLE t ADD COLUMN c int"',
+        'mongosh --eval "db.t.updateMany({},{})"',
+        # package publish
+        "npm publish", "uv publish", "cargo publish", "poetry publish",
+        "twine upload dist/*", "pnpm publish", "yarn publish", "gem push g.gem",
+        "mvn deploy",
+    ]
+
+    # Schema-dropping migration variants must hard-block (data loss).
+    HARD_BLOCK = [
+        "prisma migrate reset --force",
+        "flyway clean",
+    ]
+
+    # Benign read-only variants must stay `allow` (no interactive over-blocking).
+    STAYS_ALLOW = [
+        "vercel ls", "git status", "kubectl get pods", "gh pr view 5",
+        'psql -c "SELECT * FROM users WHERE id = 1"',
+        'psql -c "SELECT update_time FROM updates"',
+        "mysql -e 'SELECT 1'",
+    ]
+
+    @pytest.mark.parametrize("cmd", ASK_OR_BLOCK)
+    def test_high_impact_verb_is_gated(self, bash_hook, bundled_config, cmd):
+        decision = bash_hook.check_command(cmd, bundled_config)["decision"]
+        assert decision in ("ask", "block"), f"{cmd!r} resolved to {decision}"
+
+    @pytest.mark.parametrize("cmd", HARD_BLOCK)
+    def test_destructive_migration_hard_blocks(self, bash_hook, bundled_config, cmd):
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    @pytest.mark.parametrize("cmd", STAYS_ALLOW)
+    def test_benign_variant_stays_allow(self, bash_hook, bundled_config, cmd):
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
 # edit-tool-damage-control.py & write-tool-damage-control.py
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Audits and closes the damage-control rule-coverage gaps for high-impact verbs that the #401 unattended guardrail must catch. The guardrail only fails-closed the **`ask`** tier — a destructive verb left at `allow` sailed straight through a headless scheduler session. This promotes the missing verb classes to `ask`.

## Why `ask` (and why it doesn't over-block interactive)

`ask` resolves per session mode:
- **interactive bypass/auto** (the common agentwire posture) → **allow** — no friction
- **interactive non-bypass** → confirm prompt
- **unattended** (`AGENTWIRE_UNATTENDED=1`) → **block + email owner**, unless the rule id is on the task's `unattended_allow`

Genuinely never-reversible verbs stay hard-`block`.

## Coverage added

| Class | Verbs promoted to `ask` | Where |
|---|---|---|
| Deploy (hosting) | vercel/netlify/fly/wrangler/railway/render/supabase-functions | `cloud-hosting.yaml` |
| Deploy (cloud) | gcloud run/app, aws cloudformation/lambda/ecs | `gcp.yaml`, `aws.yaml` |
| Deploy (IaC) | pulumi up, serverless/sls/sam/cdk deploy, ansible-playbook | `infrastructure.yaml` |
| Deploy (containers) | docker push, docker compose push | `containers.yaml` |
| Outbound comms | agentwire email/quo, twilio, aws ses/sns, sendmail, mail | **new** `outbound.yaml` |
| DB migrations | prisma/supabase/alembic/django/rails/knex/sequelize/flyway/liquibase | `databases.yaml` |
| DB raw writes | psql/mysql INSERT/UPDATE/ALTER/CREATE/GRANT, mongosh writes | `databases.yaml` |
| Package publish | cargo/poetry/pnpm/yarn/gem/twine/mvn | **new** `publish.yaml` |

`terraform apply`, `kubectl apply`, `gcloud functions deploy`, `gh release/workflow`, `npm publish`, `uv publish` were already `ask` via `access: write` tooldefs — verified, not duplicated.

**Schema-drop variants hard-block:** `prisma migrate reset`, `flyway clean`.

All new rules carry stable ids (`deploy.*`, `outbound.*`, `db.*`, `publish.*`, `container.*`) so the block message / owner email name the exact id for copy-paste into `unattended_allow`.

## Not code, no regen

Rules are runtime-loaded YAML — no `_core.py` change, so no hook regen needed (`test_damage_control_sync` still green).

## Residual gaps (documented in the wiki matrix)

- **MCP send paths bypass the hook** — `email_send`/`quo_send` MCP tools aren't Bash/Edit/Write; `outbound.*` only catches CLI shell-outs. Needs an MCP-layer guard, out of scope here.
- **File-fed SQL** (`psql -f`, `mysql < file`) can't be regex-introspected; inline catastrophic statements still block.
- **Bare `vercel`** (implicit deploy) not gated — would false-positive every read subcommand.

## Verification

- New matrix harness: 79 commands across every verb class land in the expected tier.
- End-to-end hook subprocess confirmed: unattended → exit 2 + notify + named id; allowlisted id → exit 0; interactive bypass → exit 0; catastrophic → exit 2 in all modes.
- Regression tests added (`TestUnattendedVerbCoverage`). Full safety suite: **235 passed**.

Closes #428

Built by [dotdev.dev](https://dotdev.dev)