### PR TITLE
docs: wiki hygiene — broken links, INDEX, dated ADR (#563)

### DIFF
--- a/docs/decisions/obsidian-second-brain.md
+++ b/docs/decisions/obsidian-second-brain.md
@@ -3,6 +3,8 @@
 > Decision record for [issue #183](https://github.com/dotdevdotdev/agentwire-dev/issues/183).
 > Research/decision task — **no code shipped in this PR**. This file records yes/no/defer
 > for each proposed direction and resolves the open questions for the ones we accept.
+>
+> **Superseded:** the `wiki-ingest` batch task was retired in #473; wiki authoring is now in-context via the `agentwire wiki` CLI.
 
 ## Context
 

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -50,6 +50,8 @@ Headless and scheduled execution.
 - **[Secrets & API keys](security/secrets.md)** — `~/.agentwire/.env` is the one place every key lives; which vars each feature reads; the `api_key_env` pattern for new integrations
 - **[Remote-access hardening](security/remote-access-hardening.md)** — threat model for the any-device→tunnel→portal→shell path; network footprint map (what agentwire owns vs BYO tunnels); the portal auth boundary and the per-device / capability-scope / freeze-config hardening plan (#396, #420, #423–#425)
 - **[Damage control](internals/damage-control.md)** — safety hooks: rules, patterns, audit log
+- **[Damage-control matcher hardening](security/damage-control-hardening.md)** — consolidated note for the matcher hardening shipped in PR #500
+- **[pip-audit](security/pip-audit.md)** — dependency CVE triage workflow
 
 ## Integrations
 
@@ -69,6 +71,7 @@ Running AgentWire across machines and exposing the portal.
 Recon notes and evaluations that inform direction (not yet implemented).
 
 - **[Orchestration transport alternatives](research/orchestration-transport-alternatives.md)** — the "we don't use SSH" competitor pitch, evaluated: claims-vs-reality on faster/more-secure, and why the cheap wins are SSH `ControlMaster` multiplexing + a Tailscale mesh underlay rather than a new transport ([#297](https://github.com/dotdevdotdev/agentwire-dev/issues/297))
+- **[Briefing Mode feasibility](research/briefing-mode-feasibility.md)** — asymmetric-verbosity orchestration evaluation that informed the shipped Briefing Mode
 
 ## Voice (TTS & STT)
 

--- a/docs/wiki/briefing-mode.md
+++ b/docs/wiki/briefing-mode.md
@@ -22,7 +22,7 @@ The anchor is the calm funnel: pushed only by the human, pulling from correspond
 | **`anchor`** | `agentwire new -s <name> --roles anchor` | Replaces the orchestrator persona. Terse with the human; fans out correspondents; **acts only on the human's cue**; briefs asymmetrically; tears down. |
 | **`correspondent`** | `worktree_create(name, roles="correspondent", prompt=…)` (or `agentwire worktree <name> --roles correspondent`) | Stacks on the worktree-session safety rail. Exhaustive; files a report to the dropbox; signals passively. |
 
-`anchor` *replaces* the persona (persona kind); `correspondent` *adds to* the worktree-session etiquette (safety-rail kind) — see [roles](roles.md).
+`anchor` *replaces* the persona (persona kind); `correspondent` *adds to* the worktree-session etiquette (safety-rail kind) — see the role docs in the `agentwire-project-config` skill and CLAUDE.md.
 
 ## The two channels (asymmetric brief)
 

--- a/docs/wiki/internals/portal.md
+++ b/docs/wiki/internals/portal.md
@@ -1,6 +1,6 @@
 # AgentWire Portal
 
-> Web portal documentation. For project overview, see [CLAUDE.md](../CLAUDE.md).
+> Web portal documentation. For project overview, see [CLAUDE.md](../../../CLAUDE.md).
 
 ## Architecture: CLI-First
 


### PR DESCRIPTION
Closes #563

Small wiki-hygiene batch.

## Changes
- **B-3** `docs/wiki/briefing-mode.md` — dropped the dead `[roles](roles.md)` link (no such page); prose now points to the `agentwire-project-config` skill + CLAUDE.md role docs.
- **B-4** `docs/wiki/internals/portal.md` — fixed the `CLAUDE.md` link. Issue suggested `../../CLAUDE.md`, but from `docs/wiki/internals/` that resolves to the nonexistent `docs/CLAUDE.md` — it needed **three** `../` (`../../../CLAUDE.md`) to reach the repo-root file. Verified on disk.
- **B-5** `docs/wiki/INDEX.md` — added the 3 existing-but-unlisted pages: `security/damage-control-hardening.md`, `security/pip-audit.md`, `research/briefing-mode-feasibility.md`.
- **B-7** `docs/decisions/obsidian-second-brain.md` — added one "Superseded" line near the top (wiki-ingest retired in #473); historical record otherwise untouched.

## Verification
Both fixed link targets confirmed to resolve to real files on disk; all 3 newly-listed INDEX pages exist.

Built by [dotdev.dev](https://dotdev.dev)