### PR TITLE
Validate inbox recipient/session names (path-traversal hardening)

### DIFF
--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -148,8 +149,28 @@ def _short_uuid() -> str:
     return uuid.uuid4().hex[:6]
 
 
+# Session names are agent-controlled (msg_send `to`), so they must never be
+# able to path-traverse out of INBOX_ROOT. Worktree session names legitimately
+# contain `/` (they nest one directory level per segment — see module
+# docstring), so segments are validated individually; `..`, absolute paths,
+# and empty names/segments are rejected.
+_SESSION_RE = re.compile(r"^[A-Za-z0-9._@-]+(?:/[A-Za-z0-9._@-]+)*$")
+
+
+def _validate_session(session: str) -> str:
+    if not session or not _SESSION_RE.match(session) or ".." in session.split("/"):
+        raise ValueError(f"invalid session name: {session!r}")
+    return session
+
+
 def session_dir(session: str) -> Path:
-    return INBOX_ROOT / session
+    _validate_session(session)
+    path = INBOX_ROOT / session
+    # Belt and braces: the regex already forbids traversal, but confine the
+    # result to INBOX_ROOT so a validator regression can't escape it.
+    if not path.resolve().is_relative_to(INBOX_ROOT.resolve()):
+        raise ValueError(f"invalid session name: {session!r}")
+    return path
 
 
 def dead_dir(session: str) -> Path:
@@ -440,7 +461,7 @@ def resolve_targets(to: str, sender: "str | None") -> list[str]:
     """
     if to == BROADCAST_TOKEN:
         return [s for s in _live_agent_sessions() if s != sender]
-    return [to]
+    return [_validate_session(to)]
 
 
 def enqueue(

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -730,3 +730,51 @@ class TestGcSender:
         assert res == {"dead": 0, "dropped": 0}
         assert len(inbox.list_messages("orch")) == 1  # other sender's done kept
         assert inbox.list_ingest("orch")  # ingest untouched
+
+
+# =============================================================================
+# Session-name validation — path-traversal hardening
+# =============================================================================
+
+
+class TestSessionNameValidation:
+    BAD = ["../../x", "/etc/x", "a/../../b", "..", "a/..", "", "a//b", "a/", "/a",
+           "a b", "a\x00b", "~root"]
+
+    @pytest.mark.parametrize("name", BAD)
+    def test_session_dir_rejects_traversal(self, isolate, name):
+        with pytest.raises(ValueError):
+            inbox.session_dir(name)
+        assert not isolate.exists() or all(
+            p.resolve().is_relative_to(isolate.resolve()) for p in isolate.rglob("*")
+        )
+
+    @pytest.mark.parametrize("name", BAD)
+    def test_helpers_reject_traversal(self, isolate, name):
+        for fn in (inbox.dead_dir, inbox.ingest_dir, inbox.pending_files,
+                   inbox.list_messages, inbox.list_dead, inbox.list_ingest,
+                   inbox.purge_pending):
+            with pytest.raises(ValueError):
+                fn(name)
+
+    @pytest.mark.parametrize("name", ["orchestrator", "myproj-fix", "proj/child",
+                                      "a.b_c@host-1", "p/c/grandchild"])
+    def test_valid_names_accepted(self, isolate, name):
+        assert inbox.session_dir(name) == isolate / name
+
+    def test_enqueue_traversal_raises_before_any_write(self, isolate, tmp_path):
+        with pytest.raises(ValueError):
+            inbox.enqueue("../../evil", "pwned", sender="attacker")
+        assert not isolate.exists()  # nothing created at all
+        assert not (tmp_path / "evil").exists()
+
+    def test_enqueue_absolute_path_raises(self, isolate):
+        with pytest.raises(ValueError):
+            inbox.enqueue("/tmp/evil", "pwned", sender="attacker")
+        assert not isolate.exists()
+
+    def test_nested_worktree_delivery_still_works(self, isolate):
+        msgs = inbox.enqueue("proj/child", "hello", sender="orch")
+        assert len(msgs) == 1
+        assert msgs[0].path.is_relative_to(isolate / "proj" / "child")
+        assert [m.text for m in inbox.list_messages("proj/child")] == ["hello"]


### PR DESCRIPTION
## Security fix (medium)

The polite-message inbox took the recipient name verbatim from the agent-controlled `to` field (`msg_send` MCP tool, `agentwire msg send --to`) and built `INBOX_ROOT / session` with no validation. `to="../../../../evil"` escaped `~/.agentwire/inbox/`, created arbitrary directory trees, and wrote an agent-controlled JSON blob there — an in-process write bypassing the Write/Edit/Bash damage-control hooks.

## Fix

- New `_validate_session()` in `agentwire/inbox.py`: strict per-segment regex (`[A-Za-z0-9._@-]`, single-level `/` separators preserved for worktree session names, which legitimately nest a directory level), rejecting `..`, absolute paths, empty names/segments.
- `session_dir()` validates and belt-and-braces confines the resolved path to `INBOX_ROOT`. All helpers (`dead_dir`, `ingest_dir`, `pending_files`, list/purge/lock paths) route through it, so every surface — read, dead, ingest, purge — rejects the same inputs.
- `resolve_targets()` validates at the enqueue boundary, so `enqueue(to="../../evil", ...)` raises before any mkdir/write.

## Tests

New `TestSessionNameValidation` in `tests/unit/test_inbox.py`: traversal/absolute/empty/malformed names raise across all helpers with nothing created outside a tmp INBOX_ROOT; enqueue raises pre-write; normal names (`orchestrator`, `myproj-fix`) and `/`-nested worktree names (`proj/child`) still deliver.

Verified: `uv run pytest tests/unit/test_inbox.py -q` (95 passed) and full `uv run pytest -q` (2210 passed, 8 skipped).

Built by [dotdev.dev](https://dotdev.dev)