### PR TITLE
Verify Kokoro model download integrity (pinned SHA-256)

### DIFF
--- a/agentwire/tts/engines/kokoro.py
+++ b/agentwire/tts/engines/kokoro.py
@@ -117,11 +117,22 @@ class KokoroEngine(TTSEngine):
     _VOICES_FILE = "voices-v1.0.bin"
     _VOICES_URL = f"https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/{_VOICES_FILE}"
 
+    # Pinned SHA-256 digests for the release assets above. GitHub release
+    # assets are mutable, so downloads are verified against these before
+    # being cached. Obtained 2026-07-02 by hashing the files downloaded
+    # from the model-files-v1.0 release (shasum -a 256).
+    _MODEL_SHA256 = "c1610a859f3bdea01107e73e50100685af38fff88f5cd8e5c56df109ec880204"
+    _VOICES_SHA256 = "bca610b8308e8d99f32e6fe4197e7ec01679264efed0cac9140fe9c29f1fbf7d"
+
     def __init__(self, voices_dir: Path | None = None):
         from kokoro_onnx import Kokoro
 
-        model_path = self._ensure_file(self._MODEL_FILE, self._MODEL_URL)
-        voices_path = self._ensure_file(self._VOICES_FILE, self._VOICES_URL)
+        model_path = self._ensure_file(
+            self._MODEL_FILE, self._MODEL_URL, self._MODEL_SHA256
+        )
+        voices_path = self._ensure_file(
+            self._VOICES_FILE, self._VOICES_URL, self._VOICES_SHA256
+        )
 
         print("Loading Kokoro ONNX model...")
         self._model = Kokoro(str(model_path), str(voices_path))
@@ -138,8 +149,8 @@ class KokoroEngine(TTSEngine):
         Public entry point for the portal's background warm-up and the
         `agentwire tts warm` CLI command.
         """
-        cls._ensure_file(cls._MODEL_FILE, cls._MODEL_URL, progress_cb)
-        cls._ensure_file(cls._VOICES_FILE, cls._VOICES_URL, progress_cb)
+        cls._ensure_file(cls._MODEL_FILE, cls._MODEL_URL, cls._MODEL_SHA256, progress_cb)
+        cls._ensure_file(cls._VOICES_FILE, cls._VOICES_URL, cls._VOICES_SHA256, progress_cb)
 
     @classmethod
     def model_files_cached(cls) -> bool:
@@ -153,17 +164,21 @@ class KokoroEngine(TTSEngine):
     def _ensure_file(
         filename: str,
         url: str,
+        sha256: str,
         progress_cb: Callable[[str, int, int], None] | None = None,
     ) -> Path:
         """Download file to ~/.cache/kokoro_onnx/ if not already present.
 
-        Downloads to a .part file and renames atomically so an interrupted
-        download never leaves a truncated file that passes the exists() check.
+        Downloads to a .part file, verifies its SHA-256 against the pinned
+        digest, and renames atomically — so an interrupted or tampered
+        download never leaves a file that passes the exists() check.
 
         Args:
