### PR TITLE
fix(worktree): record creator so notify-parent resolves (#578)

### DIFF
--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -1,6 +1,7 @@
 """MCP tools — worktree domain."""
 
 from .mcp_core import (
+    get_caller_session,
     mcp,
     run_agentwire_cmd,
 )
@@ -44,6 +45,13 @@ def worktree_create(
         args += ["--base", base]
     if prompt:
         args += ["--prompt", prompt]
+    # Forward the calling session as the new worktree's creator so prompt
+    # routing (resolve_parent) and notify-parent resolve back to the spawner.
+    # The CLI's own get_current_session() can't see the caller through the MCP
+    # subprocess boundary, so we pass it explicitly (issue #578).
+    caller = get_caller_session()
+    if caller:
+        args += ["--created-by", caller]
     # Seeding waits for agent boot (~up to 60s); give the CLI room to finish.
     data = run_agentwire_cmd(args, timeout=90)
     if not data.get("success"):

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -881,6 +881,7 @@ def cmd_worktree(args) -> int:
             'instructions': None, 'persist': False,
             'first_message': getattr(args, 'prompt', None),
             'env': getattr(args, 'env', None),
+            'created_by': getattr(args, 'created_by', None),
         })())
 
     # If worktree already exists, reattach (and heal the registry entry).
@@ -1741,5 +1742,9 @@ def register_session_parser(subparsers) -> None:
     wt_parser.add_argument("--prompt", help="First message to deliver once the agent is booted/ready (spawn + seed in one step)")
     wt_parser.add_argument("--model", help="Model override (e.g., haiku, sonnet, opus)")
     wt_parser.add_argument("--env", action="append", metavar="KEY=VAL", help="Inject env var via `tmux set-environment` (repeatable)")
+    wt_parser.add_argument("--created-by", dest="created_by",
+                           help="Record this session as the creator/parent for prompt routing "
+                                "(default: the calling tmux session; pass '' to opt out). "
+                                "MCP forwards the caller here so notify-parent resolves.")
     wt_parser.add_argument("--json", action="store_true", help="Output as JSON")
     wt_parser.set_defaults(func=cmd_worktree)

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -70,7 +70,7 @@ def _run(monkeypatch, cfg, **arg_overrides):
         name=None, base=None, current=False, existing=False, ref=None,
         project=None, list=False, remove=False, prune=False, all=False,
         json=True, type=None, posture=None, harness=None, model=None,
-        roles=None, env=None,
+        roles=None, env=None, created_by=None,
     )
     base.update(arg_overrides)
     return m.cmd_worktree(Namespace(**base))
@@ -96,6 +96,32 @@ def test_default_base_is_repo_derived(tmp_path, monkeypatch, wt_env):
     assert len(entries) == 1
     assert entries[0]["base"] == "develop"
     assert entries[0]["session"] == "clone-repo-fix-bug"
+
+
+def test_created_by_forwarded_to_cmd_new(tmp_path, monkeypatch, wt_env):
+    """--created-by (the spawner) flows through to cmd_new so the worktree
+    session records its creator → notify-parent / resolve_parent resolves (#578)."""
+    _, clone = _origin_and_clone(tmp_path)
+    cfg = _config(tmp_path / "worktrees")
+
+    rc = _run(monkeypatch, cfg, name="fix-bug", project=str(clone),
+              created_by="orchestrator")
+    assert rc == 0
+    # The captured cmd_new Args carries the creator through unchanged.
+    assert wt_env["args"].created_by == "orchestrator"
+
+
+def test_record_session_creator_persists_creator(tmp_path, monkeypatch):
+    """The creator-registry mechanism cmd_new uses records the spawner so
+    _display_parent (and resolve_parent) returns it for a worktree session."""
+    from agentwire import core
+
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path / "agentwire")
+    monkeypatch.setattr(core, "get_parent_from_config", lambda *_a, **_k: None)
+
+    core._record_session_creator("clone-repo-fix-bug", "orchestrator", via="worktree")
+    assert core.load_session_metadata("clone-repo-fix-bug")["created_by"] == "orchestrator"
+    assert core._display_parent("clone-repo-fix-bug") == "orchestrator"
 
 
 def test_base_flag_overrides(tmp_path, monkeypatch, wt_env):


### PR DESCRIPTION
## Summary

`worktree_create` (MCP) shelled out to `agentwire worktree` without forwarding the calling session, so the new worktree session recorded no creator. None of `resolve_parent`'s rungs (worker-pane → creator-registry → `.agentwire.yml parent:`) resolved, so `notify-parent` from inside a worktree session errored **"no parent recorded"** and report-backs never reached the orchestrator that spawned it.

`mcp_worktree.worktree_create` now forwards the caller (`get_caller_session()`) as `--created-by`; the `agentwire worktree` CLI accepts the flag and threads it into `cmd_new`, which records it via `_record_session_creator` exactly like `agentwire new`. The CLI's own `get_current_session()` can't see the caller across the MCP subprocess boundary, hence the explicit forward.

Scope: `agentwire/mcp_worktree.py` + `agentwire/session_cli.py` only. No back-compat shims (pre-launch).

## Tests

- `test_created_by_forwarded_to_cmd_new` — `--created-by` flows through `cmd_worktree` → `cmd_new`.
- `test_record_session_creator_persists_creator` — the recorded creator makes `_display_parent` / `resolve_parent` return the spawner.
- Broader subset (worktree/session_cli/mcp/parent/creator): 228 passed.

Closes #578

Built by [dotdev.dev](https://dotdev.dev)