### PR TITLE
Portal hardening: atomic token file, security headers, bounded multipart uploads

### DIFF
--- a/agentwire/routes/voice.py
+++ b/agentwire/routes/voice.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 from aiohttp import web
 
+from ..security import read_multipart_field_limited
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,7 +121,16 @@ class VoiceRoutesMixin:
             if audio_field is None:
                 return web.json_response({"error": "No audio data"})
 
-            audio_data = await audio_field.read()
+            # Stream with a size cap: abort 413 before buffering an over-limit
+            # body into RAM. Dedicated stt.max_upload_mb wins if configured,
+            # else reuse the general uploads cap.
+            max_mb = (
+                getattr(self.config.stt, "max_upload_mb", None)
+                or self.config.uploads.max_size_mb
+            )
+            audio_data = await read_multipart_field_limited(
+                audio_field, max_mb * 1024 * 1024
+            )
             if not audio_data:
                 return web.json_response({"error": "Empty audio data"})
 
@@ -148,6 +159,8 @@ class VoiceRoutesMixin:
             finally:
                 Path(wav_path).unlink(missing_ok=True)
 
+        except web.HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Transcription failed: {e}")
             return web.json_response({"error": str(e)})

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -23,11 +23,15 @@ Two layers, both enforced by a single aiohttp middleware:
 disable auth (loopback binds only); any other string → explicit override.
 """
 
+import base64
+import hashlib
 import hmac
 import ipaddress
 import logging
+import os
 import re
 import secrets
+import tempfile
 import time
 from pathlib import Path
 from typing import Callable, Optional
@@ -80,10 +84,29 @@ def read_token_file() -> Optional[str]:
 
 
 def write_token_file(token: str) -> None:
-    """Write the token file with owner-only permissions."""
-    TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TOKEN_FILE.write_text(token + "\n")
-    TOKEN_FILE.chmod(0o600)
+    """Write the token file with owner-only permissions.
+
+    Atomic and never wider than 0600: the token is written to a same-directory
+    temp file created at 0600 (fchmod before any bytes land), then renamed over
+    the destination — there is no window where the god-token is group/world
+    readable, even on first creation under a permissive umask. The config dir
+    itself is created 0700 when missing. Rotation over an existing 0600 file
+    keeps 0600 (os.replace swaps the inode; the new one is already 0600).
+    """
+    parent = TOKEN_FILE.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".portal.token.")
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(token + "\n")
+        os.replace(tmp_path, TOKEN_FILE)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def resolve_auth_token(config) -> Optional[str]:
@@ -345,6 +368,138 @@ def resolve_device(provided: Optional[str], auth_token: Optional[str]) -> Option
     if auth_token and hmac.compare_digest(provided.encode(), auth_token.encode()):
         return BOOTSTRAP_DEVICE
     return devices_mod.load_registry_cached().resolve(provided)
+
+
+# ---------------------------------------------------------------------------
+# Security response headers (CSP & friends)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+_INLINE_SCRIPT_RE = re.compile(r"<script\b[^>]*>(.*?)</script>", re.DOTALL | re.IGNORECASE)
+
+
+def _inline_script_hashes() -> list[str]:
+    """CSP sha256 sources for inline <script> blocks in the bundled templates.
+
+    The pair page ships a small inline module (no Jinja interpolation inside
+    it), so ``script-src 'self'`` alone would break pairing. Hashing the blocks
+    at startup keeps script-src locked down while auto-healing when a template's
+    inline script changes.
+    """
+    hashes: list[str] = []
+    try:
+        for tpl in sorted(_TEMPLATES_DIR.glob("*.html")):
+            for m in _INLINE_SCRIPT_RE.finditer(tpl.read_text()):
+                body = m.group(1)
+                if not body.strip():
+                    continue
+                digest = base64.b64encode(hashlib.sha256(body.encode()).digest()).decode()
+                hashes.append(f"'sha256-{digest}'")
+    except OSError:
+        pass
+    return hashes
+
+
+def _build_csp() -> str:
+    """Portal-wide Content-Security-Policy.
+
+    Constraints baked in from the real UI:
+    - xterm.js / marked load from cdn.jsdelivr.net (script + css).
+    - Inline <style> attributes are used throughout (and WinBox injects a
+      style element) → style-src needs 'unsafe-inline'.
+    - WinBox uses data: SVG background images; uploads render as blobs.
+    - The dashboard/session/terminal WebSockets need ws:/wss:, and the
+      announcement modal fetches raw.githubusercontent.com.
+    - Voice playback uses blob: audio; browser STT records via MediaRecorder.
+    """
+    script_src = " ".join(["'self'", "https://cdn.jsdelivr.net"] + _inline_script_hashes())
+    return "; ".join([
+        "default-src 'self'",
+        f"script-src {script_src}",
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        "img-src 'self' data: blob:",
+        "font-src 'self' data:",
+        "connect-src 'self' ws: wss: https://raw.githubusercontent.com",
+        "media-src 'self' blob: data:",
+        "worker-src 'self' blob:",
+        "frame-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "frame-ancestors 'self'",
+    ])
+
+
+# Artifacts are agent-generated HTML rendered in sandboxed iframes; they may
+# legitimately carry inline scripts/styles and pull CDN libraries, so the
+# policy stays permissive on content while locking embedding (frame-ancestors)
+# and plugins. The iframe sandbox attribute remains the primary containment.
+_ARTIFACTS_CSP = "; ".join([
+    "default-src 'self' 'unsafe-inline' data: blob: https:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'self'",
+])
+
+
+def create_security_headers_middleware():
+    """Middleware stamping security response headers on every response.
+
+    HSTS is emitted only on TLS requests (an HSTS header over plain HTTP is
+    ignored by browsers, and pinning localhost dev to HTTPS would be wrong).
+    """
+    csp = _build_csp()
+
+    @web.middleware
+    async def security_headers_middleware(request: web.Request, handler):
+        try:
+            response = await handler(request)
+        except web.HTTPException as exc:
+            _stamp_security_headers(request, exc, csp)
+            raise
+        _stamp_security_headers(request, response, csp)
+        return response
+
+    return security_headers_middleware
+
+
+def _stamp_security_headers(request: web.Request, response, csp: str) -> None:
+    headers = response.headers
+    headers.setdefault("X-Content-Type-Options", "nosniff")
+    headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    headers.setdefault("Referrer-Policy", "same-origin")
+    if request.path.startswith("/artifacts/"):
+        headers["Content-Security-Policy"] = _ARTIFACTS_CSP
+    else:
+        headers.setdefault("Content-Security-Policy", csp)
+    if request.secure:
+        headers.setdefault("Strict-Transport-Security", "max-age=31536000")
+
+
+# ---------------------------------------------------------------------------
+# Bounded multipart reads (upload DoS guard)
+
+
+async def read_multipart_field_limited(field, max_bytes: int) -> bytes:
+    """Read a multipart field, aborting with 413 once ``max_bytes`` is exceeded.
+
+    ``await field.read()`` buffers the entire part into RAM before any size
+    check can run (aiohttp's ``client_max_size`` does not bound the streaming
+    ``request.multipart()`` path) — an oversized upload would balloon the
+    portal's memory before being rejected. Streaming chunk-by-chunk caps the
+    buffered amount at ``max_bytes`` + one chunk.
+    """
+    chunks: list[bytes] = []
+    size = 0
+    while True:
+        chunk = await field.read_chunk()
+        if not chunk:
+            break
+        size += len(chunk)
+        if size > max_bytes:
+            raise web.HTTPRequestEntityTooLarge(
+                max_size=max_bytes, actual_size=size,
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 # ---------------------------------------------------------------------------

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -55,9 +55,11 @@ from .routes.sessions_admin import SessionsAdminRoutesMixin, register_sessions_a
 from .routes.voice import VoiceRoutesMixin, register_voice_routes
 from .security import (
     WS_PROTOCOL_PREFIX,
+    create_security_headers_middleware,
     create_security_middleware,
     ensure_auth_token,
     is_loopback_host,
+    read_multipart_field_limited,
     resolve_auth_token,
     validate_startup_security,
 )
@@ -271,13 +273,21 @@ class AgentWireServer(
         # Origin + token enforcement. The middleware is a pure function of
         # config — run_server() resolves the token file into
         # config.server.auth_token before constructing the server.
+        # client_max_size is defense-in-depth for non-multipart bodies (JSON
+        # config saves, artifact uploads); the streaming multipart paths
+        # (/upload, /transcribe) enforce their own per-field limits because
+        # aiohttp does not apply client_max_size to request.multipart().
+        max_body = (max(config.uploads.max_size_mb, config.artifacts.max_size_mb) + 2) * 1024 * 1024
         self.app = web.Application(
+            client_max_size=max_body,
             middlewares=[
+                # Outermost so headers land on auth-rejected responses too.
+                create_security_headers_middleware(),
                 create_security_middleware(
                     config.server.auth_token,
                     config.server.allowed_origins,
                     on_lockout=self._on_auth_lockout,
-                )
+                ),
             ]
         )
         self._setup_jinja2()
@@ -2385,18 +2395,13 @@ class AgentWireServer(
             if not content_type.startswith("image/"):
                 return web.json_response({"error": f"File must be an image (got {content_type or 'unknown'})"})
 
-            # Read image data
-            image_data = await image_field.read()
+            # Read image data, aborting with 413 before buffering an
+            # over-limit body into RAM.
+            max_bytes = self.config.uploads.max_size_mb * 1024 * 1024
+            image_data = await read_multipart_field_limited(image_field, max_bytes)
 
             if not image_data:
                 return web.json_response({"error": "Empty image data"})
-
-            # Check file size
-            max_bytes = self.config.uploads.max_size_mb * 1024 * 1024
-            if len(image_data) > max_bytes:
-                return web.json_response({
-                    "error": f"File too large (max {self.config.uploads.max_size_mb}MB)"
-                })
 
             # Ensure uploads directory exists
             uploads_dir = self.config.uploads.dir
@@ -2418,6 +2423,8 @@ class AgentWireServer(
                 "filename": filename
             })
 
+        except web.HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Upload failed: {e}")
             return web.json_response({"error": str(e)})

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1493,3 +1493,88 @@ class TestMonitorInProcessCapture:
             if c.args[0] == "session_activity" and c.args[1].get("active") is True
         }
         assert {"watched", "headless"} <= active
+
+
+# ---------------------------------------------------------------------------
+# Security response headers (CSP & friends)
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeaders:
+    async def test_headers_on_index(self, portal_client):
+        client, _ = portal_client
+        resp = await client.get("/")
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
+        assert resp.headers["Referrer-Policy"] == "same-origin"
+        csp = resp.headers["Content-Security-Policy"]
+        assert "script-src 'self' https://cdn.jsdelivr.net" in csp
+        assert "connect-src 'self' ws: wss: https://raw.githubusercontent.com" in csp
+        # Plain-HTTP test transport: no HSTS.
+        assert "Strict-Transport-Security" not in resp.headers
+
+    async def test_headers_on_api_route(self, portal_client):
+        client, _ = portal_client
+        resp = await client.get("/api/artifacts")
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert "Content-Security-Policy" in resp.headers
+
+    async def test_artifacts_get_stricter_csp(self, portal_client, tmp_path):
+        client, server = portal_client
+        (server.config.artifacts.dir / "t.html").write_text("<h1>hi</h1>")
+        resp = await client.get("/artifacts/t.html")
+        assert resp.status == 200
+        csp = resp.headers["Content-Security-Policy"]
+        assert "frame-ancestors 'self'" in csp
+        assert "object-src 'none'" in csp
+
+    async def test_headers_on_error_response(self, portal_client_with_token):
+        client, _ = portal_client_with_token
+        resp = await client.get("/api/artifacts")  # 401: no token
+        assert resp.status == 401
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+
+# ---------------------------------------------------------------------------
+# Bounded multipart uploads (413 before buffering)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadSizeLimits:
+    async def test_upload_over_limit_413(self, portal_client, tmp_path):
+        client, server = portal_client
+        server.config.uploads = type(server.config.uploads)(
+            dir=tmp_path / "uploads", max_size_mb=1
+        )
+        import aiohttp
+        form = aiohttp.FormData()
+        form.add_field("image", b"\x89PNG" + b"x" * (2 * 1024 * 1024),
+                       filename="big.png", content_type="image/png")
+        resp = await client.post("/upload", data=form)
+        assert resp.status == 413
+
+    async def test_upload_under_limit_succeeds(self, portal_client, tmp_path):
+        client, server = portal_client
+        server.config.uploads = type(server.config.uploads)(
+            dir=tmp_path / "uploads", max_size_mb=1
+        )
+        import aiohttp
+        form = aiohttp.FormData()
+        form.add_field("image", b"\x89PNGsmall",
+                       filename="small.png", content_type="image/png")
+        resp = await client.post("/upload", data=form)
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["filename"].endswith(".png")
+
+    async def test_transcribe_over_limit_413(self, portal_client, tmp_path):
+        client, server = portal_client
+        server.config.uploads = type(server.config.uploads)(
+            dir=tmp_path / "uploads", max_size_mb=1
+        )
+        import aiohttp
+        form = aiohttp.FormData()
+        form.add_field("audio", b"a" * (2 * 1024 * 1024),
+                       filename="rec.webm", content_type="audio/webm")
+        resp = await client.post("/transcribe", data=form)
+        assert resp.status == 413

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,5 +1,6 @@
 """Unit tests for agentwire.security — origin policy, token lifecycle, bind policy."""
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -372,3 +373,75 @@ class TestMiddlewareLockout:
             with pytest.raises(web.HTTPUnauthorized):
                 await mw(self._request("127.0.0.1"), self._handler)
         assert locked == []
+
+
+# ---------------------------------------------------------------------------
+# Token file hardening (atomic 0600 write, 0700 config dir)
+
+
+class TestWriteTokenFile:
+    def test_new_file_is_0600_and_dir_0700(self, tmp_path, monkeypatch):
+        path = tmp_path / "aw" / "portal.token"
+        monkeypatch.setattr(security, "TOKEN_FILE", path)
+        old_umask = os.umask(0o000)  # worst-case permissive umask
+        try:
+            security.write_token_file("tok-1")
+        finally:
+            os.umask(old_umask)
+        assert path.read_text() == "tok-1\n"
+        assert (path.stat().st_mode & 0o777) == 0o600
+        assert (path.parent.stat().st_mode & 0o777) == 0o700
+
+    def test_rotate_over_existing_stays_0600(self, tmp_path, monkeypatch):
+        path = tmp_path / "portal.token"
+        monkeypatch.setattr(security, "TOKEN_FILE", path)
+        security.write_token_file("tok-1")
+        security.write_token_file("tok-2")
+        assert path.read_text() == "tok-2\n"
+        assert (path.stat().st_mode & 0o777) == 0o600
+        # No leftover temp files from the atomic write.
+        assert list(path.parent.glob(".portal.token.*")) == []
+
+
+# ---------------------------------------------------------------------------
+# Security response headers
+
+
+class TestSecurityHeaders:
+    def test_csp_covers_ui_requirements(self):
+        csp = security._build_csp()
+        assert "script-src 'self' https://cdn.jsdelivr.net" in csp
+        assert "ws: wss:" in csp
+        assert "https://raw.githubusercontent.com" in csp
+        assert "frame-ancestors 'self'" in csp
+        # pair.html's inline module must be hash-allowed, not broken.
+        assert "'sha256-" in csp
+
+    def test_inline_script_hashes_found(self):
+        # pair.html ships an inline <script type="module"> block.
+        assert security._inline_script_hashes()
+
+
+# ---------------------------------------------------------------------------
+# Bounded multipart reads
+
+
+class _FakeField:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    async def read_chunk(self, size=None):
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+class TestReadMultipartFieldLimited:
+    async def test_under_limit_returns_bytes(self):
+        field = _FakeField([b"aa", b"bb"])
+        assert await security.read_multipart_field_limited(field, 10) == b"aabb"
+
+    async def test_over_limit_raises_413_before_buffering_rest(self):
+        field = _FakeField([b"x" * 8, b"y" * 8, b"z" * 8])
+        with pytest.raises(web.HTTPRequestEntityTooLarge):
+            await security.read_multipart_field_limited(field, 10)
+        # The third chunk was never consumed — we aborted mid-stream.
+        assert field._chunks == [b"z" * 8]


### PR DESCRIPTION
Three low-severity portal security fixes sharing security.py/server.py.

## Fix A — atomic 0600 token file + 0700 config dir
`write_token_file` previously did `write_text` then `chmod(0o600)` — a window where the god-token was world-readable under a permissive umask, and `~/.agentwire` was created 0755. Now: `tempfile.mkstemp` in the target dir + `os.fchmod(fd, 0o600)` before any bytes land + `os.replace` (atomic). Parent dir created `mode=0o700`. Rotation over an existing file stays 0600 with no leftover temp files.

## Fix B — security response headers
New outermost middleware (so headers land on auth-rejected responses too) sets on every response:
- `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: same-origin`
- CSP: `script-src 'self' https://cdn.jsdelivr.net` + sha256 hashes for inline template scripts (pair.html DOES ship an inline module — hashes are computed from the templates at startup, so they auto-heal on template edits); `style-src` needs `'unsafe-inline'` (inline style attrs + WinBox-injected styles); `img-src` allows `data:`/`blob:` (WinBox SVG buttons, upload previews); `connect-src 'self' ws: wss: https://raw.githubusercontent.com` (dashboard/terminal WebSockets + announcements fetch); `media-src blob:` for voice playback.
- HSTS (`max-age=31536000`) only when `request.secure`.
- `/artifacts/*` responses get a separate policy: content stays permissive (agent-generated HTML legitimately carries inline scripts/CDN libs; the iframe `sandbox` attribute is the primary containment) but `frame-ancestors 'self'`, `object-src 'none'`, `base-uri 'self'` are locked.

## Fix C — bounded multipart uploads
`/transcribe` buffered the whole body with no limit; `/upload` checked size only after a full read (aiohttp's `client_max_size` does not bound `request.multipart()`). Both now stream via a shared `read_multipart_field_limited` helper that aborts with **413** once the cap is exceeded, before buffering the payload. `/transcribe` uses `stt.max_upload_mb` if configured, else `uploads.max_size_mb` (config.py was out of scope for this PR, so the field is read via getattr). Explicit `client_max_size` added to `web.Application` as defense-in-depth for non-multipart bodies.

## Verification
- `uv run --extra dev pytest -q` — **2191 passed, 8 skipped** (full suite, includes new tests)
- New tests: token file 0600 under `umask 0` + rotate + 0700 dir; CSP content incl. inline-script hashes; headers asserted on `/`, `/api/artifacts`, `/artifacts/<f>`, and a 401 error response; 413 on over-limit `/upload` and `/transcribe` with a 1MB cap; under-limit upload still succeeds; streaming abort verified to stop mid-stream.
- ruff clean.
- Live-portal behavior (real browser against the CSP) can only be checked after merge+rebuild — the CSP was derived from the actual templates/static JS, and inline-script hashing keeps pairing working, but flagging it for a post-merge smoke check of the desktop UI (xterm, WinBox, announcements modal).

Built by [dotdev.dev](https://dotdev.dev)