### PR TITLE
Split server.py — foundation: routes/ package + mixin seam (scratchpad)

### DIFF
--- a/agentwire/routes/__init__.py
+++ b/agentwire/routes/__init__.py
@@ -1,0 +1,22 @@
+"""Per-domain aiohttp route modules for the portal.
+
+The portal's ``AgentWireServer`` was a single god-class owning every route
+handler (#560). Handlers are being split per-domain, mirroring the #495
+``mcp_server`` split — but with one structural twist: portal handlers share
+mutable ``self`` state (active_sessions, dashboard_clients, caches, …), so
+they cannot become stateless free functions the way MCP tools did.
+
+The seam is therefore a **handler mixin per domain**:
+
+* Each ``routes/<domain>.py`` defines ``class <Domain>RoutesMixin`` whose
+  methods are the domain's handlers, moved verbatim — ``self.`` references to
+  shared state and core helpers stay intact and resolve through the final
+  class's MRO.
+* ``AgentWireServer`` inherits every mixin, so the composed instance still
+  exposes all handlers and all state on ``self`` exactly as before. Tests that
+  do ``AgentWireServer(config)`` / ``server.broadcast_dashboard = AsyncMock()``
+  keep working unchanged.
+* Each module also exposes ``register_<domain>_routes(server, app)`` which runs
+  that domain's ``app.router.add_*`` calls. ``_setup_routes`` calls these in a
+  registrar loop, so adding a domain is a new module + one import + one append.
+"""

--- a/agentwire/routes/scratchpad.py
+++ b/agentwire/routes/scratchpad.py
@@ -1,0 +1,71 @@
+"""Portal routes — scratchpad domain (shared notes drawer).
+
+Spike slice for the #560 server.py split. Handlers moved verbatim from
+``AgentWireServer``; they depend only on the ``scratchpad`` module and the
+core ``self.broadcast_dashboard`` helper, which resolves through the MRO of
+the composed server class.
+"""
+
+from aiohttp import web
+
+
+class ScratchpadRoutesMixin:
+    async def _broadcast_scratchpad(self):
+        from .. import scratchpad
+        await self.broadcast_dashboard("scratchpad_updated", {"notes": scratchpad.load_notes()})
+
+    async def api_scratchpad_list(self, request: web.Request) -> web.Response:
+        """GET /api/scratchpad - All notes, newest first."""
+        from .. import scratchpad
+        return web.json_response({"notes": scratchpad.load_notes()})
+
+    async def api_scratchpad_add(self, request: web.Request) -> web.Response:
+        """POST /api/scratchpad/notes {text, source?} - Create a note."""
+        from .. import scratchpad
+        try:
+            data = await request.json()
+            note = scratchpad.add_note(data.get("text", ""), source=data.get("source"))
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+        await self._broadcast_scratchpad()
+        return web.json_response({"success": True, "note": note})
+
+    async def api_scratchpad_update(self, request: web.Request) -> web.Response:
+        """PUT /api/scratchpad/notes/{note_id} {text} - Edit a note."""
+        from .. import scratchpad
+        try:
+            data = await request.json()
+            note = scratchpad.update_note(request.match_info["note_id"], data.get("text", ""))
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+        if note is None:
+            return web.json_response({"error": "Note not found"}, status=404)
+        await self._broadcast_scratchpad()
+        return web.json_response({"success": True, "note": note})
+
+    async def api_scratchpad_remove(self, request: web.Request) -> web.Response:
+        """DELETE /api/scratchpad/notes/{note_id} - Delete a note."""
+        from .. import scratchpad
+        if not scratchpad.remove_note(request.match_info["note_id"]):
+            return web.json_response({"error": "Note not found"}, status=404)
+        await self._broadcast_scratchpad()
+        return web.json_response({"success": True})
+
+    async def api_scratchpad_changed(self, request: web.Request) -> web.Response:
+        """POST /api/scratchpad/changed - External writer (CLI/MCP) ping.
+
+        The file is already written; just rebroadcast so open drawers refresh.
+        """
+        await self._broadcast_scratchpad()
+        return web.json_response({"success": True})
+
+
+def register_scratchpad_routes(server, app):
+    """Wire the scratchpad domain's routes onto ``app``."""
+    app.router.add_get("/api/scratchpad", server.api_scratchpad_list)
+    app.router.add_post("/api/scratchpad/notes", server.api_scratchpad_add)
+    app.router.add_put("/api/scratchpad/notes/{note_id}", server.api_scratchpad_update)
+    app.router.add_delete("/api/scratchpad/notes/{note_id}", server.api_scratchpad_remove)
+    app.router.add_post("/api/scratchpad/changed", server.api_scratchpad_changed)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -39,6 +39,7 @@ from aiohttp import web
 from . import prompt_router, security
 from .cached_status import CachedStatusChecker
 from .config import Config, load_config
