### PR TITLE
Size-cap the five unbounded JSONL event logs (#499)

### DIFF
--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -35,6 +35,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from agentwire.utils.event_log import append_event
+
 INBOX_ROOT = Path.home() / ".agentwire" / "inbox"
 EVENTS_FILE = Path.home() / ".agentwire" / "inbox-events.jsonl"
 
@@ -137,12 +139,7 @@ def ingest_dir(session: str) -> Path:
 
 def _log_event(event: str, **fields) -> None:
     record = {"ts": _now_ms(), "event": event, **fields}
-    try:
-        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(EVENTS_FILE, "a") as f:
-            f.write(json.dumps(record) + "\n")
-    except OSError:
-        pass
+    append_event(EVENTS_FILE, record)
 
 
 def _read_message(path: Path) -> "Message | None":

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -41,6 +41,7 @@ from .usage_limit import (
 )
 from .usage_limit import detect_dialog as _usage_limit_dialog
 from .usage_limit import is_parked as _is_parked
+from .utils.event_log import append_event
 
 STATE_DIR = Path.home() / ".agentwire" / "prompt-router"
 EVENTS_FILE = Path.home() / ".agentwire" / "prompt-router-events.jsonl"
@@ -392,12 +393,7 @@ def detect_prompt(visible: str) -> "PromptInfo | None":
 
 def _log_event(event: str, **fields) -> None:
     record = {"ts": _now().isoformat(), "event": event, **fields}
-    try:
-        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(EVENTS_FILE, "a") as f:
-            f.write(json.dumps(record) + "\n")
-    except OSError:
-        pass
+    append_event(EVENTS_FILE, record)
 
 
 def marker_path(session: str, pane_index: int) -> Path:

--- a/agentwire/scheduler.py
+++ b/agentwire/scheduler.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import yaml
 
 from .config import get_config
+from .utils.event_log import append_event
 
 
 def _sched_config():
@@ -844,11 +845,9 @@ def _log_event(event: str, **fields) -> None:
     }
     try:
         events_path = _sched_config().events_file
-        events_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(events_path, "a") as f:
-            f.write(json.dumps(entry) + "\n")
-    except OSError:
-        pass
+    except Exception:
+        return
+    append_event(events_path, entry)
 
 
 def _write_live_state(**fields) -> None:

--- a/agentwire/session_context.py
+++ b/agentwire/session_context.py
@@ -50,13 +50,13 @@ gracefully (surfaced as non-interactive, never flagged).
 
 from __future__ import annotations
 
-import json
 import re
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from .usage_limit import _capture, _tmux
+from .utils.event_log import append_event
 
 # The context bar: a bracketed run of block-element glyphs (U+2580–U+259F
 # covers full/partial/empty blocks) followed by "NN%". ANSI is stripped first.
@@ -253,12 +253,7 @@ def _log_event(event: str, **fields) -> None:
     from datetime import datetime, timezone
 
     record = {"ts": datetime.now(timezone.utc).isoformat(), "event": event, **fields}
-    try:
-        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(EVENTS_FILE, "a") as f:
-            f.write(json.dumps(record) + "\n")
-    except OSError:
-        pass
+    append_event(EVENTS_FILE, record)
 
 
 def resolve_policy(session: str, cfg=None) -> str:

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -40,6 +40,8 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from .utils.event_log import append_event
+
 STATE_DIR = Path.home() / ".agentwire" / "usage-limit"
 DONE_DIR = STATE_DIR / "done"
 EVENTS_FILE = Path.home() / ".agentwire" / "usage-limit-events.jsonl"
@@ -110,12 +112,7 @@ def _atomic_write(path: Path, data: dict) -> None:
 def log_event(event: str, **fields) -> None:
     """Append an event to the usage-limit events log (best-effort)."""
     record = {"ts": _now().isoformat(), "event": event, **fields}
-    try:
-        EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(EVENTS_FILE, "a") as f:
-            f.write(json.dumps(record) + "\n")
-    except OSError:
-        pass
+    append_event(EVENTS_FILE, record)
 
 
 def _tmux(args: list[str], timeout: float = 5) -> subprocess.CompletedProcess:

