### PR TITLE
fix(session): exclude infra services from shared-dir guard (#618)

### DIFF
--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -18,7 +18,7 @@ import sys
 import time
 from pathlib import Path
 
-from . import pane_manager, worktree_registry
+from . import pane_manager, services, worktree_registry
 from .core import (
     KIND_DEFAULT_POSTURE,
     _build_tmux_env_flags,
@@ -93,6 +93,32 @@ def cmd_session_defaults(args) -> int:
         "postures": list(POSTURES),
     })
     return 0
+
+
+def _shared_dir_conflicts(panes_output: str, session_name: str, target: str) -> set[str]:
+    """Sessions (excluding *session_name* and infra services) whose cwd is *target*.
+
+    *panes_output* is `tmux list-panes -a -F '#{session_name}\t#{pane_current_path}'`.
+    Infrastructure service sessions (portal/tts/stt/kokoro/scheduler/notifications)
+    run from the repo root but never edit the tree, so they co-reside with an agent
+    without conflict and are excluded via the SSOT classifier. Non-service agent
+    sessions (including the hardcoded `agentwire` dev session) still count.
+    """
+    conflicting: set[str] = set()
+    for line in panes_output.splitlines():
+        if "\t" not in line:
+            continue
+        sess, p = line.split("\t", 1)
+        if sess == session_name:
+            continue
+        if services.is_service_session(sess):
+            continue
+        try:
+            if str(Path(p).resolve()) == target:
+                conflicting.add(sess)
+        except (OSError, RuntimeError):
+            continue
+    return conflicting
 
 
 def cmd_new(args) -> int:
@@ -374,18 +400,7 @@ def cmd_new(args) -> int:
             capture_output=True, text=True,
         )
         if panes_result.returncode == 0:
-            conflicting: set[str] = set()
-            for line in panes_result.stdout.splitlines():
-                if "\t" not in line:
-                    continue
-                sess, p = line.split("\t", 1)
-                if sess == session_name:
-                    continue
-                try:
-                    if str(Path(p).resolve()) == target:
-                        conflicting.add(sess)
-                except (OSError, RuntimeError):
-                    continue
+            conflicting = _shared_dir_conflicts(panes_result.stdout, session_name, target)
             if conflicting:
                 others = ", ".join(sorted(conflicting))
                 hint = (

--- a/tests/unit/test_shared_dir_guard.py
+++ b/tests/unit/test_shared_dir_guard.py
@@ -1,0 +1,44 @@
+"""Shared-dir conflict guard (#618): infra services co-reside, agents conflict."""
+
+import os
+
+from agentwire.session_cli import _shared_dir_conflicts
+
+REPO = os.path.realpath(os.getcwd())
+
+
+def _panes(*pairs: tuple[str, str]) -> str:
+    return "\n".join(f"{s}\t{p}" for s, p in pairs)
+
+
+def test_services_excluded():
+    out = _panes(
+        ("agentwire-portal", REPO),
+        ("agentwire-tts", REPO),
+        ("agentwire-stt", REPO),
+        ("agentwire-kokoro", REPO),
+        ("agentwire-scheduler", REPO),
+        ("agentwire-notifications", REPO),
+    )
+    assert _shared_dir_conflicts(out, "agentwire-dev", REPO) == set()
+
+
+def test_dev_orchestrator_still_conflicts():
+    # The hardcoded `agentwire` dev session is NOT a service — must still trip.
+    out = _panes(("agentwire", REPO), ("agentwire-portal", REPO))
+    assert _shared_dir_conflicts(out, "agentwire-dev", REPO) == {"agentwire"}
+
+
+def test_self_skipped():
+    out = _panes(("agentwire-dev", REPO))
+    assert _shared_dir_conflicts(out, "agentwire-dev", REPO) == set()
+
+
+def test_machine_suffixed_service_excluded():
+    out = _panes(("agentwire-portal@box", REPO))
+    assert _shared_dir_conflicts(out, "agentwire-dev", REPO) == set()
+
+
+def test_non_matching_path_ignored():
+    out = _panes(("other-agent", "/some/other/dir"))
+    assert _shared_dir_conflicts(out, "agentwire-dev", REPO) == set()


### PR DESCRIPTION
## What

The shared-dir guard in `session_cli.py` scanned every tmux pane's cwd and refused to start a session when any other session shared the target tree. This over-matched long-lived **infrastructure services** (portal/tts/stt/kokoro/scheduler/notifications) which run *from* the repo root but never edit its working tree — blocking a project session from starting just because services co-reside there.

## Fix

Exclude service sessions from the `conflicting` set using the existing SSOT classifier `services.is_service_session()` (already used by `notify_cli.py`). The non-service `agentwire` dev/orchestrator session is **deliberately not** excluded, so a genuine agent-on-agent collision on one tree still trips the guard. `--force` / `--allow-shared-dir` continue to override.

Extracted the conflict scan into a pure `_shared_dir_conflicts()` helper with unit coverage (services excluded, dev orchestrator still conflicts, self-skip, `@machine`-suffix tolerance).

## Verify

Full suite green: `2152 passed, 8 skipped`.

Closes #618

Built by [dotdev.dev](https://dotdev.dev)