### PR TITLE
fix(notify): suppress idle parent-notify for service sessions

### DIFF
--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -380,7 +380,7 @@ complete | incomplete | error
         # (whose parent lives in metadata, not config) never notified anyone.
         # TMUX_PANE is inherited, so the CLI knows which session this is; a
         # top-level session resolves to no parent and this is a harmless no-op.
-        $AGENTWIRE notify-parent -q "is idle and done working" 2>/dev/null &
+        $AGENTWIRE notify-parent --on-idle -q "is idle and done working" 2>/dev/null &
       fi
     fi
   fi

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -51,6 +51,17 @@ def cmd_notify_parent(args) -> int:
     current_session = pane_manager.get_current_session()
     current_pane = pane_manager.get_current_pane_index()
 
+    # --on-idle: the idle hook is reporting that a pane-0 session went idle.
+    # Infrastructure services (portal, tts/stt, scheduler, the idle-nag bridge,
+    # custom services) cycle active→idle constantly and are NOT delegated work,
+    # so they must never fire a "child finished" ping at their parent. A
+    # worktree / `agentwire new` child is not a service and is unaffected.
+    if getattr(args, 'on_idle', False) and current_session:
+        from agentwire import services
+
+        if services.is_service_session(current_session):
+            return _output_result(True, json_mode, "", skipped="service-session")
+
     # If no explicit target, resolve the parent through the SAME precedence the
     # prompt router uses (worker pane → pane 0; else creator recorded at
     # `agentwire new` time; else `.agentwire.yml parent:`). The old path looked
@@ -263,6 +274,9 @@ def register_notify_parser(subparsers) -> None:
     notify_cmd_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     notify_cmd_parser.add_argument("--raw", action="store_true",
                                    help="Send the message verbatim (no [NOTIFY from ...] prefix)")
+    notify_cmd_parser.add_argument("--on-idle", dest="on_idle", action="store_true",
+                                   help="Idle-hook mode: suppress the notify if the current session "
+                                        "is an infrastructure service (they cycle idle constantly)")
     notify_cmd_parser.add_argument("--json", action="store_true", help="Output as JSON")
     notify_cmd_parser.set_defaults(func=cmd_notify_parent)
 

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -78,6 +78,42 @@ def notifications_session_name() -> str:
     )
 
 
+# Built-in infrastructure sessions — the Python mirror of the frontend's
+# SERVICE_SESSIONS allowlist (static/js/service-classification.js). These are
+# long-lived services, not delegated work, so they must never fire a
+# "child finished" idle notification at a parent (the idle-nag bridge alone
+# cycles active→idle ~1440×/day). Kept in lockstep with the JS set.
+_BUILTIN_SERVICE_SESSIONS = frozenset({
+    "agentwire-portal",
+    "agentwire-tts",
+    "agentwire-stt",
+    "agentwire-kokoro",
+    "agentwire-scheduler",
+})
+
+
+def is_service_session(name: str) -> bool:
+    """Is *name* an infrastructure service session (vs. a working session)?
+
+    True for the built-in infra sessions, the configurable idle-nag bridge, and
+    any user-defined custom service. Used to suppress idle parent-notifications
+    for services — a worktree / `agentwire new` child is NOT a service and still
+    notifies. Name-only and dependency-light so the idle hook can call it cheaply
+    on every idle event.
+    """
+    bare = (name or "").split("@")[0]
+    if not bare:
+        return False
+    if bare in _BUILTIN_SERVICE_SESSIONS or bare == notifications_session_name():
+        return True
+    try:
+        from .config import load_config
+
+        return any(s.name == bare for s in load_config().services.custom)
+    except Exception:
+        return False
+
+
 def _source_dir() -> str:
     """agentwire source dir (dev.source_dir), project for built-in services."""
     try:


### PR DESCRIPTION
## What

Follow-up to #616. That fix made pane-0 sessions notify their resolved parent on idle — but it swept in long-lived **infrastructure services**. `agentwire-notifications` (the idle-nag bridge) cycles active→idle ~1440×/day and has `created_by=agentwire`, so it pinged its parent on every cycle (observed live: a stray "is idle and done working").

## Changes

- **`services.is_service_session(name)`** — Python mirror of the frontend `SERVICE_SESSIONS` allowlist (portal/tts/stt/kokoro/scheduler + configurable notifications bridge + custom services). Name-only, dependency-light so the idle hook can call it per-event.
- **`notify-parent --on-idle`** — suppresses the notify when the current session is a service. Worker-pane and explicit `--to` callers are unaffected.
- **`idle-handler.sh`** passes `--on-idle`.

The `agentwire-` prefix is deliberately **not** the discriminator: worktree children in this repo are `agentwire-dev-<branch>` and would be wrongly silenced. The explicit allowlist gets them right.

## Verification

- `is_service_session`: notifications/portal → True; `agentwire-dev-myfix`, `documentscribe/bundle-split-461` → False.
- Live from the notifications pane: `notify-parent --on-idle` → `skipped: service-session`.

Built by [dotdev.dev](https://dotdev.dev)