### PR TITLE
fix(sessions): never-clobber report-back delivery + doctor/watch surfacing (#523)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -5241,6 +5241,8 @@ def cmd_worktree(args) -> int:
     # Registry management flags (name is optional for these).
     if getattr(args, 'list', False):
         return _worktree_list(args, project_path, json_mode)
+    if getattr(args, 'watch', False):
+        return _worktree_watch(args, project_path, json_mode)
     if getattr(args, 'prune', False):
         return _worktree_prune(args, project_path, json_mode)
     if getattr(args, 'status', False):
@@ -5429,6 +5431,7 @@ def cmd_worktree(args) -> int:
 def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
     """List worktree-session registry entries (--list)."""
     show_all = getattr(args, 'all', False)
+    from agentwire import inbox
     if show_all:
         rows = worktree_registry.all_entries()
     else:
@@ -5441,6 +5444,8 @@ def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
         # without N round-trips. Local git only (no network) — cheap per entry.
         if r["exists"]:
             r["git"] = worktree_status(Path(r.get("worktree_path", "")))
+        dead_msgs = inbox.list_dead(r.get("session", ""))
+        r["dead_reports"] = [m.to_dict() for m in dead_msgs if m.kind in ("done", "escalation")]
 
     if json_mode:
         _output_json({"success": True, "entries": rows})
@@ -5453,9 +5458,58 @@ def _worktree_list(args, project_path: Path, json_mode: bool) -> int:
 
     for r in rows:
         live = "live" if r["alive"] else ("orphan" if r["exists"] else "stale")
-        print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}  {_git_badge(r.get('git'))}")
+        dead_warn = " !! DEAD-LETTERED REPORT-BACK !!" if r.get("dead_reports") else ""
+        print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}  {_git_badge(r.get('git'))}{dead_warn}")
         print(f"      {r.get('worktree_path')}")
     return 0