+from .routes.scratchpad import ScratchpadRoutesMixin, register_scratchpad_routes
 from .security import (
     WS_PROTOCOL_PREFIX,
     create_security_middleware,
@@ -212,7 +213,7 @@ class Session:
     is_active: bool = False  # Current active/idle state for transition detection
 
 
-class AgentWireServer:
+class AgentWireServer(ScratchpadRoutesMixin):
     """Main server managing sessions, WebSockets, and agent backends."""
 
     def __init__(self, config: Config):
@@ -353,11 +354,7 @@ class AgentWireServer:
         self.app.router.add_get("/api/services/custom", self.api_services_custom)
 
         # Scratch pad (shared notes drawer)
-        self.app.router.add_get("/api/scratchpad", self.api_scratchpad_list)
-        self.app.router.add_post("/api/scratchpad/notes", self.api_scratchpad_add)
-        self.app.router.add_put("/api/scratchpad/notes/{note_id}", self.api_scratchpad_update)
-        self.app.router.add_delete("/api/scratchpad/notes/{note_id}", self.api_scratchpad_remove)
-        self.app.router.add_post("/api/scratchpad/changed", self.api_scratchpad_changed)
+        register_scratchpad_routes(self, self.app)
         # Scheduler monitoring endpoints
         self.app.router.add_get("/api/scheduler/live", self.api_scheduler_live)
         self.app.router.add_get("/api/scheduler/events", self.api_scheduler_events)
@@ -5306,57 +5303,6 @@ projects:
     # Storage logic lives in agentwire/scratchpad.py (shared with the CLI and
     # MCP tool). Every mutation broadcasts scratchpad_updated so all connected
     # clients (desktop + phone) refresh their drawers.
-
-    async def _broadcast_scratchpad(self):
-        from . import scratchpad
-        await self.broadcast_dashboard("scratchpad_updated", {"notes": scratchpad.load_notes()})
-
-    async def api_scratchpad_list(self, request: web.Request) -> web.Response:
-        """GET /api/scratchpad - All notes, newest first."""
-        from . import scratchpad
-        return web.json_response({"notes": scratchpad.load_notes()})
-
-    async def api_scratchpad_add(self, request: web.Request) -> web.Response:
-        """POST /api/scratchpad/notes {text, source?} - Create a note."""
-        from . import scratchpad
-        try:
-            data = await request.json()
-            note = scratchpad.add_note(data.get("text", ""), source=data.get("source"))
-        except ValueError as e:
-            return web.json_response({"error": str(e)}, status=400)
-        except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
-        await self._broadcast_scratchpad()
-        return web.json_response({"success": True, "note": note})
-
-    async def api_scratchpad_update(self, request: web.Request) -> web.Response:
-        """PUT /api/scratchpad/notes/{note_id} {text} - Edit a note."""
-        from . import scratchpad
-        try:
-            data = await request.json()
-            note = scratchpad.update_note(request.match_info["note_id"], data.get("text", ""))
-        except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
-        if note is None:
-            return web.json_response({"error": "Note not found"}, status=404)
-        await self._broadcast_scratchpad()
-        return web.json_response({"success": True, "note": note})
-
-    async def api_scratchpad_remove(self, request: web.Request) -> web.Response:
-        """DELETE /api/scratchpad/notes/{note_id} - Delete a note."""
-        from . import scratchpad
-        if not scratchpad.remove_note(request.match_info["note_id"]):
-            return web.json_response({"error": "Note not found"}, status=404)
-        await self._broadcast_scratchpad()
-        return web.json_response({"success": True})
-
-    async def api_scratchpad_changed(self, request: web.Request) -> web.Response:
-        """POST /api/scratchpad/changed - External writer (CLI/MCP) ping.
-
-        The file is already written; just rebroadcast so open drawers refresh.
-        """
-        await self._broadcast_scratchpad()
-        return web.json_response({"success": True})
 
     async def api_scheduler_live(self, request: web.Request) -> web.Response:
         """GET /api/scheduler/live - Live scheduler state.

--- a/tests/unit/test_routes_snapshot.py
+++ b/tests/unit/test_routes_snapshot.py
@@ -1,0 +1,51 @@
+"""Route-table snapshot guard for the #560 server.py split.
+
+Each domain slice moves handlers into a ``routes/<domain>.py`` mixin and its
+registration into ``register_<domain>_routes``. A route accidentally dropped
+from a registrar would 404 silently at runtime with nothing else catching it.
+This test freezes the full ``(method, canonical-path)`` set so any such drop
+(or unintended addition) fails loudly.
+
+Updating the baseline is intentional only when routes legitimately change —
+diff the assertion error to confirm the delta is what you meant.
+"""
+
+from agentwire.config import Config
+from agentwire.server import AgentWireServer
+
+
+def _route_set(app):
+    routes = set()
+    for r in app.router.routes():
+        canonical = getattr(r.resource, "canonical", None)
+        if canonical is None:
+            continue
+        routes.add((r.method, canonical))
+    return routes
+
+
+def test_route_table_unchanged():
+    server = AgentWireServer(Config())
+    actual = _route_set(server.app)
+    # Sanity: the split must not lose routes. The exact count is a guard, not
+    # a contract — bump it deliberately alongside a real route change.
+    assert len(actual) >= 100, f"route table collapsed to {len(actual)} routes"
+
+    # Spot-check representative routes from several domains survive the split.
+    expected_present = {
+        ("GET", "/health"),
+        ("GET", "/api/sessions"),
+        ("GET", "/api/scratchpad"),
+        ("POST", "/api/scratchpad/changed"),
+        ("GET", "/api/scheduler/live"),
+        ("GET", "/api/council/sittings"),
+        ("GET", "/api/desktop/windows"),
+        ("GET", "/api/safety/status"),
+        ("GET", "/api/config"),
+        ("GET", "/api/history"),
+        ("GET", "/api/machines"),
+        ("GET", "/api/projects"),
+        ("POST", "/api/notify"),
+    }
+    missing = expected_present - actual
+    assert not missing, f"routes vanished from registration: {sorted(missing)}"

--- a/tests/unit/test_routes_snapshot.py
+++ b/tests/unit/test_routes_snapshot.py
@@ -3,15 +3,174 @@
 Each domain slice moves handlers into a ``routes/<domain>.py`` mixin and its
 registration into ``register_<domain>_routes``. A route accidentally dropped
 from a registrar would 404 silently at runtime with nothing else catching it.
-This test freezes the full ``(method, canonical-path)`` set so any such drop
-(or unintended addition) fails loudly.
 
-Updating the baseline is intentional only when routes legitimately change —
-diff the assertion error to confirm the delta is what you meant.
+Every slice is a PURE RELOCATION: the full ``(method, canonical-path)`` route
+*set* is invariant — only *where* each route registers changes. So this guard
+freezes the complete set and asserts equality. Any dropped or added route
+fails loudly, on every slice — not just the spot-checked handful.
+
+``BASELINE_ROUTES`` is the contract. Update it deliberately ONLY when routes
+genuinely change (a real feature add/remove) — diff the assertion delta first
+to confirm the change is exactly what you intended.
 """
 
 from agentwire.config import Config
 from agentwire.server import AgentWireServer
+
+# Complete (method, canonical-path) set registered by a fresh AgentWireServer.
+# Frozen baseline — see module docstring before editing.
+BASELINE_ROUTES = frozenset({
+    ("DELETE", "/api/artifacts/{filename}"),
+    ("DELETE", "/api/machines/{machine_id}"),
+    ("DELETE", "/api/scratchpad/notes/{note_id}"),
+    ("DELETE", "/api/sessions/{name}"),
+    ("GET", "/"),
+    ("GET", "/api/artifacts"),
+    ("GET", "/api/check-branches"),
+    ("GET", "/api/check-path"),
+    ("GET", "/api/config"),
+    ("GET", "/api/council/archive"),
+    ("GET", "/api/council/live"),
+    ("GET", "/api/council/sittings"),
+    ("GET", "/api/council/status"),
+    ("GET", "/api/desktop/notifications"),
+    ("GET", "/api/desktop/windows"),
+    ("GET", "/api/history"),
+    ("GET", "/api/history/{session_id}"),
+    ("GET", "/api/icons/{category}"),
+    ("GET", "/api/machine/{machine_id}/status"),
+    ("GET", "/api/machines"),
+    ("GET", "/api/projects"),
+    ("GET", "/api/push/config"),
+    ("GET", "/api/review/{name}"),
+    ("GET", "/api/roles"),
+    ("GET", "/api/safety/logs"),
+    ("GET", "/api/safety/rules"),
+    ("GET", "/api/safety/status"),
+    ("GET", "/api/scheduler/board"),
+    ("GET", "/api/scheduler/events"),
+    ("GET", "/api/scheduler/live"),
+    ("GET", "/api/scheduler/output"),
+    ("GET", "/api/scheduler/tasks/{name}/events"),
+    ("GET", "/api/scratchpad"),
+    ("GET", "/api/services/custom"),
+    ("GET", "/api/session/defaults"),
+    ("GET", "/api/sessions"),
+    ("GET", "/api/sessions/local"),
+    ("GET", "/api/sessions/remote"),
+    ("GET", "/api/sessions/{name}/connections"),
+    ("GET", "/api/voice-status"),
+    ("GET", "/api/voices"),
+    ("GET", "/api/worktrees"),
+    ("GET", "/artifacts"),
+    ("GET", "/health"),
+    ("GET", "/manifest.webmanifest"),
+    ("GET", "/mobile"),
+    ("GET", "/pair"),
+    ("GET", "/service-worker.js"),
+    ("GET", "/static/{path}"),
+    ("GET", "/ws"),
+    ("GET", "/ws/terminal/{name}"),
+    ("GET", "/ws/{name}"),
+    ("HEAD", "/"),
+    ("HEAD", "/api/artifacts"),
+    ("HEAD", "/api/check-branches"),
+    ("HEAD", "/api/check-path"),
+    ("HEAD", "/api/config"),
+    ("HEAD", "/api/council/archive"),
+    ("HEAD", "/api/council/live"),
+    ("HEAD", "/api/council/sittings"),
+    ("HEAD", "/api/council/status"),
+    ("HEAD", "/api/desktop/notifications"),
+    ("HEAD", "/api/desktop/windows"),
+    ("HEAD", "/api/history"),
+    ("HEAD", "/api/history/{session_id}"),
+    ("HEAD", "/api/icons/{category}"),
+    ("HEAD", "/api/machine/{machine_id}/status"),
+    ("HEAD", "/api/machines"),
+    ("HEAD", "/api/projects"),
+    ("HEAD", "/api/push/config"),
+    ("HEAD", "/api/review/{name}"),
+    ("HEAD", "/api/roles"),
+    ("HEAD", "/api/safety/logs"),
+    ("HEAD", "/api/safety/rules"),
+    ("HEAD", "/api/safety/status"),
+    ("HEAD", "/api/scheduler/board"),
+    ("HEAD", "/api/scheduler/events"),
+    ("HEAD", "/api/scheduler/live"),
+    ("HEAD", "/api/scheduler/output"),
+    ("HEAD", "/api/scheduler/tasks/{name}/events"),
+    ("HEAD", "/api/scratchpad"),
+    ("HEAD", "/api/services/custom"),
+    ("HEAD", "/api/session/defaults"),
+    ("HEAD", "/api/sessions"),
+    ("HEAD", "/api/sessions/local"),
+    ("HEAD", "/api/sessions/remote"),
+    ("HEAD", "/api/sessions/{name}/connections"),
+    ("HEAD", "/api/voice-status"),
+    ("HEAD", "/api/voices"),
+    ("HEAD", "/api/worktrees"),
+    ("HEAD", "/artifacts"),
+    ("HEAD", "/health"),
+    ("HEAD", "/manifest.webmanifest"),
+    ("HEAD", "/mobile"),
+    ("HEAD", "/pair"),
+    ("HEAD", "/service-worker.js"),
+    ("HEAD", "/static/{path}"),
+    ("HEAD", "/ws"),
+    ("HEAD", "/ws/terminal/{name}"),
+    ("HEAD", "/ws/{name}"),
+    ("POST", "/api/active-session"),
+    ("POST", "/api/answer/{name}"),
+    ("POST", "/api/artifacts/upload"),
+    ("POST", "/api/config"),
+    ("POST", "/api/config/reload"),
+    ("POST", "/api/council/ask"),
+    ("POST", "/api/council/start"),
+    ("POST", "/api/council/stop"),
+    ("POST", "/api/create"),
+    ("POST", "/api/desktop/collage"),
+    ("POST", "/api/desktop/layout"),
+    ("POST", "/api/desktop/notification"),
+    ("POST", "/api/desktop/notification/dismiss"),
+    ("POST", "/api/desktop/window/close"),
+    ("POST", "/api/desktop/window/focus"),
+    ("POST", "/api/desktop/window/minimize-all"),
+    ("POST", "/api/desktop/window/open"),
+    ("POST", "/api/desktop/window/tile"),
+    ("POST", "/api/history/{session_id}/resume"),
+    ("POST", "/api/local-tts/{name}"),
+    ("POST", "/api/machines"),
+    ("POST", "/api/notify"),
+    ("POST", "/api/pair"),
+    ("POST", "/api/permission/{name}"),
+    ("POST", "/api/permission/{name}/respond"),
+    ("POST", "/api/projects/create"),
+    ("POST", "/api/projects/delete"),
+    ("POST", "/api/push/subscribe"),
+    ("POST", "/api/push/unsubscribe"),
+    ("POST", "/api/review/{name}/answer"),
+    ("POST", "/api/safety/config"),
+    ("POST", "/api/say/{name}"),
+    ("POST", "/api/scheduler/start"),
+    ("POST", "/api/scheduler/stop"),
+    ("POST", "/api/scheduler/tasks/{name}/disable"),
+    ("POST", "/api/scheduler/tasks/{name}/enable"),
+    ("POST", "/api/scheduler/tasks/{name}/run"),
+    ("POST", "/api/scratchpad/changed"),
+    ("POST", "/api/scratchpad/notes"),
+    ("POST", "/api/session/{name}/broadcast"),
+    ("POST", "/api/session/{name}/config"),
+    ("POST", "/api/session/{name}/fork"),
+    ("POST", "/api/session/{name}/recreate"),
+    ("POST", "/api/session/{name}/restart-service"),
+    ("POST", "/api/session/{name}/spawn-sibling"),
+    ("POST", "/api/sessions/refresh"),
+    ("POST", "/send/{name}"),
+    ("POST", "/transcribe"),
+    ("POST", "/upload"),
+    ("PUT", "/api/scratchpad/notes/{note_id}"),
+})
 
 
 def _route_set(app):
@@ -25,27 +184,22 @@ def _route_set(app):
 
 
 def test_route_table_unchanged():
+    """The full route set must exactly match the frozen baseline.
+
+    Load-bearing for every #560 slice: because each slice only relocates
+    handlers, the set is invariant. A dropped route (missing from the new
+    registrar) or a stray addition fails here with an explicit delta.
+    """
     server = AgentWireServer(Config())
     actual = _route_set(server.app)
-    # Sanity: the split must not lose routes. The exact count is a guard, not
-    # a contract — bump it deliberately alongside a real route change.
-    assert len(actual) >= 100, f"route table collapsed to {len(actual)} routes"
 
-    # Spot-check representative routes from several domains survive the split.
-    expected_present = {
-        ("GET", "/health"),
-        ("GET", "/api/sessions"),
-        ("GET", "/api/scratchpad"),
-        ("POST", "/api/scratchpad/changed"),
-        ("GET", "/api/scheduler/live"),
-        ("GET", "/api/council/sittings"),
-        ("GET", "/api/desktop/windows"),
-        ("GET", "/api/safety/status"),
-        ("GET", "/api/config"),
-        ("GET", "/api/history"),
-        ("GET", "/api/machines"),
-        ("GET", "/api/projects"),
-        ("POST", "/api/notify"),
-    }
-    missing = expected_present - actual
-    assert not missing, f"routes vanished from registration: {sorted(missing)}"
+    missing = BASELINE_ROUTES - actual
+    extra = actual - BASELINE_ROUTES
+    assert not missing and not extra, (
+        "Route table drifted from the frozen baseline.\n"
+        f"  DROPPED (in baseline, not registered): {sorted(missing)}\n"
+        f"  ADDED   (registered, not in baseline): {sorted(extra)}\n"
+        "If a slice merely relocated routes, a non-empty delta means a route "
+        "was lost or duplicated — fix the registrar. Update BASELINE_ROUTES "
+        "only when routes genuinely change (real feature add/remove)."
+    )


### PR DESCRIPTION
## Foundation slice for #560

Stands up `agentwire/routes/` + the handler-mixin/registrar seam every later slice copies, proven by relocating the **scratchpad** domain. Pure relocation — no behavior change. Cut fresh from current `main` (supersedes the validated spike #595, whose ruff check was failing).

### Seam (matches the #595 spike)
- `agentwire/routes/__init__.py` — package + seam docstring.
- `agentwire/routes/scratchpad.py` — `ScratchpadRoutesMixin` (`api_scratchpad_list/add/update/remove/changed` + `_broadcast_scratchpad`) + `register_scratchpad_routes(server, app)`.
- `server.py` — `class AgentWireServer(ScratchpadRoutesMixin)`; scratchpad block in `_setup_routes` → `register_scratchpad_routes(self, self.app)`; 6 moved methods deleted.
- `tests/unit/test_routes_snapshot.py` — **route-snapshot guard**: freezes the full `(method, path)` table so a route silently dropped from a registrar in any later slice fails CI instead of 404ing at runtime.

### Verified
- ✅ ruff clean — `uv run --extra dev ruff check agentwire/ tests/` (the #595 failure: a misordered `.routes.scratchpad` import — fixed).
- ✅ full suite green — `pytest tests/unit tests/integration tests/e2e`: **2147 passed, 8 skipped**.
- ✅ route-snapshot guard passes.
- ✅ portal boots in-worktree (non-default port): **150 routes register**, `/api/scratchpad` → **200**.

Scope: foundation seam + scratchpad only. Must merge **first** — all other #560 slices depend on the package + seam + guard.

Closes #584

Built by [dotdev.dev](https://dotdev.dev)