### PR TITLE
Portal auth hardening: per-device credentials + frozen config (#423, #425)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -74,8 +74,13 @@ agentwire portal start          # start in tmux
 agentwire portal stop           # stop portal
 agentwire portal restart        # stop + start
 agentwire portal status         # check health
-agentwire portal token          # print the auth token (devices enter it once)
-agentwire portal token --rotate # generate a new token (re-enter on devices)
+agentwire portal token          # print the bootstrap auth token (host/CLI/MCP credential)
+agentwire portal token --rotate # generate a new bootstrap token (re-enter on devices)
+
+# Per-device credentials (#423) — pair a device for its OWN revocable token
+agentwire portal pair [--name phone]   # print a short-lived pairing code + QR → /pair?code=
+agentwire portal devices [--json]      # list paired devices (id, name, last-seen, status)
+agentwire portal revoke <id>           # revoke ONE device (others keep working)
 
 # Scratch pad (shared notes — portal drawer Alt+N; file: ~/.agentwire/scratchpad.json)
 agentwire scratchpad list       # list notes (newest first)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -820,9 +820,6 @@ def _start_portal_local(args, attach: bool = True) -> int:
     When attach is False (used by `agentwire up`), the portal is started
     detached and we return without attaching.
     """
-    from .network import NetworkContext
-    from .tunnels import TunnelManager
-
     session_name = get_portal_session_name()
 
     if tmux_session_exists(session_name):
@@ -832,31 +829,10 @@ def _start_portal_local(args, attach: bool = True) -> int:
             subprocess.run(["tmux", "attach-session", "-t", session_name])
         return 0
 
-    # Ensure required tunnels are up before starting portal
-    ctx = NetworkContext.from_config()
-    required_tunnels = ctx.get_required_tunnels()
-
-    if required_tunnels:
-        print("Ensuring tunnels to remote services...")
-        tm = TunnelManager()
-
-        for spec in required_tunnels:
-            status = tm.check_tunnel(spec)
-
-            if status.status == "up":
-                print(f"  [ok] {spec.remote_machine}:{spec.remote_port} (already up)")
-            else:
-                print(f"  [..] Creating tunnel to {spec.remote_machine}:{spec.remote_port}...", end=" ", flush=True)
-                result = tm.create_tunnel(spec, ctx)
-
-                if result.status == "up":
-                    print("[ok]")
-                else:
-                    print("[!!]")
-                    print(f"      Warning: Could not create tunnel: {result.error}")
-                    print(f"      The portal may not be able to reach {spec.remote_machine}.")
-
-        print()
+    # No tunnel auto-spawn (#420): agentwire owns only the local portal
+    # boundary. Reaching the portal from elsewhere is bring-your-own
+    # (cloudflared/tailscale/ssh -L), and `agentwire tunnels *` remains as an
+    # opt-in manual helper for the vestigial remote-service-split case.
 
     # Build the server command
     # --dev runs from source with uv run (picks up code changes immediately)
@@ -1222,6 +1198,80 @@ def cmd_portal_token(args) -> int:
     if override:
         print("(from server.auth_token override in config.yaml)", file=sys.stderr)
     return 0
+
+
+def cmd_portal_pair(args) -> int:
+    """Create a short-lived pairing code (+ QR) for a new device."""
+    from .devices import PAIRING_TTL_SECONDS, create_pairing
+
+    pairing = create_pairing(name=getattr(args, "name", None) or "device")
+
+    portal_url = _default_portal_url()
+    pair_url = f"{portal_url}/pair?code={pairing.code}"
+    ttl_min = PAIRING_TTL_SECONDS // 60
+
+    print(f"Pairing code: {pairing.code}")
+    print(f"  Name:  {pairing.name}")
+    print(f"  Expires in {ttl_min} minutes.")
+    print()
+    print("On the device, open:")
+    print(f"  {pair_url}")
+    print("or visit", f"{portal_url}/pair", "and enter the code.")
+    print()
+
+    try:
+        import qrcode  # type: ignore
+
+        qr = qrcode.QRCode(border=1)
+        qr.add_data(pair_url)
+        qr.make()
+        qr.print_ascii(invert=True)
+    except Exception:
+        print("(install `qrcode` to render a scannable QR here)")
+
+    return 0
+
+
+def cmd_portal_devices(args) -> int:
+    """List paired portal devices."""
+    from .devices import DeviceRegistry
+
+    registry = DeviceRegistry.load()
+    json_mode = getattr(args, "json", False)
+
+    if json_mode:
+        _output_json({"success": True, "devices": [d.public() for d in registry.devices]})
+        return 0
+
+    if not registry.devices:
+        print("No paired devices. The host bootstrap token (agentwire portal token)")
+        print("is the only credential. Add one with: agentwire portal pair")
+        return 0
+
+    print(f"{'ID':<14}{'NAME':<24}{'LAST SEEN':<22}STATUS")
+    for d in registry.devices:
+        status = "revoked" if d.revoked else "active"
+        print(
+            f"{d.id:<14}{(d.name or '')[:23]:<24}"
+            f"{(d.last_seen or 'never'):<22}{status}"
+        )
+    return 0
+
+
+def cmd_portal_revoke(args) -> int:
+    """Revoke one paired device without affecting the others."""
+    from .devices import DeviceRegistry
+
+    registry = DeviceRegistry.load()
+    if registry.revoke(args.device_id):
+        print(f"Revoked device '{args.device_id}'. It now gets 401 on every route.")
+        return 0
+    print(
+        f"No active device with id '{args.device_id}'. "
+        "List them with: agentwire portal devices",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_portal_restart(args) -> int:
@@ -6248,8 +6298,11 @@ def cmd_machine_add(args) -> int:
     print()
     print("Next steps:")
     print("  1. Ensure SSH access: ssh", f"{user}@{host}" if user else host)
-    print("  2. Start tunnel: autossh -M 0 -f -N -R 8765:localhost:8765", machine_id)
-    print("  3. Restart portal: agentwire portal stop && agentwire portal start")
+    print("  2. Restart portal: agentwire portal stop && agentwire portal start")
+    print()
+    print("Remote session management uses plain SSH — no tunnel needed. To reach")
+    print("the portal from another network, bring your own tunnel (cloudflared/")
+    print("tailscale); see docs/wiki/deployment/remote-access.md.")
     print()
     print("For full setup guide, run: /machine-setup in a Claude session")
 
@@ -6287,28 +6340,6 @@ def cmd_machine_remove(args) -> int:
     print(f"Removing machine '{machine_id}' (host: {host})...")
     print()
 
-    # Step 2: Kill autossh tunnel
-    print("Stopping tunnel...")
-    result = subprocess.run(
-        ["pkill", "-f", f"autossh.*{machine_id}"],
-        capture_output=True,
-    )
-    if result.returncode == 0:
-        print(f"  ✓ Killed autossh tunnel for {machine_id}")
-    else:
-        # Also try by host if different from id
-        if host != machine_id:
-            result = subprocess.run(
-                ["pkill", "-f", f"autossh.*{host}"],
-                capture_output=True,
-            )
-            if result.returncode == 0:
-                print(f"  ✓ Killed autossh tunnel for {host}")
-            else:
-                print("  - No tunnel running (or already stopped)")
-        else:
-            print("  - No tunnel running (or already stopped)")
-
     # Step 3: Remove from machines.json
     print("Updating machines.json...")
     machines_data["machines"] = [m for m in machines if m.get("id") != machine_id]
@@ -6326,21 +6357,17 @@ def cmd_machine_remove(args) -> int:
     print("1. Remove SSH config entry:")
     print(f"   Edit ~/.ssh/config and remove the 'Host {machine_id}' block")
     print()
-    print("2. Remove from tunnel startup script (if using):")
-    print("   Edit ~/.local/bin/agentwire-tunnels")
-    print(f"   Remove '{machine_id}' from the MACHINES list")
-    print()
-    print("3. Delete GitHub deploy keys:")
+    print("2. Delete GitHub deploy keys:")
     print("   gh repo deploy-key list --repo <user>/<repo>")
     print(f"   # Find keys titled '{machine_id}' and delete them:")
     print("   gh repo deploy-key delete <key-id> --repo <user>/<repo>")
     print()
-    print("4. Destroy remote machine:")
+    print("3. Destroy remote machine:")
     print("   Option A: Delete user only")
     print("     ssh root@<ip> 'pkill -u agentwire; userdel -r agentwire'")
     print("   Option B: Destroy the VM entirely via provider console")
     print()
-    print("5. Restart portal to pick up changes:")
+    print("4. Restart portal to pick up changes:")
     print("   agentwire portal stop && agentwire portal start")
     print()
 
@@ -10928,6 +10955,27 @@ def main() -> int:
         "--rotate", action="store_true", help="Generate and save a new token"
     )
     portal_token.set_defaults(func=cmd_portal_token)
+
+    # portal pair — mint a pairing code (+QR) for a new device
+    portal_pair = portal_subparsers.add_parser(
+        "pair", help="Pair a new device (prints a short-lived code + QR)"
+    )
+    portal_pair.add_argument("--name", help="Friendly device name (e.g. 'phone')")
+    portal_pair.set_defaults(func=cmd_portal_pair)
+
+    # portal devices — list paired devices
+    portal_devices = portal_subparsers.add_parser(
+        "devices", help="List paired portal devices"
+    )
+    portal_devices.add_argument("--json", action="store_true", help="Output JSON")
+    portal_devices.set_defaults(func=cmd_portal_devices)
+
+    # portal revoke — revoke one device
+    portal_revoke = portal_subparsers.add_parser(
+        "revoke", help="Revoke one paired device by id"
+    )
+    portal_revoke.add_argument("device_id", help="Device id (see `portal devices`)")
+    portal_revoke.set_defaults(func=cmd_portal_revoke)
 
     # === tts command group ===
     tts_parser = subparsers.add_parser("tts", help="Manage TTS server")

--- a/agentwire/devices.py
+++ b/agentwire/devices.py
@@ -27,14 +27,23 @@ phone no longer logs out the laptop.
 
 from __future__ import annotations
 
+import calendar
 import hashlib
 import hmac
 import json
+import os
 import secrets
+import tempfile
 import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
+
+try:
+    import fcntl  # POSIX only — agentwire targets macOS/Linux.
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    fcntl = None
 
 DEVICES_FILE = Path.home() / ".agentwire" / "devices.json"
 PAIRINGS_FILE = Path.home() / ".agentwire" / "pairings.json"
@@ -76,6 +85,61 @@ def _iso(ts: Optional[float] = None) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts if ts is not None else _now()))
 
 
+def _parse_iso(value: Optional[str]) -> float:
+    """Parse a stored UTC ISO stamp back to epoch seconds (0 on failure)."""
+    try:
+        return calendar.timegm(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ"))
+    except (ValueError, TypeError):
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Concurrency-safe persistence
+#
+# Both files (devices.json, pairings.json) are shared across processes — the
+# portal serves auth on every request while the CLI revokes/pairs out of band.
+# Every read-modify-write therefore runs under an exclusive flock on a sibling
+# ``.lock`` file (a dedicated lock target, so the atomic os.replace below never
+# swaps the inode we're holding), and writes go through a temp-file + rename so
+# a reader never sees a half-written file.
+
+
+@contextmanager
+def _file_lock(path: Path):
+    """Exclusive cross-process lock keyed on ``<path>.lock``."""
+    if fcntl is None:  # pragma: no cover - non-POSIX fallback
+        yield
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.parent / (path.name + ".lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    """Write JSON via temp-file + atomic rename, owner-only. Call under lock."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(payload, indent=2) + "\n")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Device registry
 
@@ -102,8 +166,39 @@ class Device:
 BOOTSTRAP_DEVICE = Device(id="host", name="host (bootstrap token)", token_hash="")
 
 
+def _read_devices(path: Path) -> list[Device]:
+    """Parse the on-disk registry into Device rows (authoritative current state)."""
+    devices: list[Device] = []
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        raw = None
+    if isinstance(raw, dict):
+        for entry in raw.get("devices", []):
+            if not isinstance(entry, dict) or "token_hash" not in entry:
+                continue
+            devices.append(
+                Device(
+                    id=entry.get("id", ""),
+                    name=entry.get("name", ""),
+                    token_hash=entry["token_hash"],
+                    created=entry.get("created", ""),
+                    last_seen=entry.get("last_seen"),
+                    revoked=bool(entry.get("revoked", False)),
+                )
+            )
+    return devices
+
+
 class DeviceRegistry:
-    """Load/save the device registry and resolve presented tokens to devices."""
+    """Load/save the device registry and resolve presented tokens to devices.
+
+    Reads (``resolve``/``active``) use the in-memory snapshot from ``load``.
+    **Writes (``add``/``revoke``/``touch``) re-read the file fresh under an
+    exclusive lock and write authoritatively** — never persisting a stale
+    snapshot. This is what makes revoke a real kill-switch: a concurrent
+    ``touch`` can't resurrect a device revoked between load and write.
+    """
 
     def __init__(self, path: Path, devices: Optional[list[Device]] = None):
         self.path = path
@@ -112,34 +207,14 @@ class DeviceRegistry:
     @classmethod
     def load(cls, path: Optional[Path] = None) -> "DeviceRegistry":
         path = path or DEVICES_FILE
-        devices: list[Device] = []
-        try:
-            raw = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            raw = None
-        if isinstance(raw, dict):
-            for entry in raw.get("devices", []):
-                if not isinstance(entry, dict) or "token_hash" not in entry:
-                    continue
-                devices.append(
-                    Device(
-                        id=entry.get("id", ""),
-                        name=entry.get("name", ""),
-                        token_hash=entry["token_hash"],
-                        created=entry.get("created", ""),
-                        last_seen=entry.get("last_seen"),
-                        revoked=bool(entry.get("revoked", False)),
-                    )
-                )
-        return cls(path, devices)
+        return cls(path, _read_devices(path))
 
     def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"devices": [asdict(d) for d in self.devices]}
