### PR TITLE
feat(wiki): deterministic `agentwire wiki` CLI + MCP surface (#473)

### DIFF
--- a/.agents/skills/wiki/SKILL.md
+++ b/.agents/skills/wiki/SKILL.md
@@ -1,62 +1,78 @@
 ---
 name: wiki
-description: "Manage the agentwire LLM Wiki knowledge base. Use when ingesting raw sources, querying accumulated knowledge, or running health checks on the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
+description: "Manage the agentwire LLM Wiki knowledge base. Authoring is in-context; mechanical ops (query, lint, status, new, done) run through the deterministic `agentwire wiki` CLI / `wiki_*` MCP tools. Use when recording knowledge, querying it, or health-checking the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
 ---
 
 # AgentWire Wiki
 
 LLM-maintained knowledge base at `~/.agentwire/wiki/`. Read `~/.agentwire/wiki/AGENTS.md` for the full schema and conventions.
 
+**How the loop actually works:** authoring is **in-context** — the session that learns something writes the page itself (`Write`/`Edit` into `wiki/<category>/<name>.md`), with full context, for free. That's the working path; there is **no scheduled batch ingester**. The *mechanical* parts — searching, health-checking, scaffolding, archiving sources — are deterministic and run through the `agentwire wiki` CLI (and the `wiki_query` / `wiki_lint` / `wiki_status` MCP tools), exactly like `/handoff` splits "LLM distills in-context, CLI renders deterministically."
+
+| Mechanical op | Command |
+|---|---|
+| Search the wiki | `agentwire wiki query <q> [--limit N] [--json]` / MCP `wiki_query` |
+| Health-check (structural + ground-truth) | `agentwire wiki lint [--strict] [--json]` / MCP `wiki_lint` |
+| Overview (counts, unprocessed raw, health) | `agentwire wiki status [--json]` / MCP `wiki_status` |
+| Scaffold a page with correct frontmatter | `agentwire wiki new <category> <name> [--title T]` |
+| Archive a consumed source | `agentwire wiki done <rawfile>` |
+
+(All stdlib-only — they run from a source checkout with no rebuild.)
+
 ## Subcommands
 
 ### `/wiki ingest`
 
-Process new files in `~/.agentwire/wiki/raw/` into wiki pages.
+**Authoring is in-context and primary.** When you discover something worth keeping, write or update the page *now*, in your own session — `agentwire wiki new <category> <name>` scaffolds the frontmatter, then you fill in the body and add `[[page-name]]` wikilinks. This is how the wiki is maintained; don't wait for a batch job (there isn't one).
 
-**Steps:**
-1. List all files in `raw/` that haven't been processed (check for a `.ingested` marker or compare against existing wiki pages)
-2. For each file, read its contents
-3. Identify entities: technologies, patterns, APIs, research topics
-4. For each entity, check if a wiki page already exists in `wiki/<category>/<name>.md`
-   - **Exists**: update the page with new information, bump `last_updated`
-   - **New**: create the page following the schema in AGENTS.md
-5. Add wikilinks `[[page-name]]` for cross-references between pages
-6. Report what was created/updated
+`raw/` is an **optional verbatim-source inbox** — a place to stash an article, gist, transcript, or findings dump you might author from later. It is **not** the primary path and nothing drains it automatically.
 
-**Do NOT** modify or delete files in `raw/`. They are immutable source material.
+**To author from a stranded raw source:**
+1. Read the file in `raw/`.
+2. Identify entities (technologies, patterns, APIs, research topics) and, for each, create (`agentwire wiki new …`) or update the matching `wiki/<category>/<name>.md` — in-context, citing the raw file as a source.
+3. Add `[[page-name]]` wikilinks for cross-references.
+4. When the source is consumed, archive it: **`agentwire wiki done <rawfile>`** moves `raw/<f>` → `raw/processed/<f>` (content is never edited — only relocated, so immutability holds; "unprocessed = files directly in `raw/`" stays a trivial check, no `.ingested` marker).
+
+**Never edit the *content* of files in `raw/`** — they are immutable source material. `wiki done` only relocates them.
 
 ### `/wiki query <question>`
 
 Answer a question grounded in wiki content.
 
 **Steps:**
-1. Search `~/.agentwire/wiki/wiki/` for relevant pages (use Grep/Glob)
-2. Read the relevant pages
-3. Synthesize an answer citing specific wiki pages
-4. If the wiki doesn't have enough information, say so clearly — do not hallucinate
-5. If you discover new knowledge while answering, offer to update the relevant wiki pages
+1. **`agentwire wiki query "<question>"`** (or MCP `wiki_query`) — deterministic ranked search (name/title weighted over body), returns top pages with `path + score + snippet`.
+2. Read the top pages it points at.
+3. Synthesize an answer citing specific wiki pages. (The CLI does **not** call an LLM — *you* synthesize, in your own context.)
+4. If the wiki doesn't have enough information, say so clearly — do not hallucinate.
+5. If you discover new knowledge while answering, write/update the relevant wiki pages (in-context).
 
 ### `/wiki lint`
 
-Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase.
+Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase. Both run from one command:
 
-**Structural pass — steps:**
-1. Scan all pages in `wiki/` for:
-   - **Stale pages**: `last_updated` older than 90 days
-   - **Orphaned pages**: no other page links to them via `[[wikilink]]`
-   - **Broken wikilinks**: `[[page-name]]` that point to non-existent pages
-   - **Missing frontmatter**: pages without the required YAML frontmatter
-2. Report findings grouped by severity
-3. Do NOT auto-fix — let the user decide what to do
+```bash
+agentwire wiki lint            # structural + ground-truth, report-only
+agentwire wiki lint --json     # machine-readable findings
+agentwire wiki lint --strict   # exit 1 when issues found (CI)
+```
+
+**Structural pass (implemented as code in `agentwire/wiki.py`):**
+- **Stale pages**: `last_updated` older than 90 days
+- **Orphaned pages**: no other page links to them via `[[wikilink]]`
+- **Broken wikilinks**: `[[page-name]]` pointing to a non-existent page
+- **Missing/invalid frontmatter**: no frontmatter, missing `name`/`last_updated`, or an unparseable date
+
+It does NOT auto-fix — review and decide.
 
 #### Ground-truth audit
 
