### PR TITLE
CSP: allow Google Fonts (Council window) + fix stale listen-log doc path

### DIFF
--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -415,9 +415,11 @@ def _build_csp() -> str:
     return "; ".join([
         "default-src 'self'",
         f"script-src {script_src}",
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        # fonts.googleapis.com: the Council window injects a Google Fonts
+        # stylesheet (council-window.js); fonts.gstatic.com serves the woff2s.
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com",
         "img-src 'self' data: blob:",
-        "font-src 'self' data:",
+        "font-src 'self' data: https://fonts.gstatic.com",
         "connect-src 'self' ws: wss: https://raw.githubusercontent.com",
         "media-src 'self' blob: data:",
         "worker-src 'self' blob:",

--- a/docs/wiki/communication/hammerspoon.md
+++ b/docs/wiki/communication/hammerspoon.md
@@ -85,4 +85,4 @@ To rebind, edit the two `hs.hotkey.bind` calls at the bottom of `init.lua` (e.g.
 | ⌥Space sends to the wrong/default session | `cat ~/.agentwire/active-session`; focus a session window in the portal |
 | Chooser shows "No sessions running" | `agentwire list --sessions` from a normal shell |
 | `agentwire: not found` | Fix the `agentwire` path or `PATH` at the top of `init.lua` |
-| Debug the CLI side | `tail -f /tmp/agentwire-listen.log` |
+| Debug the CLI side | `tail -f ~/.agentwire/logs/listen.log` |

--- a/examples/hammerspoon-ptt/README.md
+++ b/examples/hammerspoon-ptt/README.md
@@ -42,4 +42,4 @@ Tap once to start recording, tap the **same** key to stop. For ⌥⌘Space you c
 | ⌥Space sends to the wrong/default session | `cat ~/.agentwire/active-session`; focus a session window in the portal |
 | Chooser shows "No sessions running" | `agentwire list --sessions` from a normal shell |
 | `agentwire: not found` | Fix the `agentwire` path or `PATH` at the top of `init.lua` |
-| Debug the CLI side | `tail -f /tmp/agentwire-listen.log` |
+| Debug the CLI side | `tail -f ~/.agentwire/logs/listen.log` |


### PR DESCRIPTION
Follow-ups to the security-hardening batch (#645–649).

**CSP font gap (regression from #649):** the portal-wide CSP omitted `fonts.googleapis.com`/`fonts.gstatic.com`, but `council-window.js` injects a Google Fonts stylesheet + woff2 files for its typography. Under the new CSP those loads were refused (broken Council fonts + console CSP violations). Added the two origins to `style-src`/`font-src`. Verified by grepping all frontend external origins against the policy — everything else (jsdelivr, raw.githubusercontent, ws/wss) was already covered; `agentwire.dev`/`github.com` are `<a href>` navigation, not resource loads.

**Stale docs (from #648):** two docs still said `tail -f /tmp/agentwire-listen.log`; the log moved to `~/.agentwire/logs/listen.log`.

No `Closes #` — these track the private security batch.