### PR TITLE
fix: adaptive verified paste submit — never leave text unsent (#579)

### DIFF
--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -18,9 +18,18 @@ import time
 # 60 lines) so a submitted prompt that scrolled up is still found.
 VERIFY_SCROLLBACK_LINES = 200
 
-# Delay for the early snapshot — catches the placeholder/fragment before a fast
-# agent scrolls it away. The remaining settle gives a slow agent time to render.
-EARLY_SETTLE = 0.15
+# Adaptive submit tuning (replaces the old fixed pre-Enter sleep). Delivery is a
+# two-phase poll: wait for the paste to land in the input box, then press Enter
+# and wait for the box to clear — re-pressing Enter a bounded number of times if
+# the first keystroke is swallowed under load (or a large paste needs a second
+# Enter to dismiss its ``[Pasted text]`` banner before submitting).
+POLL_INTERVAL = 0.15
+# Max wait for a paste to appear in the input box before giving up on this try.
+LAND_TIMEOUT = 5.0
+# Max wait, after an Enter, for the box to clear (the keystroke to register).
+SUBMIT_TIMEOUT = 3.0
+# Bounded Enter re-presses before declaring a hard failure.
+MAX_ENTER_ATTEMPTS = 4
 
 # Substrings that mean "Claude is actively working" — a spinner footer, the
 # token counter, the esc-to-interrupt hint, or tool-output glyphs. A
@@ -39,11 +48,27 @@ ACTIVITY_MARKERS = (
 )
 
 
-def send_to_session(session: str, message: str, pane_index: int = 0) -> None:
-    """Inject a message into a session's pane (pane 0 by default)."""
+def paste_no_enter(session: str, message: str, pane_index: int = 0) -> None:
+    """Paste a message into a session's pane WITHOUT pressing Enter.
+
+    Decoupling the paste from the Enter is the whole point of the adaptive
+    submit: it lets us poll the input box and confirm the text actually landed
+    before we commit it. Pressing Enter in the same breath (the old behavior)
+    fires the keystroke on a fixed delay that, under load, lands before the
+    paste does — Enter is swallowed and the message sits unsent.
+    """
     from agentwire import pane_manager
 
-    pane_manager.send_to_target(f"{session}.{pane_index}", message, enter=True)
+    pane_manager.send_to_target(f"{session}.{pane_index}", message, enter=False)
+
+
+def press_enter(session: str, pane_index: int = 0) -> None:
+    """Send a single Enter keystroke to a session's pane."""
+    from agentwire import pane_manager
+
+    pane_manager.run_command(
+        ["tmux", "send-keys", "-t", f"{session}.{pane_index}", "Enter"], timeout=5
+    )
 
 
 def capture_session(session: str, lines: int = 60, pane_index: int = 0) -> str:
@@ -58,22 +83,66 @@ def pane_shows_activity(capture: str) -> bool:
     return any(marker.lower() in lowered for marker in ACTIVITY_MARKERS)
 
 
-def consumed_and_working(session: str, capture: str, pane_index: int = 0) -> bool:
-    """Positive "consumed" signal: input box empty AND pane shows activity.
+def input_box(capture: str) -> "str | None":
+    """The input-box content for *capture*, or None if it can't be parsed.
 
-    A submitted prompt leaves the input box empty while the agent works. We
-    require *both* — empty alone is also the idle/never-received state, so an
-    empty box with no activity is NOT treated as delivered (guards the genuine
-    vanish case against a false positive).
+    Thin pass-through to :func:`prompt_router.input_box_content` so the verified
+    submit can reason about exactly one thing: is our pasted text still sitting
+    unsent in the box, or has it cleared?
     """
-    if not pane_shows_activity(capture):
-        return False
     from agentwire import prompt_router
 
-    try:
-        return prompt_router.prompt_is_empty(session, pane_index)
-    except Exception:
+    return prompt_router.input_box_content(capture)
+
+
+def text_landed(capture: str, message: str) -> bool:
+    """Has *message* landed in the input box, ready to submit?
+
+    True iff the box is parseable and shows the message fragment (or Claude's
+    ``[Pasted text …]`` placeholder for a large paste).
+    """
+    box = input_box(capture)
+    if box is None:
         return False
+    return message_visible(box, message)
+
+
+def submitted(capture: str, message: str, marker: str | None = None) -> bool:
+    """Did the paste actually get *submitted* (Enter registered)?
+
+    The discriminating signal is the input box: if our text still sits in a
+    readable box, it is NOT submitted — this is the exact false-positive the old
+    check made (treating "text visible anywhere" as success while it sat unsent).
+
+    Once the box no longer holds our text, we confirm with positive evidence:
+      - *marker* given → the marker line is present in scrollback.
+      - empty box → the pane shows activity OR the message scrolled into history
+        (an empty box with neither is the idle/never-received vanish case).
+      - unparseable box (tool output / dialog covering it) → activity AND the
+        message visible in scrollback.
+    """
+    box = input_box(capture)
+    if box is not None and message_visible(box, message):
+        return False  # still sitting unsent in the box
+    if marker is not None:
+        return marker in capture
+    if box == "":
+        return pane_shows_activity(capture) or message_visible(capture, message)
+    return pane_shows_activity(capture) and message_visible(capture, message)
+
+
+def _poll(predicate, timeout: float) -> bool:
+    """Poll *predicate* until it returns truthy or *timeout* elapses."""
+    deadline = time.time() + timeout
+    while True:
+        try:
+            if predicate():
+                return True
+        except Exception:
+            pass
+        if time.time() >= deadline:
+            return False
+        time.sleep(POLL_INTERVAL)
 
 
 def wait_for_session_ready(
@@ -168,6 +237,43 @@ def message_visible(capture: str, message: str) -> bool:
     return "[Pasted text" in capture
 
 
+def _snapshot(session: str, pane_index: int) -> str:
+    return capture_session(
+        session, lines=VERIFY_SCROLLBACK_LINES, pane_index=pane_index
+    )
+
+
+def _deliver_once(
+    session: str, message: str, marker: str | None, pane_index: int
+) -> bool:
+    """One adaptive paste→land→submit attempt. True iff the message submitted."""
+    paste_no_enter(session, message, pane_index=pane_index)
+
+    # Phase 1 — wait for the paste to actually land in the input box (or for a
+    # very fast bypass agent to have already consumed AND submitted it). If it
+    # never lands, the paste vanished — let the caller retry the whole send.
+    def landed_or_done() -> bool:
+        cap = _snapshot(session, pane_index)
+        return submitted(cap, message, marker) or text_landed(cap, message)
+
+    if not _poll(landed_or_done, LAND_TIMEOUT):
+        return False
+
+    # Phase 2 — press Enter and confirm the box cleared. Bounded re-press: a
+    # single Enter can be swallowed under load, and a large paste needs a second
+    # Enter (dismiss the ``[Pasted text]`` banner, then submit).
+    for _ in range(MAX_ENTER_ATTEMPTS):
+        if submitted(_snapshot(session, pane_index), message, marker):
+            return True
+        press_enter(session, pane_index=pane_index)
+        if _poll(
+            lambda: submitted(_snapshot(session, pane_index), message, marker),
+            SUBMIT_TIMEOUT,
+        ):
+            return True
+    return False
+
+
 def send_verified(
     session: str,
     message: str,
@@ -176,50 +282,30 @@ def send_verified(
     settle: float = 2.0,
     pane_index: int = 0,
 ) -> bool:
-    """Send a message and verify it actually landed in the pane.
+    """Paste a message and verify it was actually *submitted* — adaptively.
 
-    After sending, confirm the message is visible in the pane — via
-    *marker* if given (council's explicit-marker pattern), otherwise via
-    :func:`message_visible` on the message itself. Retry once if not.
+    Replaces the old blind fixed-delay-then-Enter with a verified, two-phase
+    submit (the same compare-and-send rigor ``agentwire prompts answer`` uses):
 
-    Verification reads *scrollback* (not just the visible tail) and snapshots
-    twice — once ~150ms after the paste (to catch the ``[Pasted text …]``
-    placeholder / fragment before a fast agent scrolls it away) and once after
-    *settle*. A hit at *either* time counts. For the markerless case a positive
-    "consumed" signal (input box went empty AND the pane shows activity) also
-    counts — a submitted-and-working agent is delivery, not failure. The
-    genuine vanish case (empty box, no activity, nothing in scrollback) still
-    returns False.
+    1. Paste WITHOUT Enter, then poll the input box (bounded, ``LAND_TIMEOUT``)
+       until the pasted text is actually visible there — never press Enter on a
+       box that hasn't received the paste yet.
+    2. Press Enter and poll (bounded, ``SUBMIT_TIMEOUT``) until the box clears.
+       If a keystroke is swallowed, re-press up to ``MAX_ENTER_ATTEMPTS`` times.
 
+    Returns True once submission is confirmed. Returns False — a hard, surfaced
+    failure the caller must handle — only after exhausting *retries* whole-send
+    attempts; it NEVER silently leaves text sitting unsent.
+
+    *marker* uses council's explicit-marker scrollback check; otherwise the
+    message's own fragment is used. *settle* is retained for signature
+    stability — the adaptive poll supersedes the old fixed pre-Enter sleep.
     *pane_index* targets a worker pane (1+) instead of the session's pane 0.
     """
-
-    def confirmed() -> bool:
-        capture = capture_session(
-            session, lines=VERIFY_SCROLLBACK_LINES, pane_index=pane_index
-        )
-        if marker is not None:
-            return marker in capture
-        if message_visible(capture, message):
-            return True
-        return consumed_and_working(session, capture, pane_index=pane_index)
-
+    del settle  # superseded by adaptive polling; kept for signature stability
     for _ in range(retries + 1):
-        send_to_session(session, message, pane_index=pane_index)
-        # Early snapshot — placeholder/fragment still on screen before the
-        # agent consumes and scrolls it away.
-        time.sleep(EARLY_SETTLE)
         try:
-            if confirmed():
-                return True
-        except Exception:
-            pass
-        # Late snapshot — gives a slow agent time to render the paste.
-        remaining = settle - EARLY_SETTLE
-        if remaining > 0:
-            time.sleep(remaining)
-        try:
-            if confirmed():
+            if _deliver_once(session, message, marker, pane_index):
                 return True
         except Exception:
             pass

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -97,67 +97,108 @@ class TestMessageVisible:
         assert not session_ready.message_visible("❯ \nBypassing Permissions", "my unique idea")
 
 
-class TestSendVerified:
-    def _quiet(self, monkeypatch):
-        monkeypatch.setattr(session_ready.time, "sleep", lambda _: None)
+RULE = "─" * 20
 
+
+def render_box(content: str = "") -> str:
+    """A parseable Claude input box wrapped in horizontal rules."""
+    glyph = f"❯ {content}" if content else "❯"
+    return f"{RULE}\n{glyph}\n{RULE}"
+
+
+def render_working(content: str = "") -> str:
+    """An empty input box plus a visible activity marker (submitted+working)."""
+    return "✶ Working… (esc to interrupt)\n" + render_box(content)
+
+
+def _fake_clock(monkeypatch, step: float = 0.5):
+    """No-op sleep + a monotonically advancing clock so bounded polls time out
+    fast in tests instead of busy-waiting real wall-clock seconds."""
+    t = {"v": 0.0}
+
+    def now():
+        t["v"] += step
+        return t["v"]
+
+    monkeypatch.setattr(session_ready.time, "sleep", lambda _: None)
+    monkeypatch.setattr(session_ready.time, "time", now)
+
+
+def _env(monkeypatch, frame):
+    """Wire paste/enter/capture stubs. *frame(actions)* returns the current
+    capture given the running tally of pastes/enters/captures."""
+    actions = {"pastes": 0, "enters": 0, "caps": 0}
+
+    def paste(s, m, pane_index=0):
+        actions["pastes"] += 1
+        actions["paste_pane"] = pane_index
+
+    def enter(s, pane_index=0):
+        actions["enters"] += 1
+        actions["enter_pane"] = pane_index
+
+    def capture(s, lines=60, pane_index=0):
+        actions["caps"] += 1
+        actions["cap_lines"] = lines
+        actions["cap_pane"] = pane_index
+        return frame(actions)
+
+    monkeypatch.setattr(session_ready, "paste_no_enter", paste)
+    monkeypatch.setattr(session_ready, "press_enter", enter)
+    monkeypatch.setattr(session_ready, "capture_session", capture)
+    return actions
+
+
+class TestSendVerified:
     def test_marker_mode_confirms(self, monkeypatch):
-        self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(
-            session_ready, "capture_session",
-            lambda s, lines=60, pane_index=0: "...[COUNCIL PROMPT #1]...")
+        _fake_clock(monkeypatch)
+        # Marker already in scrollback, box cleared → submitted, no Enter needed.
+        _env(monkeypatch, lambda a: "...[COUNCIL PROMPT #1]...\n" + render_box())
         assert session_ready.send_verified("s", "msg", "[COUNCIL PROMPT #1]")
 
     def test_marker_mode_retries_then_fails(self, monkeypatch):
-        self._quiet(monkeypatch)
-        sends = []
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: sends.append(s))
-        monkeypatch.setattr(
-            session_ready, "capture_session", lambda s, lines=60, pane_index=0: "no marker here")
+        _fake_clock(monkeypatch)
+        # Marker never appears and the box never shows our text → never lands,
+        # so each whole-send attempt times out. Two pastes (initial + 1 retry).
+        actions = _env(monkeypatch, lambda a: "no marker here\n" + render_box())
         assert not session_ready.send_verified("s", "msg", "[COUNCIL PROMPT #1]")
