### PR TITLE
fix: targeted uv cache invalidation + install-then-swap rebuild (#643)

### DIFF
--- a/agentwire/system_cli.py
+++ b/agentwire/system_cli.py
@@ -33,6 +33,7 @@ from .core import (
 from .project_config import detect_default_agent_type, load_project_config
 from .roles import inject_soul, load_roles, resolve_roles
 
+
 def _clean_uv_cache_for_agentwire() -> None:
     """Drop only agentwire-dev's entries from the uv cache.
 

--- a/agentwire/system_cli.py
+++ b/agentwire/system_cli.py
@@ -8,7 +8,6 @@ session: ``up`` (boot all services then the dev session), ``dev``, ``init``,
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 import urllib.request
@@ -34,7 +33,22 @@ from .core import (
 from .project_config import detect_default_agent_type, load_project_config
 from .roles import inject_soul, load_roles, resolve_roles
 
-UV_CACHE_DIR = Path.home() / ".cache" / "uv"
+def _clean_uv_cache_for_agentwire() -> None:
+    """Drop only agentwire-dev's entries from the uv cache.
+
+    The uv cache (~/.cache/uv) is shared by every uv tool and project on the
+    machine — never rmtree it wholesale. `uv cache clean <package>` evicts just
+    this package's wheels/sdists so the next install rebuilds from source.
+    """
+    result = subprocess.run(
+        ["uv", "cache", "clean", "agentwire-dev"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print("  ✓ Cleared agentwire-dev entries from uv cache")
+    else:
+        print(f"  - uv cache clean skipped: {result.stderr.strip() or 'unknown error'}")
 
 
 # === Dev Command ===
@@ -464,10 +478,14 @@ def cmd_listen_toggle(args) -> int:
 # === Rebuild / Uninstall Commands ===
 
 def cmd_rebuild(args) -> int:
-    """Rebuild: clear uv cache, uninstall, reinstall from source.
+    """Rebuild: reinstall from source, bypassing cached wheels.
 
     This is the correct way to pick up source changes when developing.
-    `uv tool install . --force` does NOT work - it uses cached wheels.
+    Plain `uv tool install . --force` does NOT work - it uses cached wheels -
+    so agentwire-dev's cache entries are evicted first (never the whole cache),
+    then a single install --force --reinstall atomically replaces the old
+    install. There is no separate uninstall step: a failed install leaves the
+    existing tool untouched.
     """
     force = getattr(args, "force", False)
 
@@ -479,6 +497,13 @@ def cmd_rebuild(args) -> int:
     project_root = Path(__file__).parent.parent
     if not (project_root / "pyproject.toml").exists():
         project_root = get_source_dir()
+    if not (project_root / "pyproject.toml").exists():
+        print(
+            f"  ✗ No source checkout at {project_root} (pyproject.toml missing).\n"
+            "    Rebuild needs the agentwire-dev repo. Nothing was changed.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Git-drift guard: rebuild is otherwise git-blind and will happily reinstall
     # stale code when local main was never pulled after a remote merge. Refuse
@@ -499,37 +524,23 @@ def cmd_rebuild(args) -> int:
         print("  ✓ Checkout up to date with origin/main")
     print()
 
-    # Step 1: Clear uv cache
-    if UV_CACHE_DIR.exists():
-        print(f"Clearing uv cache ({UV_CACHE_DIR})...")
-        shutil.rmtree(UV_CACHE_DIR)
-        print("  ✓ Cache cleared")
-    else:
-        print("  - No cache to clear")
+    # Step 1: Evict only agentwire-dev's cached wheels so the reinstall
+    # rebuilds from source.
+    print("Clearing agentwire-dev from uv cache...")
+    _clean_uv_cache_for_agentwire()
 
-    # Step 2: Uninstall
-    print("Uninstalling agentwire-dev...")
-    result = subprocess.run(
-        ["uv", "tool", "uninstall", "agentwire-dev"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        print("  ✓ Uninstalled")
-    else:
-        # Might not be installed, that's fine
-        print("  - Not installed (continuing)")
-
-    # Step 3: Reinstall from the source checkout resolved above.
+    # Step 2: Install-then-swap. --force --reinstall atomically replaces the
+    # existing install; on failure the old install is still in place.
     print(f"Installing from {project_root}...")
     result = subprocess.run(
-        ["uv", "tool", "install", "."],
+        ["uv", "tool", "install", ".", "--force", "--reinstall"],
         cwd=project_root,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         print(f"  ✗ Install failed: {result.stderr}", file=sys.stderr)
+        print("    Existing install was left untouched.", file=sys.stderr)
         return 1
 
     print("  ✓ Installed")
@@ -539,17 +550,13 @@ def cmd_rebuild(args) -> int:
 
 
 def cmd_uninstall(args) -> int:
-    """Uninstall: clear uv cache and remove agentwire-dev tool."""
+    """Uninstall: drop agentwire-dev's cache entries and remove the tool."""
     print("Uninstalling agentwire-dev...")
     print()
 
-    # Step 1: Clear uv cache
-    if UV_CACHE_DIR.exists():
-        print(f"Clearing uv cache ({UV_CACHE_DIR})...")
-        shutil.rmtree(UV_CACHE_DIR)
-        print("  ✓ Cache cleared")
-    else:
-        print("  - No cache to clear")
+    # Step 1: Evict only agentwire-dev's entries from the shared uv cache.
+    print("Clearing agentwire-dev from uv cache...")
+    _clean_uv_cache_for_agentwire()
 
     # Step 2: Uninstall
     print("Uninstalling tool...")

--- a/tests/unit/test_rebuild_guard.py
+++ b/tests/unit/test_rebuild_guard.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from agentwire.core import _git_behind_origin
-from agentwire.system_cli import cmd_rebuild
+from agentwire.system_cli import cmd_rebuild, cmd_uninstall
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -110,7 +110,6 @@ class TestRebuildGuard:
             return subprocess.CompletedProcess(cmd, 0, "", "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: None)
         rc = cmd_rebuild(_args(force=False))
         out = capsys.readouterr().out
         assert rc == 1
@@ -128,8 +127,108 @@ class TestRebuildGuard:
             return subprocess.CompletedProcess(cmd, 0, "ok", "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: None)
         rc = cmd_rebuild(_args(force=True))
         out = capsys.readouterr().out
         assert "--force given" in out
         assert rc == 0
+
+
+@pytest.fixture
+def up_to_date_checkout(tmp_path):
+    """A clone that is level with its origin/main, laid out as a source root."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    (origin / "f.txt").write_text("0\n")
+    _git(origin, "add", ".")
+    _git(origin, "commit", "-qm", "c0")
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    (clone / "pyproject.toml").write_text("[project]\nname='x'\n")
+    fake_file = clone / "agentwire" / "system_cli.py"
+    fake_file.parent.mkdir(parents=True, exist_ok=True)
+    fake_file.write_text("")
+    return clone, fake_file
+
+
+class TestRebuildSafety:
+    """#643: rebuild must never nuke the shared uv cache or uninstall-before-install."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_root(self, up_to_date_checkout, monkeypatch):
+        clone, fake_file = up_to_date_checkout
+        import agentwire.system_cli as sys_mod
+        monkeypatch.setattr(sys_mod, "__file__", str(fake_file))
+        self.clone = clone
+
+    def _capture_uv(self, monkeypatch, install_rc=0):
+        real_run = subprocess.run
+        calls = []
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "git":
+                return real_run(cmd, *a, **k)
+            calls.append(cmd)
+            rc = install_rc if cmd[:3] == ["uv", "tool", "install"] else 0
+            return subprocess.CompletedProcess(cmd, rc, "", "boom" if rc else "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        return calls
+
+    def test_targeted_cache_clean_and_no_rmtree(self, monkeypatch):
+        calls = self._capture_uv(monkeypatch)
+        rmtree_calls = []
+        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: rmtree_calls.append(a))
+        rc = cmd_rebuild(_args(force=False))
+        assert rc == 0
+        assert rmtree_calls == []
+        assert ["uv", "cache", "clean", "agentwire-dev"] in calls
+
+    def test_no_uninstall_step_atomic_replace(self, monkeypatch):
+        calls = self._capture_uv(monkeypatch)
+        rc = cmd_rebuild(_args(force=False))
+        assert rc == 0
+        assert not any(cmd[:3] == ["uv", "tool", "uninstall"] for cmd in calls)
+        assert ["uv", "tool", "install", ".", "--force", "--reinstall"] in calls
+
+    def test_failed_install_never_uninstalls(self, monkeypatch, capsys):
+        calls = self._capture_uv(monkeypatch, install_rc=1)
+        rc = cmd_rebuild(_args(force=False))
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert not any(cmd[:3] == ["uv", "tool", "uninstall"] for cmd in calls)
+        assert "left untouched" in err
+
+    def test_missing_checkout_fails_before_any_uv_call(self, monkeypatch, capsys, tmp_path):
+        import agentwire.system_cli as sys_mod
+        fake_file = tmp_path / "nocheckout" / "agentwire" / "system_cli.py"
+        fake_file.parent.mkdir(parents=True)
+        fake_file.write_text("")
+        monkeypatch.setattr(sys_mod, "__file__", str(fake_file))
+        monkeypatch.setattr(sys_mod, "get_source_dir", lambda: tmp_path / "also-missing")
+        calls = []
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda cmd, *a, **k: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0, "", ""),
+        )
+        rc = cmd_rebuild(_args(force=False))
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "pyproject.toml missing" in err
+        assert not any(cmd[0] == "uv" for cmd in calls)
+
+
+class TestUninstallSafety:
+    def test_targeted_cache_clean_and_no_rmtree(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda cmd, *a, **k: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0, "", ""),
+        )
+        rmtree_calls = []
+        monkeypatch.setattr("shutil.rmtree", lambda *a, **k: rmtree_calls.append(a))
+        rc = cmd_uninstall(_args())
+        assert rc == 0
+        assert rmtree_calls == []
+        assert ["uv", "cache", "clean", "agentwire-dev"] in calls
+        assert ["uv", "tool", "uninstall", "agentwire-dev"] in calls


### PR DESCRIPTION
## What

Fixes both hazards in `agentwire/system_cli.py`:

1. **Global cache nuke** — `cmd_rebuild` and `cmd_uninstall` ran `shutil.rmtree(~/.cache/uv)`, wiping the uv cache shared by every tool/project on the machine. Replaced with a shared `_clean_uv_cache_for_agentwire()` helper that runs `uv cache clean agentwire-dev` — only this package's wheels/sdists are evicted, which is all that's needed to force a source rebuild.
2. **Uninstall-before-install** — rebuild used clear-cache → `uv tool uninstall` → `uv tool install .`; a failed install left the user with no agentwire at all. Now rebuild validates the source checkout up front (clear error if `pyproject.toml` is missing, before any uv command) and does a single `uv tool install . --force --reinstall` — atomic replace, no uninstall step, so a failed install leaves the old tool intact.

## Verification

- New tests: targeted cache clean (no `rmtree`), no uninstall step, failed install never uninstalls, missing checkout fails before any uv call; same coverage for `cmd_uninstall`.
- Full suite: **2243 passed, 8 skipped** (`uv run --extra dev pytest`).
- Confirmed `uv tool install --force --reinstall` flags exist in the installed uv.

Closes #643

Built by [dotdev.dev](https://dotdev.dev)