### PR TITLE
fix(tmux): selection-aware copy-mode wheel + paste-freeze in default table (#471, #472)

### DIFF
--- a/agentwire/templates/tmux.conf
+++ b/agentwire/templates/tmux.conf
@@ -52,8 +52,22 @@ setw -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-selection-and-cancel
 
-# Don't exit copy mode when mouse drag ends — lets you review the selection
+# Don't exit copy mode when mouse drag ends — lets you review the selection.
+# Unbind in BOTH tables: a stray click-drag can drop the pane into the default
+# copy-mode table (not just copy-mode-vi), where a lingering selection wedges
+# the portal's chunked WebSocket-terminal paste (writes chunked 512B/10ms).
 unbind -T copy-mode-vi MouseDragEnd1Pane
+unbind -T copy-mode    MouseDragEnd1Pane
+
+# Selection-aware mouse wheel in copy mode (governs tablet two-finger scroll too:
+# the portal converts touch swipes into real SGR wheel sequences to the PTY).
+# No selection → scroll-up/down keeps smooth view scrolling (a plain cursor-up
+# binding makes the cursor walk ~a full screen before the view moves — a
+# dead-zone that feels broken on touch). Active selection → cursor-up/down moves
+# the selection end so the highlight grows and the view auto-scrolls at the edge
+# (tmux's only real "grow selection while scrolling").
+bind -T copy-mode-vi WheelUpPane   if -F '#{selection_present}' 'send -X -N 3 cursor-up'   'send -X -N 3 scroll-up'
+bind -T copy-mode-vi WheelDownPane if -F '#{selection_present}' 'send -X -N 3 cursor-down' 'send -X -N 3 scroll-down'
 
 # ─────────────────────────────────────────────────────────────
 # Mouse Click/Drag — Disabled

--- a/tests/unit/test_tmux_template.py
+++ b/tests/unit/test_tmux_template.py
@@ -30,6 +30,12 @@ class TestBundledTemplate:
         "bind -T copy-mode-vi v send -X begin-selection",
         "bind -T copy-mode-vi y send -X copy-selection-and-cancel",
         "unbind -T copy-mode-vi MouseDragEnd1Pane",
+        # Default copy-mode table also unbound — a stray drag can land there and
+        # wedge the portal's chunked WebSocket-terminal paste (#471)
+        "unbind -T copy-mode    MouseDragEnd1Pane",
+        # Selection-aware wheel: grow selection when present, view-scroll when not (#472)
+        "bind -T copy-mode-vi WheelUpPane   if -F '#{selection_present}' 'send -X -N 3 cursor-up'   'send -X -N 3 scroll-up'",
+        "bind -T copy-mode-vi WheelDownPane if -F '#{selection_present}' 'send -X -N 3 cursor-down' 'send -X -N 3 scroll-down'",
         # Multi-client sizing: portal Monitor must not shrink windows, and
         # explicit resize-window calls must not lock manual mode permanently
         "set -g window-size largest",


### PR DESCRIPTION
Two paired tmux copy-mode fixes in the shipped template `agentwire/templates/tmux.conf`.

## #471 — paste-freeze fix
`MouseDragEnd1Pane` was unbound only in the `copy-mode-vi` table. A stray click-drag can drop the pane into the DEFAULT `copy-mode` table, where it stayed bound — leaving an active selection that wedges the portal's chunked WebSocket-terminal paste (writes chunked 512B/10ms). Now unbound in both tables. `set -g mouse on` kept as-is for wheel scrollback.

## #472 — selection-aware copy-mode wheel
Copy-mode wheel used tmux defaults, so a drag-selection didn't grow while scrolling — the highlight just scrolled out of view. New `WheelUp/DownPane` bindings branch on `#{selection_present}`: no selection → smooth `scroll-up/down` view scroll; active selection → `cursor-up/down` grows the highlight and auto-scrolls at the edge. Also governs the portal's tablet two-finger scroll (swipes → real SGR wheel sequences to the PTY).

Verified: config loads clean against a scratch tmux server; `tests/unit/test_tmux_template.py` extended for the new unbind + both wheel bindings, 20 passed.

Closes #471
Closes #472

Built by dotdev.dev