-        self.path.write_text(json.dumps(payload, indent=2) + "\n")
-        self.path.chmod(0o600)
+        """Authoritatively persist the in-memory snapshot (locked, atomic)."""
+        with _file_lock(self.path):
+            _atomic_write_json(self.path, {"devices": [asdict(d) for d in self.devices]})
 
-    # -- mutation ---------------------------------------------------------
+    # -- mutation (re-read fresh under lock, write authoritatively) --------
 
     def add(self, name: str, token: Optional[str] = None) -> tuple[Device, str]:
         """Register a new device, returning (device, plaintext_token).
@@ -154,35 +229,46 @@ class DeviceRegistry:
             token_hash=hash_token(token),
             created=_iso(),
         )
-        self.devices.append(device)
-        self.save()
+        with _file_lock(self.path):
+            devices = _read_devices(self.path)
+            devices.append(device)
+            _atomic_write_json(self.path, {"devices": [asdict(d) for d in devices]})
+            self.devices = devices
         return device, token
 
     def revoke(self, device_id: str) -> bool:
-        for d in self.devices:
-            if d.id == device_id and not d.revoked:
-                d.revoked = True
-                self.save()
-                return True
-        return False
+        with _file_lock(self.path):
+            devices = _read_devices(self.path)
+            found = False
+            for d in devices:
+                if d.id == device_id and not d.revoked:
+                    d.revoked = True
+                    found = True
+            if found:
+                _atomic_write_json(self.path, {"devices": [asdict(d) for d in devices]})
+            self.devices = devices
+        return found
 
     def touch(self, device_id: str) -> None:
-        """Best-effort last_seen update, throttled to one write per minute."""
-        for d in self.devices:
-            if d.id != device_id:
-                continue
-            now = _now()
+        """Best-effort last_seen update, throttled to one write per minute.
+
+        Re-reads under the lock and refuses to write a device that is absent or
+        already revoked — so it can never undo a concurrent revoke.
+        """
+        now = _now()
+        with _file_lock(self.path):
+            devices = _read_devices(self.path)
+            target = next((d for d in devices if d.id == device_id), None)
+            if target is None or target.revoked:
+                return
+            if now - _parse_iso(target.last_seen) < _LAST_SEEN_THROTTLE:
+                return
+            target.last_seen = _iso(now)
             try:
-                prev = time.mktime(time.strptime(d.last_seen, "%Y-%m-%dT%H:%M:%SZ")) if d.last_seen else 0
-            except (ValueError, TypeError):
-                prev = 0
-            if now - prev >= _LAST_SEEN_THROTTLE:
-                d.last_seen = _iso(now)
-                try:
-                    self.save()
-                except OSError:
-                    pass
-            return
+                _atomic_write_json(self.path, {"devices": [asdict(d) for d in devices]})
+                self.devices = devices
+            except OSError:
+                pass
 
     # -- lookup -----------------------------------------------------------
 
@@ -258,9 +344,8 @@ def _load_pairings(path: Path) -> list[Pairing]:
 
 
 def _save_pairings(path: Path, pairings: list[Pairing]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"pairings": [asdict(p) for p in pairings]}, indent=2) + "\n")
-    path.chmod(0o600)
+    """Persist pending pairings (locked, atomic). Call under ``_file_lock``."""
+    _atomic_write_json(path, {"pairings": [asdict(p) for p in pairings]})
 
 
 def create_pairing(
@@ -270,37 +355,41 @@ def create_pairing(
 ) -> Pairing:
     """Create and persist a pending pairing code (host side)."""
     path = path or PAIRINGS_FILE
-    pairings = [p for p in _load_pairings(path) if not p.expired()]
     pairing = Pairing(
         code=generate_pairing_code(),
         name=name or "device",
         expires=_now() + ttl,
     )
-    pairings.append(pairing)
-    _save_pairings(path, pairings)
+    with _file_lock(path):
+        pairings = [p for p in _load_pairings(path) if not p.expired()]
+        pairings.append(pairing)
+        _save_pairings(path, pairings)
     return pairing
 
 
 def consume_pairing(code: str, path: Optional[Path] = None) -> Optional[Pairing]:
     """Validate a pairing code, removing it (one-shot). Portal side.
 
