### PR TITLE
fix(ci): keep main ruff gate green (N818 in watchdog test)

### DIFF
--- a/tests/unit/test_limits_tick_isolation.py
+++ b/tests/unit/test_limits_tick_isolation.py
@@ -12,7 +12,7 @@ import pytest
 from agentwire import limits_cli
 
 
-class _Boom(RuntimeError):
+class _Boom(RuntimeError):  # noqa: N818  # test-only stage-failure sentinel, not a public error type
     pass
 
 


### PR DESCRIPTION
#505 merged a test carrying an intentional N818 (the _Boom stage-failure sentinel) AFTER #509 turned ruff into a required gate, which turned main red. noqa it with a reason, consistent with how #509 handled intentional exception names. Test-only, no behavior change.