### PR TITLE
docs: remove Discord advertising from README + SPONSORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="https://github.com/dotdevdotdev/agentwire-dev/stargazers"><img src="https://img.shields.io/github/stars/dotdevdotdev/agentwire-dev?style=flat&logo=github&color=00d4ff" alt="GitHub Stars"></a>
   <a href="https://pypi.org/project/agentwire-dev/"><img src="https://img.shields.io/pypi/pyversions/agentwire-dev" alt="Python"></a>
   <a href="https://github.com/dotdevdotdev/agentwire-dev/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dotdevdotdev/agentwire-dev" alt="License"></a>
-  <a href="https://discord.gg/bspFZNTdUr"><img src="https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 ---
@@ -280,7 +279,6 @@ Quick links:
 
 ## Community
 
-- [Discord](https://discord.gg/bspFZNTdUr) - Chat, support, feature requests
 - [Issues](https://github.com/dotdevdotdev/agentwire-dev/issues) - Bug reports
 - [Website](https://agentwire.dev) - Docs and demos
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -35,11 +35,11 @@ AgentWire is made possible by these generous supporters.
 
 | Tier | Amount | What you get |
 |---|---|---|
-| **Supporter** | $5/mo | Name in SPONSORS.md · Supporter role in Discord |
+| **Supporter** | $5/mo | Name in SPONSORS.md |
 | **Backer** | $15/mo | Everything in Supporter · Priority responses on your GitHub issues · Input on what gets built next |
 | **Pro** | $35/mo | Everything in Backer · Early access to new features · Vote on roadmap priorities · Beta branch access |
 | **Team** | $100/mo | Everything in Pro · Logo in README · Monthly 30-minute support call · Priority bug fixes |
-| **Enterprise** | $500/mo | Everything in Team · Dedicated Discord channel · 48-hour bug response · Quarterly roadmap review · Featured logo placement |
+| **Enterprise** | $500/mo | Everything in Team · 48-hour bug response · Quarterly roadmap review · Featured logo placement |
 
 ### One-Time
 


### PR DESCRIPTION
Unadvertising the Discord server across our properties. This handles the **agentwire-dev repo**; the two website repos (`agentwire-website` and `dotdev.dev`) are getting their own PRs from dedicated sessions.

## Changes
- **README.md** — removed the Discord join-badge (top) and the Community → Discord link.
- **SPONSORS.md** — removed the Discord perks: "Supporter role in Discord" (Supporter tier) and "Dedicated Discord channel" (Enterprise tier).

## Left intentionally
Technical-doc mentions of Discord as a **removed** inbound bridge — `docs/wiki/architecture.md`, `docs/wiki/communication/channels.md`, `.claude/commands/handoff.md`. These describe architecture (inbound chat bridges were removed; the portal is the single inbound surface), not advertising.

Built by [dotdev.dev](https://dotdev.dev)