-    Returns the Pairing on success, None if unknown/expired. Expired entries are
+    Atomic compare-and-delete under the pairings lock: concurrent redemptions of
+    the same code can't all win — exactly one acquires the lock, removes the
+    code, and returns it; the rest re-read and find it gone. Expired entries are
     swept on the way through.
     """
     if not code:
         return None
     path = path or PAIRINGS_FILE
     code = code.strip().upper()
-    pairings = _load_pairings(path)
-    match: Optional[Pairing] = None
-    survivors: list[Pairing] = []
-    now = _now()
-    for p in pairings:
-        if p.expired(now):
-            continue  # drop expired
-        if match is None and hmac.compare_digest(p.code, code):
-            match = p
-            continue  # consume (don't carry forward)
-        survivors.append(p)
-    _save_pairings(path, survivors)
+    with _file_lock(path):
+        pairings = _load_pairings(path)
+        match: Optional[Pairing] = None
+        survivors: list[Pairing] = []
+        now = _now()
+        for p in pairings:
+            if p.expired(now):
+                continue  # drop expired
+            if match is None and hmac.compare_digest(p.code, code):
+                match = p
+                continue  # consume (don't carry forward)
+            survivors.append(p)
+        _save_pairings(path, survivors)
     return match

--- a/agentwire/devices.py
+++ b/agentwire/devices.py
@@ -1,0 +1,306 @@
+"""Per-device portal credentials: a hashed device registry + pairing flow.
+
+The portal's bootstrap credential is still ``~/.agentwire/portal.token`` (the
+host/owner's full-scope token, used by the CLI, MCP server, hooks and daemons —
+see :func:`agentwire.security.get_local_portal_token`). What this module adds is
+*additional, individually-revocable* device credentials so a phone that only does
+push-to-talk no longer has to hold the same god-token as the laptop.
+
+Two files under ``~/.agentwire/`` (both 0600):
+
+* ``devices.json`` — the registry. One entry per paired device::
+
+      { "id", "name", "token_hash", "scope", "session",
+        "created", "last_seen", "revoked" }
+
+  Only the **sha256 hash** of each device token is stored; the plaintext is shown
+  once at pairing time and never persisted.
+
+* ``pairings.json`` — short-lived pending pairing codes. ``agentwire portal pair``
+  (host process) writes one; the portal's ``POST /api/pair`` (server process)
+  consumes it and mints the device token. File-backed so the two processes share.
+
+Every credential is full-access; the win over the old single shared token is that
+each device is *named, individually revocable, and attributable* — revoking one
+phone no longer logs out the laptop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+DEVICES_FILE = Path.home() / ".agentwire" / "devices.json"
+PAIRINGS_FILE = Path.home() / ".agentwire" / "pairings.json"
+
+PAIRING_TTL_SECONDS = 600  # pairing codes expire after 10 minutes
+_LAST_SEEN_THROTTLE = 60  # at most one last_seen write per device per minute
+
+# Crockford-ish alphabet — no ambiguous 0/O/1/I/L.
+_PAIRING_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+
+
+def hash_token(token: str) -> str:
+    """Stable sha256 hex digest of a device token (what the registry stores)."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def generate_device_token() -> str:
+    """A fresh device token (32 bytes, urlsafe) — same strength as the bootstrap."""
+    return secrets.token_urlsafe(32)
+
+
+def generate_device_id() -> str:
+    return "dev_" + secrets.token_hex(4)
+
+
+def generate_pairing_code() -> str:
+    return "".join(secrets.choice(_PAIRING_ALPHABET) for _ in range(8))
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _iso(ts: Optional[float] = None) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts if ts is not None else _now()))
+
+
+# ---------------------------------------------------------------------------
+# Device registry
+
+
+@dataclass
+class Device:
+    id: str
+    name: str
+    token_hash: str
+    created: str = ""
+    last_seen: Optional[str] = None
+    revoked: bool = False
+
+    def public(self) -> dict:
+        """Registry entry without the token hash — safe to hand to the UI/CLI."""
+        d = asdict(self)
+        d.pop("token_hash", None)
+        return d
+
+
+# A synthetic device for the bootstrap token (portal.token / config override).
+# It never lives in the registry — revoking it means rotating the token file
+# (`agentwire portal token --rotate`).
+BOOTSTRAP_DEVICE = Device(id="host", name="host (bootstrap token)", token_hash="")
+
+
+class DeviceRegistry:
+    """Load/save the device registry and resolve presented tokens to devices."""
+
+    def __init__(self, path: Path, devices: Optional[list[Device]] = None):
+        self.path = path
+        self.devices: list[Device] = devices or []
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "DeviceRegistry":
+        path = path or DEVICES_FILE
+        devices: list[Device] = []
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            raw = None
+        if isinstance(raw, dict):
+            for entry in raw.get("devices", []):
+                if not isinstance(entry, dict) or "token_hash" not in entry:
+                    continue
+                devices.append(
+                    Device(
+                        id=entry.get("id", ""),
+                        name=entry.get("name", ""),
+                        token_hash=entry["token_hash"],
+                        created=entry.get("created", ""),
+                        last_seen=entry.get("last_seen"),
+                        revoked=bool(entry.get("revoked", False)),
+                    )
+                )
+        return cls(path, devices)
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"devices": [asdict(d) for d in self.devices]}
+        self.path.write_text(json.dumps(payload, indent=2) + "\n")
+        self.path.chmod(0o600)
+
+    # -- mutation ---------------------------------------------------------
+
+    def add(self, name: str, token: Optional[str] = None) -> tuple[Device, str]:
+        """Register a new device, returning (device, plaintext_token).
+
+        The plaintext is the only time the token exists on the host — store the
+        hash, hand the caller the secret.
+        """
+        token = token or generate_device_token()
+        device = Device(
+            id=generate_device_id(),
+            name=name or "device",
+            token_hash=hash_token(token),
+            created=_iso(),
+        )
+        self.devices.append(device)
+        self.save()
+        return device, token
+
+    def revoke(self, device_id: str) -> bool:
+        for d in self.devices:
+            if d.id == device_id and not d.revoked:
+                d.revoked = True
+                self.save()
+                return True
+        return False
+
+    def touch(self, device_id: str) -> None:
+        """Best-effort last_seen update, throttled to one write per minute."""
+        for d in self.devices:
+            if d.id != device_id:
+                continue
+            now = _now()
+            try:
+                prev = time.mktime(time.strptime(d.last_seen, "%Y-%m-%dT%H:%M:%SZ")) if d.last_seen else 0
+            except (ValueError, TypeError):
+                prev = 0
+            if now - prev >= _LAST_SEEN_THROTTLE:
+                d.last_seen = _iso(now)
+                try:
+                    self.save()
+                except OSError:
+                    pass
+            return
+
+    # -- lookup -----------------------------------------------------------
+
+    def resolve(self, token: str) -> Optional[Device]:
+        """Hash the presented token and return the matching live device, if any."""
+        if not token:
+            return None
+        presented = hash_token(token)
+        for d in self.devices:
+            if d.revoked:
+                continue
+            if hmac.compare_digest(presented, d.token_hash):
+                return d
+        return None
+
+    def active(self) -> list[Device]:
+        return [d for d in self.devices if not d.revoked]
+
+
+# Cache the registry by file mtime so the security middleware doesn't reparse
+# JSON on every request. A revoke/add/touch rewrites the file → mtime changes →
+# the next read reparses, so revocation is effective immediately.
+_cache: dict[str, tuple[Optional[float], DeviceRegistry]] = {}
+
+
+def load_registry_cached(path: Optional[Path] = None) -> DeviceRegistry:
+    path = path or DEVICES_FILE
+    try:
+        mtime: Optional[float] = path.stat().st_mtime
+    except OSError:
+        mtime = None
+    key = str(path)
+    cached = _cache.get(key)
+    if cached and cached[0] == mtime:
+        return cached[1]
+    reg = DeviceRegistry.load(path)
+    _cache[key] = (mtime, reg)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Pending pairings (host writes, portal consumes)
+
+
+@dataclass
+class Pairing:
+    code: str
+    name: str
+    expires: float
+
+    def expired(self, now: Optional[float] = None) -> bool:
+        return (now if now is not None else _now()) > self.expires
+
+
+def _load_pairings(path: Path) -> list[Pairing]:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    out: list[Pairing] = []
+    if isinstance(raw, dict):
+        for e in raw.get("pairings", []):
+            if not isinstance(e, dict) or "code" not in e:
+                continue
+            out.append(
+                Pairing(
+                    code=e["code"],
+                    name=e.get("name", "device"),
+                    expires=float(e.get("expires", 0)),
+                )
+            )
+    return out
+
+
+def _save_pairings(path: Path, pairings: list[Pairing]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"pairings": [asdict(p) for p in pairings]}, indent=2) + "\n")
+    path.chmod(0o600)
+
+
+def create_pairing(
+    name: str,
+    ttl: int = PAIRING_TTL_SECONDS,
+    path: Optional[Path] = None,
+) -> Pairing:
+    """Create and persist a pending pairing code (host side)."""
+    path = path or PAIRINGS_FILE
+    pairings = [p for p in _load_pairings(path) if not p.expired()]
+    pairing = Pairing(
+        code=generate_pairing_code(),
+        name=name or "device",
+        expires=_now() + ttl,
+    )
+    pairings.append(pairing)
+    _save_pairings(path, pairings)
+    return pairing
+
+
+def consume_pairing(code: str, path: Optional[Path] = None) -> Optional[Pairing]:
+    """Validate a pairing code, removing it (one-shot). Portal side.
+
+    Returns the Pairing on success, None if unknown/expired. Expired entries are
+    swept on the way through.
+    """
+    if not code:
+        return None
+    path = path or PAIRINGS_FILE
+    code = code.strip().upper()
+    pairings = _load_pairings(path)
+    match: Optional[Pairing] = None
+    survivors: list[Pairing] = []
+    now = _now()
+    for p in pairings:
+        if p.expired(now):
+            continue  # drop expired
+        if match is None and hmac.compare_digest(p.code, code):
+            match = p
+            continue  # consume (don't carry forward)
+        survivors.append(p)
+    _save_pairings(path, survivors)
+    return match

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -1,4 +1,4 @@
-"""Portal security: Origin validation (CSRF guard) and bearer-token auth.
+"""Portal security: Origin validation (CSRF guard) and per-device bearer auth.
 
 Two layers, both enforced by a single aiohttp middleware:
 
@@ -7,20 +7,26 @@ Two layers, both enforced by a single aiohttp middleware:
    origin, a localhost equivalent, or an entry in ``server.allowed_origins``.
    Absent Origin is allowed (curl/CLI/scripts don't send one). Always on.
 
-2. Token auth — when an auth token is configured, every request outside the
-   public bootstrap surface (``GET /``, ``/health``, ``/static/*``) must carry
-   it: ``Authorization: Bearer <token>`` on HTTP, or a
-   ``Sec-WebSocket-Protocol: agentwire.bearer.<token>`` subprotocol on
-   WebSocket upgrades. Required whenever the bind is non-loopback.
+2. Token auth — when auth is configured, every request outside the public
+   bootstrap surface (``GET /``, ``/mobile``, ``/pair``, ``/health``,
+   ``/static/*``, ``POST /api/pair``) must carry a credential:
+   ``Authorization: Bearer <token>`` on HTTP, or a
+   ``Sec-WebSocket-Protocol: agentwire.bearer.<token>`` subprotocol on WS
+   upgrades. The presented token resolves to a *device* — either the bootstrap
+   token (``~/.agentwire/portal.token`` / ``server.auth_token``, used by the
+   CLI/MCP/hooks) or a paired device in the registry (``devices.json``; see
+   :mod:`agentwire.devices`). Unknown or revoked → 401. Every credential is
+   full-access; per-device identity buys named, individually-revocable
+   attribution, not capability scoping.
 
-The token lives at ``~/.agentwire/portal.token`` (0600, auto-generated).
-``server.auth_token`` in config overrides it: ``""`` disables auth (loopback
-binds only), any other string replaces the file token.
+``server.auth_token`` semantics: ``None`` → use the token file; ``""`` →
+disable auth (loopback binds only); any other string → explicit override.
 """
 
 import hmac
 import ipaddress
 import logging
