### PR TITLE
refactor: remove leftover back-compat shims (#558)

### DIFF
--- a/agentwire/channels/email.py
+++ b/agentwire/channels/email.py
@@ -160,7 +160,7 @@ def _render_email_template(
 
 
 def _get_email_config() -> EmailConfig:
-    """Get email config from channels registry or legacy path."""
+    """Get email config from channels registry."""
     from agentwire.config import get_config
 
     config = get_config()

--- a/agentwire/channels/quo.py
+++ b/agentwire/channels/quo.py
@@ -30,8 +30,8 @@ class QuoConfigError(NotificationError):
 class QuoConfig:
     """Quo (OpenPhone) SMS configuration.
 
-    The API key is env-only: QUO_API_KEY (or legacy OPENPHONE_API_KEY),
-    normally a line in ~/.agentwire/.env (docs/wiki/security/secrets.md).
+    The API key is env-only: QUO_API_KEY, normally a line in
+    ~/.agentwire/.env (docs/wiki/security/secrets.md).
     It is never read from config.yaml.
     """
 
@@ -40,7 +40,7 @@ class QuoConfig:
     api_key: str = field(init=False, default="")
 
     def __post_init__(self):
-        self.api_key = os.environ.get("QUO_API_KEY", "") or os.environ.get("OPENPHONE_API_KEY", "")
+        self.api_key = os.environ.get("QUO_API_KEY", "")
 
 
 API_URL = "https://api.openphone.com/v1/messages"

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -43,7 +43,6 @@ from agentwire.safety._core import (  # noqa: F401
     matches_path_in_command,
 )
 
-
 # Default config directory
 CONFIG_DIR = Path.home() / ".agentwire"
 HOOKS_DIR = CONFIG_DIR / "hooks" / "damage-control"

--- a/agentwire/cli_safety.py
+++ b/agentwire/cli_safety.py
@@ -43,9 +43,6 @@ from agentwire.safety._core import (  # noqa: F401
     matches_path_in_command,
 )
 
-# Backwards-compat alias used by older tests
-_match_allowed_path = match_path
-
 
 # Default config directory
 CONFIG_DIR = Path.home() / ".agentwire"

--- a/agentwire/completion.py
+++ b/agentwire/completion.py
@@ -220,13 +220,10 @@ def clear_task_context(session: str) -> None:
         session: tmux session name
     """
     context_file = TASKS_DIR / f"{session}.json"
-    complete_file = TASKS_DIR / f"{session}.complete"
-
-    for f in [context_file, complete_file]:
-        try:
-            f.unlink(missing_ok=True)
-        except OSError:
-            pass
+    try:
+        context_file.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def wait_for_completion_signal(
@@ -253,8 +250,6 @@ def wait_for_completion_signal(
     Raises:
         CompletionTimeout: If session dies before task completed
     """
-    complete_file = TASKS_DIR / f"{session}.complete"
-
     # Build glob pattern for fuzzy summary detection (agents sometimes
     # invent their own timestamp instead of using the provided filename).
     summary_glob = None
@@ -303,14 +298,6 @@ def wait_for_completion_signal(
                     "summary_file": str(found_summary),
                 }
             except CompletionError:
-                pass  # File may be partially written, retry
-
-        # Fallback: check for legacy .complete signal file
-        if complete_file.exists():
-            try:
-                signal = json.loads(complete_file.read_text())
-                return signal
-            except (json.JSONDecodeError, OSError):
                 pass  # File may be partially written, retry
 
         # Usage-limit dialog: park deterministically (zero-LLM) and report a

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -201,52 +201,6 @@ def resolve_name(args) -> tuple[str | None, str | None]:
     )
 
 
-# --- first-run legacy zombie sweep ----------------------------------------------
-
-
-def _sweep_legacy_once() -> list[str]:
-    """Tear down the pre-namespace global layout, exactly once.
-
-    Pre-namespace, the council was a singleton: orchestrator ``agentwire-council``,
-    lens sessions ``council-<lens>``, a global ``~/.agentwire/council/sitting.json``
-    + ``workspace/``. After upgrade those panes keep burning tokens invisibly —
-    this exact zombie state has been hit live. Kill them and remove the orphaned
-    global state; ``prompts/`` history is kept. Marker-guarded so it runs once.
-    """
-    marker = state.COUNCIL_ROOT / ".namespaced"
-    if marker.exists():
-        return []
-
-    legacy_sitting = state.COUNCIL_ROOT / "sitting.json"
-    targets: set[str] = {"agentwire-council"}
-    targets.update(f"council-{lens}" for lens in state.DEFAULT_ROSTER)
-    if legacy_sitting.exists():
-        try:
-            data = json.loads(legacy_sitting.read_text())
-            if isinstance(data, dict):
-                targets.update(
-                    v for v in data.get("sessions", {}).values() if isinstance(v, str)
-                )
-                orch = data.get("orchestrator")
-                if isinstance(orch, str):
-                    targets.add(orch)
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    live = list_live_sessions()
-    killed = [t for t in sorted(targets) if t and t in live and kill_session(t)]
-
-    for orphan in (legacy_sitting, state.COUNCIL_ROOT / "workspace" / ".agentwire.yml"):
-        try:
-            orphan.unlink()
-        except (FileNotFoundError, OSError):
-            pass
-
-    state.COUNCIL_ROOT.mkdir(parents=True, exist_ok=True)
-    marker.write_text(state.now_iso())
-    return killed
-
-
 # --- workspace ------------------------------------------------------------------
 
 
@@ -267,8 +221,6 @@ def _write_workspace(name: str, session_type: str) -> None:
 
 
 def cmd_council_start(args) -> int:
-    _sweep_legacy_once()
-
     explicit = getattr(args, "name", None)
     name = explicit or state.default_name()
     if not state.valid_name(name):
@@ -371,7 +323,6 @@ def cmd_council_start(args) -> int:
 
 
 def cmd_council_stop(args) -> int:
-    _sweep_legacy_once()
     name, err = resolve_name(args)
     if err:
         return _emit_error(args, err)
@@ -399,7 +350,6 @@ def cmd_council_stop(args) -> int:
 
 
 def cmd_council_status(args) -> int:
-    _sweep_legacy_once()
     name, err = resolve_name(args)
     if err:
         return _emit(args, {"success": True, "running": False, "error": err}, err)
@@ -467,7 +417,6 @@ def _prompt_text_from(args) -> str | None:
 
 
 def cmd_council_ask(args) -> int:
-    _sweep_legacy_once()
     name, err = resolve_name(args)
     if err:
         return _emit_error(args, err)
@@ -530,7 +479,6 @@ def cmd_council_ask(args) -> int:
 
 
 def cmd_council_collect(args) -> int:
-    _sweep_legacy_once()
     name, err = resolve_name(args)
     if err:
         return _emit_error(args, err)
@@ -577,7 +525,6 @@ def _infer_soul(sitting: state.Sitting, session: str | None) -> str | None:
 
 
 def cmd_council_reply(args) -> int:
-    _sweep_legacy_once()
     kinds = [k for k in inbox.KINDS if getattr(args, k.replace("-", "_"), False)]
     if len(kinds) != 1:
         return _emit_error(args, "specify exactly one of --take / --ack / --pass")
@@ -659,7 +606,6 @@ def _age(iso: str) -> str:
 
 
 def cmd_council_list(args) -> int:
-    _sweep_legacy_once()
     live = list_live_sessions()
     rows = []
     for name in state.list_sittings():

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -736,9 +736,7 @@ def cmd_doctor(args) -> int:
     if channels_cfg.get("email"):
         expected_keys.append(("channels.email (Resend)", ["RESEND_API_KEY"]))
     if channels_cfg.get("quo"):
-        expected_keys.append(
-            ("channels.quo (OpenPhone)", ["QUO_API_KEY", "OPENPHONE_API_KEY"])
-        )
+        expected_keys.append(("channels.quo (OpenPhone)", ["QUO_API_KEY"]))
     for pname, pcfg in (raw_cfg.get("pi", {}).get("providers", {}) or {}).items():
         p_env_var = (pcfg or {}).get(
             "env_var", f"{pname.upper().replace('-', '_')}_API_KEY"

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -180,14 +180,6 @@ class TestQuoChannel:
         config = QuoConfig()
         assert config.api_key == "quo-key-123"
 
-    def test_quo_config_openphone_env_fallback(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.delenv("QUO_API_KEY", raising=False)
-        monkeypatch.setenv("OPENPHONE_API_KEY", "op-key-456")
-        from agentwire.channels.quo import QuoConfig
-        config = QuoConfig()
-        assert config.api_key == "op-key-456"
-
     def test_quo_config_rejects_explicit_key(self):
         """Keys are env-only (~/.agentwire/.env) — not a config field."""
         from agentwire.channels.quo import QuoConfig
@@ -202,7 +194,6 @@ class TestQuoChannel:
 
     def test_send_quo_no_api_key(self, tmp_path, monkeypatch):
         monkeypatch.delenv("QUO_API_KEY", raising=False)
-        monkeypatch.delenv("OPENPHONE_API_KEY", raising=False)
         config_data = {"channels": {"quo": {}}}
         config_path = tmp_path / "config.yaml"
         config_path.write_text(yaml.safe_dump(config_data))

--- a/tests/unit/test_cli_safety.py
+++ b/tests/unit/test_cli_safety.py
@@ -3,7 +3,6 @@
 import pytest
 
 from agentwire.cli_safety import (
-    _match_allowed_path,
     _parse_allowed_entry,
     check_command_safety,
     glob_to_regex,
@@ -11,6 +10,7 @@ from agentwire.cli_safety import (
     is_glob_pattern,
     is_path_allowed_for_op,
     load_allowed_paths,
+    match_path,
     matches_path_in_command,
 )
 
@@ -139,7 +139,7 @@ class TestCheckCommandSafety:
         assert result["command"] == "ls -la"
 
 
-# --- _match_allowed_path ---
+# --- match_path ---
 
 class TestMatchAllowedPath:
     @pytest.mark.parametrize("path,pattern,expected", [
@@ -154,7 +154,7 @@ class TestMatchAllowedPath:
         ("/home/user/project/pkg.egg-info/top_level.txt", "*.egg-info/*", True),
     ])
     def test_match(self, path, pattern, expected):
-        assert _match_allowed_path(path, pattern) is expected
+        assert match_path(path, pattern) is expected
 
 
 # --- is_command_path_allowed ---

--- a/tests/unit/test_council_cli.py
+++ b/tests/unit/test_council_cli.py
@@ -392,22 +392,3 @@ class TestReply:
         sent_before = len(mocks["sent"])
         self._reply(take=True, soul="brain", text="x")
         assert len(mocks["sent"]) == sent_before
-
-
-class TestLegacySweep:
-    def test_kills_legacy_singleton_once(self, mocks, capsys, monkeypatch):
-        # A live pre-namespace global sitting + orphaned global state.
-        mocks["live"].update({"agentwire-council", "council-brain"})
-        global_sitting = state.COUNCIL_ROOT / "sitting.json"
-        global_sitting.parent.mkdir(parents=True, exist_ok=True)
-        global_sitting.write_text(
-            json.dumps(
-                {"orchestrator": "agentwire-council", "sessions": {"brain": "council-brain"}}
-            )
-        )
-        killed = cli._sweep_legacy_once()
-        assert "agentwire-council" in killed and "council-brain" in killed
-        assert not global_sitting.exists()
-        assert (state.COUNCIL_ROOT / ".namespaced").exists()
-        # Idempotent — second call is a no-op.
-        assert cli._sweep_legacy_once() == []


### PR DESCRIPTION
## Summary

Removes leftover pre-launch back-compat shims listed in #558. Each was independent; verified the noted caveat before touching.

## Removed

| Site | What |
|------|------|
| `cli_safety.py:46-47` | `_match_allowed_path` test-only alias deleted; `tests/unit/test_cli_safety.py` now calls `match_path` directly. |
| `completion.py:308-315` | Dead legacy `.complete` signal-file fallback deleted (grep confirmed **nothing writes** `{session}.complete`). Also dropped the now-unused `complete_file` paths in `wait_for_completion_signal` and `clear_task_context`. |
| `council/cli.py` | `_sweep_legacy_once()` + all 8 call sites removed. **Verified safe**: `~/.agentwire/council/.namespaced` marker exists on this host, so the one-time sweep has already run — no orphan panes. Dropped the guarding `TestLegacySweep` test. |
| `channels/quo.py:33,43` | Dropped `OPENPHONE_API_KEY` legacy env fallback + the "(or legacy …)" docstring note; key is `QUO_API_KEY` only. Mirrored in `doctor_cli.py` expected-keys and removed the `test_quo_config_openphone_env_fallback` test. |
| `channels/email.py:163` | Reworded docstring to drop "or legacy path" (no such branch existed). |

## Skipped (caveat tripped)

- **`scheduler.py:268-275` — legacy embedded `state:` read.** SKIPPED. The live `~/.agentwire/scheduler.yaml` on this box **still carries an embedded `state:` block** (real run-state for `dev-health-check`, `dev-cli-test`, etc. at line 59+). Removing the read would orphan that state, so per the issue caveat it's left in place. The guarding `test_scheduler_board.py:453-459` test is therefore also untouched.

## Verification

`uv run python -m pytest` — **2145 passed, 8 skipped**.

Closes #558

Built by [dotdev.dev](https://dotdev.dev)
