### PR TITLE
fix(sidebar): classify agentwire-kokoro as a service

### DIFF
--- a/agentwire/static/js/service-classification.js
+++ b/agentwire/static/js/service-classification.js
@@ -11,6 +11,7 @@ const SERVICE_SESSIONS = new Set([
     'agentwire-portal',
     'agentwire-tts',
     'agentwire-stt',
+    'agentwire-kokoro',  // default-tier Kokoro TTS shim subprocess (:8102)
     'agentwire-scheduler',
     'agentwire-notifications',
 ]);


### PR DESCRIPTION
`agentwire-kokoro` (the default-tier Kokoro TTS shim, uvicorn on `:8102`) was showing under **Sessions** in the portal sidebar instead of **Services**.

Root cause: the frontend allowlist `service-classification.js` — the SSOT for sidebar/palette/mobile classification — was missing `agentwire-kokoro` (the STT shim `agentwire-stt` was already listed; only Kokoro was omitted). One-line fix: add it to `SERVICE_SESSIONS`.

Closes #608

Built by [dotdev.dev](https://dotdev.dev)