### PR TITLE
Harden remote-access edges: auth lockout, plaintext-bind refusal, SSH probe trust (#498)

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -70,6 +70,10 @@ class ServerConfig:
     # None = use ~/.agentwire/portal.token (auto-generated). "" = auth
     # disabled (loopback binds only). Any other string = explicit override.
     auth_token: Optional[str] = None
+    # Acknowledge a plaintext (non-TLS) bind on a network-reachable host: the
+    # bearer token then transits in cleartext. Required to start a non-loopback
+    # bind without TLS — the BYO-tunnel case where the tunnel terminates TLS.
+    allow_insecure: bool = False
 
 
 @dataclass
@@ -585,6 +589,7 @@ def _dict_to_config(data: dict) -> Config:
         allowed_origins=server_data.get("allowed_origins") or [],
         # "" (explicit disable) must survive — don't collapse it to None.
         auth_token=server_data.get("auth_token"),
+        allow_insecure=bool(server_data.get("allow_insecure", False)),
     )
 
     # Projects

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -28,8 +28,9 @@ import ipaddress
 import logging
 import re
 import secrets
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 from urllib.parse import urlsplit
 
 import yaml
@@ -144,17 +145,39 @@ def is_loopback_host(host: str) -> bool:
 
 
 def validate_startup_security(config) -> None:
-    """Refuse non-loopback binds without an auth token.
+    """Refuse unsafe non-loopback binds.
+
+    Two guards, both only apply when the bind host is reachable from the network:
+
+    1. **No auth token** — refuse always (the portal would be wide open).
+    2. **Plaintext transport** — when TLS is off, the bearer token rides the wire
+       in cleartext (``Authorization: Bearer <token>``). Refuse unless the
+       operator explicitly opts in with ``server.allow_insecure: true`` (the BYO
+       reverse-tunnel case, where the tunnel terminates TLS and connects to the
+       portal locally).
 
     Call after ``ensure_auth_token()`` has populated config.server.auth_token.
     """
-    if not is_loopback_host(config.server.host) and not config.server.auth_token:
+    if is_loopback_host(config.server.host):
+        return
+    if not config.server.auth_token:
         raise SystemExit(
             f"Refusing to start: server.host is {config.server.host!r} (reachable "
             "from the network) but portal auth is disabled (server.auth_token: \"\" "
             "in config). Either remove auth_token from config to use the generated "
             "token, run `agentwire portal token --rotate` to create one, or bind "
             "to 127.0.0.1."
+        )
+    if not config.server.ssl.enabled and not getattr(
+        config.server, "allow_insecure", False
+    ):
+        raise SystemExit(
+            f"Refusing to start: server.host is {config.server.host!r} (reachable "
+            "from the network) but TLS is not configured, so the auth token would "
+            "transit the network in cleartext (Authorization: Bearer ...). Either "
+            "configure server.ssl.cert/key, bind to 127.0.0.1, or — if a reverse "
+            "tunnel terminates TLS in front of the portal — set "
+            "server.allow_insecure: true to acknowledge the plaintext local bind."
         )
 
 
@@ -320,13 +343,72 @@ def resolve_device(provided: Optional[str], auth_token: Optional[str]) -> Option
     return devices_mod.load_registry_cached().resolve(provided)
 
 
-def create_security_middleware(auth_token: Optional[str], allowed_origins: list):
+# ---------------------------------------------------------------------------
+# Auth-failure tracking + lockout (gap #5)
+
+# A token-spray against an internet-exposed portal must not be invisible. We log
+# every rejected credential and count failures per source IP over a sliding
+# window; once a non-loopback IP crosses the threshold it is locked out (429)
+# for the rest of the window and the owner is notified once. Loopback is never
+# counted or locked — local dev/CLI/MCP/hooks fail-and-retry freely.
+AUTH_FAIL_WINDOW = 300.0  # seconds
+AUTH_FAIL_LOCKOUT = 10    # failures within the window before an IP is locked out
+
+
+class AuthFailureTracker:
+    """Sliding-window per-IP auth-failure counter with lockout.
+
+    ``record`` appends a failure and returns the count in the current window;
+    ``is_locked`` reports whether an IP has reached the lockout threshold. State
+    is pruned lazily so the dict can't grow unbounded.
+    """
+
+    def __init__(self, threshold: int = AUTH_FAIL_LOCKOUT, window: float = AUTH_FAIL_WINDOW):
+        self.threshold = threshold
+        self.window = window
+        self._fails: dict[str, list[float]] = {}
+
+    def _live(self, ip: str, now: float) -> list[float]:
+        cutoff = now - self.window
+        return [t for t in self._fails.get(ip, []) if t > cutoff]
+
+    def is_locked(self, ip: str, *, now: Optional[float] = None) -> bool:
+        now = time.monotonic() if now is None else now
+        return len(self._live(ip, now)) >= self.threshold
+
+    def record(self, ip: str, *, now: Optional[float] = None) -> int:
+        """Record a failure for ``ip``; return its failure count in the window."""
+        now = time.monotonic() if now is None else now
+        cutoff = now - self.window
+        # Prune every IP's stale timestamps, then drop emptied buckets, so the
+        # dict can't grow unbounded under a spray from many one-off source IPs.
+        pruned = {
+            k: kept
+            for k, ts in self._fails.items()
+            if (kept := [t for t in ts if t > cutoff])
+        }
+        live = pruned.get(ip, [])
+        live.append(now)
+        pruned[ip] = live
+        self._fails = pruned
+        return len(live)
+
+
+def create_security_middleware(
+    auth_token: Optional[str],
+    allowed_origins: list,
+    on_lockout: Optional[Callable[[str, int], None]] = None,
+):
     """Build the aiohttp middleware enforcing origin + per-device token auth.
 
     ``auth_token`` is the bootstrap credential. Auth is enforced whenever it is
     set *or* the registry holds an active paired device; a loopback dev portal
     with neither configured stays open (origin checks still cover the browser).