--- a/agentwire/utils/event_log.py
+++ b/agentwire/utils/event_log.py
@@ -1,0 +1,102 @@
+"""Size-capped append for the append-only ``*-events.jsonl`` debug logs.
+
+Single source of truth for the five event-log writers (inbox, prompt-router,
+usage-limit, session-context, scheduler). Each writer used to be a bare
+``open(path, "a")`` with no size bound, so a long-lived self-host box would
+accumulate unbounded debug history (#499). They all now route through
+:func:`append_event`, which rolls the file once it crosses a size threshold,
+keeping a bounded number of ``.1``/``.2`` backups.
+
+The on-disk line format is unchanged: one ``json.dumps(record) + "\n"`` per
+event. Rotation only renames whole files; it never rewrites a line.
+
+Both knobs are env-configurable (host-side, no rebuild) with sane defaults:
+
+- ``AGENTWIRE_EVENT_LOG_MAX_BYTES`` — roll once the active file would exceed
+  this many bytes. Default 5 MiB. ``0`` (or negative) disables rotation.
+- ``AGENTWIRE_EVENT_LOG_BACKUPS`` — how many rolled files to retain
+  (``.1`` .. ``.N``). Default 3. ``0`` keeps no backups (oldest is dropped).
+"""
+
+import json
+import os
+from pathlib import Path
+
+# Sane defaults — activity-proportional growth (#499) means these rarely roll,
+# but they cap a slow-burn paper-cut for unattended boxes.
+DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
+DEFAULT_BACKUPS = 3
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a non-negative int from the environment, falling back on garbage."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _max_bytes() -> int:
+    return _env_int("AGENTWIRE_EVENT_LOG_MAX_BYTES", DEFAULT_MAX_BYTES)
+
+
+def _backups() -> int:
+    return max(0, _env_int("AGENTWIRE_EVENT_LOG_BACKUPS", DEFAULT_BACKUPS))
+
+
+def _rotate(path: Path, backups: int) -> None:
+    """Roll ``path`` -> ``path.1`` -> ... -> ``path.N``, dropping the oldest.
+
+    No-op if the file is gone by the time we get here. Mirrors the scheduler's
+    ``_rotate_backups`` shift, but for the events file instead of the state
+    file: oldest first so nothing is clobbered.
+    """
+    # Drop the oldest retained backup (or the active file itself if backups==0).
+    oldest = path.with_name(path.name + f".{backups}") if backups else path
+    try:
+        if oldest.exists():
+            oldest.unlink()
+    except OSError:
+        pass
+    # Shift .{i} -> .{i+1} from the top down so we never overwrite a kept file.
+    for i in range(backups - 1, 0, -1):
+        src = path.with_name(path.name + f".{i}")
+        if src.exists():
+            try:
+                os.replace(src, path.with_name(path.name + f".{i + 1}"))
+            except OSError:
+                pass
+    if backups:
+        try:
+            os.replace(path, path.with_name(path.name + ".1"))
+        except OSError:
+            pass
+
+
+def append_event(path: Path, record: dict) -> None:
+    """Append one JSONL event to ``path``, rotating first if oversized.
+
+    Best-effort: any OS error is swallowed so logging never breaks a caller.
+    The caller owns the record's contents (``ts``/``event``/fields); this helper
+    owns serialization (``json.dumps(record) + "\n"``) and the size cap.
+    """
+    line = json.dumps(record) + "\n"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        max_bytes = _max_bytes()
+        if max_bytes > 0:
+            try:
+                size = path.stat().st_size
+            except OSError:
+                size = 0
+            # Roll before the write that would push us past the threshold, so a
+            # single fresh file can always hold at least one event.
+            if size and size + len(line.encode("utf-8")) > max_bytes:
+                _rotate(path, _backups())
+        with open(path, "a") as f:
+            f.write(line)
+    except OSError:
+        pass

