### PR TITLE
fix(portal): --no-stt actually disables the STT shim (set stt.backend=none)

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2849,6 +2849,25 @@ async def run_server(config: Config):
         await runner.cleanup()
 
 
+def apply_cli_overrides(config, overrides: dict) -> None:
+    """Apply portal CLI flag overrides onto the loaded config.
+
+    ``--no-tts`` / ``--no-stt`` both flip the backend to ``"none"`` — the
+    backend field is what gates the default-tier shim autostarts in
+    ``run_server``, so nulling only ``stt.url`` would leave the Moonshine
+    shim spawning anyway.
+    """
+    if overrides.get("port"):
+        config.server.port = overrides["port"]
+    if overrides.get("host"):
+        config.server.host = overrides["host"]
+    if overrides.get("no_tts"):
+        config.tts.backend = "none"
+    if overrides.get("no_stt"):
+        config.stt.backend = "none"
+        config.stt.url = None
+
+
 def main(config_path: str | None = None, **overrides) -> None:
     """Entry point for running the server."""
     logging.basicConfig(
@@ -2857,16 +2876,7 @@ def main(config_path: str | None = None, **overrides) -> None:
     )
 
     config = load_config(config_path)
-
-    # Apply CLI overrides
-    if overrides.get("port"):
-        config.server.port = overrides["port"]
-    if overrides.get("host"):
-        config.server.host = overrides["host"]
-    if overrides.get("no_tts"):
-        config.tts.backend = "none"
-    if overrides.get("no_stt"):
-        config.stt.url = None
+    apply_cli_overrides(config, overrides)
 
     try:
         asyncio.run(run_server(config))

