### PR TITLE
feat(init): end on portal URL by default; gate agent spawn behind --assisted

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -256,7 +256,8 @@ agentwire limits install        # install + load the launchd watchdog (60s tick)
 agentwire limits uninstall      # unload + remove the watchdog
 
 # Setup & Development
-agentwire init                  # interactive setup wizard
+agentwire init                  # interactive setup wizard (ends on the portal URL)
+agentwire init --assisted       # ...and spawn the Claude TTS/STT setup session at the end
 agentwire generate-certs        # generate SSL certificates
 agentwire up                    # boot all services + dev session (see "Boot everything")
 agentwire dev                   # start/attach to dev session ONLY (no services)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -6874,8 +6874,10 @@ def cmd_up(args) -> int:
 def cmd_init(args) -> int:
     """Initialize AgentWire configuration with interactive wizard.
 
-    Default behavior: Run full wizard with optional agentwire setup at the end.
-    Quick mode (--quick): Run wizard only, skip agentwire setup prompt.
+    Default behavior: Run the wizard and end on the concrete portal-URL next
+    steps, so a first-run evaluator lands on a working voice portal.
+    Assisted mode (--assisted): also spawn the interactive Claude setup
+    session at the end to configure TTS/STT and other services.
     """
     # Check Python version first
     if not check_python_version():
@@ -6888,14 +6890,9 @@ def cmd_init(args) -> int:
 
     from .onboarding import run_onboarding
 
-    if args.quick:
-        # Quick mode: run wizard but skip agentwire step
-        # We do this by running onboarding and returning before agentwire prompt
-        # The onboarding module handles this internally
-        return run_onboarding(skip_session=True)
-
-    # Default: run full wizard (ends with optional agentwire setup)
-    return run_onboarding()
+    # Default ends on the portal-URL next steps; --assisted opts into the
+    # interactive Claude setup session.
+    return run_onboarding(skip_session=not args.assisted)
 
 
 def cmd_generate_certs(args) -> int:
@@ -11355,8 +11352,9 @@ Command Categories:
     # === init command ===
     init_parser = subparsers.add_parser("init", help="Interactive setup wizard")
     init_parser.add_argument(
-        "--quick", action="store_true",
-        help="Quick mode: skip agentwire setup at end"
+        "--assisted", action="store_true",
+        help="Spawn the interactive Claude setup session at the end "
+             "(default: end on the portal-URL next steps)"
     )
     init_parser.set_defaults(func=cmd_init)
 

--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -153,7 +153,7 @@ def get_install_instructions(platform: str) -> dict[str, str]:
 # ─────────────────────────────────────────────────────────────
 
 
-def run_onboarding(skip_session: bool = False) -> int:
+def run_onboarding(skip_session: bool = True) -> int:
     """Run the minimal onboarding wizard.
 
     Asks 3 questions:
@@ -161,10 +161,13 @@ def run_onboarding(skip_session: bool = False) -> int:
     2. Agent (Claude Code)
     3. Topology (Standalone / Multi-machine)
 
-    Then writes minimal config and spawns Claude for interactive setup.
+    Then writes minimal config and ends on the concrete portal-URL next
+    steps (the default), or spawns Claude for interactive setup (--assisted).
 
     Args:
-        skip_session: If True, skip spawning Claude session at the end.
+        skip_session: If True (the default), end the wizard on the portal-URL
+            next-steps block. If False (--assisted), spawn the interactive
+            Claude setup session at the end.
     """
     print()
     print(f"{BOLD}Welcome to AgentWire Setup!{RESET}")
@@ -468,7 +471,7 @@ services:
         print(f"  1. {CYAN}agentwire portal start{RESET}")
         print(f"  2. Open {CYAN}{portal_open_url}{RESET} in Chrome — voice works immediately")
         print()
-        print_info("Run 'agentwire init' again to complete setup with Claude's help.")
+        print_info("Run 'agentwire init --assisted' to configure TTS/STT with Claude's help.")
         return 0
 
     print()

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -1,0 +1,38 @@
+"""Tests for `agentwire init` default vs --assisted dispatch (issue #493)."""
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from agentwire.__main__ import cmd_init
+
+
+def _run(assisted: bool) -> dict:
+    """Invoke cmd_init with the version/pip preflight stubbed out, capturing
+    the skip_session value passed to run_onboarding."""
+    captured = {}
+
+    def fake_onboarding(skip_session: bool = True) -> int:
+        captured["skip_session"] = skip_session
+        return 0
+
+    with patch("agentwire.__main__.check_python_version", return_value=True), \
+         patch("agentwire.__main__.check_pip_environment", return_value=True), \
+         patch("agentwire.onboarding.run_onboarding", side_effect=fake_onboarding):
+        rc = cmd_init(Namespace(assisted=assisted))
+
+    captured["rc"] = rc
+    return captured
+
+
+def test_init_default_skips_agent_session():
+    """Default `agentwire init` ends on the portal-URL next steps."""
+    result = _run(assisted=False)
+    assert result["skip_session"] is True
+    assert result["rc"] == 0
+
+
+def test_init_assisted_spawns_agent_session():
+    """`agentwire init --assisted` opts back into the Claude setup session."""
+    result = _run(assisted=True)
+    assert result["skip_session"] is False
+    assert result["rc"] == 0


### PR DESCRIPTION
## What

Make the default `agentwire init` happy path end on a concrete "here's your portal URL, voice works now" payoff instead of dropping a first-run evaluator into an unexpected interactive `claude --dangerously-skip-permissions` session.

- `run_onboarding` now defaults `skip_session=True` — the wizard ends on the existing portal-URL next-steps block (`agentwire portal start` → open URL).
- The Claude-assisted TTS/STT setup is demoted behind an explicit opt-in: `agentwire init --assisted`. This replaces the now-redundant `--quick` flag (whose behavior is the new default; pre-launch, no back-compat shim).
- Updated `cmd_init`/argparse help text, the `agentwire-cli` skill reference, and the skip-path next-steps hint (now points at `--assisted`).
- Added `tests/unit/test_init_command.py` covering the default→`skip_session=True` and `--assisted`→`skip_session=False` dispatch.

## Decision note

The issue's proposed approach #1 is "end with the existing next-steps block (`agentwire portal start` → open URL)". I followed that exactly — the wizard prints the reachable URL and the start command rather than auto-launching a long-running portal process at the end of init (untested, riskier, and a larger behavioral change than the issue scopes). README Quick Start already matches this flow.

## Verification

- `uv run --extra dev pytest tests/unit/test_init_command.py -q` → 2 passed.
- `uv run --extra dev ruff check agentwire/__main__.py agentwire/onboarding.py tests/unit/test_init_command.py` → All checks passed.
- Did not rebuild/restart the main install (worktree session).

Closes #493

Built by [dotdev.dev](https://dotdev.dev)