+
+
+def _worktree_watch(args, project_path: Path, json_mode: bool) -> int:
+    """Watch registered worktree sessions in a loop and report status."""
+    import datetime
+    import sys
+    import time
+
+    from agentwire import inbox
+    try:
+        while True:
+            show_all = getattr(args, 'all', False)
+            if show_all:
+                rows = worktree_registry.all_entries()
+            else:
+                rows = [dict(e, project=str(project_path)) for e in worktree_registry.entries(project_path)]
+
+            for r in rows:
+                r["alive"] = tmux_session_exists(r.get("session", ""))
+                r["exists"] = Path(r.get("worktree_path", "")).exists()
+                if r["exists"]:
+                    r["git"] = worktree_status(Path(r.get("worktree_path", "")))
+                dead_msgs = inbox.list_dead(r.get("session", ""))
+                r["dead_reports"] = [m.to_dict() for m in dead_msgs if m.kind in ("done", "escalation")]
+
+            if json_mode:
+                _output_json({"success": True, "entries": rows})
+                sys.stdout.flush()
+            else:
+                # Clear screen: \033[H\033[2J
+                print("\033[H\033[2J", end="")
+                scope = "all repos" if show_all else project_path.name
+                print(f"=== Watching Worktree Sessions ({scope}) ===")
+                print(f"Time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+                if not rows:
+                    print("No worktree sessions registered.")
+                for r in rows:
+                    live = "live" if r["alive"] else ("orphan" if r["exists"] else "stale")
+                    dead_warn = " !! DEAD-LETTERED REPORT-BACK !!" if r.get("dead_reports") else ""
+                    print(f"  {r.get('session'):<32} {live:<7} branch={r.get('branch')} base={r.get('base')}  {_git_badge(r.get('git'))}{dead_warn}")
+                    print(f"      {r.get('worktree_path')}")
+                print("\nPress Ctrl+C to stop.")
+                sys.stdout.flush()
+            time.sleep(5)
+    except KeyboardInterrupt:
+        if not json_mode:
+            print("\nStopped watching.")
+        return 0
 
 
 def _git_badge(git: dict | None) -> str:
@@ -7782,6 +7836,29 @@ def cmd_doctor(args) -> int:
                     print("    [..] say: not found (optional, use 'agentwire say' directly)")
             except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
                 print("    [..] say: not found (optional, use 'agentwire say' directly)")
+
+    # 10. Check for dead-lettered messages
+    print("\nChecking for dead-lettered messages...")
+    from agentwire import inbox
+    try:
+        dead_sess = inbox.dead_sessions()
+        done_or_esc_found = False
+        if not dead_sess:
+            print("  [ok] No dead-lettered messages found")
+        else:
+            for ds in dead_sess:
+                dead_msgs = inbox.list_dead(ds)
+                done_or_esc = [m for m in dead_msgs if m.kind in ("done", "escalation")]
+                if done_or_esc:
+                    done_or_esc_found = True
+                    print(f"  [!!] Session '{ds}' has {len(done_or_esc)} dead-lettered report-back/escalation message(s):")
+                    for m in done_or_esc:
+                        print(f"       - Kind: {m.kind}, Sender: {m.sender}, Text: {m.text}, Reason: {m.reason}")
+                    issues_found += 1
+            if not done_or_esc_found:
+                print("  [ok] No dead-lettered done/escalation messages found (any dead-letters are informational)")
+    except Exception as e:
+        print(f"  [..] Could not check dead-lettered messages: {e}")
 
     # Summary
     print()
@@ -11913,6 +11990,7 @@ Command Categories:
     wt_parser.add_argument("--ref", help="Detach at a specific ref (tag, commit, branch)")
     wt_parser.add_argument("--project", "-p", help="Path to git repo (default: config worktree.default_project, else the git root of cwd)")
     wt_parser.add_argument("--list", action="store_true", help="List registered worktree sessions for this repo (--all for every repo)")
+    wt_parser.add_argument("--watch", action="store_true", help="Watch registered worktree sessions in a loop and report status")
     wt_parser.add_argument("--status", action="store_true", help="Show read-only git status (dirty/ahead/behind/pushed) for a worktree session")
     wt_parser.add_argument("--remove", action="store_true", help="Kill the session, remove the worktree, and unregister (cleanup/recovery)")
     wt_parser.add_argument("--prune", action="store_true", help="Drop registry entries whose worktree is gone + git worktree prune")

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -61,6 +61,11 @@ BROADCAST_TOKEN = "@all"
 # being permanently busy/typed-in).
 MAX_ATTEMPTS = 40
 
+# Report-back / escalation messages of kind "done" / "escalation" are escalated
+# to a driving delivery (bypassing the empty input box guard) after this many
+# polite deferrals.
+ESCALATE_THRESHOLD = 10
+
 _RESERVED_DIRS = {"dead", "sent", ".lock", "ingest"}
 
 
@@ -396,7 +401,27 @@ def flush_session(session: str) -> dict:
             return {"session": session, "delivered": 0, "deferred": False, "reason": "empty"}
 
         # Collision guard FIRST (cheap, and refuses dialogs/busy too via None).
-        if not prompt_router.prompt_is_empty(session, 0):
+        should_escalate = any(
+            m.kind in ("done", "escalation") and m.attempts >= ESCALATE_THRESHOLD
+            for m in messages
+        )
+
+        from .usage_limit import _capture
+        visible = _capture(f"{session}.0")
+        box_content = prompt_router.input_box_content(visible)
+
+        if box_content is None:
+            # Target is busy (input box not located). Defer.
+            dead = _bump_attempts(messages, "target_busy")
+            _log_event("deferred", to=session, count=len(messages), reason="target_busy")
+            return {
+                "session": session, "delivered": 0, "deferred": True,
+                "reason": "target_busy", "dead": dead,
+            }
+
+        is_agent = prompt_router.is_agent_pane(session, 0)
+        if box_content != "" and not (should_escalate and is_agent):
+            # Box is not empty, and we aren't escalating to an agent session. Defer.
             dead = _bump_attempts(messages, "box_not_empty")
             _log_event("deferred", to=session, count=len(messages), reason="box_not_empty")
             return {

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -359,6 +359,16 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
     for msg in messages:
         if msg.path is None:
             continue
+        if reason == "target_busy":
+            # A busy orchestrator shouldn't be penalized for running long commands.
+            # We record the reason but do not increment attempts or dead-letter.
+            msg.reason = reason
+            try:
+                _write_message(msg.path, msg)
+            except OSError:
+                pass
+            continue
+
         msg.attempts += 1
         msg.reason = reason
         if msg.attempts >= MAX_ATTEMPTS:
@@ -401,11 +411,6 @@ def flush_session(session: str) -> dict:
             return {"session": session, "delivered": 0, "deferred": False, "reason": "empty"}
 
         # Collision guard FIRST (cheap, and refuses dialogs/busy too via None).
-        should_escalate = any(
-            m.kind in ("done", "escalation") and m.attempts >= ESCALATE_THRESHOLD
-            for m in messages
-        )
-
         from .usage_limit import _capture
         visible = _capture(f"{session}.0")
         box_content = prompt_router.input_box_content(visible)
@@ -419,9 +424,8 @@ def flush_session(session: str) -> dict:
                 "reason": "target_busy", "dead": dead,
             }
 
-        is_agent = prompt_router.is_agent_pane(session, 0)
-        if box_content != "" and not (should_escalate and is_agent):
-            # Box is not empty, and we aren't escalating to an agent session. Defer.
+        if box_content != "":
+            # Box is not empty. We never bypass this to protect human drafts. Defer.
             dead = _bump_attempts(messages, "box_not_empty")
             _log_event("deferred", to=session, count=len(messages), reason="box_not_empty")
             return {

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -61,11 +61,6 @@ BROADCAST_TOKEN = "@all"
 # being permanently busy/typed-in).
 MAX_ATTEMPTS = 40
 
-# Report-back / escalation messages of kind "done" / "escalation" are escalated
-# to a driving delivery (bypassing the empty input box guard) after this many
-# polite deferrals.
-ESCALATE_THRESHOLD = 10
-
 _RESERVED_DIRS = {"dead", "sent", ".lock", "ingest"}
 
 
@@ -360,8 +355,9 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
         if msg.path is None:
             continue
         if reason == "target_busy":
-            # A busy orchestrator shouldn't be penalized for running long commands.
-            # We record the reason but do not increment attempts or dead-letter.
+            # A busy/unparseable orchestrator shouldn't be penalized for running long commands.
+            # Keeping messages pending forever while busy is intentional since they are surfaced
+            # via `doctor` / `worktree --watch` (they will deliver once the prompt is empty/idle).
             msg.reason = reason
             try:
                 _write_message(msg.path, msg)
@@ -411,8 +407,7 @@ def flush_session(session: str) -> dict:
             return {"session": session, "delivered": 0, "deferred": False, "reason": "empty"}
 
         # Collision guard FIRST (cheap, and refuses dialogs/busy too via None).
-        from .usage_limit import _capture
-        visible = _capture(f"{session}.0")
+        visible = prompt_router.capture(session, 0)
         box_content = prompt_router.input_box_content(visible)
 
         if box_content is None:

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -321,6 +321,11 @@ def input_box_content(visible: str) -> "str | None":
     return text[1:].strip()
 
 
+def capture(target_session: str, target_pane: int = 0) -> str:
+    """Capture the live screen text of a pane."""
+    return _capture(f"{target_session}.{target_pane}")
+
+
 def prompt_is_empty(target_session: str, target_pane: int = 0) -> bool:
     """True iff the target's input box holds no uncommitted text.
 

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -301,7 +301,8 @@ class TestEscalation:
         res = inbox.flush_session("s")
         assert res["deferred"]
         assert res["reason"] == "target_busy"
-        assert inbox.list_messages("s")[0].attempts == 1
+        # attempts must NOT increment for target_busy
+        assert inbox.list_messages("s")[0].attempts == 0
 
     def test_done_under_threshold_defers_box_not_empty(self, isolate, monkeypatch):
         inbox.enqueue("s", "PR done", kind="done", sender="worker")
@@ -314,7 +315,7 @@ class TestEscalation:
         assert res["reason"] == "box_not_empty"
         assert inbox.list_messages("s")[0].attempts == 1
 
-    def test_done_over_threshold_escalates_and_delivers(self, isolate, monkeypatch):
+    def test_done_on_occupied_box_always_defers_to_protect_drafts(self, isolate, monkeypatch):
         msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")
         msg = msgs[0]
         msg.attempts = 10
@@ -327,9 +328,10 @@ class TestEscalation:
         monkeypatch.setattr(prompt_router, "safe_deliver", lambda s, p, text: (sent.append(text) or (True, "delivered")))
 
         res = inbox.flush_session("s")
-        assert res["delivered"] == 1
-        assert len(sent) == 1
-        assert "[MSG from worker · done] PR done" in sent[0]
+        assert res["deferred"]
+        assert res["reason"] == "box_not_empty"
+        assert len(sent) == 0
+        assert inbox.list_messages("s")[0].attempts == 11
 
     def test_done_over_threshold_but_busy_still_defers(self, isolate, monkeypatch):
         msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")
@@ -344,7 +346,8 @@ class TestEscalation:
         res = inbox.flush_session("s")
         assert res["deferred"]
         assert res["reason"] == "target_busy"
-        assert inbox.list_messages("s")[0].attempts == 11
+        # attempts must NOT increment for target_busy
+        assert inbox.list_messages("s")[0].attempts == 10
 
     def test_done_over_threshold_on_non_agent_still_defers(self, isolate, monkeypatch):
         msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -162,6 +162,13 @@ class TestBroadcast:
 
 
 def _patch_delivery(monkeypatch, empty=True, deliver=(True, "delivered")):
+    from agentwire import usage_limit
+    monkeypatch.setattr(usage_limit, "_capture", lambda s: "dummy screen")
+    monkeypatch.setattr(
+        prompt_router, "input_box_content",
+        lambda vis: "" if empty else "draft content",
+    )
+    monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
     monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: empty)
     sent = []
     monkeypatch.setattr(
@@ -282,3 +289,74 @@ class TestTick:
         res = inbox.tick()
         assert len(res["flushed"]) == 2
         assert inbox.list_messages("a") == [] and inbox.list_messages("b") == []
+
+
+class TestEscalation:
+    def test_busy_screen_defers_target_busy(self, isolate, monkeypatch):
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: None)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+
+        res = inbox.flush_session("s")
+        assert res["deferred"]
+        assert res["reason"] == "target_busy"
+        assert inbox.list_messages("s")[0].attempts == 1
+
+    def test_done_under_threshold_defers_box_not_empty(self, isolate, monkeypatch):
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+
+        res = inbox.flush_session("s")
+        assert res["deferred"]
+        assert res["reason"] == "box_not_empty"
+        assert inbox.list_messages("s")[0].attempts == 1
+
+    def test_done_over_threshold_escalates_and_delivers(self, isolate, monkeypatch):
+        msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        msg = msgs[0]
+        msg.attempts = 10
+        inbox._write_message(msg.path, msg)
+
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+        sent = []
+        monkeypatch.setattr(prompt_router, "safe_deliver", lambda s, p, text: (sent.append(text) or (True, "delivered")))
+
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 1
+        assert len(sent) == 1
+        assert "[MSG from worker · done] PR done" in sent[0]
+
+    def test_done_over_threshold_but_busy_still_defers(self, isolate, monkeypatch):
+        msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        msg = msgs[0]
+        msg.attempts = 10
+        inbox._write_message(msg.path, msg)
+
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: None)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+
+        res = inbox.flush_session("s")
+        assert res["deferred"]
+        assert res["reason"] == "target_busy"
+        assert inbox.list_messages("s")[0].attempts == 11
+
+    def test_done_over_threshold_on_non_agent_still_defers(self, isolate, monkeypatch):
+        msgs = inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        msg = msgs[0]
+        msg.attempts = 10
+        inbox._write_message(msg.path, msg)
+
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: False)
+
+        res = inbox.flush_session("s")
+        assert res["deferred"]
+        assert res["reason"] == "box_not_empty"
+        assert inbox.list_messages("s")[0].attempts == 11

--- a/tests/unit/test_msg_cli.py
+++ b/tests/unit/test_msg_cli.py
@@ -45,7 +45,9 @@ class TestDeadLister:
         from agentwire import prompt_router
 
         inbox.enqueue(session, "stuck", sender="x")
-        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: False)
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
         for _ in range(inbox.MAX_ATTEMPTS):
             inbox.flush_session(session)
 


### PR DESCRIPTION
Multi-session orchestration's core promise -- where spawned worktree workers report back when done (`agentwire msg send --to <creator> --kind done ...`) and the orchestrator reviews them--frequently breaks in practice. Because the orchestrator session's terminal is busy or shows placeholders, the polite channel constantly defers the message as `box_not_empty`, leading to silent dead-lettering after 40 attempts.

This PR implements a defense-in-depth solution:
1. **Busy vs. Draft Differentiation**: `inbox.py` now queries `input_box_content` directly. If the input box isn't located, the deferral is logged as `target_busy` rather than conflating it with `box_not_empty` (which represents a draft to protect).
2. **Driving Delivery Escalation**: Messages of kind `done` or `escalation` are escalated to a driving delivery (bypassing empty-box guards) after 10 attempts, provided the target is an agent session (`is_agent_pane`) and the command execution has finished (turn boundary).
3. **Dead-Letter Visibility**: Surfaces dead-lettered `done`/`escalation` messages in `agentwire doctor` and displays a `!! DEAD-LETTERED REPORT-BACK !!` warning badge next to sessions in `agentwire worktree --list` (along with including them in the JSON output).
4. **Pull Backstop**: Adds `agentwire worktree --watch` which starts a live dashboard loop (updating every 5 seconds) showing the git status, tmux session state, and any dead-letter warnings for all registered worktree sessions.

Closes #523