-        assert len(sends) == 2  # initial + one retry
+        assert actions["pastes"] == 2
 
-    def test_markerless_uses_message_visible(self, monkeypatch):
-        self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(
-            session_ready, "capture_session",
-            lambda s, lines=60, pane_index=0: "❯ build a voice diary app")
+    def test_markerless_lands_then_submits(self, monkeypatch):
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box("build a voice diary app")  # landed, unsent
+            return render_working()  # Enter registered, box cleared, working
+
+        actions = _env(monkeypatch, frame)
         assert session_ready.send_verified("s", "build a voice diary app")
-
-    def test_markerless_confirms_on_retry(self, monkeypatch):
-        self._quiet(monkeypatch)
-        sends = []
-        captures = ["", "❯ my idea text"]
-
-        def fake_capture(s, lines=60, pane_index=0):
-            return captures[min(len(sends) - 1, 1)]
-
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: sends.append(s))
-        monkeypatch.setattr(session_ready, "capture_session", fake_capture)
-        assert session_ready.send_verified("s", "my idea text")
-        assert len(sends) == 2
+        assert actions["enters"] == 1
 
     def test_capture_exception_counts_as_miss(self, monkeypatch):
-        self._quiet(monkeypatch)
+        _fake_clock(monkeypatch)
 
