### PR TITLE
refactor(portal): extract shared push-to-talk pipeline into ptt.js

### DIFF
--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -33,7 +33,7 @@ import { scratchpad } from './scratchpad.js';
 import { armDeadKeySuppressor, disarmDeadKeySuppressor } from './dead-key-suppressor.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import { setupHelp, openHelp, isHelpOpen } from './help-modal.js';
-import * as browserStt from './voice/browser-stt.js';
+import { PttController } from './ptt.js';
 import { voicePromptWrap } from './voice/prompt.js';
 import { isAutoSend } from './voice/autosend-prefs.js';
 import { initAnnouncements } from './announcement-modal.js';
@@ -45,9 +45,7 @@ const reviewWindows = new Map();  // windowId -> ReviewWindow instance
 let councilWindow = null;  // single CouncilWindow instance (one board at a time)
 
 // Global PTT state
-let globalPttState = 'idle';  // idle | recording | processing
-let globalMediaRecorder = null;
-let globalAudioChunks = [];
+let globalPttState = 'idle';  // idle | recording | processing (mirrors globalPttCtl)
 
 // AgentWire session activity state
 let agentwireSessionActive = false;
@@ -1027,75 +1025,31 @@ function setupGlobalPtt() {
     });
 }
 
-function usesBrowserStt() {
-    // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio to
-    // the portal's /transcribe; otherwise recognition happens in the browser.
-    return !browserStt.serverTranscribes(desktop.voiceStatus);
-}
-
-let globalSttCancelled = false;
-
-async function startGlobalRecording() {
-    if (globalPttState !== 'idle') return;
-
-    // Default tier: browser speech recognition → edit-before-send bar
-    if (usesBrowserStt()) {
-        if (!browserStt.isSupported()) {
+const globalPttCtl = new PttController({
+    getVoiceStatus: () => desktop.voiceStatus,
+    onState: updateGlobalPttState,
+    onResult: (text) => {
+        if (isAutoSend()) sendGlobalVoiceText(text);
+        else showGlobalTranscript(text);
+    },
+    onError: (kind, message) => {
+        if (kind === 'unsupported') {
             console.warn('[GlobalPTT] SpeechRecognition unsupported — use Chrome or set stt.backend: cloud/custom');
             const icon = elements.globalPtt?.querySelector('.ptt-icon');
             if (icon) icon.textContent = '🚫';
-            elements.globalPtt.title = 'Browser voice input requires Chrome (or set stt.backend: cloud/custom)';
+            elements.globalPtt.title = message;
             return;
         }
-        globalSttCancelled = false;
-        const ok = browserStt.start({
-            onFinal: (text) => {
-                updateGlobalPttState('idle');
-                if (globalSttCancelled || !text) return;
-                if (isAutoSend()) sendGlobalVoiceText(text);
-                else showGlobalTranscript(text);
-            },
-            onError: () => updateGlobalPttState('idle'),
-        }, desktop.voiceStatus?.corrections || {});
-        if (ok) updateGlobalPttState('recording');
-        return;
-    }
+        console.warn(`[GlobalPTT] ${message}`);
+    },
+});
 
-    try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        globalMediaRecorder = new MediaRecorder(stream, {
-            mimeType: 'audio/webm;codecs=opus'
-        });
-
-        globalAudioChunks = [];
-        globalMediaRecorder.ondataavailable = (e) => {
-            if (e.data.size > 0) globalAudioChunks.push(e.data);
-        };
-
-        globalMediaRecorder.onstop = async () => {
-            stream.getTracks().forEach(t => t.stop());
-            if (globalAudioChunks.length > 0) {
-                await processGlobalRecording();
-            }
-        };
-
-        globalMediaRecorder.start();
-        updateGlobalPttState('recording');
-    } catch (err) {
-        console.error('[GlobalPTT] Failed to start recording:', err);
-    }
+function startGlobalRecording() {
+    globalPttCtl.start();
 }
 
 function stopGlobalRecording() {
-    if (globalPttState !== 'recording') return;
-    if (usesBrowserStt()) {
-        updateGlobalPttState('processing');
-        browserStt.stop();  // onFinal fires from onend
-        return;
-    }
-    if (!globalMediaRecorder) return;
-    globalMediaRecorder.stop();
-    updateGlobalPttState('processing');
+    globalPttCtl.stop();
 }
 
 async function sendGlobalVoiceText(text) {
@@ -1110,30 +1064,7 @@ async function sendGlobalVoiceText(text) {
     }
 }
 
-async function processGlobalRecording() {
-    try {
-        const blob = new Blob(globalAudioChunks, { type: 'audio/webm' });
-        const formData = new FormData();
-        formData.append('audio', blob, 'recording.webm');
-
-        // Transcribe
-        const transcribeRes = await apiFetch('/transcribe', {
-            method: 'POST',
-            body: formData
-        });
-        const { text } = await transcribeRes.json();
-
-        if (text && text.trim()) {
-            await sendGlobalVoiceText(text.trim());
-        }
-    } catch (err) {
-        console.error('[GlobalPTT] Processing failed:', err);
-    } finally {
-        updateGlobalPttState('idle');
-    }
-}
-
-// --- Edit-before-send transcript bar (default STT tier) ---
+// --- Edit-before-send transcript bar ---
 
 function setupTranscriptBar() {
     const { transcriptBar, transcriptInput, transcriptSend, transcriptDismiss } = elements;

--- a/agentwire/static/js/mobile.js
+++ b/agentwire/static/js/mobile.js
@@ -16,7 +16,7 @@
 import { apiFetch, wsProtocols } from './api.js';
 import { attachHorizontalSwipe } from './utils/swipe.js';
 import { isService, isCouncil, loadCustomServices } from './service-classification.js';
-import * as browserStt from './voice/browser-stt.js';
+import { PttController } from './ptt.js';
 import * as browserTts from './voice/browser-tts.js';
 import { voicePromptWrap } from './voice/prompt.js';
 import { isAutoSend } from './voice/autosend-prefs.js';
@@ -44,10 +44,7 @@ let voiceStatus = null;
 let sessions = [];
 let selectedSession = null;
 let activeTab = 'sessions'; // 'sessions' | 'services' — classification shared with the desktop sidebar
-let pttState = 'idle'; // idle | recording | processing
-let sttCancelled = false;
-let mediaRecorder = null;
-let audioChunks = [];
+let pttState = 'idle'; // idle | recording | processing (mirrors ptt controller)
 
 // ---------------------------------------------------------------------------
 // Status + transcript
@@ -399,11 +396,21 @@ function setupPtt() {
     els.ptt.addEventListener('contextmenu', (e) => e.preventDefault());
 }
 
-function usesBrowserStt() {
-    // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio to
-    // /transcribe; otherwise recognition happens in the browser.
-    return !browserStt.serverTranscribes(voiceStatus);
-}
+const ptt = new PttController({
+    getVoiceStatus: () => voiceStatus,
+    onState: setPttState,
+    onResult: (text) => {
+        if (isAutoSend()) sendText(text);
+        else showEditBar(text);
+    },
+    onError: (kind, message) => {
+        if (kind === 'unsupported') {
+            setStatus('No speech recognition in this browser — set stt.backend: cloud or custom for phone STT', true);
+            return;
+        }
+        setStatus(message, true);
+    },
+});
 
 function setPttState(state) {
     pttState = state;
@@ -422,97 +429,18 @@ function setPttState(state) {
     }
 }
 
-async function startRecording() {
+function startRecording() {
     if (pttState !== 'idle' || !selectedSession) return;
     hideEditBar();
-
-    if (usesBrowserStt()) {
-        if (!browserStt.isSupported()) {
-            setStatus('No speech recognition in this browser — set stt.backend: cloud or custom for phone STT', true);
-            return;
-        }
-        sttCancelled = false;
-        const ok = browserStt.start({
-            onFinal: (text) => {
-                setPttState('idle');
-                if (sttCancelled || !text) return;
-                if (isAutoSend()) sendText(text);
-                else showEditBar(text);
-            },
-            onError: (err) => {
-                setStatus(`Speech recognition failed: ${err}`, true);
-                setPttState('idle');
-            },
-        }, voiceStatus?.corrections || {});
-        if (ok) setPttState('recording');
-        return;
-    }
-
-    try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        audioChunks = [];
-        const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-            ? 'audio/webm;codecs=opus'
-            : (MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '');
-        mediaRecorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
-        mediaRecorder.ondataavailable = (e) => {
-            if (e.data.size > 0) audioChunks.push(e.data);
-        };
-        mediaRecorder.onstop = () => {
-            stream.getTracks().forEach(track => track.stop());
-            if (audioChunks.length > 0 && pttState === 'processing') {
-                transcribeUpload(new Blob(audioChunks, { type: mediaRecorder.mimeType || 'audio/webm' }));
-            }
-        };
-        mediaRecorder.start();
-        setPttState('recording');
-    } catch (err) {
-        console.error('[Mobile] Failed to start recording:', err);
-        setStatus('Microphone access denied', true);
-        setPttState('idle');
-    }
+    ptt.start();
 }
 
 function stopRecording() {
-    if (pttState !== 'recording') return;
-    setPttState('processing');
-    if (usesBrowserStt()) {
-        browserStt.stop(); // onFinal fires from onend
-        return;
-    }
-    mediaRecorder?.stop();
+    ptt.stop();
 }
 
 function cancelRecording() {
-    if (usesBrowserStt()) {
-        sttCancelled = true;
-        browserStt.stop();
-        setPttState('idle');
-        return;
-    }
-    audioChunks = [];
-    mediaRecorder?.stop();
-    setPttState('idle');
-}
-
-async function transcribeUpload(blob) {
-    try {
-        const formData = new FormData();
-        formData.append('audio', blob, 'recording.webm');
-        const res = await apiFetch('/transcribe', { method: 'POST', body: formData });
-        const data = await res.json();
-        if (data.error) throw new Error(data.error);
-        const text = data.text?.trim();
-        if (text) {
-            if (isAutoSend()) sendText(text);
-            else showEditBar(text);
-        } else setStatus('No speech detected', true);
-    } catch (err) {
-        console.error('[Mobile] Transcription failed:', err);
-        setStatus(err.message || 'Transcription failed', true);
-    } finally {
-        setPttState('idle');
-    }
+    ptt.cancel();
 }
 
 // ---------------------------------------------------------------------------

--- a/agentwire/static/js/ptt.js
+++ b/agentwire/static/js/ptt.js
@@ -1,0 +1,148 @@
+/**
+ * ptt.js — shared push-to-talk pipeline (#631).
+ *
+ * One implementation of the record → transcribe → deliver flow used by the
+ * desktop global PTT (desktop.js), the mobile PTT page (mobile.js), and the
+ * per-window PTT (session-window.js). Two tiers, mirroring browser-stt.js:
+ *
+ *   - browser tier: SpeechRecognition in the browser (Chrome) — no upload
+ *   - server tier (cloud/custom/default-with-Moonshine): MediaRecorder →
+ *     POST /transcribe
+ *
+ * The controller owns the state machine (idle → recording → processing →
+ * idle), the recorder, and the transcribe call. Surfaces own everything
+ * intentionally different per surface: trigger events (pointer capture vs
+ * mouse vs Ctrl+Space), what to do with the transcript (auto-send target,
+ * edit-before-send bar), and where errors are shown (status line, window
+ * status, console).
+ */
+
+import { apiFetch } from './api.js';
+import * as browserStt from './voice/browser-stt.js';
+
+export class PttController {
+    /**
+     * @param {Object} opts
+     * @param {Function} opts.getVoiceStatus - () => portal voice status (STT tier + corrections)
+     * @param {Function} opts.onState - (state) => render 'idle'|'recording'|'processing'
+     * @param {Function} opts.onResult - (text) => non-empty trimmed transcript
+     * @param {Function} opts.onError - (kind, message) => kind is one of
+     *   'unsupported' | 'stt' | 'mic' | 'empty' | 'transcribe'
+     */
+    constructor({ getVoiceStatus, onState, onResult, onError }) {
+        this.getVoiceStatus = getVoiceStatus;
+        this.onState = onState || (() => {});
+        this.onResult = onResult || (() => {});
+        this.onError = onError || (() => {});
+        this.state = 'idle'; // idle | recording | processing
+        this._mediaRecorder = null;
+        this._audioChunks = [];
+        this._sttCancelled = false;
+    }
+
+    usesBrowserStt() {
+        // Server-side tiers (cloud, custom, default-with-Moonshine) upload
+        // audio to /transcribe; otherwise recognition happens in the browser.
+        return !browserStt.serverTranscribes(this.getVoiceStatus());
+    }
+
+    _setState(state) {
+        this.state = state;
+        this.onState(state);
+    }
+
+    async start() {
+        if (this.state !== 'idle') return;
+
+        if (this.usesBrowserStt()) {
+            if (!browserStt.isSupported()) {
+                this.onError('unsupported', 'Browser voice input requires Chrome (or set stt.backend: cloud/custom)');
+                return;
+            }
+            this._sttCancelled = false;
+            const ok = browserStt.start({
+                onFinal: (text) => {
+                    this._setState('idle');
+                    if (this._sttCancelled || !text) return;
+                    this.onResult(text);
+                },
+                onError: (err) => {
+                    this._setState('idle');
+                    this.onError('stt', `Speech recognition failed: ${err}`);
+                },
+            }, this.getVoiceStatus()?.corrections || {});
+            if (ok) this._setState('recording');
+            return;
+        }
+
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            this._audioChunks = [];
+            const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+                ? 'audio/webm;codecs=opus'
+                : (MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '');
+            this._mediaRecorder = mimeType
+                ? new MediaRecorder(stream, { mimeType })
+                : new MediaRecorder(stream);
+            this._mediaRecorder.ondataavailable = (e) => {
+                if (e.data.size > 0) this._audioChunks.push(e.data);
+            };
+            this._mediaRecorder.onstop = () => {
+                // Release the microphone; only process if we weren't cancelled
+                stream.getTracks().forEach((t) => t.stop());
+                if (this._audioChunks.length > 0 && this.state === 'processing') {
+                    const blob = new Blob(this._audioChunks, {
+                        type: this._mediaRecorder.mimeType || 'audio/webm',
+                    });
+                    this._transcribe(blob);
+                }
+            };
+            this._mediaRecorder.start();
+            this._setState('recording');
+        } catch (err) {
+            console.error('[PTT] Failed to start recording:', err);
+            this._setState('idle');
+            this.onError('mic', 'Microphone access denied');
+        }
+    }
+
+    stop() {
+        if (this.state !== 'recording') return;
+        this._setState('processing');
+        if (this.usesBrowserStt()) {
+            browserStt.stop(); // onFinal fires from onend
+            return;
+        }
+        this._mediaRecorder?.stop();
+    }
+
+    cancel() {
+        if (this.state !== 'recording') return;
+        this._setState('idle');
+        if (this.usesBrowserStt()) {
+            this._sttCancelled = true;
+            browserStt.stop();
+            return;
+        }
+        this._audioChunks = [];
+        this._mediaRecorder?.stop(); // onstop skips processing (state is idle)
+    }
+
+    async _transcribe(blob) {
+        try {
+            const formData = new FormData();
+            formData.append('audio', blob, 'recording.webm');
+            const res = await apiFetch('/transcribe', { method: 'POST', body: formData });
+            const data = await res.json();
+            if (data.error) throw new Error(data.error);
+            const text = data.text?.trim();
+            if (text) this.onResult(text);
+            else this.onError('empty', 'No speech detected');
+        } catch (err) {
+            console.error('[PTT] Transcription failed:', err);
+            this.onError('transcribe', err.message || 'Transcription failed');
+        } finally {
+            this._setState('idle');
+        }
+    }
+}

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -13,7 +13,7 @@ import { sessionIcons } from './icon-manager.js';
 import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
 import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
 import { ansiToHtml } from './utils/ansi.js';
-import * as browserStt from './voice/browser-stt.js';
+import { PttController } from './ptt.js';
 import { voicePromptWrap } from './voice/prompt.js';
 import { isAutoSend } from './voice/autosend-prefs.js';
 
@@ -75,9 +75,16 @@ export class SessionWindow {
 
         // PTT (Push-to-talk) state
         this.pttButton = null;
-        this.mediaRecorder = null;
-        this.audioChunks = [];
-        this.pttState = 'idle'; // idle | recording | processing
+        this.pttState = 'idle'; // idle | recording | processing (mirrors this.ptt)
+        this.ptt = new PttController({
+            getVoiceStatus: () => desktop.voiceStatus,
+            onState: (state) => this._setPTTState(state),
+            onResult: (text) => {
+                if (isAutoSend()) this._sendVoiceText(text);
+                else this._showTranscriptBar(text);
+            },
+            onError: (kind, message) => this._updateStatus('error', message),
+        });
 
         // Activity indicator state
         this.activityIndicator = null;
@@ -199,7 +206,7 @@ export class SessionWindow {
         }
 
         // Cancel any active recording
-        if (this.mediaRecorder && this.pttState === 'recording') {
+        if (this.pttState === 'recording') {
             this._cancelRecording();
         }
 
@@ -1158,102 +1165,16 @@ export class SessionWindow {
         document.addEventListener('keyup', this._pttKeyHandler);
     }
 
-    _usesBrowserStt() {
-        // Server-side tiers (cloud, custom, default-with-Moonshine) upload audio
-        // to /transcribe; otherwise recognition happens in the browser.
-        return !browserStt.serverTranscribes(desktop.voiceStatus);
-    }
-
-    async _startRecording() {
-        if (this.pttState !== 'idle') return;
-
-        // Default tier: recognition happens in the browser (Chrome),
-        // transcript lands in an edit-before-send bar — no audio upload.
-        if (this._usesBrowserStt()) {
-            if (!browserStt.isSupported()) {
-                this._updateStatus('error', 'Browser voice input requires Chrome (or set stt.backend: cloud/custom)');
-                return;
-            }
-            this._sttCancelled = false;
-            const ok = browserStt.start({
-                onFinal: (text) => {
-                    this._setPTTState('idle');
-                    if (this._sttCancelled || !text) return;
-                    if (isAutoSend()) this._sendVoiceText(text);
-                    else this._showTranscriptBar(text);
-                },
-                onError: (err) => {
-                    this._updateStatus('error', `Speech recognition failed: ${err}`);
-                    this._setPTTState('idle');
-                },
-            }, desktop.voiceStatus?.corrections || {});
-            if (ok) this._setPTTState('recording');
-            return;
-        }
-
-        try {
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            this.audioChunks = [];
-
-            // Use webm/opus for efficient transfer
-            const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-                ? 'audio/webm;codecs=opus'
-                : 'audio/webm';
-
-            this.mediaRecorder = new MediaRecorder(stream, { mimeType });
-
-            this.mediaRecorder.ondataavailable = (e) => {
-                if (e.data.size > 0) {
-                    this.audioChunks.push(e.data);
-                }
-            };
-
-            this.mediaRecorder.onstop = () => {
-                // Stop all tracks to release microphone
-                stream.getTracks().forEach(track => track.stop());
-
-                if (this.audioChunks.length > 0 && this.pttState === 'processing') {
-                    const blob = new Blob(this.audioChunks, { type: mimeType });
-                    this._processRecording(blob);
-                }
-            };
-
-            this.mediaRecorder.start();
-            this._setPTTState('recording');
-
-        } catch (err) {
-            console.error('[SessionWindow] Failed to start recording:', err);
-            this._updateStatus('error', 'Microphone access denied');
-            this._setPTTState('idle');
-        }
+    _startRecording() {
+        this.ptt.start();
     }
 
     _stopRecording() {
-        if (this.pttState !== 'recording') return;
-
-        if (this._usesBrowserStt()) {
-            this._setPTTState('processing');
-            browserStt.stop();  // onFinal fires from onend
-            return;
-        }
-
-        if (!this.mediaRecorder) return;
-        this._setPTTState('processing');
-        this.mediaRecorder.stop();
+        this.ptt.stop();
     }
 
     _cancelRecording() {
-        if (this._usesBrowserStt()) {
-            this._sttCancelled = true;
-            browserStt.stop();
-            this._setPTTState('idle');
-            return;
-        }
-
-        if (!this.mediaRecorder) return;
-        this.audioChunks = [];
-        this.mediaRecorder.stop();
-        this._setPTTState('idle');
+        this.ptt.cancel();
     }
 
     /**
@@ -1317,41 +1238,6 @@ export class SessionWindow {
         } catch (err) {
             console.error('[SessionWindow] Voice send failed:', err);
             this._updateStatus('error', err.message || 'Voice input failed');
-        }
-    }
-
-    async _processRecording(blob) {
-        try {
-            // Step 1: Transcribe audio
-            const formData = new FormData();
-            formData.append('audio', blob, 'recording.webm');
-
-            const transcribeRes = await apiFetch('/transcribe', {
-                method: 'POST',
-                body: formData,
-            });
-
-            const transcribeData = await transcribeRes.json();
-
-            if (transcribeData.error) {
-                throw new Error(transcribeData.error);
-            }
-
-            const text = transcribeData.text?.trim();
-            if (!text) {
-                this._updateStatus('error', 'No speech detected');
-                this._setPTTState('idle');
-                return;
-            }
-
-            // Step 2: Send to session with voice prompt hint
-            await this._sendVoiceText(text);
-
-        } catch (err) {
-            console.error('[SessionWindow] PTT processing failed:', err);
-            this._updateStatus('error', err.message || 'Voice input failed');
-        } finally {
-            this._setPTTState('idle');
         }
     }
 


### PR DESCRIPTION
## What

The PTT flow (mic capture → POST `/transcribe` → deliver text) was implemented three separate times — `desktop.js` (global PTT), `mobile.js` (PTT page), `session-window.js` (per-window PTT) — each with its own MediaRecorder setup, chunk handling, transcribe call, and error handling, subtly different. This extracts ONE shared module, `agentwire/static/js/ptt.js` (`PttController` with `start()/stop()/cancel()` + `onState/onResult/onError` callbacks, covering both the browser-SpeechRecognition tier and the server `/transcribe` tier), and routes all three call sites through it. No template changes needed — the portal JS is ES modules, so `ptt.js` is a plain import. Net: −107 lines, one place to fix voice bugs.

## Kept per-surface (intentional, passed as callbacks / left at call sites)

- **Trigger events**: desktop uses mouse events + global Ctrl/Cmd+Space; mobile and session-window use pointer capture + `pointercancel`; session-window's window-focused Ctrl+Space.
- **Result handling**: desktop sends to the `agentwire` session / global transcript bar; mobile sends to the selected session / edit bar; session-window sends to its own session / in-window transcript bar.
- **Error UI**: desktop → console + 🚫 icon/title on unsupported; mobile → status line (keeps its phone-specific unsupported message); session-window → window status indicator.
- **Mobile-only gate**: `!selectedSession` check and `hideEditBar()` before starting stay in mobile's wrapper.

## Unified (drift, reconciled deliberately)

1. **mimeType selection** — desktop hardcoded `audio/webm;codecs=opus` (would throw on Safari); session-window fell back only to `audio/webm`; mobile had full `isTypeSupported` feature-detection. Unified to mobile's version (opus → webm → recorder default).
2. **Blob type** — desktop hardcoded `audio/webm`; unified to the recorder's actual `mimeType` (session-window/mobile behavior).
3. **Cancel-discard guard** — desktop's `onstop` processed chunks regardless of state; unified to the `state === 'processing'` guard (mobile/session-window), which also makes cancel semantics correct everywhere.
4. **`/transcribe` error handling** — desktop ignored `data.error` in the response and silently dropped empty transcripts; unified to check `data.error` and emit `onError('empty', 'No speech detected')` / `onError('transcribe', …)`. Desktop surfaces these as console warnings (it had no status UI), mobile/session-window as before.
5. **Auto-send preference on the server tier** — desktop and session-window always auto-sent server-tier transcripts, while mobile (and every browser-tier path) respected the `isAutoSend()` edit-before-send preference. Unified: the pref now governs both tiers on all three surfaces. Judged drift because the edit bars already exist on desktop and session-window (built for the browser tier) and mobile already did the unified thing.
6. **Mic-denied handling** — desktop only console-logged and left no state reset on failure; unified to reset to idle + `onError('mic', 'Microphone access denied')`.
7. **session-window destroy-while-recording** — the cleanup guard was `this.mediaRecorder && recording`, which never cancelled a browser-tier (SpeechRecognition) recording; now `pttState === 'recording'` → `ptt.cancel()` covers both tiers.

## Verification

- No JS test suite / lint config exists; `node --check` passes on all four files.
- Full pytest suite (unit + integration): **2238 passed, 8 skipped** (`uv run --extra dev pytest`).
- Manual traces against the originals, per surface × tier:
  - **desktop / browser tier**: Ctrl+Space or mousedown → `browserStt.start` with corrections → recording; keyup/mouseup → processing → `onFinal` → idle → autosend or global transcript bar; unsupported → 🚫 icon + title, no state change. Identical (error path now also warns).
  - **desktop / server tier**: mousedown → getUserMedia → record; mouseup → stop → onstop releases tracks → upload → send/edit-bar → idle. Differences are items 1–6 above, all deliberate.
  - **mobile / both tiers**: pointerdown (session selected, edit bar hidden) → record; pointerup → stop → transcribe → autosend/edit bar; pointercancel → cancel discards chunks (browser tier: cancelled flag suppresses `onFinal`). Behavior-identical to the original, including all status-line messages.
  - **session-window / both tiers**: pointer + focused-Ctrl+Space triggers unchanged; state renders via `_setPTTState`; errors via `_updateStatus('error', …)`; result → `_sendVoiceText` or transcript bar (item 5 changes server tier to respect autosend); destroy cancels active recording (item 7).

Closes #631

Built by [dotdev.dev](https://dotdev.dev)