### PR TITLE
Cleanup nits: rename cli_safety.py, fix RELEASING token extraction (#564)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,10 +34,13 @@ unzip -l dist/agentwire_dev-{VERSION}-py3-none-any.whl | grep -E "templates/|sta
 
 ### 4. Publish to PyPI
 
-The `PYPI_TOKEN` lives in `~/.agentwire/.env`. Pass it explicitly:
+The `PYPI_TOKEN` lives in `~/.agentwire/.env`. Don't `source` the file — it can
+contain unquoted `&` in other values (e.g. a URL with query params), which makes
+the shell hit a parse error before `uv publish` ever runs. Grep the token out
+directly:
 
 ```bash
-source ~/.agentwire/.env && uv publish --token "$PYPI_TOKEN" dist/agentwire_dev-{VERSION}*
+uv publish --token "$(grep '^PYPI_TOKEN=' ~/.agentwire/.env | cut -d= -f2-)" dist/agentwire_dev-{VERSION}*
 ```
 
 ### 5. Create GitHub release

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -286,13 +286,13 @@ def _render_damage_control_section() -> int:
         print("  [ok] Damage control enabled (enabled: true)")
 
     try:
-        from . import cli_safety
+        from . import safety_commands
     except Exception as e:
         print(f"  [..] Could not load safety module: {e}")
         return issues
 
     # DC hook-script staleness (bash/edit/write/mcp-tool + audit_logger).
-    hook_drift = cli_safety.damage_control_hook_drift()
+    hook_drift = safety_commands.damage_control_hook_drift()
     stale_hooks = [f for f, s in hook_drift.items() if s == "stale"]
     missing_hooks = [f for f, s in hook_drift.items() if s == "missing"]
     if stale_hooks or missing_hooks:
@@ -306,7 +306,7 @@ def _render_damage_control_section() -> int:
         print("  [ok] DC hook scripts current")
 
     # Installed-rules drift vs bundled rules (the incident's missing files).
-    rule_drift = cli_safety.rules_drift()
+    rule_drift = safety_commands.rules_drift()
     missing_rules = [f for f, s in rule_drift.items() if s == "missing"]
     stale_rules = [f for f, s in rule_drift.items() if s == "stale"]
     if missing_rules:
@@ -322,7 +322,7 @@ def _render_damage_control_section() -> int:
         print("  [ok] Damage-control rules installed and match bundled")
 
     # Matcher presence in ~/.claude/settings.json.
-    missing_matchers = cli_safety.missing_damage_control_matchers()
+    missing_matchers = safety_commands.missing_damage_control_matchers()
     if missing_matchers:
         print(f"  [!!] PreToolUse matchers not registered: {', '.join(missing_matchers)}")
         print("       Fix: agentwire safety install --yes")

--- a/agentwire/hooks_cli.py
+++ b/agentwire/hooks_cli.py
@@ -184,7 +184,7 @@ def skill_drift() -> dict[str, str]:
     """Drift state of agentwire-owned global skills.
 
     Returns {name: ok|stale|missing|source-unavailable}. Mirrors
-    cli_safety.*_drift() so `agentwire doctor` can flag a hand-placed or drifted
+    safety_commands.*_drift() so `agentwire doctor` can flag a hand-placed or drifted
     skill the same way it flags hook drift.
 
     `source-unavailable` means the packaged skill can't be resolved in the
@@ -355,7 +355,7 @@ def install_hooks(force: bool = False, copy: bool = False) -> dict[str, str]:
     # after a rebuild, so it must actually sync the DC files/rules — drift-aware,
     # never clobbering a customized rule.
     try:
-        from agentwire.cli_safety import heal_damage_control
+        from agentwire.safety_commands import heal_damage_control
         heal_damage_control(quiet=True)
     except Exception:
         pass

--- a/agentwire/safety_cli.py
+++ b/agentwire/safety_cli.py
@@ -1,30 +1,30 @@
 """CLI for damage control — ``agentwire safety ...``.
 
-Thin command wrappers; the actual logic lives in ``cli_safety`` (the same
+Thin command wrappers; the actual logic lives in ``safety_commands`` (the same
 module the PreToolUse hooks invoke), so the CLI surface and the hook surface
 share one implementation.
 """
 
 from __future__ import annotations
 
-from . import cli_safety
+from . import safety_commands
 
 
 def cmd_safety_check(args) -> int:
     """CLI command: agentwire safety check"""
     command = args.command
     verbose = getattr(args, 'verbose', False)
-    return cli_safety.safety_check_cmd(command, verbose)
+    return safety_commands.safety_check_cmd(command, verbose)
 
 
 def cmd_safety_status(args) -> int:
     """CLI command: agentwire safety status"""
-    return cli_safety.safety_status_cmd()
+    return safety_commands.safety_status_cmd()
 
 
 def cmd_safety_notify_unattended_block(args) -> int:
     """CLI command: agentwire safety notify-unattended-block (hook-invoked)"""
-    return cli_safety.safety_notify_unattended_block_cmd(
+    return safety_commands.safety_notify_unattended_block_cmd(
         getattr(args, "reason", "") or "",
         getattr(args, "rule_id", "") or "",
         getattr(args, "command", "") or "",
@@ -37,22 +37,22 @@ def cmd_safety_logs(args) -> int:
     session = getattr(args, 'session', None)
     today = getattr(args, 'today', False)
     pattern = getattr(args, 'pattern', None)
-    return cli_safety.safety_logs_cmd(tail, session, today, pattern)
+    return safety_commands.safety_logs_cmd(tail, session, today, pattern)
 
 
 def cmd_safety_install(args) -> int:
     """CLI command: agentwire safety install"""
-    return cli_safety.safety_install_cmd(assume_yes=getattr(args, "yes", False))
+    return safety_commands.safety_install_cmd(assume_yes=getattr(args, "yes", False))
 
 
 def cmd_safety_tooldefs_list(args) -> int:
     """CLI command: agentwire safety tooldefs list"""
-    return cli_safety.safety_tooldefs_list_cmd()
+    return safety_commands.safety_tooldefs_list_cmd()
 
 
 def cmd_safety_tooldefs_show(args) -> int:
     """CLI command: agentwire safety tooldefs show <tool>"""
-    return cli_safety.safety_tooldefs_show_cmd(args.tool)
+    return safety_commands.safety_tooldefs_show_cmd(args.tool)
 
 
 def register_safety_parser(subparsers) -> None:

--- a/agentwire/safety_commands.py
+++ b/agentwire/safety_commands.py
@@ -21,7 +21,7 @@ except ImportError:
     yaml = None
 
 # Re-exported from safety._core so callers and tests can import the whole
-# damage-control surface from agentwire.cli_safety.
+# damage-control surface from agentwire.safety_commands.
 from agentwire.safety._core import (  # noqa: F401
     ALL_OPERATIONS,
     NO_DELETE_BLOCKED,

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -4001,7 +4001,7 @@ projects:
     async def api_safety_status(self, request: web.Request) -> web.Response:
         """Damage-control current state: master enable, disabled rules, today's counts."""
         try:
-            from .cli_safety import LOGS_DIR, load_patterns
+            from .safety_commands import LOGS_DIR, load_patterns
             patterns = load_patterns()
             today = datetime.now().strftime("%Y-%m-%d")
             log_file = LOGS_DIR / f"{today}.jsonl"
@@ -4034,7 +4034,7 @@ projects:
     async def api_safety_logs(self, request: web.Request) -> web.Response:
         """Recent safety audit log entries with optional filters."""
         try:
-            from .cli_safety import query_audit_logs
+            from .safety_commands import query_audit_logs
             limit = int(request.query.get("limit", "200"))
             decision = request.query.get("decision")
             entries = query_audit_logs()  # all entries, newest-first by file
@@ -4050,7 +4050,7 @@ projects:
     async def api_safety_rules(self, request: web.Request) -> web.Response:
         """Flat list of bash-rule IDs with their patterns/reasons."""
         try:
-            from .cli_safety import load_patterns
+            from .safety_commands import load_patterns
             patterns = load_patterns()
             rules = []
             for p in patterns.get("bashToolPatterns", []):

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -71,14 +71,14 @@ class TestCmdRolesList:
 
 class TestCmdSafetyCheck:
     def test_allowed_command(self, tmp_path, monkeypatch):
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         monkeypatch.setattr(mod, "RULES_DIR", tmp_path / "empty-rules")
 
         result = mod.check_command_safety("echo hello")
         assert result["decision"] == "allow"
 
     def test_blocked_by_pattern(self, tmp_path, monkeypatch):
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
 
         # Create a rules dir with a blocking pattern
         rules_dir = tmp_path / "rules"

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 
-from agentwire.cli_safety import load_patterns
+from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import (
     check_command,
     check_path,

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -11,7 +11,6 @@ import os
 
 import pytest
 
-from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import (
     check_command,
     check_path,
@@ -19,6 +18,7 @@ from agentwire.safety._core import (
     load_allowed_paths,
     load_safety_config,
 )
+from agentwire.safety_commands import load_patterns
 
 CONTROL_PLANE_FILES = [
     os.path.expanduser("~/.agentwire/damagecontrol.yml"),

--- a/tests/unit/test_damage_control_bypass.py
+++ b/tests/unit/test_damage_control_bypass.py
@@ -145,7 +145,7 @@ def test_normal_file_read_allowed(cfg):
 def test_every_content_reading_tool_is_policed():
     """Each native content-reading tool must route to the read-tool hook, or a
     secret could be exfiltrated without traversing damage control."""
-    from agentwire.cli_safety import DAMAGE_CONTROL_MATCHERS
+    from agentwire.safety_commands import DAMAGE_CONTROL_MATCHERS
 
     for tool in ("Read", "Grep", "Glob"):
         assert DAMAGE_CONTROL_MATCHERS.get(tool) == "read-tool-damage-control.py", (

--- a/tests/unit/test_safety_commands.py
+++ b/tests/unit/test_safety_commands.py
@@ -1,8 +1,8 @@
-"""Tests for agentwire/cli_safety.py — Glob patterns, command safety checks."""
+"""Tests for agentwire/safety_commands.py — Glob patterns, command safety checks."""
 
 import pytest
 
-from agentwire.cli_safety import (
+from agentwire.safety_commands import (
     _parse_allowed_entry,
     check_command_safety,
     glob_to_regex,
@@ -121,14 +121,14 @@ class TestIsPathAllowedForOp:
 class TestCheckCommandSafety:
     def test_allowed_with_empty_patterns(self, tmp_path, monkeypatch):
         """If RULES_DIR has no yaml files, everything is allowed."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         monkeypatch.setattr(mod, "RULES_DIR", tmp_path / "empty-rules")
 
         result = check_command_safety("echo hello")
         assert result["decision"] == "allow"
 
     def test_result_structure(self, tmp_path, monkeypatch):
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         monkeypatch.setattr(mod, "RULES_DIR", tmp_path / "empty-rules")
 
         result = check_command_safety("ls -la")
@@ -230,7 +230,7 @@ class TestCheckCommandSafetyAllowlist:
         return rules_dir
 
     def test_allowlist_bypasses_readonly(self, tmp_path, monkeypatch):
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "readOnlyPaths": ["dist/"],
             "allowedPaths": [{"path": "*/dist/*", "allow": "all"}],
@@ -241,7 +241,7 @@ class TestCheckCommandSafetyAllowlist:
         assert result["decision"] == "allow"
 
     def test_allowlist_bypasses_nodelete(self, tmp_path, monkeypatch):
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "noDeletePaths": [".git/"],
             "allowedPaths": [],  # .git/ not allowlisted
@@ -254,7 +254,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_hard_blocked_rm_rf_never_bypassed(self, tmp_path, monkeypatch):
         """rm -rf is hard-blocked even with all perms on target path."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "bashToolPatterns": [
                 {"pattern": r"\brm\s+(-[^\s]*)*-[rRf]", "reason": "rm with flags"},
@@ -268,7 +268,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_bypassable_rm_with_delete_permission(self, tmp_path, monkeypatch):
         """Plain rm (bypassable) should be allowed if target has delete permission."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "bashToolPatterns": [
                 {"pattern": r"\brm\s+[^-]", "reason": "rm file deletion", "bypassable": True},
@@ -282,7 +282,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_bypassable_rm_without_delete_permission(self, tmp_path, monkeypatch):
         """Plain rm (bypassable) should block if target only has read/write."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "bashToolPatterns": [
                 {"pattern": r"\brm\s+[^-]", "reason": "rm file deletion", "bypassable": True},
@@ -296,7 +296,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_bypassable_rm_non_allowed_path(self, tmp_path, monkeypatch):
         """Plain rm (bypassable) should block if target is not in allowlist at all."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "bashToolPatterns": [
                 {"pattern": r"\brm\s+[^-]", "reason": "rm file deletion", "bypassable": True},
@@ -310,7 +310,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_read_only_permission_blocks_delete(self, tmp_path, monkeypatch):
         """Path with only read permission should not bypass noDelete."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "noDeletePaths": ["README.md"],
             "allowedPaths": [{"path": "README.md", "allow": ["read"]}],
@@ -322,7 +322,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_multiple_paths_all_must_match(self, tmp_path, monkeypatch):
         """Security: ALL paths in command must be allowed for bypass."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "bashToolPatterns": [
                 {"pattern": r"\brm\s+[^-]", "reason": "rm file deletion", "bypassable": True},
@@ -337,7 +337,7 @@ class TestCheckCommandSafetyAllowlist:
 
     def test_empty_allowedpaths_no_change(self, tmp_path, monkeypatch):
         """With empty allowedPaths, behavior is unchanged."""
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = self._make_rules_dir(tmp_path, {
             "readOnlyPaths": ["dist/"],
             "allowedPaths": [],
@@ -357,7 +357,7 @@ class TestCheckCommandSafetyDecisionPaths:
     def _rules(self, tmp_path, monkeypatch, patterns):
         import yaml
 
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = tmp_path / "rules"
         rd.mkdir(exist_ok=True)
         (rd / "patterns.yaml").write_text(yaml.safe_dump(patterns))
@@ -476,7 +476,7 @@ class TestCheckCommandSafetyDecisionPaths:
     ("", "write"),  # empty reason → write
 ])
 def test_infer_operation_from_reason(reason, expected_op):
-    from agentwire.cli_safety import _infer_operation_from_reason
+    from agentwire.safety_commands import _infer_operation_from_reason
     assert _infer_operation_from_reason(reason) == expected_op
 
 
@@ -484,7 +484,7 @@ def test_infer_operation_from_reason(reason, expected_op):
 
 class TestExtractCommandPaths:
     def _extract(self, cmd):
-        from agentwire.cli_safety import _extract_command_paths
+        from agentwire.safety_commands import _extract_command_paths
         return _extract_command_paths(cmd)
 
     def test_absolute_path(self):
@@ -519,7 +519,7 @@ class TestReadOnlyPathMutationOperators:
     def _rules(self, tmp_path, monkeypatch, patterns):
         import yaml
 
-        import agentwire.cli_safety as mod
+        import agentwire.safety_commands as mod
         rd = tmp_path / "rules"
         rd.mkdir(exist_ok=True)
         (rd / "patterns.yaml").write_text(yaml.safe_dump(patterns))
@@ -557,7 +557,7 @@ class TestReadOnlyPathMutationOperators:
         assert check_command_safety(cmd)["decision"] == "allow"
 
     @pytest.mark.parametrize("cmd", [
-        # Operators newly caught after #164 (cli_safety adopted the hook's regex set)
+        # Operators newly caught after #164 (safety_commands adopted the hook's regex set)
         "chmod 777 /readonly/file",
         "chown root /readonly/file",
         "chgrp staff /readonly/file",
@@ -569,6 +569,6 @@ class TestReadOnlyPathMutationOperators:
         "unlink /readonly/file",
     ])
     def test_richer_mutation_operators_caught(self, cmd, tmp_path, monkeypatch):
-        """After #164, cli_safety uses the same regex pattern set as the bash hook."""
+        """After #164, safety_commands uses the same regex pattern set as the bash hook."""
         self._rules(tmp_path, monkeypatch, {"readOnlyPaths": ["/readonly/"]})
         assert check_command_safety(cmd)["decision"] == "block"

--- a/tests/unit/test_safety_disabled_rules.py
+++ b/tests/unit/test_safety_disabled_rules.py
@@ -1,6 +1,6 @@
 """Disabled rules in safety config skip the matching pattern."""
 
-from agentwire.cli_safety import load_patterns
+from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command
 
 

--- a/tests/unit/test_safety_disabled_rules.py
+++ b/tests/unit/test_safety_disabled_rules.py
@@ -1,7 +1,7 @@
 """Disabled rules in safety config skip the matching pattern."""
 
-from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command
+from agentwire.safety_commands import load_patterns
 
 
 def test_rule_ids_are_populated():

--- a/tests/unit/test_safety_escape_hatch.py
+++ b/tests/unit/test_safety_escape_hatch.py
@@ -1,6 +1,6 @@
 """Escape hatch: `# allow: <reason>` makes the hook skip pattern checks and log it."""
 
-from agentwire.cli_safety import load_patterns
+from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command, detect_escape_hatch
 
 

--- a/tests/unit/test_safety_escape_hatch.py
+++ b/tests/unit/test_safety_escape_hatch.py
@@ -1,7 +1,7 @@
 """Escape hatch: `# allow: <reason>` makes the hook skip pattern checks and log it."""
 
-from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command, detect_escape_hatch
+from agentwire.safety_commands import load_patterns
 
 
 def test_detect_escape_hatch_basic():

--- a/tests/unit/test_safety_heal.py
+++ b/tests/unit/test_safety_heal.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from agentwire import cli_safety
+from agentwire import safety_commands
 
 
 @pytest.fixture
@@ -21,29 +21,29 @@ def fake_env(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
 
     cfg = home / ".agentwire"
-    monkeypatch.setattr(cli_safety, "CONFIG_DIR", cfg)
-    monkeypatch.setattr(cli_safety, "HOOKS_DIR", cfg / "hooks" / "damage-control")
-    monkeypatch.setattr(cli_safety, "LOGS_DIR", cfg / "logs" / "damage-control")
-    monkeypatch.setattr(cli_safety, "RULES_DIR", cfg / "damage-control")
-    monkeypatch.setattr(cli_safety, "TOOLDEFS_DIR", cfg / "tooldefs")
-    monkeypatch.setattr(cli_safety, "DAMAGECONTROL_FILE", cfg / "damagecontrol.yml")
+    monkeypatch.setattr(safety_commands, "CONFIG_DIR", cfg)
+    monkeypatch.setattr(safety_commands, "HOOKS_DIR", cfg / "hooks" / "damage-control")
+    monkeypatch.setattr(safety_commands, "LOGS_DIR", cfg / "logs" / "damage-control")
+    monkeypatch.setattr(safety_commands, "RULES_DIR", cfg / "damage-control")
+    monkeypatch.setattr(safety_commands, "TOOLDEFS_DIR", cfg / "tooldefs")
+    monkeypatch.setattr(safety_commands, "DAMAGECONTROL_FILE", cfg / "damagecontrol.yml")
     return home
 
 
 class TestHealIdempotency:
     def test_fresh_heal_installs_everything(self, fake_env):
-        summary = cli_safety.heal_damage_control(quiet=True)
+        summary = safety_commands.heal_damage_control(quiet=True)
         assert summary["hooks_installed"]          # all DC hook scripts
         assert summary["rules_installed"]          # all bundled rules
-        assert summary["matchers_added"] == len(cli_safety.DAMAGE_CONTROL_MATCHERS)
+        assert summary["matchers_added"] == len(safety_commands.DAMAGE_CONTROL_MATCHERS)
         # Every bundled rule landed.
-        installed = {p.name for p in cli_safety.RULES_DIR.glob("*.yaml")}
-        bundled = {p.name for p in cli_safety.get_damage_control_source().glob("*.yaml")}
+        installed = {p.name for p in safety_commands.RULES_DIR.glob("*.yaml")}
+        bundled = {p.name for p in safety_commands.get_damage_control_source().glob("*.yaml")}
         assert bundled <= installed
 
     def test_second_heal_is_noop(self, fake_env):
-        cli_safety.heal_damage_control(quiet=True)
-        summary = cli_safety.heal_damage_control(quiet=True)
+        safety_commands.heal_damage_control(quiet=True)
+        summary = safety_commands.heal_damage_control(quiet=True)
         assert summary["hooks_installed"] == []
         assert summary["hooks_updated"] == []
         assert summary["rules_installed"] == []
@@ -52,27 +52,27 @@ class TestHealIdempotency:
 
 class TestHealDriftAwareness:
     def test_missing_rule_reinstalled(self, fake_env):
-        cli_safety.heal_damage_control(quiet=True)
-        victim = next(cli_safety.RULES_DIR.glob("*.yaml"))
+        safety_commands.heal_damage_control(quiet=True)
+        victim = next(safety_commands.RULES_DIR.glob("*.yaml"))
         name = victim.name
         victim.unlink()
-        summary = cli_safety.heal_damage_control(quiet=True)
+        summary = safety_commands.heal_damage_control(quiet=True)
         assert name in summary["rules_installed"]
-        assert (cli_safety.RULES_DIR / name).exists()
+        assert (safety_commands.RULES_DIR / name).exists()
 
     def test_customized_rule_survives(self, fake_env):
-        cli_safety.heal_damage_control(quiet=True)
-        rule = next(cli_safety.RULES_DIR.glob("*.yaml"))
+        safety_commands.heal_damage_control(quiet=True)
+        rule = next(safety_commands.RULES_DIR.glob("*.yaml"))
         rule.write_text("# my hand-customized rule\n")
-        cli_safety.heal_damage_control(quiet=True)
+        safety_commands.heal_damage_control(quiet=True)
         # Never blind-clobbered: the customization is intact.
         assert rule.read_text() == "# my hand-customized rule\n"
 
     def test_stale_owned_hook_refreshed(self, fake_env):
-        cli_safety.heal_damage_control(quiet=True)
-        hook = cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]
+        safety_commands.heal_damage_control(quiet=True)
+        hook = safety_commands.HOOKS_DIR / safety_commands.DAMAGE_CONTROL_FILES[0]
         hook.write_text("# stale\n")
-        summary = cli_safety.heal_damage_control(quiet=True)
+        summary = safety_commands.heal_damage_control(quiet=True)
         # Owned hook scripts carry no user edits — drift is overwritten.
         assert hook.name in summary["hooks_updated"]
         assert "# stale" not in hook.read_text()
@@ -80,24 +80,24 @@ class TestHealDriftAwareness:
 
 class TestDriftDetectors:
     def test_hook_drift_states(self, fake_env):
-        assert set(cli_safety.damage_control_hook_drift().values()) == {"missing"}
-        cli_safety.heal_damage_control(quiet=True)
-        assert set(cli_safety.damage_control_hook_drift().values()) == {"ok"}
-        hook = cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]
+        assert set(safety_commands.damage_control_hook_drift().values()) == {"missing"}
+        safety_commands.heal_damage_control(quiet=True)
+        assert set(safety_commands.damage_control_hook_drift().values()) == {"ok"}
+        hook = safety_commands.HOOKS_DIR / safety_commands.DAMAGE_CONTROL_FILES[0]
         hook.write_text("# drifted\n")
-        assert cli_safety.damage_control_hook_drift()[hook.name] == "stale"
+        assert safety_commands.damage_control_hook_drift()[hook.name] == "stale"
 
     def test_rules_drift_states(self, fake_env):
-        assert set(cli_safety.rules_drift().values()) == {"missing"}
-        cli_safety.heal_damage_control(quiet=True)
-        assert set(cli_safety.rules_drift().values()) == {"ok"}
+        assert set(safety_commands.rules_drift().values()) == {"missing"}
+        safety_commands.heal_damage_control(quiet=True)
+        assert set(safety_commands.rules_drift().values()) == {"ok"}
 
     def test_missing_matchers(self, fake_env):
-        assert set(cli_safety.missing_damage_control_matchers()) == set(
-            cli_safety.DAMAGE_CONTROL_MATCHERS
+        assert set(safety_commands.missing_damage_control_matchers()) == set(
+            safety_commands.DAMAGE_CONTROL_MATCHERS
         )
-        cli_safety.heal_damage_control(quiet=True)
-        assert cli_safety.missing_damage_control_matchers() == []
+        safety_commands.heal_damage_control(quiet=True)
+        assert safety_commands.missing_damage_control_matchers() == []
 
     def test_partial_shared_command_matcher_still_flagged(self, fake_env):
         """Read/Grep/Glob share one hook script. Registering only Read must NOT
@@ -109,7 +109,7 @@ class TestDriftDetectors:
         settings.write_text(json.dumps({"hooks": {"PreToolUse": [
             {"matcher": "Read", "hooks": [{"type": "command", "command": cmd}]},
         ]}}))
-        missing = set(cli_safety.missing_damage_control_matchers())
+        missing = set(safety_commands.missing_damage_control_matchers())
         assert "Read" not in missing            # the one we registered
         assert {"Grep", "Glob"} <= missing      # genuinely absent, must be flagged
 
@@ -118,22 +118,22 @@ class TestInstallCmdNonInteractive:
     def test_yes_does_not_prompt(self, fake_env, monkeypatch):
         # input() must never be called in --yes mode.
         monkeypatch.setattr("builtins.input", lambda *a: pytest.fail("prompted"))
-        rc = cli_safety.safety_install_cmd(assume_yes=True)
+        rc = safety_commands.safety_install_cmd(assume_yes=True)
         assert rc == 0
-        assert (cli_safety.HOOKS_DIR / cli_safety.DAMAGE_CONTROL_FILES[0]).exists()
+        assert (safety_commands.HOOKS_DIR / safety_commands.DAMAGE_CONTROL_FILES[0]).exists()
 
 
 class TestDoctorDamageControlSection:
     @pytest.fixture(autouse=True)
     def _healed(self, fake_env):
-        cli_safety.heal_damage_control(quiet=True)
+        safety_commands.heal_damage_control(quiet=True)
         return fake_env
 
     def _patch_safety_enabled(self, monkeypatch, enabled):
         # The kill switch now lives in the host-owned damagecontrol.yml, read by
         # load_safety_config (#466). Write it directly in the fake home.
-        cli_safety.DAMAGECONTROL_FILE.parent.mkdir(parents=True, exist_ok=True)
-        cli_safety.DAMAGECONTROL_FILE.write_text(
+        safety_commands.DAMAGECONTROL_FILE.parent.mkdir(parents=True, exist_ok=True)
+        safety_commands.DAMAGECONTROL_FILE.write_text(
             f"enabled: {str(bool(enabled)).lower()}\n"
         )
 
@@ -156,7 +156,7 @@ class TestDoctorDamageControlSection:
     def test_missing_rule_flagged(self, monkeypatch, capsys):
         from agentwire.doctor_cli import _render_damage_control_section
         self._patch_safety_enabled(monkeypatch, True)
-        next(cli_safety.RULES_DIR.glob("*.yaml")).unlink()
+        next(safety_commands.RULES_DIR.glob("*.yaml")).unlink()
         issues = _render_damage_control_section()
         out = capsys.readouterr().out
         assert issues >= 1

--- a/tests/unit/test_safety_kill_switch.py
+++ b/tests/unit/test_safety_kill_switch.py
@@ -1,6 +1,6 @@
 """Global kill switch (safety.enabled = false) short-circuits all blocks."""
 
-from agentwire.cli_safety import load_patterns
+from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command, check_path
 
 

--- a/tests/unit/test_safety_kill_switch.py
+++ b/tests/unit/test_safety_kill_switch.py
@@ -1,7 +1,7 @@
 """Global kill switch (safety.enabled = false) short-circuits all blocks."""
 
-from agentwire.safety_commands import load_patterns
 from agentwire.safety._core import check_command, check_path
+from agentwire.safety_commands import load_patterns
 
 
 def test_kill_switch_allows_dangerous_bash():

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -175,7 +175,7 @@ def test_install_hooks_installs_skills(env, tmp_path, monkeypatch):
     # Stub out the hook half so we exercise only the skill wiring, and keep
     # damage-control healing from touching the real machine.
     monkeypatch.setattr(m, "get_hooks_source", lambda: tmp_path / "no-hooks")
-    import agentwire.cli_safety as cs
+    import agentwire.safety_commands as cs
     monkeypatch.setattr(cs, "heal_damage_control", lambda quiet=True: None)
 
     _, target_root = env


### PR DESCRIPTION
Closes #564 — two of the three nits resolved; one left as an owner decision.

## 1. Rename `cli_safety.py` → `safety_commands.py` ✅
The impl module name inverted the `<domain>_cli.py` registrar convention and was easy to confuse with its real registrar `safety_cli.py`. `git mv`'d to `agentwire/safety_commands.py`, renamed the test module `test_cli_safety.py` → `test_safety_commands.py`, and updated every importer (`safety_cli.py`, `doctor_cli.py`, `hooks_cli.py`, `server.py`, 9 test files + the `safety_cli.py` docstring). `rg cli_safety agentwire/ tests/` now returns nothing. Full suite: **2145 passed, 8 skipped**.

## 2. `RELEASING.md` — `source ~/.agentwire/.env` ✅ (confirmed real)
The parse error is **real in zsh** (the owner's release shell): the canonical `.env` has an unquoted `&` in a URL value (`DISCORD_BOT_INVITE_URL`, line 26), so `source ~/.agentwire/.env` hits `parse error near '&'` and exits **126** — the `&&` chain never reaches `uv publish`. (In non-interactive bash it silently exits 0, but zsh is what releases run in.) Switched the example to:
```bash
uv publish --token "$(grep '^PYPI_TOKEN=' ~/.agentwire/.env | cut -d= -f2-)" dist/agentwire_dev-{VERSION}*
```

## 3. `chatbot` role — OWNER DECISION NEEDED ⏸️
`agentwire/roles/chatbot.md` is user-selectable (globbed by `roles_cli.py`) but never auto-injected by any code path. **Not touched** — keep it as a valid opt-in persona, or delete if unused? Your call.

Built by [dotdev.dev](https://dotdev.dev)