-        def boom(s, lines=60, pane_index=0):
+        def boom(a):
             raise RuntimeError("gone")
 
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(session_ready, "capture_session", boom)
+        actions = _env(monkeypatch, boom)
         assert not session_ready.send_verified("s", "msg")
+        assert actions["pastes"] == 2  # retried, still failed
 
     def test_pane_index_threads_through(self, monkeypatch):
-        self._quiet(monkeypatch)
-        seen = {}
-        monkeypatch.setattr(session_ready, "send_to_session",
-                            lambda s, m, pane_index=0: seen.update(send=pane_index))
-        monkeypatch.setattr(session_ready, "capture_session",
-                            lambda s, lines=60, pane_index=0: seen.update(cap=pane_index) or "❯ hi there")
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box("hi there")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
         assert session_ready.send_verified("s", "hi there", pane_index=2)
-        assert seen == {"send": 2, "cap": 2}
+        assert actions["paste_pane"] == 2
+        assert actions["enter_pane"] == 2
+        assert actions["cap_pane"] == 2
 
 
 class TestPaneShowsActivity:
@@ -174,58 +215,78 @@ class TestPaneShowsActivity:
         assert not session_ready.pane_shows_activity("❯ \nBypassing Permissions")
 
 
-class TestSendVerifiedRegression:
-    """Pins #478 — fast bypass agent submits + scrolls the paste away."""
+class TestSendVerifiedAdaptive:
+    """#579 — paste/Enter is decoupled; Enter waits for the paste to land and
+    re-presses if swallowed, never leaving text unsent."""
 