+
+    ``on_lockout(ip, failures)`` is invoked once when a non-loopback IP first
+    crosses the failure threshold — wire it to the owner-notification path.
     """
+    tracker = AuthFailureTracker()
 
     @web.middleware
     async def security_middleware(request: web.Request, handler):
@@ -346,9 +428,35 @@ def create_security_middleware(auth_token: Optional[str], allowed_origins: list)
             devices_mod.load_registry_cached().active()
         )
         if auth_enabled and not _is_public_path(request):
+            ip = request.remote or "?"
+            # Loopback callers (CLI/MCP/hooks/local dev) are exempt from the
+            # spray lockout so a bad local token never wedges the dev portal.
+            countable = not is_loopback_host(ip)
+            if countable and tracker.is_locked(ip):
+                logger.warning(
+                    "Locked out %s %s from %s (too many auth failures)",
+                    request.method, request.path, ip,
+                )
+                raise web.HTTPTooManyRequests(
+                    text="Too many failed auth attempts — try again later.",
+                )
             provided = _extract_token(request, is_ws)
             device = resolve_device(provided, auth_token)
             if device is None:
+                failures = tracker.record(ip) if countable else 0
+                logger.warning(
+                    "Rejected %s %s: invalid auth token from %s (failures: %d)",
+                    request.method, request.path, ip, failures,
+                )
+                if countable and failures >= tracker.threshold:
+                    if on_lockout is not None:
+                        try:
+                            on_lockout(ip, failures)
+                        except Exception:
+                            logger.exception("auth-lockout notification failed")
+                    raise web.HTTPTooManyRequests(
+                        text="Too many failed auth attempts — try again later.",
+                    )
                 raise web.HTTPUnauthorized(
                     text="Missing or invalid auth token",
                     headers={"WWW-Authenticate": 'Bearer realm="agentwire"'},

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -34,7 +34,7 @@ import jinja2
 import yaml
 from aiohttp import web
 
-from . import prompt_router
+from . import prompt_router, security
 from .cached_status import CachedStatusChecker
 from .config import Config, load_config
 from .security import (
@@ -224,7 +224,9 @@ class AgentWireServer:
         self.app = web.Application(
             middlewares=[
                 create_security_middleware(
-                    config.server.auth_token, config.server.allowed_origins
+                    config.server.auth_token,
+                    config.server.allowed_origins,
+                    on_lockout=self._on_auth_lockout,
                 )
             ]
         )
@@ -1053,6 +1055,37 @@ class AgentWireServer:
         # Drop IP buckets that pruned to empty so the dict can't grow unbounded.
         self._pair_attempts = {k: v for k, v in self._pair_attempts.items() if v}
         return True
+
+    def _on_auth_lockout(self, ip: str, failures: int) -> None:
+        """Owner-notify when an IP is locked out for auth-token spraying (#498).
+
+        The security middleware calls this synchronously on the lockout-crossing;
+        send_email blocks (HTTP to Resend), so offload it to a thread to keep the
+        event loop responsive. Best-effort — a failed email never wedges auth.
+        """
+        import socket as _socket
+
+        def _send() -> None:
+            try:
+                from .channels.email import send_email
+
+                send_email(
+                    subject=f"[agentwire] portal auth lockout: {ip}",
+                    body=(
+                        f"The portal on `{_socket.gethostname()}` locked out "
+                        f"`{ip}` after {failures} failed auth attempts within "
+                        f"{int(security.AUTH_FAIL_WINDOW)}s — possible token spray "
+                        "against an exposed portal. Further requests from that IP "
+                        "are rejected with 429 until the window clears."
+                    ),
+                )
+            except Exception:
+                logger.exception("auth-lockout owner email failed")
+
+        try:
+            asyncio.get_running_loop().run_in_executor(None, _send)
+        except RuntimeError:
+            _send()
 
     async def api_pair(self, request: web.Request) -> web.Response:
         """Redeem a pairing code for a freshly-minted device token (#423).

--- a/agentwire/tunnels.py
+++ b/agentwire/tunnels.py
@@ -334,7 +334,10 @@ def test_ssh_connectivity(host: str, user: Optional[str] = None, timeout: int = 
                 "ssh",
                 *ssh_base_opts(),
                 "-o", f"ConnectTimeout={timeout}",
-                "-o", "StrictHostKeyChecking=accept-new",
+                # Do NOT TOFU-accept unknown host keys (was accept-new): an
+                # unrecognised host is treated as unreachable, not silently
+                # trusted. Hosts must be in known_hosts to probe as healthy.
+                "-o", "StrictHostKeyChecking=yes",
                 "-o", "BatchMode=yes",
                 target,
                 "echo ok",
@@ -366,12 +369,19 @@ def test_service_health(url: str, timeout: int = 5) -> tuple[bool, Optional[str]
     import ssl
     import urllib.error
     import urllib.request
+    from urllib.parse import urlparse
+
+    from .security import is_loopback_host
 
     try:
-        # Create SSL context that accepts self-signed certs
         ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        # Only disable TLS verification for loopback targets (self-signed local
+        # dev certs). Remote health URLs get full certificate + hostname
+        # verification — no blanket CERT_NONE (CWE-295).
+        host = urlparse(url).hostname or ""
+        if is_loopback_host(host):
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
 
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=timeout, context=ctx) as response:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
+from aiohttp import web
 
 from agentwire import security
 from agentwire.config import load_config
@@ -129,10 +130,11 @@ class TestTokenLifecycle:
 
 
 class TestValidateStartupSecurity:
-    def _config(self, tmp_path, host, auth_token):
+    def _config(self, tmp_path, host, auth_token, allow_insecure=False):
         config = load_config(tmp_path / "nonexistent.yaml")
         config.server.host = host
         config.server.auth_token = auth_token
+        config.server.allow_insecure = allow_insecure
         return config
 
     def test_non_loopback_without_token_refuses(self, tmp_path):
@@ -140,13 +142,61 @@ class TestValidateStartupSecurity:
         with pytest.raises(SystemExit):
             security.validate_startup_security(config)
 
-    def test_non_loopback_with_token_passes(self, tmp_path):
+    def test_non_loopback_plaintext_refuses(self, tmp_path):
+        # Token set, but no TLS and no opt-in: token would transit in cleartext.
         config = self._config(tmp_path, "0.0.0.0", "tok")
+        with pytest.raises(SystemExit, match="cleartext"):
+            security.validate_startup_security(config)
+
+    def test_non_loopback_plaintext_with_optin_passes(self, tmp_path):
+        config = self._config(tmp_path, "0.0.0.0", "tok", allow_insecure=True)
         security.validate_startup_security(config)
 
     def test_loopback_without_token_passes(self, tmp_path):
         config = self._config(tmp_path, "127.0.0.1", None)
         security.validate_startup_security(config)
+
+    def test_loopback_plaintext_passes(self, tmp_path):
+        # Local dev: plaintext loopback bind must never be refused.
+        config = self._config(tmp_path, "127.0.0.1", "tok")
+        security.validate_startup_security(config)
+
+
+# ---------------------------------------------------------------------------
+# Auth-failure tracking + lockout (gap #5)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFailureTracker:
+    def test_records_and_counts_within_window(self):
+        t = security.AuthFailureTracker(threshold=3, window=100.0)
+        assert t.record("1.2.3.4", now=0.0) == 1
+        assert t.record("1.2.3.4", now=1.0) == 2
+        assert not t.is_locked("1.2.3.4", now=1.0)
+        assert t.record("1.2.3.4", now=2.0) == 3
+        assert t.is_locked("1.2.3.4", now=2.0)
+
+    def test_window_slides(self):
+        t = security.AuthFailureTracker(threshold=2, window=100.0)
+        t.record("1.2.3.4", now=0.0)
+        t.record("1.2.3.4", now=1.0)
+        assert t.is_locked("1.2.3.4", now=1.0)
+        # Old failures age out of the window.
+        assert not t.is_locked("1.2.3.4", now=200.0)
+
+    def test_per_ip_isolation(self):
+        t = security.AuthFailureTracker(threshold=2, window=100.0)
+        t.record("1.1.1.1", now=0.0)
+        t.record("1.1.1.1", now=1.0)
+        assert t.is_locked("1.1.1.1", now=1.0)
+        assert not t.is_locked("2.2.2.2", now=1.0)
+
+    def test_empty_buckets_pruned(self):
+        t = security.AuthFailureTracker(threshold=5, window=10.0)
+        t.record("1.1.1.1", now=0.0)
+        # A later record on a different IP prunes the now-stale first bucket.
+        t.record("2.2.2.2", now=100.0)
+        assert "1.1.1.1" not in t._fails
 
 
 # ---------------------------------------------------------------------------
@@ -267,3 +317,58 @@ class TestResolveDevice:
         resolved = security.resolve_device(token, auth_token="boot")
         assert resolved is not None
         assert resolved.id == device.id
+
+
+# ---------------------------------------------------------------------------
+# Middleware lockout behaviour (gap #5)
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareLockout:
+    """Drive the middleware directly: bad tokens log, count, and eventually 429."""
+
+    def _request(self, remote, token="badtoken"):
+        # Minimal stand-in: the middleware only reads method/path/headers/remote
+        # and item-assigns request["device"] on success (never hit here).
+        class _Req(dict):
+            pass
+
+        req = _Req()
+        req.method = "GET"
+        req.path = "/api/sessions"
+        req.headers = {"Authorization": f"Bearer {token}"}
+        req.remote = remote
+        return req
+
+    async def _handler(self, request):
+        return web.Response(text="ok")
+
+    async def test_spray_locks_out_and_notifies(self, monkeypatch):
+        monkeypatch.setattr(security, "resolve_device", lambda *a, **k: None)
+        locked = []
+        mw = security.create_security_middleware(
+            "secret", [], on_lockout=lambda ip, n: locked.append((ip, n))
+        )
+        # First AUTH_FAIL_LOCKOUT-1 failures are 401; the threshold crossing is 429.
+        for _ in range(security.AUTH_FAIL_LOCKOUT - 1):
+            with pytest.raises(web.HTTPUnauthorized):
+                await mw(self._request("9.9.9.9"), self._handler)
+        with pytest.raises(web.HTTPTooManyRequests):
+            await mw(self._request("9.9.9.9"), self._handler)
+        assert locked == [("9.9.9.9", security.AUTH_FAIL_LOCKOUT)]
+        # Subsequent requests stay locked out (429) without re-notifying.
+        with pytest.raises(web.HTTPTooManyRequests):
+            await mw(self._request("9.9.9.9"), self._handler)
+        assert len(locked) == 1
+
+    async def test_loopback_never_locked_out(self, monkeypatch):
+        monkeypatch.setattr(security, "resolve_device", lambda *a, **k: None)
+        locked = []
+        mw = security.create_security_middleware(
+            "secret", [], on_lockout=lambda ip, n: locked.append(ip)
+        )
+        # Far more than the threshold from loopback: always 401, never 429.
+        for _ in range(security.AUTH_FAIL_LOCKOUT + 5):
+            with pytest.raises(web.HTTPUnauthorized):
+                await mw(self._request("127.0.0.1"), self._handler)
+        assert locked == []

--- a/tests/unit/test_tunnels_probe.py
+++ b/tests/unit/test_tunnels_probe.py
@@ -1,0 +1,73 @@
+"""Unit tests for the SSH/service probe trust model (issue #498, gap #3).
+
+`test_ssh_connectivity` must not TOFU-accept unknown host keys, and
+`test_service_health` must only disable TLS verification for loopback targets.
+"""
+
+import ssl
+
+from agentwire import tunnels
+
+
+class _Result:
+    success = True
+
+
+class TestSshConnectivityHostKeys:
+    def test_rejects_unknown_host_keys(self, monkeypatch):
+        captured = {}
+
+        def fake_run_command(cmd, timeout=None):
+            captured["cmd"] = cmd
+            return _Result()
+
+        monkeypatch.setattr(tunnels, "run_command", fake_run_command)
+        tunnels.test_ssh_connectivity("example.com", user="me")
+
+        cmd = captured["cmd"]
+        # No silent trust-on-first-use of unknown host keys.
+        assert "StrictHostKeyChecking=accept-new" not in cmd
+        assert "StrictHostKeyChecking=yes" in cmd
+
+
+class _FakeResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class TestServiceHealthTlsVerification:
+    def test_loopback_skips_verification(self, monkeypatch):
+        import urllib.request
+
+        seen = {}
+
+        def fake_urlopen(req, timeout=None, context=None):
+            seen["ctx"] = context
+            return _FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        ok, err = tunnels.test_service_health("https://127.0.0.1:9000/health")
+        assert ok
+        assert seen["ctx"].verify_mode == ssl.CERT_NONE
+        assert seen["ctx"].check_hostname is False
+
+    def test_remote_keeps_verification(self, monkeypatch):
+        import urllib.request
+
+        seen = {}
+
+        def fake_urlopen(req, timeout=None, context=None):
+            seen["ctx"] = context
+            return _FakeResponse()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        ok, err = tunnels.test_service_health("https://example.com/health")
+        assert ok
+        # Remote target: full certificate + hostname verification, no CERT_NONE.
+        assert seen["ctx"].verify_mode == ssl.CERT_REQUIRED
+        assert seen["ctx"].check_hostname is True


### PR DESCRIPTION
## Summary

Closes three defense-in-depth gaps on the remote-access surface (the maintainer's own parked backlog items).

1. **Auth-failure logging + lockout (gap #5).** The portal security middleware previously raised `HTTPUnauthorized` on every bad token with zero side effects — a token-spray was invisible. Now it logs each rejected credential with source IP + path and counts failures per **non-loopback** IP over a 5-minute sliding window (`AuthFailureTracker`). After 10 failures the IP is locked out (`429`) for the rest of the window and the owner is emailed once via the existing Resend path. Loopback callers (CLI/MCP/hooks/local dev) are never counted or locked.

2. **Plaintext non-loopback bind (gap #6).** `validate_startup_security` only refused a non-loopback bind when the token was empty — it never checked TLS, so `host: 0.0.0.0` + token + no certs shipped `Authorization: Bearer <token>` in cleartext. It now refuses such a bind unless the operator opts in with `server.allow_insecure: true` (the BYO-reverse-tunnel case where the tunnel terminates TLS and connects to the portal locally). Loopback binds are unaffected.

3. **SSH probe trust model.** `test_ssh_connectivity` dropped `StrictHostKeyChecking=accept-new` (TOFU) for `=yes` — unknown host keys are treated as unreachable, not silently trusted. `test_service_health` scoped the `CERT_NONE` blanket to loopback targets only; remote health URLs now get full certificate + hostname verification (CWE-295).

## Decisions / notes

- **Opt-in is config-only** (`server.allow_insecure: true`), not a `--insecure` CLI flag — smallest reasonable change; the issue suggested either.
- Lockout exempts loopback specifically to **not regress local dev** (a wrong local token retries freely).
- Lockout state is in-memory per middleware instance (mirrors the existing `_pair_rate_ok` limiter); the owner email is best-effort and offloaded to a thread so it can't block the event loop.

## Verification

- `uv run --extra dev pytest tests/unit/test_security.py tests/unit/test_tunnels_probe.py tests/unit/test_portal_api.py tests/unit/test_server_async.py` → **158 passed**.
- New tests cover: tracker windowing/per-IP isolation/bucket pruning, middleware spray→429 + owner-notify-once + loopback exemption, plaintext-refusal + opt-in startup paths, SSH `StrictHostKeyChecking=yes` flag, and per-target TLS verification (loopback `CERT_NONE` vs remote `CERT_REQUIRED`).
- `uv run --extra dev ruff check` on all changed files → **All checks passed**.

Closes #498

Built by [dotdev.dev](https://dotdev.dev)