### PR TITLE
fix(portal): edge-trigger the idle-nag loop (#464)

### DIFF
--- a/agentwire/roles/notifications.md
+++ b/agentwire/roles/notifications.md
@@ -12,7 +12,7 @@ You are the portal's notification voice. The portal sends you periodic updates a
 The portal's idle nag loop sends you `[IDLE NAG]` messages listing sessions that are idle with open windows. Each entry includes:
 - **session name**: the tmux session (e.g., `website-deploy`, `piinpoint`)
 - **idle_minutes**: how long it's been idle
-- **nag_count**: how many times you've already nagged about this session (1 = first time)
+- **nag_count**: how many times this idle episode has produced a *new* event worth nagging (1 = first time). The portal only sends you a session when it first goes idle, or when its output genuinely changes (a new question/error) — it does **not** re-send the same unchanged idle session, so every message you get reflects a real change, not a timer tick.
 - **last_output_snippet**: the last few lines of session output (what it's waiting on)
 
 ## How to respond
@@ -48,7 +48,6 @@ Not every idle session needs a reminder. Use the last_output_snippet to judge:
 - **Waiting at a clean prompt** — the session is at a bare `>` or `$` prompt with no pending question. Nothing to nag about. **Skip it.**
 - **Agent asked a question or needs input** — output ends with a question, a choice to make, a confirmation prompt, or "waiting for". **Nag.**
 - **Agent hit an error and stopped** — output shows an error or failure the user should see. **Nag.**
-- **Ambiguous** — when in doubt after many nags (nag_count >= 5), lean toward skipping. If it was important, earlier nags already flagged it.
 
 ## What NOT to comment on
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -122,6 +122,30 @@ def _is_allowed_in_restricted_mode(tool_name: str, tool_input: dict) -> bool:
     return bool(re.match(pattern, command))
 
 
+def should_nag_idle_session(
+    name: str,
+    last_output_timestamp: float,
+    nagged_output_ts: dict[str, float],
+) -> bool:
+    """Edge-trigger decision for the idle-nag loop (pure, unit-testable).
+
+    A session is included in the nag batch only when it has never been
+    nagged this episode, or when its ``last_output_timestamp`` has advanced
+    since the last nag (a genuinely new question/error/activity). A session
+    that stays continuously idle keeps a *fixed* ``last_output_timestamp``,
+    so it nags exactly once per idle episode instead of every scan.
+
+    ``nagged_output_ts`` maps session name -> the ``last_output_timestamp``
+    captured at its last nag. The caller is responsible for recording the
+    timestamp on include and for popping the entry when the session drops
+    below the idle threshold (resetting the episode).
+    """
+    prior = nagged_output_ts.get(name)
+    if prior is None:
+        return True
+    return last_output_timestamp > prior
+
+
 @dataclass
 class SessionConfig:
     """Runtime configuration for a session."""
@@ -1781,7 +1805,11 @@ class AgentWireServer:
         NAG_IDLE_THRESHOLD = 120  # seconds idle before including in nag (2 min minimum)
         NAG_SESSION = "agentwire-notifications"
         SERVICE_PREFIX = "agentwire-"
-        nag_counts: dict[str, int] = {}  # session -> consecutive nag count
+        nag_counts: dict[str, int] = {}  # session -> nag count this idle episode
+        # session -> last_output_timestamp captured at its last nag. Drives the
+        # edge-trigger: a continuously-idle session keeps a fixed timestamp, so
+        # it nags once; a new question/error advances the timestamp and re-nags.
+        nagged_output_ts: dict[str, float] = {}
 
         logger.info("[IdleNag] Starting idle nag loop (interval: %ds, threshold: %ds)",
                      NAG_INTERVAL, NAG_IDLE_THRESHOLD)
@@ -1793,6 +1821,7 @@ class AgentWireServer:
             try:
                 if not self.dashboard_clients:
                     nag_counts.clear()
+                    nagged_output_ts.clear()
                     await asyncio.sleep(NAG_INTERVAL)
                     continue
 
@@ -1809,10 +1838,18 @@ class AgentWireServer:
                     last_ts = info.get("last_output_timestamp", 0.0)
                     idle_secs = time.time() - last_ts if last_ts else float('inf')
                     if idle_secs > NAG_IDLE_THRESHOLD:
-                        idle_sessions.append((name, idle_secs))
+                        # Edge-trigger: only nag on a never-nagged session or
+                        # when its output has genuinely changed since last nag.
+                        if should_nag_idle_session(name, last_ts, nagged_output_ts):
+                            idle_sessions.append((name, idle_secs, last_ts))
                     else:
+                        # Active again — reset the episode so it can nag afresh.
                         nag_counts.pop(name, None)
+                        nagged_output_ts.pop(name, None)
 
+                # Empty batch → do NOT wake the notifications agent. This is the
+                # core of the edge-trigger: a continuously-idle session is sent
+                # exactly once, then the agent stays asleep.
                 if not idle_sessions:
                     await asyncio.sleep(NAG_INTERVAL)
                     continue
@@ -1823,8 +1860,9 @@ class AgentWireServer:
 
                 # Fetch fresh output for each idle session
                 session_data = []
-                for name, idle_secs in idle_sessions:
+                for name, idle_secs, last_ts in idle_sessions:
                     nag_counts[name] = nag_counts.get(name, 0) + 1
+                    nagged_output_ts[name] = last_ts
                     idle_min = int(idle_secs / 60)
 
                     # Session metadata

--- a/tests/unit/test_idle_nag.py
+++ b/tests/unit/test_idle_nag.py
@@ -1,0 +1,62 @@
+"""Unit tests for the edge-triggered idle-nag decision helper (#464).
+
+`should_nag_idle_session` is a pure function: it decides whether an idle
+session should be included in the nag batch this scan, given its current
+`last_output_timestamp` and the timestamp captured at its last nag. These
+tests exercise it without the async loop / tmux.
+"""
+
+from agentwire.server import should_nag_idle_session
+
+
+def test_never_nagged_session_is_included():
+    nagged: dict[str, float] = {}
+    assert should_nag_idle_session("piinpoint", 1000.0, nagged) is True
+
+
+def test_continuously_idle_session_nags_once():
+    """An unchanged last_output_timestamp across scans → nag once, then silent."""
+    nagged: dict[str, float] = {}
+    ts = 1000.0
+
+    # First scan: never nagged → include, caller records the timestamp.
+    assert should_nag_idle_session("piinpoint", ts, nagged) is True
+    nagged["piinpoint"] = ts
+
+    # Subsequent scans with the same (fixed) timestamp → skipped forever.
+    for _ in range(30):
+        assert should_nag_idle_session("piinpoint", ts, nagged) is False
+
+
+def test_advancing_timestamp_triggers_new_nag():
+    """New output (advanced timestamp) → a fresh nag."""
+    nagged = {"piinpoint": 1000.0}
+
+    # New question/error arrived: timestamp moved forward.
+    assert should_nag_idle_session("piinpoint", 1500.0, nagged) is True
+    nagged["piinpoint"] = 1500.0
+
+    # And it then settles back to nagging once for the new fixed timestamp.
+    assert should_nag_idle_session("piinpoint", 1500.0, nagged) is False
+
+
+def test_reset_on_active_nags_again_next_episode():
+    """Dropping below the idle threshold pops the entry → nags again next time."""
+    nagged: dict[str, float] = {}
+    ts = 1000.0
+
+    assert should_nag_idle_session("piinpoint", ts, nagged) is True
+    nagged["piinpoint"] = ts
+    assert should_nag_idle_session("piinpoint", ts, nagged) is False
+
+    # Session became active → caller resets episode state.
+    nagged.pop("piinpoint", None)
+
+    # New idle episode (even at the same timestamp) → nags again.
+    assert should_nag_idle_session("piinpoint", ts, nagged) is True
+
+
+def test_sessions_are_independent():
+    nagged: dict[str, float] = {"a": 1000.0}
+    assert should_nag_idle_session("a", 1000.0, nagged) is False
+    assert should_nag_idle_session("b", 1000.0, nagged) is True


### PR DESCRIPTION
Closes #464

## Problem
`idle_nag_loop` was **level-triggered**: every 120s it re-sent *every* still-idle session to the `agentwire-notifications` agent, bumping `nag_count` forever. A session idle 98 min got "Nagged: 47x"; the LLM agent was woken ~4550 times over a week (~\$2307) re-announcing the same idle sessions.

## Fix — edge-trigger on output change
- New pure helper `should_nag_idle_session(name, last_output_timestamp, nagged_output_ts) -> bool` (server.py, module level): include a session only if never nagged this episode, or its `last_output_timestamp` advanced since the last nag. A continuously-idle session keeps a fixed timestamp → nags **once**.
- `idle_nag_loop` tracks `nagged_output_ts[name]` at each nag; records it on include.
- Reset **both** `nag_counts[name]` and `nagged_output_ts[name]` when a session drops below the idle threshold (active again) and clear both when `dashboard_clients` is empty.
- **Empty filtered batch → do not `send` to `NAG_SESSION` at all** — the agent stays asleep. This is what kills the spend + spam.
- Persistent `notify_user` toast is unaffected, so a single nag loses nothing.

## Role tweak
`roles/notifications.md`: `nag_count` now documented as "times this idle episode produced a new event" (change-triggered, not a 2-min counter); dropped the soft "lean toward skipping after nag_count >= 5" line since the loop no longer level-triggers.

## Tests
`tests/unit/test_idle_nag.py` — unchanged timestamp across scans → nagged once; advancing timestamp → new nag; reset-on-active → nags again next episode; session independence. All 5 pass.

## Verification
Helper unit-tested in-worktree (cannot rebuild/restart the shared live portal). After merge: rebuild + portal restart, then relaunch `agentwire-notifications` fresh.

Built by [dotdev.dev](https://dotdev.dev)