-    def _quiet(self, monkeypatch):
-        monkeypatch.setattr(session_ready.time, "sleep", lambda _: None)
+    def test_paste_lands_late_enter_waits(self, monkeypatch):
+        # The paste hasn't rendered for the first few polls (empty box, no
+        # activity). Enter must NOT fire until the text actually lands.
+        _fake_clock(monkeypatch)
 
-    def test_scrolled_out_but_working_is_delivered(self, monkeypatch):
-        # Prompt fragment/placeholder has scrolled OUT of the capture, the
-        # input box is empty, and the agent is visibly working → DELIVERED.
-        self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(
-            session_ready, "capture_session",
-            lambda s, lines=60, pane_index=0: "⏺ Read(foo.py)\n  ⎿ 42 lines\n✶ Working… (esc to interrupt)")
-        from agentwire import prompt_router
-        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        def frame(a):
+            if a["enters"] == 0:
+                if a["caps"] <= 3:
+                    return render_box()  # empty: paste not landed yet
+                return render_box("seed prompt")  # landed
+            return render_working()  # submitted + working
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "seed prompt")
+        # Enter was pressed exactly once, and only after the paste landed.
+        assert actions["enters"] == 1
+
+    def test_swallowed_enter_is_re_pressed(self, monkeypatch):
+        # Text lands, but the first Enter is swallowed (box still holds it).
+        # The bounded retry must re-press until the box clears.
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] < 2:
+                return render_box("resilient prompt")  # still sitting unsent
+            return render_working()  # second Enter registered
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "resilient prompt")
+        assert actions["enters"] == 2
+
+    def test_fast_agent_already_submitted(self, monkeypatch):
+        # A fast bypass agent consumed+submitted before our first poll: empty
+        # box + visible activity → delivered, no Enter needed.
+        _fake_clock(monkeypatch)
+        actions = _env(monkeypatch, lambda a: render_working())
         assert session_ready.send_verified("s", "my unique multiline prompt")
