### PR TITLE
fix(safety): matcher-aware damage-control drift check (no false-negative)

### DIFF
--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -669,21 +669,31 @@ def rules_drift() -> Dict[str, str]:
 
 
 def missing_damage_control_matchers() -> List[str]:
-    """Damage-control matchers not registered in ``~/.claude/settings.json``."""
+    """Damage-control matchers not registered in ``~/.claude/settings.json``.
+
+    Checks the (matcher, command) PAIR, mirroring
+    ``register_damage_control_in_settings``'s dedup. Several matchers
+    (Read/Grep/Glob) legitimately share one hook script, so a command-only
+    check would treat all three as present the moment *any* one is registered —
+    silently hiding a real gap in a security hook (e.g. Read guarded but
+    Grep/Glob not).
+    """
     settings_file = Path.home() / ".claude" / "settings.json"
     try:
         settings = json.loads(settings_file.read_text())
     except (OSError, json.JSONDecodeError):
         settings = {}
     pre = settings.get("hooks", {}).get("PreToolUse", []) if isinstance(settings, dict) else []
-    registered = {
-        h.get("command")
-        for entry in pre
-        for h in (entry.get("hooks", []) if isinstance(entry, dict) else [])
+    registered_pairs = {
+        (entry.get("matcher"), h.get("command"))
+        for entry in pre if isinstance(entry, dict)
+        for h in (entry.get("hooks", []) if isinstance(entry.get("hooks"), list) else [])
+        if isinstance(h, dict)
     }
     missing = []
     for matcher, hook_file in DAMAGE_CONTROL_MATCHERS.items():
-        if f"~/.agentwire/hooks/damage-control/{hook_file}" not in registered:
+        command = f"~/.agentwire/hooks/damage-control/{hook_file}"
+        if (matcher, command) not in registered_pairs:
             missing.append(matcher)
     return missing
 

--- a/tests/unit/test_safety_heal.py
+++ b/tests/unit/test_safety_heal.py
@@ -99,6 +99,20 @@ class TestDriftDetectors:
         cli_safety.heal_damage_control(quiet=True)
         assert cli_safety.missing_damage_control_matchers() == []
 
+    def test_partial_shared_command_matcher_still_flagged(self, fake_env):
+        """Read/Grep/Glob share one hook script. Registering only Read must NOT
+        mark Grep/Glob as present — a command-only check would (the bug); the
+        (matcher, command) check catches the gap."""
+        settings = Path.home() / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        cmd = "~/.agentwire/hooks/damage-control/read-tool-damage-control.py"
+        settings.write_text(json.dumps({"hooks": {"PreToolUse": [
+            {"matcher": "Read", "hooks": [{"type": "command", "command": cmd}]},
+        ]}}))
+        missing = set(cli_safety.missing_damage_control_matchers())
+        assert "Read" not in missing            # the one we registered
+        assert {"Grep", "Glob"} <= missing      # genuinely absent, must be flagged
+
 
 class TestInstallCmdNonInteractive:
     def test_yes_does_not_prompt(self, fake_env, monkeypatch):


### PR DESCRIPTION
## Found while diagnosing a `doctor` warning

Run-down of the `[!!] PreToolUse matchers not registered: Read, Grep, Glob` warning: the **cause was runtime drift** — #500 (`c17e9e0`) added Read/Grep/Glob damage-control matchers, but matcher registration only happens via `agentwire safety install` (not `rebuild`/`hooks install`), and this machine hadn't been re-synced since. Healed at runtime with `agentwire safety install --yes` (doctor now: *All checks passed!*).

While in there, I found a **genuine latent bug** in the drift check itself — this PR fixes it.

## The bug

`missing_damage_control_matchers()` built a set of **commands only**, then asked "is this matcher's command registered?". But the installer (`register_damage_control_in_settings`) dedups on the **(matcher, command) pair** — because Read/Grep/Glob deliberately share one hook script (`read-tool-damage-control.py`).

Consequence: if only **Read** is registered, the command `read-tool-damage-control.py` is in the set, so the check reports **Grep and Glob as present too** — even though their matcher entries are absent. For a *security* drift check that's a false "all clear" while damage-control isn't actually watching two read tools.

(It didn't affect the warning above — there all three were genuinely absent, so the report was correct. This is the *partial-registration* blind spot.)

## Fix

Check the **(matcher, command) pair**, mirroring the installer's own dedup. Proven:

```
partial settings = [Read → read-tool-damage-control.py]
OLD (command-only): missing = []              # bug: Grep/Glob silently unflagged
NEW (matcher,cmd):  missing = ['Grep','Glob'] # correctly flagged
```

## Verify

- New test `test_partial_shared_command_matcher_still_flagged` (registers Read only, asserts Grep/Glob flagged) — fails on old logic, passes on new.
- `tests/unit/test_safety_heal.py` 14 passed; full suite **2134 passed**; ruff clean.

Built by [dotdev.dev](https://dotdev.dev)