### PR TITLE
fix(delivery): make verified submit patient under host load

### DIFF
--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -186,13 +186,17 @@ def cmd_send(args) -> int:
 
     if verify:
         # Same delivery verification as --wait-ready, but without waiting for a
-        # fresh-boot banner — for an already-running session, just confirm the
-        # paste landed and report verified vs unconfirmed. retries=0: send ONCE
-        # and report — a re-paste on a false miss (a busy session that scrolled
-        # the echo past the capture window) would deliver the message twice.
+        # fresh-boot banner — for an already-running session, confirm the paste
+        # landed AND submitted. retries=1: a whole-send retry only fires when the
+        # paste never landed in the box (phase 1 of _deliver_once) — i.e. it
+        # genuinely vanished, so re-pasting can't double-deliver. Once text has
+        # landed, _deliver_once re-presses Enter in place (never re-pastes), so
+        # the old double-delivery worry the retries=0 choice guarded against
+        # can't happen anymore. Staying patient here is what keeps a laggy host
+        # from surfacing a false failure the parent has to clean up by hand.
         from agentwire.session_ready import send_verified
 
-        ok = send_verified(session, prompt, retries=0)
+        ok = send_verified(session, prompt, retries=1)
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None,
                               "verified": ok,

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -25,11 +25,21 @@ VERIFY_SCROLLBACK_LINES = 200
 # Enter to dismiss its ``[Pasted text]`` banner before submitting).
 POLL_INTERVAL = 0.15
 # Max wait for a paste to appear in the input box before giving up on this try.
-LAND_TIMEOUT = 5.0
-# Max wait, after an Enter, for the box to clear (the keystroke to register).
-SUBMIT_TIMEOUT = 3.0
-# Bounded Enter re-presses before declaring a hard failure.
-MAX_ENTER_ATTEMPTS = 4
+# Generous because under host load tmux ``capture-pane`` itself lags and a large
+# paste renders slowly — a tight budget here is the #1 cause of "the text landed
+# but delivery reported failure" on a bogged-down machine.
+LAND_TIMEOUT = 8.0
+# Max wait, after a single Enter, for the box to clear (the keystroke to
+# register). Per-press, not the whole submit phase — see SUBMIT_BUDGET.
+SUBMIT_TIMEOUT = 4.0
+# Wall-clock ceiling on the whole press-Enter-and-confirm phase. Re-pressing is
+# driven by this deadline rather than a fixed count so a laggy box is waited out
+# (each idle Enter on an already-submitted/empty box is a harmless no-op), but a
+# genuinely wedged session still fails in bounded time instead of hanging.
+SUBMIT_BUDGET = 20.0
+# Floor on re-presses regardless of how fast the budget burns (slow snapshots
+# can eat the wall-clock before we've pressed Enter enough times).
+MIN_ENTER_ATTEMPTS = 4
 
 # Substrings that mean "Claude is actively working" — a spinner footer, the
 # token counter, the esc-to-interrupt hint, or tool-output glyphs. A
@@ -259,19 +269,27 @@ def _deliver_once(
     if not _poll(landed_or_done, LAND_TIMEOUT):
         return False
 
-    # Phase 2 — press Enter and confirm the box cleared. Bounded re-press: a
-    # single Enter can be swallowed under load, and a large paste needs a second
-    # Enter (dismiss the ``[Pasted text]`` banner, then submit).
-    for _ in range(MAX_ENTER_ATTEMPTS):
+    # Phase 2 — press Enter and confirm the box cleared. Re-press is driven by a
+    # wall-clock budget, not a fixed count: a single Enter can be swallowed under
+    # load, a large paste needs a second Enter (dismiss the ``[Pasted text]``
+    # banner, then submit), and on a bogged-down host the box renders slowly. We
+    # keep pressing until the box clears or SUBMIT_BUDGET elapses — an idle Enter
+    # on an already-submitted/empty box is a harmless no-op, so over-pressing is
+    # safe, while a tight count would give up before a laggy box ever caught up.
+    deadline = time.time() + SUBMIT_BUDGET
+    attempts = 0
+    while True:
         if submitted(_snapshot(session, pane_index), message, marker):
             return True
         press_enter(session, pane_index=pane_index)
+        attempts += 1
         if _poll(
             lambda: submitted(_snapshot(session, pane_index), message, marker),
             SUBMIT_TIMEOUT,
         ):
             return True
-    return False
+        if attempts >= MIN_ENTER_ATTEMPTS and time.time() >= deadline:
+            return False
 
 
 def send_verified(


### PR DESCRIPTION
## What

`session_send` / `agentwire send --verify` surfaced false delivery failures under host load — the pasted text landed in the input box but reported as unsubmitted, forcing the parent agent to press Enter manually.

## Root cause

Budget, not logic. `session_ready._deliver_once` already does the correct adaptive loop (paste-without-Enter → poll until text lands → Enter → poll until box clears → re-press if swallowed), but its budgets were tuned for an idle host (`LAND=5s`, `SUBMIT=3s`, 4 presses max ≈ 12s), and `--verify` ran `retries=0`. Under load, tmux `capture-pane` and the box render lag, so the loop exhausted before the sluggish box caught up.

## Changes

- **Wall-clock submit budget** (`SUBMIT_BUDGET=20s`) + attempt floor (`MIN_ENTER_ATTEMPTS=4`) replaces the fixed press cap — re-press until the box clears or the budget elapses. Idle Enters on an empty box are harmless no-ops; a wedged session still fails in bounded time.
- **Wider timeouts**: `LAND 5→8s`, `SUBMIT 3→4s`.
- **`--verify` now `retries=1`** — safe because `_deliver_once` only bubbles a whole-send retry when the paste never landed (box empty = vanished = no double-delivery); once landed it only re-presses Enter, never re-pastes. Stale `retries=0` comment removed.

Plain `agentwire send` (no `--verify`) keeps the fixed-sleep path deliberately — it serves `bare` shell targets with no input box to verify. Agent→agent calls all use the verified path.

## Verification

Reproduced clean on the rebuilt build: `send_verified -> True`, input box cleared, target responded.

Closes #613

Built by [dotdev.dev](https://dotdev.dev)