### PR TITLE
docs: point safety-policy references to damagecontrol.yml (#466/#467 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ agentwire rebuild
 git pull --ff-only && agentwire rebuild && agentwire portal restart --dev
 ```
 
-Rebuild alone = stale static files. Restart alone = stale Python. The MCP server runs as a separate process started by Claude Code — session restart required after rebuild to pick up MCP changes. `rebuild` now refuses (warn + `--force` to override) when the checkout is behind `origin/main`, and `agentwire doctor` flags a behind-main checkout, a disabled kill switch (`safety.enabled: false`), and damage-control rule/hook/matcher drift.
+Rebuild alone = stale static files. Restart alone = stale Python. The MCP server runs as a separate process started by Claude Code — session restart required after rebuild to pick up MCP changes. `rebuild` now refuses (warn + `--force` to override) when the checkout is behind `origin/main`, and `agentwire doctor` flags a behind-main checkout, a disabled kill switch (`enabled: false` in `~/.agentwire/damagecontrol.yml`), and damage-control rule/hook/matcher drift.
 
 ## CLI is the Single Source of Truth
 

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -162,7 +162,7 @@ Decision shortcut:
 Defense in depth, three layers:
 
 1. **Damage control hooks** (always on if `agentwire hooks install` was run): PreToolUse hooks on Bash/Edit/Write match commands and paths against `agentwire/hooks/damage-control/rules/*.yaml`. Block hard-blocked patterns, prompt for ask-patterns, run bypassable patterns through allowlist checks.
-2. **Per-project allowlists** (`safety.allowed_paths` in `.agentwire.yml`): override the global rules for paths inside this project (e.g., `dist/*` allow-all, `.env.development` allow read/write/edit).
+2. **Per-project allowlists** (`allowed_paths` in the protected `.damagecontrol.yml` at the repo root): override the global rules for paths inside this project (e.g., `dist/*` allow-all, `.env.development` allow read/write/edit). The allowlist is host-owned — an agent can't edit `.damagecontrol.yml` to widen its own freedom (#466/#467).
 3. **Classifier-mode auto sessions** (`type: claude-auto`): a Sonnet 4.6 classifier reviews each tool call before execution. Safe ops auto-approve at zero cost; dangerous ops are blocked. Layered on top of the hook-level checks.
 
 → [Damage control](internals/damage-control.md), [claude-auto](sessions/claude-code-auto-mode.md).

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -729,7 +729,7 @@ Damage Control is ONE layer:
 ### Q: What if I need to run a blocked command?
 
 **A**: Four options:
-1. Add the path to `allowedPaths` in a user-override `*.yaml` under `~/.agentwire/damage-control/` (global) or to `safety.allowed_paths` in `.agentwire.yml` (per-project)
+1. Add the path to `allowedPaths` in a user-override `*.yaml` under `~/.agentwire/damage-control/` (global) or to `allowed_paths` in the protected `.damagecontrol.yml` at the repo root (per-project — a host-side edit; the agent can't widen its own allowlist)
 2. Use "ask" patterns (prompts for confirmation)
 3. Temporarily comment out the pattern in your override YAML
 4. Run command outside AgentWire session

--- a/docs/wiki/security/remote-access-hardening.md
+++ b/docs/wiki/security/remote-access-hardening.md
@@ -145,7 +145,7 @@ confirm "an agentwire portal lives here" (fingerprint).
 3. **Config-write is an auth-disable + RCE pivot.** `POST /api/config` writes raw YAML; an attacker
    who's in can set `auth_token: ""`, rewrite `executables`, and persist. → **#425**
 4. **Safety rules are API-writable.** `POST /api/safety/config` can disable the rm-rf hooks with
-   the same token — defense-in-depth defeated by one secret. → **#425**
+   the same token — defense-in-depth defeated by one secret. → **#425** *(closed; **#466/#467** then went further — the kill switch, rules, and allowlist moved out of `config.yaml`/`.agentwire.yml` entirely into the protected, agent-unwritable `~/.agentwire/damagecontrol.yml` + `<repo>/.damagecontrol.yml`, closing the **local-agent** write path too, not just the token/API one.)*
 5. **No auth-failure logging, no lockout, no alerting.** 401s are silent. → backlog (action E).
 6. **Token transport relies on opt-in TLS.** SSL only turns on if cert+key exist (`config.py:45`).
    A non-loopback *plaintext* LAN bind sends the bearer token in cleartext. Fine when the BYO


### PR DESCRIPTION
Doc-consistency follow-up to #466/#467 (the damage-control control-plane lockdown, already merged + live).

#466/#467 moved the safety kill switch, rule knobs, and per-project allowlist out of `config.yaml` / `.agentwire.yml` into the protected, agent-unwritable `~/.agentwire/damagecontrol.yml` + `<repo>/.damagecontrol.yml`. This sweeps the remaining docs/instructions that still pointed at the old locations.

## Changes
- **CLAUDE.md** — `doctor` kill-switch reference: `safety.enabled: false` → `enabled: false` in `~/.agentwire/damagecontrol.yml`
- **docs/wiki/architecture.md** — per-project allowlist: `safety.allowed_paths` in `.agentwire.yml` → `allowed_paths` in the protected `.damagecontrol.yml` (+ host-owned note)
- **docs/wiki/internals/damage-control.md** — "run a blocked command" FAQ: allowlist now lives in `.damagecontrol.yml`, not `.agentwire.yml`
- **docs/wiki/security/remote-access-hardening.md** — forward-note on the #425 audit that #466/#467 relocated the whole control plane, closing the local-agent write path too (not just the token/API one)

## Verification
`grep` for `safety.allowed_paths` / `safety.enabled` across all docs/skills/instructions → zero hits. Per-task `unattended_allow` in `.agentwire.yml` task defs (a different, unchanged knob) left intact; the PR-updated `agentwire-project-config` skill + `damage-control.md` body were already correct.

Built by [dotdev.dev](https://dotdev.dev)