+import re
 import secrets
 from pathlib import Path
 from typing import Optional
@@ -29,12 +35,29 @@ from urllib.parse import urlsplit
 import yaml
 from aiohttp import web
 
+from . import devices as devices_mod
+from .devices import BOOTSTRAP_DEVICE, Device
+
 logger = logging.getLogger(__name__)
 
 MUTATING_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
 TOKEN_FILE = Path.home() / ".agentwire" / "portal.token"
 WS_PROTOCOL_PREFIX = "agentwire.bearer."
 _LOCALHOST_NAMES = {"localhost", "127.0.0.1", "::1"}
+
+# Config keys that the portal API must never be able to change — editing them is
+# host-file-only (#425). A leaked/compromised token must not be able to disable
+# its own auth, rewrite the executables/services that run as RCE, move the bind
+# host, or turn off the rm-rf damage-control rules.
+FROZEN_CONFIG_KEYS = (
+    "server.auth_token",
+    "server.host",
+    "executables",
+    "services",
+    "safety",
+)
+REDACTION_MARKER = "[REDACTED]"
+_REDACTED_FIELDS = ("api_key", "auth_token")
 
 
 # ---------------------------------------------------------------------------
@@ -168,11 +191,96 @@ def origin_allowed(origin: str, request: web.Request, allowed_origins: list) -> 
 
 
 def _is_public_path(request: web.Request) -> bool:
-    """The unauthenticated bootstrap surface: the page shells + health check."""
+    """The unauthenticated bootstrap surface: page shells, health, pairing.
+
+    ``POST /api/pair`` is public because an unpaired device has no token yet — it
+    is instead gated by the short-lived pairing code it must present.
+    """
+    path = request.path
+    if request.method == "POST":
+        return path == "/api/pair"
     if request.method != "GET":
         return False
-    path = request.path
-    return path in ("/", "/mobile", "/health") or path.startswith("/static/")
+    return path in ("/", "/mobile", "/pair", "/health") or path.startswith("/static/")
+
+
+# ---------------------------------------------------------------------------
+# Frozen security-critical config (#425)
+
+
+def _dig(data, dotted: str):
+    """Walk a dotted path into a nested dict; None if any segment is missing."""
+    cur = data
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _load_yaml(text: str) -> dict:
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def restore_redactions(new_content: str, old_content: str) -> str:
+    """Reverse the read-side secret redaction before a config save.
+
+    ``GET /api/config`` replaces ``auth_token``/``api_key`` values with
+    ``"[REDACTED]"``. If that text is saved back verbatim it would overwrite the
+    real secret on disk (and falsely trip the frozen-key check on
+    ``server.auth_token``). Restore any redaction marker to the on-disk value.
+    """
+    old = _load_yaml(old_content)
+    real_auth = _dig(old, "server.auth_token")
+
+    def _find_first(d, key):
+        if not isinstance(d, dict):
+            return None
+        if key in d and not isinstance(d[key], (dict, list)):
+            return d[key]
+        for v in d.values():
+            found = _find_first(v, key) if isinstance(v, dict) else None
+            if found is not None:
+                return found
+        return None
+
+    def repl(m: "re.Match") -> str:
+        field = m.group("field")
+        if field == "auth_token" and real_auth is not None:
+            return f'{m.group("prefix")}{_yaml_scalar(real_auth)}'
+        if field == "api_key":
+            val = _find_first(old, "api_key")
+            if val is not None:
+                return f'{m.group("prefix")}{_yaml_scalar(val)}'
+        return m.group(0)
+
+    pattern = re.compile(
+        r'(?P<prefix>(?P<field>api_key|auth_token)\s*:\s*)'
+        r'["\']?\[REDACTED\]["\']?'
+    )
+    return pattern.sub(repl, new_content)
+
+
+def _yaml_scalar(value) -> str:
+    if isinstance(value, str):
+        return f'"{value}"'
+    return str(value)
+
+
+def frozen_config_violations(new_content: str, old_content: str) -> list[str]:
+    """Frozen keys whose value differs between the submitted and on-disk config.
+
+    Run *after* :func:`restore_redactions` so a redacted-but-unchanged
+    ``auth_token`` doesn't read as a change. An empty list means the save is
+    allowed.
+    """
+    new = _load_yaml(new_content)
+    old = _load_yaml(old_content)
+    return [key for key in FROZEN_CONFIG_KEYS if _dig(new, key) != _dig(old, key)]
 
 
 def _extract_token(request: web.Request, is_ws: bool) -> Optional[str]:
@@ -187,8 +295,27 @@ def _extract_token(request: web.Request, is_ws: bool) -> Optional[str]:
     return None
 
 
+def resolve_device(provided: Optional[str], auth_token: Optional[str]) -> Optional[Device]:
+    """Resolve a presented token to a device, or None.
+
+    The bootstrap token (``portal.token`` / config override) maps to a synthetic
+    full-scope ``host`` device; everything else is looked up (by hash) in the
+    device registry. Revoked devices resolve to None.
+    """
+    if not provided:
+        return None
+    if auth_token and hmac.compare_digest(provided.encode(), auth_token.encode()):
+        return BOOTSTRAP_DEVICE
+    return devices_mod.load_registry_cached().resolve(provided)
+
+
 def create_security_middleware(auth_token: Optional[str], allowed_origins: list):
-    """Build the aiohttp middleware enforcing origin + token policy."""
+    """Build the aiohttp middleware enforcing origin + per-device token auth.
+
+    ``auth_token`` is the bootstrap credential. Auth is enforced whenever it is
+    set *or* the registry holds an active paired device; a loopback dev portal
+    with neither configured stays open (origin checks still cover the browser).
+    """
 
     @web.middleware
     async def security_middleware(request: web.Request, handler):
@@ -204,16 +331,20 @@ def create_security_middleware(auth_token: Optional[str], allowed_origins: list)
                 )
                 raise web.HTTPForbidden(text="Origin not allowed")
 
-        # Token check: everything except the public bootstrap surface.
-        if auth_token and not _is_public_path(request):
+        auth_enabled = bool(auth_token) or bool(
+            devices_mod.load_registry_cached().active()
+        )
+        if auth_enabled and not _is_public_path(request):
             provided = _extract_token(request, is_ws)
-            if not provided or not hmac.compare_digest(
-                provided.encode(), auth_token.encode()
-            ):
+            device = resolve_device(provided, auth_token)
+            if device is None:
                 raise web.HTTPUnauthorized(
                     text="Missing or invalid auth token",
                     headers={"WWW-Authenticate": 'Bearer realm="agentwire"'},
                 )
+            request["device"] = device
+            if device.id != BOOTSTRAP_DEVICE.id:
+                devices_mod.load_registry_cached().touch(device.id)
 
         return await handler(request)
 

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -226,43 +226,54 @@ def _load_yaml(text: str) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+_REDACTED_LINE = re.compile(
+    r'^(?P<indent>[ \t]*)(?P<field>[A-Za-z0-9_]+)(?P<sep>[ \t]*:[ \t]*)'
+    r'["\']?\[REDACTED\]["\']?[ \t]*(?P<eol>\r?\n?)$'
+)
+_MAPPING_KEY = re.compile(r'^(?P<indent>[ \t]*)(?P<key>[A-Za-z0-9_]+)[ \t]*:[ \t]*(?P<val>.*?)[ \t]*\r?\n?$')
+
+
 def restore_redactions(new_content: str, old_content: str) -> str:
     """Reverse the read-side secret redaction before a config save.
 
     ``GET /api/config`` replaces ``auth_token``/``api_key`` values with
-    ``"[REDACTED]"``. If that text is saved back verbatim it would overwrite the
-    real secret on disk (and falsely trip the frozen-key check on
-    ``server.auth_token``). Restore any redaction marker to the on-disk value.
+    ``"[REDACTED]"``. Saving that text back verbatim would overwrite the real
+    secret on disk (and falsely trip the frozen-key check on
+    ``server.auth_token``).
+
+    Restores each redacted field to the on-disk value **at its own YAML path** —
+    so multiple ``api_key`` entries (e.g. several pi providers) each get their
+    own secret back, not a single global first-match. Operates on the raw text so
+    comments and formatting survive the round-trip; only redacted scalar lines
+    change.
     """
     old = _load_yaml(old_content)
-    real_auth = _dig(old, "server.auth_token")
+    out: list[str] = []
+    stack: list[tuple[int, str]] = []  # (indent, key) path to the current mapping
 
-    def _find_first(d, key):
-        if not isinstance(d, dict):
-            return None
-        if key in d and not isinstance(d[key], (dict, list)):
-            return d[key]
-        for v in d.values():
-            found = _find_first(v, key) if isinstance(v, dict) else None
-            if found is not None:
-                return found
-        return None
+    for line in new_content.splitlines(keepends=True):
+        key_m = _MAPPING_KEY.match(line)
+        if key_m:
+            indent = len(key_m.group("indent").expandtabs())
+            # Pop siblings/deeper levels so the path reflects this key's parent.
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            red_m = _REDACTED_LINE.match(line)
+            if red_m and red_m.group("field") in _REDACTED_FIELDS:
+                path = ".".join([k for _, k in stack] + [red_m.group("field")])
+                real = _dig(old, path)
+                if real is not None:
+                    out.append(
+                        f'{red_m.group("indent")}{red_m.group("field")}'
+                        f'{red_m.group("sep")}{_yaml_scalar(real)}{red_m.group("eol")}'
+                    )
+                    continue  # scalar leaf — don't push onto the path
+            # A key that opens a nested mapping (no inline value) extends the path.
+            if key_m.group("val") == "":
+                stack.append((indent, key_m.group("key")))
+        out.append(line)
 
