### PR TITLE
feat(portal): mobile-first Review window — diff + tap-to-approve/deny (#484)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -12589,6 +12589,10 @@ Command Categories:
     )
     l_uninstall.set_defaults(func=limits_cli.cmd_limits_uninstall)
 
+    # === diff command (structured git diff for the mobile Review window) ===
+    from . import diff_cli
+    diff_cli.register_diff_parser(subparsers)
+
     # === prompts command group (prompt routing, rides the limits watchdog) ===
     from . import prompts_cli
     prompts_cli.register_prompts_parser(subparsers)

--- a/agentwire/diff_cli.py
+++ b/agentwire/diff_cli.py
@@ -1,0 +1,236 @@
+"""CLI for the mobile Review window — ``agentwire diff -s <session>``.
+
+The portal's "Review" WinBox window shows what an agent changed and lets a
+human tap Approve / Request-changes on a phone. Per the CLAUDE.md SSOT rule,
+the diff itself is computed here in the CLI; the MCP tool and the portal are
+thin wrappers that parse this command's ``--json`` output.
+
+Output shape (``--json``)::
+
+    {
+      "success": true,
+      "session": "...",
+      "path": "/abs/worktree/path",
+      "base": "HEAD" | "origin/main" | "<ref>",
+      "files": [
+        {
+          "path": "b/path", "old_path": "a/path",
+          "status": "modified|added|deleted|renamed|binary",
+          "additions": N, "deletions": M, "binary": false,
+          "hunks": [
+            {"header": "@@ ... @@", "section": "func foo()",
+             "lines": [{"type": "context|add|del", "content": "...",
+                        "old_n": 12, "new_n": 12}]}
+          ]
+        }
+      ],
+      "additions": N, "deletions": M, "truncated": false
+    }
+
+Base resolution (no ``--base``): if the worktree has uncommitted changes the
+diff is vs ``HEAD`` (what the agent just did, not yet committed); otherwise it
+is vs ``origin/main`` (a worktree-session's committed branch work). The portal
+relies on this so a phone review needs zero flags.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+# Keep the JSON payload (and the phone DOM that renders it) bounded. A diff
+# this large is better reviewed at a desk anyway.
+MAX_DIFF_LINES = 4000
+
+_HUNK_RE = re.compile(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)")
+_GIT_HEADER_RE = re.compile(r"diff --git a/(.*) b/(.*)")
+
+
+def _resolve_path(session: str) -> "Path | None":
+    """The session's working directory — same resolver the rest of the CLI uses."""
+    from .__main__ import _get_session_project_path
+
+    return _get_session_project_path(session)
+
+
+def _run_git(path: Path, args: list[str], timeout: int = 15) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _has_uncommitted(path: Path) -> bool:
+    result = _run_git(path, ["status", "--porcelain"])
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _resolve_base(path: Path, explicit: "str | None") -> str:
+    if explicit:
+        return explicit
+    if _has_uncommitted(path):
+        return "HEAD"
+    if _run_git(path, ["rev-parse", "--verify", "--quiet", "origin/main"]).returncode == 0:
+        return "origin/main"
+    return "HEAD"
+
+
+def parse_unified_diff(text: str, max_lines: int = MAX_DIFF_LINES) -> "tuple[list[dict], bool]":
+    """Parse ``git diff --no-color`` output into structured per-file hunks."""
+    lines = text.split("\n")
+    truncated = False
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        truncated = True
+
+    files: list[dict] = []
+    cur: "dict | None" = None
+    hunk: "dict | None" = None
+    old_n = new_n = 0
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            cur = {
+                "path": None,
+                "old_path": None,
+                "status": "modified",
+                "additions": 0,
+                "deletions": 0,
+                "binary": False,
+                "hunks": [],
+            }
+            files.append(cur)
+            hunk = None
+            m = _GIT_HEADER_RE.match(line)
+            if m:
+                cur["old_path"] = m.group(1)
+                cur["path"] = m.group(2)
+            continue
+        if cur is None:
+            continue
+        if line.startswith("new file"):
+            cur["status"] = "added"
+            continue
+        if line.startswith("deleted file"):
+            cur["status"] = "deleted"
+            continue
+        if line.startswith("rename from "):
+            cur["old_path"] = line[len("rename from "):]
+            cur["status"] = "renamed"
+            continue
+        if line.startswith("rename to "):
+            cur["path"] = line[len("rename to "):]
+            cur["status"] = "renamed"
+            continue
+        if line.startswith("Binary files"):
+            cur["binary"] = True
+            cur["status"] = "binary"
+            continue
+        if line.startswith("--- "):
+            continue
+        if line.startswith("+++ "):
+            p = line[4:]
+            if p.startswith("b/"):
+                cur["path"] = p[2:]
+            continue
+        if line.startswith("@@"):
+            m = _HUNK_RE.match(line)
+            old_n = int(m.group(1)) if m else 0
+            new_n = int(m.group(2)) if m else 0
+            hunk = {"header": line, "section": (m.group(3).strip() if m else ""), "lines": []}
+            cur["hunks"].append(hunk)
+            continue
+        if hunk is None:
+            continue
+        if line.startswith("+"):
+            hunk["lines"].append({"type": "add", "content": line[1:], "new_n": new_n})
+            new_n += 1
+            cur["additions"] += 1
+        elif line.startswith("-"):
+            hunk["lines"].append({"type": "del", "content": line[1:], "old_n": old_n})
+            old_n += 1
+            cur["deletions"] += 1
+        elif line.startswith("\\"):
+            continue  # "\ No newline at end of file"
+        else:
+            content = line[1:] if line.startswith(" ") else line
+            hunk["lines"].append(
+                {"type": "context", "content": content, "old_n": old_n, "new_n": new_n}
+            )
+            old_n += 1
+            new_n += 1
+
+    return files, truncated
+
+
+def _emit_error(json_mode: bool, message: str) -> int:
+    if json_mode:
+        print(json.dumps({"success": False, "error": message}))
+    else:
+        print(message)
+    return 1
+
+
+def cmd_diff(args) -> int:
+    """Emit a session's git diff as structured JSON (or a human summary)."""
+    session = args.session
+    json_mode = getattr(args, "json", False)
+
+    path = _resolve_path(session)
+    if path is None or not path.exists():
+        return _emit_error(
+            json_mode, f"Could not resolve a working directory for session '{session}'"
+        )
+    if _run_git(path, ["rev-parse", "--git-dir"]).returncode != 0:
+        return _emit_error(json_mode, f"{path} is not a git repository")
+
+    base = _resolve_base(path, getattr(args, "base", None))
+    result = _run_git(path, ["diff", "--no-color", base])
+    if result.returncode != 0:
+        return _emit_error(json_mode, result.stderr.strip() or "git diff failed")
+
+    files, truncated = parse_unified_diff(result.stdout)
+    additions = sum(f["additions"] for f in files)
+    deletions = sum(f["deletions"] for f in files)
+    payload = {
+        "success": True,
+        "session": session,
+        "path": str(path),
+        "base": base,
+        "files": files,
+        "additions": additions,
+        "deletions": deletions,
+        "truncated": truncated,
+    }
+
+    if json_mode:
+        print(json.dumps(payload))
+        return 0
+
+    if not files:
+        print(f"No changes vs {base}")
+        return 0
+    for f in files:
+        print(f"{f['status'][:3].upper():3}  {f['path']}  +{f['additions']} -{f['deletions']}")
+    print(f"\n{len(files)} file(s) changed vs {base}  (+{additions} -{deletions})")
+    if truncated:
+        print(f"[diff truncated at {MAX_DIFF_LINES} lines]")
+    return 0
+
+
+def register_diff_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "diff",
+        help="Structured git diff for a session (drives the mobile Review window)",
+    )
+    parser.add_argument("-s", "--session", required=True, help="Session name")
+    parser.add_argument(
+        "--base",
+        help="Diff base ref (default: HEAD if uncommitted changes, else origin/main)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    parser.set_defaults(func=cmd_diff)

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -712,6 +712,44 @@ def session_output(session: str, lines: int = 50) -> str:
 
 
 @mcp.tool()
+def diff(session: str, base: str = "") -> str:
+    """Summarize a session's git diff (what the agent changed).
+
+    Thin wrapper over `agentwire diff`. Use this to review a worktree
+    session's work before approving it. The portal's mobile Review window
+    renders the same data with tap-to-approve controls.
+
+    Args:
+        session: Session name to inspect.
+        base: Diff base ref. Empty = HEAD if there are uncommitted changes,
+            else origin/main (a worktree-session's committed branch work).
+
+    Returns:
+        A per-file summary of additions/deletions, or "No changes".
+    """
+    args = ["diff", "-s", session]
+    if base:
+        args += ["--base", base]
+    data = run_agentwire_cmd(args)
+    if not data.get("success"):
+        return f"Failed to get diff: {data.get('error', 'Unknown error')}"
+    files = data.get("files", [])
+    if not files:
+        return f"No changes vs {data.get('base')}."
+    lines = [
+        f"Diff vs {data.get('base')} "
+        f"(+{data.get('additions')} -{data.get('deletions')}):"
+    ]
+    for f in files:
+        lines.append(
+            f"  {f['status']}: {f['path']} (+{f['additions']} -{f['deletions']})"
+        )
+    if data.get("truncated"):
+        lines.append("  … diff truncated (review at a desk)")
+    return "\n".join(lines)
+
+
+@mcp.tool()
 def session_info(session: str) -> str:
     """Get detailed information about a session.
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -274,6 +274,9 @@ class AgentWireServer:
         self.app.router.add_get("/api/sessions/{name:.+}/connections", self.api_session_connections)
         self.app.router.add_post("/api/local-tts/{name:.+}", self.api_local_tts)
         self.app.router.add_post("/api/answer/{name:.+}", self.api_answer)
+        # Mobile Review window: structured diff + tap-to-approve/deny
+        self.app.router.add_get("/api/review/{name:.+}", self.api_review)
+        self.app.router.add_post("/api/review/{name:.+}/answer", self.api_review_answer)
         self.app.router.add_post("/api/session/{name:.+}/recreate", self.api_recreate_session)
         self.app.router.add_post("/api/session/{name:.+}/spawn-sibling", self.api_spawn_sibling)
         self.app.router.add_post("/api/session/{name:.+}/fork", self.api_fork_session)
@@ -4440,6 +4443,83 @@ projects:
         except Exception as e:
             logger.error(f"Answer API failed: {e}")
             return web.json_response({"error": str(e)}, status=500)
+
+    def _live_prompt(self, session: str, pane: int = 0) -> "dict | None":
+        """The live interactive prompt on a pane, shaped for the Review window.
+
+        Returns kind/question/options plus the ``expect`` hash the guarded
+        answer path needs. Prefers the router marker's hash when present (hook-
+        routed permission prompts carry a payload-derived hash that can't be
+        recomputed from the screen; ``prompt_router.answer`` bridges it), else
+        the screen-derived content hash.
+        """
+        visible = prompt_router._capture(f"{session}.{pane}")
+        info = prompt_router.detect_prompt(visible)
+        if info is None:
+            return None
+        marker = prompt_router.read_marker(session, pane)
+        expect = (marker or {}).get("hash") or info.content_hash()
+        return {
+            "kind": info.kind,
+            "question": info.question,
+            "summary": info.summary,
+            "options": info.options,
+            "expect": expect,
+            "pane": pane,
+        }
+
+    async def api_review(self, request: web.Request) -> web.Response:
+        """GET /api/review/{session} — structured diff + any live prompt."""
+        name = request.match_info["name"]
+        ok, diff = await self.run_agentwire_cmd(["diff", "-s", name])
+        if not ok:
+            return web.json_response(
+                {"error": diff.get("error", "Failed to load diff")}, status=502
+            )
+        try:
+            prompt = await asyncio.get_event_loop().run_in_executor(
+                None, self._live_prompt, name
+            )
+        except Exception as e:
+            logger.warning(f"[{name}] Review prompt detection failed: {e}")
+            prompt = None
+        return web.json_response({"success": True, "diff": diff, "prompt": prompt})
+
+    async def api_review_answer(self, request: web.Request) -> web.Response:
+        """POST /api/review/{session}/answer — approve/deny the live prompt.
+
+        Drives the existing guarded compare-and-send path so a stale tap (the
+        prompt already answered, or a different one now live) is a safe no-op.
+        Approve selects option 1 (allow / proceed); deny sends Escape, which
+        cancels a permission, plan, or question dialog.
+        """
+        name = request.match_info["name"]
+        try:
+            data = await request.json()
+            decision = (data.get("decision") or "").strip().lower()
+            expect = (data.get("expect") or "").strip()
+            pane = int(data.get("pane", 0) or 0)
+        except (ValueError, TypeError):
+            return web.json_response({"error": "Invalid request body"}, status=400)
+
+        if decision not in ("approve", "deny"):
+            return web.json_response(
+                {"error": "decision must be 'approve' or 'deny'"}, status=400
+            )
+        if not expect:
+            return web.json_response({"error": "Missing 'expect' hash"}, status=400)
+
+        keys = ["1"] if decision == "approve" else ["Escape"]
+        try:
+            ok, message = await asyncio.get_event_loop().run_in_executor(
+                None, prompt_router.answer, name, pane, expect, keys
+            )
+        except Exception as e:
+            logger.error(f"[{name}] Review answer failed: {e}")
+            return web.json_response({"error": str(e)}, status=500)
+
+        status = 200 if ok else 409
+        return web.json_response({"success": ok, "message": message}, status=status)
 
     async def api_permission_request(self, request: web.Request) -> web.Response:
         """POST /api/permission/{session} - Handle permission request from Claude Code hook.

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -3937,6 +3937,199 @@ body .winbox.max {
 }
 
 /* ============================================
+   Review Window (mobile-first diff + approve/deny)
+   ============================================ */
+
+.review-window .wb-body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.review-window-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    background: var(--background);
+    color: var(--text);
+}
+
+.review-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--chrome-border);
+    flex: 0 0 auto;
+}
+
+.review-session {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 45%;
+}
+
+.review-summary {
+    flex: 1;
+    color: var(--text-muted);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.review-btn {
+    background: var(--chrome);
+    color: var(--text);
+    border: 1px solid var(--chrome-border);
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    min-height: 40px;  /* comfortable phone tap target */
+}
+
+.review-btn:hover { background: var(--hover); border-color: var(--accent); }
+.review-refresh { padding: 8px 10px; min-width: 40px; }
+
+.review-body {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+}
+
+.review-loading, .review-empty, .review-error, .review-truncated, .review-binary {
+    padding: 16px;
+    color: var(--text-muted);
+}
+.review-error { color: var(--error); }
+
+.review-file { border-bottom: 1px solid var(--chrome-border); }
+
+.review-file-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px;
+    cursor: pointer;
+    background: var(--chrome);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+.review-file-head:hover { background: var(--hover); }
+
+.review-caret { width: 12px; color: var(--text-muted); }
+
+.review-status {
+    font-size: 10px;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: var(--background);
+    color: var(--text-muted);
+}
+.review-status-added { color: #39ff14; }
+.review-status-deleted { color: var(--error); }
+.review-status-renamed { color: #00bfff; }
+
+.review-file-path {
+    flex: 1;
+    word-break: break-all;
+    font-family: inherit;
+}
+
+.review-file-stat { color: var(--text-muted); white-space: nowrap; }
+
+.review-hunks.hidden { display: none; }
+
+.review-hunk-head {
+    padding: 4px 10px;
+    color: var(--text-muted);
+    background: color-mix(in srgb, var(--chrome) 60%, transparent);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.review-hunk-section { opacity: 0.7; }
+
+.review-line {
+    display: flex;
+    align-items: stretch;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.review-line-add { background: rgba(57, 255, 20, 0.10); }
+.review-line-del { background: rgba(220, 50, 50, 0.12); }
+
+.review-gutter {
+    flex: 0 0 auto;
+    width: 36px;
+    padding: 0 4px;
+    text-align: right;
+    color: var(--text-muted);
+    opacity: 0.6;
+    user-select: none;
+    border-right: 1px solid var(--chrome-border);
+}
+
+.review-code {
+    flex: 1;
+    padding: 0 6px 0 8px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.review-sign { display: inline-block; width: 1ch; opacity: 0.7; }
+
+.review-actions {
+    flex: 0 0 auto;
+    border-top: 1px solid var(--chrome-border);
+    background: var(--chrome);
+    padding: 10px;
+}
+.review-actions.hidden { display: none; }
+
+.review-prompt {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 8px;
+    font-size: 13px;
+}
+.review-prompt-kind {
+    text-transform: uppercase;
+    font-size: 10px;
+    color: var(--text-muted);
+    border: 1px solid var(--chrome-border);
+    border-radius: 3px;
+    padding: 1px 5px;
+}
+.review-prompt-q { color: var(--text); }
+
+.review-action-buttons {
+    display: flex;
+    gap: 10px;
+}
+.review-action-buttons .review-btn {
+    flex: 1;
+    min-height: 48px;  /* big, thumb-friendly */
+    font-size: 16px;
+    font-weight: 600;
+}
+.review-approve { border-color: #39ff14; color: #39ff14; }
+.review-approve:hover { background: rgba(57, 255, 20, 0.12); }
+.review-deny { border-color: var(--error); color: var(--error); }
+.review-deny:hover { background: rgba(220, 50, 50, 0.12); }
+.review-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ============================================
    Scheduler Panel
    ============================================ */
 

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -13,6 +13,7 @@ import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
+import { ReviewWindow } from './review-window.js';
 import { CouncilWindow, COUNCIL_WINDOW_ID } from './council-window.js';
 import { sidebar } from './sidebar.js';
 import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
@@ -39,6 +40,7 @@ import { initAnnouncements } from './announcement-modal.js';
 // State - track open windows
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
 const artifactWindows = new Map();  // artifactId -> ArtifactWindow instance
+const reviewWindows = new Map();  // windowId -> ReviewWindow instance
 let councilWindow = null;  // single CouncilWindow instance (one board at a time)
 
 // Global PTT state
@@ -656,6 +658,50 @@ export function openArtifactWindow(url, title = 'Artifact', artifactId = null) {
 }
 
 /**
+ * Open a mobile-first Review window for a session — diff + tap-to-approve/deny.
+ * Re-opening focuses (and refreshes) the existing window for that session.
+ *
+ * @param {string} session - Session whose diff to review
+ */
+export function openReviewWindow(session) {
+    const id = `review-${session}`;
+    if (reviewWindows.has(id)) {
+        const existing = reviewWindows.get(id);
+        if (existing.isMinimized) {
+            if (!desktop.isTiled(id)) desktop.minimizeAllExcept(id);
+            existing.restore();
+        } else {
+            existing.focus();
+        }
+        existing.refresh();
+        return;
+    }
+
+    desktop.minimizeAllExcept(null);
+
+    const rw = new ReviewWindow({
+        session,
+        windowId: id,
+        root: elements.desktopArea,
+        onClose: () => {
+            reviewWindows.delete(id);
+            removeTaskbarButton(id);
+            unrecordTaskbarEntry(id);
+        },
+        onFocus: () => {
+            updateTaskbarActive(id);
+            desktop.setActiveWindow(id);
+            saveTaskbarState();
+        },
+    });
+
+    rw.open();
+    reviewWindows.set(id, rw);
+    addTaskbarButton(id, rw);
+    recordTaskbarEntry({ kind: 'review', id, session });
+}
+
+/**
  * Open the council workspace window. Registers through the same desktop path as
  * a session window (single-window maximize + taskbar tab), so it opens
  * maximized, appears in the open-sessions area, and is tabbable. Only one board
@@ -760,6 +806,8 @@ function _openByRecord(rec) {
         openArtifactWindow(rec.url, rec.title || 'Artifact', rec.id);
     } else if (rec.kind === 'council') {
         openCouncilWindow(rec.sitting || null);
+    } else if (rec.kind === 'review') {
+        openReviewWindow(rec.session);
     }
 }
 

--- a/agentwire/static/js/review-window.js
+++ b/agentwire/static/js/review-window.js
@@ -1,0 +1,250 @@
+/**
+ * review-window.js
+ *
+ * ReviewWindow — a mobile-first WinBox window that shows a session's git diff
+ * (from `agentwire diff`, via GET /api/review/{session}) as collapsible,
+ * syntax-light hunks, plus an Approve / Request-changes bar that drives the
+ * existing guarded prompt-answer path (POST /api/review/{session}/answer →
+ * prompt_router.answer). One tap approves; the compare-and-send guard makes a
+ * stale tap a safe no-op.
+ */
+
+import { apiFetch } from './api.js';
+import { desktop } from './desktop-manager.js';
+import { toastSuccess, toastError } from './toast.js';
+
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+}
+
+export class ReviewWindow {
+    /**
+     * @param {Object} options
+     * @param {string} options.session - Session whose diff to review
+     * @param {string} options.windowId - Unique window identifier
+     * @param {HTMLElement} options.root - Parent element for WinBox
+     * @param {Function} options.onClose - Callback when window closes
+     * @param {Function} options.onFocus - Callback when window gains focus
+     */
+    constructor(options) {
+        this.session = options.session;
+        this.windowId = options.windowId;
+        this.root = options.root || document.body;
+        this.onCloseCallback = options.onClose || null;
+        this.onFocusCallback = options.onFocus || null;
+
+        this.winbox = null;
+        this.isOpen = false;
+        this._prompt = null;     // live prompt {kind, question, options, expect, pane}
+        this._collapsed = new Set();  // file paths collapsed by the user
+    }
+
+    open() {
+        if (this.isOpen) { this.focus(); return; }
+        const container = this._createContainer();
+        this._createWinBox(container);
+        this.isOpen = true;
+        this.refresh();
+    }
+
+    close() {
+        if (!this.isOpen) return;
+        if (this.winbox) {
+            const wb = this.winbox;
+            this.winbox = null;
+            wb.close();
+        }
+        desktop.unregisterWindow(this.windowId);
+        this.isOpen = false;
+        if (this.onCloseCallback) this.onCloseCallback(this);
+    }
+
+    focus() { if (this.winbox) this.winbox.focus(); }
+    minimize() { if (this.winbox) this.winbox.minimize(); }
+    restore() { if (this.winbox) this.winbox.restore(); }
+    get isMinimized() { return this.winbox ? this.winbox.min : false; }
+
+    _content() {
+        return this.winbox ? this.winbox.body.querySelector('.review-window-content') : null;
+    }
+
+    _createContainer() {
+        const container = document.createElement('div');
+        container.className = 'review-window-content';
+        container.innerHTML = `
+            <div class="review-toolbar">
+                <span class="review-session" title="${esc(this.session)}">${esc(this.session)}</span>
+                <span class="review-summary"></span>
+                <button class="review-btn review-refresh" title="Reload diff">↻</button>
+            </div>
+            <div class="review-body"><div class="review-loading">Loading diff…</div></div>
+            <div class="review-actions hidden"></div>
+        `;
+        container.querySelector('.review-refresh').addEventListener('click', () => this.refresh());
+        container.addEventListener('click', (e) => this._onClick(e));
+        return container;
+    }
+
+    _createWinBox(container) {
+        this.winbox = new WinBox({
+            title: `Review · ${this.session}`,
+            icon: '<span style="font-size:14px">&#x1F50D;</span>',
+            mount: container,
+            root: this.root,
+            width: '80%',
+            height: '80%',
+            x: 'center',
+            y: 'center',
+            minwidth: 300,
+            minheight: 240,
+            class: ['review-window'],
+            onclose: () => { this.winbox = null; this.close(); return false; },
+            onfocus: () => { if (this.onFocusCallback) this.onFocusCallback(this); },
+            onminimize: () => desktop.emit('window_minimized', { id: this.windowId }),
+            onrestore: () => {
+                desktop.emit('window_restored', { id: this.windowId });
+                if (this.onFocusCallback) this.onFocusCallback(this);
+            },
+        });
+        desktop.registerWindow(this.windowId, this.winbox);
+    }
+
+    async refresh() {
+        const content = this._content();
+        if (!content) return;
+        const body = content.querySelector('.review-body');
+        body.innerHTML = '<div class="review-loading">Loading diff…</div>';
+        try {
+            const res = await apiFetch(`/api/review/${encodeURIComponent(this.session)}`);
+            const data = await res.json();
+            if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+            this._prompt = data.prompt || null;
+            this._renderDiff(content, data.diff || {});
+            this._renderActions(content);
+        } catch (e) {
+            body.innerHTML = `<div class="review-error">Failed to load diff: ${esc(e.message)}</div>`;
+        }
+    }
+
+    _renderDiff(content, diff) {
+        const files = diff.files || [];
+        const summary = content.querySelector('.review-summary');
+        summary.textContent = files.length
+            ? `${files.length} file${files.length > 1 ? 's' : ''} · +${diff.additions || 0} −${diff.deletions || 0} · vs ${diff.base || '?'}`
+            : `No changes vs ${diff.base || '?'}`;
+
+        const body = content.querySelector('.review-body');
+        if (!files.length) {
+            body.innerHTML = '<div class="review-empty">Nothing to review — working tree matches the base.</div>';
+            return;
+        }
+        body.innerHTML = files.map((f) => this._renderFile(f)).join('') +
+            (diff.truncated ? '<div class="review-truncated">Diff truncated — review the rest at a desk.</div>' : '');
+    }
+
+    _renderFile(f) {
+        const path = f.path || f.old_path || '(unknown)';
+        const collapsed = this._collapsed.has(path);
+        const renamed = f.status === 'renamed' && f.old_path && f.old_path !== f.path;
+        const title = renamed ? `${esc(f.old_path)} → ${esc(f.path)}` : esc(path);
+        const hunks = f.binary
+            ? '<div class="review-binary">Binary file — no text diff.</div>'
+            : (f.hunks || []).map((h) => this._renderHunk(h)).join('');
+        return `<div class="review-file" data-path="${esc(path)}">
+            <div class="review-file-head" data-action="toggle-file">
+                <span class="review-caret">${collapsed ? '▸' : '▾'}</span>
+                <span class="review-status review-status-${esc(f.status)}">${esc((f.status || '').slice(0, 3))}</span>
+                <span class="review-file-path">${title}</span>
+                <span class="review-file-stat">+${f.additions || 0} −${f.deletions || 0}</span>
+            </div>
+            <div class="review-hunks ${collapsed ? 'hidden' : ''}">${hunks}</div>
+        </div>`;
+    }
+
+    _renderHunk(h) {
+        const rows = (h.lines || []).map((ln) => {
+            const cls = ln.type === 'add' ? 'add' : ln.type === 'del' ? 'del' : 'ctx';
+            const oldN = ln.type === 'add' ? '' : (ln.old_n ?? '');
+            const newN = ln.type === 'del' ? '' : (ln.new_n ?? '');
+            const sign = ln.type === 'add' ? '+' : ln.type === 'del' ? '−' : ' ';
+            return `<div class="review-line review-line-${cls}">
+                <span class="review-gutter">${oldN}</span>
+                <span class="review-gutter">${newN}</span>
+                <span class="review-code"><span class="review-sign">${sign}</span>${esc(ln.content)}</span>
+            </div>`;
+        }).join('');
+        const section = h.section ? ` <span class="review-hunk-section">${esc(h.section)}</span>` : '';
+        return `<div class="review-hunk">
+            <div class="review-hunk-head">${esc(h.header)}${section}</div>
+            ${rows}
+        </div>`;
+    }
+
+    _renderActions(content) {
+        const bar = content.querySelector('.review-actions');
+        if (!this._prompt) {
+            bar.classList.add('hidden');
+            bar.innerHTML = '';
+            return;
+        }
+        const p = this._prompt;
+        bar.classList.remove('hidden');
+        bar.innerHTML = `
+            <div class="review-prompt">
+                <span class="review-prompt-kind">${esc(p.kind)}</span>
+                <span class="review-prompt-q">${esc(p.question)}</span>
+            </div>
+            <div class="review-action-buttons">
+                <button class="review-btn review-deny" data-action="deny">Request changes</button>
+                <button class="review-btn review-approve" data-action="approve">Approve</button>
+            </div>`;
+    }
+
+    _onClick(e) {
+        const toggle = e.target.closest('[data-action="toggle-file"]');
+        if (toggle) {
+            const path = toggle.closest('.review-file')?.dataset.path;
+            if (path) {
+                if (this._collapsed.has(path)) this._collapsed.delete(path);
+                else this._collapsed.add(path);
+                const file = toggle.closest('.review-file');
+                file.querySelector('.review-hunks')?.classList.toggle('hidden');
+                const caret = file.querySelector('.review-caret');
+                if (caret) caret.textContent = this._collapsed.has(path) ? '▸' : '▾';
+            }
+            return;
+        }
+        const action = e.target.closest('[data-action="approve"], [data-action="deny"]');
+        if (action) this._answer(action.dataset.action);
+    }
+
+    async _answer(decision) {
+        if (!this._prompt) return;
+        const content = this._content();
+        const buttons = content.querySelectorAll('.review-action-buttons button');
+        buttons.forEach((b) => { b.disabled = true; });
+        try {
+            const res = await apiFetch(`/api/review/${encodeURIComponent(this.session)}/answer`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    decision,
+                    expect: this._prompt.expect,
+                    pane: this._prompt.pane || 0,
+                }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok || data.success === false) {
+                throw new Error(data.message || data.error || `HTTP ${res.status}`);
+            }
+            toastSuccess(decision === 'approve' ? 'Approved' : 'Requested changes');
+            this._prompt = null;
+            this._renderActions(content);
+        } catch (e) {
+            toastError(`Could not ${decision}: ${e.message}`);
+            buttons.forEach((b) => { b.disabled = false; });
+        }
+    }
+}

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -95,6 +95,7 @@ export function renderCard(s, opts = {}) {
             ${childBadge}
             <button class="sidebar-list-item-btn" data-action="connect" title="Connect">▸</button>
             <button class="sidebar-list-item-btn" data-action="monitor" title="Monitor">👁</button>
+            <button class="sidebar-list-item-btn" data-action="review" title="Review diff (approve/deny)">🔍</button>
             ${opts.closable ? renderCloseButton(name) : ''}
         </div>
         ${path ? `<div class="sidebar-session-row2"><span class="sidebar-session-path">${path}</span></div>` : ''}
@@ -169,6 +170,11 @@ export async function handleSessionClick(e) {
     const action = btn.dataset.action;
     if (action === 'close') {
         handleCloseClick(session);
+        return;
+    }
+    if (action === 'review') {
+        const { openReviewWindow } = await import('../desktop.js');
+        openReviewWindow(session);
         return;
     }
     const { openSessionTerminal } = await import('../desktop.js');

--- a/tests/unit/test_diff_cli.py
+++ b/tests/unit/test_diff_cli.py
@@ -1,0 +1,134 @@
+"""Tests for ``agentwire diff`` — the structured diff behind the mobile Review
+window (#484). Covers the unified-diff parser and the command's JSON shape +
+base-resolution, with git fully mocked so no real repo is needed.
+"""
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+from agentwire import diff_cli
+
+SAMPLE_DIFF = """\
+diff --git a/foo.py b/foo.py
+index 1111111..2222222 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,4 @@ def greet():
+ import os
+-print("old")
++print("new")
++print("added")
+ done = True
+diff --git a/new.txt b/new.txt
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,1 @@
++hello
+diff --git a/gone.txt b/gone.txt
+deleted file mode 100644
+index 4444444..0000000
+--- a/gone.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-bye
+"""
+
+
+def _ns(**kw):
+    base = dict(session="proj/feat", base=None, json=True)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class TestParser:
+    def test_files_and_counts(self):
+        files, truncated = diff_cli.parse_unified_diff(SAMPLE_DIFF)
+        assert not truncated
+        assert [f["path"] for f in files] == ["foo.py", "new.txt", "gone.txt"]
+        modified, added, deleted = files
+        assert modified["status"] == "modified"
+        assert modified["additions"] == 2 and modified["deletions"] == 1
+        assert added["status"] == "added" and added["additions"] == 1
+        assert deleted["status"] == "deleted" and deleted["deletions"] == 1
+
+    def test_line_numbering(self):
+        files, _ = diff_cli.parse_unified_diff(SAMPLE_DIFF)
+        lines = files[0]["hunks"][0]["lines"]
+        # context "import os" is line 1 on both sides
+        ctx = lines[0]
+        assert ctx["type"] == "context" and ctx["old_n"] == 1 and ctx["new_n"] == 1
+        add = next(ln for ln in lines if ln["type"] == "add")
+        assert add["content"] == 'print("new")' and add["new_n"] == 2
+
+    def test_hunk_section_header(self):
+        files, _ = diff_cli.parse_unified_diff(SAMPLE_DIFF)
+        assert files[0]["hunks"][0]["section"] == "def greet():"
+
+    def test_truncation(self):
+        files, truncated = diff_cli.parse_unified_diff(SAMPLE_DIFF, max_lines=5)
+        assert truncated
+
+
+class TestBaseResolution:
+    def test_uncommitted_uses_head(self, monkeypatch):
+        monkeypatch.setattr(diff_cli, "_has_uncommitted", lambda p: True)
+        assert diff_cli._resolve_base(diff_cli.Path("/x"), None) == "HEAD"
+
+    def test_clean_tree_uses_origin_main(self, monkeypatch):
+        monkeypatch.setattr(diff_cli, "_has_uncommitted", lambda p: False)
+        monkeypatch.setattr(
+            diff_cli, "_run_git", lambda p, a, **k: SimpleNamespace(returncode=0, stdout="", stderr="")
+        )
+        assert diff_cli._resolve_base(diff_cli.Path("/x"), None) == "origin/main"
+
+    def test_explicit_base_wins(self):
+        assert diff_cli._resolve_base(diff_cli.Path("/x"), "v1.2") == "v1.2"
+
+
+class TestCommand:
+    def test_json_output(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(diff_cli, "_resolve_path", lambda s: tmp_path)
+
+        def fake_git(path, args, **kw):
+            if args[:1] == ["rev-parse"]:
+                return SimpleNamespace(returncode=0, stdout=".git", stderr="")
+            if args[:1] == ["status"]:
+                return SimpleNamespace(returncode=0, stdout=" M foo.py", stderr="")
+            if args[:2] == ["diff", "--no-color"]:
+                assert args[2] == "HEAD"  # uncommitted → HEAD
+                return SimpleNamespace(returncode=0, stdout=SAMPLE_DIFF, stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(diff_cli, "_run_git", fake_git)
+        rc = diff_cli.cmd_diff(_ns())
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["base"] == "HEAD"
+        assert out["additions"] == 3 and out["deletions"] == 2
+        assert len(out["files"]) == 3
+
+    def test_unresolved_session_errors(self, monkeypatch, capsys):
+        monkeypatch.setattr(diff_cli, "_resolve_path", lambda s: None)
+        rc = diff_cli.cmd_diff(_ns())
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is False
+
+    def test_not_a_repo_errors(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(diff_cli, "_resolve_path", lambda s: tmp_path)
+        monkeypatch.setattr(
+            diff_cli, "_run_git",
+            lambda p, a, **k: SimpleNamespace(returncode=128, stdout="", stderr="not a git repo"),
+        )
+        rc = diff_cli.cmd_diff(_ns())
+        assert rc == 1
+        assert json.loads(capsys.readouterr().out)["success"] is False
+
+
+def test_subprocess_import_present():
+    # guard: cmd_diff relies on subprocess via _run_git
+    assert hasattr(subprocess, "run")


### PR DESCRIPTION
## Summary

Adds a mobile-first **Review** WinBox window to the portal: a session's git diff rendered as collapsible, line-numbered hunks with big **Approve** / **Request changes** buttons that drive the *existing* guarded prompt-answer path. Turns "read raw `git diff` scrollback in a tmux pane on a phone" into one-tap review. (Issue #484.)

Reuses existing rails rather than duplicating:
- **Diff plumbing** is a new CLI command (SSOT), with MCP + portal as thin wrappers — no diff logic in the browser or server.
- **Approve/deny** goes through `prompt_router.answer` (the same compare-and-send `--expect <hash>` guard the CLI/agent path uses), so a stale tap (prompt already answered, or a different one now live) is a safe no-op.

## Changes

- **CLI** `agentwire diff -s <session> [--base <ref>] --json` (`agentwire/diff_cli.py`): resolves the session's cwd via the shared `_get_session_project_path`, runs `git diff --no-color <base>`, parses the unified diff into structured per-file hunks with line numbers. Base defaults to `HEAD` when the worktree is dirty (uncommitted agent work), else `origin/main` (a worktree-session's committed branch) — so a phone review needs zero flags.
- **MCP** `diff` tool — thin wrapper returning a per-file +/- summary.
- **Portal** `GET /api/review/{session}` (diff + any live prompt, with the `expect` hash) and `POST /api/review/{session}/answer` (`approve` → key `1`, `deny` → `Escape`) → `prompt_router.answer`.
- **Frontend** `review-window.js` (ReviewWindow class, mirrors ArtifactWindow), mobile-friendly `desktop.css` (48px thumb targets, word-wrapped code, sticky file headers), and a 🔍 Review action on each session card. Window persists across refresh via the taskbar `review` record kind.

## Smallest-reasonable choices (noted per instructions)

- **Approve = option 1, Deny = Escape.** Covers permission (1=allow), plan (1=proceed), and question dialogs uniformly; Escape cancels all three. The window is intended for permission/plan approval, where this is unambiguous.
- **Diff base auto-resolves** (dirty→HEAD, clean→origin/main); `--base` overrides. Untracked new files aren't shown (uses `git diff <ref>`, tracked changes only) — acceptable for review-of-committed-work; flagged here rather than expanding scope.
- **Deep-linked Web Push** (approach step 4) is out of scope — it depends on the separate PWA issue.

## Verification

- `uv run --extra dev ruff check` on all changed Python files — **All checks passed**.
- New `tests/unit/test_diff_cli.py` (11 tests: parser counts/line-numbering/section-headers/truncation, base resolution, command JSON shape + error paths) — **pass**.
- `tests/unit/test_cli_smoke.py` + `test_cli_commands.py` (204) and prompt/router suite (109) — **pass**; `agentwire/server.py` & `mcp_server.py` parse clean.
- Parser checked against real `git diff HEAD` output in this worktree.
- `node --check` on the three changed JS files — OK.
- `agentwire diff --help` registers correctly.

Did not rebuild or restart the main install (worktree session).

Closes #484

Built by [dotdev.dev](https://dotdev.dev)
