### PR TITLE
build: stop shipping never-served source art in wheel/sdist (#557)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,21 @@ exclude = [
     # source — don't ship them in the wheel.
     "agentwire/static/icons/**/*.jpeg",
     "agentwire/static/icons/**/custom/*.png",
+    # Unreferenced root splash/Echo/banner source PNGs (0 refs across
+    # templates/static/js/css/server.py). The wallpaper uses only the 5
+    # decomposed --tree/--telephone/--echo/--echo-claw-fg/--agentwire-text
+    # layers; email banner/Echo default to config-driven PUBLIC urls, not
+    # these local copies. Kept in-repo as source, not shipped.
+    "agentwire/static/agentwire-Echo.png",
+    "agentwire/static/agentwire-Echo--black.png",
+    "agentwire/static/agentwire-Echo--transparent.png",
+    "agentwire/static/agentwire-email-banner.png",
+    "agentwire/static/agentwire-splash-logo-layers.png",
+    "agentwire/static/agentwire-splash-logo-layers--full--transparent-top.png",
+    "agentwire/static/agentwire-splash-logo-layers--full-black.png",
+    "agentwire/static/agentwire-splash-logo-layers--telephone-fg.png",
+    "agentwire/static/agentwire-splash-logo-layers--transparent-top.png",
+    "agentwire/static/agentwire-splash-logo-layers--transparent.png",
 ]
 
 # Ship the agentwire-owned GLOBAL skill into the package so get_skills_source()
@@ -176,6 +191,17 @@ exclude = [
     # and full-res custom .png originals are regen source, not shipped.
     "agentwire/static/icons/**/*.jpeg",
     "agentwire/static/icons/**/custom/*.png",
+    # Unreferenced root splash/Echo/banner source PNGs (see wheel exclude).
+    "agentwire/static/agentwire-Echo.png",
+    "agentwire/static/agentwire-Echo--black.png",
+    "agentwire/static/agentwire-Echo--transparent.png",
+    "agentwire/static/agentwire-email-banner.png",
+    "agentwire/static/agentwire-splash-logo-layers.png",
+    "agentwire/static/agentwire-splash-logo-layers--full--transparent-top.png",
+    "agentwire/static/agentwire-splash-logo-layers--full-black.png",
+    "agentwire/static/agentwire-splash-logo-layers--telephone-fg.png",
+    "agentwire/static/agentwire-splash-logo-layers--transparent-top.png",
+    "agentwire/static/agentwire-splash-logo-layers--transparent.png",
 ]
 
 # The sdist excludes .claude/, but the wheel force-includes .claude/skills/wiki

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,12 +132,12 @@ artifacts = [
     "agentwire/hooks/**/*.sh",
 ]
 exclude = [
-    "agentwire/static/*.xcf",
-    "agentwire/static/*-blue.*",
-    "agentwire/static/agentwire-logo-splash.jpeg",
-    "agentwire/static/agentwire-logo-splash-dark.jpeg",
-    "agentwire/static/agentwire-logo-splash-green.jpeg",
-    "agentwire/static/agentwire-logo-splash-green-dark.jpeg",
+    # Never-served source art kept in-repo for regen only. The portal serves
+    # WebP exclusively (server.py list_images suffix filter), so the heavyweight
+    # .jpeg session icons and full-res custom .png originals are pure regen
+    # source — don't ship them in the wheel.
+    "agentwire/static/icons/**/*.jpeg",
+    "agentwire/static/icons/**/custom/*.png",
 ]
 
 # Ship the agentwire-owned GLOBAL skill into the package so get_skills_source()
@@ -172,13 +172,10 @@ exclude = [
     # Dev examples and scripts
     "examples/",
     "scripts/",
-    # Static file dev assets
-    "agentwire/static/*.xcf",
-    "agentwire/static/*-blue.*",
-    "agentwire/static/agentwire-logo-splash.jpeg",
-    "agentwire/static/agentwire-logo-splash-dark.jpeg",
-    "agentwire/static/agentwire-logo-splash-green.jpeg",
-    "agentwire/static/agentwire-logo-splash-green-dark.jpeg",
+    # Never-served source art (see wheel exclude above): .jpeg session icons
+    # and full-res custom .png originals are regen source, not shipped.
+    "agentwire/static/icons/**/*.jpeg",
+    "agentwire/static/icons/**/custom/*.png",
 ]
 
 # The sdist excludes .claude/, but the wheel force-includes .claude/skills/wiki


### PR DESCRIPTION
## What

The portal serves WebP exclusively (`server.py` `list_images` suffix filter), so the `.jpeg` session icons and full-res custom `.png` originals are pure regen source. They shipped via `include = ["agentwire/static/**/*"]` while the `exclude` lists guarded only files deleted in #556. This PR also covers the unreferenced root splash/Echo/banner PNGs (§3 / C-8).

## Change — packaging only, no files deleted

Replaced the stale dead-guard patterns and extended both the wheel and sdist `exclude` lists:

| Excluded (regen source, kept in-repo) | Count |
|---|---|
| `agentwire/static/icons/**/*.jpeg` | 14 session JPEGs |
| `agentwire/static/icons/**/custom/*.png` | 3 full-res originals |
| 10 root `agentwire-Echo*` / `agentwire-email-banner` / `agentwire-splash-logo-layers*` PNGs | 10 (0 refs each) |

**Kept packaged:** the 5 served wallpaper layers (`--tree`, `--telephone`, `--echo`, `--echo-claw-fg`, `--agentwire-text`), `favicon.png`, `img/icon-192.png`, `img/icon-512.png`, and all served `.webp`.

Root splash/Echo/banner default to config-driven **public** URLs, not these local `/static` copies — grep-confirmed 0 refs across templates/static/js/css/server.py.

## Verification — `uv build`

- Wheel: **22.3 MB → 5.9 MB** (~16.4 MB drop)
- 0 excluded source-art files in wheel and sdist
- 5 layers + favicon + icon-192/512 + 17 served `.webp` all present

Closes #557

Built by [dotdev.dev](https://dotdev.dev)