### PR TITLE
chore: remove unused import in notify_cli (greens ruff CI)

### DIFF
--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -20,7 +20,6 @@ from .core import (
     _portal_auth_headers,
     _post_desktop_notification,
 )
-from .project_config import get_parent_from_config
 
 
 def cmd_notify_parent(args) -> int:


### PR DESCRIPTION
`agentwire/notify_cli.py` imported `get_parent_from_config` from `.project_config` but never used it (left over from the prompt-routing refactor). Ruff flags it `F401`, which has been failing the `ruff (lint)` CI job on **every** PR (a stale red that masks real lint regressions).

One-line deletion. `ruff check` now passes; `agentwire notify-parent --help` loads cleanly.

Built by [dotdev.dev](https://dotdev.dev)