### PR TITLE
perf(portal): capture session output in-process, drop per-session CLI subprocess

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1839,13 +1839,23 @@ class AgentWireServer:
     async def monitor_all_sessions(self):
         """Background task to monitor all session activity for dashboard indicators.
 
-        Polls tmux output for all sessions and broadcasts activity state changes.
+        Single source of truth for the dashboard's per-session activity dots:
+        captures every session's output once per tick **in-process** via
+        `self.agent.get_output` (the same `tmux capture-pane` `_poll_output`
+        uses) and broadcasts `session_activity` only on state change. This
+        replaces the previous per-session `agentwire output` subprocess, which
+        re-imported the full CLI on every tick (#489).
+
+        `_poll_output` remains live-streaming only — it does not touch the
+        dashboard activity broadcasts.
         """
         threshold = self.config.server.activity_threshold_seconds
         # Track per-session state: {session_name: {"last_output": str, "last_active": bool}}
         session_states: dict[str, dict] = {}
 
         logger.info(f"[Monitor] Starting session monitor (threshold: {threshold}s)")
+
+        loop = asyncio.get_event_loop()
 
         while True:
             try:
@@ -1869,15 +1879,11 @@ class AgentWireServer:
                 # Poll each session
                 for session_name in session_names:
                     try:
-                        # Get current output
-                        success, output_result = await self.run_agentwire_cmd(
-                            ["output", "-s", session_name, "-n", "50"]
+                        # Capture output in-process (no subprocess / CLI re-import).
+                        current_output = await loop.run_in_executor(
+                            None,
+                            lambda n=session_name: self.agent.get_output(n, lines=50),
                         )
-
-                        if not success:
-                            continue
-
-                        current_output = output_result.get("output", "")
 
                         # Initialize state for new sessions
                         if session_name not in session_states:

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1,12 +1,13 @@
 """Integration tests for portal API handlers via aiohttp TestClient."""
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 from agentwire.config import load_config
-from agentwire.server import AgentWireServer
+from agentwire.server import AgentWireServer, Session
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1400,3 +1401,77 @@ class TestStaticAssets:
         client, _ = portal_client
         resp = await client.get("/static/does-not-exist.js")
         assert resp.status == 404
+
+
+class TestMonitorInProcessCapture:
+    """#489 — the monitor captures session output IN-PROCESS via
+    agent.get_output instead of spawning a per-session `agentwire output`
+    subprocess, while still broadcasting dashboard activity for every session."""
+
+    def _server(self, tmp_path):
+        server = AgentWireServer(_make_config(tmp_path))
+        server.agent = MagicMock()
+        server.agent.get_output = MagicMock(return_value="scrollback")
+        return server
+
+    async def _run_one_tick(self, server):
+        task = asyncio.create_task(server.monitor_all_sessions())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_captures_in_process_no_output_subprocess(self, tmp_path):
+        server = self._server(tmp_path)
+
+        cli_calls = []
+
+        async def fake_cmd(args):
+            cli_calls.append(args)
+            if args[:1] == ["list"] and "--local" in args:
+                return True, {"sessions": [{"name": "alpha"}, {"name": "beta"}]}
+            return True, {"sessions": []}
+
+        server.run_agentwire_cmd = AsyncMock(side_effect=fake_cmd)
+        server.broadcast_dashboard = AsyncMock()
+
+        await self._run_one_tick(server)
+
+        # Output captured in-process for every listed session...
+        captured = {c.args[0] for c in server.agent.get_output.call_args_list}
+        assert {"alpha", "beta"} <= captured
+        # ...and NEVER via an `agentwire output` subprocess.
+        assert not any(a[:1] == ["output"] for a in cli_calls), cli_calls
+
+    async def test_dashboard_activity_broadcast_for_all_sessions(self, tmp_path):
+        """A session with fresh output gets active:true on the dashboard,
+        whether or not it has an open window (single source = the monitor)."""
+        server = self._server(tmp_path)
+        # Distinct output per session so each registers a change → active.
+        server.agent.get_output = MagicMock(
+            side_effect=lambda name, lines=50: f"output-for-{name}"
+        )
+
+        async def fake_cmd(args):
+            if args[:1] == ["list"] and "--local" in args:
+                return True, {"sessions": [{"name": "watched"}, {"name": "headless"}]}
+            return True, {"sessions": []}
+
+        server.run_agentwire_cmd = AsyncMock(side_effect=fake_cmd)
+        server.broadcast_dashboard = AsyncMock()
+
+        # "watched" has an open window; "headless" does not. Both must broadcast.
+        sess = Session(name="watched", config=server._get_session_config("watched"))
+        sess.clients.add(object())
+        server.active_sessions["watched"] = sess
+
+        await self._run_one_tick(server)
+
+        active = {
+            c.args[1]["session"]
+            for c in server.broadcast_dashboard.call_args_list
+            if c.args[0] == "session_activity" and c.args[1].get("active") is True
+        }
+        assert {"watched", "headless"} <= active


### PR DESCRIPTION
## Summary

Lands the valuable, well-bounded part of #489: the portal's always-on `monitor_all_sessions` loop no longer spawns an `agentwire output -s <name>` **subprocess per session every 500ms** (each re-importing the 12k-line CLI module). It now captures each session's output **in-process** via `self.agent.get_output` — the same `tmux capture-pane` call `_poll_output` already uses — run in the executor.

### Change (`agentwire/server.py`)
- `monitor_all_sessions`: per-session `run_agentwire_cmd(["output", ...])` → `self.agent.get_output(name, lines=50)` in the executor. The 2 `list` calls per tick (needed for session-close detection) are unchanged.
- The monitor remains the **single source of truth** for the dashboard's per-session activity dots, for watched and headless sessions alike — exactly as on `main`. `_poll_output` is live-streaming only.

**Net behavioral change vs `main`: only the subprocess → in-process capture swap.** Activity-broadcast semantics are untouched.

### Deferred to a follow-up
The issue's second sub-goal — *stop double-polling sessions that already have an open window* (have `_poll_output` own watched sessions, skip them in the monitor) — was implemented and then reverted in this PR: moving ownership of dashboard activity between the two loops produced a string of edge-case regressions in the activity dot (idle not clearing, takeover blips, lost-recency). It needs a cleaner design (one owner, no hand-off mid-stream) and will land separately. The subprocess elimination here is independent and is the real perf win.

## Verification
- `uv run --extra dev ruff check agentwire/server.py tests/unit/test_portal_api.py` → **All checks passed** (required gate).
- `uv run --extra dev pytest tests/unit/test_portal_api.py tests/integration/test_server_websockets.py` → **117 passed**.
- New `TestMonitorInProcessCapture`: asserts the monitor calls `get_output` in-process for every listed session and **never** issues an `agentwire output` subprocess, and that dashboard `session_activity{active:true}` still fires for both a windowed and a headless session.
- Live updates preserved: `_poll_output` is byte-for-byte back to `main`, so the WS output stream is unchanged (existing `test_server_websockets.py` suite still passes).

Did not rebuild or restart the main install (worktree isolation).

Closes #489

Built by [dotdev.dev](https://dotdev.dev)