### PR TITLE
test(cli): parser-build + per-subcommand help smoke tests (#486)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -11302,8 +11302,13 @@ class VersionAction(argparse.Action):
         parser.exit()
 
 
-def main() -> int:
-    """Main entry point."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argparse parser with every registered subcommand.
+
+    Extracted from ``main()`` so the parser tree can be constructed without
+    dispatching, which the CLI smoke tests rely on to enumerate subcommands
+    and invoke their ``--help`` (see ``tests/unit/test_cli_smoke.py``).
+    """
     parser = argparse.ArgumentParser(
         prog="agentwire",
         description="Multi-session voice web interface for AI coding agents.",
@@ -12698,94 +12703,54 @@ Command Categories:
     c_reply.add_argument("--json", action="store_true", help="Output JSON")
     c_reply.set_defaults(func=council_cli.cmd_council_reply)
 
+    return parser
+
+
+def _find_subparser(parser: argparse.ArgumentParser, *names: str):
+    """Walk the subparser tree by command name(s); return the parser or None."""
+    current = parser
+    for name in names:
+        sub = None
+        for action in current._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                sub = action.choices.get(name)
+                break
+        if sub is None:
+            return None
+        current = sub
+    return current
+
+
+# Command groups whose bare invocation (no subcommand) prints group help.
+_GROUP_COMMANDS = [
+    "portal", "tts", "stt", "tunnels", "machine", "history", "handoff",
+    "wiki", "hooks", "projects", "safety", "network", "listen",
+    "voiceclone", "roles", "task", "lock", "scheduler", "council", "limits",
+]
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = build_parser()
     args = parser.parse_args()
 
     if args.command is None:
         parser.print_help()
         return 0
 
-    if args.command == "portal" and getattr(args, "portal_command", None) is None:
-        portal_parser.print_help()
+    if (
+        args.command in _GROUP_COMMANDS
+        and getattr(args, f"{args.command}_command", None) is None
+    ):
+        _find_subparser(parser, args.command).print_help()
         return 0
 
-    if args.command == "tts" and getattr(args, "tts_command", None) is None:
-        tts_parser.print_help()
-        return 0
-
-    if args.command == "stt" and getattr(args, "stt_command", None) is None:
-        stt_parser.print_help()
-        return 0
-
-    if args.command == "tunnels" and getattr(args, "tunnels_command", None) is None:
-        tunnels_parser.print_help()
-        return 0
-
-    if args.command == "machine" and getattr(args, "machine_command", None) is None:
-        machine_parser.print_help()
-        return 0
-
-    if args.command == "history" and getattr(args, "history_command", None) is None:
-        history_parser.print_help()
-        return 0
-
-    if args.command == "handoff" and getattr(args, "handoff_command", None) is None:
-        handoff_parser.print_help()
-        return 0
-
-    if args.command == "wiki" and getattr(args, "wiki_command", None) is None:
-        wiki_parser.print_help()
-        return 0
-
-    if args.command == "hooks" and getattr(args, "hooks_command", None) is None:
-        hooks_parser.print_help()
-        return 0
-
-    if args.command == "projects" and getattr(args, "projects_command", None) is None:
-        projects_parser.print_help()
-        return 0
-
-    if args.command == "safety" and getattr(args, "safety_command", None) is None:
-        safety_parser.print_help()
-        return 0
-
-    if args.command == "safety" and getattr(args, "safety_command", None) == "tooldefs" and getattr(args, "tooldefs_command", None) is None:
-        safety_tooldefs.print_help()
-        return 0
-
-    if args.command == "network" and getattr(args, "network_command", None) is None:
-        network_parser.print_help()
-        return 0
-
-    if args.command == "listen" and getattr(args, "listen_command", None) is None:
-        listen_parser.print_help()
-        return 0
-
-    if args.command == "voiceclone" and getattr(args, "voiceclone_command", None) is None:
-        voiceclone_parser.print_help()
-        return 0
-
-    if args.command == "roles" and getattr(args, "roles_command", None) is None:
-        roles_parser.print_help()
-        return 0
-
-    if args.command == "task" and getattr(args, "task_command", None) is None:
-        task_parser.print_help()
-        return 0
-
-    if args.command == "lock" and getattr(args, "lock_command", None) is None:
-        lock_parser.print_help()
-        return 0
-
-    if args.command == "scheduler" and getattr(args, "scheduler_command", None) is None:
-        scheduler_parser.print_help()
-        return 0
-
-    if args.command == "council" and getattr(args, "council_command", None) is None:
-        council_parser.print_help()
-        return 0
-
-    if args.command == "limits" and getattr(args, "limits_command", None) is None:
-        limits_parser.print_help()
+    if (
+        args.command == "safety"
+        and getattr(args, "safety_command", None) == "tooldefs"
+        and getattr(args, "tooldefs_command", None) is None
+    ):
+        _find_subparser(parser, "safety", "tooldefs").print_help()
         return 0
 
     if hasattr(args, "func"):

--- a/tests/unit/test_cli_smoke.py
+++ b/tests/unit/test_cli_smoke.py
@@ -1,0 +1,68 @@
+"""Smoke tests for the CLI SSOT layer (agentwire/__main__.py).
+
+These guard the NameError/typo/bad-help-string bug class that crashes commands
+without any handler ever running — e.g. the bare ``%`` in an argparse help
+string that broke every command on Python 3.14 (see issue #486). They build the
+full parser and invoke ``--help`` for every registered subcommand, asserting the
+help renders cleanly (argparse exits 0) rather than raising.
+"""
+
+import argparse
+
+import pytest
+
+
+def _iter_subcommand_paths(parser, prefix=()):
+    """Yield the argv path to every (sub)command in the parser tree.
+
+    Each yielded path is a tuple like ``("portal",)`` or ``("safety", "tooldefs")``
+    that can be passed to ``parse_args`` followed by ``--help``.
+    """
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for name, subparser in action.choices.items():
+                path = prefix + (name,)
+                yield path
+                yield from _iter_subcommand_paths(subparser, path)
+
+
+def test_build_parser_constructs():
+    """The top-level parser builds without raising (catches bad help strings)."""
+    from agentwire.__main__ import build_parser
+
+    parser = build_parser()
+    assert isinstance(parser, argparse.ArgumentParser)
+    # At least the headline subcommands should be registered.
+    top_level = {p[0] for p in _iter_subcommand_paths(parser) if len(p) == 1}
+    assert {"portal", "new", "say", "scheduler"} <= top_level
+
+
+def _all_paths():
+    from agentwire.__main__ import build_parser
+
+    return list(_iter_subcommand_paths(build_parser()))
+
+
+def test_at_least_one_subcommand_discovered():
+    assert len(_all_paths()) > 0
+
+
+@pytest.mark.parametrize(
+    "path",
+    _all_paths(),
+    ids=lambda p: " ".join(p),
+)
+def test_subcommand_help_renders(path, capsys):
+    """`agentwire <subcmd...> --help` renders cleanly and exits 0.
+
+    Help-string formatting (e.g. a stray ``%`` that argparse treats as a
+    printf token) raises here at the parser layer, before any handler runs.
+    """
+    from agentwire.__main__ import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([*path, "--help"])
+    assert exc_info.value.code == 0
+    # Help should actually print something.
+    assert capsys.readouterr().out.strip()


### PR DESCRIPTION
## What

Adds cheap smoke coverage over the CLI SSOT layer (`agentwire/__main__.py`), which both the portal and MCP wrap. Catches the NameError/typo/bad-help-string bug class that crashes commands *before any handler runs* — e.g. the bare `%` in an argparse help string that broke every command on Python 3.14.

- **Refactor:** extract `build_parser()` from `main()` so the full argparse tree can be constructed without dispatching. This also unblocks the argparse-builder refactor noted in the issue.
- **Test:** `tests/unit/test_cli_smoke.py` builds the parser and, parametrized over every registered subcommand (walked recursively, including nested groups like `safety tooldefs`), invokes `--help` and asserts argparse exits 0 and prints help. Plus a `build_parser()` construction test.
- The bare-name fallback help block in `main()` (previously ~20 lines each referencing a distinct local `*_parser` variable, which no longer exist post-extraction) is rewritten to walk the subparser tree generically via `_find_subparser()` + a `_GROUP_COMMANDS` list. Behavior is identical.

## Smallest-reasonable-choice notes

- The issue floated either invoking `main()` or extracting `build_parser()`; I chose the extraction since it's cleaner to enumerate subcommands and the issue calls it out as also unblocking a separate refactor.
- I did **not** add the `--cov` advisory reporting or the additional handler-branch tests (item 2/3 in the issue) — kept scope to the parser/help smoke layer that closes the actual bug class. The existing `test_cli_commands.py` already covers handler branches and still passes.

## Verification (in worktree)

- `uv run --extra dev pytest tests/unit/test_cli_smoke.py -q` → **179 passed** (one help case per discovered subcommand).
- `uv run --extra dev pytest tests/unit/test_cli_commands.py -q` → 24 passed (no regression).
- `uv run --extra dev ruff check agentwire/__main__.py tests/unit/test_cli_smoke.py` → **All checks passed!**
- Smoke-ran the real CLI: `agentwire --help`, `agentwire portal` (group fallback), `agentwire safety tooldefs` (nested fallback) all behave as before.

Did not rebuild or restart the main install.

Closes #486

Built by [dotdev.dev](https://dotdev.dev)