### PR TITLE
fix(safety): make safety UI read-only after #425 config-freeze

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -1740,18 +1740,43 @@ body {
     margin-bottom: 8px;
 }
 
-.safety-toggle {
-    display: flex;
+.safety-badge {
+    display: inline-flex;
     align-items: center;
     gap: 8px;
-    cursor: pointer;
     font-size: 14px;
+    font-weight: 600;
     color: var(--text);
 }
 
-.safety-toggle input[type="checkbox"] {
-    accent-color: var(--accent);
-    cursor: pointer;
+.safety-badge-dot {
+    font-size: 12px;
+    line-height: 1;
+}
+
+.safety-badge.on .safety-badge-dot {
+    color: var(--accent);
+}
+
+.safety-badge.off {
+    color: var(--text-muted);
+}
+
+.safety-badge.off .safety-badge-dot {
+    color: var(--text-muted);
+}
+
+.safety-managed-note {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.safety-managed-note code {
+    font-size: 10px;
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: var(--chrome-bg, rgba(255, 255, 255, 0.06));
 }
 
 .safety-stats {
@@ -1884,26 +1909,8 @@ body {
     margin-bottom: 6px;
 }
 
-.safety-disabled-add {
-    background: transparent;
-    border: 1px solid var(--chrome-border);
-    color: var(--text-muted);
-    border-radius: 4px;
-    width: 24px;
-    height: 22px;
-    cursor: pointer;
-    font-size: 14px;
-    line-height: 1;
-}
-
-.safety-disabled-add:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-}
-
 .safety-disabled-rule {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     padding: 3px 0;
     font-size: 12px;
@@ -1911,19 +1918,6 @@ body {
 
 .safety-disabled-rule code {
     color: var(--accent);
-}
-
-.safety-rule-remove {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    font-size: 14px;
-    padding: 0 4px;
-}
-
-.safety-rule-remove:hover {
-    color: var(--error);
 }
 
 .safety-empty {
@@ -1977,62 +1971,6 @@ body {
     white-space: pre-wrap;
     word-break: break-all;
     margin-top: 4px;
-}
-
-.safety-disable-from-event {
-    margin-top: 12px;
-    padding: 8px 12px;
-    background: rgba(249, 115, 22, 0.18);
-    border: 1px solid #f97316;
-    color: #f97316;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 13px;
-}
-
-.safety-disable-from-event:hover {
-    background: rgba(249, 115, 22, 0.3);
-}
-
-/* Rule picker modal */
-
-.safety-rule-picker {
-    width: 600px;
-    max-width: 90vw;
-}
-
-.safety-rule-filter {
-    width: 100%;
-    background: var(--background);
-    border: 1px solid var(--chrome-border);
-    color: var(--text);
-    padding: 6px 10px;
-    border-radius: 4px;
-    font-size: 13px;
-    margin-bottom: 10px;
-}
-
-.safety-rule-list {
-    max-height: 50vh;
-    overflow-y: auto;
-}
-
-.safety-rule-row {
-    display: grid;
-    grid-template-columns: 280px 1fr;
-    gap: 10px;
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--chrome-border);
-    cursor: pointer;
-    font-size: 12px;
-}
-
-.safety-rule-row:hover {
-    background: var(--hover);
-}
-
-.safety-rule-row code {
-    color: var(--accent);
 }
 
 /* "Show all" affordance in the sidebar */

--- a/agentwire/static/js/safety-shared.js
+++ b/agentwire/static/js/safety-shared.js
@@ -69,22 +69,7 @@ export async function fetchSafetyLogs(decisionFilter = '', limit = 200) {
     } catch { return []; }
 }
 
-export async function fetchSafetyRules() {
-    try {
-        const data = await apiFetch('/api/safety/rules').then((r) => r.json());
-        return data.rules || [];
-    } catch { return []; }
-}
-
-export async function postSafetyConfig(payload) {
-    return apiFetch('/api/safety/config', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-    }).then((r) => r.json());
-}
-
-export function showEventModal(e, onDisabledChange) {
+export function showEventModal(e) {
     const existing = document.getElementById('safetyEventOverlay');
     if (existing) existing.remove();
     const wrap = document.createElement('div');
@@ -108,59 +93,10 @@ export function showEventModal(e, onDisabledChange) {
                 <span>Command</span>
                 <pre>${escapeHtml(e.command || '')}</pre>
             </div>
-            ${e.rule_id ? `<button class="safety-disable-from-event" data-action="disable-rule" data-rule-id="${escapeHtml(e.rule_id)}">Disable rule "${escapeHtml(e.rule_id)}"</button>` : ''}
         </div>
     </div>`;
     document.body.appendChild(wrap);
-    wrap.addEventListener('click', async (ev) => {
-        if (ev.target === wrap || ev.target.closest('[data-close]')) { wrap.remove(); return; }
-        const btn = ev.target.closest('[data-action="disable-rule"]');
-        if (btn) {
-            const status = await fetchSafetyStatus();
-            const id = btn.dataset.ruleId;
-            const next = [...(status.disabled_rules || []), id];
-            await postSafetyConfig({ disabled_rules: next });
-            wrap.remove();
-            if (onDisabledChange) onDisabledChange();
-        }
-    });
-}
-
-export async function openAddRulePicker(currentDisabled, onChange) {
-    const rules = await fetchSafetyRules();
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    overlay.innerHTML = `<div class="modal safety-rule-picker">
-        <div class="modal-header"><h3>Disable a rule</h3><button class="modal-close" data-close>×</button></div>
-        <div class="modal-body">
-            <input type="search" class="safety-rule-filter" placeholder="Filter rules…" autocomplete="off" />
-            <div class="safety-rule-list">
-                ${rules.map((r) => `
-                    <div class="safety-rule-row" data-rule-id="${escapeHtml(r.id)}">
-                        <code>${escapeHtml(r.id)}</code>
-                        <span>${escapeHtml(r.reason || '')}</span>
-                    </div>
-                `).join('')}
-            </div>
-        </div>
-    </div>`;
-    document.body.appendChild(overlay);
-    const filterInput = overlay.querySelector('.safety-rule-filter');
-    filterInput?.focus();
-    filterInput?.addEventListener('input', () => {
-        const q = filterInput.value.toLowerCase();
-        overlay.querySelectorAll('.safety-rule-row').forEach((row) => {
-            row.hidden = q && !row.textContent.toLowerCase().includes(q);
-        });
-    });
-    overlay.addEventListener('click', async (e) => {
-        if (e.target === overlay || e.target.closest('[data-close]')) { overlay.remove(); return; }
-        const row = e.target.closest('.safety-rule-row');
-        if (row) {
-            const id = row.dataset.ruleId;
-            await postSafetyConfig({ disabled_rules: [...currentDisabled, id] });
-            overlay.remove();
-            if (onChange) onChange();
-        }
+    wrap.addEventListener('click', (ev) => {
+        if (ev.target === wrap || ev.target.closest('[data-close]')) wrap.remove();
     });
 }

--- a/agentwire/static/js/safety-window.js
+++ b/agentwire/static/js/safety-window.js
@@ -9,10 +9,10 @@ import {
     escapeHtml,
     fetchSafetyStatus,
     fetchSafetyLogs,
-    postSafetyConfig,
     showEventModal,
-    openAddRulePicker,
 } from './safety-shared.js';
+
+const HOST_MANAGED_NOTE = 'Managed in <code>~/.agentwire/config.yaml</code> — frozen from the API (#425).';
 
 let activeWindow = null;
 const state = {
@@ -30,10 +30,11 @@ function pageHtml(status, entries) {
     return `
         <div class="safety-window-content">
             <aside class="safety-window-sidebar">
-                <label class="safety-toggle">
-                    <input type="checkbox" data-action="toggle-enabled" ${enabled ? 'checked' : ''} />
-                    <span>Damage control ${enabled ? 'enabled' : 'disabled'}</span>
-                </label>
+                <div class="safety-badge ${enabled ? 'on' : 'off'}">
+                    <span class="safety-badge-dot">${enabled ? '●' : '○'}</span>
+                    <span>Damage control ${enabled ? 'ON' : 'OFF'}</span>
+                </div>
+                <div class="safety-managed-note">${HOST_MANAGED_NOTE}</div>
                 <div class="safety-window-stats">
                     <div class="safety-window-stat"><span class="safety-decision blocked">${fmt('blocked')}</span><label>blocked</label></div>
                     <div class="safety-window-stat"><span class="safety-decision escape">${fmt('allowed_by_escape')}</span><label>escape</label></div>
@@ -60,13 +61,11 @@ function pageHtml(status, entries) {
                 <div class="safety-window-section">
                     <div class="safety-disabled-rules-header">
                         <h4>Disabled rules (${disabled.length})</h4>
-                        <button class="safety-disabled-add" data-action="add-rule">+</button>
                     </div>
                     <div class="safety-disabled-rules-list">
                         ${disabled.length ? disabled.map((id) => `
                             <div class="safety-disabled-rule" data-rule-id="${escapeHtml(id)}">
                                 <code>${escapeHtml(id)}</code>
-                                <button class="safety-rule-remove" data-action="remove-rule" data-rule-id="${escapeHtml(id)}" title="Re-enable rule">×</button>
                             </div>
                         `).join('') : '<div class="safety-empty">No rules disabled.</div>'}
                     </div>
@@ -105,14 +104,10 @@ async function loadAndRender(container) {
         entries = entries.filter((e) => projectFromCwd(e.cwd) === state.project);
     }
     container.innerHTML = pageHtml(status, entries);
-    bindControls(container, status);
+    bindControls(container);
 }
 
-function bindControls(container, status) {
-    container.querySelector('[data-action="toggle-enabled"]')?.addEventListener('change', async (e) => {
-        await postSafetyConfig({ enabled: e.target.checked });
-        loadAndRender(container);
-    });
+function bindControls(container) {
     container.querySelectorAll('.safety-chip').forEach((chip) => {
         chip.addEventListener('click', () => {
             state.decision = chip.dataset.decision || '';
@@ -123,23 +118,11 @@ function bindControls(container, status) {
         state.project = e.target.value || '';
         loadAndRender(container);
     });
-    container.querySelectorAll('[data-action="remove-rule"]').forEach((btn) => {
-        btn.addEventListener('click', async (e) => {
-            e.stopPropagation();
-            const id = btn.dataset.ruleId;
-            const next = (status.disabled_rules || []).filter((r) => r !== id);
-            await postSafetyConfig({ disabled_rules: next });
-            loadAndRender(container);
-        });
-    });
-    container.querySelector('[data-action="add-rule"]')?.addEventListener('click', () => {
-        openAddRulePicker(status.disabled_rules || [], () => loadAndRender(container));
-    });
     container.querySelector('[data-action="refresh"]')?.addEventListener('click', () => loadAndRender(container));
     container.querySelectorAll('.safety-event').forEach((row) => {
         row.addEventListener('click', () => {
             try {
-                showEventModal(JSON.parse(row.dataset.event), () => loadAndRender(container));
+                showEventModal(JSON.parse(row.dataset.event));
             } catch (_) {}
         });
     });

--- a/agentwire/static/js/sidebar/safety-section.js
+++ b/agentwire/static/js/sidebar/safety-section.js
@@ -10,25 +10,25 @@ import {
     escapeHtml,
     fetchSafetyStatus,
     fetchSafetyLogs,
-    postSafetyConfig,
     showEventModal,
-    openAddRulePicker,
 } from '../safety-shared.js';
+
+const HOST_MANAGED_NOTE = 'Managed in <code>~/.agentwire/config.yaml</code> — frozen from the API (#425).';
 
 const SIDEBAR_LIMIT = 10;
 
 let currentFilter = { decision: '' };
-let cachedStatus = { disabled_rules: [] };
 
 function renderHeader(status) {
     const enabled = status?.enabled ?? true;
     const counts = status?.today_counts || {};
     const fmt = (k) => counts[k] || 0;
     return `<div class="safety-header">
-        <label class="safety-toggle">
-            <input type="checkbox" data-action="toggle-enabled" ${enabled ? 'checked' : ''} />
-            <span>Damage control ${enabled ? 'enabled' : 'disabled'}</span>
-        </label>
+        <div class="safety-badge ${enabled ? 'on' : 'off'}">
+            <span class="safety-badge-dot">${enabled ? '●' : '○'}</span>
+            <span>Damage control ${enabled ? 'ON' : 'OFF'}</span>
+        </div>
+        <div class="safety-managed-note">${HOST_MANAGED_NOTE}</div>
         <div class="safety-stats">
             <span class="safety-decision blocked">${fmt('blocked')}</span>
             <span class="safety-decision escape">${fmt('allowed_by_escape')}</span>
@@ -49,13 +49,11 @@ function renderDisabledRules(status) {
     return `<div class="safety-disabled-rules">
         <div class="safety-disabled-rules-header">
             <span>Disabled rules (${disabled.length})</span>
-            <button class="safety-disabled-add" data-action="add-rule">+</button>
         </div>
         <div class="safety-disabled-rules-list">
             ${disabled.length ? disabled.map((id) => `
                 <div class="safety-disabled-rule" data-rule-id="${escapeHtml(id)}">
                     <code>${escapeHtml(id)}</code>
-                    <button class="safety-rule-remove" data-action="remove-rule" data-rule-id="${escapeHtml(id)}" title="Re-enable rule">×</button>
                 </div>
             `).join('') : '<div class="safety-empty">No rules disabled.</div>'}
         </div>
@@ -75,7 +73,6 @@ export const safetySection = {
             fetchSafetyStatus(),
             fetchSafetyLogs(currentFilter.decision, 500),
         ]);
-        cachedStatus = status || { disabled_rules: [] };
 
         const newestFirst = allEntries.slice().reverse();
         const shown = newestFirst.slice(0, SIDEBAR_LIMIT);
@@ -90,32 +87,16 @@ export const safetySection = {
                 ? `<button class="safety-show-all" data-action="open-window">Show all ${newestFirst.length} events →</button>`
                 : '');
 
-        body.querySelector('[data-action="toggle-enabled"]')?.addEventListener('change', async (e) => {
-            await postSafetyConfig({ enabled: e.target.checked });
-            this.refresh(body);
-        });
         body.querySelectorAll('.safety-chip').forEach((chip) => {
             chip.addEventListener('click', () => {
                 currentFilter.decision = chip.dataset.decision || '';
                 this.refresh(body);
             });
         });
-        body.querySelectorAll('[data-action="remove-rule"]').forEach((btn) => {
-            btn.addEventListener('click', async (e) => {
-                e.stopPropagation();
-                const id = btn.dataset.ruleId;
-                const next = (cachedStatus.disabled_rules || []).filter((r) => r !== id);
-                await postSafetyConfig({ disabled_rules: next });
-                this.refresh(body);
-            });
-        });
-        body.querySelector('[data-action="add-rule"]')?.addEventListener('click', () => {
-            openAddRulePicker(cachedStatus.disabled_rules || [], () => this.refresh(body));
-        });
         body.querySelectorAll('.safety-event').forEach((row) => {
             row.addEventListener('click', () => {
                 try {
-                    showEventModal(JSON.parse(row.dataset.event), () => this.refresh(body));
+                    showEventModal(JSON.parse(row.dataset.event));
                 } catch (_) {}
             });
         });


### PR DESCRIPTION
## Summary

PR #458 shipped #425, which froze the `safety:` block from the portal API — `POST /api/safety/config` now returns **403 unconditionally** (`server.py:3890`), by design. But the frontend safety UI still rendered interactive write controls (master toggle, disabled-rules `+`/`×`, and the event-modal re-enable) that all POSTed to that frozen endpoint and **silently failed**.

Owner's decision (#460): make the safety UI **read-only / host-managed** — show state, don't change it.

## Changes

- **Master toggle → read-only badge** in both `sidebar/safety-section.js` and `safety-window.js`: `● ON` / `○ OFF` from `GET /api/safety/status`, non-interactive, with a note — *"Managed in `~/.agentwire/config.yaml` — frozen from the API (#425)."*
- **Disabled-rules list is display-only**: removed the `+` add button, the `×` re-enable button, and the event-modal disable-rule action; rule ids still shown.
- **Deleted now-dead code** (no-dead-code rule): `postSafetyConfig`, `openAddRulePicker`, `fetchSafetyRules`, the event-modal re-enable handler, unused imports, and the now-unused `cachedStatus`.
- **CSS**: `.safety-toggle` → read-only `.safety-badge` (ON = neon-green dot `#39ff14` via `--accent`, OFF = muted) + `.safety-managed-note`; removed dead picker/add/remove styles.
- **Untouched**: backend freeze (`server.py:3890`) and the GET read endpoints — they're correct.

## Verification

- `grep` confirms **no frontend caller of `/api/safety/config`** remains (and no dangling `postSafetyConfig`/`openAddRulePicker`/`toggle-enabled`/`add-rule`/`remove-rule`/`disable-rule` refs).
- All three JS modules pass `node --check`.
- Badge derives from `status.enabled`; disabled-rules render from `status.disabled_rules`.
- **Left for owner's eyes**: visual confirmation in the live portal (can't restart the shared portal/MCP from this worktree). The badge + read-only list are static-verified.

Closes #460

Built by [dotdev.dev](https://dotdev.dev)