--- a/tests/unit/test_event_log.py
+++ b/tests/unit/test_event_log.py
@@ -1,0 +1,87 @@
+"""Size-based rotation for the shared event-log append helper (#499)."""
+
+import json
+
+import pytest
+
+from agentwire.utils import event_log
+from agentwire.utils.event_log import append_event
+
+
+@pytest.fixture
+def events_path(tmp_path):
+    return tmp_path / "sub" / "demo-events.jsonl"
+
+
+def _read_lines(path):
+    return path.read_text().splitlines()
+
+
+def test_appends_jsonl_line_unchanged(events_path):
+    """Each event is one ``json.dumps(record) + "\\n"`` line — format intact."""
+    append_event(events_path, {"ts": 1, "event": "a", "x": 2})
+    append_event(events_path, {"ts": 3, "event": "b"})
+
+    lines = _read_lines(events_path)
+    assert lines == ['{"ts": 1, "event": "a", "x": 2}', '{"ts": 3, "event": "b"}']
+    # Round-trips back to the original records.
+    assert json.loads(lines[0]) == {"ts": 1, "event": "a", "x": 2}
+
+
+def test_creates_parent_dir(events_path):
+    assert not events_path.parent.exists()
+    append_event(events_path, {"event": "a"})
+    assert events_path.exists()
+
+
+def test_rotation_triggers_past_threshold(events_path, monkeypatch):
+    """Crossing the size cap rolls the active file to ``.1`` and starts fresh."""
+    monkeypatch.setenv("AGENTWIRE_EVENT_LOG_MAX_BYTES", "1000")
+    monkeypatch.setenv("AGENTWIRE_EVENT_LOG_BACKUPS", "3")
+
+    rolled = events_path.with_name(events_path.name + ".1")
+    payload = "x" * 40  # each line ~ 64 bytes; ~15 fill the 1000-byte cap
+
+    # Below the cap: no rotation, everything stays in the active file.
+    for i in range(10):
+        append_event(events_path, {"event": "fill", "i": i, "pad": payload})
+    assert not rolled.exists()
+    assert len(_read_lines(events_path)) == 10
+
+    # Keep going until the active file would cross the cap — it rolls to .1 and
+    # the active file is reset to hold the new line(s).
+    for i in range(10, 20):
+        append_event(events_path, {"event": "fill", "i": i, "pad": payload})
+
+    assert rolled.exists(), "expected the active log to roll to .1 past threshold"
+    assert events_path.stat().st_size <= 1000
+    # No events lost across the single rotation: active + .1 holds all 20.
+    total = _read_lines(events_path) + _read_lines(rolled)
+    assert len(total) == 20
+    assert {json.loads(line)["i"] for line in total} == set(range(20))
+
+
+def test_backup_count_is_bounded(events_path, monkeypatch):
+    """Only ``AGENTWIRE_EVENT_LOG_BACKUPS`` rolled files are retained."""
+    monkeypatch.setenv("AGENTWIRE_EVENT_LOG_MAX_BYTES", "120")
+    monkeypatch.setenv("AGENTWIRE_EVENT_LOG_BACKUPS", "2")
+
+    for i in range(60):
+        append_event(events_path, {"event": "fill", "i": i, "pad": "y" * 40})
+
+    # .1 and .2 may exist; .3 must never appear.
+    assert not events_path.with_name(events_path.name + ".3").exists()
+
+
+def test_rotation_disabled_when_max_bytes_zero(events_path, monkeypatch):
+    monkeypatch.setenv("AGENTWIRE_EVENT_LOG_MAX_BYTES", "0")
+    for i in range(50):
+        append_event(events_path, {"event": "fill", "i": i, "pad": "z" * 40})
+
+    assert not events_path.with_name(events_path.name + ".1").exists()
+    assert len(_read_lines(events_path)) == 50
+
+
+def test_default_threshold_is_five_mib():
+    assert event_log.DEFAULT_MAX_BYTES == 5 * 1024 * 1024
+    assert event_log.DEFAULT_BACKUPS == 3


### PR DESCRIPTION
## What

Bounds the five append-only `~/.agentwire/*-events.jsonl` debug logs (`inbox-events`, `prompt-router-events`, `usage-limit-events`, `session-context-events`, `scheduler-events`) so a long-lived self-host box no longer accumulates unbounded debug history.

All five writers were independent bare `open(path, "a")` calls. They now route through a single shared helper — **`agentwire/utils/event_log.py::append_event`** (single source of truth) — which rolls the active file to `.1` / `.2` / … once it would cross a size threshold and retains a bounded number of backups (oldest dropped).

- **JSONL line format unchanged** — still one `json.dumps(record) + "\n"` per event; the helper now owns serialization, rotation only renames whole files (never rewrites a line).
- **Configurable with sane defaults** (env, host-side, no rebuild):
  - `AGENTWIRE_EVENT_LOG_MAX_BYTES` — roll past this size. Default **5 MiB**. `0` disables rotation.
  - `AGENTWIRE_EVENT_LOG_BACKUPS` — rolled files retained. Default **3**.
- Still best-effort: every OS error is swallowed, logging never breaks a caller.
- Removed a now-unused `import json` from `session_context.py`.

## Smallest-reasonable choices (noted per the task)

- **Config via env vars rather than `config.yaml`.** These helpers are scattered across five modules that don't all already read config; env keeps it a one-line read with no config-schema churn, and matches the "host-side toggle, no rebuild" pattern. Easy to promote to `config.yaml` later if wanted.
- **Did not add the optional `doctor` oversize-flag / `prune` command** from the issue's "alternatively/additionally" — the shared cap makes unbounded growth impossible, so those are redundant for the core goal. Can be a follow-up.

## Verification

Ran in this worktree:

- `tests/unit/test_event_log.py` (new) — 6 pass: line-format-unchanged, parent-dir creation, **rotation triggers past threshold with no event loss across the roll**, backup count bounded, rotation disabled at `max_bytes=0`, default constants.
- Regression on all touched modules: `test_inbox`, `test_prompt_router`, `test_msg_cli`, `test_scheduler`, `test_scheduler_parsing`, `test_session_context`, `test_usage_limit` — **265 pass**.
- `python -c "import ..."` on all five edited modules + the new helper — clean.

Closes #499

Built by [dotdev.dev](https://dotdev.dev)