### PR TITLE
refactor(cli): repo-info/branches CLI + portal endpoints call them (#495 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,15 @@ All session/machine logic lives in CLI commands (`agentwire/__main__.py`). The p
 2. Portal calls CLI, doesn't duplicate logic
 3. Never bypass CLI with direct tmux/subprocess calls
 
+**CLI layout (#495):** the old `__main__.py` monolith is split per-domain. Shared
+helpers (machine config, SSH `_run_remote`, JSON output, session resolution, etc.)
+live in `agentwire/core.py`; each command group lives in its own `agentwire/<domain>_cli.py`
+module exposing a `register_<domain>_parser(subparsers)` registrar. `build_parser()`
+imports them and runs the `_REGISTRARS` loop — adding a command means writing a new
+`*_cli.py` + appending its registrar, not editing a god-file. Example: the portal git
+endpoints (`api_check_path` / `api_check_branches`) shell out to `agentwire repo-info`
+and `agentwire branches` (in `repo_cli.py`) rather than embedding their own git/SSH logic.
+
 Full CLI command reference lives in the `agentwire-cli` skill.
 
 ## MCP Server (For Agents)

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -191,7 +191,7 @@ Command Categories:
     from . import scheduler_cli, ensure_cli
     from . import doctor_cli, history_cli, machine_cli, safety_cli
     from . import handoff_cli, hooks_cli, mcp_cli, roles_cli, tunnels_cli
-    from . import notify_cli, push_cli, system_cli, wiki_cli
+    from . import notify_cli, push_cli, repo_cli, system_cli, wiki_cli
     from .council import cli as council_cli
 
     _REGISTRARS = [  # noqa: N806  # registry constant; Phase 1 of #495 appends here
@@ -221,6 +221,7 @@ Command Categories:
         wiki_cli.register_wiki_parser,
         system_cli.register_system_parser,
         push_cli.register_push_parser,
+        repo_cli.register_repo_parser,
     ]
     for _reg in _REGISTRARS:
         _reg(subparsers)

--- a/agentwire/repo_cli.py
+++ b/agentwire/repo_cli.py
@@ -1,0 +1,159 @@
+"""CLI for repo inspection — ``agentwire repo-info`` / ``agentwire branches``.
+
+The portal's "new session" / "worktree" flows need to know whether a path is a
+git repo (and on which branch) and which branches already match a prefix, for
+both the local machine and remote machines registered in ``machines.json``.
+
+Per the CLAUDE.md SSOT rule, that git logic lives here in the CLI. The portal
+endpoints (``api_check_path`` / ``api_check_branches``) are thin wrappers that
+shell out to these commands and parse the ``--json`` output — they no longer
+embed forked local/SSH git logic.
+
+Output shapes (``--json``)::
+
+    repo-info: {"exists": bool, "is_git": bool, "current_branch": str | null}
+    branches:  {"existing": [branch names]}
+
+Local logic mirrors the old inline portal code exactly: ``expanduser().resolve()``,
+``.git`` existence, ``git rev-parse --abbrev-ref HEAD`` / ``git branch --list``.
+Remote logic runs the same shell commands over SSH via ``core._run_remote`` (which
+resolves the target ``user@host`` from ``machines.json``), keeping the portal's
+"stdout only on success, else empty" semantics.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+from .core import _output_json, _run_remote
+
+
+def _remote_stdout(machine_id: str, command: str) -> str:
+    """Run ``command`` on ``machine_id`` via SSH, returning stdout on success.
+
+    Mirrors the portal's old ``_run_ssh_command`` contract: stdout when the
+    remote command exits 0, otherwise an empty string.
+    """
+    result = _run_remote(machine_id, command)
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _repo_info(path: str, machine: str) -> dict:
+    """Compute {exists, is_git, current_branch} for a local or remote path."""
+    if machine and machine != "local":
+        exists = "exists" in _remote_stdout(
+            machine, f"test -d {shlex.quote(path)} && echo exists"
+        )
+        is_git = False
+        current_branch = None
+
+        if exists:
+            is_git = "git" in _remote_stdout(
+                machine, f"test -d {shlex.quote(path)}/.git && echo git"
+            )
+            if is_git:
+                branch = _remote_stdout(
+                    machine,
+                    f"cd {shlex.quote(path)} && git rev-parse --abbrev-ref HEAD",
+                )
+                current_branch = branch.strip() if branch else None
+    else:
+        expanded = Path(path).expanduser().resolve()
+        exists = expanded.exists() and expanded.is_dir()
+        is_git = exists and (expanded / ".git").exists()
+        current_branch = None
+
+        if is_git:
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=expanded,
+                capture_output=True,
+                text=True,
+            )
+            current_branch = result.stdout.strip() if result.returncode == 0 else None
+
+    return {"exists": exists, "is_git": is_git, "current_branch": current_branch}
+
+
+def _branches(path: str, machine: str, prefix: str) -> list[str]:
+    """Existing branch names matching ``prefix`` for a local or remote repo."""
+    if machine and machine != "local":
+        cmd = (
+            f"cd {shlex.quote(path)} && git branch --list "
+            f"{shlex.quote(prefix + '*')} --format='%(refname:short)'"
+        )
+        out = _remote_stdout(machine, cmd)
+        branches = out.strip().split("\n") if out else []
+    else:
+        expanded = Path(path).expanduser().resolve()
+        if not expanded.exists():
+            return []
+        result = subprocess.run(
+            ["git", "branch", "--list", f"{prefix}*", "--format=%(refname:short)"],
+            cwd=expanded,
+            capture_output=True,
+            text=True,
+        )
+        branches = result.stdout.strip().split("\n") if result.returncode == 0 else []
+
+    return [b for b in branches if b]
+
+
+def cmd_repo_info(args) -> int:
+    """Report whether a path exists / is a git repo and its current branch."""
+    json_mode = getattr(args, "json", False)
+    if not args.path:
+        info = {"exists": False, "is_git": False, "current_branch": None}
+    else:
+        info = _repo_info(args.path, args.machine)
+
+    if json_mode:
+        _output_json(info)
+    else:
+        print(f"exists:         {info['exists']}")
+        print(f"is_git:         {info['is_git']}")
+        print(f"current_branch: {info['current_branch']}")
+    return 0
+
+
+def cmd_branches(args) -> int:
+    """List existing branch names matching a prefix."""
+    json_mode = getattr(args, "json", False)
+    if not args.path:
+        existing: list[str] = []
+    else:
+        existing = _branches(args.path, args.machine, args.prefix)
+
+    if json_mode:
+        _output_json({"existing": existing})
+    else:
+        for b in existing:
+            print(b)
+    return 0
+
+
+def register_repo_parser(subparsers) -> None:
+    info_parser = subparsers.add_parser(
+        "repo-info",
+        help="Check if a path exists / is a git repo and its current branch (local or remote)",
+    )
+    info_parser.add_argument("--path", required=True, help="Path to check")
+    info_parser.add_argument(
+        "--machine", default="local", help="Machine ID ('local' or a remote from machines.json)"
+    )
+    info_parser.add_argument("--json", action="store_true", help="Output JSON")
+    info_parser.set_defaults(func=cmd_repo_info)
+
+    branches_parser = subparsers.add_parser(
+        "branches",
+        help="List existing branch names matching a prefix (local or remote)",
+    )
+    branches_parser.add_argument("--path", required=True, help="Git repo path")
+    branches_parser.add_argument(
+        "--machine", default="local", help="Machine ID ('local' or a remote from machines.json)"
+    )
+    branches_parser.add_argument("--prefix", default="", help="Branch name prefix filter")
+    branches_parser.add_argument("--json", action="store_true", help="Output JSON")
+    branches_parser.set_defaults(func=cmd_branches)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -988,46 +988,6 @@ class AgentWireServer:
             pass
         return False, {"error": stderr.decode().strip() or f"Command failed with exit code {proc.returncode}"}
 
-    async def _run_ssh_command(self, machine_id: str, command: str) -> str:
-        """Run command on remote machine via SSH.
-
-        Args:
-            machine_id: The machine ID from machines.json
-            command: Shell command to run remotely
-
-        Returns:
-            stdout output if successful, empty string on failure
-        """
-        machines_file = self.config.machines.file
-        if not machines_file.exists():
-            return ""
-
-        try:
-            with open(machines_file) as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, IOError):
-            return ""
-
-        machine = next((m for m in data.get("machines", []) if m.get("id") == machine_id), None)
-        if not machine:
-            return ""
-
-        host = machine.get("host", "")
-        user = machine.get("user", "")
-        ssh_target = f"{user}@{host}" if user else host
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "ssh", *ssh_base_opts(), "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
-                ssh_target, command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await proc.communicate()
-            return stdout.decode() if proc.returncode == 0 else ""
-        except Exception:
-            return ""
-
     # HTTP Handlers
 
     async def handle_health(self, request: web.Request) -> web.Response:
@@ -3235,49 +3195,21 @@ class AgentWireServer:
                 "current_branch": None
             })
 
-        if machine and machine != "local":
-            # Remote path check via SSH
-            result = await self._run_ssh_command(
-                machine,
-                f"test -d {shlex.quote(path)} && echo exists"
+        # Thin wrapper: the git/SSH logic lives in the CLI (SSOT).
+        success, result = await self.run_agentwire_cmd(
+            ["repo-info", "--path", path, "--machine", machine]
+        )
+        if not success:
+            logger.error(f"repo-info failed for {path} on {machine}: {result.get('error')}")
+            return web.json_response(
+                {"exists": False, "is_git": False, "current_branch": None},
+                status=500,
             )
-            exists = "exists" in result
-            is_git = False
-            current_branch = None
-
-            if exists:
-                result = await self._run_ssh_command(
-                    machine,
-                    f"test -d {shlex.quote(path)}/.git && echo git"
-                )
-                is_git = "git" in result
-
-                if is_git:
-                    result = await self._run_ssh_command(
-                        machine,
-                        f"cd {shlex.quote(path)} && git rev-parse --abbrev-ref HEAD"
-                    )
-                    current_branch = result.strip() if result else None
-        else:
-            # Local path check
-            expanded = Path(path).expanduser().resolve()
-            exists = expanded.exists() and expanded.is_dir()
-            is_git = exists and (expanded / ".git").exists()
-            current_branch = None
-
-            if is_git:
-                result = subprocess.run(
-                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                    cwd=expanded,
-                    capture_output=True,
-                    text=True
-                )
-                current_branch = result.stdout.strip() if result.returncode == 0 else None
 
         return web.json_response({
-            "exists": exists,
-            "is_git": is_git,
-            "current_branch": current_branch
+            "exists": result.get("exists", False),
+            "is_git": result.get("is_git", False),
+            "current_branch": result.get("current_branch"),
         })
 
     async def api_check_branches(self, request: web.Request) -> web.Response:
@@ -3298,29 +3230,15 @@ class AgentWireServer:
         if not path:
             return web.json_response({"existing": []})
 
-        if machine and machine != "local":
-            # Remote branch check via SSH
-            cmd = f"cd {shlex.quote(path)} && git branch --list {shlex.quote(prefix + '*')} --format='%(refname:short)'"
-            result = await self._run_ssh_command(machine, cmd)
-            branches = result.strip().split('\n') if result else []
-        else:
-            # Local branch check
-            expanded = Path(path).expanduser().resolve()
-            if not expanded.exists():
-                return web.json_response({"existing": []})
+        # Thin wrapper: the git/SSH logic lives in the CLI (SSOT).
+        success, result = await self.run_agentwire_cmd(
+            ["branches", "--path", path, "--machine", machine, "--prefix", prefix]
+        )
+        if not success:
+            logger.error(f"branches failed for {path} on {machine}: {result.get('error')}")
+            return web.json_response({"existing": []}, status=500)
 
-            result = subprocess.run(
-                ["git", "branch", "--list", f"{prefix}*", "--format=%(refname:short)"],
-                cwd=expanded,
-                capture_output=True,
-                text=True
-            )
-            branches = result.stdout.strip().split('\n') if result.returncode == 0 else []
-
-        # Filter out empty strings
-        branches = [b for b in branches if b]
-
-        return web.json_response({"existing": branches})
+        return web.json_response({"existing": result.get("existing", [])})
 
     async def api_active_session(self, request: web.Request) -> web.Response:
         """Record which session the portal desktop is currently focused on.

--- a/tests/unit/test_repo_cli.py
+++ b/tests/unit/test_repo_cli.py
@@ -1,0 +1,115 @@
+"""Tests for ``agentwire repo-info`` / ``agentwire branches`` (#495 Phase 2).
+
+These commands hold the git logic the portal's ``api_check_path`` /
+``api_check_branches`` endpoints used to embed inline. The tests pin the JSON
+shape + local/remote parity with that old inline behavior. Real git is used for
+the local cases (against a tmp repo); the remote path mocks ``core._run_remote``.
+"""
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import repo_cli
+
+
+def _ns(**kw):
+    base = dict(path="", machine="local", prefix="", json=True)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _capture(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, capture_output=True)
+    (repo / "f.txt").write_text("hi")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, env={**env})
+    subprocess.run(["git", "branch", "feature/a"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "branch", "feature/b"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "branch", "other"], cwd=repo, capture_output=True)
+    return repo
+
+
+class TestRepoInfoLocal:
+    def test_git_repo(self, git_repo, capsys):
+        assert repo_cli.cmd_repo_info(_ns(path=str(git_repo))) == 0
+        out = _capture(capsys)
+        assert out == {"exists": True, "is_git": True, "current_branch": "main"}
+
+    def test_nonexistent(self, tmp_path, capsys):
+        repo_cli.cmd_repo_info(_ns(path=str(tmp_path / "nope")))
+        assert _capture(capsys) == {"exists": False, "is_git": False, "current_branch": None}
+
+    def test_non_git_dir(self, tmp_path, capsys):
+        repo_cli.cmd_repo_info(_ns(path=str(tmp_path)))
+        assert _capture(capsys) == {"exists": True, "is_git": False, "current_branch": None}
+
+    def test_empty_path(self, capsys):
+        repo_cli.cmd_repo_info(_ns(path=""))
+        assert _capture(capsys) == {"exists": False, "is_git": False, "current_branch": None}
+
+
+class TestBranchesLocal:
+    def test_all(self, git_repo, capsys):
+        repo_cli.cmd_branches(_ns(path=str(git_repo), prefix=""))
+        assert set(_capture(capsys)["existing"]) == {"main", "feature/a", "feature/b", "other"}
+
+    def test_prefix(self, git_repo, capsys):
+        repo_cli.cmd_branches(_ns(path=str(git_repo), prefix="feature/"))
+        assert sorted(_capture(capsys)["existing"]) == ["feature/a", "feature/b"]
+
+    def test_nonexistent(self, tmp_path, capsys):
+        repo_cli.cmd_branches(_ns(path=str(tmp_path / "nope")))
+        assert _capture(capsys) == {"existing": []}
+
+    def test_empty_path(self, capsys):
+        repo_cli.cmd_branches(_ns(path=""))
+        assert _capture(capsys) == {"existing": []}
+
+
+class TestRemote:
+    def test_repo_info_remote(self, monkeypatch, capsys):
+        calls = []
+
+        def fake_remote(machine, cmd):
+            calls.append(cmd)
+            if "echo exists" in cmd:
+                out = "exists\n"
+            elif "echo git" in cmd:
+                out = "git\n"
+            else:  # rev-parse
+                out = "develop\n"
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=out, stderr="")
+
+        monkeypatch.setattr(repo_cli, "_run_remote", fake_remote)
+        repo_cli.cmd_repo_info(_ns(path="/srv/app", machine="gpu"))
+        assert _capture(capsys) == {"exists": True, "is_git": True, "current_branch": "develop"}
+
+    def test_repo_info_remote_failure_is_empty(self, monkeypatch, capsys):
+        # Non-zero remote exit → stdout dropped → reads as absent (parity with portal).
+        def fake_remote(machine, cmd):
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout="exists\n", stderr="boom")
+
+        monkeypatch.setattr(repo_cli, "_run_remote", fake_remote)
+        repo_cli.cmd_repo_info(_ns(path="/srv/app", machine="gpu"))
+        assert _capture(capsys) == {"exists": False, "is_git": False, "current_branch": None}
+
+    def test_branches_remote(self, monkeypatch, capsys):
+        def fake_remote(machine, cmd):
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="feature/a\nfeature/b\n", stderr=""
+            )
+
+        monkeypatch.setattr(repo_cli, "_run_remote", fake_remote)
+        repo_cli.cmd_branches(_ns(path="/srv/app", machine="gpu", prefix="feature/"))
+        assert _capture(capsys) == {"existing": ["feature/a", "feature/b"]}


