### PR TITLE
Isolate watchdog tick stages so one subsystem's exception can't starve the others

### DIFF
--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -89,6 +89,46 @@ def _fmt_local(iso: str) -> str:
         return str(iso)
 
 
+WATCHDOG_EVENTS_FILE = Path.home() / ".agentwire" / "watchdog-events.jsonl"
+
+
+def _log_stage_failure(stage: str, exc: BaseException) -> None:
+    """Append a stage-failure record to the watchdog events log (best-effort).
+
+    The watchdog runs unattended under launchd; a stage raising must never go
+    silent. We log to stderr (captured in the launchd log) AND to a jsonl event
+    so the failure is both immediately visible and durably auditable.
+    """
+    record = {
+        "ts": datetime.now().astimezone().isoformat(),
+        "event": "stage_failed",
+        "stage": stage,
+        "error": f"{type(exc).__name__}: {exc}",
+    }
+    print(f"watchdog stage '{stage}' failed: {record['error']}", file=sys.stderr)
+    try:
+        WATCHDOG_EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(WATCHDOG_EVENTS_FILE, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def _run_stage(stage: str, fn, default):
+    """Run one watchdog stage in isolation.
+
+    A raise in one stage is logged and swallowed so the remaining stages still
+    run this cycle — without this guard the first raise propagates out of the
+    CLI dispatcher, the process exits, and every later stage is silently skipped
+    until the next minute's tick (see #490).
+    """
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 — isolate stages, never starve the rest
+        _log_stage_failure(stage, exc)
+        return default
+
+
 def cmd_limits_tick(args) -> int:
     """One watchdog pass (called by launchd every minute).
 
@@ -98,13 +138,21 @@ def cmd_limits_tick(args) -> int:
     looks at the pane, that the inbox only ever delivers to panes the prompt
     sweep already cleared, and that auto-``/clear`` runs LAST so it never fights
     a pending paste/prompt for the same idle, empty box.
+
+    Each stage runs inside :func:`_run_stage` so an exception in one subsystem
+    is logged and skipped rather than aborting the whole cycle (#490).
     """
     from agentwire import inbox, prompt_router, session_context
 
-    result = usage_limit.tick()
-    prompts = prompt_router.tick()
-    messages = inbox.tick()
-    context = session_context.tick()
+    result = _run_stage(
+        "usage_limit", usage_limit.tick,
+        {"skipped": None, "parked": [], "resumed": [], "waiting": []})
+    prompts = _run_stage(
+        "prompt_router", prompt_router.tick, {"routed": [], "deferred": []})
+    messages = _run_stage(
+        "inbox", inbox.tick, {"flushed": [], "deferred": []})
+    context = _run_stage(
+        "session_context", session_context.tick, {"acted": [], "deferred": []})
     if getattr(args, "json", False):
         print(json.dumps({
             **result, "prompts": prompts, "messages": messages, "context": context,

--- a/tests/unit/test_limits_tick_isolation.py
+++ b/tests/unit/test_limits_tick_isolation.py
@@ -1,0 +1,109 @@
+"""Watchdog stage isolation (agentwire/limits_cli.py, #490).
+
+The 60s watchdog runs four ``*.tick()`` stages sequentially. A raise in one
+must be logged and skipped, not propagate out and starve the rest of the cycle.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from agentwire import limits_cli
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+@pytest.fixture
+def stub_stages(monkeypatch):
+    """Stub all four stage entry points with recording fakes.
+
+    Returns a dict mapping stage name -> list that gets a sentinel appended
+    when that stage actually runs, so the test can assert which stages ran.
+    """
+    ran: dict[str, list] = {k: [] for k in
+                            ("usage_limit", "prompt_router", "inbox", "session_context")}
+
+    def make(name, result):
+        def _tick():
+            ran[name].append(True)
+            return result
+        return _tick
+
+    import agentwire.inbox as inbox_mod
+    import agentwire.prompt_router as pr_mod
+    import agentwire.session_context as sc_mod
+
+    monkeypatch.setattr(limits_cli.usage_limit, "tick",
+                        make("usage_limit",
+                             {"skipped": None, "parked": [], "resumed": [], "waiting": []}))
+    monkeypatch.setattr(pr_mod, "tick", make("prompt_router", {"routed": [], "deferred": []}))
+    monkeypatch.setattr(inbox_mod, "tick", make("inbox", {"flushed": [], "deferred": []}))
+    monkeypatch.setattr(sc_mod, "tick", make("session_context", {"acted": [], "deferred": []}))
+    return ran
+
+
+def test_failing_first_stage_does_not_block_the_rest(stub_stages, monkeypatch, capsys, tmp_path):
+    """usage_limit raises — prompt routing, inbox drain, context all still run."""
+    monkeypatch.setattr(limits_cli, "WATCHDOG_EVENTS_FILE", tmp_path / "watchdog-events.jsonl")
+
+    def boom():
+        stub_stages["usage_limit"].append(True)
+        raise _Boom("usage-limit stage exploded")
+
+    monkeypatch.setattr(limits_cli.usage_limit, "tick", boom)
+
+    rc = limits_cli.cmd_limits_tick(argparse.Namespace(json=True))
+
+    assert rc == 0
+    # Every downstream stage ran despite the first one raising.
+    assert stub_stages["prompt_router"], "prompt routing was starved"
+    assert stub_stages["inbox"], "inbox drain was starved"
+    assert stub_stages["session_context"], "context auto-management was starved"
+
+    # The failure is logged, not swallowed: stderr + jsonl event.
+    err = capsys.readouterr().err
+    assert "usage_limit" in err and "exploded" in err
+
+    events = (tmp_path / "watchdog-events.jsonl").read_text().strip().splitlines()
+    assert len(events) == 1
+    rec = json.loads(events[0])
+    assert rec["event"] == "stage_failed"
+    assert rec["stage"] == "usage_limit"
+    assert "_Boom" in rec["error"]
+
+
+def test_failing_middle_stage_isolated(stub_stages, monkeypatch, capsys, tmp_path):
+    """inbox raises — earlier and later stages are unaffected."""
+    monkeypatch.setattr(limits_cli, "WATCHDOG_EVENTS_FILE", tmp_path / "watchdog-events.jsonl")
+
+    import agentwire.inbox as inbox_mod
+
+    def boom():
+        raise _Boom("inbox stage exploded")
+
+    monkeypatch.setattr(inbox_mod, "tick", boom)
+
+    rc = limits_cli.cmd_limits_tick(argparse.Namespace(json=False))
+
+    assert rc == 0
+    assert stub_stages["usage_limit"]
+    assert stub_stages["prompt_router"]
+    assert stub_stages["session_context"], "context stage starved by inbox failure"
+
+    rec = json.loads((tmp_path / "watchdog-events.jsonl").read_text().strip())
+    assert rec["stage"] == "inbox"
+
+
+def test_all_stages_clean_logs_nothing(stub_stages, monkeypatch, tmp_path):
+    """No failures → no watchdog event file written."""
+    events_file = tmp_path / "watchdog-events.jsonl"
+    monkeypatch.setattr(limits_cli, "WATCHDOG_EVENTS_FILE", events_file)
+
+    rc = limits_cli.cmd_limits_tick(argparse.Namespace(json=True))
+
+    assert rc == 0
+    assert all(stub_stages[k] for k in stub_stages)
+    assert not events_file.exists()


### PR DESCRIPTION
## What

`cmd_limits_tick` (the 60s launchd watchdog) ran its four stages —
`usage_limit.tick()`, `prompt_router.tick()`, `inbox.tick()`,
`session_context.tick()` — back-to-back with no inter-stage guard, and the CLI
dispatcher is also unwrapped. A raise in the first stage (usage-limit, run first
by design) propagated out, the process exited, launchd silently reran next
minute, and the inbox drain + context auto-clear never ran that cycle. Invisible
failure: no crash surfaced, no alert.

## Change

- Add `_run_stage(name, fn, default)` wrapping each `*.tick()` call. A raise is
  logged to **stderr** (captured in the launchd log) **and** to
  `~/.agentwire/watchdog-events.jsonl` as a `stage_failed` event, then the stage
  returns a safe default and the next stage still runs.
- Errors are logged, never swallowed silently.

## Smallest-reasonable choices (noted per instructions)

- Per-stage `except Exception` (not `BaseException`) — KeyboardInterrupt/SystemExit
  still propagate, matching the rest of the codebase.
- New events file `~/.agentwire/watchdog-events.jsonl` rather than overloading an
  existing per-subsystem log, since the failure is cross-stage.
- Left the per-pane sweep loop bodies alone — the issue itself notes those are
  already defensive (`_capture` swallows tmux errors, `route_prompt` is fully
  wrapped); the real gap was cross-stage isolation.

## Verification

In-worktree (`uv run --extra dev pytest`):
- New `tests/unit/test_limits_tick_isolation.py` (3 tests): a failing first
  stage, a failing middle stage, and an all-clean cycle — asserting downstream
  stages still run, the failure is logged to stderr + jsonl, and a clean cycle
  writes nothing. All pass.
- Existing `test_usage_limit.py` / `test_prompt_router.py` / `test_inbox.py` —
  146 passed, no regression.

Closes #490

Built by [dotdev.dev](https://dotdev.dev)