### PR TITLE
fix(sessions): verify first-message delivery against scrollback + consumed signal (#478)

### DIFF
--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -11,6 +11,33 @@ through here.
 
 import time
 
+# How far back into scrollback to look when verifying delivery. A fast bypass
+# agent consumes the paste, submits it, and emits tool output within the settle
+# window, scrolling the ``[Pasted text …]`` placeholder / first-line fragment
+# past the visible tail. Verification reads scrollback (not just the visible
+# 60 lines) so a submitted prompt that scrolled up is still found.
+VERIFY_SCROLLBACK_LINES = 200
+
+# Delay for the early snapshot — catches the placeholder/fragment before a fast
+# agent scrolls it away. The remaining settle gives a slow agent time to render.
+EARLY_SETTLE = 0.15
+
+# Substrings that mean "Claude is actively working" — a spinner footer, the
+# token counter, the esc-to-interrupt hint, or tool-output glyphs. A
+# submitted-and-working agent is the success case the old check mistook for a
+# vanished paste.
+ACTIVITY_MARKERS = (
+    "esc to interrupt",
+    "esc-to-interrupt",
+    "tokens",
+    "⎿",  # tool-result indent
+    "⏺",  # tool-call bullet
+    "✶",  # spinner glyphs Claude cycles while thinking
+    "✻",
+    "✽",
+    "✢",
+)
+
 
 def send_to_session(session: str, message: str, pane_index: int = 0) -> None:
     """Inject a message into a session's pane (pane 0 by default)."""
@@ -23,6 +50,30 @@ def capture_session(session: str, lines: int = 60, pane_index: int = 0) -> str:
     from agentwire import pane_manager
 
     return pane_manager.capture_pane(session, pane_index, lines=lines)
+
+
+def pane_shows_activity(capture: str) -> bool:
+    """Does the pane show Claude actively working (spinner / tokens / output)?"""
+    lowered = capture.lower()
+    return any(marker.lower() in lowered for marker in ACTIVITY_MARKERS)
+
+
+def consumed_and_working(session: str, capture: str, pane_index: int = 0) -> bool:
+    """Positive "consumed" signal: input box empty AND pane shows activity.
+
+    A submitted prompt leaves the input box empty while the agent works. We
+    require *both* — empty alone is also the idle/never-received state, so an
+    empty box with no activity is NOT treated as delivered (guards the genuine
+    vanish case against a false positive).
+    """
+    if not pane_shows_activity(capture):
+        return False
+    from agentwire import prompt_router
+
+    try:
+        return prompt_router.prompt_is_empty(session, pane_index)
+    except Exception:
+        return False
 
 
 def wait_for_session_ready(
@@ -131,17 +182,44 @@ def send_verified(
     *marker* if given (council's explicit-marker pattern), otherwise via
     :func:`message_visible` on the message itself. Retry once if not.
 
+    Verification reads *scrollback* (not just the visible tail) and snapshots
+    twice — once ~150ms after the paste (to catch the ``[Pasted text …]``
+    placeholder / fragment before a fast agent scrolls it away) and once after
+    *settle*. A hit at *either* time counts. For the markerless case a positive
+    "consumed" signal (input box went empty AND the pane shows activity) also
+    counts — a submitted-and-working agent is delivery, not failure. The
+    genuine vanish case (empty box, no activity, nothing in scrollback) still
+    returns False.
+
     *pane_index* targets a worker pane (1+) instead of the session's pane 0.
     """
+
+    def confirmed() -> bool:
+        capture = capture_session(
+            session, lines=VERIFY_SCROLLBACK_LINES, pane_index=pane_index
+        )
+        if marker is not None:
+            return marker in capture
+        if message_visible(capture, message):
+            return True
+        return consumed_and_working(session, capture, pane_index=pane_index)
+
     for _ in range(retries + 1):
         send_to_session(session, message, pane_index=pane_index)
-        time.sleep(settle)
+        # Early snapshot — placeholder/fragment still on screen before the
+        # agent consumes and scrolls it away.
+        time.sleep(EARLY_SETTLE)
         try:
-            capture = capture_session(session, pane_index=pane_index)
-            if marker is not None:
-                if marker in capture:
-                    return True
-            elif message_visible(capture, message):
+            if confirmed():
+                return True
+        except Exception:
+            pass
+        # Late snapshot — gives a slow agent time to render the paste.
+        remaining = settle - EARLY_SETTLE
+        if remaining > 0:
+            time.sleep(remaining)
+        try:
+            if confirmed():
                 return True
         except Exception:
             pass

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -161,6 +161,74 @@ class TestSendVerified:
         assert seen == {"send": 2, "cap": 2}
 
 
+class TestPaneShowsActivity:
+    def test_esc_to_interrupt(self):
+        assert session_ready.pane_shows_activity("✶ Cogitating… (esc to interrupt)")
+
+    def test_token_counter(self):
+        assert session_ready.pane_shows_activity("· 1.2k tokens · esc")
+
+    def test_tool_output_glyph(self):
+        assert session_ready.pane_shows_activity("⏺ Bash(ls)\n  ⎿ file.py")
+
+    def test_idle_no_activity(self):
+        assert not session_ready.pane_shows_activity("❯ \nBypassing Permissions")
+
+
+class TestSendVerifiedRegression:
+    """Pins #478 — fast bypass agent submits + scrolls the paste away."""
+
+    def _quiet(self, monkeypatch):
+        monkeypatch.setattr(session_ready.time, "sleep", lambda _: None)
+
+    def test_scrolled_out_but_working_is_delivered(self, monkeypatch):
+        # Prompt fragment/placeholder has scrolled OUT of the capture, the
+        # input box is empty, and the agent is visibly working → DELIVERED.
+        self._quiet(monkeypatch)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
+        monkeypatch.setattr(
+            session_ready, "capture_session",
+            lambda s, lines=60, pane_index=0: "⏺ Read(foo.py)\n  ⎿ 42 lines\n✶ Working… (esc to interrupt)")
+        from agentwire import prompt_router
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        assert session_ready.send_verified("s", "my unique multiline prompt")
+
+    def test_placeholder_in_scrollback_is_delivered(self, monkeypatch):
+        # Large paste renders only as the placeholder, still in scrollback.
+        self._quiet(monkeypatch)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
+        monkeypatch.setattr(
+            session_ready, "capture_session",
+            lambda s, lines=60, pane_index=0: "older output...\n❯ [Pasted text #1 +40 lines]\nmore")
+        assert session_ready.send_verified("s", "line one\nline two\n...forty lines")
+
+    def test_genuine_vanish_is_not_delivered(self, monkeypatch):
+        # Empty input box, no activity, nothing in scrollback → NOT delivered.
+        self._quiet(monkeypatch)
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
+        monkeypatch.setattr(
+            session_ready, "capture_session",
+            lambda s, lines=60, pane_index=0: "❯ \nBypassing Permissions")
+        from agentwire import prompt_router
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        assert not session_ready.send_verified("s", "this prompt vanished entirely")
+
+    def test_verification_reads_scrollback(self, monkeypatch):
+        # send_verified must request scrollback, not just the visible tail.
+        self._quiet(monkeypatch)
+        seen = {}
+        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
+
+        def fake_capture(s, lines=60, pane_index=0):
+            seen["lines"] = lines
+            return ""
+        monkeypatch.setattr(session_ready, "capture_session", fake_capture)
+        from agentwire import prompt_router
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        session_ready.send_verified("s", "anything")
+        assert seen["lines"] == session_ready.VERIFY_SCROLLBACK_LINES
+
+
 class TestCouncilDelegation:
     """council.cli.send_verified / wait_ready now delegate here."""
 


### PR DESCRIPTION
## Root cause

`send_verified()` pasted the first message with `enter=True` (submit immediately), slept `settle=2.0s`, then captured only the last **60 visible lines** and checked for the prompt's first-line fragment or the `[Pasted text …]` placeholder. A fast **bypass** agent consumes + submits the prompt and emits tool output within the 2s window, scrolling the placeholder/fragment past the 60-line tail → `message_visible` returns False → false-negative "first message not delivered". `--json` then returned `first_message_delivered: false`, a duplicate-dispatch hazard. This hit **every worktree session** (bypass posture).

## What changed (`agentwire/session_ready.py`)

1. **Verify against scrollback.** Verification now captures `VERIFY_SCROLLBACK_LINES=200` (via the existing `capture_pane` `-S -<N>` wrapper — no duplicated tmux call), so a submitted prompt that scrolled up is still found.
2. **Capture early + late.** Snapshot ~150ms after the paste (catches the placeholder/fragment before the agent scrolls it away) **and** after `settle`. A hit at either time counts.
3. **Positive "consumed" signal.** If the input box went empty (`prompt_router.prompt_is_empty`) **and** the pane shows activity (spinner / token counter / esc-to-interrupt / tool glyphs), treat as delivered — a submitted-and-working agent is the success case the old check mistook for failure.

**False-positive guard kept:** empty box **and** no activity **and** nothing in scrollback still returns `False` (genuine vanish). The council explicit-marker path is unchanged in semantics and benefits from the scrollback capture.

## Tests

Extended `tests/unit/test_session_ready.py`: scrolled-out-but-working → delivered; placeholder-only in scrollback → delivered; genuine vanish → not delivered; plus activity-detection and scrollback-request assertions. Full fast suite green (`1701 passed`).

Closes #478

Built by dotdev.dev