### PR TITLE
fix(portal): register image/webp mimetype so static .webp serves correctly in hermetic CI

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -58,6 +58,8 @@ logger = logging.getLogger(__name__)
 
 # Static asset serving (#488): gzip text on the fly + Cache-Control headers.
 mimetypes.add_type("image/webp", ".webp")
+mimetypes.add_type("image/avif", ".avif")
+mimetypes.add_type("font/woff2", ".woff2")
 mimetypes.add_type("text/javascript", ".js")
 mimetypes.add_type("application/manifest+json", ".webmanifest")
 STATIC_ROOT = (Path(__file__).parent / "static").resolve()
@@ -3635,7 +3637,13 @@ class AgentWireServer:
                 },
             )
 
-        return web.FileResponse(target, headers={"Cache-Control": cache})
+        # Pass Content-Type explicitly: web.FileResponse otherwise guesses via
+        # aiohttp's private mimetypes instance, which (unlike our module-level
+        # add_type registrations) lacks .webp/.avif/.woff2 on hermetic CI
+        # runners whose system mime DB is bare — serving octet-stream (#525).
+        return web.FileResponse(
+            target, headers={"Cache-Control": cache, "Content-Type": content_type}
+        )
 
     def _gzipped_static(self, path: Path) -> bytes:
         """Return gzipped bytes for a static file, cached by path + mtime."""

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1384,6 +1384,26 @@ class TestStaticAssets:
         assert "max-age=604800" in resp.headers["Cache-Control"]
         assert resp.content_type == "image/webp"
 
+    async def test_webp_served_with_bare_aiohttp_mime_db(self, portal_client):
+        """Regression for #525: hermetic CI runners have a bare system mime DB,
+        so aiohttp's private mimetypes instance doesn't know .webp and would
+        serve octet-stream. The handler must pass Content-Type explicitly."""
+        import aiohttp.web_fileresponse as fr
+
+        client, _ = portal_client
+        saved = {
+            ext: fr.CONTENT_TYPES.types_map[1].pop(ext, None)
+            for ext in (".webp",)
+        }
+        try:
+            resp = await client.get("/static/icons/sessions/fox.webp")
+            assert resp.status == 200
+            assert resp.content_type == "image/webp"
+        finally:
+            for ext, ct in saved.items():
+                if ct is not None:
+                    fr.CONTENT_TYPES.types_map[1][ext] = ct
+
     async def test_no_gzip_without_accept_encoding(self, portal_client):
         client, _ = portal_client
         resp = await client.get(


### PR DESCRIPTION
## Root cause

`TestStaticAssets::test_image_has_long_cache_and_no_gzip` has been red on `main` for days. The portal's static handler (`_handle_static` in `agentwire/server.py`) serves images via `web.FileResponse`, which determines `Content-Type` using aiohttp's **own private** `mimetypes.MimeTypes()` instance — *not* the global `mimetypes` module that our startup `mimetypes.add_type("image/webp", ".webp")` mutates.

On hermetic CI runners the system mime DB is bare, so aiohttp's private instance has no `.webp` entry and falls back to `application/octet-stream`. Locally the test passes only because the dev machine's system mime DB already knows webp (confirmed by simulating a bare aiohttp DB — its `guess_type('x.webp')` returns `None` while our global returns `image/webp`).

## Fix

- Pass the `Content-Type` we already compute (via the global `mimetypes`, registered at startup) **explicitly** to `web.FileResponse`. aiohttp honors a `Content-Type` header that's already present and skips its private guess (`web_fileresponse.py`: `if hdrs.CONTENT_TYPE not in self._headers`).
- Also register `.avif` and `.woff2` on the global instance for the same hermetic-DB reason.
- New regression test `test_webp_served_with_bare_aiohttp_mime_db` reproduces the bare-DB condition by popping `.webp` from aiohttp's private map, proving the handler still serves `image/webp`.

## Verification (in worktree)

- `uv run --extra dev pytest tests/unit/test_portal_api.py::TestStaticAssets -q` → 7 passed
- `uv run --extra dev pytest tests/unit/test_portal_api.py -q` → 103 passed
- `uv run --extra dev ruff check agentwire/` → clean

Unblocks the red base check on #525.

Built by [dotdev.dev](https://dotdev.dev)