### PR TITLE
Harden install/sync tooling against drift (#462)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Voice interface for AI coding agents. Push-to-talk from any device to tmux sessi
 `uv tool install` caches builds and ignores source changes.
 
 ```bash
+# Step 0 — after a remote merge, pull first. rebuild reinstalls whatever is
+# checked out, so a never-pulled main silently ships stale code.
+git pull --ff-only
+
 # During development (picks up changes instantly)
 agentwire portal start --dev
 
@@ -16,10 +20,10 @@ agentwire portal start --dev
 agentwire rebuild
 
 # After code changes: ALWAYS do both
-agentwire rebuild && agentwire portal restart --dev
+git pull --ff-only && agentwire rebuild && agentwire portal restart --dev
 ```
 
-Rebuild alone = stale static files. Restart alone = stale Python. The MCP server runs as a separate process started by Claude Code — session restart required after rebuild to pick up MCP changes.
+Rebuild alone = stale static files. Restart alone = stale Python. The MCP server runs as a separate process started by Claude Code — session restart required after rebuild to pick up MCP changes. `rebuild` now refuses (warn + `--force` to override) when the checkout is behind `origin/main`, and `agentwire doctor` flags a behind-main checkout, a disabled kill switch (`safety.enabled: false`), and damage-control rule/hook/matcher drift.
 
 ## CLI is the Single Source of Truth
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7114,7 +7114,7 @@ def cmd_safety_logs(args) -> int:
 
 def cmd_safety_install(args) -> int:
     """CLI command: agentwire safety install"""
-    return cli_safety.safety_install_cmd()
+    return cli_safety.safety_install_cmd(assume_yes=getattr(args, "yes", False))
 
 
 def cmd_safety_tooldefs_list(args) -> int:
@@ -7125,6 +7125,79 @@ def cmd_safety_tooldefs_list(args) -> int:
 def cmd_safety_tooldefs_show(args) -> int:
     """CLI command: agentwire safety tooldefs show <tool>"""
     return cli_safety.safety_tooldefs_show_cmd(args.tool)
+
+
+def _render_damage_control_section() -> int:
+    """Print the damage-control health block. Returns the count of issues found.
+
+    Covers the four #462 blind spots plus DC hook staleness: the global kill
+    switch (``safety.enabled: false``), installed-rules drift vs the bundled
+    rules, PreToolUse matcher registration, and DC hook-script staleness.
+    """
+    issues = 0
+
+    # Kill switch — config.safety.enabled gates ALL damage control. A silent
+    # `false` is the loudest possible failure, so flag it first and hard.
+    try:
+        from .config import load_config as _load_config_typed
+        safety_enabled = _load_config_typed().safety.enabled
+    except Exception as e:
+        print(f"  [..] Could not read safety config: {e}")
+        safety_enabled = True
+    if not safety_enabled:
+        print("  [!!] Damage control is DISABLED (safety.enabled: false)")
+        print("       ALL command/path/outbound gating is off.")
+        print("       Fix: set safety.enabled: true in ~/.agentwire/config.yaml")
+        issues += 1
+    else:
+        print("  [ok] Damage control enabled (safety.enabled: true)")
+
+    try:
+        from . import cli_safety
+    except Exception as e:
+        print(f"  [..] Could not load safety module: {e}")
+        return issues
+
+    # DC hook-script staleness (bash/edit/write/mcp-tool + audit_logger).
+    hook_drift = cli_safety.damage_control_hook_drift()
+    stale_hooks = [f for f, s in hook_drift.items() if s == "stale"]
+    missing_hooks = [f for f, s in hook_drift.items() if s == "missing"]
+    if stale_hooks or missing_hooks:
+        if missing_hooks:
+            print(f"  [!!] DC hook scripts missing: {', '.join(sorted(missing_hooks))}")
+        if stale_hooks:
+            print(f"  [!!] DC hook scripts STALE: {', '.join(sorted(stale_hooks))}")
+        print("       Fix: agentwire safety install --yes")
+        issues += 1
+    else:
+        print("  [ok] DC hook scripts current")
+
+    # Installed-rules drift vs bundled rules (the incident's missing files).
+    rule_drift = cli_safety.rules_drift()
+    missing_rules = [f for f, s in rule_drift.items() if s == "missing"]
+    stale_rules = [f for f, s in rule_drift.items() if s == "stale"]
+    if missing_rules:
+        print(f"  [!!] Damage-control rules NOT installed: {', '.join(sorted(missing_rules))}")
+        print("       Fix: agentwire safety install --yes")
+        issues += 1
+    elif stale_rules:
+        # Stale = installed copy differs from bundled. Could be an intentional
+        # customization, so warn (not error) and don't auto-overwrite.
+        print(f"  [..] Damage-control rules differ from bundled: {', '.join(sorted(stale_rules))}")
+        print("       (customized? `agentwire safety install --yes` leaves these untouched)")
+    else:
+        print("  [ok] Damage-control rules installed and match bundled")
+
+    # Matcher presence in ~/.claude/settings.json.
+    missing_matchers = cli_safety.missing_damage_control_matchers()
+    if missing_matchers:
+        print(f"  [!!] PreToolUse matchers not registered: {', '.join(missing_matchers)}")
+        print("       Fix: agentwire safety install --yes")
+        issues += 1
+    else:
+        print("  [ok] PreToolUse damage-control matchers registered")
+
+    return issues
 
 
 def _render_voice_loop_section(config, ctx) -> int:
@@ -7307,6 +7380,36 @@ def cmd_doctor(args) -> int:
         else:
             print(f"  [..] {label}: not found ({why})")
             print("     Run: agentwire hooks install")
+
+    # 4b. Damage control (safety) — the kill switch, install drift, and the
+    # PreToolUse matcher registration. The #462 incident: a global disable and
+    # missing rule files were both invisible to every diagnostic.
+    print("\nChecking damage control (safety)...")
+    issues_found += _render_damage_control_section()
+
+    # 4c. Local checkout vs origin/main — rebuild reinstalls whatever is checked
+    # out, so a never-pulled main silently ships stale code. Today only worktree
+    # creation fetches; surface the drift here too.
+    print("\nChecking source checkout...")
+    src_root = Path(__file__).parent.parent
+    if not (src_root / "pyproject.toml").exists():
+        try:
+            src_root = get_source_dir()
+        except Exception:
+            src_root = None
+    if src_root is None:
+        print("  [..] Could not locate source checkout — skipping git-drift check")
+    else:
+        behind, err = _git_behind_origin(src_root)
+        if err:
+            print(f"  [..] Source checkout: skipped git-drift check ({err})")
+        elif behind and behind > 0:
+            print(f"  [!!] Local main is {behind} commit(s) behind origin/main")
+            print(f"       {src_root}")
+            print("       Fix: git pull --ff-only  (then agentwire rebuild)")
+            issues_found += 1
+        else:
+            print("  [ok] Local main up to date with origin/main")
 
     # Check custom services (registry-driven: built-in notifications bridge
     # + user-defined services from services.custom)
@@ -7705,13 +7808,68 @@ def cmd_voiceclone_delete(args) -> int:
 UV_CACHE_DIR = Path.home() / ".cache" / "uv"
 
 
+def _git_behind_origin(repo: Path, base: str = "main", do_fetch: bool = True):
+    """How many commits ``origin/<base>`` is ahead of the checkout's HEAD.
+
+    Returns ``(behind, error)``: ``behind`` is the commit count (0 = up to date),
+    or ``None`` with a human-readable ``error`` string when the comparison can't
+    be made (not a git repo, no remote, offline fetch failure, etc.).
+    """
+    if not (repo / ".git").exists():
+        return None, "not a git checkout"
+    if do_fetch:
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", base],
+            cwd=repo, capture_output=True, text=True,
+        )
+        if fetch.returncode != 0:
+            return None, (fetch.stderr or fetch.stdout or "git fetch failed").strip()
+    count = subprocess.run(
+        ["git", "rev-list", "--count", f"HEAD..origin/{base}"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    if count.returncode != 0:
+        return None, (count.stderr or count.stdout or "git rev-list failed").strip()
+    try:
+        return int(count.stdout.strip()), None
+    except ValueError:
+        return None, f"unexpected rev-list output: {count.stdout.strip()!r}"
+
+
 def cmd_rebuild(args) -> int:
     """Rebuild: clear uv cache, uninstall, reinstall from source.
 
     This is the correct way to pick up source changes when developing.
     `uv tool install . --force` does NOT work - it uses cached wheels.
     """
+    force = getattr(args, "force", False)
+
     print("Rebuilding agentwire-dev...")
+    print()
+
+    # Resolve the source checkout up front so the git-drift guard and the
+    # install step agree on which tree they're operating over.
+    project_root = Path(__file__).parent.parent
+    if not (project_root / "pyproject.toml").exists():
+        project_root = get_source_dir()
+
+    # Git-drift guard: rebuild is otherwise git-blind and will happily reinstall
+    # stale code when local main was never pulled after a remote merge. Refuse
+    # (unless --force) so the fix happens before the reinstall, not after.
+    behind, err = _git_behind_origin(project_root)
+    if err:
+        print(f"  - Skipping git-drift check ({err})")
+    elif behind and behind > 0:
+        print(f"  [!!] Local checkout is {behind} commit(s) behind origin/main.")
+        print(f"       {project_root}")
+        print("       Rebuild would reinstall stale code. Run first:")
+        print("         git pull --ff-only")
+        if not force:
+            print("       (or re-run with --force to rebuild anyway)")
+            return 1
+        print("       --force given: rebuilding from the behind checkout anyway.")
+    else:
+        print("  ✓ Checkout up to date with origin/main")
     print()
 
     # Step 1: Clear uv cache
@@ -7735,13 +7893,7 @@ def cmd_rebuild(args) -> int:
         # Might not be installed, that's fine
         print("  - Not installed (continuing)")
 
-    # Step 3: Reinstall from current directory
-    # Find the project root (where pyproject.toml is)
-    project_root = Path(__file__).parent.parent
-    if not (project_root / "pyproject.toml").exists():
-        # Fallback to configured source directory
-        project_root = get_source_dir()
-
+    # Step 3: Reinstall from the source checkout resolved above.
     print(f"Installing from {project_root}...")
     result = subprocess.run(
         ["uv", "tool", "install", "."],
@@ -8579,11 +8731,14 @@ def install_hooks(force: bool = False, copy: bool = False) -> dict[str, str]:
         if event:
             register_hook_in_settings(event, hook_name)
 
-    # Heal the damage-control PreToolUse matchers (Bash/Edit/Write + the outbound
-    # MCP tools) in settings.json so `hooks install` keeps them current too.
+    # Heal the full damage-control surface (hook scripts + rules + tooldefs +
+    # PreToolUse matchers), not just the settings.json matchers. This closes the
+    # documented post-rebuild gap: CLAUDE.md tells users to re-run `hooks install`
+    # after a rebuild, so it must actually sync the DC files/rules — drift-aware,
+    # never clobbering a customized rule.
     try:
-        from agentwire.cli_safety import register_damage_control_in_settings
-        register_damage_control_in_settings()
+        from agentwire.cli_safety import heal_damage_control
+        heal_damage_control(quiet=True)
     except Exception:
         pass
 
@@ -11781,7 +11936,12 @@ def main() -> int:
 
     # safety install
     safety_install = safety_subparsers.add_parser(
-        "install", help="Install damage control hooks (interactive)"
+        "install", help="Install/heal damage control hooks, rules, and matchers"
+    )
+    safety_install.add_argument(
+        "-y", "--yes", action="store_true",
+        help="Non-interactive, drift-aware heal (install missing + update stale "
+             "owned hooks; never clobbers existing rules)",
     )
     safety_install.set_defaults(func=cmd_safety_install)
 
@@ -11825,6 +11985,10 @@ def main() -> int:
     # === rebuild command ===
     rebuild_parser = subparsers.add_parser(
         "rebuild", help="Clear uv cache and reinstall from source (for development)"
+    )
+    rebuild_parser.add_argument(
+        "--force", action="store_true",
+        help="Rebuild even when the local checkout is behind origin/main",
     )
     rebuild_parser.set_defaults(func=cmd_rebuild)
 

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -544,90 +544,200 @@ def register_damage_control_in_settings() -> int:
     return added
 
 
-def safety_install_cmd() -> int:
-    """CLI command: ``agentwire safety install`` — interactive setup."""
+def _file_drift_state(target: Path, source: Path) -> str:
+    """Drift state of an installed damage-control file: missing | stale | ok.
+
+    ``ok`` when the bundled source is absent (nothing to compare) or the
+    installed bytes match it; ``missing`` when the source ships but no copy is
+    installed; ``stale`` when an installed copy differs from the bundled bytes.
+    """
+    if not source.exists():
+        return "ok"
+    if not target.exists():
+        return "missing"
+    try:
+        return "ok" if target.read_bytes() == source.read_bytes() else "stale"
+    except OSError:
+        return "stale"
+
+
+def damage_control_hook_drift() -> Dict[str, str]:
+    """Drift state per DC hook script (``bash/edit/write/mcp-tool-...`` + logger).
+
+    Returns ``{filename: missing|stale|ok}`` comparing the installed copies in
+    ``~/.agentwire/hooks/damage-control/`` against the bundled package source.
+    """
+    hooks_source = Path(__file__).parent / "hooks" / "damage-control"
+    return {
+        fn: _file_drift_state(HOOKS_DIR / fn, hooks_source / fn)
+        for fn in DAMAGE_CONTROL_FILES
+    }
+
+
+def rules_drift() -> Dict[str, str]:
+    """Drift state per bundled rule file vs ``~/.agentwire/damage-control/``.
+
+    Only the bundled rule set is inspected (user-added rules with no bundled
+    counterpart are not "drift"). Returns ``{filename: missing|stale|ok}``.
+    """
+    try:
+        source_dir = get_damage_control_source()
+    except FileNotFoundError:
+        return {}
+    return {
+        src.name: _file_drift_state(RULES_DIR / src.name, src)
+        for src in sorted(source_dir.glob("*.yaml"))
+    }
+
+
+def missing_damage_control_matchers() -> List[str]:
+    """Damage-control matchers not registered in ``~/.claude/settings.json``."""
+    settings_file = Path.home() / ".claude" / "settings.json"
+    try:
+        settings = json.loads(settings_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        settings = {}
+    pre = settings.get("hooks", {}).get("PreToolUse", []) if isinstance(settings, dict) else []
+    registered = {
+        h.get("command")
+        for entry in pre
+        for h in (entry.get("hooks", []) if isinstance(entry, dict) else [])
+    }
+    missing = []
+    for matcher, hook_file in DAMAGE_CONTROL_MATCHERS.items():
+        if f"~/.agentwire/hooks/damage-control/{hook_file}" not in registered:
+            missing.append(matcher)
+    return missing
+
+
+def heal_damage_control(quiet: bool = False) -> Dict[str, Any]:
+    """Drift-aware sync of DC hook scripts, rules, tooldefs, and matchers.
+
+    Non-interactive. Agentwire-owned hook scripts are installed when missing and
+    overwritten when stale (they carry no user edits). Rules and tooldefs are
+    install-missing-only — an existing rule, including a hand-customized one, is
+    left untouched, so this never blind-clobbers user rules. Matchers are
+    registered if absent. Returns a summary dict of what changed.
+    """
+    log = (lambda *a: None) if quiet else print
+
+    HOOKS_DIR.mkdir(parents=True, exist_ok=True)
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    RULES_DIR.mkdir(parents=True, exist_ok=True)
+    TOOLDEFS_DIR.mkdir(parents=True, exist_ok=True)
+
+    summary: Dict[str, Any] = {
+        "hooks_installed": [], "hooks_updated": [],
+        "rules_installed": [], "tooldefs_installed": [], "matchers_added": 0,
+    }
+
+    hooks_source = Path(__file__).parent / "hooks" / "damage-control"
+    for fn in DAMAGE_CONTROL_FILES:
+        src = hooks_source / fn
+        if not src.exists():
+            log(f"⚠️  Missing {fn} in package")
+            continue
+        target = HOOKS_DIR / fn
+        state = _file_drift_state(target, src)
+        if state == "ok":
+            continue
+        shutil.copy2(src, target)
+        if fn.endswith(".py"):
+            target.chmod(0o755)
+        if state == "missing":
+            summary["hooks_installed"].append(fn)
+            log(f"✓ Installed hook {fn}")
+        else:
+            summary["hooks_updated"].append(fn)
+            log(f"✓ Updated stale hook {fn}")
+
+    # Rules: install missing only — never overwrite an existing (possibly
+    # hand-customized) rule file.
+    try:
+        rules_source = get_damage_control_source()
+        for src in sorted(rules_source.glob("*.yaml")):
+            target = RULES_DIR / src.name
+            if not target.exists():
+                shutil.copy2(src, target)
+                summary["rules_installed"].append(src.name)
+                log(f"✓ Installed rule {src.name}")
+    except FileNotFoundError as e:
+        log(f"⚠️  {e}")
+
+    # Tooldefs: install missing only (user overrides win, same as rules).
+    try:
+        tooldefs_source = get_tooldefs_source()
+        for src in sorted(tooldefs_source.glob("*.yaml")):
+            target = TOOLDEFS_DIR / src.name
+            if not target.exists():
+                shutil.copy2(src, target)
+                summary["tooldefs_installed"].append(src.name)
+                log(f"✓ Installed tooldef {src.name}")
+    except FileNotFoundError as e:
+        log(f"⚠️  {e}")
+
+    added = register_damage_control_in_settings()
+    summary["matchers_added"] = added
+    if added:
+        log(f"✓ Registered {added} damage-control matcher{'s' if added != 1 else ''}")
+
+    return summary
+
+
+def safety_install_cmd(assume_yes: bool = False) -> int:
+    """CLI command: ``agentwire safety install``.
+
+    With ``--yes``/``assume_yes`` it runs unattended and drift-aware: installs
+    missing hook scripts/rules/tooldefs, updates stale *owned* hook scripts, and
+    registers any absent matchers, without prompting and without clobbering an
+    existing (possibly customized) rule. Without it, the same heal runs behind
+    the two interactive confirmations.
+    """
     print("AgentWire Safety Installation")
     print("=" * 50)
     print()
 
-    if HOOKS_DIR.exists() and RULES_DIR.exists() and any(RULES_DIR.glob("*.yaml")):
-        print("⚠️  Safety hooks already installed")
-        print(f"   Location: {HOOKS_DIR}")
-        if input("Reinstall? [y/N] ").strip().lower() != "y":
+    if not assume_yes:
+        if HOOKS_DIR.exists() and RULES_DIR.exists() and any(RULES_DIR.glob("*.yaml")):
+            print("⚠️  Safety hooks already installed")
+            print(f"   Location: {HOOKS_DIR}")
+            if input("Re-sync (drift-aware heal)? [y/N] ").strip().lower() != "y":
+                print("Installation cancelled.")
+                return 0
+
+        print("This will install/heal damage control security hooks at:")
+        print(f"  {HOOKS_DIR}")
+        print()
+        print("The hooks will:")
+        print("  • Block dangerous commands (rm -rf /, etc.)")
+        print("  • Protect sensitive files (.env, SSH keys, etc.)")
+        print("  • Log all security decisions")
+        print()
+
+        if input("Proceed with installation? [y/N] ").strip().lower() != "y":
             print("Installation cancelled.")
             return 0
 
-    print("This will install damage control security hooks to:")
-    print(f"  {HOOKS_DIR}")
-    print()
-    print("The hooks will:")
-    print("  • Block dangerous commands (rm -rf /, etc.)")
-    print("  • Protect sensitive files (.env, SSH keys, etc.)")
-    print("  • Log all security decisions")
-    print()
-
-    if input("Proceed with installation? [y/N] ").strip().lower() != "y":
-        print("Installation cancelled.")
-        return 0
-
     try:
-        source_dir = get_damage_control_source()
+        get_damage_control_source()
     except FileNotFoundError as e:
         print(f"\n⚠️  {e}")
         print("   The damage-control hooks are missing from the package.")
         return 1
 
     print()
-    print("Creating directories...")
-    HOOKS_DIR.mkdir(parents=True, exist_ok=True)
-    LOGS_DIR.mkdir(parents=True, exist_ok=True)
-    RULES_DIR.mkdir(parents=True, exist_ok=True)
-    TOOLDEFS_DIR.mkdir(parents=True, exist_ok=True)
-    for d in (HOOKS_DIR, LOGS_DIR, RULES_DIR, TOOLDEFS_DIR):
-        print(f"✓ Created {d}")
+    summary = heal_damage_control()
 
-    hooks_source = Path(__file__).parent / "hooks" / "damage-control"
+    touched = (
+        summary["hooks_installed"] or summary["hooks_updated"]
+        or summary["rules_installed"] or summary["tooldefs_installed"]
+        or summary["matchers_added"]
+    )
     print()
-    print("Installing hooks...")
-    for filename in DAMAGE_CONTROL_FILES:
-        source_file = hooks_source / filename
-        target_file = HOOKS_DIR / filename
-        if source_file.exists():
-            shutil.copy2(source_file, target_file)
-            if filename.endswith(".py"):
-                target_file.chmod(0o755)
-            print(f"✓ Installed {filename}")
-        else:
-            print(f"⚠️  Missing {filename} in package")
-
-    print()
-    print("Installing rules...")
-    for rules_file in sorted(source_dir.glob("*.yaml")):
-        target_file = RULES_DIR / rules_file.name
-        shutil.copy2(rules_file, target_file)
-        print(f"✓ Installed {rules_file.name}")
-
-    print()
-    print("Installing tooldefs...")
-    try:
-        tooldefs_source = get_tooldefs_source()
-        for tooldef_file in sorted(tooldefs_source.glob("*.yaml")):
-            target_file = TOOLDEFS_DIR / tooldef_file.name
-            shutil.copy2(tooldef_file, target_file)
-            print(f"✓ Installed {tooldef_file.name}")
-    except FileNotFoundError as e:
-        print(f"⚠️  {e}")
-
-    print()
-    print("Registering PreToolUse hooks in ~/.claude/settings.json...")
-    added = register_damage_control_in_settings()
-    if added:
-        print(f"✓ Registered {added} damage-control matcher{'s' if added != 1 else ''}")
+    if touched:
+        print("✓ Damage control synced.")
     else:
-        print("✓ All damage-control matchers already registered")
-
-    print()
-    print("✓ Installation complete!")
+        print("✓ Damage control already in sync — nothing to do.")
     print()
     print("Next steps:")
     print("  1. Test with: agentwire safety check 'rm -rf /'")

--- a/tests/unit/test_rebuild_guard.py
+++ b/tests/unit/test_rebuild_guard.py
@@ -1,0 +1,134 @@
+"""Tests for the `agentwire rebuild` git-drift guard (#462).
+
+`rebuild` is otherwise git-blind: it reinstalls whatever is checked out, so a
+never-pulled local main silently ships stale code. The guard fetches origin and
+refuses (unless --force) when the checkout is behind origin/main.
+"""
+
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+from agentwire.__main__ import _git_behind_origin, cmd_rebuild
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True, env={**env},
+    ).stdout.strip()
+
+
+@pytest.fixture
+def behind_checkout(tmp_path):
+    """A clone whose local main is 2 commits behind its origin/main."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    (origin / "f.txt").write_text("0\n")
+    _git(origin, "add", ".")
+    _git(origin, "commit", "-qm", "c0")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+
+    # Advance origin by 2 commits the clone hasn't pulled.
+    for i in (1, 2):
+        (origin / "f.txt").write_text(f"{i}\n")
+        _git(origin, "commit", "-qam", f"c{i}")
+    return clone, origin
+
+
+class TestGitBehindOrigin:
+    def test_up_to_date_returns_zero(self, tmp_path):
+        origin = tmp_path / "origin"
+        origin.mkdir()
+        _git(origin, "init", "-q", "-b", "main")
+        (origin / "f.txt").write_text("0\n")
+        _git(origin, "add", ".")
+        _git(origin, "commit", "-qm", "c0")
+        clone = tmp_path / "clone"
+        _git(tmp_path, "clone", "-q", str(origin), str(clone))
+
+        behind, err = _git_behind_origin(clone)
+        assert err is None
+        assert behind == 0
+
+    def test_behind_returns_count(self, behind_checkout):
+        clone, _ = behind_checkout
+        behind, err = _git_behind_origin(clone)
+        assert err is None
+        assert behind == 2
+
+    def test_not_a_repo_returns_error(self, tmp_path):
+        behind, err = _git_behind_origin(tmp_path)
+        assert behind is None
+        assert "not a git checkout" in err
+
+    def test_no_fetch_uses_local_remote_ref(self, behind_checkout):
+        clone, _ = behind_checkout
+        behind, err = _git_behind_origin(clone, do_fetch=False)
+        # Without fetch the clone's stale origin/main ref shows up to date.
+        assert err is None
+        assert behind == 0
+
+
+def _args(**kw):
+    return types.SimpleNamespace(**kw)
+
+
+class TestRebuildGuard:
+    @pytest.fixture(autouse=True)
+    def _patch_root(self, behind_checkout, monkeypatch):
+        clone, _ = behind_checkout
+        # Make a pyproject so cmd_rebuild treats the clone as the source root.
+        (clone / "pyproject.toml").write_text("[project]\nname='x'\n")
+        import agentwire.__main__ as main_mod
+        # __file__.parent.parent must resolve to the clone.
+        fake_file = clone / "agentwire" / "__main__.py"
+        fake_file.parent.mkdir(parents=True, exist_ok=True)
+        fake_file.write_text("")
+        monkeypatch.setattr(main_mod, "__file__", str(fake_file))
+        self.clone = clone
+
+    def test_refuses_when_behind(self, monkeypatch, capsys):
+        # Let the real git fetch/rev-list run (so behind is computed), but fail
+        # loudly if rebuild ever reaches the uv install path.
+        real_run = subprocess.run
+        reached_install = {"hit": False}
+
+        def fake_run(cmd, *a, **k):
+            if cmd[:2] in (["git", "fetch"], ["git", "rev-list"]):
+                return real_run(cmd, *a, **k)
+            reached_install["hit"] = True
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: None)
+        rc = cmd_rebuild(_args(force=False))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "behind origin/main" in out
+        assert reached_install["hit"] is False
+
+    def test_force_overrides(self, monkeypatch, capsys):
+        # With --force the guard prints a warning and proceeds past it. Stub the
+        # uv subprocess calls so the real install isn't attempted.
+        real_run = subprocess.run
+
+        def fake_run(cmd, *a, **k):
+            if cmd[:2] == ["git", "fetch"] or cmd[:2] == ["git", "rev-list"]:
+                return real_run(cmd, *a, **k)
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: None)
+        rc = cmd_rebuild(_args(force=True))
+        out = capsys.readouterr().out
+        assert "--force given" in out
+        assert rc == 0

--- a/tests/unit/test_safety_heal.py
+++ b/tests/unit/test_safety_heal.py
@@ -1,0 +1,158 @@
+"""Tests for the drift-aware safety heal and doctor's damage-control checks (#462).
+
+`safety install --yes` must run unattended and drift-aware: install missing hook
+scripts/rules, refresh *owned* hook scripts that drifted, register missing
+matchers — and never clobber an existing (possibly hand-customized) rule.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentwire import cli_safety
+
+
+@pytest.fixture
+def fake_env(tmp_path, monkeypatch):
+    """Redirect every ~/.agentwire and ~/.claude path used by the heal."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    cfg = home / ".agentwire"
+    monkeypatch.setattr(cli_safety, "CONFIG_DIR", cfg)
+    monkeypatch.setattr(cli_safety, "HOOKS_DIR", cfg / "hooks" / "damage-control")
+    monkeypatch.setattr(cli_safety, "LOGS_DIR", cfg / "logs" / "damage-control")
+    monkeypatch.setattr(cli_safety, "RULES_DIR", cfg / "damage-control")
+    monkeypatch.setattr(cli_safety, "TOOLDEFS_DIR", cfg / "tooldefs")
+    return home
+
+
+class TestHealIdempotency:
+    def test_fresh_heal_installs_everything(self, fake_env):
+        summary = cli_safety.heal_damage_control(quiet=True)
+        assert summary["hooks_installed"]          # all DC hook scripts
+        assert summary["rules_installed"]          # all bundled rules
+        assert summary["matchers_added"] == len(cli_safety.DAMAGE_CONTROL_MATCHERS)
+        # Every bundled rule landed.
+        installed = {p.name for p in cli_safety.RULES_DIR.glob("*.yaml")}
+        bundled = {p.name for p in cli_safety.get_damage_control_source().glob("*.yaml")}
+        assert bundled <= installed
+
+    def test_second_heal_is_noop(self, fake_env):
+        cli_safety.heal_damage_control(quiet=True)
+        summary = cli_safety.heal_damage_control(quiet=True)
+        assert summary["hooks_installed"] == []
+        assert summary["hooks_updated"] == []
+        assert summary["rules_installed"] == []
+        assert summary["matchers_added"] == 0
+
+
+class TestHealDriftAwareness:
+    def test_missing_rule_reinstalled(self, fake_env):
+        cli_safety.heal_damage_control(quiet=True)
+        victim = next(cli_safety.RULES_DIR.glob("*.yaml"))
+        name = victim.name
+        victim.unlink()
+        summary = cli_safety.heal_damage_control(quiet=True)
+        assert name in summary["rules_installed"]
+        assert (cli_safety.RULES_DIR / name).exists()
+
+    def test_customized_rule_survives(self, fake_env):
+        cli_safety.heal_damage_control(quiet=True)
+        rule = next(cli_safety.RULES_DIR.glob("*.yaml"))
+        rule.write_text("# my hand-customized rule\n")
+        cli_safety.heal_damage_control(quiet=True)
+        # Never blind-clobbered: the customization is intact.
+        assert rule.read_text() == "# my hand-customized rule\n"
+
+    def test_stale_owned_hook_refreshed(self, fake_env):
+        cli_safety.heal_damage_control(quiet=True)
+        hook = cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]
+        hook.write_text("# stale\n")
+        summary = cli_safety.heal_damage_control(quiet=True)
+        # Owned hook scripts carry no user edits — drift is overwritten.
+        assert hook.name in summary["hooks_updated"]
+        assert "# stale" not in hook.read_text()
+
+
+class TestDriftDetectors:
+    def test_hook_drift_states(self, fake_env):
+        assert set(cli_safety.damage_control_hook_drift().values()) == {"missing"}
+        cli_safety.heal_damage_control(quiet=True)
+        assert set(cli_safety.damage_control_hook_drift().values()) == {"ok"}
+        hook = cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]
+        hook.write_text("# drifted\n")
+        assert cli_safety.damage_control_hook_drift()[hook.name] == "stale"
+
+    def test_rules_drift_states(self, fake_env):
+        assert set(cli_safety.rules_drift().values()) == {"missing"}
+        cli_safety.heal_damage_control(quiet=True)
+        assert set(cli_safety.rules_drift().values()) == {"ok"}
+
+    def test_missing_matchers(self, fake_env):
+        assert set(cli_safety.missing_damage_control_matchers()) == set(
+            cli_safety.DAMAGE_CONTROL_MATCHERS
+        )
+        cli_safety.heal_damage_control(quiet=True)
+        assert cli_safety.missing_damage_control_matchers() == []
+
+
+class TestInstallCmdNonInteractive:
+    def test_yes_does_not_prompt(self, fake_env, monkeypatch):
+        # input() must never be called in --yes mode.
+        monkeypatch.setattr("builtins.input", lambda *a: pytest.fail("prompted"))
+        rc = cli_safety.safety_install_cmd(assume_yes=True)
+        assert rc == 0
+        assert (cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]).exists()
+
+
+class TestDoctorDamageControlSection:
+    @pytest.fixture(autouse=True)
+    def _healed(self, fake_env):
+        cli_safety.heal_damage_control(quiet=True)
+        return fake_env
+
+    def _patch_safety_enabled(self, monkeypatch, enabled):
+        import agentwire.config as cfg_mod
+
+        class _Cfg:
+            safety = type("S", (), {"enabled": enabled})()
+
+        monkeypatch.setattr(cfg_mod, "load_config", lambda *a, **k: _Cfg())
+
+    def test_clean_when_healed_and_enabled(self, monkeypatch, capsys):
+        from agentwire.__main__ import _render_damage_control_section
+        self._patch_safety_enabled(monkeypatch, True)
+        issues = _render_damage_control_section()
+        out = capsys.readouterr().out
+        assert issues == 0
+        assert "[ok] Damage control enabled" in out
+
+    def test_disabled_kill_switch_flagged(self, monkeypatch, capsys):
+        from agentwire.__main__ import _render_damage_control_section
+        self._patch_safety_enabled(monkeypatch, False)
+        issues = _render_damage_control_section()
+        out = capsys.readouterr().out
+        assert issues >= 1
+        assert "DISABLED" in out
+
+    def test_missing_rule_flagged(self, monkeypatch, capsys):
+        from agentwire.__main__ import _render_damage_control_section
+        self._patch_safety_enabled(monkeypatch, True)
+        next(cli_safety.RULES_DIR.glob("*.yaml")).unlink()
+        issues = _render_damage_control_section()
+        out = capsys.readouterr().out
+        assert issues >= 1
+        assert "rules NOT installed" in out
+
+    def test_missing_matcher_flagged(self, monkeypatch, capsys):
+        from agentwire.__main__ import _render_damage_control_section
+        self._patch_safety_enabled(monkeypatch, True)
+        settings = Path.home() / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": {"PreToolUse": []}}))
+        issues = _render_damage_control_section()
+        out = capsys.readouterr().out
+        assert issues >= 1
+        assert "matchers not registered" in out


### PR DESCRIPTION
## Summary

Harden the install/sync tooling so common drift is **caught, not silently tolerated**. The episode behind #462 hit four traps; this is purely additive hardening (none of these guards ever existed — history-confirmed).

### 1. `rebuild` git-guard — `cmd_rebuild`
`agentwire rebuild` was git-blind: a never-pulled local `main` silently reinstalled stale code. It now `git fetch`es origin and **refuses (warn + behind-count) unless `--force`** when the checkout is behind `origin/main`, pointing at `git pull --ff-only`. New `_git_behind_origin(repo, base, do_fetch)` helper.

### 2. `doctor` drift + security checks — `cmd_doctor`
New `_render_damage_control_section()` + a source-checkout block add:
- **Kill switch**: `safety.enabled: false` → loud `[!!]` (it silently disables ALL gating).
- **Local main behind origin**: fetch + behind-count for the primary checkout.
- **Rules drift**: installed `~/.agentwire/damage-control/*.yaml` vs bundled rules (missing = error, customized/stale = warn, never auto-overwritten).
- **Matcher presence**: `DAMAGE_CONTROL_MATCHERS` registered in `~/.claude/settings.json`.
- **DC hook staleness**: now covers `bash/edit/write/mcp-tool-damage-control.py` + `audit_logger.py` (previously only the 3 managed hooks).

### 3. Non-interactive, drift-aware safety heal — `safety_install_cmd`
New `heal_damage_control()`:
- Owned DC hook scripts → install missing + **overwrite stale** (no user edits to preserve).
- Rules / tooldefs → **install-missing-only**; an existing (possibly hand-customized) rule is left untouched — never blind-`copy2`-clobbered.
- Matchers → registered if absent.

`safety install --yes` runs it unattended; the interactive path runs the same heal behind the confirmations. **`hooks install` / `rebuild` now call the heal** (replacing the matchers-only sync) so the documented post-rebuild step actually syncs DC files + rules.

### 4. CLAUDE.md "pull first"
`git pull --ff-only` added as **step 0** of the rebuild sequence.

## Tests
- `test_rebuild_guard.py` — `_git_behind_origin` (up-to-date / behind / not-a-repo / no-fetch), rebuild refuses when behind, `--force` overrides.
- `test_safety_heal.py` — heal idempotency, drift-awareness (customized rule survives, missing rule reinstalled, stale owned hook refreshed), drift detectors, `--yes` never prompts, and each doctor DC check (clean / disabled kill switch / missing rule / missing matcher).

## Verified in-worktree
`uv run pytest` over the new + related suites (hooks_install, cli_safety, damage_control_sync, safety_kill_switch): **147 passed**. CLI flags parse (`rebuild --force`, `safety install --yes`). No new ruff errors (main 19→19, cli_safety 14→14, tests clean). Did **not** rebuild/restart — the live portal/MCP belong to the owner's session.

Closes #462

Built by [dotdev.dev](https://dotdev.dev)