--- a/agentwire/stt/__init__.py
+++ b/agentwire/stt/__init__.py
@@ -11,6 +11,7 @@ from .server_backend import STTServerBackend
 
 __all__ = [
     "CloudSTTBackend",
+    "NullSTTBackend",
     "STTBackend",
     "STTServerBackend",
     "get_stt_backend",
@@ -20,6 +21,17 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 DEFAULT_STT_URL = "http://localhost:8101"
+
+
+class NullSTTBackend(STTBackend):
+    """No-op backend for ``stt.backend: none`` (server STT disabled)."""
+
+    @property
+    def name(self) -> str:
+        return "NullSTT"
+
+    async def transcribe(self, audio_path) -> str | None:
+        raise RuntimeError("STT is disabled (stt.backend 'none')")
 
 
 def _default_stt_url(stt_config: Any) -> str:
@@ -45,6 +57,13 @@ def get_stt_backend(config: Any) -> STTBackend:
     """
     stt_config = getattr(config, "stt", None)
     backend = getattr(stt_config, "backend", "default") if stt_config is not None else "default"
+
+    if backend == "none":
+        # STT disabled (--no-stt / stt.backend: none). The browser's
+        # SpeechRecognition fallback still works client-side; server
+        # transcription just isn't available.
+        logger.info("STT disabled (backend 'none')")
+        return NullSTTBackend()
 
     if backend == "cloud":
         cloud = getattr(stt_config, "cloud", None) or {}

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -969,6 +969,59 @@ class TestEnsureManagedStt:
 
 
 # ---------------------------------------------------------------------------
+# CLI overrides (--no-stt / --no-tts) — apply_cli_overrides
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCliOverrides:
+    @staticmethod
+    def _config():
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            server=SimpleNamespace(host="127.0.0.1", port=8000),
+            tts=SimpleNamespace(backend="default", url=None),
+            stt=SimpleNamespace(backend="default", url=None),
+        )
+
+    def test_no_stt_disables_backend_and_shim_gate(self):
+        from agentwire.server import apply_cli_overrides
+
+        config = self._config()
+        apply_cli_overrides(config, {"no_stt": True})
+        assert config.stt.backend == "none"
+        assert config.stt.url is None
+        # This is the run_server autostart gate for ensure_managed_stt —
+        # with backend "none" the Moonshine shim must not be scheduled.
+        assert not (config.stt.backend == "default")
+
+    def test_no_tts_unchanged(self):
+        from agentwire.server import apply_cli_overrides
+
+        config = self._config()
+        apply_cli_overrides(config, {"no_tts": True})
+        assert config.tts.backend == "none"
+        assert config.stt.backend == "default"
+
+    def test_both_disabled(self):
+        from agentwire.server import apply_cli_overrides
+
+        config = self._config()
+        apply_cli_overrides(config, {"no_tts": True, "no_stt": True})
+        assert config.tts.backend == "none"
+        assert config.stt.backend == "none"
+
+    def test_no_overrides_is_noop(self):
+        from agentwire.server import apply_cli_overrides
+
+        config = self._config()
+        apply_cli_overrides(config, {})
+        assert config.stt.backend == "default"
+        assert config.tts.backend == "default"
+        assert config.server.port == 8000
+
+
+# ---------------------------------------------------------------------------
 # Default-tier managed Kokoro TTS shim lifecycle (ensure_managed_tts)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_stt_backend.py
+++ b/tests/unit/test_stt_backend.py
@@ -8,7 +8,9 @@ standalone shim subprocess and talks to it over HTTP. So both ``default`` and
 
 from types import SimpleNamespace
 
-from agentwire.stt import STTServerBackend, _default_stt_url, get_stt_backend
+import pytest
+
+from agentwire.stt import NullSTTBackend, STTServerBackend, _default_stt_url, get_stt_backend
 
 
 def _cfg(backend: str, url: str | None = None, timeout: int = 30):
@@ -36,6 +38,24 @@ class TestGetSttBackend:
         backend = get_stt_backend(SimpleNamespace())
         assert isinstance(backend, STTServerBackend)
         assert backend.url == "http://localhost:8101"
+
+
+class TestNoneTier:
+    def test_none_tier_returns_null_backend(self):
+        backend = get_stt_backend(_cfg("none"))
+        assert isinstance(backend, NullSTTBackend)
+        assert backend.name == "NullSTT"
+
+    def test_none_tier_with_null_url_does_not_crash(self):
+        # --no-stt sets backend="none" AND url=None; the factory must not
+        # fall through to STTServerBackend(url=None).
+        backend = get_stt_backend(_cfg("none", url=None))
+        assert isinstance(backend, NullSTTBackend)
+
+    async def test_null_backend_transcribe_raises(self, tmp_path):
+        backend = get_stt_backend(_cfg("none"))
+        with pytest.raises(RuntimeError, match="disabled"):
+            await backend.transcribe(tmp_path / "x.wav")
 
 
 class TestDefaultSttUrl:


### PR DESCRIPTION
## Root cause

`agentwire portal start --no-stt` only set `config.stt.url = None`, leaving `config.stt.backend == "default"`. The Moonshine shim autostart gate in `run_server` keys on the backend field (`if config.stt.backend == "default" and moonshine_importable()`), so the `agentwire-stt` shim still spawned — the flag was a no-op for the shim. `--no-tts` worked because it sets `tts.backend = "none"`.

## Fix

- `--no-stt` now mirrors `--no-tts`: sets `stt.backend = "none"` (and still nulls `stt.url`), so the autostart branch is never taken.
- Extracted the override block into `apply_cli_overrides(config, overrides)` so it's unit-testable.
- `get_stt_backend` gets an explicit `"none"` branch returning a `NullSTTBackend` — without it, `backend="none"` + `url=None` would fall through to `STTServerBackend(url=None)` and crash on `None.rstrip()` in `init_backends`. Voice-status keeps `server_transcribe=False` for `"none"`, so the browser SpeechRecognition fallback is unaffected.

## Tests

- `TestApplyCliOverrides` (test_portal_api.py): `--no-stt` sets `backend="none"` / gate not taken, `--no-tts` unchanged, both together, no-op case.
- `TestNoneTier` (test_stt_backend.py): factory returns `NullSTTBackend`, no crash with `url=None`, transcribe raises cleanly.

`uv run pytest -q`: 2232 passed, 8 skipped.

Built by [dotdev.dev](https://dotdev.dev)