### PR TITLE
fix(cli): escape bare % in --context help to survive Python 3.14 argparse

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11760,7 +11760,7 @@ Command Categories:
     list_parser.add_argument("--sessions", action="store_true", help="Show sessions instead of panes")
     list_parser.add_argument("--context", action="store_true",
                              help="Annotate each session with its Claude Code context headroom "
-                                  "(remaining %); flags sessions running low (implies --sessions)")
+                                  "(remaining %%); flags sessions running low (implies --sessions)")
     list_parser.set_defaults(func=cmd_list)
 
     new_parser = subparsers.add_parser("new", help="Create new Claude Code session")


### PR DESCRIPTION
### Problem

Python 3.14 tightened argparse's help-string validation: a bare `%` that isn't part of a `%(...)s` token now raises `ValueError: badly formed help string` at parser-construction time.

The `list --context` help string contains `(remaining %)`, so on Python 3.14 **every** `agentwire` invocation crashes before it can dispatch — including `agentwire tts serve`, which means the TTS shim never comes up (observed live: TTS server dead after a reboot onto a 3.14 interpreter, CLI crashing with this traceback).

### Fix

Escape the literal percent to `%%` in the help string. One-character change, no behavior change on older Pythons.

### Verification

`agentwire list --help` / `agentwire tts serve` parse and run cleanly on Python 3.14.2 after the fix; both crashed before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)