+            sha256: Expected hex digest; mismatch deletes the download and raises.
             progress_cb: Optional callback(filename, downloaded_bytes, total_bytes)
                 invoked as the download progresses (total is 0 if unknown).
         """
+        import hashlib
         import urllib.request
 
         cache_dir = Path.home() / ".cache" / "kokoro_onnx"
@@ -187,6 +202,14 @@ class KokoroEngine(TTSEngine):
             socket.setdefaulttimeout(60)
             try:
                 urllib.request.urlretrieve(url, part, reporthook=_hook)
+                actual = hashlib.sha256(part.read_bytes()).hexdigest()
+                if actual != sha256:
+                    part.unlink(missing_ok=True)
+                    raise RuntimeError(
+                        f"SHA-256 mismatch for {filename}: expected {sha256}, "
+                        f"got {actual}. The downloaded file was discarded — "
+                        f"the release asset at {url} may have been tampered with."
+                    )
                 part.replace(dest)
             except BaseException:
                 part.unlink(missing_ok=True)

--- a/tests/unit/test_tts_local.py
+++ b/tests/unit/test_tts_local.py
@@ -78,6 +78,12 @@ class TestResolveVoiceName:
 # ---------------------------------------------------------------------------
 
 
+import hashlib
+
+# SHA-256 of the b"model-bytes" fixture used throughout TestEnsureFile
+GOOD_SHA = hashlib.sha256(b"model-bytes").hexdigest()
+
+
 class TestEnsureFile:
     @pytest.fixture(autouse=True)
     def fake_home(self, tmp_path, monkeypatch):
@@ -91,7 +97,7 @@ class TestEnsureFile:
 
         with patch("urllib.request.urlretrieve", side_effect=boom):
             with pytest.raises(OSError):
-                KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx")
+                KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx", GOOD_SHA)
 
         assert not (self.cache_dir / "model.onnx").exists()
         assert not (self.cache_dir / "model.onnx.part").exists()
@@ -106,7 +112,7 @@ class TestEnsureFile:
         progress_calls = []
         with patch("urllib.request.urlretrieve", side_effect=ok):
             dest = KokoroEngine._ensure_file(
-                "model.onnx", "http://x/model.onnx",
+                "model.onnx", "http://x/model.onnx", GOOD_SHA,
                 progress_cb=lambda f, d, t: progress_calls.append((f, d, t)),
             )
 
@@ -118,8 +124,30 @@ class TestEnsureFile:
         self.cache_dir.mkdir(parents=True)
         (self.cache_dir / "model.onnx").write_bytes(b"cached")
         with patch("urllib.request.urlretrieve") as mock_dl:
-            KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx")
+            KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx", GOOD_SHA)
         mock_dl.assert_not_called()
+
+    def test_sha256_mismatch_rejected_and_no_file_left(self):
+        def ok(url, dest, reporthook=None):
+            from pathlib import Path
+            Path(dest).write_bytes(b"tampered-bytes")
+
+        with patch("urllib.request.urlretrieve", side_effect=ok):
+            with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+                KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx", GOOD_SHA)
+
+        assert not (self.cache_dir / "model.onnx").exists()
+        assert not (self.cache_dir / "model.onnx.part").exists()
+
+    def test_sha256_match_accepted(self):
+        def ok(url, dest, reporthook=None):
+            from pathlib import Path
+            Path(dest).write_bytes(b"model-bytes")
+
+        with patch("urllib.request.urlretrieve", side_effect=ok):
+            dest = KokoroEngine._ensure_file("model.onnx", "http://x/model.onnx", GOOD_SHA)
+
+        assert dest.read_bytes() == b"model-bytes"
 
     def test_model_files_cached(self):
         assert KokoroEngine.model_files_cached() is False


### PR DESCRIPTION
## Security fix (MEDIUM, supply-chain)

The default-tier Kokoro TTS engine downloaded ~206 MB of model + voice files from a third-party GitHub release (`thewh1teagle/kokoro-onnx`, tag `model-files-v1.0`) via `urllib.request.urlretrieve` with **no integrity verification**, then loaded the files into onnxruntime and cached them persistently in `~/.cache/kokoro_onnx/`. GitHub release assets are mutable, so an asset swap (or upstream account compromise) would go undetected.

## Fix

- Pin known-good SHA-256 digests as `_MODEL_SHA256` / `_VOICES_SHA256` module constants in `agentwire/tts/engines/kokoro.py`.
- `_ensure_file` now takes the expected digest, hashes the completed `.part` download, and on mismatch deletes it and raises a clear `RuntimeError` — **before** the atomic rename, so a tampered file never passes the cache-exists check.
- Portal warm-up (`agentwire/tts/local.py::_warm_up`) already stores `str(e)` into `self.error` and flips state to `failed` on any download exception, so the mismatch message propagates unchanged — no change needed there.

## Digest provenance

Hashed on 2026-07-02 (`shasum -a 256`) from copies of `kokoro-v1.0.fp16.onnx` and `voices-v1.0.bin` previously downloaded from the official `model-files-v1.0` release URLs (the same URLs in the code). Recorded in a code comment next to the constants.

## Tests

Added to `tests/unit/test_tts_local.py::TestEnsureFile` (no network, no heavy deps — `urlretrieve` mocked with a small fixture):
- match → file accepted and cached
- mismatch → `RuntimeError("SHA-256 mismatch…")`, no `.onnx` or `.part` left behind
- existing tests updated for the new required digest parameter

`uv run --extra dev pytest -q`: 2180 passed, 8 skipped.

Built by [dotdev.dev](https://dotdev.dev)