### PR TITLE
feat(skills): drift-aware global skill sync (/wiki) via hooks install + doctor (#475)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7183,6 +7183,32 @@ def cmd_safety_tooldefs_show(args) -> int:
     return cli_safety.safety_tooldefs_show_cmd(args.tool)
 
 
+def _render_skill_section() -> int:
+    """Print the global-skill drift block. Returns the count of issues found.
+
+    Hand-placed at wiki-setup and never resynced, so a stale or missing copy was
+    invisible until #475. Flagged the same way as hooks. `source-unavailable`
+    (running from a checkout, where skills only live in the built wheel) is NOT a
+    drift problem — there's nothing to install from — so it never bumps the count.
+    """
+    issues = 0
+    for name, state in sorted(skill_drift().items()):
+        target = CLAUDE_SKILLS_DIR / name
+        if state == "ok":
+            print(f"  [ok] /{name} skill: {target}")
+        elif state == "source-unavailable":
+            print(f"  [..] /{name} skill: source not packaged here (running from a checkout)")
+        elif state == "stale":
+            print(f"  [!!] /{name} skill: STALE — installed copy differs from packaged source")
+            print("     Run: agentwire hooks install")
+            issues += 1
+        else:
+            print(f"  [!!] /{name} skill: not installed")
+            print("     Run: agentwire hooks install")
+            issues += 1
+    return issues
+
+
 def _render_damage_control_section() -> int:
     """Print the damage-control health block. Returns the count of issues found.
 
@@ -7442,19 +7468,7 @@ def cmd_doctor(args) -> int:
     # never resynced, so a stale or missing copy was invisible until #475. Flag
     # the same way as hooks — drift-aware against the packaged source.
     print("\nChecking AgentWire global skills...")
-    skills = skill_drift()
-    for name, state in sorted(skills.items()):
-        target = CLAUDE_SKILLS_DIR / name
-        if state == "ok":
-            print(f"  [ok] /{name} skill: {target}")
-        elif state == "stale":
-            print(f"  [!!] /{name} skill: STALE — installed copy differs from packaged source")
-            print("     Run: agentwire hooks install")
-            issues_found += 1
-        else:
-            print(f"  [!!] /{name} skill: not installed")
-            print("     Run: agentwire hooks install")
-            issues_found += 1
+    issues_found += _render_skill_section()
 
     # 4b. Damage control (safety) — the kill switch, install drift, and the
     # PreToolUse matcher registration. The #462 incident: a global disable and
@@ -8771,22 +8785,31 @@ def install_skills(force: bool = False, copy: bool = False) -> dict[str, str]:
 
 
 def skill_drift() -> dict[str, str]:
-    """Drift state of agentwire-owned global skills: {name: ok|stale|missing}.
+    """Drift state of agentwire-owned global skills.
 
-    Mirrors cli_safety.*_drift() so `agentwire doctor` can flag a hand-placed or
-    drifted skill the same way it flags hook drift.
+    Returns {name: ok|stale|missing|source-unavailable}. Mirrors
+    cli_safety.*_drift() so `agentwire doctor` can flag a hand-placed or drifted
+    skill the same way it flags hook drift.
+
+    `source-unavailable` means the packaged skill can't be resolved in the
+    running context — e.g. doctor invoked from a SOURCE checkout, where skills
+    only exist inside the built wheel (`agentwire/skills/`), not on disk. That is
+    NOT a drift problem: there is nothing to install from, so doctor skips it
+    rather than crying "missing". `missing`/`stale` are reserved for the case
+    where the source IS resolvable (installed tool) and the installed copy is
+    genuinely absent or wrong.
     """
     try:
         skills_source = get_skills_source()
     except FileNotFoundError:
-        return {name: "missing" for name in _managed_global_skills()}
+        return {name: "source-unavailable" for name in _managed_global_skills()}
 
     drift: dict[str, str] = {}
     for name in _managed_global_skills():
         source = skills_source / name
         target = CLAUDE_SKILLS_DIR / name
         if not source.exists():
-            drift[name] = "missing"
+            drift[name] = "source-unavailable"
             continue
         drift[name] = _managed_skill_state(target, source)
     return drift

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -7438,6 +7438,24 @@ def cmd_doctor(args) -> int:
             print(f"  [..] {label}: not found ({why})")
             print("     Run: agentwire hooks install")
 
+    # 4a-bis. Global skills (currently just /wiki). Hand-placed at wiki-setup and
+    # never resynced, so a stale or missing copy was invisible until #475. Flag
+    # the same way as hooks — drift-aware against the packaged source.
+    print("\nChecking AgentWire global skills...")
+    skills = skill_drift()
+    for name, state in sorted(skills.items()):
+        target = CLAUDE_SKILLS_DIR / name
+        if state == "ok":
+            print(f"  [ok] /{name} skill: {target}")
+        elif state == "stale":
+            print(f"  [!!] /{name} skill: STALE — installed copy differs from packaged source")
+            print("     Run: agentwire hooks install")
+            issues_found += 1
+        else:
+            print(f"  [!!] /{name} skill: not installed")
+            print("     Run: agentwire hooks install")
+            issues_found += 1
+
     # 4b. Damage control (safety) — the kill switch, install drift, and the
     # PreToolUse matcher registration. The #462 incident: a global disable and
     # missing rule files were both invisible to every diagnostic.
@@ -8650,6 +8668,130 @@ def install_commands(force: bool = False) -> list[str]:
     return installed
 
 
+CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+
+
+def get_skills_source() -> Path:
+    """Get the path to the skills directory in the installed package.
+
+    Mirrors get_commands_source(): resolves to the bundled package dir so the
+    installed symlink is auto-current after `agentwire rebuild` (which reinstalls
+    the wheel), never a transient checkout path.
+    """
+    package_dir = Path(__file__).parent
+    skills_dir = package_dir / "skills"
+    if skills_dir.exists():
+        return skills_dir
+
+    try:
+        with importlib.resources.files("agentwire").joinpath("skills") as p:
+            if p.exists():
+                return Path(p)
+    except (TypeError, FileNotFoundError):
+        pass
+
+    raise FileNotFoundError("Could not find skills directory in package")
+
+
+def _managed_global_skills() -> list[str]:
+    """Agentwire-owned skills that belong GLOBALLY in ~/.claude/skills/.
+
+    Only `wiki` is global — the wiki store lives at ~/.agentwire/wiki/ and is
+    usable from any session. The agentwire-* skills stay project-scoped (shipped
+    via the repo's .claude/skills/, discovered per-project) and are NOT installed
+    here. Third-party skills (cua-driver, shadcn-ui, …) are never touched.
+    """
+    return ["wiki"]
+
+
+def _managed_skill_state(target: Path, source: Path) -> str:
+    """Drift state of a managed global skill DIRECTORY: missing | stale | ok.
+
+    Skills are directories, so unlike _managed_file_state this never compares
+    bytes. A symlink is ok only when it resolves to the packaged source; a real
+    directory (the hand-placed pre-#475 state) or a symlink pointing elsewhere is
+    stale and must be removed before re-symlinking.
+    """
+    if target.is_symlink():
+        if not target.exists():
+            return "stale"  # dangling symlink
+        return "ok" if target.resolve() == source.resolve() else "stale"
+    if not target.exists():
+        return "missing"
+    return "stale"  # real dir/file occupying the slot
+
+
+def _remove_skill_target(target: Path) -> None:
+    """Clear whatever occupies a skill slot — symlink, real dir, or stray file."""
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.is_dir():
+        shutil.rmtree(target)
+
+
+def install_skills(force: bool = False, copy: bool = False) -> dict[str, str]:
+    """Install/refresh agentwire-owned global skills into ~/.claude/skills/.
+
+    Each managed skill is a directory installed as a symlink (or copied with
+    --copy) pointing at the packaged source, drift-aware: a correct symlink is
+    left alone, a real-dir / wrong-symlink target is replaced.
+
+    Returns {name: "installed" | "updated" | "current" | "missing-source"}.
+    """
+    try:
+        skills_source = get_skills_source()
+    except FileNotFoundError:
+        print("  Warning: skills directory not found, skipping skill installation")
+        return {}
+
+    results: dict[str, str] = {}
+    for name in _managed_global_skills():
+        source = skills_source / name
+        if not source.exists():
+            print(f"  Warning: skill '{name}' not found in package, skipping")
+            results[name] = "missing-source"
+            continue
+
+        target = CLAUDE_SKILLS_DIR / name
+        state = _managed_skill_state(target, source)
+        if state == "ok" and not force:
+            results[name] = "current"
+            continue
+
+        existed = target.exists() or target.is_symlink()
+        CLAUDE_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        _remove_skill_target(target)
+        if copy:
+            shutil.copytree(source, target)
+        else:
+            target.symlink_to(source.resolve(), target_is_directory=True)
+        results[name] = "updated" if existed else "installed"
+
+    return results
+
+
+def skill_drift() -> dict[str, str]:
+    """Drift state of agentwire-owned global skills: {name: ok|stale|missing}.
+
+    Mirrors cli_safety.*_drift() so `agentwire doctor` can flag a hand-placed or
+    drifted skill the same way it flags hook drift.
+    """
+    try:
+        skills_source = get_skills_source()
+    except FileNotFoundError:
+        return {name: "missing" for name in _managed_global_skills()}
+
+    drift: dict[str, str] = {}
+    for name in _managed_global_skills():
+        source = skills_source / name
+        target = CLAUDE_SKILLS_DIR / name
+        if not source.exists():
+            drift[name] = "missing"
+            continue
+        drift[name] = _managed_skill_state(target, source)
+    return drift
+
+
 def register_hook_in_settings(event: str, hook_name: str) -> bool:
     """Register a hook under `event` in Claude's settings.json.
 
@@ -8799,6 +8941,11 @@ def install_hooks(force: bool = False, copy: bool = False) -> dict[str, str]:
     except Exception:
         pass
 
+    # Global skills (currently just /wiki) are agentwire-owned too, and rotted
+    # silently because nothing ever resynced the hand-placed copies. Heal them
+    # on the same install pass — drift-aware, like the hooks above.
+    results.update(install_skills(force=force, copy=copy))
+
     return results
 
 
@@ -8819,6 +8966,15 @@ def cmd_hooks_install(args) -> int:
             print(f"  /{name}")
     else:
         print("Slash commands already installed.")
+
+    refreshed_skills = False
+    for name in _managed_global_skills():
+        state = results.get(name)
+        if state in ("installed", "updated"):
+            print(f"{state.capitalize()} skill -> /{name} ({CLAUDE_SKILLS_DIR / name})")
+            refreshed_skills = True
+    if not refreshed_skills:
+        print("Skills already current.")
 
     return 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,14 @@ exclude = [
     "agentwire/office/node_modules/**",
 ]
 
+# Ship the agentwire-owned GLOBAL skill into the package so get_skills_source()
+# resolves it and `hooks install` can symlink ~/.claude/skills/wiki at it. SSOT:
+# the source lives at .claude/skills/wiki (also the project-scoped copy); this
+# maps it to agentwire/skills/wiki in the wheel, so it is auto-current on every
+# rebuild — the same posture as hooks/commands bundled inside the package.
+[tool.hatch.build.targets.wheel.force-include]
+".claude/skills/wiki" = "agentwire/skills/wiki"
+
 [tool.hatch.version]
 path = "agentwire/__init__.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ exclude = [
 # resolves it and `hooks install` can symlink ~/.claude/skills/wiki at it. SSOT:
 # the source lives at .claude/skills/wiki (also the project-scoped copy); this
 # maps it to agentwire/skills/wiki in the wheel, so it is auto-current on every
-# rebuild — the same posture as hooks/commands bundled inside the package.
+# rebuild — the same posture as hooks/roles/prompts bundled inside the package.
 [tool.hatch.build.targets.wheel.force-include]
 ".claude/skills/wiki" = "agentwire/skills/wiki"
 

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -15,6 +15,8 @@ import agentwire.__main__ as m
 from agentwire.__main__ import (
     _managed_global_skills,
     _managed_skill_state,
+    _render_skill_section,
+    install_hooks,
     install_skills,
     skill_drift,
 )
@@ -117,9 +119,70 @@ def test_skill_drift_ok_stale_missing(env):
     assert skill_drift() == {"wiki": "stale"}
 
 
-def test_skill_drift_missing_when_no_source(env, monkeypatch):
+def test_skill_drift_source_unavailable_when_no_source(env, monkeypatch):
+    """A source checkout (skill only in the built wheel) → source-unavailable,
+    NOT missing — so doctor doesn't false-positive."""
     def boom():
         raise FileNotFoundError("no skills dir")
 
     monkeypatch.setattr(m, "get_skills_source", boom)
-    assert skill_drift() == {"wiki": "missing"}
+    assert skill_drift() == {"wiki": "source-unavailable"}
+
+
+def test_install_force_resymlinks_when_ok(env):
+    """state 'ok' + force → still re-creates the symlink (updated, not current)."""
+    source, target_root = env
+    install_skills()
+    assert _managed_skill_state(target_root / "wiki", source / "wiki") == "ok"
+
+    results = install_skills(force=True)
+    assert results == {"wiki": "updated"}
+    assert (target_root / "wiki").resolve() == (source / "wiki").resolve()
+
+
+# --- doctor wiring (issue #475 fix: source-unavailable must not be an issue) ---
+
+def test_doctor_section_flags_missing_and_increments(env):
+    """Source resolvable + target absent → doctor reports an issue."""
+    assert _render_skill_section() == 1
+
+
+def test_doctor_section_flags_stale_and_increments(env):
+    """Source resolvable + real-dir target → stale → doctor reports an issue."""
+    _, target_root = env
+    target = target_root / "wiki"
+    target.mkdir(parents=True)
+    assert _render_skill_section() == 1
+
+
+def test_doctor_section_clean_when_installed(env):
+    install_skills()
+    assert _render_skill_section() == 0
+
+
+def test_doctor_section_no_issue_when_source_unavailable(env, monkeypatch):
+    """Running from a checkout (no packaged source) must NOT bump issues_found."""
+    def boom():
+        raise FileNotFoundError("no skills dir")
+
+    monkeypatch.setattr(m, "get_skills_source", boom)
+    assert _render_skill_section() == 0
+
+
+# --- install_hooks() actually drives install_skills() ---
+
+def test_install_hooks_installs_skills(env, tmp_path, monkeypatch):
+    """install_hooks() must heal global skills on the same pass."""
+    # Stub out the hook half so we exercise only the skill wiring, and keep
+    # damage-control healing from touching the real machine.
+    monkeypatch.setattr(m, "get_hooks_source", lambda: tmp_path / "no-hooks")
+    import agentwire.cli_safety as cs
+    monkeypatch.setattr(cs, "heal_damage_control", lambda quiet=True: None)
+
+    _, target_root = env
+    target = target_root / "wiki"
+    assert not target.exists()
+
+    results = install_hooks()
+    assert results.get("wiki") == "installed"
+    assert target.is_symlink()

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -1,0 +1,125 @@
+"""Tests for agentwire-owned GLOBAL skill install/drift (issue #475).
+
+Global skills (currently just `/wiki`) were hand-placed at wiki-setup and never
+resynced, so a stale or missing copy rotted invisibly. These tests cover the
+drift-aware symlink install + doctor-facing drift report. Everything runs against
+monkeypatched temp dirs — the real ~/.claude/skills/ is never touched.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+import agentwire.__main__ as m
+from agentwire.__main__ import (
+    _managed_global_skills,
+    _managed_skill_state,
+    install_skills,
+    skill_drift,
+)
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A fake packaged-source skills dir and a fake ~/.claude/skills target dir."""
+    source = tmp_path / "pkg" / "skills"
+    (source / "wiki").mkdir(parents=True)
+    (source / "wiki" / "SKILL.md").write_text("# wiki skill\n")
+
+    target_root = tmp_path / "claude" / "skills"
+
+    monkeypatch.setattr(m, "CLAUDE_SKILLS_DIR", target_root)
+    monkeypatch.setattr(m, "get_skills_source", lambda: source)
+    return source, target_root
+
+
+def test_managed_global_skills_is_just_wiki():
+    assert _managed_global_skills() == ["wiki"]
+
+
+def test_install_symlinks_fresh(env):
+    source, target_root = env
+    results = install_skills()
+    assert results == {"wiki": "installed"}
+
+    target = target_root / "wiki"
+    assert target.is_symlink()
+    assert target.resolve() == (source / "wiki").resolve()
+
+
+def test_install_replaces_real_dir_copy(env):
+    """The pre-#475 state: ~/.claude/skills/wiki is a REAL directory."""
+    source, target_root = env
+    target = target_root / "wiki"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("# stale hand-placed copy\n")
+
+    assert _managed_skill_state(target, source / "wiki") == "stale"
+
+    results = install_skills()
+    assert results == {"wiki": "updated"}
+    assert target.is_symlink()
+    assert target.resolve() == (source / "wiki").resolve()
+
+
+def test_install_heals_wrong_symlink(env, tmp_path):
+    source, target_root = env
+    bogus = tmp_path / "somewhere-else"
+    bogus.mkdir()
+    target_root.mkdir(parents=True)
+    target = target_root / "wiki"
+    target.symlink_to(bogus, target_is_directory=True)
+
+    assert _managed_skill_state(target, source / "wiki") == "stale"
+
+    results = install_skills()
+    assert results == {"wiki": "updated"}
+    assert target.resolve() == (source / "wiki").resolve()
+
+
+def test_install_is_idempotent(env):
+    assert install_skills() == {"wiki": "installed"}
+    assert install_skills() == {"wiki": "current"}
+
+
+def test_install_copy_mode(env):
+    source, target_root = env
+    results = install_skills(copy=True)
+    assert results == {"wiki": "installed"}
+
+    target = target_root / "wiki"
+    assert not target.is_symlink()
+    assert target.is_dir()
+    assert (target / "SKILL.md").read_text() == "# wiki skill\n"
+
+
+def test_install_missing_source(env):
+    source, _ = env
+    shutil.rmtree(source / "wiki")
+    assert install_skills() == {"wiki": "missing-source"}
+
+
+def test_skill_drift_ok_stale_missing(env):
+    source, target_root = env
+
+    # missing
+    assert skill_drift() == {"wiki": "missing"}
+
+    # ok after install
+    install_skills()
+    assert skill_drift() == {"wiki": "ok"}
+
+    # stale when replaced with a real dir
+    target = target_root / "wiki"
+    target.unlink()
+    target.mkdir()
+    assert skill_drift() == {"wiki": "stale"}
+
+
+def test_skill_drift_missing_when_no_source(env, monkeypatch):
+    def boom():
+        raise FileNotFoundError("no skills dir")
+
+    monkeypatch.setattr(m, "get_skills_source", boom)
+    assert skill_drift() == {"wiki": "missing"}

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -7,7 +7,6 @@ monkeypatched temp dirs — the real ~/.claude/skills/ is never touched.
 """
 
 import shutil
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## What

Makes agentwire-owned **global** skills drift-aware, exactly like hooks already are. Today nothing syncs `~/.claude/skills/` — the `/wiki` skill was hand-placed at wiki-setup and rots silently. Now `agentwire hooks install` syncs it and `agentwire doctor` flags stale/missing.

The only agentwire-owned global skill is **`wiki`** (global because the wiki store lives at `~/.agentwire/wiki/`). The `agentwire-*` skills stay project-scoped; third-party skills are never touched. The set is an explicit manifest: `_managed_global_skills() -> ["wiki"]`.

## How

Mirrors the existing hook/commands machinery in `agentwire/__main__.py`:

- `CLAUDE_SKILLS_DIR`, `get_skills_source()` (resolves to the packaged dir → auto-current on `rebuild`), `_managed_global_skills()`.
- `install_skills(force, copy)` — drift-aware install of each managed skill **directory** as a symlink (or `--copy`). Skills are dirs, so a real-dir / wrong-symlink target is "stale" and removal uses `shutil.rmtree` (not `unlink`). Idempotent: second run → `current`.
- `skill_drift() -> {name: ok|stale|missing}` for doctor.
- Wired into `install_hooks()`; printed in `cmd_hooks_install()` ("Installed/refreshed skill -> /wiki" / "Skills already current.").
- Doctor: new **"AgentWire global skills"** drift block next to the hook block.
- **Packaging:** `force-include` maps `.claude/skills/wiki` → `agentwire/skills/wiki` in the wheel — SSOT source stays at `.claude/skills/wiki`, and the wheel ships it so the symlink target exists. Verified the built wheel contains `agentwire/skills/wiki/SKILL.md`.

## Tests

`tests/unit/test_skill_install.py` (9 tests, temp dirs only — real `~/.claude/skills/` untouched): manifest; symlink fresh; replaces a real-dir copy; heals a wrong symlink; idempotent; `--copy`; missing-source; `skill_drift` ok/stale/missing. All pass; existing `test_hooks_install.py` (22) still green.

Closes #475

Built by [dotdev.dev](https://dotdev.dev)