### PR TITLE
Isolate artifact iframes in an opaque origin (srcdoc) — portal token-theft hardening

### DIFF
--- a/agentwire/static/js/artifact-window.js
+++ b/agentwire/static/js/artifact-window.js
@@ -5,7 +5,7 @@
  * in a sandboxed iframe within a WinBox window.
  */
 
-import { apiFetch, getToken } from './api.js';
+import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 
 // If the iframe's `load` event hasn't fired by now, treat it as stuck and flip
@@ -35,7 +35,6 @@ export class ArtifactWindow {
         this.winbox = null;
         this.iframe = null;
         this.isOpen = false;
-        this._objectUrl = null; // blob URL for token-authed artifact loads
         this._loadTimer = null; // stuck-spinner watchdog
     }
 
@@ -64,10 +63,10 @@ export class ArtifactWindow {
 
         // Remove iframe to stop any running scripts
         if (this.iframe) {
+            this.iframe.removeAttribute('srcdoc');
             this.iframe.src = 'about:blank';
             this.iframe = null;
         }
-        this._revokeObjectUrl();
 
         if (this.winbox) {
             const wb = this.winbox;
@@ -221,36 +220,29 @@ export class ArtifactWindow {
         return this.url.startsWith('http://') || this.url.startsWith('https://');
     }
 
-    _revokeObjectUrl() {
-        if (this._objectUrl) {
-            URL.revokeObjectURL(this._objectUrl);
-            this._objectUrl = null;
-        }
-    }
-
     /**
      * Point the iframe at the artifact. Plain iframe GETs can't carry the
-     * Authorization header, so when token auth is active we fetch the
-     * portal-served artifact with credentials and load it as a blob URL.
+     * Authorization header, so local artifacts are fetched with credentials
+     * (apiFetch) and rendered via `srcdoc`. Under `sandbox="allow-scripts"`
+     * (no allow-same-origin) the srcdoc document gets a null/opaque origin:
+     * its scripts run, but it cannot read the portal's localStorage (bearer
+     * token) or make authenticated same-origin API calls. Artifacts are
+     * agent-written arbitrary HTML/JS — this isolation is load-bearing.
      * Note: relative sub-resources inside multi-file artifacts won't resolve
-     * under a blob URL — self-contained HTML is the supported shape there.
+     * under srcdoc — self-contained HTML is the supported shape there.
      */
     async _setIframeSrc() {
         const resolved = this._resolveUrl();
-        if (this._isExternalUrl() || !getToken()) {
+        if (this._isExternalUrl()) {
             this.iframe.src = resolved;
             return;
         }
         try {
             const resp = await apiFetch(resolved);
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            const blob = await resp.blob();
-            this._revokeObjectUrl();
-            this._objectUrl = URL.createObjectURL(blob);
-            this.iframe.src = this._objectUrl;
+            this.iframe.srcdoc = await resp.text();
         } catch (e) {
-            // Fall back to a direct load; the iframe error handler reports it.
-            this.iframe.src = resolved;
+            this._showLoadError(`Failed to load: ${this.url}`);
         }
     }
 
@@ -268,13 +260,18 @@ export class ArtifactWindow {
         this.iframe = document.createElement('iframe');
         this.iframe.className = 'artifact-iframe';
 
-        // Smart sandboxing:
-        // - Local files: allow-scripts allow-same-origin (needed for local JS/CSS)
-        // - External URLs: allow-scripts allow-forms allow-popups (no same-origin for security)
+        // Sandboxing:
+        // - Local artifacts: allow-scripts ONLY. SECURITY: never add
+        //   allow-same-origin here — local artifacts are agent-generated HTML
+        //   rendered via srcdoc, and allow-same-origin would run their scripts
+        //   in the portal origin, letting a poisoned artifact steal the bearer
+        //   token from localStorage and drive every authenticated portal API.
+        // - External URLs: allow-scripts allow-forms allow-popups (real origin,
+        //   but cross-origin to the portal).
         if (this._isExternalUrl()) {
             this.iframe.sandbox = 'allow-scripts allow-forms allow-popups';
         } else {
-            this.iframe.sandbox = 'allow-scripts allow-same-origin';
+            this.iframe.sandbox = 'allow-scripts';
         }
 
         this.iframe.addEventListener('load', () => {


### PR DESCRIPTION
## Vulnerability (HIGH)

`artifact-window.js` rendered local (agent-generated) artifacts as a **blob URL** built from an apiFetch response, inside an iframe sandboxed with `allow-scripts allow-same-origin`. A blob URL inherits the portal's origin, so with `allow-same-origin` the artifact's `<script>` ran **in the portal origin**: it could read the bearer token via `localStorage.getItem('agentwire_token')` (`api.js`) and call every authenticated portal API. Artifact content is arbitrary agent-written HTML/JS (only the filename is sanitized), so a poisoned/prompt-injected artifact meant full portal takeover.

## Fix

- Local artifacts: `sandbox = 'allow-scripts'` only (no `allow-same-origin`), rendered via `iframe.srcdoc` from the apiFetch'd text. srcdoc under `allow-scripts` gets a **null/opaque origin**: the artifact still renders and its scripts still run, but `localStorage` access throws, cookies are absent, and `fetch('/api/...')` is cross-origin/unauthenticated.
- The token is still sent on the *fetch* of the artifact bytes — only the render origin changes.
- External-URL artifacts unchanged (`allow-scripts allow-forms allow-popups`).
- Dead blob/object-URL plumbing removed (`_objectUrl`, `_revokeObjectUrl`, `createObjectURL`).
- Added a code comment warning that re-adding `allow-same-origin` reintroduces token theft.

## Verification

- `grep -rn allow-same-origin agentwire/static/js/` — matches only in the warning comments; no iframe uses it for local artifacts.
- By spec: a sandboxed iframe without `allow-same-origin` has an opaque origin — `window.localStorage` access throws a `SecurityError` and same-origin credentials (cookies, portal token) are unreachable; srcdoc content executes scripts under `allow-scripts`, so self-contained HTML+JS+CSS artifacts keep working. srcdoc has no base URL for relative sub-resources, matching the previously documented blob-URL limitation (self-contained HTML remains the supported shape).
- `reload()` re-runs `_setIframeSrc()`, which re-assigns `srcdoc` and re-renders; the iframe `load` event fires on srcdoc assignment, so the spinner/watchdog flow is unchanged. Fetch failures now surface through `_showLoadError` instead of silently falling back to an unauthenticated direct load.
- `uv run --extra dev pytest -q`: **2178 passed, 8 skipped** (no JS test harness exists; live-portal manual check not possible from this worktree — noted per worktree etiquette).

Built by [dotdev.dev](https://dotdev.dev)