### PR DESCRIPTION
Final piece of #495. New `agentwire/repo_cli.py` exposes `repo-info` + `branches` (local + remote/SSH, JSON parity with the old inline portal logic). Rewires `server.py` `api_check_path`/`api_check_branches` to shell to the CLI via `run_agentwire_cmd` (no helper imports — thin-wrapper rule). Deletes the now-dead `_run_ssh_command`. Updates CLAUDE.md CLI-SSOT section. Closes the last #495 sub-problem (c). Part of #495.

## Parity notes (behavior-touching)
The portal's old `_run_ssh_command` and `core._run_remote` resolve the **same** SSH target (`user@host` from `machines.json`). Two non-regressive deltas in the new remote path, both via `core._run_remote`:
- adds `port` support (portal version ignored a machine's custom port) — an improvement, identical for the common no-port case;
- uses `core`'s ssh opts instead of `ssh_base_opts()` ControlMaster multiplexing — a connection-reuse optimization, not output-changing.

Both keep the portal's "stdout only on exit 0, else empty" contract. No target-resolution divergence.

## Verify
- imports clean; `repo-info`/`branches` JSON matches old endpoints for git repo / non-git dir / nonexistent path / prefix filter
- new `tests/unit/test_repo_cli.py` (11 tests, local real-git + mocked remote) green
- full `pytest tests/unit tests/integration` green (2103 passed); `ruff` clean

Built by [dotdev.dev](https://dotdev.dev)