+        assert actions["enters"] == 0
 
-    def test_placeholder_in_scrollback_is_delivered(self, monkeypatch):
-        # Large paste renders only as the placeholder, still in scrollback.
-        self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(
-            session_ready, "capture_session",
-            lambda s, lines=60, pane_index=0: "older output...\n❯ [Pasted text #1 +40 lines]\nmore")
+    def test_large_paste_placeholder_lands(self, monkeypatch):
+        # Large paste renders as the [Pasted text] placeholder in the box; that
+        # counts as landed, then submits.
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box("[Pasted text #1 +40 lines]")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
         assert session_ready.send_verified("s", "line one\nline two\n...forty lines")
+        assert actions["enters"] == 1
 
-    def test_genuine_vanish_is_not_delivered(self, monkeypatch):
-        # Empty input box, no activity, nothing in scrollback → NOT delivered.
-        self._quiet(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-        monkeypatch.setattr(
-            session_ready, "capture_session",
-            lambda s, lines=60, pane_index=0: "❯ \nBypassing Permissions")
-        from agentwire import prompt_router
-        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+    def test_genuine_failure_returns_false_not_silent(self, monkeypatch):
+        # Empty box, no activity, never lands → hard False (caller learns), and
+        # Enter is never blindly pressed into a box that never received the paste.
+        _fake_clock(monkeypatch)
+        actions = _env(monkeypatch, lambda a: render_box())
         assert not session_ready.send_verified("s", "this prompt vanished entirely")
+        assert actions["enters"] == 0
+        assert actions["pastes"] == 2  # initial + one retry
 
     def test_verification_reads_scrollback(self, monkeypatch):
-        # send_verified must request scrollback, not just the visible tail.
-        self._quiet(monkeypatch)
-        seen = {}
-        monkeypatch.setattr(session_ready, "send_to_session", lambda s, m, pane_index=0: None)
-
-        def fake_capture(s, lines=60, pane_index=0):
-            seen["lines"] = lines
-            return ""
-        monkeypatch.setattr(session_ready, "capture_session", fake_capture)
-        from agentwire import prompt_router
-        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        # Submission verification must request scrollback, not just the tail.
+        _fake_clock(monkeypatch)
+        actions = _env(monkeypatch, lambda a: render_working())
         session_ready.send_verified("s", "anything")
-        assert seen["lines"] == session_ready.VERIFY_SCROLLBACK_LINES
+        assert actions["cap_lines"] == session_ready.VERIFY_SCROLLBACK_LINES
 
 
 class TestCouncilDelegation:


### PR DESCRIPTION
## What

Fixes the paste-settle race where `send_verified` sometimes pasted text into a session's input box but Enter never registered, leaving the message **unsent**.

## Root cause

`send_verified` → `send_to_session` → `pane_manager.send_to_target(enter=True)` pasted and pressed Enter **atomically** after a fixed sleep. Under load the Enter fired before the paste had landed and was swallowed — the text sat in the box, never submitted. The old verification compounded it: "message visible anywhere in the capture" counted as success even while the text was sitting unsent in the input box.

## Fix — two-phase adaptive submit

Same compare-and-send rigor as `agentwire prompts answer`:

1. **Paste without Enter**, then poll the input box (bounded, `LAND_TIMEOUT`) until the pasted text actually shows there — never press Enter on a box that hasn't received the paste.
2. **Press Enter** and poll (bounded, `SUBMIT_TIMEOUT`) until the box clears; re-press up to `MAX_ENTER_ATTEMPTS` if a keystroke is swallowed (or a large paste needs a second Enter to dismiss its `[Pasted text]` banner).

Submission is judged off the **input box** (`prompt_router.input_box_content`): text still sitting in a readable box is **not** submitted. After the configured whole-send retries it returns a hard `False` the caller must handle — it **never silently drops text**.

- Public `send_verified` signature unchanged (`settle` retained for stability, now superseded by polling).
- Replaced `send_to_session`/`consumed_and_working` with `paste_no_enter`/`press_enter` + box-based `text_landed`/`submitted` helpers.
- Scope: only `agentwire/session_ready.py` + its tests. Untouched: `mcp_worktree.py`, `session_cli.py` (#578), `server.py`.

## Tests

Rewrote the delivery tests around the new box-based model and added the three required scenarios:
- paste lands late (box empty then fills) → Enter waits, fires once
- Enter swallowed → bounded retry re-presses until the box clears
- genuine failure → hard `False` (Enter never blindly pressed), not a silent drop

`tests/unit/test_session_ready.py`: 27 passed. Full unit suite: 2047 passed, 8 skipped. `test_council_cli` / `test_prompt_router` / `test_cli_commands` green.

Closes #579

Built by [dotdev.dev](https://dotdev.dev)