### PR TITLE
fix(notify): idle notifications reach metadata-recorded parents

### DIFF
--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -370,10 +370,17 @@ complete | incomplete | error
           echo "[$(date -Iseconds)] TASK-ORPHAN: killing tmux session" >> "$dlog"
           tmux kill-session -t "$tmux_session" 2>/dev/null &
         ) &
-      elif [[ -n "$parent_session" ]]; then
-        # Orchestrator pane with parent: notify parent
-        message="${session_name} is idle"
-        $AGENTWIRE notify-parent -q --to "$parent_session" "$message" 2>/dev/null &
+      else
+        # Pane-0 session went idle: tell its parent. Resolution lives inside
+        # notify-parent (prompt_router.resolve_parent) so all three precedence
+        # sources are honored — worker pane → pane 0, creator recorded at
+        # `agentwire new` time (session metadata), then `.agentwire.yml parent:`.
+        # The old code passed only the .agentwire.yml value and skipped the call
+        # entirely when it was empty, so worktree / `agentwire new` children
+        # (whose parent lives in metadata, not config) never notified anyone.
+        # TMUX_PANE is inherited, so the CLI knows which session this is; a
+        # top-level session resolves to no parent and this is a harmless no-op.
+        $AGENTWIRE notify-parent -q "is idle and done working" 2>/dev/null &
       fi
     fi
   fi

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -51,11 +51,19 @@ def cmd_notify_parent(args) -> int:
     current_session = pane_manager.get_current_session()
     current_pane = pane_manager.get_current_pane_index()
 
-    # If no explicit target, try parent from config
-    if not target_session:
-        parent = get_parent_from_config()
-        if parent:
-            target_session = parent
+    # If no explicit target, resolve the parent through the SAME precedence the
+    # prompt router uses (worker pane → pane 0; else creator recorded at
+    # `agentwire new` time; else `.agentwire.yml parent:`). The old path looked
+    # only at `.agentwire.yml`, so a worktree/`agentwire new` child — whose
+    # parent lives in session metadata, not config — resolved to nothing and its
+    # idle notification silently dropped (the parent never heard the child go
+    # idle). resolve_parent reads the creator metadata, closing that gap.
+    if not target_session and current_session is not None and current_pane is not None:
+        from agentwire import prompt_router
+
+        resolved = prompt_router.resolve_parent(current_session, current_pane)
+        if resolved:
+            target_session = resolved[0]
 
     # Build notification message (--raw sends verbatim — queued messages
     # already carry their own [WORKER SUMMARY ...] / [PROMPT ...] headers)


### PR DESCRIPTION
## What

Parents never heard worktree / `agentwire new` children go idle — the owner had to manually nudge sessions to notice their kids had finished.

## Root cause

Parent resolution has three precedence sources (`prompt_router.resolve_parent`): worker pane → pane 0; creator recorded at `agentwire new` (session metadata); then `.agentwire.yml parent:`. But the idle hook and `notify-parent`'s auto-resolve both used only the last one. A spawned child records its parent in **metadata** (`created_by`), not in the checked-out (gitignored) `.agentwire.yml` — so resolution returned nothing and the idle notification was silently dropped.

## Changes

- `notify-parent` (no `--to`) now resolves via the full `resolve_parent` precedence, reading creator metadata.
- `idle-handler.sh` always calls `notify-parent` for pane-0 non-task sessions and lets the CLI resolve, instead of grepping `.agentwire.yml` and skipping the call when empty. Top-level sessions resolve to no parent → harmless no-op.

## Verification

From a live child pane (`documentscribe/bundle-split-461`): resolves to `documentscribe`, `delivered: true` end-to-end.

Closes #615

Built by [dotdev.dev](https://dotdev.dev)