-    def repl(m: "re.Match") -> str:
-        field = m.group("field")
-        if field == "auth_token" and real_auth is not None:
-            return f'{m.group("prefix")}{_yaml_scalar(real_auth)}'
-        if field == "api_key":
-            val = _find_first(old, "api_key")
-            if val is not None:
-                return f'{m.group("prefix")}{_yaml_scalar(val)}'
-        return m.group(0)
-
-    pattern = re.compile(
-        r'(?P<prefix>(?P<field>api_key|auth_token)\s*:\s*)'
-        r'["\']?\[REDACTED\]["\']?'
-    )
-    return pattern.sub(repl, new_content)
+    return "".join(out)
 
 
 def _yaml_scalar(value) -> str:

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -41,8 +41,10 @@ from .security import (
     WS_PROTOCOL_PREFIX,
     create_security_middleware,
     ensure_auth_token,
+    frozen_config_violations,
     is_loopback_host,
     resolve_auth_token,
+    restore_redactions,
     validate_startup_security,
 )
 from .ssh import ssh_base_opts
@@ -215,6 +217,8 @@ class AgentWireServer:
         self.app.router.add_get("/health", self.handle_health)
         self.app.router.add_get("/", self.handle_index)
         self.app.router.add_get("/mobile", self.handle_mobile)
+        self.app.router.add_get("/pair", self.handle_pair_page)
+        self.app.router.add_post("/api/pair", self.api_pair)
         self.app.router.add_get("/ws", self.handle_dashboard_ws)
         self.app.router.add_get("/ws/{name:.+}", self.handle_websocket)
         self.app.router.add_get("/ws/terminal/{name:.+}", self.handle_terminal_ws)