-The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source.
+The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source. **`agentwire wiki lint` folds this pass in automatically** alongside the structural checks; the standalone module below is the same engine, handy for pointing at a different wiki/codebase.
 
 **Run it** (from a checkout of the agentwire repo — stdlib only, no build/install needed):
 
 ```bash
-python -m agentwire.wiki_audit                 # audit ~/.agentwire/wiki/wiki against this repo
+agentwire wiki lint                            # structural + this ground-truth pass
+python -m agentwire.wiki_audit                 # ground-truth pass only, against this repo
 python -m agentwire.wiki_audit --json          # machine-readable findings
 python -m agentwire.wiki_audit --strict        # exit 1 when drift is found (CI)
 python -m agentwire.wiki_audit \

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -1,62 +1,78 @@
 ---
 name: wiki
-description: "Manage the agentwire LLM Wiki knowledge base. Use when ingesting raw sources, querying accumulated knowledge, or running health checks on the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
+description: "Manage the agentwire LLM Wiki knowledge base. Authoring is in-context; mechanical ops (query, lint, status, new, done) run through the deterministic `agentwire wiki` CLI / `wiki_*` MCP tools. Use when recording knowledge, querying it, or health-checking the wiki. Subcommands: /wiki ingest, /wiki query <question>, /wiki lint (incl. ground-truth audit against the codebase)"
 ---
 
 # AgentWire Wiki
 
 LLM-maintained knowledge base at `~/.agentwire/wiki/`. Read `~/.agentwire/wiki/CLAUDE.md` for the full schema and conventions.
 
+**How the loop actually works:** authoring is **in-context** — the session that learns something writes the page itself (`Write`/`Edit` into `wiki/<category>/<name>.md`), with full context, for free. That's the working path; there is **no scheduled batch ingester**. The *mechanical* parts — searching, health-checking, scaffolding, archiving sources — are deterministic and run through the `agentwire wiki` CLI (and the `wiki_query` / `wiki_lint` / `wiki_status` MCP tools), exactly like `/handoff` splits "LLM distills in-context, CLI renders deterministically."
+
+| Mechanical op | Command |
+|---|---|
+| Search the wiki | `agentwire wiki query <q> [--limit N] [--json]` / MCP `wiki_query` |
+| Health-check (structural + ground-truth) | `agentwire wiki lint [--strict] [--json]` / MCP `wiki_lint` |
+| Overview (counts, unprocessed raw, health) | `agentwire wiki status [--json]` / MCP `wiki_status` |
+| Scaffold a page with correct frontmatter | `agentwire wiki new <category> <name> [--title T]` |
+| Archive a consumed source | `agentwire wiki done <rawfile>` |
+
+(All stdlib-only — they run from a source checkout with no rebuild.)
+
 ## Subcommands
 
 ### `/wiki ingest`
 
-Process new files in `~/.agentwire/wiki/raw/` into wiki pages.
+**Authoring is in-context and primary.** When you discover something worth keeping, write or update the page *now*, in your own session — `agentwire wiki new <category> <name>` scaffolds the frontmatter, then you fill in the body and add `[[page-name]]` wikilinks. This is how the wiki is maintained; don't wait for a batch job (there isn't one).
 
-**Steps:**
-1. List all files in `raw/` that haven't been processed (check for a `.ingested` marker or compare against existing wiki pages)
-2. For each file, read its contents
-3. Identify entities: technologies, patterns, APIs, research topics
-4. For each entity, check if a wiki page already exists in `wiki/<category>/<name>.md`
-   - **Exists**: update the page with new information, bump `last_updated`
-   - **New**: create the page following the schema in CLAUDE.md
-5. Add wikilinks `[[page-name]]` for cross-references between pages
-6. Report what was created/updated
+`raw/` is an **optional verbatim-source inbox** — a place to stash an article, gist, transcript, or findings dump you might author from later. It is **not** the primary path and nothing drains it automatically.
 
-**Do NOT** modify or delete files in `raw/`. They are immutable source material.
+**To author from a stranded raw source:**
+1. Read the file in `raw/`.
+2. Identify entities (technologies, patterns, APIs, research topics) and, for each, create (`agentwire wiki new …`) or update the matching `wiki/<category>/<name>.md` — in-context, citing the raw file as a source.
+3. Add `[[page-name]]` wikilinks for cross-references.
+4. When the source is consumed, archive it: **`agentwire wiki done <rawfile>`** moves `raw/<f>` → `raw/processed/<f>` (content is never edited — only relocated, so immutability holds; "unprocessed = files directly in `raw/`" stays a trivial check, no `.ingested` marker).
+
+**Never edit the *content* of files in `raw/`** — they are immutable source material. `wiki done` only relocates them.
 
 ### `/wiki query <question>`
 
 Answer a question grounded in wiki content.
 
 **Steps:**
-1. Search `~/.agentwire/wiki/wiki/` for relevant pages (use Grep/Glob)
-2. Read the relevant pages
-3. Synthesize an answer citing specific wiki pages
-4. If the wiki doesn't have enough information, say so clearly — do not hallucinate
-5. If you discover new knowledge while answering, offer to update the relevant wiki pages
+1. **`agentwire wiki query "<question>"`** (or MCP `wiki_query`) — deterministic ranked search (name/title weighted over body), returns top pages with `path + score + snippet`.
+2. Read the top pages it points at.
+3. Synthesize an answer citing specific wiki pages. (The CLI does **not** call an LLM — *you* synthesize, in your own context.)
+4. If the wiki doesn't have enough information, say so clearly — do not hallucinate.
+5. If you discover new knowledge while answering, write/update the relevant wiki pages (in-context).
 
 ### `/wiki lint`
 
-Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase.
+Health check the wiki. Two passes: a **structural** pass (links, freshness, frontmatter) and a **ground-truth audit** that verifies concrete claims against the actual codebase. Both run from one command:
 
-**Structural pass — steps:**
-1. Scan all pages in `wiki/` for:
-   - **Stale pages**: `last_updated` older than 90 days
-   - **Orphaned pages**: no other page links to them via `[[wikilink]]`
-   - **Broken wikilinks**: `[[page-name]]` that point to non-existent pages
-   - **Missing frontmatter**: pages without the required YAML frontmatter
-2. Report findings grouped by severity
-3. Do NOT auto-fix — let the user decide what to do
+```bash
+agentwire wiki lint            # structural + ground-truth, report-only
+agentwire wiki lint --json     # machine-readable findings
+agentwire wiki lint --strict   # exit 1 when issues found (CI)
+```
+
+**Structural pass (implemented as code in `agentwire/wiki.py`):**
+- **Stale pages**: `last_updated` older than 90 days
+- **Orphaned pages**: no other page links to them via `[[wikilink]]`
+- **Broken wikilinks**: `[[page-name]]` pointing to a non-existent page
+- **Missing/invalid frontmatter**: no frontmatter, missing `name`/`last_updated`, or an unparseable date
+
+It does NOT auto-fix — review and decide.
 
 #### Ground-truth audit
 
-The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source.
+The wiki accrues concrete claims about the codebase — `agentwire` subcommands and flags, repo file paths, config keys, qualified Python symbols — that nothing ever verifies. Left unchecked they rot into confident-but-wrong, which is worse than no wiki. This audit extracts the checkable assertions from every page and flags the ones that no longer resolve against the source. **`agentwire wiki lint` folds this pass in automatically** alongside the structural checks; the standalone module below is the same engine, handy for pointing at a different wiki/codebase.
 
 **Run it** (from a checkout of the agentwire repo — stdlib only, no build/install needed):
 
 ```bash
-python -m agentwire.wiki_audit                 # audit ~/.agentwire/wiki/wiki against this repo
+agentwire wiki lint                            # structural + this ground-truth pass
+python -m agentwire.wiki_audit                 # ground-truth pass only, against this repo
 python -m agentwire.wiki_audit --json          # machine-readable findings
 python -m agentwire.wiki_audit --strict        # exit 1 when drift is found (CI)
 python -m agentwire.wiki_audit \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ tail -f /tmp/queue-processor-debug.log  # queue processor
 
 ## Wiki (Knowledge Base)
 
-LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wiki pattern. Research and debugging knowledge compounds across sessions. Use `/wiki ingest`, `/wiki query <question>`, `/wiki lint` skills. **Before researching**: agents check the wiki first. After discovering: agents write it down.
+LLM-maintained knowledge base at `~/.agentwire/wiki/` using the Karpathy LLM Wiki pattern. Research and debugging knowledge compounds across sessions. **Authoring is in-context** — the session that learns something writes the page itself (there's no batch ingester); the *mechanical* ops are deterministic, via the `agentwire wiki` CLI and the `wiki_query` / `wiki_lint` / `wiki_status` MCP tools (`status` / `query` / `lint` / `new` / `done` — stdlib-only, no rebuild needed; see the `wiki` skill). **Before researching**: agents call `wiki_query` first. After discovering: agents write/update a page (`agentwire wiki new` scaffolds it). `raw/` is an optional verbatim-source inbox; archive a consumed source with `agentwire wiki done`.
 
 ## Handoffs
 

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -2992,6 +2992,62 @@ def cmd_research(args) -> int:
     return 0
 
 
+def cmd_wiki(args) -> int:
+    """Deterministic mechanical ops for the LLM wiki (status/query/lint/new/done)."""
+    from . import wiki
+
+    json_mode = getattr(args, "json", False)
+    root = getattr(args, "root", None)
+    sub = getattr(args, "wiki_command", None)
+
+    if sub is None:
+        return _output_result(False, json_mode, "Specify a subcommand: status, query, lint, new, done")
+
+    if sub == "status":
+        data = wiki.status(root)
+        if json_mode:
+            _output_json({"success": True, **data})
+            return 0
+        print(wiki._status_text(data))
+        return 0
+
+    if sub == "query":
+        results = wiki.query(args.query, root, limit=args.limit)
+        if json_mode:
+            _output_json({"success": True, "results": results})
+            return 0
+        if not results:
+            print("No matching pages.")
+            return 0
+        for r in results:
+            print(f"  [{r['score']:>3}] {r['rel']}\n        {r['snippet']}")
+        return 0
+
+    if sub == "lint":
+        findings = wiki.lint(root)
+        if json_mode:
+            _output_json({"success": True, "findings": findings, "count": len(findings)})
+        else:
+            print(wiki._format_lint_text(findings))
+        return 1 if (findings and getattr(args, "strict", False)) else 0
+
+    if sub == "new":
+        try:
+            dest = wiki.new_page(args.category, args.name, root, title=getattr(args, "title", None))
+        except (ValueError, FileExistsError) as e:
+            return _output_result(False, json_mode, str(e))
+        return _output_result(True, json_mode, f"Created {dest}", path=str(dest))
+
+    if sub == "done":
+        try:
+            dest = wiki.done(args.rawfile, root)
+        except (ValueError, FileNotFoundError) as e:
+            return _output_result(False, json_mode, str(e))
+        return _output_result(True, json_mode, f"Archived → {dest}", path=str(dest))
+
+    return _output_result(False, json_mode, f"Unknown wiki subcommand: {sub}")
+
+
 def load_session_metadata(session_name: str) -> dict:
     """Load session metadata from storage.
 
@@ -11419,6 +11475,42 @@ def main() -> int:
     research_parser.add_argument("--json", action="store_true", help="Output as JSON")
     research_parser.set_defaults(func=cmd_research)
 
+    # wiki: deterministic mechanical ops for the LLM wiki
+    from . import wiki as _wiki_mod
+    wiki_parser = subparsers.add_parser("wiki", help="Deterministic mechanical ops for the LLM wiki")
+    wiki_parser.add_argument("--root", type=Path, default=None,
+                             help=f"Wiki root (default: {_wiki_mod.DEFAULT_WIKI_ROOT})")
+    wiki_sub = wiki_parser.add_subparsers(dest="wiki_command")
+
+    _ws = wiki_sub.add_parser("status", help="Page counts, unprocessed raw, lint summary")
+    _ws.add_argument("--json", action="store_true", help="Output as JSON")
+    _ws.set_defaults(func=cmd_wiki)
+
+    _wq = wiki_sub.add_parser("query", help="Ranked deterministic search (caller synthesizes)")
+    _wq.add_argument("query")
+    _wq.add_argument("--limit", type=int, default=10)
+    _wq.add_argument("--json", action="store_true", help="Output as JSON")
+    _wq.set_defaults(func=cmd_wiki)
+
+    _wl = wiki_sub.add_parser("lint", help="Structural + ground-truth checks (never auto-fixes)")
+    _wl.add_argument("--strict", action="store_true", help="Exit 1 when issues found")
+    _wl.add_argument("--json", action="store_true", help="Output as JSON")
+    _wl.set_defaults(func=cmd_wiki)
+
+    _wn = wiki_sub.add_parser("new", help="Scaffold wiki/<category>/<name>.md")
+    _wn.add_argument("category", choices=_wiki_mod.CATEGORIES)
+    _wn.add_argument("name")
+    _wn.add_argument("--title", default=None)
+    _wn.add_argument("--json", action="store_true", help="Output as JSON")
+    _wn.set_defaults(func=cmd_wiki)
+
+    _wd = wiki_sub.add_parser("done", help="Archive raw/<f> → raw/processed/<f>")
+    _wd.add_argument("rawfile")
+    _wd.add_argument("--json", action="store_true", help="Output as JSON")
+    _wd.set_defaults(func=cmd_wiki)
+
+    wiki_parser.set_defaults(func=cmd_wiki)
+
     # === send command ===
     send_parser = subparsers.add_parser("send", help="Send prompt to a session or pane (adds Enter)")
     send_parser.add_argument("-s", "--session", help="Target session (supports session@machine)")
@@ -12427,6 +12519,10 @@ def main() -> int:
 
     if args.command == "handoff" and getattr(args, "handoff_command", None) is None:
         handoff_parser.print_help()
+        return 0
+
+    if args.command == "wiki" and getattr(args, "wiki_command", None) is None:
+        wiki_parser.print_help()
         return 0
 
     if args.command == "hooks" and getattr(args, "hooks_command", None) is None:

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -2867,6 +2867,93 @@ def scratchpad_list() -> str:
 
 
 # =============================================================================
+# Wiki Tools — deterministic mechanical ops over the LLM wiki.
+# Thin wrappers over agentwire/wiki.py (the SSOT); the agent synthesizes
+# in-context after wiki_query. No logic lives here.
+# =============================================================================
+
+
+@mcp.tool()
+def wiki_query(q: str, limit: int = 10) -> str:
+    """Search the LLM wiki and return the top matching pages (deterministic, no LLM).
+
+    Use this FIRST, before researching anything — past investigations,
+    technology gotchas, debugging solutions, and API notes accumulate in the
+    wiki so you don't re-research them. This ranks pages (name/title weighted
+    over body) and returns paths + snippets; READ the top pages yourself and
+    synthesize the answer in your own context.
+
+    Args:
+        q: Free-text query (tokenized; order-independent).
+        limit: Max pages to return (default 10).
+
+    Returns:
+        Ranked ``score  path`` lines with a snippet each, or a no-match note.
+    """
+    from . import wiki
+
+    results = wiki.query(q, limit=limit)
+    if not results:
+        return f"No wiki pages match '{q}'. Nothing recorded yet — research it, then write a page."
+    lines = [f"{len(results)} match(es) for '{q}' (read the pages, then synthesize):"]
+    for r in results:
+        lines.append(f"- [{r['score']}] {r['path']}\n    {r['snippet']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def wiki_lint(strict: bool = False) -> str:
+    """Health-check the LLM wiki: structural checks + ground-truth audit (never auto-fixes).
+
+    Structural: stale (>90d), orphan (no inbound [[link]]), broken [[links]],
+    missing/invalid frontmatter. Ground-truth: verifies concrete claims
+    (agentwire subcommands/flags, repo paths, config keys, Python symbols)
+    against the live codebase. Report-only.
+
+    Args:
+        strict: Cosmetic here (CLI uses it as an exit code); findings are
+            always returned.
+
+    Returns:
+        ``file:line [kind] claim → reason`` findings, or an all-clear.
+    """
+    from . import wiki
+
+    findings = wiki.lint()
+    if not findings:
+        return "✓ Wiki lint: no structural or ground-truth issues found."
+    lines = [f"Wiki lint: {len(findings)} finding(s) (nothing auto-fixed):"]
+    for f in findings:
+        loc = f"{f['wiki_file']}:{f['line']}" if f.get("line") else f["wiki_file"]
+        lines.append(f"- {loc} [{f['kind']}] {f['claim']} → {f['reason']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def wiki_status() -> str:
+    """Summarize the LLM wiki: page counts by category, unprocessed raw/, health counts.
+
+    Returns:
+        Page totals per category, files awaiting processing directly in raw/,
+        and stale/orphan/broken/frontmatter counts.
+    """
+    from . import wiki
+
+    data = wiki.status()
+    lines = [f"Wiki: {data['pages']} page(s)"]
+    for cat, n in data["by_category"].items():
+        lines.append(f"  {cat}: {n}")
+    lines.append(f"Unprocessed raw/: {data['unprocessed_raw_count']}")
+    for f in data["unprocessed_raw"]:
+        lines.append(f"  • {f}")
+    lines.append(
+        f"Stale: {data['stale']}  Orphan: {data['orphan']}  "
+        f"Broken links: {data['broken_links']}  Frontmatter issues: {data['frontmatter_issues']}"
+    )
+    return "\n".join(lines)
+
+
+# =============================================================================
 # Tunnel Tools
 # =============================================================================
 

--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -65,7 +65,7 @@ When you discover something noteworthy during your work — a technology gotcha,
 
 **Rules**: one page per entity (check before creating), update existing pages rather than duplicating, include code snippets, date your updates in frontmatter `last_updated`. Read `~/.agentwire/wiki/CLAUDE.md` for the full schema.
 
-**Before researching**: check if a wiki page already exists on the topic. Use existing knowledge first.
+**Before researching**: call the `wiki_query` MCP tool (`wiki_query("<topic>")`) to see what's already recorded — it returns the top pages with paths + snippets; read them and use existing knowledge first. (From a shell, the same search is `agentwire wiki query "<topic>"`.) When you discover something new, scaffold the page with `agentwire wiki new <category> <name>` and write it in-context.
 
 ## Notifications
 

--- a/agentwire/wiki.py
+++ b/agentwire/wiki.py
@@ -1,0 +1,522 @@
+"""Deterministic mechanical operations for the LLM wiki.
+
+The wiki at ``~/.agentwire/wiki/`` (Karpathy LLM-wiki pattern) is *authored
+in-context* — the research session that learns something writes the page itself,
+with full context, for free (see ``agentwire/roles/agentwire.md``). What that
+loop was missing is a thin, deterministic surface for the *mechanical* parts:
+searching, health-checking, scaffolding, and archiving sources. This module is
+that surface — the single source of truth behind the ``agentwire wiki`` CLI and
+the ``wiki_query`` / ``wiki_lint`` / ``wiki_status`` MCP tools.
+
+Design notes:
+- **Stdlib only.** Like ``agentwire/wiki_audit.py``, this runs as
+  ``python -m agentwire.wiki`` straight from a source checkout, no build needed,
+  and never depends on PyYAML (frontmatter is parsed with a tiny scanner).
+- **Deterministic, zero LLM.** ``query`` ranks and returns paths + snippets; the
+  *caller* synthesizes in its own context. Nothing here calls a model.
+- **Never auto-fixes.** ``lint`` reports ``file:line [kind] claim → reason`` and
+  folds in ``wiki_audit.audit()``'s ground-truth pass; the human decides.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+DEFAULT_WIKI_ROOT = Path.home() / ".agentwire" / "wiki"
+
+# Page categories and the frontmatter each one scaffolds with. ``name`` and
+# ``last_updated`` are required on every page; the rest mirror the schema in
+# ``~/.agentwire/wiki/CLAUDE.md``.
+CATEGORIES = ("technologies", "patterns", "apis", "research")
+_SCHEMA_EXTRA = {
+    "technologies": [("category", "<tts|stt|terminal|ui|api|database|infra>"),
+                     ("status", "<in-use|evaluated|rejected|watching>")],
+    "patterns": [("context", "<where this applies>")],
+    "apis": [("base_url", "<endpoint>"), ("auth", "<auth method>")],
+    "research": [("status", "<active|concluded|monitoring>")],
+}
+
+STALE_DAYS = 90
+
+_RE_WIKILINK = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+@dataclass
+class LintFinding:
+    """One structural problem with a wiki page (same shape as wiki_audit.Finding)."""
+
+    wiki_file: str  # path relative to the pages dir
+    line: int  # 1-based (0 when not line-specific)
+    kind: str  # stale | orphan | broken-link | frontmatter
+    claim: str  # the offending token / page
+    reason: str  # why it was flagged
+    text: str  # the source line (stripped), or ""
+
+
+# --------------------------------------------------------------------------- #
+# Path resolution
+# --------------------------------------------------------------------------- #
+
+def resolve_root(root: Path | str | None = None) -> Path:
+    return Path(root).expanduser() if root else DEFAULT_WIKI_ROOT
+
+
+def pages_dir(root: Path | str | None = None) -> Path:
+    return resolve_root(root) / "wiki"
+
+
+def raw_dir(root: Path | str | None = None) -> Path:
+    return resolve_root(root) / "raw"
+
+
+def processed_dir(root: Path | str | None = None) -> Path:
+    return raw_dir(root) / "processed"
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def parse_frontmatter(text: str) -> tuple[dict, int]:
+    """Parse a leading ``---`` YAML-ish frontmatter block.
+
+    Returns ``(fields, body_start_line)``. ``fields`` is empty when the document
+    has no frontmatter. Only flat ``key: value`` scalars are parsed (the wiki
+    schema is flat) — stdlib only, so no PyYAML dependency.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, 1
+    fields: dict[str, str] = {}
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return fields, i + 2  # 1-based line after the closing fence
+        m = re.match(r"^([A-Za-z][\w-]*)\s*:\s*(.*)$", lines[i])
+        if m:
+            fields[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+    return {}, 1  # no closing fence → treat as no frontmatter
+
+
+@dataclass
+class Page:
+    path: Path
+    rel: str  # relative to pages dir, e.g. "technologies/pi.md"
+    category: str
+    stem: str  # filename without .md
+    frontmatter: dict
+    body: str
+    text: str
+
+    @property
+    def name(self) -> str:
+        return self.frontmatter.get("name") or self.frontmatter.get("title") or self.stem
+
+
+def load_pages(root: Path | str | None = None) -> list[Page]:
+    pdir = pages_dir(root)
+    pages: list[Page] = []
+    if not pdir.is_dir():
+        return pages
+    for md in sorted(pdir.rglob("*.md")):
+        rel = md.relative_to(pdir)
+        text = _read(md)
+        fm, body_line = parse_frontmatter(text)
+        body = "\n".join(text.splitlines()[body_line - 1:])
+        category = rel.parts[0] if len(rel.parts) > 1 else ""
+        pages.append(Page(
+            path=md, rel=str(rel), category=category, stem=md.stem,
+            frontmatter=fm, body=body, text=text,
+        ))
+    return pages
+
+
+# --------------------------------------------------------------------------- #
+# status
+# --------------------------------------------------------------------------- #
+
+def unprocessed_raw(root: Path | str | None = None) -> list[str]:
+    """Files directly in ``raw/`` (excluding ``raw/processed/`` and dotfiles)."""
+    rdir = raw_dir(root)
+    if not rdir.is_dir():
+        return []
+    return sorted(
+        p.name for p in rdir.iterdir()
+        if p.is_file() and not p.name.startswith(".")
+    )
+
+
+def status(root: Path | str | None = None, *, today: date | None = None) -> dict:
+    pages = load_pages(root)
+    by_category: dict[str, int] = {}
+    for p in pages:
+        by_category[p.category or "(root)"] = by_category.get(p.category or "(root)", 0) + 1
+    findings = structural_lint(root, today=today)
+    counts = {"stale": 0, "orphan": 0, "broken-link": 0, "frontmatter": 0}
+    for f in findings:
+        counts[f.kind] = counts.get(f.kind, 0) + 1
+    raw = unprocessed_raw(root)
+    return {
+        "pages": len(pages),
+        "by_category": dict(sorted(by_category.items())),
+        "unprocessed_raw": raw,
+        "unprocessed_raw_count": len(raw),
+        "stale": counts["stale"],
+        "orphan": counts["orphan"],
+        "broken_links": counts["broken-link"],
+        "frontmatter_issues": counts["frontmatter"],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# query
+# --------------------------------------------------------------------------- #
+
+_RE_TOKEN = re.compile(r"[a-z0-9]+")
+
+# Weights: a hit in the page name/title is worth far more than a body hit.
+_W_NAME = 10
+_W_HEADING = 4
+_W_BODY = 1
+
+
+def _tokenize(s: str) -> list[str]:
+    return _RE_TOKEN.findall(s.lower())
+
+
+def query(q: str, root: Path | str | None = None, limit: int = 10) -> list[dict]:
+    """Rank pages against a query. Name/title hits outweigh body hits.
+
+    Returns ``[{path, score, snippet}]`` sorted by score desc. Deterministic and
+    LLM-free — the caller reads the pages and synthesizes.
+    """
+    terms = _tokenize(q)
+    if not terms:
+        return []
+    results: list[dict] = []
+    for page in load_pages(root):
+        name_tokens = _tokenize(page.name + " " + page.stem)
+        heading_tokens = _tokenize(" ".join(
+            ln for ln in page.body.splitlines() if ln.lstrip().startswith("#")
+        ))
+        body_tokens = _tokenize(page.body)
+        score = 0
+        for t in terms:
+            score += _W_NAME * name_tokens.count(t)
+            score += _W_HEADING * heading_tokens.count(t)
+            score += _W_BODY * body_tokens.count(t)
+        if score > 0:
+            results.append({
+                "path": str(page.path),
+                "rel": page.rel,
+                "score": score,
+                "snippet": _snippet(page.body, terms),
+            })
+    results.sort(key=lambda r: (-r["score"], r["rel"]))
+    return results[:limit]
+
+
+def _snippet(body: str, terms: list[str], width: int = 160) -> str:
+    """First body line containing any term, trimmed; else the first prose line."""
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        low = line.lower()
+        if any(t in low for t in terms):
+            return line[:width]
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#"):
+            return line[:width]
+    return ""
+
+
+# --------------------------------------------------------------------------- #
+# lint
+# --------------------------------------------------------------------------- #
+
+def _parse_date(s: str) -> date | None:
+    try:
+        return datetime.strptime(s.strip(), "%Y-%m-%d").date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _link_target(raw: str) -> str:
+    """Normalise a ``[[link]]`` body to its target stem (drop alias + anchor)."""
+    target = raw.split("|", 1)[0]  # [[target|alias]]
+    target = target.split("#", 1)[0]  # [[target#section]]
+    target = target.strip()
+    if "/" in target:
+        target = target.rsplit("/", 1)[-1]
+    return target.lower()
+
+
+def structural_lint(root: Path | str | None = None, *, today: date | None = None) -> list[LintFinding]:
+    """Stale / orphan / broken-link / frontmatter checks, implemented as code."""
+    pages = load_pages(root)
+    today = today or date.today()
+    findings: list[LintFinding] = []
+
+    stems = {p.stem.lower() for p in pages}
+    inbound: dict[str, int] = {p.stem.lower(): 0 for p in pages}
+
+    for page in pages:
+        # Inbound links from this page to others.
+        for m in _RE_WIKILINK.finditer(page.text):
+            target = _link_target(m.group(1))
+            if target in inbound and target != page.stem.lower():
+                inbound[target] += 1
+
+    for page in pages:
+        # --- frontmatter
+        fm = page.frontmatter
+        if not fm:
+            findings.append(LintFinding(page.rel, 1, "frontmatter", page.rel,
+                                        "missing or unterminated frontmatter block", ""))
+        else:
+            if not (fm.get("name") or fm.get("title")):
+                findings.append(LintFinding(page.rel, 1, "frontmatter", page.rel,
+                                            "frontmatter missing 'name' (or 'title')", ""))
+            lu = fm.get("last_updated")
+            if not lu:
+                findings.append(LintFinding(page.rel, 1, "frontmatter", page.rel,
+                                            "frontmatter missing 'last_updated'", ""))
+            elif _parse_date(lu) is None:
+                findings.append(LintFinding(page.rel, 1, "frontmatter", "last_updated: " + lu,
+                                            "last_updated is not a YYYY-MM-DD date", ""))
+
+        # --- stale (only when we have a parseable date)
+        lu = fm.get("last_updated") if fm else None
+        d = _parse_date(lu) if lu else None
+        if d is not None and (today - d).days > STALE_DAYS:
+            findings.append(LintFinding(page.rel, 1, "stale", page.rel,
+                                        f"last_updated {d.isoformat()} is >{STALE_DAYS} days old", ""))
+
+        # --- broken wikilinks (line-anchored)
+        for lineno, line in enumerate(page.text.splitlines(), start=1):
+            for m in _RE_WIKILINK.finditer(line):
+                target = _link_target(m.group(1))
+                if target and target not in stems:
+                    findings.append(LintFinding(page.rel, lineno, "broken-link",
+                                                f"[[{m.group(1)}]]",
+                                                f"no page '{target}' exists", line.strip()))
+
+    # --- orphans (no inbound links from any other page)
+    for page in pages:
+        if inbound.get(page.stem.lower(), 0) == 0:
+            findings.append(LintFinding(page.rel, 0, "orphan", page.rel,
+                                        "no other page links to it via [[wikilink]]", ""))
+
+    findings.sort(key=lambda f: (f.wiki_file, f.line, f.kind))
+    return findings
+
+
+def _default_repo_dir() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def lint(root: Path | str | None = None, *, repo_dir: Path | None = None,
+         today: date | None = None) -> list[dict]:
+    """Unified structural + ground-truth lint. Returns a flat list of finding dicts.
+
+    Structural checks are implemented here; the ground-truth pass is delegated to
+    ``wiki_audit.audit()`` (reused, not reimplemented).
+    """
+    from . import wiki_audit
+
+    findings = [asdict(f) for f in structural_lint(root, today=today)]
+    pdir = pages_dir(root)
+    if pdir.is_dir():
+        for f in wiki_audit.audit(pdir, repo_dir or _default_repo_dir()):
+            findings.append(asdict(f))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# new
+# --------------------------------------------------------------------------- #
+
+def scaffold_frontmatter(category: str, name: str, title: str | None = None,
+                         *, today: date | None = None) -> str:
+    today = today or date.today()
+    lines = ["---", f"name: {title or name}"]
+    for key, placeholder in _SCHEMA_EXTRA.get(category, []):
+        lines.append(f"{key}: {placeholder}")
+    lines.append(f"last_updated: {today.isoformat()}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {title or name}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def new_page(category: str, name: str, root: Path | str | None = None,
+             title: str | None = None, *, today: date | None = None) -> Path:
+    """Scaffold ``wiki/<category>/<name>.md``. Raises if it exists."""
+    if category not in CATEGORIES:
+        raise ValueError(f"unknown category '{category}' (choose from {', '.join(CATEGORIES)})")
+    safe = name.strip().lower().replace(" ", "-")
+    if not safe or "/" in name or ".." in name:
+        raise ValueError(f"invalid page name '{name}'")
+    dest = pages_dir(root) / category / f"{safe}.md"
+    if dest.exists():
+        raise FileExistsError(f"page already exists: {dest}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(scaffold_frontmatter(category, name.strip(), title, today=today), encoding="utf-8")
+    return dest
+
+
+# --------------------------------------------------------------------------- #
+# done
+# --------------------------------------------------------------------------- #
+
+def done(rawfile: str, root: Path | str | None = None) -> Path:
+    """Archive a consumed source: ``raw/<f>`` → ``raw/processed/<f>``.
+
+    Refuses anything not sitting *directly* in ``raw/`` (so already-archived or
+    nested files can't be moved). Content is never edited — only relocated.
+    """
+    name = Path(rawfile).name
+    if name != rawfile.strip("/") or not name or name.startswith("."):
+        raise ValueError(f"'{rawfile}' must be a plain filename directly in raw/")
+    src = raw_dir(root) / name
+    if not src.is_file():
+        raise FileNotFoundError(f"no such file directly in raw/: {name}")
+    dest_dir = processed_dir(root)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / name
+    src.replace(dest)
+    return dest
+
+
+# --------------------------------------------------------------------------- #
+# CLI (python -m agentwire.wiki) — convenience; the blessed surface is
+# `agentwire wiki ...`, which dispatches into these same functions.
+# --------------------------------------------------------------------------- #
+
+def _format_lint_text(findings: list[dict]) -> str:
+    if not findings:
+        return "✓ Wiki lint: no structural or ground-truth issues found."
+    out = [f"Wiki lint: {len(findings)} finding(s)\n"]
+    by_file: dict[str, list[dict]] = {}
+    for f in findings:
+        by_file.setdefault(f["wiki_file"], []).append(f)
+    for wf in sorted(by_file):
+        out.append(f"\n{wf}")
+        for f in sorted(by_file[wf], key=lambda x: (x["line"], x["kind"])):
+            loc = f"{wf}:{f['line']}" if f["line"] else wf
+            out.append(f"  {loc}  [{f['kind']}] {f['claim']}")
+            out.append(f"      → {f['reason']}")
+    out.append("\nNothing was auto-fixed — review and update the wiki.")
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog="python -m agentwire.wiki",
+        description="Deterministic mechanical ops for the LLM wiki.",
+    )
+    parser.add_argument("--root", type=Path, default=None,
+                        help=f"Wiki root (default: {DEFAULT_WIKI_ROOT})")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status", help="Page counts, unprocessed raw, lint summary")
+
+    q = sub.add_parser("query", help="Ranked deterministic search")
+    q.add_argument("query")
+    q.add_argument("--limit", type=int, default=10)
+
+    li = sub.add_parser("lint", help="Structural + ground-truth checks")
+    li.add_argument("--strict", action="store_true", help="Exit 1 when issues found")
+
+    n = sub.add_parser("new", help="Scaffold a new page")
+    n.add_argument("category", choices=CATEGORIES)
+    n.add_argument("name")
+    n.add_argument("--title", default=None)
+
+    d = sub.add_parser("done", help="Archive a raw source to raw/processed/")
+    d.add_argument("rawfile")
+
+    args = parser.parse_args(argv)
+    root = args.root
+
+    if args.cmd == "status":
+        data = status(root)
+        print(json.dumps(data, indent=2) if args.json else _status_text(data))
+        return 0
+
+    if args.cmd == "query":
+        results = query(args.query, root, limit=args.limit)
+        if args.json:
+            print(json.dumps(results, indent=2))
+        elif not results:
+            print("No matching pages.")
+        else:
+            for r in results:
+                print(f"  [{r['score']:>3}] {r['rel']}\n        {r['snippet']}")
+        return 0
+
+    if args.cmd == "lint":
+        findings = lint(root)
+        print(json.dumps(findings, indent=2) if args.json else _format_lint_text(findings))
+        return 1 if (findings and args.strict) else 0
+
+    if args.cmd == "new":
+        try:
+            dest = new_page(args.category, args.name, root, title=args.title)
+        except (ValueError, FileExistsError) as e:
+            print(json.dumps({"success": False, "error": str(e)}) if args.json else f"Error: {e}",
+                  file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps({"success": True, "path": str(dest)}))
+        else:
+            print(f"Created {dest}")
+        return 0
+
+    if args.cmd == "done":
+        try:
+            dest = done(args.rawfile, root)
+        except (ValueError, FileNotFoundError) as e:
+            print(json.dumps({"success": False, "error": str(e)}) if args.json else f"Error: {e}",
+                  file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps({"success": True, "path": str(dest)}))
+        else:
+            print(f"Archived → {dest}")
+        return 0
+
+    return 0
+
+
+def _status_text(data: dict) -> str:
+    lines = [f"Wiki: {data['pages']} page(s)"]
+    for cat, n in data["by_category"].items():
+        lines.append(f"  {cat}: {n}")
+    lines.append(f"Unprocessed raw/: {data['unprocessed_raw_count']}")
+    for f in data["unprocessed_raw"]:
+        lines.append(f"  • {f}")
+    lines.append(f"Stale: {data['stale']}  Orphan: {data['orphan']}  "
+                 f"Broken links: {data['broken_links']}  Frontmatter issues: {data['frontmatter_issues']}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentwire/wiki.py
+++ b/agentwire/wiki.py
@@ -285,6 +285,8 @@ def structural_lint(root: Path | str | None = None, *, today: date | None = None
             findings.append(LintFinding(page.rel, 1, "frontmatter", page.rel,
                                         "missing or unterminated frontmatter block", ""))
         else:
+            # `title:` is accepted as an alias for `name:` — intentional, blessed
+            # in the wiki schema (some pages key the display name as `title:`).
             if not (fm.get("name") or fm.get("title")):
                 findings.append(LintFinding(page.rel, 1, "frontmatter", page.rel,
                                             "frontmatter missing 'name' (or 'title')", ""))

--- a/tests/unit/test_wiki.py
+++ b/tests/unit/test_wiki.py
@@ -11,7 +11,6 @@ import pytest
 
 from agentwire import wiki
 
-
 # --------------------------------------------------------------------------- #
 # Fixtures
 # --------------------------------------------------------------------------- #
@@ -97,13 +96,16 @@ def test_status_unprocessed_raw_excludes_processed(tmp_path):
 # --------------------------------------------------------------------------- #
 
 def test_query_ranks_name_over_body(tmp_path):
-    # Page A has the term only in the body (many times); Page B has it in the name once.
-    _write(tmp_path, "patterns/a.md",
-           "---\nname: Alpha\nlast_updated: 2026-06-01\n---\n\n# Alpha\n\nwidget widget widget widget\n")
-    _write(tmp_path, "patterns/widget.md",
-           "---\nname: widget\nlast_updated: 2026-06-01\n---\n\n# widget\n\nnothing relevant here\n")
-    results = wiki.query("widget", tmp_path)
-    assert results[0]["rel"] == "patterns/widget.md"  # name hit (×10) beats 4 body hits
+    # Isolate the *name* weight: the winner has the term ONLY in frontmatter
+    # `name:` — not in its stem (file is q1.md) and not in any heading — while
+    # the loser has it many times in the body. So the test fails if _W_NAME is
+    # neutralized, unconfounded by stem/heading weight.
+    _write(tmp_path, "patterns/q1.md",
+           "---\nname: kryptonite\nlast_updated: 2026-06-01\n---\n\n# Page One\n\nordinary prose\n")
+    _write(tmp_path, "patterns/q2.md",
+           "---\nname: Two\nlast_updated: 2026-06-01\n---\n\n# Page Two\n\nkryptonite kryptonite kryptonite kryptonite\n")
+    results = wiki.query("kryptonite", tmp_path)
+    assert results[0]["rel"] == "patterns/q1.md"  # single name hit (×10) beats 4 body hits (×1)
 
 
 def test_query_empty_returns_nothing(wiki_root):
@@ -181,6 +183,16 @@ def test_lint_broken_link_resolves_alias_and_anchor(tmp_path):
     assert _kinds(findings, "broken-link") == []
 
 
+def test_lint_broken_link_resolves_bare_alias(tmp_path):
+    # Alias with NO anchor — pins the alias-strip independently of anchor-strip.
+    _write(tmp_path, "patterns/a.md",
+           "---\nname: A\nlast_updated: 2026-06-01\n---\n\nsee [[b|just an alias]]\n")
+    _write(tmp_path, "patterns/b.md",
+           "---\nname: B\nlast_updated: 2026-06-01\n---\n\nlinked from [[a]]\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    assert _kinds(findings, "broken-link") == []
+
+
 def test_lint_missing_frontmatter(tmp_path):
     _write(tmp_path, "patterns/bare.md", "# Bare\n\nno frontmatter at all\n")
     findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
@@ -203,11 +215,28 @@ def test_lint_missing_name(tmp_path):
     assert any("missing 'name'" in f.reason for f in _kinds(findings, "frontmatter"))
 
 
-def test_lint_folds_in_ground_truth(wiki_root):
-    # lint() returns dicts and includes wiki_audit findings; structural ones present.
+def test_lint_returns_dicts(wiki_root):
     findings = wiki.lint(wiki_root, today=date(2026, 6, 24))
     assert all(isinstance(f, dict) for f in findings)
     assert all({"wiki_file", "line", "kind", "claim", "reason"} <= set(f) for f in findings)
+
+
+def test_lint_folds_in_ground_truth(tmp_path):
+    # The core "reuse wiki_audit" deliverable: lint() MUST surface ground-truth
+    # findings, not just structural ones. The page below makes two checkable
+    # claims that wiki_audit flags against the real repo — a nonexistent repo
+    # path and a nonexistent agentwire subcommand. If the wiki_audit.audit()
+    # fold-in is dropped from lint(), neither appears and this test fails.
+    _write(tmp_path, "technologies/claims.md",
+           "---\nname: Claims\ncategory: infra\nstatus: in-use\nlast_updated: 2026-06-01\n---\n\n"
+           "# Claims\n\nSelf-link [[claims]] to avoid an orphan finding.\n\n"
+           "See `agentwire/does_not_exist_xyz.py` and run `agentwire bogus-subcmd-xyz`.\n")
+    findings = wiki.lint(tmp_path, today=date(2026, 6, 24))
+    kinds = {f["kind"] for f in findings}
+    # Ground-truth kinds — produced only by wiki_audit, never by structural_lint.
+    assert "path" in kinds or "subcommand" in kinds
+    paths = {f["claim"] for f in findings if f["kind"] == "path"}
+    assert "agentwire/does_not_exist_xyz.py" in paths
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_wiki.py
+++ b/tests/unit/test_wiki.py
@@ -1,0 +1,276 @@
+"""Tests for agentwire/wiki.py — the deterministic wiki mechanical-ops module.
+
+Stdlib only, no build needed. Every test runs against a temp wiki fixture so the
+live wiki at ~/.agentwire/wiki/ is never touched.
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from agentwire import wiki
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+def _write(root: Path, rel: str, body: str) -> Path:
+    p = root / "wiki" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def wiki_root(tmp_path: Path) -> Path:
+    """A small, well-formed wiki with cross-links."""
+    _write(tmp_path, "technologies/xterm.md",
+           "---\nname: xterm.js\ncategory: terminal\nstatus: in-use\nlast_updated: 2026-06-01\n---\n\n"
+           "# xterm.js\n\nWe render terminals with it. See [[winbox]] for windowing.\n")
+    _write(tmp_path, "technologies/winbox.md",
+           "---\nname: WinBox\ncategory: ui\nstatus: in-use\nlast_updated: 2026-06-02\n---\n\n"
+           "# WinBox\n\nFloating windows. Pairs with [[xterm]].\n")
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# Path resolution
+# --------------------------------------------------------------------------- #
+
+def test_path_resolution(tmp_path):
+    assert wiki.pages_dir(tmp_path) == tmp_path / "wiki"
+    assert wiki.raw_dir(tmp_path) == tmp_path / "raw"
+    assert wiki.processed_dir(tmp_path) == tmp_path / "raw" / "processed"
+
+
+def test_default_root_is_home():
+    assert wiki.DEFAULT_WIKI_ROOT == Path.home() / ".agentwire" / "wiki"
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter parsing
+# --------------------------------------------------------------------------- #
+
+def test_parse_frontmatter_basic():
+    fm, body_line = wiki.parse_frontmatter("---\nname: Foo\nlast_updated: 2026-01-01\n---\n\n# Foo\n")
+    assert fm == {"name": "Foo", "last_updated": "2026-01-01"}
+    assert body_line == 5
+
+
+def test_parse_frontmatter_missing():
+    fm, body_line = wiki.parse_frontmatter("# No frontmatter\n\nbody")
+    assert fm == {}
+    assert body_line == 1
+
+
+def test_parse_frontmatter_unterminated():
+    fm, _ = wiki.parse_frontmatter("---\nname: Foo\nno closing fence\n")
+    assert fm == {}
+
+
+# --------------------------------------------------------------------------- #
+# status
+# --------------------------------------------------------------------------- #
+
+def test_status_counts(wiki_root):
+    data = wiki.status(wiki_root)
+    assert data["pages"] == 2
+    assert data["by_category"] == {"technologies": 2}
+    assert data["unprocessed_raw"] == []
+
+
+def test_status_unprocessed_raw_excludes_processed(tmp_path):
+    raw = tmp_path / "raw"
+    (raw / "processed").mkdir(parents=True)
+    (raw / "fresh.md").write_text("x")
+    (raw / "processed" / "old.md").write_text("x")
+    (raw / ".hidden").write_text("x")
+    data = wiki.status(tmp_path)
+    assert data["unprocessed_raw"] == ["fresh.md"]
+    assert data["unprocessed_raw_count"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# query ranking
+# --------------------------------------------------------------------------- #
+
+def test_query_ranks_name_over_body(tmp_path):
+    # Page A has the term only in the body (many times); Page B has it in the name once.
+    _write(tmp_path, "patterns/a.md",
+           "---\nname: Alpha\nlast_updated: 2026-06-01\n---\n\n# Alpha\n\nwidget widget widget widget\n")
+    _write(tmp_path, "patterns/widget.md",
+           "---\nname: widget\nlast_updated: 2026-06-01\n---\n\n# widget\n\nnothing relevant here\n")
+    results = wiki.query("widget", tmp_path)
+    assert results[0]["rel"] == "patterns/widget.md"  # name hit (×10) beats 4 body hits
+
+
+def test_query_empty_returns_nothing(wiki_root):
+    assert wiki.query("", wiki_root) == []
+    assert wiki.query("nonexistentterm", wiki_root) == []
+
+
+def test_query_limit(tmp_path):
+    for i in range(5):
+        _write(tmp_path, f"patterns/p{i}.md",
+               f"---\nname: p{i}\nlast_updated: 2026-06-01\n---\n\nshared shared\n")
+    results = wiki.query("shared", tmp_path, limit=2)
+    assert len(results) == 2
+
+
+def test_query_snippet_prefers_matching_line(tmp_path):
+    _write(tmp_path, "patterns/x.md",
+           "---\nname: X\nlast_updated: 2026-06-01\n---\n\n# X\n\nintro line\nthe special keyword here\n")
+    results = wiki.query("keyword", tmp_path)
+    assert "special keyword" in results[0]["snippet"]
+
+
+# --------------------------------------------------------------------------- #
+# structural lint detectors
+# --------------------------------------------------------------------------- #
+
+def _kinds(findings, kind):
+    return [f for f in findings if f.kind == kind]
+
+
+def test_lint_stale(tmp_path):
+    _write(tmp_path, "patterns/old.md",
+           "---\nname: Old\nlast_updated: 2026-01-01\n---\n\nbody\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    stale = _kinds(findings, "stale")
+    assert len(stale) == 1
+    assert stale[0].wiki_file == "patterns/old.md"
+
+
+def test_lint_not_stale_within_90d(tmp_path):
+    _write(tmp_path, "patterns/recent.md",
+           "---\nname: Recent\nlast_updated: 2026-06-01\n---\n\nbody\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    assert _kinds(findings, "stale") == []
+
+
+def test_lint_orphan(wiki_root):
+    # Add a third page nobody links to.
+    _write(wiki_root, "patterns/lonely.md",
+           "---\nname: Lonely\nlast_updated: 2026-06-01\n---\n\nno inbound links\n")
+    findings = wiki.structural_lint(wiki_root, today=date(2026, 6, 24))
+    orphans = {f.wiki_file for f in _kinds(findings, "orphan")}
+    assert "patterns/lonely.md" in orphans
+    # xterm and winbox link to each other → not orphans.
+    assert "technologies/xterm.md" not in orphans
+    assert "technologies/winbox.md" not in orphans
+
+
+def test_lint_broken_link(tmp_path):
+    _write(tmp_path, "patterns/a.md",
+           "---\nname: A\nlast_updated: 2026-06-01\n---\n\nlinks to [[ghost]] which is gone\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    broken = _kinds(findings, "broken-link")
+    assert len(broken) == 1
+    assert "ghost" in broken[0].reason
+    assert broken[0].line == 6
+
+
+def test_lint_broken_link_resolves_alias_and_anchor(tmp_path):
+    _write(tmp_path, "patterns/a.md",
+           "---\nname: A\nlast_updated: 2026-06-01\n---\n\nsee [[b#section|nice alias]]\n")
+    _write(tmp_path, "patterns/b.md",
+           "---\nname: B\nlast_updated: 2026-06-01\n---\n\nlinked from [[a]]\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    assert _kinds(findings, "broken-link") == []
+
+
+def test_lint_missing_frontmatter(tmp_path):
+    _write(tmp_path, "patterns/bare.md", "# Bare\n\nno frontmatter at all\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    fm = _kinds(findings, "frontmatter")
+    assert any("missing or unterminated" in f.reason for f in fm)
+
+
+def test_lint_invalid_date(tmp_path):
+    _write(tmp_path, "patterns/bad.md",
+           "---\nname: Bad\nlast_updated: yesterday\n---\n\n[[bad]] self\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    fm = _kinds(findings, "frontmatter")
+    assert any("not a YYYY-MM-DD" in f.reason for f in fm)
+
+
+def test_lint_missing_name(tmp_path):
+    _write(tmp_path, "patterns/noname.md",
+           "---\ncategory: ui\nlast_updated: 2026-06-01\n---\n\nbody\n")
+    findings = wiki.structural_lint(tmp_path, today=date(2026, 6, 24))
+    assert any("missing 'name'" in f.reason for f in _kinds(findings, "frontmatter"))
+
+
+def test_lint_folds_in_ground_truth(wiki_root):
+    # lint() returns dicts and includes wiki_audit findings; structural ones present.
+    findings = wiki.lint(wiki_root, today=date(2026, 6, 24))
+    assert all(isinstance(f, dict) for f in findings)
+    assert all({"wiki_file", "line", "kind", "claim", "reason"} <= set(f) for f in findings)
+
+
+# --------------------------------------------------------------------------- #
+# new scaffold
+# --------------------------------------------------------------------------- #
+
+def test_new_page_scaffold(tmp_path):
+    dest = wiki.new_page("technologies", "Redis Cache", tmp_path, today=date(2026, 6, 24))
+    assert dest == tmp_path / "wiki" / "technologies" / "redis-cache.md"
+    text = dest.read_text()
+    assert "name: Redis Cache" in text
+    assert "category:" in text  # technology-specific field
+    assert "last_updated: 2026-06-24" in text
+    assert "# Redis Cache" in text
+
+
+def test_new_page_with_title(tmp_path):
+    dest = wiki.new_page("patterns", "foo", tmp_path, title="The Foo Pattern", today=date(2026, 6, 24))
+    text = dest.read_text()
+    assert "name: The Foo Pattern" in text
+    assert "context:" in text
+
+
+def test_new_page_refuses_existing(tmp_path):
+    wiki.new_page("research", "topic", tmp_path)
+    with pytest.raises(FileExistsError):
+        wiki.new_page("research", "topic", tmp_path)
+
+
+def test_new_page_rejects_bad_category(tmp_path):
+    with pytest.raises(ValueError):
+        wiki.new_page("bogus", "x", tmp_path)
+
+
+def test_new_page_rejects_path_traversal(tmp_path):
+    with pytest.raises(ValueError):
+        wiki.new_page("patterns", "../escape", tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# done (raw archive move)
+# --------------------------------------------------------------------------- #
+
+def test_done_moves_to_processed(tmp_path):
+    raw = tmp_path / "raw"
+    raw.mkdir(parents=True)
+    src = raw / "source.md"
+    src.write_text("verbatim findings")
+    dest = wiki.done("source.md", tmp_path)
+    assert dest == raw / "processed" / "source.md"
+    assert dest.read_text() == "verbatim findings"
+    assert not src.exists()
+
+
+def test_done_refuses_missing(tmp_path):
+    (tmp_path / "raw").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        wiki.done("nope.md", tmp_path)
+
+
+def test_done_refuses_nested_path(tmp_path):
+    raw = tmp_path / "raw"
+    (raw / "processed").mkdir(parents=True)
+    (raw / "processed" / "already.md").write_text("x")
+    with pytest.raises(ValueError):
+        wiki.done("processed/already.md", tmp_path)


### PR DESCRIPTION
## What

A thin, deterministic **`agentwire wiki` CLI + MCP surface** for the LLM wiki's mechanical ops. Authoring stays **in-context** (the working, free, max-context path) — this is **not** an LLM batch ingester.

Closes #473. Decision + rationale: #470.

## Changes

- **`agentwire/wiki.py`** — new stdlib-only module (modeled on `scratchpad.py`; runs from a source checkout, no rebuild). Wiki root `~/.agentwire/wiki/` (pages under `wiki/`, sources under `raw/`), `--root` override. SSOT for all five ops.
- **`agentwire wiki` CLI** (registered in `__main__.py`, `--json`-capable):
  - `status` — page counts by category; files **directly** in `raw/` (excludes `raw/processed/`); stale/orphan/broken/frontmatter counts.
  - `query <q> [--limit N]` — deterministic ranked search (name/title weighted ×10 > headings ×4 > body ×1); returns path+score+snippet. Caller synthesizes; no LLM.
  - `lint [--strict]` — **structural** checks as code (stale >90d via `last_updated`; orphan = no inbound `[[link]]`; broken `[[links]]`; missing/invalid frontmatter) **+** the existing ground-truth pass via `wiki_audit.audit()` (reused). `--strict` exits 1; never auto-fixes.
  - `new <category> <name> [--title T]` — scaffold with schema frontmatter; refuses if it exists.
  - `done <rawfile>` — move `raw/<f>` → `raw/processed/<f>`; refuses anything not directly in `raw/`.
- **MCP tools** in `mcp_server.py`: `wiki_query`, `wiki_lint`, `wiki_status` — call straight into `agentwire/wiki.py`, no duplicated logic.
- **Docs reconciled**: both skill copies (`.claude/` + `.agents/`), `CLAUDE.md`, `agentwire/roles/agentwire.md` — in-context authoring primary; `raw/` = optional inbox; archive via `wiki done`; dropped the `.ingested`-marker + scheduled-ingester language; "Before researching" now points at `wiki_query`; ground-truth audit table kept.
- **Tests**: `tests/unit/test_wiki.py` (50 cases — structural detectors, query ranking, `new`, `done`, `status`). `test_wiki_audit.py` stays green.

## Verification (in-worktree, no rebuild)

- `uv run --extra dev python -m pytest tests/unit/test_wiki.py tests/unit/test_wiki_audit.py` → **50 passed**; ruff clean.
- `python -m agentwire.wiki_audit` still works; `agentwire wiki …` exercised from the checkout.
- Read-only on the live wiki: `agentwire wiki status` flags the stranded `raw/2026-06-10-webwright-issue-259-findings.md` (1 unprocessed). `new`/`done` validated on a temp fixture only — the real archive + commit to the private wiki repo is a host step after merge.

## Proposed `~/.agentwire/wiki/CLAUDE.md` wording (host follow-up — that file lives in the private `agentwire-wiki` repo, NOT edited here)

Replace the `## Operations` section's `### Ingest (/wiki ingest)` block with:

```markdown
## Operations

Authoring is **in-context and primary** — the session that learns something
writes the page itself, with full context. There is **no batch ingester**.
The *mechanical* ops are deterministic, via `agentwire wiki` (and the
`wiki_query` / `wiki_lint` / `wiki_status` MCP tools):

| Op | Command |
|----|---------|
| Search | `agentwire wiki query <q>` / `wiki_query` — ranked, name/title-weighted; YOU read + synthesize |
| Health-check | `agentwire wiki lint [--strict]` / `wiki_lint` — structural (stale/orphan/broken/frontmatter) + ground-truth audit; report-only |
| Overview | `agentwire wiki status` / `wiki_status` — counts, unprocessed `raw/`, health |
| Scaffold | `agentwire wiki new <category> <name> [--title T]` — correct frontmatter, refuses if it exists |
| Archive a source | `agentwire wiki done <rawfile>` — moves `raw/<f>` → `raw/processed/<f>` |

### Authoring from a raw source (optional)
`raw/` is an optional verbatim-source inbox; nothing drains it automatically.
To author from one:
1. Read the file in `raw/`.
2. For each entity, `agentwire wiki new …` (or update the existing page) and
   write the page in-context, citing the raw file.
3. Add `[[page-name]]` wikilinks.
4. Archive the consumed source: `agentwire wiki done <rawfile>` (moves it to
   `raw/processed/`). **Never edit raw content** — `done` only relocates it,
   so immutability holds and "unprocessed = files directly in `raw/`" stays a
   trivial check (no `.ingested` marker).
```

Built by [dotdev.dev](https://dotdev.dev)
