### PR TITLE
security: gate HSTS behind server.hsts (default off) — avoid self-signed lockout

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -74,6 +74,12 @@ class ServerConfig:
     # bearer token then transits in cleartext. Required to start a non-loopback
     # bind without TLS — the BYO-tunnel case where the tunnel terminates TLS.
     allow_insecure: bool = False
+    # Emit HTTP Strict-Transport-Security. Leave OFF for self-signed /
+    # localhost / LAN — HSTS + a self-signed cert locks the browser out of the
+    # portal if the cert ever rotates. Enable ONLY when serving a real
+    # (CA-signed) cert directly. Behind Cloudflare Tunnel / a reverse proxy,
+    # set HSTS at the edge instead.
+    hsts: bool = False
 
 
 @dataclass
@@ -590,6 +596,7 @@ def _dict_to_config(data: dict) -> Config:
         # "" (explicit disable) must survive — don't collapse it to None.
         auth_token=server_data.get("auth_token"),
         allow_insecure=bool(server_data.get("allow_insecure", False)),
+        hsts=bool(server_data.get("hsts", False)),
     )
 
     # Projects

--- a/agentwire/security.py
+++ b/agentwire/security.py
@@ -442,11 +442,13 @@ _ARTIFACTS_CSP = "; ".join([
 ])
 
 
-def create_security_headers_middleware():
+def create_security_headers_middleware(hsts_enabled: bool = False):
     """Middleware stamping security response headers on every response.
 
-    HSTS is emitted only on TLS requests (an HSTS header over plain HTTP is
-    ignored by browsers, and pinning localhost dev to HTTPS would be wrong).
+    HSTS is opt-in (``server.hsts``) and emitted only on TLS requests: agentwire
+    commonly serves HTTPS with a self-signed cert, and a pinned HSTS policy
+    removes the cert-error click-through — a rotated/expired self-signed cert
+    would hard-lock the browser out of the portal.
     """
     csp = _build_csp()
 
@@ -455,15 +457,17 @@ def create_security_headers_middleware():
         try:
             response = await handler(request)
         except web.HTTPException as exc:
-            _stamp_security_headers(request, exc, csp)
+            _stamp_security_headers(request, exc, csp, hsts_enabled)
             raise
-        _stamp_security_headers(request, response, csp)
+        _stamp_security_headers(request, response, csp, hsts_enabled)
         return response
 
     return security_headers_middleware
 
 
-def _stamp_security_headers(request: web.Request, response, csp: str) -> None:
+def _stamp_security_headers(
+    request: web.Request, response, csp: str, hsts_enabled: bool
+) -> None:
     headers = response.headers
     headers.setdefault("X-Content-Type-Options", "nosniff")
     headers.setdefault("X-Frame-Options", "SAMEORIGIN")
@@ -472,7 +476,7 @@ def _stamp_security_headers(request: web.Request, response, csp: str) -> None:
         headers["Content-Security-Policy"] = _ARTIFACTS_CSP
     else:
         headers.setdefault("Content-Security-Policy", csp)
-    if request.secure:
+    if hsts_enabled and request.secure:
         headers.setdefault("Strict-Transport-Security", "max-age=31536000")
 
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -282,7 +282,7 @@ class AgentWireServer(
             client_max_size=max_body,
             middlewares=[
                 # Outermost so headers land on auth-rejected responses too.
-                create_security_headers_middleware(),
+                create_security_headers_middleware(hsts_enabled=config.server.hsts),
                 create_security_middleware(
                     config.server.auth_token,
                     config.server.allowed_origins,

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -421,6 +421,40 @@ class TestSecurityHeaders:
         # pair.html ships an inline <script type="module"> block.
         assert security._inline_script_hashes()
 
+    @staticmethod
+    def _stamp(secure: bool, hsts_enabled: bool, path: str = "/"):
+        request = SimpleNamespace(secure=secure, path=path)
+        response = SimpleNamespace(headers={})
+        security._stamp_security_headers(request, response, "default-csp", hsts_enabled)
+        return response.headers
+
+    def test_hsts_off_by_default_even_on_secure_request(self):
+        headers = self._stamp(secure=True, hsts_enabled=False)
+        assert "Strict-Transport-Security" not in headers
+
+    def test_hsts_emitted_when_enabled_and_secure(self):
+        headers = self._stamp(secure=True, hsts_enabled=True)
+        assert headers["Strict-Transport-Security"] == "max-age=31536000"
+
+    def test_hsts_never_on_plain_http(self):
+        headers = self._stamp(secure=False, hsts_enabled=True)
+        assert "Strict-Transport-Security" not in headers
+
+    def test_other_headers_unchanged_by_hsts_gate(self):
+        headers = self._stamp(secure=True, hsts_enabled=False)
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert headers["X-Frame-Options"] == "SAMEORIGIN"
+        assert headers["Referrer-Policy"] == "same-origin"
+        assert headers["Content-Security-Policy"] == "default-csp"
+
+    def test_artifacts_csp_unaffected(self):
+        headers = self._stamp(secure=True, hsts_enabled=True, path="/artifacts/x.html")
+        assert headers["Content-Security-Policy"] == security._ARTIFACTS_CSP
+
+    def test_server_hsts_config_defaults_false(self, tmp_path):
+        config = load_config(tmp_path / "nonexistent.yaml")
+        assert config.server.hsts is False
+
 
 # ---------------------------------------------------------------------------
 # Bounded multipart reads


### PR DESCRIPTION
## The footgun

PR #649's security-headers middleware emitted `Strict-Transport-Security: max-age=31536000` on every TLS request. agentwire commonly serves HTTPS with a **self-signed cert** on localhost/LAN. Once a browser pins HSTS for a host, it both enforces HTTPS *and removes the cert-error click-through* — so if the self-signed cert rotates or expires, the user is hard-blocked from their own portal with no bypass for up to a year.

## The fix (opt-in gate, default OFF)

- New config field `server.hsts` (bool, **default `false`**) in `agentwire/config.py`.
- `create_security_headers_middleware(hsts_enabled)` — HSTS is emitted only when `hsts_enabled AND request.secure`.
- `server.py` passes `config.server.hsts`.
- All other headers (CSP incl. stricter `/artifacts/` policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) unchanged.

Enable `server.hsts: true` only when serving a real CA-signed cert directly; behind Cloudflare Tunnel / a reverse proxy, set HSTS at the edge.

## Tests

New unit coverage of `_stamp_security_headers`: default → no HSTS even on secure requests; enabled+secure → HSTS present; plain HTTP → never; other headers + artifacts CSP unaffected; config default is `false`. Full suite: **2231 passed, 8 skipped**.

Built by [dotdev.dev](https://dotdev.dev)