@@ -990,6 +994,51 @@ class AgentWireServer:
         response = aiohttp_jinja2.render_template("mobile.html", request, {})
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         return response
+
+    async def handle_pair_page(self, request: web.Request) -> web.Response:
+        """Serve the device-pairing page (#423).
+
+        Public bootstrap surface: an unpaired device has no token yet. The page
+        reads the pairing code from `?code=` (or a manual field), POSTs it to
+        `/api/pair`, and stores the minted device token in localStorage — the
+        same key `apiFetch` reads — then bounces to the portal.
+        """
+        response = aiohttp_jinja2.render_template("pair.html", request, {})
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        return response
+
+    async def api_pair(self, request: web.Request) -> web.Response:
+        """Redeem a pairing code for a freshly-minted device token (#423).
+
+        Public (no bearer required) but gated by the short-lived pairing code the
+        host printed via `agentwire portal pair`. One-shot: the code is consumed.
+        """
+        from .devices import DeviceRegistry, consume_pairing
+
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        code = str(data.get("code", "")).strip()
+        if not code:
+            return web.json_response({"error": "Missing pairing code"}, status=400)
+
+        pairing = consume_pairing(code)
+        if pairing is None:
+            return web.json_response(
+                {"error": "Invalid or expired pairing code"}, status=403
+            )
+
+        name = str(data.get("name") or pairing.name or "device")
+        registry = DeviceRegistry.load()
+        device, token = registry.add(name=name)
+        logger.info("Paired device %s (%r)", device.id, device.name)
+        return web.json_response(
+            {
+                "token": token,
+                "device": device.public(),
+            }
+        )
 
     def _ws_response(self, request: web.Request) -> web.WebSocketResponse:
         """WebSocketResponse that echoes the auth bearer subprotocol.
@@ -3677,7 +3726,13 @@ projects:
         })
 
     async def api_save_config(self, request: web.Request) -> web.Response:
-        """Save config file contents."""
+        """Save config file contents.
+
+        Security-critical keys are frozen (#425): even a valid token cannot use
+        this endpoint to disable auth, move the bind host, rewrite the
+        executables/services that run as RCE, or turn off the damage-control
+        rules. Those are host-file-edit-only.
+        """
         try:
             data = await request.json()
             content = data.get("content", "")
@@ -3690,6 +3745,27 @@ projects:
                 return web.json_response({"error": f"Invalid YAML: {e}"})
 
             config_path = Path.home() / ".agentwire" / "config.yaml"
+            old_content = config_path.read_text() if config_path.exists() else ""
+
+            # Reverse the read-side secret redaction so saving the editor's text
+            # back doesn't overwrite real secrets with "[REDACTED]" (and so the
+            # frozen-key check below sees the true auth_token, not the marker).
+            content = restore_redactions(content, old_content)
+
+            violations = frozen_config_violations(content, old_content)
+            if violations:
+                return web.json_response(
+                    {
+                        "error": (
+                            "These keys are frozen and can only be changed by "
+                            "editing ~/.agentwire/config.yaml on the host: "
+                            + ", ".join(violations)
+                        ),
+                        "frozen_keys": violations,
+                    },
+                    status=403,
+                )
+
             config_path.parent.mkdir(parents=True, exist_ok=True)
             config_path.write_text(content)
 
@@ -3778,41 +3854,25 @@ projects:
             return web.json_response({"error": str(e)}, status=500)
 
     async def api_safety_config_post(self, request: web.Request) -> web.Response:
-        """Update ~/.agentwire/config.yaml safety block (enabled, disabled_rules)."""
-        try:
-            data = await request.json()
-            cfg_path = Path.home() / ".agentwire" / "config.yaml"
-            raw: Dict[str, Any] = {}
-            if cfg_path.exists():
-                try:
-                    with open(cfg_path, "r") as f:
-                        raw = yaml.safe_load(f) or {}
-                except Exception:
-                    raw = {}
-            safety = raw.get("safety", {})
-            if not isinstance(safety, dict):
-                safety = {}
-            if "enabled" in data:
-                safety["enabled"] = bool(data["enabled"])
-            if "disabled_rules" in data and isinstance(data["disabled_rules"], list):
-                safety["disabled_rules"] = sorted({str(r) for r in data["disabled_rules"] if r})
-            raw["safety"] = safety
-            cfg_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(cfg_path, "w") as f:
-                yaml.safe_dump(raw, f, sort_keys=False)
-            # Reload runtime config so /api/safety/status sees the change immediately
-            try:
-                from .config import reload_config
-                self.config = reload_config()
-            except Exception:
-                pass
-            return web.json_response({
-                "success": True,
-                "enabled": safety.get("enabled", True),
-                "disabled_rules": safety.get("disabled_rules", []),
-            })
-        except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+        """Frozen (#425): the safety block is host-file-edit-only.
+
+        Disabling the damage-control rules with the same token that the rules are
+        meant to contain defeats defense-in-depth. The master switch and
+        disabled-rules list can now only be changed by editing
+        ~/.agentwire/config.yaml on the host. GET /api/safety/* still works for
+        viewing status, rules and logs.
+        """
+        return web.json_response(
+            {
+                "error": (
+                    "Safety configuration is frozen and can only be changed by "
+                    "editing the `safety:` block in ~/.agentwire/config.yaml on "
+                    "the host, then reloading the portal."
+                ),
+                "frozen_keys": ["safety"],
+            },
+            status=403,
+        )
 
     async def api_refresh_sessions(self, request: web.Request) -> web.Response:
         """Refresh sessions and broadcast update to all dashboard clients.

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -179,6 +179,10 @@ class AgentWireServer:
         self.session_client_counts: dict[str, int] = {}  # Attached tmux client counts per session
         self.active_notifications: dict[str, dict] = {}  # id -> notification for persistence across refresh
         self._background_tasks: set[asyncio.Task] = set()  # strong refs so create_task work isn't GC'd
+        # Rate-limit state for the public, unauthenticated POST /api/pair (#423 S1).
+        # Per-IP and global sliding-window attempt logs (monotonic timestamps).
+        self._pair_attempts: dict[str, list[float]] = {}
+        self._pair_attempts_global: list[float] = []
         self.machine_status_checker = CachedStatusChecker(ttl_seconds=30)  # Progressive loading for machines
         self.remote_sessions_checker = CachedStatusChecker(ttl_seconds=20)  # Progressive loading for remote sessions
         self.projects_checker = CachedStatusChecker(ttl_seconds=30)  # Progressive loading for projects
@@ -1007,6 +1011,27 @@ class AgentWireServer:
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         return response
 
+    # Pairing rate limit: max 5 attempts / IP / minute, 30 globally / minute.
+    _PAIR_WINDOW = 60.0
+    _PAIR_PER_IP = 5
+    _PAIR_GLOBAL = 30
+
+    def _pair_rate_ok(self, ip: str) -> bool:
+        """Record a pairing attempt; False if it exceeds the per-IP or global cap."""
+        now = time.monotonic()
+        cutoff = now - self._PAIR_WINDOW
+        self._pair_attempts_global = [t for t in self._pair_attempts_global if t > cutoff]
+        per_ip = [t for t in self._pair_attempts.get(ip, []) if t > cutoff]
+        if len(per_ip) >= self._PAIR_PER_IP or len(self._pair_attempts_global) >= self._PAIR_GLOBAL:
+            self._pair_attempts[ip] = per_ip  # keep pruned state, don't record the rejected attempt
+            return False
+        per_ip.append(now)
+        self._pair_attempts[ip] = per_ip
+        self._pair_attempts_global.append(now)
+        # Drop IP buckets that pruned to empty so the dict can't grow unbounded.
+        self._pair_attempts = {k: v for k, v in self._pair_attempts.items() if v}
+        return True
+
     async def api_pair(self, request: web.Request) -> web.Response:
         """Redeem a pairing code for a freshly-minted device token (#423).
 
@@ -1014,6 +1039,15 @@ class AgentWireServer:
         host printed via `agentwire portal pair`. One-shot: the code is consumed.
         """
         from .devices import DeviceRegistry, consume_pairing
+
+        # Rate limit (#423 S1): this is the one unauthenticated token-minting
+        # endpoint. Throttle per-IP and globally over a sliding window so a
+        # brute-forcer can't grind pairing codes (40-bit, 10-min TTL).
+        if not self._pair_rate_ok(request.remote or "?"):
+            return web.json_response(
+                {"error": "Too many pairing attempts — wait a minute and retry."},
+                status=429,
+            )
 
         try:
             data = await request.json()

--- a/agentwire/static/js/token-modal.js
+++ b/agentwire/static/js/token-modal.js
@@ -24,7 +24,7 @@ function renderModal() {
                         <span class="quicktask-label">Auth token</span>
                         <input type="password" name="token" placeholder="Paste your portal token" autocomplete="off" required />
                     </label>
-                    <p class="quicktask-hint">Run <code>agentwire portal token</code> on the portal machine to see it. You only need to do this once per device.</p>
+                    <p class="quicktask-hint">Run <code>agentwire portal token</code> on the portal machine to see it — or pair this device with <code>agentwire portal pair</code> (scan the QR / open <code>/pair</code>) for its own revocable credential. Once per device.</p>
                     <div class="quicktask-footer">
                         <button type="submit" class="quicktask-btn-submit">Connect</button>
                     </div>

--- a/agentwire/templates/pair.html
+++ b/agentwire/templates/pair.html
@@ -1,0 +1,86 @@
+{% extends 'base.html' %}
+
+{% block title %}Pair device — AgentWire{% endblock %}
+
+{% block content %}
+<div class="pair-app" style="max-width:420px;margin:10vh auto;padding:0 1.25rem;font-family:system-ui,sans-serif;">
+    <h1 style="display:flex;align-items:center;gap:.5rem;">
+        <img src="/static/favicon.png" alt="" style="width:32px;height:32px;"> Pair this device
+    </h1>
+    <p class="pair-sub" style="opacity:.75;">
+        Enter the pairing code from <code>agentwire portal pair</code> on the portal
+        machine. The code is single-use and expires after a few minutes.
+    </p>
+
+    <div id="pairError" hidden
+         style="background:#3a1a1a;border:1px solid #a33;border-radius:.5rem;padding:.75rem;margin:.75rem 0;"></div>
+    <div id="pairOk" hidden
+         style="background:#163016;border:1px solid #3a7;border-radius:.5rem;padding:.75rem;margin:.75rem 0;"></div>
+
+    <form id="pairForm" autocomplete="off">
+        <label style="display:block;margin:.5rem 0 .25rem;">Pairing code</label>
+        <input id="pairCode" name="code" inputmode="latin" autocapitalize="characters"
+               placeholder="ABCD2345" required
+               style="width:100%;padding:.6rem;font-size:1.2rem;letter-spacing:.15em;text-transform:uppercase;border-radius:.5rem;border:1px solid #555;box-sizing:border-box;">
+        <button type="submit" id="pairSubmit"
+                style="margin-top:1rem;width:100%;padding:.7rem;font-size:1rem;border-radius:.5rem;border:none;background:#39ff14;color:#000;font-weight:600;cursor:pointer;">
+            Pair device
+        </button>
+    </form>
+</div>
+
+<script type="module">
+    import { setToken } from '/static/js/api.js';
+
+    const params = new URLSearchParams(location.search);
+    const form = document.getElementById('pairForm');
+    const codeInput = document.getElementById('pairCode');
+    const errEl = document.getElementById('pairError');
+    const okEl = document.getElementById('pairOk');
+    const submitBtn = document.getElementById('pairSubmit');
+
+    function showError(msg) { errEl.textContent = msg; errEl.hidden = false; okEl.hidden = true; }
+
+    async function pair(code) {
+        errEl.hidden = true;
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Pairing…';
+        try {
+            const resp = await fetch('/api/pair', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ code }),
+            });
+            const data = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                showError(data.error || `Pairing failed (${resp.status})`);
+                return;
+            }
+            setToken(data.token);
+            okEl.textContent = `Paired as “${data.device?.name || 'device'}”. Redirecting…`;
+            okEl.hidden = false;
+            setTimeout(() => { location.href = '/'; }, 800);
+        } catch (e) {
+            showError('Network error — is the portal reachable?');
+        } finally {
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Pair device';
+        }
+    }
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const code = codeInput.value.trim().toUpperCase();
+        if (code) pair(code);
+    });
+
+    // QR deep-link: /pair?code=XXXX auto-submits.
+    const presetCode = (params.get('code') || '').trim().toUpperCase();
+    if (presetCode) {
+        codeInput.value = presetCode;
+        pair(presetCode);
+    } else {
+        codeInput.focus();
+    }
+</script>
+{% endblock %}

--- a/docs/wiki/deployment/remote-access.md
+++ b/docs/wiki/deployment/remote-access.md
@@ -2,6 +2,17 @@
 
 Access your AgentWire portal from anywhere using Cloudflare Tunnel with Zero Trust authentication.
 
+> **agentwire ships no tunnel code (#420).** Internet exposure is bring-your-own —
+> cloudflared, tailscale, or a plain `ssh -L` you run yourself. agentwire owns only
+> the portal's *local* security boundary: 127.0.0.1 default, per-device bearer
+> tokens, refuse-to-start on a non-loopback bind without a token, self-signed TLS.
+> The tunnel in front of it is yours to operate. (The internal `agentwire tunnels *`
+> SSH service-router still exists as an opt-in manual helper for the vestigial
+> remote-GPU-service case, but is **no longer auto-spawned at portal start**.)
+>
+> Pair a device once with `agentwire portal pair` (prints a code + QR); see
+> [remote-access-hardening](../security/remote-access-hardening.md) for the auth model.
+
 ## Overview
 
 This guide covers:

--- a/docs/wiki/security/remote-access-hardening.md
+++ b/docs/wiki/security/remote-access-hardening.md
@@ -27,6 +27,28 @@ Two corrections frame everything below:
 
 ---
 
+## What shipped (2026-06-22)
+
+The hardening wave landed as **#425 + #423** plus the **#420** networking cuts. **#424 (capability
+scopes, `full` vs `ptt`) was dropped not-planned** — its only real use case (restricted guest/PTT
+devices) was cut by the owner, so every credential is full-access and there is no scope system.
+
+| Item | Status | Shape |
+|---|---|---|
+| **#420** networking cuts | ✅ shipped | Tunnel auto-spawn removed from `portal start`; reverse-tunnel (`autossh -R` / `~/.local/bin/agentwire-tunnels`) guidance stripped from `machine add/remove`; `network status` is read-only (already was — confirmed). `agentwire tunnels *` stays as an opt-in manual helper, never auto-fired. |
+| **#425** freeze config | ✅ shipped | `POST /api/config` rejects (403) any change to frozen keys `server.auth_token`, `server.host`, `executables`, `services`, `safety`; `POST /api/safety/config` is frozen entirely (host-edit-only). The read-side redaction round-trip is now reversed on save so the editor can't blank `auth_token`. Constant: `security.FROZEN_CONFIG_KEYS`. |
+| **#423** per-device creds | ✅ shipped | New `agentwire/devices.py`: `devices.json` registry (0600) stores a **sha256 hash** per device + `pairings.json` for short-lived codes. Pairing: `agentwire portal pair` → code + QR → `GET /pair?code=` page → `POST /api/pair` mints a device token. Middleware resolves the presented token to a device (bootstrap token = synthetic `host` device, else registry lookup); unknown/revoked → 401. CLI: `portal pair` / `portal devices` / `portal revoke <id>`. |
+| **#424** scopes | ❌ dropped | Not-planned. No `full`/`ptt`, no per-route allowlist, no PTT session whitelist. |
+
+**Auth model now:** the bootstrap token (`~/.agentwire/portal.token` / `server.auth_token`) is the
+host/owner full credential used by the CLI, MCP, hooks and daemons — unchanged. *Remote* devices no
+longer paste that shared token; they pair to get their own named, individually-revocable credential.
+Revoking one device (`agentwire portal revoke dev_xxxx`) doesn't log out the others. Every credential
+is full-access. The registry is read through an mtime-cached loader so revocation takes effect on the
+next request without a portal restart.
+
+---
+
 ## Part 1 — Network footprint map (#420)
 
 ### What agentwire actually opens / owns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ dependencies = [
     "useful-moonshine-onnx>=20250101; python_version < '3.14'",
     # Used by agentwire.tts.base (TTSRequest); explicit rather than transitive via mcp.
     "pydantic>=2.0.0",
+    # Device-pairing QR codes in the terminal (`agentwire portal pair`). Pure
+    # Python; ASCII output needs no Pillow. Import is guarded so it degrades to
+    # a printed URL if absent.
+    "qrcode>=7.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,22 @@ def scheduler_board_file(tmp_config_dir):
     return board_path
 
 
+@pytest.fixture(autouse=True)
+def isolated_device_registry(tmp_path, monkeypatch):
+    """Point the device registry + pairings at a temp dir for every test.
+
+    Keeps the suite from reading/writing the developer's real
+    ~/.agentwire/devices.json, and clears the mtime cache between tests.
+    """
+    from agentwire import devices
+
+    monkeypatch.setattr(devices, "DEVICES_FILE", tmp_path / "aw-devices.json")
+    monkeypatch.setattr(devices, "PAIRINGS_FILE", tmp_path / "aw-pairings.json")
+    devices._cache.clear()
+    yield
+    devices._cache.clear()
+
+
 @pytest.fixture
 def clean_env(monkeypatch):
     """Remove all AGENTWIRE_* env vars."""

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1,6 +1,7 @@
 """Unit tests for agentwire.devices — registry, hashing, pairing lifecycle."""
 
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -140,3 +141,68 @@ class TestPairing:
         path = tmp_path / "pairings.json"
         pairing = create_pairing("phone", path=path)
         assert consume_pairing(pairing.code.lower(), path=path) is not None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the race window where B1/B2 hid (PR #458 red-team)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_revoke_survives_concurrent_touches(self, reg_path):
+        """B1: a touch racing a revoke must NOT resurrect the device.
+
+        Each worker loads a snapshot (active), then touches — exactly the
+        unlocked read-modify-write that used to wipe revoked=true. With the
+        re-read-under-lock fix, the device must end revoked regardless of order.
+        """
+        reg = DeviceRegistry(reg_path)
+        device, token = reg.add("phone")
+        # Make last_seen stale so touch() actually wants to write.
+        from agentwire.devices import _read_devices, _atomic_write_json, _iso
+        from dataclasses import asdict
+        ds = _read_devices(reg_path)
+        ds[0].last_seen = _iso(0)
+        _atomic_write_json(reg_path, {"devices": [asdict(d) for d in ds]})
+
+        def toucher():
+            r = DeviceRegistry.load(reg_path)  # snapshot: active
+            time.sleep(0.001)
+            r.touch(device.id)
+
+        def revoker():
+            time.sleep(0.001)
+            DeviceRegistry.load(reg_path).revoke(device.id)
+
+        with ThreadPoolExecutor(max_workers=12) as ex:
+            futs = [ex.submit(toucher) for _ in range(11)] + [ex.submit(revoker)]
+            for f in futs:
+                f.result()
+
+        final = DeviceRegistry.load(reg_path)
+        assert final.devices[0].revoked is True
+        assert final.resolve(token) is None
+
+    def test_concurrent_redeem_is_single_use(self, tmp_path):
+        """B2: many concurrent redemptions of one code → exactly one winner."""
+        path = tmp_path / "pairings.json"
+        pairing = create_pairing("phone", path=path)
+
+        def redeem():
+            return consume_pairing(pairing.code, path=path)
+
+        with ThreadPoolExecutor(max_workers=16) as ex:
+            results = [f.result() for f in [ex.submit(redeem) for _ in range(16)]]
+
+        winners = [r for r in results if r is not None]
+        assert len(winners) == 1
+
+    def test_concurrent_adds_all_persist(self, reg_path):
+        """Parallel pairings must not clobber each other (lost-update guard)."""
+        def add(i):
+            return DeviceRegistry.load(reg_path).add(f"dev{i}")
+
+        with ThreadPoolExecutor(max_workers=10) as ex:
+            list(ex.map(add, range(20)))
+
+        assert len(DeviceRegistry.load(reg_path).devices) == 20

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -1,0 +1,142 @@
+"""Unit tests for agentwire.devices — registry, hashing, pairing lifecycle."""
+
+import time
+
+import pytest
+
+from agentwire import devices
+from agentwire.devices import (
+    DeviceRegistry,
+    consume_pairing,
+    create_pairing,
+    hash_token,
+    load_registry_cached,
+)
+
+
+@pytest.fixture
+def reg_path(tmp_path):
+    return tmp_path / "devices.json"
+
+
+# ---------------------------------------------------------------------------
+# Hashing / token issuance
+# ---------------------------------------------------------------------------
+
+
+class TestHashing:
+    def test_hash_is_stable_and_not_plaintext(self):
+        tok = "super-secret"
+        assert hash_token(tok) == hash_token(tok)
+        assert tok not in hash_token(tok)
+        assert len(hash_token(tok)) == 64  # sha256 hex
+
+    def test_added_device_stores_hash_not_token(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        device, token = reg.add("laptop")
+        assert device.token_hash == hash_token(token)
+        # The plaintext token never appears in the persisted file.
+        assert token not in reg_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Registry add / resolve / revoke
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_add_and_resolve(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        device, token = reg.add("phone")
+        resolved = DeviceRegistry.load(reg_path).resolve(token)
+        assert resolved is not None
+        assert resolved.id == device.id
+
+    def test_resolve_unknown_token_is_none(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        reg.add("phone")
+        assert DeviceRegistry.load(reg_path).resolve("nope") is None
+
+    def test_revoke_blocks_resolution(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        device, token = reg.add("phone")
+        assert reg.revoke(device.id) is True
+        assert DeviceRegistry.load(reg_path).resolve(token) is None
+
+    def test_revoke_one_keeps_others(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        d1, t1 = reg.add("laptop")
+        d2, t2 = reg.add("phone")
+        reg.revoke(d1.id)
+        fresh = DeviceRegistry.load(reg_path)
+        assert fresh.resolve(t1) is None
+        assert fresh.resolve(t2) is not None
+
+    def test_revoke_unknown_returns_false(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        assert reg.revoke("dev_nope") is False
+
+    def test_public_omits_hash(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        device, _ = reg.add("phone")
+        assert "token_hash" not in device.public()
+        assert device.public()["id"] == device.id
+
+    def test_file_is_owner_only(self, reg_path):
+        reg = DeviceRegistry(reg_path)
+        reg.add("phone")
+        assert (reg_path.stat().st_mode & 0o777) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# mtime cache
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    def test_cache_refreshes_after_revoke(self, reg_path, monkeypatch):
+        monkeypatch.setattr(devices, "DEVICES_FILE", reg_path)
+        devices._cache.clear()
+        reg = DeviceRegistry(reg_path)
+        device, token = reg.add("phone")
+        # Prime the cache, then revoke through a separate handle.
+        assert load_registry_cached(reg_path).resolve(token) is not None
+        DeviceRegistry.load(reg_path).revoke(device.id)
+        # mtime changed → cache must reparse and see the revocation.
+        assert load_registry_cached(reg_path).resolve(token) is None
+
+
+# ---------------------------------------------------------------------------
+# Pairing lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestPairing:
+    def test_create_and_consume(self, tmp_path):
+        path = tmp_path / "pairings.json"
+        pairing = create_pairing("phone", path=path)
+        consumed = consume_pairing(pairing.code, path=path)
+        assert consumed is not None
+        assert consumed.name == "phone"
+
+    def test_consume_is_one_shot(self, tmp_path):
+        path = tmp_path / "pairings.json"
+        pairing = create_pairing("phone", path=path)
+        assert consume_pairing(pairing.code, path=path) is not None
+        assert consume_pairing(pairing.code, path=path) is None
+
+    def test_consume_unknown_code(self, tmp_path):
+        path = tmp_path / "pairings.json"
+        create_pairing("phone", path=path)
+        assert consume_pairing("BOGUS123", path=path) is None
+
+    def test_expired_code_rejected(self, tmp_path):
+        path = tmp_path / "pairings.json"
+        pairing = create_pairing("phone", ttl=-1, path=path)
+        assert pairing.expired() is True
+        assert consume_pairing(pairing.code, path=path) is None
+
+    def test_consume_case_insensitive(self, tmp_path):
+        path = tmp_path / "pairings.json"
+        pairing = create_pairing("phone", path=path)
+        assert consume_pairing(pairing.code.lower(), path=path) is not None

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1156,3 +1156,140 @@ class TestPermissionRouting:
                 "/api/permission/myproj/respond", json={"decision": "allow"}
             )
             await task
+
+
+# ---------------------------------------------------------------------------
+# #425 — frozen security-critical config
+# ---------------------------------------------------------------------------
+
+
+class TestFrozenConfigEndpoint:
+    def _write_config(self, monkeypatch, tmp_path, body):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = tmp_path / ".agentwire" / "config.yaml"
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(body)
+        return cfg
+
+    async def test_changing_auth_token_rejected(self, portal_client, monkeypatch, tmp_path):
+        client, server = portal_client
+        cfg = self._write_config(
+            monkeypatch, tmp_path,
+            'server:\n  host: "127.0.0.1"\n  auth_token: "real"\n',
+        )
+        resp = await client.post("/api/config", json={
+            "content": 'server:\n  host: "127.0.0.1"\n  auth_token: ""\n',
+        })
+        assert resp.status == 403
+        data = await resp.json()
+        assert "server.auth_token" in data["frozen_keys"]
+        # On-disk config untouched.
+        assert 'auth_token: "real"' in cfg.read_text()
+
+    async def test_changing_executables_rejected(self, portal_client, monkeypatch, tmp_path):
+        client, server = portal_client
+        self._write_config(monkeypatch, tmp_path, "executables:\n  claude: /usr/bin/claude\n")
+        resp = await client.post("/api/config", json={
+            "content": "executables:\n  claude: /tmp/evil\n",
+        })
+        assert resp.status == 403
+        assert "executables" in (await resp.json())["frozen_keys"]
+
+    async def test_non_frozen_change_allowed(self, portal_client, monkeypatch, tmp_path):
+        client, server = portal_client
+        cfg = self._write_config(monkeypatch, tmp_path, "server:\n  port: 8765\n")
+        resp = await client.post("/api/config", json={
+            "content": "server:\n  port: 9000\n",
+        })
+        assert resp.status == 200
+        assert "9000" in cfg.read_text()
+
+    async def test_safety_config_frozen(self, portal_client):
+        client, server = portal_client
+        resp = await client.post("/api/safety/config", json={"enabled": False})
+        assert resp.status == 403
+        assert "safety" in (await resp.json())["frozen_keys"]
+
+
+# ---------------------------------------------------------------------------
+# #423 — device pairing + per-device credentials
+# ---------------------------------------------------------------------------
+
+
+class TestPairingEndpoint:
+    async def test_pair_with_valid_code_mints_token(self, portal_client_with_token):
+        from agentwire.devices import create_pairing
+
+        client, server = portal_client_with_token
+        pairing = create_pairing("phone")
+        # /api/pair is public — no bearer required.
+        resp = await client.post("/api/pair", json={"code": pairing.code})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["token"]
+        assert data["device"]["name"] == "phone"
+        assert "token_hash" not in data["device"]
+
+    async def test_pair_with_bad_code_rejected(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.post("/api/pair", json={"code": "BOGUS123"})
+        assert resp.status == 403
+
+    async def test_pair_missing_code_400(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.post("/api/pair", json={})
+        assert resp.status == 400
+
+
+class TestPerDeviceAuth:
+    async def test_paired_device_token_works(self, portal_client_with_token):
+        from agentwire import devices
+        from agentwire.devices import DeviceRegistry
+
+        client, server = portal_client_with_token
+        reg = DeviceRegistry.load()
+        device, token = reg.add("laptop")
+        devices._cache.clear()
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            resp = await client.get(
+                "/api/sessions/local",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status == 200
+
+    async def test_revoked_device_gets_401(self, portal_client_with_token):
+        from agentwire import devices
+        from agentwire.devices import DeviceRegistry
+
+        client, server = portal_client_with_token
+        reg = DeviceRegistry.load()
+        device, token = reg.add("laptop")
+        devices._cache.clear()
+        reg.revoke(device.id)
+        devices._cache.clear()
+        resp = await client.get(
+            "/api/sessions/local", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status == 401
+
+    async def test_revoke_one_keeps_other(self, portal_client_with_token):
+        from agentwire import devices
+        from agentwire.devices import DeviceRegistry
+
+        client, server = portal_client_with_token
+        reg = DeviceRegistry.load()
+        d1, t1 = reg.add("laptop")
+        d2, t2 = reg.add("phone")
+        reg.revoke(d1.id)
+        devices._cache.clear()
+        with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.return_value = (True, {"sessions": []})
+            assert (await client.get(
+                "/api/sessions/local", headers={"Authorization": f"Bearer {t1}"}
+            )).status == 401
+            assert (await client.get(
+                "/api/sessions/local", headers={"Authorization": f"Bearer {t2}"}
+            )).status == 200
+
+

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1240,6 +1240,18 @@ class TestPairingEndpoint:
         resp = await client.post("/api/pair", json={})
         assert resp.status == 400
 
+    async def test_pair_rate_limited(self, portal_client_with_token):
+        """S1: the public token-minting endpoint throttles brute-force attempts."""
+        client, server = portal_client_with_token
+        cap = server._PAIR_PER_IP
+        # Exhaust the per-IP budget with bad codes (each a recorded attempt).
+        for _ in range(cap):
+            r = await client.post("/api/pair", json={"code": "BADCODE0"})
+            assert r.status == 403  # invalid code, but counted
+        # The next attempt is throttled before the code is even checked.
+        r = await client.post("/api/pair", json={"code": "BADCODE0"})
+        assert r.status == 429
+
 
 class TestPerDeviceAuth:
     async def test_paired_device_token_works(self, portal_client_with_token):

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -199,6 +199,50 @@ class TestFrozenConfig:
         assert "realsecret" in restored
         assert security.frozen_config_violations(restored, self.OLD) == []
 
+    def test_redaction_restores_each_secret_by_path(self):
+        # S1 (PR #458 red-team): multiple api_key entries at different paths must
+        # each get their OWN secret back — not a single global first-match.
+        old = (
+            "pi:\n"
+            "  providers:\n"
+            "    zai:\n"
+            '      api_key: "zai-secret"\n'
+            "    openai:\n"
+            '      api_key: "openai-secret"\n'
+            "server:\n"
+            '  auth_token: "tok"\n'
+        )
+        redacted = (
+            "pi:\n"
+            "  providers:\n"
+            "    zai:\n"
+            '      api_key: "[REDACTED]"\n'
+            "    openai:\n"
+            '      api_key: "[REDACTED]"\n'
+            "server:\n"
+            '  auth_token: "[REDACTED]"\n'
+        )
+        restored = security.restore_redactions(redacted, old)
+        assert "[REDACTED]" not in restored
+        # Each key restored to its own path's value, in order.
+        assert restored.index("zai-secret") < restored.index("openai-secret")
+        assert "tok" in restored
+        # Comments and unrelated lines survive (text round-trip, not re-serialize).
+        assert restored.count("api_key") == 2
+
+    def test_redaction_preserves_comments(self):
+        old = 'server:\n  auth_token: "realsecret"\n  port: 8765\n'
+        redacted = (
+            "# my portal config\n"
+            "server:\n"
+            '  auth_token: "[REDACTED]"\n'
+            "  port: 8765  # keep this comment\n"
+        )
+        restored = security.restore_redactions(redacted, old)
+        assert "# my portal config" in restored
+        assert "# keep this comment" in restored
+        assert "realsecret" in restored
+
 
 # ---------------------------------------------------------------------------
 # Token → device resolution

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -148,3 +148,79 @@ class TestValidateStartupSecurity:
     def test_loopback_without_token_passes(self, tmp_path):
         config = self._config(tmp_path, "127.0.0.1", None)
         security.validate_startup_security(config)
+
+
+# ---------------------------------------------------------------------------
+# Frozen security-critical config (#425)
+# ---------------------------------------------------------------------------
+
+
+class TestFrozenConfig:
+    OLD = (
+        'server:\n'
+        '  host: "127.0.0.1"\n'
+        '  port: 8765\n'
+        '  auth_token: "realsecret"\n'
+        'executables:\n'
+        '  claude: "/usr/bin/claude"\n'
+        'safety:\n'
+        '  enabled: true\n'
+    )
+
+    def test_unchanged_config_allowed(self):
+        assert security.frozen_config_violations(self.OLD, self.OLD) == []
+
+    def test_changing_auth_token_blocked(self):
+        new = self.OLD.replace('"realsecret"', '""')
+        assert "server.auth_token" in security.frozen_config_violations(new, self.OLD)
+
+    def test_changing_host_blocked(self):
+        new = self.OLD.replace('"127.0.0.1"', '"0.0.0.0"')
+        assert "server.host" in security.frozen_config_violations(new, self.OLD)
+
+    def test_changing_executables_blocked(self):
+        new = self.OLD.replace('/usr/bin/claude', '/tmp/evil')
+        assert "executables" in security.frozen_config_violations(new, self.OLD)
+
+    def test_disabling_safety_blocked(self):
+        new = self.OLD.replace("enabled: true", "enabled: false")
+        assert "safety" in security.frozen_config_violations(new, self.OLD)
+
+    def test_non_frozen_change_allowed(self):
+        new = self.OLD.replace("port: 8765", "port: 9000")
+        assert security.frozen_config_violations(new, self.OLD) == []
+
+    def test_redacted_auth_token_is_not_a_change(self):
+        # The UI round-trips auth_token as "[REDACTED]"; restoring it first means
+        # an otherwise-unchanged save must not trip the frozen check.
+        redacted = self.OLD.replace('"realsecret"', '"[REDACTED]"')
+        restored = security.restore_redactions(redacted, self.OLD)
+        assert "[REDACTED]" not in restored
+        assert "realsecret" in restored
+        assert security.frozen_config_violations(restored, self.OLD) == []
+
+
+# ---------------------------------------------------------------------------
+# Token → device resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDevice:
+    def test_bootstrap_token_resolves(self):
+        dev = security.resolve_device("boot", auth_token="boot")
+        assert dev is security.BOOTSTRAP_DEVICE
+
+    def test_wrong_bootstrap_and_empty_registry_is_none(self):
+        assert security.resolve_device("nope", auth_token="boot") is None
+
+    def test_paired_token_resolves(self, monkeypatch):
+        from agentwire.devices import DeviceRegistry
+
+        reg = DeviceRegistry.load()  # path patched to tmp by autouse fixture
+        device, token = reg.add("phone")
+        from agentwire import devices as devices_mod
+
+        devices_mod._cache.clear()
+        resolved = security.resolve_device(token, auth_token="boot")
+        assert resolved is not None
+        assert resolved.id == device.id

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "qrcode" },
     { name = "requests" },
     { name = "resend" },
     { name = "useful-moonshine-onnx", marker = "python_full_version < '3.14'" },
@@ -76,6 +77,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'stt'", specifier = ">=0.0.6" },
     { name = "python-multipart", marker = "extra == 'tts'", specifier = ">=0.0.6" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "qrcode", specifier = ">=7.4" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "resend", specifier = ">=2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -4176,6 +4178,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Portal remote-access lockdown. Replaces the single shared **god-token** with **per-device, individually-revocable credentials**, and **freezes** the config keys a compromised token could use to disable its own protections. Bundles the **#420** networking cuts.

**Scope change mid-flight:** **#424 (capability scopes / `full` vs `ptt`) was dropped not-planned** by the owner (its only use case — restricted guest/PTT devices — was cut). Every credential is full-access; this PR does **not** ship a scope system.

## What changed in the auth model

| Before | After |
|---|---|
| One shared `portal.token` pasted into every device | Bootstrap token stays as the **host/CLI/MCP** credential; remote devices **pair** for their own token |
| Can't revoke one device without rotating for all | `agentwire portal revoke <id>` kills one device, others keep working |
| No attribution | Each device is named in `devices.json` (stores a **sha256 hash**, never the plaintext) |
| `POST /api/config` could set `auth_token: ""`, rewrite `executables`, disable safety | Those keys are **frozen** → `403`, host-file-edit-only |

## #425 — freeze security-critical config
- `POST /api/config` returns **403** on any change to `server.auth_token`, `server.host`, `executables`, `services`, `safety` (constant `security.FROZEN_CONFIG_KEYS`), naming the offending key.
- `POST /api/safety/config` frozen entirely — the rm-rf damage-control rules can no longer be disabled via the API.
- The read-side secret redaction (`[REDACTED]`) is now **reversed on save** so the config-editor round-trip can't blank `auth_token`.

## #423 — per-device credentials + pairing
- New `agentwire/devices.py`: `devices.json` registry (0600, hashed tokens) + `pairings.json` (short-lived codes).
- `agentwire portal pair [--name]` → prints a code + **ASCII QR** → `GET /pair?code=` page → `POST /api/pair` mints a per-device token into `localStorage`.
- Middleware resolves the presented bearer to a device (bootstrap token → synthetic `host` device; else registry lookup). Unknown/revoked → **401**. mtime-cached loader → revoke is effective on the next request, no restart.
- CLI: `portal pair` / `portal devices` / `portal revoke <id>`. Adds a guarded `qrcode` dependency (degrades to a printed URL if absent).

## #420 — networking cuts
- Removed the SSH service-router **tunnel auto-spawn** from `portal start` — single-box portal now starts with no auto-spawned `ssh`.
- Stripped reverse-tunnel guidance (`autossh -R`, `~/.local/bin/agentwire-tunnels`) from `machine add` / `machine remove`.
- `agentwire tunnels *` kept as an **opt-in manual helper**, never auto-fired. `network status` confirmed read-only. Docs reframed BYO.

## Verification
- **In-worktree**, no live portal touched. Full suite: **1567 passed, 8 skipped**.
- New tests: frozen-config rejection (incl. redaction round-trip), device add/resolve/revoke, pairing lifecycle/expiry, per-device 401-on-revoke over HTTP, bootstrap-vs-paired resolution.
- Live over-the-wire smoke (loopback :8799): public health/pair `200`, no-token `401`, bootstrap token `200`, pair-redeem `200`, frozen `auth_token`/`safety` `403`. CLI `pair`/`devices`/`revoke` exercised end-to-end.

Closes #425
Closes #423

(#424 dropped not-planned — handled separately. #420 follow-ups: tunnel auto-spawn + reverse-tunnel prints cut; `agentwire tunnels *` left as manual helper rather than deleted.)

Built by [dotdev.dev](https://dotdev.dev)