### PR TITLE
fix(safety): lock down the damage-control control plane (#466)

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -45,7 +45,7 @@ session:
 | `parent` | Session name | Parent session for hierarchical notifications |
 | `shell` | `/bin/sh`, `/bin/bash`, etc. | Default shell for task commands |
 | `tasks` | Task definitions | Scheduled workload configurations |
-| `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist |
+| `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist (the human opt-in). **Only `allowed_paths` lives here** — the kill switch / `disabled_rules` / global `unattended_allow` moved to the host-owned `~/.agentwire/damagecontrol.yml` + project `.damagecontrol.yml` (#466), which the agent cannot write. |
 
 For pi sessions (`pi-*`, e.g. `pi-zai`, `pi-deepseek`), see the `agentwire-pi` skill.
 

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -45,9 +45,17 @@ session:
 | `parent` | Session name | Parent session for hierarchical notifications |
 | `shell` | `/bin/sh`, `/bin/bash`, etc. | Default shell for task commands |
 | `tasks` | Task definitions | Scheduled workload configurations |
-| `safety` | `{allowed_paths: [...]}` | Per-project damage control allowlist (the human opt-in). **Only `allowed_paths` lives here** — the kill switch / `disabled_rules` / global `unattended_allow` moved to the host-owned `~/.agentwire/damagecontrol.yml` + project `.damagecontrol.yml` (#466), which the agent cannot write. |
 
 For pi sessions (`pi-*`, e.g. `pi-zai`, `pi-deepseek`), see the `agentwire-pi` skill.
+
+> **No safety config in `.agentwire.yml` (#466/#467).** `.agentwire.yml` is
+> agent-writable, so it carries **zero** damage-control policy. The kill switch,
+> `disabled_rules`, `unattended_allow`, **and the per-project `allowed_paths`
+> allowlist** all live in the protected, agent-unwritable `.damagecontrol.yml` at
+> the repo root (and global `~/.agentwire/damagecontrol.yml`) — edited host-side
+> only. The allowlist is the one knob that overrides the protected-control-plane
+> check, so it must itself sit behind that protection. See
+> [`docs/wiki/internals/damage-control.md`](../../docs/wiki/internals/damage-control.md).
 
 ## Task Schema
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7136,21 +7136,22 @@ def _render_damage_control_section() -> int:
     """
     issues = 0
 
-    # Kill switch — config.safety.enabled gates ALL damage control. A silent
-    # `false` is the loudest possible failure, so flag it first and hard.
+    # Kill switch — ``enabled`` in ~/.agentwire/damagecontrol.yml gates ALL
+    # damage control. A silent `false` is the loudest possible failure, so flag
+    # it first and hard.
     try:
-        from .config import load_config as _load_config_typed
-        safety_enabled = _load_config_typed().safety.enabled
+        from .safety._core import load_safety_config
+        safety_enabled = load_safety_config().get("enabled", True)
     except Exception as e:
         print(f"  [..] Could not read safety config: {e}")
         safety_enabled = True
     if not safety_enabled:
-        print("  [!!] Damage control is DISABLED (safety.enabled: false)")
+        print("  [!!] Damage control is DISABLED (enabled: false)")
         print("       ALL command/path/outbound gating is off.")
-        print("       Fix: set safety.enabled: true in ~/.agentwire/config.yaml")
+        print("       Fix: set enabled: true in ~/.agentwire/damagecontrol.yml")
         issues += 1
     else:
-        print("  [ok] Damage control enabled (safety.enabled: true)")
+        print("  [ok] Damage control enabled (enabled: true)")
 
     try:
         from . import cli_safety

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -78,6 +78,16 @@ disabled_rules: []
 # unattended_allow:
 #   - gh.pr-merge
 unattended_allow: []
+
+# Per-project/global path allowlist — the human opt-in that re-permits paths
+# (including protected control-plane files). This lives HERE, not in the
+# agent-writable .agentwire.yml, because it overrides the protected check. e.g.:
+# allowed_paths:
+#   - path: "dist/*"
+#     allow: all
+#   - path: ".env.development"
+#     allow: [read, write, edit]
+allowed_paths: []
 """
 
 

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -51,6 +51,47 @@ HOOKS_DIR = CONFIG_DIR / "hooks" / "damage-control"
 LOGS_DIR = CONFIG_DIR / "logs" / "damage-control"
 RULES_DIR = CONFIG_DIR / "damage-control"
 TOOLDEFS_DIR = CONFIG_DIR / "tooldefs"
+# Host-owned, agent-unwritable policy file: kill switch + rule knobs (#466).
+DAMAGECONTROL_FILE = CONFIG_DIR / "damagecontrol.yml"
+
+DAMAGECONTROL_SCAFFOLD = """\
+# AgentWire damage-control policy (#466) — HOST-OWNED, agent-unwritable.
+#
+# This file (and project-root `.damagecontrol.yml`) are the ONLY place the
+# damage-control kill switch and rule knobs live. They are part of the protected
+# control plane: the policed agent cannot write them (the `# allow:` escape
+# hatch and the kill switch itself cannot override that), so an agent can never
+# expand its own freedom. Loosening is always a host-side edit of this file.
+
+# Master switch. false turns ALL command/path/outbound gating off. Missing file
+# or missing key ⇒ true (fail-secure).
+enabled: true
+
+# Stable rule IDs to disable (see `agentwire safety status` / the portal Safety
+# window for IDs). e.g.:
+# disabled_rules:
+#   - git.push
+disabled_rules: []
+
+# Rule IDs an UNATTENDED (scheduler) run may resolve `ask` → allow for, on top of
+# the built-in default allowlist. e.g.:
+# unattended_allow:
+#   - gh.pr-merge
+unattended_allow: []
+"""
+
+
+def scaffold_damagecontrol_file() -> bool:
+    """Create ~/.agentwire/damagecontrol.yml with `enabled: true` if missing.
+
+    Returns True if it wrote the file, False if it already existed. Never
+    overwrites an existing policy file.
+    """
+    if DAMAGECONTROL_FILE.exists():
+        return False
+    DAMAGECONTROL_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DAMAGECONTROL_FILE.write_text(DAMAGECONTROL_SCAFFOLD)
+    return True
 
 # Files to install from the package (hook scripts only, not rules)
 DAMAGE_CONTROL_FILES = [
@@ -137,8 +178,15 @@ def get_safety_status() -> Dict[str, Any]:
     rule_files = sorted(f.name for f in RULES_DIR.glob("*.yaml")) if RULES_DIR.exists() else []
     tooldefs_count = len(list(TOOLDEFS_DIR.glob("*.yaml"))) if TOOLDEFS_DIR.exists() else 0
 
+    from agentwire.safety._core import load_safety_config
+    safety_cfg = load_safety_config()
+
     status: Dict[str, Any] = {
         "hooks_installed": HOOKS_DIR.exists(),
+        "enabled": safety_cfg.get("enabled", True),
+        "disabled_rules": list(safety_cfg.get("disabled_rules", []) or []),
+        "policy_file": str(DAMAGECONTROL_FILE),
+        "policy_file_exists": DAMAGECONTROL_FILE.exists(),
         "rules_dir": str(RULES_DIR),
         "patterns_exist": RULES_DIR.exists() and any(RULES_DIR.glob("*.yaml")),
         "rule_files": rule_files,
@@ -237,6 +285,14 @@ def format_safety_status(status: Dict[str, Any]) -> str:
         lines.append("⚠️  Hooks not installed")
         lines.append("   Run: agentwire safety install")
         return "\n".join(lines)
+
+    enabled = status.get("enabled", True)
+    lines.append(f"{'✓' if enabled else '⚠️ '} Damage control: {'ENABLED' if enabled else 'DISABLED'}")
+    lines.append(f"  Policy file: {status.get('policy_file', '')}"
+                 f"{'' if status.get('policy_file_exists') else ' (missing → defaults to enabled)'}")
+    if status.get("disabled_rules"):
+        lines.append(f"  Disabled rules: {', '.join(status['disabled_rules'])}")
+    lines.append("")
 
     lines.append(f"✓ Hooks directory: {status['hooks_installed']}")
     lines.append(f"✓ Rules directory: {status['rules_dir']}")
@@ -629,7 +685,14 @@ def heal_damage_control(quiet: bool = False) -> Dict[str, Any]:
     summary: Dict[str, Any] = {
         "hooks_installed": [], "hooks_updated": [],
         "rules_installed": [], "tooldefs_installed": [], "matchers_added": 0,
+        "policy_scaffolded": False,
     }
+
+    # Host-owned policy file: create with `enabled: true` (fail-secure) if absent.
+    # Never overwrite an existing one — it carries the owner's kill-switch state.
+    if scaffold_damagecontrol_file():
+        summary["policy_scaffolded"] = True
+        log(f"✓ Scaffolded {DAMAGECONTROL_FILE} (enabled: true)")
 
     hooks_source = Path(__file__).parent / "hooks" / "damage-control"
     for fn in DAMAGE_CONTROL_FILES:
@@ -731,7 +794,7 @@ def safety_install_cmd(assume_yes: bool = False) -> int:
     touched = (
         summary["hooks_installed"] or summary["hooks_updated"]
         or summary["rules_installed"] or summary["tooldefs_installed"]
-        or summary["matchers_added"]
+        or summary["matchers_added"] or summary["policy_scaffolded"]
     )
     print()
     if touched:

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -435,14 +435,6 @@ class SchedulerConfig:
 
 
 @dataclass
-class SafetyConfig:
-    """Global damage-control safety knobs."""
-
-    enabled: bool = True
-    disabled_rules: list[str] = field(default_factory=list)
-
-
-@dataclass
 class UsageLimitConfig:
     """Usage-limit recovery (watchdog) knobs.
 
@@ -507,7 +499,6 @@ class Config:
     session: SessionConfig = field(default_factory=SessionConfig)
     repl: ReplConfig = field(default_factory=ReplConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
-    safety: SafetyConfig = field(default_factory=SafetyConfig)
     usage_limit: UsageLimitConfig = field(default_factory=UsageLimitConfig)
     prompt_router: PromptRouterConfig = field(default_factory=PromptRouterConfig)
     session_context: SessionContextConfig = field(default_factory=SessionContextConfig)
@@ -786,18 +777,6 @@ def _dict_to_config(data: dict) -> Config:
         theme_overrides = {}
     repl = ReplConfig(theme={str(k): str(v) for k, v in theme_overrides.items()})
 
-    # Safety (damage-control kill switch + disabled rules)
-    safety_data = data.get("safety", {}) or {}
-    if not isinstance(safety_data, dict):
-        safety_data = {}
-    disabled_rules_raw = safety_data.get("disabled_rules", []) or []
-    if not isinstance(disabled_rules_raw, list):
-        disabled_rules_raw = []
-    safety = SafetyConfig(
-        enabled=bool(safety_data.get("enabled", True)),
-        disabled_rules=[str(r) for r in disabled_rules_raw if r],
-    )
-
     # Usage-limit recovery (watchdog enable + session exclusions)
     usage_limit_data = data.get("usage_limit", {}) or {}
     if not isinstance(usage_limit_data, dict):
@@ -866,7 +845,6 @@ def _dict_to_config(data: dict) -> Config:
         scheduler=scheduler,
         channels=channel_configs,
         repl=repl,
-        safety=safety,
         usage_limit=usage_limit,
         prompt_router=prompt_router,
         session_context=session_context,

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -544,11 +544,21 @@ def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective ``safety`` block from global + nearest project config.
+    """Resolve the effective safety knobs from the dedicated damage-control files.
 
-    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
-    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
-    ``unattended_allow`` are merged (set-union).
+    The kill switch and rule knobs live in HOST-OWNED, agent-unwritable files
+    (see ``is_protected_control_plane``) — never in ``config.yaml`` /
+    ``.agentwire.yml``, which the policed agent can edit:
+
+      * Global:  ``~/.agentwire/damagecontrol.yml``
+      * Project: ``.damagecontrol.yml`` (nearest, walking up from ``cwd``)
+
+    Each holds top-level ``enabled`` / ``disabled_rules`` / ``unattended_allow``.
+    Returns ``{enabled, disabled_rules, unattended_allow}``. A project
+    ``.damagecontrol.yml`` may both loosen AND tighten ``enabled`` (it simply
+    wins); ``disabled_rules`` / ``unattended_allow`` are merged (set-union).
+
+    Fail-secure: a missing/unreadable/yaml-less global file ⇒ ``enabled: true``.
     """
     enabled = True
     disabled_rules: List[str] = []
@@ -558,22 +568,29 @@ def load_safety_config(
         return {"enabled": enabled, "disabled_rules": disabled_rules,
                 "unattended_allow": unattended_allow}
 
+    def _absorb(data: Any) -> Optional[bool]:
+        """Pull knobs from a parsed policy doc; return its ``enabled`` (or None)."""
+        local_enabled: Optional[bool] = None
+        if isinstance(data, dict):
+            if "enabled" in data and data["enabled"] is not None:
+                local_enabled = bool(data["enabled"])
+            rules = data.get("disabled_rules", [])
+            if isinstance(rules, list):
+                disabled_rules.extend(str(r) for r in rules if r)
+            allow = data.get("unattended_allow", [])
+            if isinstance(allow, list):
+                unattended_allow.extend(str(a) for a in allow if a)
+        return local_enabled
+
     if global_config_path is None:
-        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+        global_config_path = Path.home() / ".agentwire" / "damagecontrol.yml"
     try:
         if global_config_path.exists():
             with open(global_config_path, "r") as f:
-                data = yaml.safe_load(f) or {}
-            safety = data.get("safety", {})
-            if isinstance(safety, dict):
-                if "enabled" in safety:
-                    enabled = bool(safety["enabled"])
-                rules = safety.get("disabled_rules", [])
-                if isinstance(rules, list):
-                    disabled_rules.extend(str(r) for r in rules if r)
-                allow = safety.get("unattended_allow", [])
-                if isinstance(allow, list):
-                    unattended_allow.extend(str(a) for a in allow if a)
+                gdata = yaml.safe_load(f) or {}
+            genabled = _absorb(gdata)
+            if genabled is not None:
+                enabled = genabled
     except Exception:
         pass
 
@@ -581,21 +598,12 @@ def load_safety_config(
         cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        candidate = os.path.join(current, ".agentwire.yml")
+        candidate = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(candidate):
             try:
                 with open(candidate, "r") as f:
                     pdata = yaml.safe_load(f) or {}
-                psafety = pdata.get("safety", {})
-                if isinstance(psafety, dict):
-                    if "enabled" in psafety and psafety["enabled"] is not None:
-                        project_enabled = bool(psafety["enabled"])
-                    prules = psafety.get("disabled_rules", [])
-                    if isinstance(prules, list):
-                        disabled_rules.extend(str(r) for r in prules if r)
-                    pallow = psafety.get("unattended_allow", [])
-                    if isinstance(pallow, list):
-                        unattended_allow.extend(str(a) for a in pallow if a)
+                project_enabled = _absorb(pdata)
             except Exception:
                 pass
             break
@@ -612,6 +620,94 @@ def load_safety_config(
         "disabled_rules": sorted(set(disabled_rules)),
         "unattended_allow": sorted(set(unattended_allow)),
     }
+
+
+# ============================================================================
+# PROTECTED CONTROL PLANE (escape-hatch- AND kill-switch-EXEMPT)
+# ============================================================================
+#
+# Damage control reads its kill switch, its rules, and its own hook
+# registration from files on disk. If the policed agent can write those files,
+# it can disable safety, act, and re-enable — defeating everything (#466). So
+# the WHOLE control plane is hard-protected: any write/edit/delete/move/chmod
+# targeting one of these paths is BLOCKED, and — unlike every other rule — the
+# ``# allow:`` escape hatch and the ``enabled: false`` kill switch do NOT
+# override it. Only the user's ``allowedPaths`` allowlist can re-permit a path,
+# because that is a human, host-side opt-in (the agent cannot add to it without
+# editing a protected file, which is itself blocked).
+#
+# The guarantee: the agent only ever operates within the freedom the human
+# preset. Loosening is always a host-side act.
+
+PROTECTED_CONTROL_PLANE_PATHS = [
+    "~/.agentwire/damagecontrol.yml",   # global kill switch + rule knobs
+    "*.damagecontrol.yml",              # project kill switch + rule knobs (any dir)
+    "~/.claude/settings.json",          # PreToolUse hook registration
+    "~/.agentwire/hooks/damage-control/*.py",  # the hook scripts themselves
+    "~/.claude/hooks/*",                # agentwire-owned Claude Code hooks
+    "~/.agentwire/damage-control/*.yaml",      # the damage-control rule files
+]
+
+
+def _protected_path_patterns() -> List[str]:
+    """Protected paths in both ``~``-form and ``$HOME``-expanded form.
+
+    Commands may reference either; including both ensures the regex/glob
+    matchers catch e.g. ``/Users/me/.claude/settings.json`` and
+    ``~/.claude/settings.json`` alike.
+    """
+    out: List[str] = []
+    for p in PROTECTED_CONTROL_PLANE_PATHS:
+        out.append(p)
+        expanded = os.path.expanduser(p)
+        if expanded != p:
+            out.append(expanded)
+    return out
+
+
+def is_protected_control_plane(file_path: str) -> bool:
+    """True if ``file_path`` is part of the damage-control control plane."""
+    for pat in _protected_path_patterns():
+        if match_path(file_path, pat):
+            return True
+    return False
+
+
+def check_protected_path(
+    file_path: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block edits/writes to a control-plane file unless the user allowlisted it.
+
+    Used by the edit/write hooks. The allowlist (a human opt-in) may override;
+    nothing else does.
+    """
+    if is_protected_control_plane(file_path):
+        if is_path_allowed_for_op(file_path, allowed_paths, "edit"):
+            return False, ""
+        return True, "protected control-plane file (host-owned; edit on the host)"
+    return False, ""
+
+
+def check_protected_command(
+    command: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block a bash command that writes/edits/deletes a control-plane file.
+
+    Mirrors the ``readOnlyPaths`` matcher but is escape-hatch- and
+    kill-switch-exempt. The user's allowlist may re-permit a specific path.
+    """
+    for path in _protected_path_patterns():
+        matched, reason = check_path_patterns(
+            command, path, READ_ONLY_BLOCKED, "protected control-plane path"
+        )
+        if matched:
+            op = _infer_operation_from_reason(reason)
+            if is_command_path_allowed(command, allowed_paths, op):
+                continue
+            return True, f"Protected control-plane path: {path}"
+    return False, ""
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -644,18 +740,36 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
-      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
-      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
-      3. Ask patterns
-      4. Bypassable bash patterns → check allowlist for required operation
-      5. zeroAccessPaths → check allowlist with ``read`` permission
-      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Protected control plane → BLOCK (escape-hatch- AND kill-switch-exempt;
+         only the user's allowlist re-permits) — runs FIRST so an agent can't
+         self-authorize a write to the files that gate everything else.
+      1. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      2. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      3. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      4. Ask patterns
+      5. Bypassable bash patterns → check allowlist for required operation
+      6. zeroAccessPaths → check allowlist with ``read`` permission
+      7. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      8. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
     is_enabled = safety_cfg.get("enabled", True)
+
+    allowed = load_allowed_paths(config)
+
+    # Protected control plane FIRST — before the escape hatch and the kill
+    # switch. An agent must never be able to self-authorize a write to the
+    # files that define safety itself (#466).
+    prot_blocked, prot_reason = check_protected_command(command, allowed)
+    if prot_blocked:
+        return {
+            "decision": "block",
+            "reason": prot_reason,
+            "pattern": "protectedControlPlane",
+            "command": command,
+            "protected": True,
+        }
 
     escape_reason = detect_escape_hatch(command)
     if escape_reason:
@@ -681,7 +795,6 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
-    allowed = load_allowed_paths(config)
 
     bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
@@ -774,12 +887,21 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
-    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``.
+
+    The protected control plane is checked FIRST, before the kill switch — the
+    files that gate safety stay agent-unwritable even when safety is disabled;
+    only the user's allowlist re-permits them (#466).
+    """
+    allowed = load_allowed_paths(config)
+
+    prot_blocked, prot_reason = check_protected_path(file_path, allowed)
+    if prot_blocked:
+        return True, prot_reason
+
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     if safety_cfg.get("enabled", True) is False:
         return False, ""
-
-    allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
         return False, ""

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -206,19 +206,26 @@ def _parse_allowed_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _find_project_config() -> Tuple[str, List[Any]]:
-    """Walk up from $PWD to find ``.agentwire.yml`` and return its allowed_paths."""
+    """Walk up from $PWD to find ``.damagecontrol.yml`` and return its allowed_paths.
+
+    The per-project allowlist lives in the PROTECTED ``.damagecontrol.yml``
+    (top-level ``allowed_paths``), never the agent-writable ``.agentwire.yml``.
+    Otherwise an agent could allowlist a control-plane path in ``.agentwire.yml``
+    and re-permit its own write to ``damagecontrol.yml`` — the exact bypass #466
+    set out to close. The allowlist is the one knob that overrides the protected
+    check, so it must itself live behind the protected control plane (#467).
+    """
     cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        config_file = os.path.join(current, ".agentwire.yml")
+        config_file = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(config_file):
             try:
                 if yaml:
                     with open(config_file, "r") as f:
                         data = yaml.safe_load(f) or {}
-                    safety = data.get("safety", {})
-                    if isinstance(safety, dict):
-                        paths = safety.get("allowed_paths", [])
+                    if isinstance(data, dict):
+                        paths = data.get("allowed_paths", [])
                         if isinstance(paths, list):
                             return current, paths
             except Exception:
@@ -232,7 +239,7 @@ def _find_project_config() -> Tuple[str, List[Any]]:
 
 
 def load_allowed_paths(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Merge global ``allowedPaths`` from config with per-project ``.agentwire.yml`` entries."""
+    """Merge global ``allowedPaths`` from config with per-project ``.damagecontrol.yml`` entries."""
     raw = list(config.get("allowedPaths", []))
 
     project_root, project_paths = _find_project_config()

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -202,19 +202,26 @@ def _parse_allowed_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _find_project_config() -> Tuple[str, List[Any]]:
-    """Walk up from $PWD to find ``.agentwire.yml`` and return its allowed_paths."""
+    """Walk up from $PWD to find ``.damagecontrol.yml`` and return its allowed_paths.
+
+    The per-project allowlist lives in the PROTECTED ``.damagecontrol.yml``
+    (top-level ``allowed_paths``), never the agent-writable ``.agentwire.yml``.
+    Otherwise an agent could allowlist a control-plane path in ``.agentwire.yml``
+    and re-permit its own write to ``damagecontrol.yml`` — the exact bypass #466
+    set out to close. The allowlist is the one knob that overrides the protected
+    check, so it must itself live behind the protected control plane (#467).
+    """
     cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        config_file = os.path.join(current, ".agentwire.yml")
+        config_file = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(config_file):
             try:
                 if yaml:
                     with open(config_file, "r") as f:
                         data = yaml.safe_load(f) or {}
-                    safety = data.get("safety", {})
-                    if isinstance(safety, dict):
-                        paths = safety.get("allowed_paths", [])
+                    if isinstance(data, dict):
+                        paths = data.get("allowed_paths", [])
                         if isinstance(paths, list):
                             return current, paths
             except Exception:
@@ -228,7 +235,7 @@ def _find_project_config() -> Tuple[str, List[Any]]:
 
 
 def load_allowed_paths(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Merge global ``allowedPaths`` from config with per-project ``.agentwire.yml`` entries."""
+    """Merge global ``allowedPaths`` from config with per-project ``.damagecontrol.yml`` entries."""
     raw = list(config.get("allowedPaths", []))
 
     project_root, project_paths = _find_project_config()

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -540,11 +540,21 @@ def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective ``safety`` block from global + nearest project config.
+    """Resolve the effective safety knobs from the dedicated damage-control files.
 
-    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
-    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
-    ``unattended_allow`` are merged (set-union).
+    The kill switch and rule knobs live in HOST-OWNED, agent-unwritable files
+    (see ``is_protected_control_plane``) — never in ``config.yaml`` /
+    ``.agentwire.yml``, which the policed agent can edit:
+
+      * Global:  ``~/.agentwire/damagecontrol.yml``
+      * Project: ``.damagecontrol.yml`` (nearest, walking up from ``cwd``)
+
+    Each holds top-level ``enabled`` / ``disabled_rules`` / ``unattended_allow``.
+    Returns ``{enabled, disabled_rules, unattended_allow}``. A project
+    ``.damagecontrol.yml`` may both loosen AND tighten ``enabled`` (it simply
+    wins); ``disabled_rules`` / ``unattended_allow`` are merged (set-union).
+
+    Fail-secure: a missing/unreadable/yaml-less global file ⇒ ``enabled: true``.
     """
     enabled = True
     disabled_rules: List[str] = []
@@ -554,22 +564,29 @@ def load_safety_config(
         return {"enabled": enabled, "disabled_rules": disabled_rules,
                 "unattended_allow": unattended_allow}
 
+    def _absorb(data: Any) -> Optional[bool]:
+        """Pull knobs from a parsed policy doc; return its ``enabled`` (or None)."""
+        local_enabled: Optional[bool] = None
+        if isinstance(data, dict):
+            if "enabled" in data and data["enabled"] is not None:
+                local_enabled = bool(data["enabled"])
+            rules = data.get("disabled_rules", [])
+            if isinstance(rules, list):
+                disabled_rules.extend(str(r) for r in rules if r)
+            allow = data.get("unattended_allow", [])
+            if isinstance(allow, list):
+                unattended_allow.extend(str(a) for a in allow if a)
+        return local_enabled
+
     if global_config_path is None:
-        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+        global_config_path = Path.home() / ".agentwire" / "damagecontrol.yml"
     try:
         if global_config_path.exists():
             with open(global_config_path, "r") as f:
-                data = yaml.safe_load(f) or {}
-            safety = data.get("safety", {})
-            if isinstance(safety, dict):
-                if "enabled" in safety:
-                    enabled = bool(safety["enabled"])
-                rules = safety.get("disabled_rules", [])
-                if isinstance(rules, list):
-                    disabled_rules.extend(str(r) for r in rules if r)
-                allow = safety.get("unattended_allow", [])
-                if isinstance(allow, list):
-                    unattended_allow.extend(str(a) for a in allow if a)
+                gdata = yaml.safe_load(f) or {}
+            genabled = _absorb(gdata)
+            if genabled is not None:
+                enabled = genabled
     except Exception:
         pass
 
@@ -577,21 +594,12 @@ def load_safety_config(
         cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        candidate = os.path.join(current, ".agentwire.yml")
+        candidate = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(candidate):
             try:
                 with open(candidate, "r") as f:
                     pdata = yaml.safe_load(f) or {}
-                psafety = pdata.get("safety", {})
-                if isinstance(psafety, dict):
-                    if "enabled" in psafety and psafety["enabled"] is not None:
-                        project_enabled = bool(psafety["enabled"])
-                    prules = psafety.get("disabled_rules", [])
-                    if isinstance(prules, list):
-                        disabled_rules.extend(str(r) for r in prules if r)
-                    pallow = psafety.get("unattended_allow", [])
-                    if isinstance(pallow, list):
-                        unattended_allow.extend(str(a) for a in pallow if a)
+                project_enabled = _absorb(pdata)
             except Exception:
                 pass
             break
@@ -608,6 +616,94 @@ def load_safety_config(
         "disabled_rules": sorted(set(disabled_rules)),
         "unattended_allow": sorted(set(unattended_allow)),
     }
+
+
+# ============================================================================
+# PROTECTED CONTROL PLANE (escape-hatch- AND kill-switch-EXEMPT)
+# ============================================================================
+#
+# Damage control reads its kill switch, its rules, and its own hook
+# registration from files on disk. If the policed agent can write those files,
+# it can disable safety, act, and re-enable — defeating everything (#466). So
+# the WHOLE control plane is hard-protected: any write/edit/delete/move/chmod
+# targeting one of these paths is BLOCKED, and — unlike every other rule — the
+# ``# allow:`` escape hatch and the ``enabled: false`` kill switch do NOT
+# override it. Only the user's ``allowedPaths`` allowlist can re-permit a path,
+# because that is a human, host-side opt-in (the agent cannot add to it without
+# editing a protected file, which is itself blocked).
+#
+# The guarantee: the agent only ever operates within the freedom the human
+# preset. Loosening is always a host-side act.
+
+PROTECTED_CONTROL_PLANE_PATHS = [
+    "~/.agentwire/damagecontrol.yml",   # global kill switch + rule knobs
+    "*.damagecontrol.yml",              # project kill switch + rule knobs (any dir)
+    "~/.claude/settings.json",          # PreToolUse hook registration
+    "~/.agentwire/hooks/damage-control/*.py",  # the hook scripts themselves
+    "~/.claude/hooks/*",                # agentwire-owned Claude Code hooks
+    "~/.agentwire/damage-control/*.yaml",      # the damage-control rule files
+]
+
+
+def _protected_path_patterns() -> List[str]:
+    """Protected paths in both ``~``-form and ``$HOME``-expanded form.
+
+    Commands may reference either; including both ensures the regex/glob
+    matchers catch e.g. ``/Users/me/.claude/settings.json`` and
+    ``~/.claude/settings.json`` alike.
+    """
+    out: List[str] = []
+    for p in PROTECTED_CONTROL_PLANE_PATHS:
+        out.append(p)
+        expanded = os.path.expanduser(p)
+        if expanded != p:
+            out.append(expanded)
+    return out
+
+
+def is_protected_control_plane(file_path: str) -> bool:
+    """True if ``file_path`` is part of the damage-control control plane."""
+    for pat in _protected_path_patterns():
+        if match_path(file_path, pat):
+            return True
+    return False
+
+
+def check_protected_path(
+    file_path: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block edits/writes to a control-plane file unless the user allowlisted it.
+
+    Used by the edit/write hooks. The allowlist (a human opt-in) may override;
+    nothing else does.
+    """
+    if is_protected_control_plane(file_path):
+        if is_path_allowed_for_op(file_path, allowed_paths, "edit"):
+            return False, ""
+        return True, "protected control-plane file (host-owned; edit on the host)"
+    return False, ""
+
+
+def check_protected_command(
+    command: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block a bash command that writes/edits/deletes a control-plane file.
+
+    Mirrors the ``readOnlyPaths`` matcher but is escape-hatch- and
+    kill-switch-exempt. The user's allowlist may re-permit a specific path.
+    """
+    for path in _protected_path_patterns():
+        matched, reason = check_path_patterns(
+            command, path, READ_ONLY_BLOCKED, "protected control-plane path"
+        )
+        if matched:
+            op = _infer_operation_from_reason(reason)
+            if is_command_path_allowed(command, allowed_paths, op):
+                continue
+            return True, f"Protected control-plane path: {path}"
+    return False, ""
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -640,18 +736,36 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
-      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
-      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
-      3. Ask patterns
-      4. Bypassable bash patterns → check allowlist for required operation
-      5. zeroAccessPaths → check allowlist with ``read`` permission
-      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Protected control plane → BLOCK (escape-hatch- AND kill-switch-exempt;
+         only the user's allowlist re-permits) — runs FIRST so an agent can't
+         self-authorize a write to the files that gate everything else.
+      1. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      2. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      3. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      4. Ask patterns
+      5. Bypassable bash patterns → check allowlist for required operation
+      6. zeroAccessPaths → check allowlist with ``read`` permission
+      7. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      8. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
     is_enabled = safety_cfg.get("enabled", True)
+
+    allowed = load_allowed_paths(config)
+
+    # Protected control plane FIRST — before the escape hatch and the kill
+    # switch. An agent must never be able to self-authorize a write to the
+    # files that define safety itself (#466).
+    prot_blocked, prot_reason = check_protected_command(command, allowed)
+    if prot_blocked:
+        return {
+            "decision": "block",
+            "reason": prot_reason,
+            "pattern": "protectedControlPlane",
+            "command": command,
+            "protected": True,
+        }
 
     escape_reason = detect_escape_hatch(command)
     if escape_reason:
@@ -677,7 +791,6 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
-    allowed = load_allowed_paths(config)
 
     bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
@@ -770,12 +883,21 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
-    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``.
+
+    The protected control plane is checked FIRST, before the kill switch — the
+    files that gate safety stay agent-unwritable even when safety is disabled;
+    only the user's allowlist re-permits them (#466).
+    """
+    allowed = load_allowed_paths(config)
+
+    prot_blocked, prot_reason = check_protected_path(file_path, allowed)
+    if prot_blocked:
+        return True, prot_reason
+
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     if safety_cfg.get("enabled", True) is False:
         return False, ""
-
-    allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
         return False, ""
@@ -825,15 +947,17 @@ def main() -> None:
     if not file_path:
         sys.exit(0)
 
-    if config["safety"].get("enabled", True) is False:
-        log_disabled("Edit", file_path)
-        sys.exit(0)
-
+    # check_path enforces the protected control plane even when safety is
+    # disabled, so it must run BEFORE the kill-switch short-circuit (#466).
     blocked, reason = check_path(file_path, config)
     if blocked:
         log_blocked("Edit", file_path, reason)
         print(f"SECURITY: Blocked edit to {reason}: {file_path}", file=sys.stderr)
         sys.exit(2)
+
+    if config["safety"].get("enabled", True) is False:
+        log_disabled("Edit", file_path)
+        sys.exit(0)
 
     log_allowed("Edit", file_path, user_approved=False)
     sys.exit(0)

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -552,11 +552,21 @@ def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective ``safety`` block from global + nearest project config.
+    """Resolve the effective safety knobs from the dedicated damage-control files.
 
-    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
-    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
-    ``unattended_allow`` are merged (set-union).
+    The kill switch and rule knobs live in HOST-OWNED, agent-unwritable files
+    (see ``is_protected_control_plane``) — never in ``config.yaml`` /
+    ``.agentwire.yml``, which the policed agent can edit:
+
+      * Global:  ``~/.agentwire/damagecontrol.yml``
+      * Project: ``.damagecontrol.yml`` (nearest, walking up from ``cwd``)
+
+    Each holds top-level ``enabled`` / ``disabled_rules`` / ``unattended_allow``.
+    Returns ``{enabled, disabled_rules, unattended_allow}``. A project
+    ``.damagecontrol.yml`` may both loosen AND tighten ``enabled`` (it simply
+    wins); ``disabled_rules`` / ``unattended_allow`` are merged (set-union).
+
+    Fail-secure: a missing/unreadable/yaml-less global file ⇒ ``enabled: true``.
     """
     enabled = True
     disabled_rules: List[str] = []
@@ -566,22 +576,29 @@ def load_safety_config(
         return {"enabled": enabled, "disabled_rules": disabled_rules,
                 "unattended_allow": unattended_allow}
 
+    def _absorb(data: Any) -> Optional[bool]:
+        """Pull knobs from a parsed policy doc; return its ``enabled`` (or None)."""
+        local_enabled: Optional[bool] = None
+        if isinstance(data, dict):
+            if "enabled" in data and data["enabled"] is not None:
+                local_enabled = bool(data["enabled"])
+            rules = data.get("disabled_rules", [])
+            if isinstance(rules, list):
+                disabled_rules.extend(str(r) for r in rules if r)
+            allow = data.get("unattended_allow", [])
+            if isinstance(allow, list):
+                unattended_allow.extend(str(a) for a in allow if a)
+        return local_enabled
+
     if global_config_path is None:
-        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+        global_config_path = Path.home() / ".agentwire" / "damagecontrol.yml"
     try:
         if global_config_path.exists():
             with open(global_config_path, "r") as f:
-                data = yaml.safe_load(f) or {}
-            safety = data.get("safety", {})
-            if isinstance(safety, dict):
-                if "enabled" in safety:
-                    enabled = bool(safety["enabled"])
-                rules = safety.get("disabled_rules", [])
-                if isinstance(rules, list):
-                    disabled_rules.extend(str(r) for r in rules if r)
-                allow = safety.get("unattended_allow", [])
-                if isinstance(allow, list):
-                    unattended_allow.extend(str(a) for a in allow if a)
+                gdata = yaml.safe_load(f) or {}
+            genabled = _absorb(gdata)
+            if genabled is not None:
+                enabled = genabled
     except Exception:
         pass
 
@@ -589,21 +606,12 @@ def load_safety_config(
         cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        candidate = os.path.join(current, ".agentwire.yml")
+        candidate = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(candidate):
             try:
                 with open(candidate, "r") as f:
                     pdata = yaml.safe_load(f) or {}
-                psafety = pdata.get("safety", {})
-                if isinstance(psafety, dict):
-                    if "enabled" in psafety and psafety["enabled"] is not None:
-                        project_enabled = bool(psafety["enabled"])
-                    prules = psafety.get("disabled_rules", [])
-                    if isinstance(prules, list):
-                        disabled_rules.extend(str(r) for r in prules if r)
-                    pallow = psafety.get("unattended_allow", [])
-                    if isinstance(pallow, list):
-                        unattended_allow.extend(str(a) for a in pallow if a)
+                project_enabled = _absorb(pdata)
             except Exception:
                 pass
             break
@@ -620,6 +628,94 @@ def load_safety_config(
         "disabled_rules": sorted(set(disabled_rules)),
         "unattended_allow": sorted(set(unattended_allow)),
     }
+
+
+# ============================================================================
+# PROTECTED CONTROL PLANE (escape-hatch- AND kill-switch-EXEMPT)
+# ============================================================================
+#
+# Damage control reads its kill switch, its rules, and its own hook
+# registration from files on disk. If the policed agent can write those files,
+# it can disable safety, act, and re-enable — defeating everything (#466). So
+# the WHOLE control plane is hard-protected: any write/edit/delete/move/chmod
+# targeting one of these paths is BLOCKED, and — unlike every other rule — the
+# ``# allow:`` escape hatch and the ``enabled: false`` kill switch do NOT
+# override it. Only the user's ``allowedPaths`` allowlist can re-permit a path,
+# because that is a human, host-side opt-in (the agent cannot add to it without
+# editing a protected file, which is itself blocked).
+#
+# The guarantee: the agent only ever operates within the freedom the human
+# preset. Loosening is always a host-side act.
+
+PROTECTED_CONTROL_PLANE_PATHS = [
+    "~/.agentwire/damagecontrol.yml",   # global kill switch + rule knobs
+    "*.damagecontrol.yml",              # project kill switch + rule knobs (any dir)
+    "~/.claude/settings.json",          # PreToolUse hook registration
+    "~/.agentwire/hooks/damage-control/*.py",  # the hook scripts themselves
+    "~/.claude/hooks/*",                # agentwire-owned Claude Code hooks
+    "~/.agentwire/damage-control/*.yaml",      # the damage-control rule files
+]
+
+
+def _protected_path_patterns() -> List[str]:
+    """Protected paths in both ``~``-form and ``$HOME``-expanded form.
+
+    Commands may reference either; including both ensures the regex/glob
+    matchers catch e.g. ``/Users/me/.claude/settings.json`` and
+    ``~/.claude/settings.json`` alike.
+    """
+    out: List[str] = []
+    for p in PROTECTED_CONTROL_PLANE_PATHS:
+        out.append(p)
+        expanded = os.path.expanduser(p)
+        if expanded != p:
+            out.append(expanded)
+    return out
+
+
+def is_protected_control_plane(file_path: str) -> bool:
+    """True if ``file_path`` is part of the damage-control control plane."""
+    for pat in _protected_path_patterns():
+        if match_path(file_path, pat):
+            return True
+    return False
+
+
+def check_protected_path(
+    file_path: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block edits/writes to a control-plane file unless the user allowlisted it.
+
+    Used by the edit/write hooks. The allowlist (a human opt-in) may override;
+    nothing else does.
+    """
+    if is_protected_control_plane(file_path):
+        if is_path_allowed_for_op(file_path, allowed_paths, "edit"):
+            return False, ""
+        return True, "protected control-plane file (host-owned; edit on the host)"
+    return False, ""
+
+
+def check_protected_command(
+    command: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block a bash command that writes/edits/deletes a control-plane file.
+
+    Mirrors the ``readOnlyPaths`` matcher but is escape-hatch- and
+    kill-switch-exempt. The user's allowlist may re-permit a specific path.
+    """
+    for path in _protected_path_patterns():
+        matched, reason = check_path_patterns(
+            command, path, READ_ONLY_BLOCKED, "protected control-plane path"
+        )
+        if matched:
+            op = _infer_operation_from_reason(reason)
+            if is_command_path_allowed(command, allowed_paths, op):
+                continue
+            return True, f"Protected control-plane path: {path}"
+    return False, ""
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -652,18 +748,36 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
-      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
-      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
-      3. Ask patterns
-      4. Bypassable bash patterns → check allowlist for required operation
-      5. zeroAccessPaths → check allowlist with ``read`` permission
-      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Protected control plane → BLOCK (escape-hatch- AND kill-switch-exempt;
+         only the user's allowlist re-permits) — runs FIRST so an agent can't
+         self-authorize a write to the files that gate everything else.
+      1. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      2. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      3. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      4. Ask patterns
+      5. Bypassable bash patterns → check allowlist for required operation
+      6. zeroAccessPaths → check allowlist with ``read`` permission
+      7. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      8. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
     is_enabled = safety_cfg.get("enabled", True)
+
+    allowed = load_allowed_paths(config)
+
+    # Protected control plane FIRST — before the escape hatch and the kill
+    # switch. An agent must never be able to self-authorize a write to the
+    # files that define safety itself (#466).
+    prot_blocked, prot_reason = check_protected_command(command, allowed)
+    if prot_blocked:
+        return {
+            "decision": "block",
+            "reason": prot_reason,
+            "pattern": "protectedControlPlane",
+            "command": command,
+            "protected": True,
+        }
 
     escape_reason = detect_escape_hatch(command)
     if escape_reason:
@@ -689,7 +803,6 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
-    allowed = load_allowed_paths(config)
 
     bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
@@ -782,12 +895,21 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
-    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``.
+
+    The protected control plane is checked FIRST, before the kill switch — the
+    files that gate safety stay agent-unwritable even when safety is disabled;
+    only the user's allowlist re-permits them (#466).
+    """
+    allowed = load_allowed_paths(config)
+
+    prot_blocked, prot_reason = check_protected_path(file_path, allowed)
+    if prot_blocked:
+        return True, prot_reason
+
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     if safety_cfg.get("enabled", True) is False:
         return False, ""
-
-    allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
         return False, ""

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -214,19 +214,26 @@ def _parse_allowed_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _find_project_config() -> Tuple[str, List[Any]]:
-    """Walk up from $PWD to find ``.agentwire.yml`` and return its allowed_paths."""
+    """Walk up from $PWD to find ``.damagecontrol.yml`` and return its allowed_paths.
+
+    The per-project allowlist lives in the PROTECTED ``.damagecontrol.yml``
+    (top-level ``allowed_paths``), never the agent-writable ``.agentwire.yml``.
+    Otherwise an agent could allowlist a control-plane path in ``.agentwire.yml``
+    and re-permit its own write to ``damagecontrol.yml`` — the exact bypass #466
+    set out to close. The allowlist is the one knob that overrides the protected
+    check, so it must itself live behind the protected control plane (#467).
+    """
     cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        config_file = os.path.join(current, ".agentwire.yml")
+        config_file = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(config_file):
             try:
                 if yaml:
                     with open(config_file, "r") as f:
                         data = yaml.safe_load(f) or {}
-                    safety = data.get("safety", {})
-                    if isinstance(safety, dict):
-                        paths = safety.get("allowed_paths", [])
+                    if isinstance(data, dict):
+                        paths = data.get("allowed_paths", [])
                         if isinstance(paths, list):
                             return current, paths
             except Exception:
@@ -240,7 +247,7 @@ def _find_project_config() -> Tuple[str, List[Any]]:
 
 
 def load_allowed_paths(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Merge global ``allowedPaths`` from config with per-project ``.agentwire.yml`` entries."""
+    """Merge global ``allowedPaths`` from config with per-project ``.damagecontrol.yml`` entries."""
     raw = list(config.get("allowedPaths", []))
 
     project_root, project_paths = _find_project_config()

--- a/agentwire/hooks/damage-control/rules/control-plane.yaml
+++ b/agentwire/hooks/damage-control/rules/control-plane.yaml
@@ -1,0 +1,24 @@
+# Damage-control control plane (#466)
+#
+# These are the files that DEFINE damage control — its kill switch, its rules,
+# and its own hook registration. If the policed agent could write them it could
+# disable safety, act, and re-enable, bypassing everything.
+#
+# The REAL guarantee lives in code: ``check_protected_command`` /
+# ``check_protected_path`` in ``agentwire/safety/_core.py`` block writes to
+# these paths BEFORE the ``# allow:`` escape hatch and BEFORE the kill switch,
+# so neither can override them. Only the user's ``allowedPaths`` allowlist (a
+# host-side opt-in) re-permits a path.
+#
+# Listing them here as ``readOnlyPaths`` too is defense-in-depth + visibility
+# (they show up in ``agentwire safety status`` rule counts). The readOnly tier
+# is escape-hatch-bypassable on its own — the code-level check is what makes the
+# protection absolute.
+
+readOnlyPaths:
+  - "~/.agentwire/damagecontrol.yml"
+  - "*.damagecontrol.yml"
+  - "~/.claude/settings.json"
+  - "~/.agentwire/hooks/damage-control/*.py"
+  - "~/.claude/hooks/*"
+  - "~/.agentwire/damage-control/*.yaml"

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -201,19 +201,26 @@ def _parse_allowed_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _find_project_config() -> Tuple[str, List[Any]]:
-    """Walk up from $PWD to find ``.agentwire.yml`` and return its allowed_paths."""
+    """Walk up from $PWD to find ``.damagecontrol.yml`` and return its allowed_paths.
+
+    The per-project allowlist lives in the PROTECTED ``.damagecontrol.yml``
+    (top-level ``allowed_paths``), never the agent-writable ``.agentwire.yml``.
+    Otherwise an agent could allowlist a control-plane path in ``.agentwire.yml``
+    and re-permit its own write to ``damagecontrol.yml`` — the exact bypass #466
+    set out to close. The allowlist is the one knob that overrides the protected
+    check, so it must itself live behind the protected control plane (#467).
+    """
     cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        config_file = os.path.join(current, ".agentwire.yml")
+        config_file = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(config_file):
             try:
                 if yaml:
                     with open(config_file, "r") as f:
                         data = yaml.safe_load(f) or {}
-                    safety = data.get("safety", {})
-                    if isinstance(safety, dict):
-                        paths = safety.get("allowed_paths", [])
+                    if isinstance(data, dict):
+                        paths = data.get("allowed_paths", [])
                         if isinstance(paths, list):
                             return current, paths
             except Exception:
@@ -227,7 +234,7 @@ def _find_project_config() -> Tuple[str, List[Any]]:
 
 
 def load_allowed_paths(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Merge global ``allowedPaths`` from config with per-project ``.agentwire.yml`` entries."""
+    """Merge global ``allowedPaths`` from config with per-project ``.damagecontrol.yml`` entries."""
     raw = list(config.get("allowedPaths", []))
 
     project_root, project_paths = _find_project_config()

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -539,11 +539,21 @@ def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective ``safety`` block from global + nearest project config.
+    """Resolve the effective safety knobs from the dedicated damage-control files.
 
-    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
-    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
-    ``unattended_allow`` are merged (set-union).
+    The kill switch and rule knobs live in HOST-OWNED, agent-unwritable files
+    (see ``is_protected_control_plane``) — never in ``config.yaml`` /
+    ``.agentwire.yml``, which the policed agent can edit:
+
+      * Global:  ``~/.agentwire/damagecontrol.yml``
+      * Project: ``.damagecontrol.yml`` (nearest, walking up from ``cwd``)
+
+    Each holds top-level ``enabled`` / ``disabled_rules`` / ``unattended_allow``.
+    Returns ``{enabled, disabled_rules, unattended_allow}``. A project
+    ``.damagecontrol.yml`` may both loosen AND tighten ``enabled`` (it simply
+    wins); ``disabled_rules`` / ``unattended_allow`` are merged (set-union).
+
+    Fail-secure: a missing/unreadable/yaml-less global file ⇒ ``enabled: true``.
     """
     enabled = True
     disabled_rules: List[str] = []
@@ -553,22 +563,29 @@ def load_safety_config(
         return {"enabled": enabled, "disabled_rules": disabled_rules,
                 "unattended_allow": unattended_allow}
 
+    def _absorb(data: Any) -> Optional[bool]:
+        """Pull knobs from a parsed policy doc; return its ``enabled`` (or None)."""
+        local_enabled: Optional[bool] = None
+        if isinstance(data, dict):
+            if "enabled" in data and data["enabled"] is not None:
+                local_enabled = bool(data["enabled"])
+            rules = data.get("disabled_rules", [])
+            if isinstance(rules, list):
+                disabled_rules.extend(str(r) for r in rules if r)
+            allow = data.get("unattended_allow", [])
+            if isinstance(allow, list):
+                unattended_allow.extend(str(a) for a in allow if a)
+        return local_enabled
+
     if global_config_path is None:
-        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+        global_config_path = Path.home() / ".agentwire" / "damagecontrol.yml"
     try:
         if global_config_path.exists():
             with open(global_config_path, "r") as f:
-                data = yaml.safe_load(f) or {}
-            safety = data.get("safety", {})
-            if isinstance(safety, dict):
-                if "enabled" in safety:
-                    enabled = bool(safety["enabled"])
-                rules = safety.get("disabled_rules", [])
-                if isinstance(rules, list):
-                    disabled_rules.extend(str(r) for r in rules if r)
-                allow = safety.get("unattended_allow", [])
-                if isinstance(allow, list):
-                    unattended_allow.extend(str(a) for a in allow if a)
+                gdata = yaml.safe_load(f) or {}
+            genabled = _absorb(gdata)
+            if genabled is not None:
+                enabled = genabled
     except Exception:
         pass
 
@@ -576,21 +593,12 @@ def load_safety_config(
         cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        candidate = os.path.join(current, ".agentwire.yml")
+        candidate = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(candidate):
             try:
                 with open(candidate, "r") as f:
                     pdata = yaml.safe_load(f) or {}
-                psafety = pdata.get("safety", {})
-                if isinstance(psafety, dict):
-                    if "enabled" in psafety and psafety["enabled"] is not None:
-                        project_enabled = bool(psafety["enabled"])
-                    prules = psafety.get("disabled_rules", [])
-                    if isinstance(prules, list):
-                        disabled_rules.extend(str(r) for r in prules if r)
-                    pallow = psafety.get("unattended_allow", [])
-                    if isinstance(pallow, list):
-                        unattended_allow.extend(str(a) for a in pallow if a)
+                project_enabled = _absorb(pdata)
             except Exception:
                 pass
             break
@@ -607,6 +615,94 @@ def load_safety_config(
         "disabled_rules": sorted(set(disabled_rules)),
         "unattended_allow": sorted(set(unattended_allow)),
     }
+
+
+# ============================================================================
+# PROTECTED CONTROL PLANE (escape-hatch- AND kill-switch-EXEMPT)
+# ============================================================================
+#
+# Damage control reads its kill switch, its rules, and its own hook
+# registration from files on disk. If the policed agent can write those files,
+# it can disable safety, act, and re-enable — defeating everything (#466). So
+# the WHOLE control plane is hard-protected: any write/edit/delete/move/chmod
+# targeting one of these paths is BLOCKED, and — unlike every other rule — the
+# ``# allow:`` escape hatch and the ``enabled: false`` kill switch do NOT
+# override it. Only the user's ``allowedPaths`` allowlist can re-permit a path,
+# because that is a human, host-side opt-in (the agent cannot add to it without
+# editing a protected file, which is itself blocked).
+#
+# The guarantee: the agent only ever operates within the freedom the human
+# preset. Loosening is always a host-side act.
+
+PROTECTED_CONTROL_PLANE_PATHS = [
+    "~/.agentwire/damagecontrol.yml",   # global kill switch + rule knobs
+    "*.damagecontrol.yml",              # project kill switch + rule knobs (any dir)
+    "~/.claude/settings.json",          # PreToolUse hook registration
+    "~/.agentwire/hooks/damage-control/*.py",  # the hook scripts themselves
+    "~/.claude/hooks/*",                # agentwire-owned Claude Code hooks
+    "~/.agentwire/damage-control/*.yaml",      # the damage-control rule files
+]
+
+
+def _protected_path_patterns() -> List[str]:
+    """Protected paths in both ``~``-form and ``$HOME``-expanded form.
+
+    Commands may reference either; including both ensures the regex/glob
+    matchers catch e.g. ``/Users/me/.claude/settings.json`` and
+    ``~/.claude/settings.json`` alike.
+    """
+    out: List[str] = []
+    for p in PROTECTED_CONTROL_PLANE_PATHS:
+        out.append(p)
+        expanded = os.path.expanduser(p)
+        if expanded != p:
+            out.append(expanded)
+    return out
+
+
+def is_protected_control_plane(file_path: str) -> bool:
+    """True if ``file_path`` is part of the damage-control control plane."""
+    for pat in _protected_path_patterns():
+        if match_path(file_path, pat):
+            return True
+    return False
+
+
+def check_protected_path(
+    file_path: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block edits/writes to a control-plane file unless the user allowlisted it.
+
+    Used by the edit/write hooks. The allowlist (a human opt-in) may override;
+    nothing else does.
+    """
+    if is_protected_control_plane(file_path):
+        if is_path_allowed_for_op(file_path, allowed_paths, "edit"):
+            return False, ""
+        return True, "protected control-plane file (host-owned; edit on the host)"
+    return False, ""
+
+
+def check_protected_command(
+    command: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block a bash command that writes/edits/deletes a control-plane file.
+
+    Mirrors the ``readOnlyPaths`` matcher but is escape-hatch- and
+    kill-switch-exempt. The user's allowlist may re-permit a specific path.
+    """
+    for path in _protected_path_patterns():
+        matched, reason = check_path_patterns(
+            command, path, READ_ONLY_BLOCKED, "protected control-plane path"
+        )
+        if matched:
+            op = _infer_operation_from_reason(reason)
+            if is_command_path_allowed(command, allowed_paths, op):
+                continue
+            return True, f"Protected control-plane path: {path}"
+    return False, ""
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -639,18 +735,36 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
-      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
-      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
-      3. Ask patterns
-      4. Bypassable bash patterns → check allowlist for required operation
-      5. zeroAccessPaths → check allowlist with ``read`` permission
-      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Protected control plane → BLOCK (escape-hatch- AND kill-switch-exempt;
+         only the user's allowlist re-permits) — runs FIRST so an agent can't
+         self-authorize a write to the files that gate everything else.
+      1. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      2. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      3. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      4. Ask patterns
+      5. Bypassable bash patterns → check allowlist for required operation
+      6. zeroAccessPaths → check allowlist with ``read`` permission
+      7. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      8. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
     is_enabled = safety_cfg.get("enabled", True)
+
+    allowed = load_allowed_paths(config)
+
+    # Protected control plane FIRST — before the escape hatch and the kill
+    # switch. An agent must never be able to self-authorize a write to the
+    # files that define safety itself (#466).
+    prot_blocked, prot_reason = check_protected_command(command, allowed)
+    if prot_blocked:
+        return {
+            "decision": "block",
+            "reason": prot_reason,
+            "pattern": "protectedControlPlane",
+            "command": command,
+            "protected": True,
+        }
 
     escape_reason = detect_escape_hatch(command)
     if escape_reason:
@@ -676,7 +790,6 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
-    allowed = load_allowed_paths(config)
 
     bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
@@ -769,12 +882,21 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
-    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``.
+
+    The protected control plane is checked FIRST, before the kill switch — the
+    files that gate safety stay agent-unwritable even when safety is disabled;
+    only the user's allowlist re-permits them (#466).
+    """
+    allowed = load_allowed_paths(config)
+
+    prot_blocked, prot_reason = check_protected_path(file_path, allowed)
+    if prot_blocked:
+        return True, prot_reason
+
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     if safety_cfg.get("enabled", True) is False:
         return False, ""
-
-    allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
         return False, ""
@@ -824,15 +946,17 @@ def main() -> None:
     if not file_path:
         sys.exit(0)
 
-    if config["safety"].get("enabled", True) is False:
-        log_disabled("Write", file_path)
-        sys.exit(0)
-
+    # check_path enforces the protected control plane even when safety is
+    # disabled, so it must run BEFORE the kill-switch short-circuit (#466).
     blocked, reason = check_path(file_path, config)
     if blocked:
         log_blocked("Write", file_path, reason)
         print(f"SECURITY: Blocked write to {reason}: {file_path}", file=sys.stderr)
         sys.exit(2)
+
+    if config["safety"].get("enabled", True) is False:
+        log_disabled("Write", file_path)
+        sys.exit(0)
 
     log_allowed("Write", file_path, user_approved=False)
     sys.exit(0)

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -138,50 +138,13 @@ def compose_session_type(harness: str, posture: str) -> str:
     return harness
 
 
-def _normalize_allowed_entry(entry: dict) -> dict:
-    """Normalize an allowed_paths entry to {path: str, allow: str|list}.
-
-    Entry must be a dict with "path" key and optional "allow" (defaults to "all").
-    """
-    allow = entry.get("allow", "all")
-    if isinstance(allow, str):
-        allow = allow.strip().lower()
-    elif isinstance(allow, list):
-        allow = [a.strip().lower() for a in allow]
-    return {"path": entry["path"], "allow": allow}
-
-
-@dataclass
-class SafetyConfig:
-    """Per-project safety overrides for damage control hooks.
-
-    Holds ONLY the ``allowed_paths`` allowlist — the human opt-in that re-permits
-    specific paths (including protected control-plane files). The kill switch and
-    rule knobs (``enabled`` / ``disabled_rules`` / ``unattended_allow``) live in
-    the agent-unwritable ``.damagecontrol.yml`` instead (#466), never here.
-    """
-    allowed_paths: list[dict] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        d: dict = {}
-        if self.allowed_paths:
-            d["allowed_paths"] = self.allowed_paths
-        return d
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "SafetyConfig":
-        raw = data.get("allowed_paths", [])
-        if not isinstance(raw, list):
-            raw = []
-        allowed_paths = [_normalize_allowed_entry(e) for e in raw if isinstance(e, dict)]
-        return cls(allowed_paths=allowed_paths)
-
-
 @dataclass
 class ProjectConfig:
     """Project-level configuration for a project directory.
 
-    Lives in .agentwire.yml in the project root.
+    Lives in .agentwire.yml in the project root. Holds NO damage-control safety
+    config — the kill switch, rule knobs, AND the per-project allowlist all live
+    in the protected, agent-unwritable ``.damagecontrol.yml`` instead (#466/#467).
     Shared by all sessions running in this project folder.
     Session name is NOT stored here - it's runtime context from environment.
     """
@@ -191,7 +154,6 @@ class ProjectConfig:
     parent: Optional[str] = None  # Parent session for hierarchical notifications
     shell: Optional[str] = None  # Default shell for task commands (default: /bin/sh)
     tasks: dict[str, Any] = field(default_factory=dict)  # Task definitions (raw dict, parsed by tasks.py)
-    safety: SafetyConfig = field(default_factory=SafetyConfig)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -208,9 +170,6 @@ class ProjectConfig:
             d["shell"] = self.shell
         if self.tasks:
             d["tasks"] = self.tasks
-        safety_dict = self.safety.to_dict()
-        if safety_dict:
-            d["safety"] = safety_dict
         return d
 
     @classmethod
@@ -222,8 +181,6 @@ class ProjectConfig:
         parent = data.get("parent")
         shell = data.get("shell")
         tasks = data.get("tasks", {})
-        safety_data = data.get("safety", {})
-        safety = SafetyConfig.from_dict(safety_data) if isinstance(safety_data, dict) else SafetyConfig()
 
         return cls(
             type=SessionType.from_str(type_value) if isinstance(type_value, str) else type_value,
@@ -232,7 +189,6 @@ class ProjectConfig:
             parent=parent,
             shell=shell,
             tasks=tasks if isinstance(tasks, dict) else {},
-            safety=safety,
         )
 
 

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -153,19 +153,19 @@ def _normalize_allowed_entry(entry: dict) -> dict:
 
 @dataclass
 class SafetyConfig:
-    """Per-project safety overrides for damage control hooks."""
+    """Per-project safety overrides for damage control hooks.
+
+    Holds ONLY the ``allowed_paths`` allowlist — the human opt-in that re-permits
+    specific paths (including protected control-plane files). The kill switch and
+    rule knobs (``enabled`` / ``disabled_rules`` / ``unattended_allow``) live in
+    the agent-unwritable ``.damagecontrol.yml`` instead (#466), never here.
+    """
     allowed_paths: list[dict] = field(default_factory=list)
-    enabled: Optional[bool] = None  # None = inherit global
-    disabled_rules: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         d: dict = {}
         if self.allowed_paths:
             d["allowed_paths"] = self.allowed_paths
-        if self.enabled is not None:
-            d["enabled"] = self.enabled
-        if self.disabled_rules:
-            d["disabled_rules"] = list(self.disabled_rules)
         return d
 
     @classmethod
@@ -174,17 +174,7 @@ class SafetyConfig:
         if not isinstance(raw, list):
             raw = []
         allowed_paths = [_normalize_allowed_entry(e) for e in raw if isinstance(e, dict)]
-        enabled = data.get("enabled")
-        if enabled is not None:
-            enabled = bool(enabled)
-        rules = data.get("disabled_rules", [])
-        if not isinstance(rules, list):
-            rules = []
-        return cls(
-            allowed_paths=allowed_paths,
-            enabled=enabled,
-            disabled_rules=[str(r) for r in rules if r],
-        )
+        return cls(allowed_paths=allowed_paths)
 
 
 @dataclass

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -508,11 +508,21 @@ def load_safety_config(
     global_config_path: Optional[Path] = None,
     cwd: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective ``safety`` block from global + nearest project config.
+    """Resolve the effective safety knobs from the dedicated damage-control files.
 
-    Returns ``{enabled: bool, disabled_rules: list[str], unattended_allow: list[str]}``.
-    Project ``.agentwire.yml`` overrides global ``enabled``; ``disabled_rules`` and
-    ``unattended_allow`` are merged (set-union).
+    The kill switch and rule knobs live in HOST-OWNED, agent-unwritable files
+    (see ``is_protected_control_plane``) — never in ``config.yaml`` /
+    ``.agentwire.yml``, which the policed agent can edit:
+
+      * Global:  ``~/.agentwire/damagecontrol.yml``
+      * Project: ``.damagecontrol.yml`` (nearest, walking up from ``cwd``)
+
+    Each holds top-level ``enabled`` / ``disabled_rules`` / ``unattended_allow``.
+    Returns ``{enabled, disabled_rules, unattended_allow}``. A project
+    ``.damagecontrol.yml`` may both loosen AND tighten ``enabled`` (it simply
+    wins); ``disabled_rules`` / ``unattended_allow`` are merged (set-union).
+
+    Fail-secure: a missing/unreadable/yaml-less global file ⇒ ``enabled: true``.
     """
     enabled = True
     disabled_rules: List[str] = []
@@ -522,22 +532,29 @@ def load_safety_config(
         return {"enabled": enabled, "disabled_rules": disabled_rules,
                 "unattended_allow": unattended_allow}
 
+    def _absorb(data: Any) -> Optional[bool]:
+        """Pull knobs from a parsed policy doc; return its ``enabled`` (or None)."""
+        local_enabled: Optional[bool] = None
+        if isinstance(data, dict):
+            if "enabled" in data and data["enabled"] is not None:
+                local_enabled = bool(data["enabled"])
+            rules = data.get("disabled_rules", [])
+            if isinstance(rules, list):
+                disabled_rules.extend(str(r) for r in rules if r)
+            allow = data.get("unattended_allow", [])
+            if isinstance(allow, list):
+                unattended_allow.extend(str(a) for a in allow if a)
+        return local_enabled
+
     if global_config_path is None:
-        global_config_path = Path.home() / ".agentwire" / "config.yaml"
+        global_config_path = Path.home() / ".agentwire" / "damagecontrol.yml"
     try:
         if global_config_path.exists():
             with open(global_config_path, "r") as f:
-                data = yaml.safe_load(f) or {}
-            safety = data.get("safety", {})
-            if isinstance(safety, dict):
-                if "enabled" in safety:
-                    enabled = bool(safety["enabled"])
-                rules = safety.get("disabled_rules", [])
-                if isinstance(rules, list):
-                    disabled_rules.extend(str(r) for r in rules if r)
-                allow = safety.get("unattended_allow", [])
-                if isinstance(allow, list):
-                    unattended_allow.extend(str(a) for a in allow if a)
+                gdata = yaml.safe_load(f) or {}
+            genabled = _absorb(gdata)
+            if genabled is not None:
+                enabled = genabled
     except Exception:
         pass
 
@@ -545,21 +562,12 @@ def load_safety_config(
         cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        candidate = os.path.join(current, ".agentwire.yml")
+        candidate = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(candidate):
             try:
                 with open(candidate, "r") as f:
                     pdata = yaml.safe_load(f) or {}
-                psafety = pdata.get("safety", {})
-                if isinstance(psafety, dict):
-                    if "enabled" in psafety and psafety["enabled"] is not None:
-                        project_enabled = bool(psafety["enabled"])
-                    prules = psafety.get("disabled_rules", [])
-                    if isinstance(prules, list):
-                        disabled_rules.extend(str(r) for r in prules if r)
-                    pallow = psafety.get("unattended_allow", [])
-                    if isinstance(pallow, list):
-                        unattended_allow.extend(str(a) for a in pallow if a)
+                project_enabled = _absorb(pdata)
             except Exception:
                 pass
             break
@@ -576,6 +584,94 @@ def load_safety_config(
         "disabled_rules": sorted(set(disabled_rules)),
         "unattended_allow": sorted(set(unattended_allow)),
     }
+
+
+# ============================================================================
+# PROTECTED CONTROL PLANE (escape-hatch- AND kill-switch-EXEMPT)
+# ============================================================================
+#
+# Damage control reads its kill switch, its rules, and its own hook
+# registration from files on disk. If the policed agent can write those files,
+# it can disable safety, act, and re-enable — defeating everything (#466). So
+# the WHOLE control plane is hard-protected: any write/edit/delete/move/chmod
+# targeting one of these paths is BLOCKED, and — unlike every other rule — the
+# ``# allow:`` escape hatch and the ``enabled: false`` kill switch do NOT
+# override it. Only the user's ``allowedPaths`` allowlist can re-permit a path,
+# because that is a human, host-side opt-in (the agent cannot add to it without
+# editing a protected file, which is itself blocked).
+#
+# The guarantee: the agent only ever operates within the freedom the human
+# preset. Loosening is always a host-side act.
+
+PROTECTED_CONTROL_PLANE_PATHS = [
+    "~/.agentwire/damagecontrol.yml",   # global kill switch + rule knobs
+    "*.damagecontrol.yml",              # project kill switch + rule knobs (any dir)
+    "~/.claude/settings.json",          # PreToolUse hook registration
+    "~/.agentwire/hooks/damage-control/*.py",  # the hook scripts themselves
+    "~/.claude/hooks/*",                # agentwire-owned Claude Code hooks
+    "~/.agentwire/damage-control/*.yaml",      # the damage-control rule files
+]
+
+
+def _protected_path_patterns() -> List[str]:
+    """Protected paths in both ``~``-form and ``$HOME``-expanded form.
+
+    Commands may reference either; including both ensures the regex/glob
+    matchers catch e.g. ``/Users/me/.claude/settings.json`` and
+    ``~/.claude/settings.json`` alike.
+    """
+    out: List[str] = []
+    for p in PROTECTED_CONTROL_PLANE_PATHS:
+        out.append(p)
+        expanded = os.path.expanduser(p)
+        if expanded != p:
+            out.append(expanded)
+    return out
+
+
+def is_protected_control_plane(file_path: str) -> bool:
+    """True if ``file_path`` is part of the damage-control control plane."""
+    for pat in _protected_path_patterns():
+        if match_path(file_path, pat):
+            return True
+    return False
+
+
+def check_protected_path(
+    file_path: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block edits/writes to a control-plane file unless the user allowlisted it.
+
+    Used by the edit/write hooks. The allowlist (a human opt-in) may override;
+    nothing else does.
+    """
+    if is_protected_control_plane(file_path):
+        if is_path_allowed_for_op(file_path, allowed_paths, "edit"):
+            return False, ""
+        return True, "protected control-plane file (host-owned; edit on the host)"
+    return False, ""
+
+
+def check_protected_command(
+    command: str,
+    allowed_paths: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Block a bash command that writes/edits/deletes a control-plane file.
+
+    Mirrors the ``readOnlyPaths`` matcher but is escape-hatch- and
+    kill-switch-exempt. The user's allowlist may re-permit a specific path.
+    """
+    for path in _protected_path_patterns():
+        matched, reason = check_path_patterns(
+            command, path, READ_ONLY_BLOCKED, "protected control-plane path"
+        )
+        if matched:
+            op = _infer_operation_from_reason(reason)
+            if is_command_path_allowed(command, allowed_paths, op):
+                continue
+            return True, f"Protected control-plane path: {path}"
+    return False, ""
 
 
 _ESCAPE_HATCH_RE = re.compile(r"#\s*allow:[ \t]*([^\n]+)", re.IGNORECASE)
@@ -608,18 +704,36 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     ``escape_reason``, ``escape``, ``disabled``.
 
     Order:
-      0. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
-      1. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
-      2. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
-      3. Ask patterns
-      4. Bypassable bash patterns → check allowlist for required operation
-      5. zeroAccessPaths → check allowlist with ``read`` permission
-      6. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
-      7. noDeletePaths → match against NO_DELETE_BLOCKED patterns
+      0. Protected control plane → BLOCK (escape-hatch- AND kill-switch-exempt;
+         only the user's allowlist re-permits) — runs FIRST so an agent can't
+         self-authorize a write to the files that gate everything else.
+      1. Escape hatch (``# allow: <reason>``) → ALLOW (escape=True)
+      2. Kill switch (``config["safety"]["enabled"] is False``) → ALLOW (disabled=True)
+      3. Hard-blocked bash patterns (skip if ``id`` in ``disabled_rules``)
+      4. Ask patterns
+      5. Bypassable bash patterns → check allowlist for required operation
+      6. zeroAccessPaths → check allowlist with ``read`` permission
+      7. readOnlyPaths → match against READ_ONLY_BLOCKED operation patterns
+      8. noDeletePaths → match against NO_DELETE_BLOCKED patterns
     """
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     disabled_rules = set(safety_cfg.get("disabled_rules", []) or [])
     is_enabled = safety_cfg.get("enabled", True)
+
+    allowed = load_allowed_paths(config)
+
+    # Protected control plane FIRST — before the escape hatch and the kill
+    # switch. An agent must never be able to self-authorize a write to the
+    # files that define safety itself (#466).
+    prot_blocked, prot_reason = check_protected_command(command, allowed)
+    if prot_blocked:
+        return {
+            "decision": "block",
+            "reason": prot_reason,
+            "pattern": "protectedControlPlane",
+            "command": command,
+            "protected": True,
+        }
 
     escape_reason = detect_escape_hatch(command)
     if escape_reason:
@@ -645,7 +759,6 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     zero_access = config.get("zeroAccessPaths", [])
     read_only = config.get("readOnlyPaths", [])
     no_delete = config.get("noDeletePaths", [])
-    allowed = load_allowed_paths(config)
 
     bypassable_matches: List[Tuple[str, str, Optional[str]]] = []
 
@@ -738,12 +851,21 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
-    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``."""
+    """File-path-only check used by edit/write hooks. Returns ``(blocked, reason)``.
+
+    The protected control plane is checked FIRST, before the kill switch — the
+    files that gate safety stay agent-unwritable even when safety is disabled;
+    only the user's allowlist re-permits them (#466).
+    """
+    allowed = load_allowed_paths(config)
+
+    prot_blocked, prot_reason = check_protected_path(file_path, allowed)
+    if prot_blocked:
+        return True, prot_reason
+
     safety_cfg = config.get("safety", {}) if isinstance(config.get("safety"), dict) else {}
     if safety_cfg.get("enabled", True) is False:
         return False, ""
-
-    allowed = load_allowed_paths(config)
 
     if is_path_allowed_for_op(file_path, allowed, "edit"):
         return False, ""

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -170,19 +170,26 @@ def _parse_allowed_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _find_project_config() -> Tuple[str, List[Any]]:
-    """Walk up from $PWD to find ``.agentwire.yml`` and return its allowed_paths."""
+    """Walk up from $PWD to find ``.damagecontrol.yml`` and return its allowed_paths.
+
+    The per-project allowlist lives in the PROTECTED ``.damagecontrol.yml``
+    (top-level ``allowed_paths``), never the agent-writable ``.agentwire.yml``.
+    Otherwise an agent could allowlist a control-plane path in ``.agentwire.yml``
+    and re-permit its own write to ``damagecontrol.yml`` — the exact bypass #466
+    set out to close. The allowlist is the one knob that overrides the protected
+    check, so it must itself live behind the protected control plane (#467).
+    """
     cwd = os.environ.get("PWD", os.getcwd())
     current = os.path.abspath(cwd)
     while True:
-        config_file = os.path.join(current, ".agentwire.yml")
+        config_file = os.path.join(current, ".damagecontrol.yml")
         if os.path.isfile(config_file):
             try:
                 if yaml:
                     with open(config_file, "r") as f:
                         data = yaml.safe_load(f) or {}
-                    safety = data.get("safety", {})
-                    if isinstance(safety, dict):
-                        paths = safety.get("allowed_paths", [])
+                    if isinstance(data, dict):
+                        paths = data.get("allowed_paths", [])
                         if isinstance(paths, list):
                             return current, paths
             except Exception:
@@ -196,7 +203,7 @@ def _find_project_config() -> Tuple[str, List[Any]]:
 
 
 def load_allowed_paths(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Merge global ``allowedPaths`` from config with per-project ``.agentwire.yml`` entries."""
+    """Merge global ``allowedPaths`` from config with per-project ``.damagecontrol.yml`` entries."""
     raw = list(config.get("allowedPaths", []))
 
     project_root, project_paths = _find_project_config()

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -3878,10 +3878,13 @@ projects:
                             counts[d] = counts.get(d, 0) + 1
                 except Exception:
                     pass
-            safety_cfg = getattr(self.config, "safety", None)
+            # Read the kill switch + disabled rules from the agent-unwritable
+            # damage-control policy files (#466), not from config.yaml.
+            from .safety._core import load_safety_config
+            safety_cfg = load_safety_config()
             return web.json_response({
-                "enabled": getattr(safety_cfg, "enabled", True) if safety_cfg else True,
-                "disabled_rules": list(getattr(safety_cfg, "disabled_rules", []) or []),
+                "enabled": safety_cfg.get("enabled", True),
+                "disabled_rules": list(safety_cfg.get("disabled_rules", []) or []),
                 "rule_count": len(patterns.get("bashToolPatterns", [])),
                 "today_counts": counts,
             })
@@ -3931,15 +3934,16 @@ projects:
         Disabling the damage-control rules with the same token that the rules are
         meant to contain defeats defense-in-depth. The master switch and
         disabled-rules list can now only be changed by editing
-        ~/.agentwire/config.yaml on the host. GET /api/safety/* still works for
-        viewing status, rules and logs.
+        ~/.agentwire/damagecontrol.yml on the host — itself a protected,
+        agent-unwritable control-plane file (#466). GET /api/safety/* still works
+        for viewing status, rules and logs.
         """
         return web.json_response(
             {
                 "error": (
                     "Safety configuration is frozen and can only be changed by "
-                    "editing the `safety:` block in ~/.agentwire/config.yaml on "
-                    "the host, then reloading the portal."
+                    "editing ~/.agentwire/damagecontrol.yml on the host, then "
+                    "reloading the portal."
                 ),
                 "frozen_keys": ["safety"],
             },

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -76,6 +76,55 @@ Hooks load every `*.yaml` file in the rules directory and merge their pattern li
 
 ---
 
+## Policy files & the protected control plane (#466)
+
+Damage control reads its kill switch, its rules, and its own hook registration
+from files on disk. If the policed agent can write those files, it can disable
+safety, act, and re-enable — defeating everything. So the **knobs live in
+dedicated, host-owned files** and the **whole control plane is hard-protected**.
+
+### Policy files (the only place the knobs live)
+
+| File | Scope |
+|------|-------|
+| `~/.agentwire/damagecontrol.yml` | Global `enabled` / `disabled_rules` / `unattended_allow` |
+| `<repo>/.damagecontrol.yml` | Per-project override (nearest, walking up from cwd). May both **loosen and tighten** — it simply wins on `enabled`; rule knobs merge (set-union) |
+
+```yaml
+# ~/.agentwire/damagecontrol.yml
+enabled: true            # master switch; missing file/key ⇒ true (fail-secure)
+disabled_rules: []       # stable rule IDs to disable
+unattended_allow: []     # extra rule IDs an unattended run may resolve ask→allow
+```
+
+These knobs **no longer live in `config.yaml` or `.agentwire.yml`** (relocated
+out entirely — `load_safety_config` reads only the files above). `.agentwire.yml`
+keeps only `safety.allowed_paths` (the human allowlist). `agentwire safety
+install` scaffolds the global file with `enabled: true` if missing.
+
+### The protected control plane (escape-hatch- AND kill-switch-exempt)
+
+Any write / edit / delete / move / chmod targeting one of these paths is
+**BLOCKED**, and — unlike every other rule — the `# allow:` escape hatch and the
+`enabled: false` kill switch **do NOT override it**:
+
+- `~/.agentwire/damagecontrol.yml`, any `.damagecontrol.yml`
+- `~/.claude/settings.json` (the PreToolUse hook registration)
+- `~/.agentwire/hooks/damage-control/*.py` (the hook scripts), `~/.claude/hooks/*`
+- `~/.agentwire/damage-control/*.yaml` (the rule files)
+
+The guarantee: **the agent only ever operates within the freedom the human
+preset; it can never expand its own freedom by editing a file.** The one
+override is the user's `allowedPaths` allowlist — a human, host-side opt-in (the
+agent can't add to it without editing a protected file, which is itself blocked).
+The mechanism is `check_protected_command` / `check_protected_path` in
+`safety/_core.py`, which run **before** `detect_escape_hatch` and the kill switch.
+`rules/control-plane.yaml` lists the same paths as `readOnlyPaths` for
+defense-in-depth + visibility, but the code-level check is what makes the
+protection absolute.
+
+---
+
 ## Security Patterns
 
 Patterns live in **categorized YAML files** under `agentwire/hooks/damage-control/rules/` (14 files, one per topic). To override or extend, drop YAML files into `~/.agentwire/damage-control/` — when that directory exists with `*.yaml` files, hooks load from there instead of the bundled rules.
@@ -223,15 +272,15 @@ spawns inherits the marker (defense in depth).
 **What's unaffected.** Hard `block` rules (`rm -rf`, `git push --force`, DB
 drops) fire regardless — they never depended on a human. Interactive `bypass`
 sessions resolve `ask` exactly as before. The kill switch still wins: with
-`safety.enabled: false`, nothing is checked, so the unattended gate is inert too
-(enable safety for scheduled projects to engage it).
+`enabled: false` in `~/.agentwire/damagecontrol.yml`, nothing is checked, so the
+unattended gate is inert too (enable safety for scheduled projects to engage it).
 
 **The allowlist** (union of three sources):
 
 | Source | Where | Scope |
 |--------|-------|-------|
 | `DEFAULT_UNATTENDED_ALLOW` | `safety/_core.py` | Built-in: `git.add`, `git.add-u`, `git.commit`, `git.push`, `gh.pr-create` — work + open a PR, nothing irreversible or outward-facing |
-| `safety.unattended_allow` | `config.yaml` / project `.agentwire.yml` | Global / per-project extension (list of rule ids) |
+| `unattended_allow` | `~/.agentwire/damagecontrol.yml` / project `.damagecontrol.yml` | Global / per-project extension (list of rule ids) |
 | `unattended_allow` | per-task in `.agentwire.yml` | Per-task extension — the pressure-relief valve: widen for one task instead of loosening the global default |
 
 Allowlisting is **by rule ID**, not command text — so `git.push` (plain push)

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -87,19 +87,24 @@ dedicated, host-owned files** and the **whole control plane is hard-protected**.
 
 | File | Scope |
 |------|-------|
-| `~/.agentwire/damagecontrol.yml` | Global `enabled` / `disabled_rules` / `unattended_allow` |
-| `<repo>/.damagecontrol.yml` | Per-project override (nearest, walking up from cwd). May both **loosen and tighten** — it simply wins on `enabled`; rule knobs merge (set-union) |
+| `~/.agentwire/damagecontrol.yml` | Global `enabled` / `disabled_rules` / `unattended_allow` (+ `allowed_paths`) |
+| `<repo>/.damagecontrol.yml` | Per-project override (nearest, walking up from cwd). May both **loosen and tighten** — it wins on `enabled`; rule knobs + `allowed_paths` merge |
 
 ```yaml
-# ~/.agentwire/damagecontrol.yml
+# ~/.agentwire/damagecontrol.yml  (or <repo>/.damagecontrol.yml)
 enabled: true            # master switch; missing file/key ⇒ true (fail-secure)
 disabled_rules: []       # stable rule IDs to disable
 unattended_allow: []     # extra rule IDs an unattended run may resolve ask→allow
+allowed_paths: []        # per-project allowlist (see allowedPaths below)
 ```
 
-These knobs **no longer live in `config.yaml` or `.agentwire.yml`** (relocated
-out entirely — `load_safety_config` reads only the files above). `.agentwire.yml`
-keeps only `safety.allowed_paths` (the human allowlist). `agentwire safety
+**ALL** damage-control policy — kill switch, rule knobs, AND the per-project
+`allowed_paths` allowlist — lives in these files. They **no longer live in
+`config.yaml` or `.agentwire.yml`** at all (relocated out entirely;
+`load_safety_config` / `_find_project_config` read only the files above). The
+allowlist had to move too (#467): it's the one knob that overrides the protected
+check, so leaving it in the agent-writable `.agentwire.yml` would let an agent
+allowlist a control-plane path and re-permit its own write. `agentwire safety
 install` scaffolds the global file with `enabled: true` if missing.
 
 ### The protected control plane (escape-hatch- AND kill-switch-exempt)
@@ -217,17 +222,17 @@ allowedPaths:
     allow: all
 ```
 
-**Per-project** (in `.agentwire.yml`):
+**Per-project** (top-level `allowed_paths` in the **protected** `.damagecontrol.yml` at the repo root — NOT `.agentwire.yml`, see [Policy files](#policy-files--the-protected-control-plane-466) and #467):
 ```yaml
-safety:
-  allowed_paths:
-    - path: ".env.development"
-      allow: [read, write, edit]
-    - path: "dist/*"
-      allow: all
+# <repo>/.damagecontrol.yml
+allowed_paths:
+  - path: ".env.development"
+    allow: [read, write, edit]
+  - path: "dist/*"
+    allow: all
 ```
 
-Plain strings (legacy format) are auto-coerced to `{path: str, allow: all}` for backwards compatibility.
+The allowlist is the one knob that overrides the protected-control-plane check, so it lives behind that same protection — an agent can't edit `.damagecontrol.yml` to widen its own freedom.
 
 Per-project paths are relative to the project root and resolved to absolute paths before matching.
 

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -1,0 +1,212 @@
+"""Control-plane lockdown (#466).
+
+The damage-control control plane — the kill-switch/rule files, the hook scripts,
+the rule YAMLs, and the Claude Code hook registration — must be unwritable by the
+policed agent, EVEN with the ``# allow:`` escape hatch and EVEN when the kill
+switch is off. Only the user's host-side ``allowedPaths`` allowlist re-permits a
+path. Loosening is always a human, host-side act.
+"""
+
+import os
+
+import pytest
+
+from agentwire.cli_safety import load_patterns
+from agentwire.safety._core import (
+    check_command,
+    check_path,
+    is_protected_control_plane,
+    load_safety_config,
+)
+
+
+CONTROL_PLANE_FILES = [
+    os.path.expanduser("~/.agentwire/damagecontrol.yml"),
+    "/some/repo/.damagecontrol.yml",
+    os.path.expanduser("~/.claude/settings.json"),
+    os.path.expanduser("~/.agentwire/hooks/damage-control/bash-tool-damage-control.py"),
+    os.path.expanduser("~/.claude/hooks/idle-handler.sh"),
+    os.path.expanduser("~/.agentwire/damage-control/core.yaml"),
+]
+
+
+@pytest.fixture
+def cfg():
+    c = load_patterns()
+    c["safety"] = {"enabled": True, "disabled_rules": []}
+    return c
+
+
+# --------------------------------------------------------------------------
+# is_protected_control_plane
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", CONTROL_PLANE_FILES)
+def test_every_control_plane_file_is_protected(path):
+    assert is_protected_control_plane(path) is True
+
+
+def test_unrelated_file_is_not_protected():
+    assert is_protected_control_plane(os.path.expanduser("~/projects/foo/main.py")) is False
+    # ``config.yaml`` / ``.agentwire.yml`` are NOT control plane (no knobs there now)
+    assert is_protected_control_plane(os.path.expanduser("~/.agentwire/config.yaml")) is False
+
+
+# --------------------------------------------------------------------------
+# Edit/Write hook (check_path)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", CONTROL_PLANE_FILES)
+def test_edit_write_to_control_plane_blocked(cfg, path):
+    blocked, reason = check_path(path, cfg)
+    assert blocked is True
+    assert "control-plane" in reason
+
+
+@pytest.mark.parametrize("path", CONTROL_PLANE_FILES)
+def test_edit_write_blocked_even_when_kill_switch_off(path):
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": False, "disabled_rules": []}
+    blocked, _ = check_path(path, cfg)
+    assert blocked is True  # absolute: kill switch does NOT re-open the control plane
+
+
+def test_unregistering_hook_via_settings_blocked(cfg):
+    blocked, _ = check_path(os.path.expanduser("~/.claude/settings.json"), cfg)
+    assert blocked is True
+
+
+# --------------------------------------------------------------------------
+# Bash hook (check_command) — escape hatch must NOT override
+# --------------------------------------------------------------------------
+
+BASH_WRITES = [
+    "echo 'enabled: false' > ~/.agentwire/damagecontrol.yml",
+    "echo '{}' > ~/.claude/settings.json",
+    "rm ~/.agentwire/damage-control/core.yaml",
+    "sed -i 's/x/y/' ~/.agentwire/hooks/damage-control/bash-tool-damage-control.py",
+    "echo 'enabled: false' > .damagecontrol.yml",
+]
+
+
+@pytest.mark.parametrize("command", BASH_WRITES)
+def test_bash_write_to_control_plane_blocked(cfg, command):
+    result = check_command(command, cfg)
+    assert result["decision"] == "block"
+    assert result.get("protected") is True
+
+
+@pytest.mark.parametrize("command", BASH_WRITES)
+def test_escape_hatch_cannot_override_control_plane(cfg, command):
+    result = check_command(command + "  # allow: I really want to", cfg)
+    assert result["decision"] == "block"
+    assert result.get("protected") is True
+    assert result.get("escape") is not True
+
+
+@pytest.mark.parametrize("command", BASH_WRITES)
+def test_kill_switch_cannot_reopen_control_plane(command):
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": False, "disabled_rules": []}
+    result = check_command(command, cfg)
+    assert result["decision"] == "block"
+    assert result.get("protected") is True
+
+
+def test_reading_control_plane_is_allowed(cfg):
+    result = check_command("cat ~/.agentwire/damagecontrol.yml", cfg)
+    assert result["decision"] == "allow"
+
+
+# --------------------------------------------------------------------------
+# Allowlist (the human opt-in) DOES re-permit
+# --------------------------------------------------------------------------
+
+
+def test_allowlisted_project_file_repermits_agent_edit():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True}
+    project_file = "/repo/.damagecontrol.yml"
+    cfg["allowedPaths"] = [{"path": project_file, "allow": "all"}]
+    blocked, _ = check_path(project_file, cfg)
+    assert blocked is False
+
+
+def test_allowlisted_path_repermits_bash_write():
+    cfg = load_patterns()
+    cfg["safety"] = {"enabled": True}
+    cfg["allowedPaths"] = [{"path": "/repo/.damagecontrol.yml", "allow": "all"}]
+    result = check_command("echo 'enabled: true' > /repo/.damagecontrol.yml", cfg)
+    assert result["decision"] != "block"
+
+
+# --------------------------------------------------------------------------
+# Loader reads the relocated knobs from damagecontrol.yml / .damagecontrol.yml
+# --------------------------------------------------------------------------
+
+
+def _write(p, text):
+    p.write_text(text)
+
+
+def test_loader_reads_knobs_from_global_file(tmp_path):
+    g = tmp_path / "damagecontrol.yml"
+    _write(g, "enabled: true\ndisabled_rules: [git.push]\nunattended_allow: [gh.pr-merge]\n")
+    out = load_safety_config(global_config_path=g, cwd=str(tmp_path))
+    assert out["enabled"] is True
+    assert out["disabled_rules"] == ["git.push"]
+    assert out["unattended_allow"] == ["gh.pr-merge"]
+
+
+def test_missing_global_file_is_enabled_true(tmp_path):
+    g = tmp_path / "does-not-exist.yml"
+    out = load_safety_config(global_config_path=g, cwd=str(tmp_path))
+    assert out["enabled"] is True
+
+
+def test_project_file_can_tighten(tmp_path):
+    # global enabled, project sets enabled: false → tightened off for that tree
+    g = tmp_path / "damagecontrol.yml"
+    _write(g, "enabled: true\n")
+    proj = tmp_path / "repo"
+    proj.mkdir()
+    _write(proj / ".damagecontrol.yml", "enabled: false\n")
+    out = load_safety_config(global_config_path=g, cwd=str(proj))
+    assert out["enabled"] is False
+
+
+def test_project_file_can_loosen(tmp_path):
+    # global disabled (host choice), project sets enabled: true → re-enabled
+    g = tmp_path / "damagecontrol.yml"
+    _write(g, "enabled: false\n")
+    proj = tmp_path / "repo"
+    proj.mkdir()
+    _write(proj / ".damagecontrol.yml", "enabled: true\n")
+    out = load_safety_config(global_config_path=g, cwd=str(proj))
+    assert out["enabled"] is True
+
+
+def test_project_merges_rule_knobs(tmp_path):
+    g = tmp_path / "damagecontrol.yml"
+    _write(g, "disabled_rules: [git.push]\nunattended_allow: [a]\n")
+    proj = tmp_path / "repo"
+    proj.mkdir()
+    _write(proj / ".damagecontrol.yml", "disabled_rules: [gh.pr-create]\nunattended_allow: [b]\n")
+    out = load_safety_config(global_config_path=g, cwd=str(proj))
+    assert set(out["disabled_rules"]) == {"git.push", "gh.pr-create"}
+    assert set(out["unattended_allow"]) == {"a", "b"}
+
+
+def test_host_side_edit_is_honored_by_loader(tmp_path):
+    """A host-side edit (writing the file directly, not via the hooks) is read.
+
+    The hooks block the AGENT from writing these files; the host/owner edits them
+    freely and the loader picks the change up on next load.
+    """
+    g = tmp_path / "damagecontrol.yml"
+    _write(g, "enabled: true\n")
+    assert load_safety_config(global_config_path=g, cwd=str(tmp_path))["enabled"] is True
+    _write(g, "enabled: false\n")  # owner flips the kill switch on the host
+    assert load_safety_config(global_config_path=g, cwd=str(tmp_path))["enabled"] is False

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -16,6 +16,7 @@ from agentwire.safety._core import (
     check_command,
     check_path,
     is_protected_control_plane,
+    load_allowed_paths,
     load_safety_config,
 )
 
@@ -197,6 +198,107 @@ def test_project_merges_rule_knobs(tmp_path):
     out = load_safety_config(global_config_path=g, cwd=str(proj))
     assert set(out["disabled_rules"]) == {"git.push", "gh.pr-create"}
     assert set(out["unattended_allow"]) == {"a", "b"}
+
+
+# --------------------------------------------------------------------------
+# The per-project allowlist lives in the PROTECTED .damagecontrol.yml, NOT the
+# agent-writable .agentwire.yml (#467 — the residual one-step bypass).
+#
+# These read the project file from DISK via _find_project_config()'s PWD walk,
+# so they exercise the real source of the allowlist — injecting a merged dict
+# would hide exactly the bug being closed.
+# --------------------------------------------------------------------------
+
+PROTECTED_TARGET = os.path.expanduser("~/.agentwire/damagecontrol.yml")  # a protected path to (try to) re-permit
+
+
+def _base_cfg():
+    c = load_patterns()
+    c["safety"] = {"enabled": True}
+    c["allowedPaths"] = []  # no host-side global allowlist for these
+    return c
+
+
+def test_agentwire_yml_allowlist_does_NOT_repermit_protected(tmp_path, monkeypatch):
+    """BUG REPRODUCER: .agentwire.yml safety.allowed_paths must NOT re-permit a
+    protected path — otherwise an agent edits .agentwire.yml to free itself."""
+    (tmp_path / ".agentwire.yml").write_text(
+        "type: claude-bypass\n"
+        "safety:\n"
+        "  allowed_paths:\n"
+        f"    - path: {PROTECTED_TARGET}\n"
+        "      allow: all\n"
+    )
+    monkeypatch.setenv("PWD", str(tmp_path))
+    cfg = _base_cfg()
+
+    blocked, _ = check_path(PROTECTED_TARGET, cfg)
+    assert blocked is True
+    result = check_command(f"echo 'enabled: false' > {PROTECTED_TARGET}", cfg)
+    assert result["decision"] == "block"
+    assert result.get("protected") is True
+
+
+def test_damagecontrol_yml_allowlist_DOES_repermit_protected(tmp_path, monkeypatch):
+    """Host-side opt-in works: an allowed_paths entry in the PROTECTED
+    .damagecontrol.yml re-permits the agent to edit that path."""
+    (tmp_path / ".damagecontrol.yml").write_text(
+        "enabled: true\n"
+        "allowed_paths:\n"
+        f"  - path: {PROTECTED_TARGET}\n"
+        "    allow: all\n"
+    )
+    monkeypatch.setenv("PWD", str(tmp_path))
+    cfg = _base_cfg()
+
+    blocked, _ = check_path(PROTECTED_TARGET, cfg)
+    assert blocked is False
+    result = check_command(f"echo 'enabled: false' > {PROTECTED_TARGET}", cfg)
+    assert result["decision"] != "block"
+
+
+def test_global_host_allowlist_still_repermits(tmp_path, monkeypatch):
+    """The host-owned global allowedPaths (from the protected rule YAMLs) still
+    overrides, as before."""
+    monkeypatch.setenv("PWD", str(tmp_path))  # no project file present
+    cfg = _base_cfg()
+    cfg["allowedPaths"] = [{"path": PROTECTED_TARGET, "allow": "all"}]
+    blocked, _ = check_path(PROTECTED_TARGET, cfg)
+    assert blocked is False
+
+
+def test_load_allowed_paths_sources_from_damagecontrol_not_agentwire(tmp_path, monkeypatch):
+    """The per-project allowlist comes from .damagecontrol.yml; an .agentwire.yml
+    safety block contributes nothing."""
+    (tmp_path / ".agentwire.yml").write_text(
+        "type: claude-bypass\n"
+        "safety:\n"
+        "  allowed_paths:\n"
+        "    - path: /from/agentwire\n"
+        "      allow: all\n"
+    )
+    (tmp_path / ".damagecontrol.yml").write_text(
+        "allowed_paths:\n"
+        "  - path: /from/damagecontrol\n"
+        "    allow: all\n"
+    )
+    monkeypatch.setenv("PWD", str(tmp_path))
+    paths = [e["path"] for e in load_allowed_paths({"allowedPaths": []})]
+    assert "/from/damagecontrol" in paths
+    assert "/from/agentwire" not in paths
+
+
+def test_agentwire_yml_alone_contributes_no_allowlist(tmp_path, monkeypatch):
+    (tmp_path / ".agentwire.yml").write_text(
+        "type: claude-bypass\n"
+        "safety:\n"
+        "  allowed_paths:\n"
+        "    - path: /from/agentwire\n"
+        "      allow: all\n"
+    )
+    monkeypatch.setenv("PWD", str(tmp_path))
+    paths = [e["path"] for e in load_allowed_paths({"allowedPaths": []})]
+    assert paths == []
 
 
 def test_host_side_edit_is_honored_by_loader(tmp_path):

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from agentwire.project_config import (
     SessionType,
     ProjectConfig,
-    SafetyConfig,
     compose_session_type,
     ensure_gitignored,
     normalize_session_type,
@@ -236,93 +235,24 @@ class TestProjectConfigIO:
         assert found is None
 
 
-# --- SafetyConfig ---
+# --- ProjectConfig holds no safety config (#466/#467) ---
 
-class TestSafetyConfig:
-    def test_from_dict_with_structured_entries(self):
-        sc = SafetyConfig.from_dict({"allowed_paths": [
-            {"path": "dist/*", "allow": "all"},
-            {"path": ".env.dev", "allow": ["read", "write"]},
-        ]})
-        assert len(sc.allowed_paths) == 2
-        assert sc.allowed_paths[0] == {"path": "dist/*", "allow": "all"}
-        assert sc.allowed_paths[1] == {"path": ".env.dev", "allow": ["read", "write"]}
+class TestProjectConfigNoSafety:
+    def test_safety_block_is_ignored(self):
+        """A `safety:` block in .agentwire.yml is no longer parsed into the config.
 
-    def test_from_dict_empty(self):
-        sc = SafetyConfig.from_dict({})
-        assert sc.allowed_paths == []
-
-    def test_from_dict_plain_strings_skipped(self):
-        """Plain strings are not valid entries and are silently skipped."""
-        sc = SafetyConfig.from_dict({"allowed_paths": ["dist/*", ".env.dev"]})
-        assert sc.allowed_paths == []
-
-    def test_from_dict_none_becomes_empty(self):
-        sc = SafetyConfig.from_dict({"allowed_paths": None})
-        assert sc.allowed_paths == []
-
-    def test_to_dict_omits_empty(self):
-        sc = SafetyConfig()
-        assert sc.to_dict() == {}
-
-    def test_to_dict_includes_populated(self):
-        sc = SafetyConfig(allowed_paths=[{"path": "dist/*", "allow": "all"}])
-        assert sc.to_dict() == {"allowed_paths": [{"path": "dist/*", "allow": "all"}]}
-
-
-class TestProjectConfigSafety:
-    def test_from_dict_with_safety(self):
-        data = {
+        Per-project safety policy (incl. allowed_paths) lives in the protected
+        .damagecontrol.yml — .agentwire.yml carries none.
+        """
+        config = ProjectConfig.from_dict({
             "type": "claude-bypass",
-            "safety": {"allowed_paths": [
-                {"path": "dist/*", "allow": "all"},
-                {"path": ".env.dev", "allow": ["read", "write"]},
-            ]},
-        }
-        config = ProjectConfig.from_dict(data)
-        assert len(config.safety.allowed_paths) == 2
-        assert config.safety.allowed_paths[0]["path"] == "dist/*"
+            "safety": {"allowed_paths": [{"path": "dist/*", "allow": "all"}]},
+        })
+        assert not hasattr(config, "safety")
 
-    def test_from_dict_without_safety(self):
-        config = ProjectConfig.from_dict({"type": "bare"})
-        assert config.safety.allowed_paths == []
-
-    def test_to_dict_includes_safety(self):
-        config = ProjectConfig(
-            type=SessionType.CLAUDE_BYPASS,
-            safety=SafetyConfig(allowed_paths=[{"path": "dist/*", "allow": "all"}]),
-        )
-        d = config.to_dict()
-        assert d["safety"] == {"allowed_paths": [{"path": "dist/*", "allow": "all"}]}
-
-    def test_to_dict_omits_empty_safety(self):
+    def test_to_dict_never_emits_safety(self):
         config = ProjectConfig(type=SessionType.CLAUDE_BYPASS)
-        d = config.to_dict()
-        assert "safety" not in d
-
-    def test_round_trip_with_safety(self):
-        original = ProjectConfig(
-            type=SessionType.CLAUDE_BYPASS,
-            safety=SafetyConfig(allowed_paths=[
-                {"path": "dist/*", "allow": "all"},
-                {"path": "/tmp/*", "allow": ["read", "write"]},
-            ]),
-        )
-        d = original.to_dict()
-        restored = ProjectConfig.from_dict(d)
-        assert len(restored.safety.allowed_paths) == len(original.safety.allowed_paths)
-        assert restored.safety.allowed_paths[0]["path"] == "dist/*"
-
-    def test_save_load_with_safety(self, project_dir):
-        config = ProjectConfig(
-            type=SessionType.CLAUDE_BYPASS,
-            safety=SafetyConfig(allowed_paths=[{"path": "dist/*", "allow": "all"}]),
-        )
-        assert save_project_config(config, project_dir) is True
-        loaded = load_project_config(project_dir)
-        assert loaded is not None
-        assert len(loaded.safety.allowed_paths) == 1
-        assert loaded.safety.allowed_paths[0]["path"] == "dist/*"
+        assert "safety" not in config.to_dict()
 
 
 # --- ensure_gitignored ---

--- a/tests/unit/test_safety_heal.py
+++ b/tests/unit/test_safety_heal.py
@@ -26,6 +26,7 @@ def fake_env(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_safety, "LOGS_DIR", cfg / "logs" / "damage-control")
     monkeypatch.setattr(cli_safety, "RULES_DIR", cfg / "damage-control")
     monkeypatch.setattr(cli_safety, "TOOLDEFS_DIR", cfg / "tooldefs")
+    monkeypatch.setattr(cli_safety, "DAMAGECONTROL_FILE", cfg / "damagecontrol.yml")
     return home
 
 
@@ -115,12 +116,12 @@ class TestDoctorDamageControlSection:
         return fake_env
 
     def _patch_safety_enabled(self, monkeypatch, enabled):
-        import agentwire.config as cfg_mod
-
-        class _Cfg:
-            safety = type("S", (), {"enabled": enabled})()
-
-        monkeypatch.setattr(cfg_mod, "load_config", lambda *a, **k: _Cfg())
+        # The kill switch now lives in the host-owned damagecontrol.yml, read by
+        # load_safety_config (#466). Write it directly in the fake home.
+        cli_safety.DAMAGECONTROL_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cli_safety.DAMAGECONTROL_FILE.write_text(
+            f"enabled: {str(bool(enabled)).lower()}\n"
+        )
 
     def test_clean_when_healed_and_enabled(self, monkeypatch, capsys):
         from agentwire.__main__ import _render_damage_control_section


### PR DESCRIPTION
Closes #466

## Problem

Damage control read its kill switch, its rules, **and its own registration** from files the policed agent could write. Any agent could set `safety.enabled: false` (in `config.yaml` or `.agentwire.yml`), delete the PreToolUse hook from `~/.claude/settings.json`, rewrite the hook scripts, or rewrite the rule YAMLs — disable safety, act, re-enable. #425 closed the portal/network path; the local-agent path was wide open.

## Fix

**1. Relocated the knobs to host-owned files.** `enabled` / `disabled_rules` / `unattended_allow` now live ONLY in `~/.agentwire/damagecontrol.yml` (global) and `<repo>/.damagecontrol.yml` (project, walked up from cwd). `load_safety_config` reads only these. Missing global ⇒ `enabled: true` (fail-secure). A project file may both **loosen and tighten** `enabled` (it wins); rule knobs merge (set-union). Removed all old `safety:` reads — `config.py` drops `SafetyConfig`; `.agentwire.yml`'s `safety` keeps only `allowed_paths`.

**2. Hard-protected the whole control plane — escape-hatch- AND kill-switch-exempt.** `check_protected_command` / `check_protected_path` run **before** `detect_escape_hatch` and the kill switch in `check_command` / `check_path`. A write/edit/delete/move/chmod to any of these is blocked, and `# allow: <reason>` cannot self-authorize it:

- `~/.agentwire/damagecontrol.yml`, any `.damagecontrol.yml`
- `~/.claude/settings.json` (hook registration)
- `~/.agentwire/hooks/damage-control/*.py`, `~/.claude/hooks/*`
- `~/.agentwire/damage-control/*.yaml` (rule files)

The **only** override is the user's `allowedPaths` allowlist — a human, host-side opt-in. The agent can't add to it without editing a protected file (itself blocked). Edit/Write hook entry points were reordered so `check_path` runs before the disabled short-circuit, so protection holds even with safety off. `rules/control-plane.yaml` lists the same paths as `readOnlyPaths` for defense-in-depth + visibility; the code-level check is the absolute guarantee.

**3. Preserved #425 / #461.** The frozen `/api/safety/config` POST stays 403; `/api/safety/status` and the read-only badge now read `enabled` from the new file. `agentwire safety status`/`install` read/scaffold `damagecontrol.yml` (create global with `enabled: true` if missing); the `--yes` heal installs the new `control-plane.yaml` rule. `agentwire doctor` reads the kill switch from the new file.

`_core.py` (the SSOT) was edited and the inlined hook scripts regenerated via `scripts/regen_damage_control_hooks.py` — `--check` is clean.

## Tests

`tests/unit/test_control_plane_protection.py` (44 cases): every control-plane file blocked for Bash/Edit/Write **including with `# allow:` appended** and **with the kill switch off**; reads allowed; allowlisting a project `.damagecontrol.yml` re-permits; loader reads/merges `enabled`/`disabled_rules`/`unattended_allow`, project file loosens+tightens, missing global ⇒ `enabled: true`; host-side edit honored. Full unit suite: **1659 passed, 8 skipped**; regen `--check` clean.

## Post-merge (orchestrator's job — NOT done here)

1. Migrate the live `safety:` block from `~/.agentwire/config.yaml` into `~/.agentwire/damagecontrol.yml` (move `enabled`/`disabled_rules`/`unattended_allow`; leave `.agentwire.yml` `safety.allowed_paths` in place).
2. `git pull --ff-only && agentwire rebuild && agentwire safety install --yes && agentwire portal restart --dev` (installs `control-plane.yaml` + scaffolds the policy file).
3. `agentwire doctor` to confirm enabled + no drift.

Built by [dotdev.dev](https://dotdev.dev)


---

## Update — closed residual bypass (verification finding)

The first cut left a one-step hole: the per-project **allowlist** (the one knob that overrides the protected check) was still read from the agent-writable `.agentwire.yml` (`safety.allowed_paths`). An agent could allowlist a control-plane path there → re-permit its own write to `damagecontrol.yml` → safety off.

**Fix:** consolidated ALL per-project safety policy into the protected `.damagecontrol.yml`. `_find_project_config` now reads top-level `allowed_paths` from `.damagecontrol.yml` (never `.agentwire.yml`); `.agentwire.yml` carries **zero** safety config. Deleted `project_config.SafetyConfig`, the `ProjectConfig.safety` field, and the dead normalizer (no back-compat). Hooks regenerated.

**Regression tests** (real on-disk discovery via `PWD`/`$HOME`, not injected dicts): an `.agentwire.yml` allowlist does NOT re-permit a protected path (reproducer — failed before, passes after); a `.damagecontrol.yml` allowlist DOES; the global host allowlist still does; `load_allowed_paths` sources the per-project list from `.damagecontrol.yml` and an `.agentwire.yml` safety block contributes nothing.

Post-merge migration note updated: also move `safety.allowed_paths` from `.agentwire.yml` into each project's `.damagecontrol.yml`.
