### PR TITLE
fix(init): guard re-init — prompt/backup config.yaml, never reset machines.json

### DIFF
--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -6,6 +6,7 @@ Asks 3 questions, writes minimal config, then spawns Claude for interactive setu
 import shutil
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".agentwire"
@@ -149,11 +150,60 @@ def get_install_instructions(platform: str) -> dict[str, str]:
 
 
 # ─────────────────────────────────────────────────────────────
+# Re-init Safety
+# ─────────────────────────────────────────────────────────────
+
+
+def confirm_reinit(config_path: Path, force: bool = False) -> bool:
+    """Decide whether the wizard may proceed when a config already exists.
+
+    Returns True if it's safe to run (no existing config, --force, or the
+    user confirmed interactively). Non-interactive runs with an existing
+    config never proceed without --force.
+    """
+    if force or not config_path.exists():
+        return True
+
+    if not sys.stdin.isatty():
+        print_warning(f"Existing config found at {config_path}")
+        print_info("Refusing to overwrite in a non-interactive run.")
+        print_info("Re-run with --force to reconfigure (a timestamped .bak is written first).")
+        return False
+
+    print_warning(f"Existing config found at {config_path}")
+    print_info("Continuing will overwrite it (a timestamped .bak is written first).")
+    print()
+    answer = input("Overwrite existing config? [y/N]: ").strip().lower()
+    return answer in ("y", "yes")
+
+
+def backup_config(config_path: Path) -> Path | None:
+    """Copy an existing config to a timestamped .bak next to it."""
+    if not config_path.exists():
+        return None
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_path = config_path.with_name(f"{config_path.name}.{stamp}.bak")
+    shutil.copy2(config_path, backup_path)
+    return backup_path
+
+
+def ensure_machines_file(machines_path: Path) -> bool:
+    """Create an empty machines.json only if one doesn't exist.
+
+    Never resets an existing registry. Returns True if the file was created.
+    """
+    if machines_path.exists():
+        return False
+    machines_path.write_text('{"machines": []}\n')
+    return True
+
+
+# ─────────────────────────────────────────────────────────────
 # Main Onboarding
 # ─────────────────────────────────────────────────────────────
 
 
-def run_onboarding(skip_session: bool = True) -> int:
+def run_onboarding(skip_session: bool = True, force: bool = False) -> int:
     """Run the minimal onboarding wizard.
 
     Asks 3 questions:
@@ -168,7 +218,13 @@ def run_onboarding(skip_session: bool = True) -> int:
         skip_session: If True (the default), end the wizard on the portal-URL
             next-steps block. If False (--assisted), spawn the interactive
             Claude setup session at the end.
+        force: If True, skip the existing-config confirmation (a timestamped
+            .bak is still written before overwriting).
     """
+    if not confirm_reinit(CONFIG_DIR / "config.yaml", force=force):
+        print_info("Setup cancelled — existing config left untouched.")
+        return 0
+
     print()
     print(f"{BOLD}Welcome to AgentWire Setup!{RESET}")
     print()
@@ -338,13 +394,18 @@ services:
 """
 
     config_path = CONFIG_DIR / "config.yaml"
+    backup_path = backup_config(config_path)
+    if backup_path:
+        print_success(f"Backed up existing config to {backup_path}")
     config_path.write_text(config_content)
     print_success(f"Created {config_path}")
 
-    # Empty machines.json
+    # Empty machines.json — never reset an existing registry
     machines_path = CONFIG_DIR / "machines.json"
-    machines_path.write_text('{"machines": []}\n')
-    print_success(f"Created {machines_path}")
+    if ensure_machines_file(machines_path):
+        print_success(f"Created {machines_path}")
+    else:
+        print_info(f"Kept existing {machines_path}")
 
     if is_multi_machine:
         # Portal auth token — required because the config binds 0.0.0.0

--- a/agentwire/system_cli.py
+++ b/agentwire/system_cli.py
@@ -419,7 +419,7 @@ def cmd_init(args) -> int:
 
     # Default ends on the portal-URL next steps; --assisted opts into the
     # interactive Claude setup session.
-    return run_onboarding(skip_session=not args.assisted)
+    return run_onboarding(skip_session=not args.assisted, force=args.force)
 
 
 def cmd_generate_certs(args) -> int:
@@ -576,6 +576,11 @@ def register_system_parser(subparsers) -> None:
         "--assisted", action="store_true",
         help="Spawn the interactive Claude setup session at the end "
              "(default: end on the portal-URL next steps)"
+    )
+    init_parser.add_argument(
+        "--force", action="store_true",
+        help="Reconfigure without prompting when a config already exists "
+             "(a timestamped config.yaml backup is written first)"
     )
     init_parser.set_defaults(func=cmd_init)
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -11,14 +11,15 @@ def _run(assisted: bool) -> dict:
     the skip_session value passed to run_onboarding."""
     captured = {}
 
-    def fake_onboarding(skip_session: bool = True) -> int:
+    def fake_onboarding(skip_session: bool = True, force: bool = False) -> int:
         captured["skip_session"] = skip_session
+        captured["force"] = force
         return 0
 
     with patch("agentwire.system_cli.check_python_version", return_value=True), \
          patch("agentwire.system_cli.check_pip_environment", return_value=True), \
          patch("agentwire.onboarding.run_onboarding", side_effect=fake_onboarding):
-        rc = cmd_init(Namespace(assisted=assisted))
+        rc = cmd_init(Namespace(assisted=assisted, force=False))
 
     captured["rc"] = rc
     return captured

--- a/tests/unit/test_onboarding_reinit.py
+++ b/tests/unit/test_onboarding_reinit.py
@@ -1,0 +1,91 @@
+"""Re-init safety for `agentwire init` (#636).
+
+Covers the existing-config guard (TTY prompt / non-TTY no-op / --force),
+the timestamped config backup, and the never-reset machines.json rule.
+"""
+
+import pytest
+
+from agentwire.onboarding import backup_config, confirm_reinit, ensure_machines_file
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("projects:\n  dir: ~/projects\n")
+    return path
+
+
+# ── confirm_reinit ──────────────────────────────────────────────
+
+
+def test_no_existing_config_proceeds(tmp_path):
+    assert confirm_reinit(tmp_path / "config.yaml") is True
+
+
+def test_force_bypasses_prompt(config_path, monkeypatch):
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: pytest.fail("must not prompt with --force")
+    )
+    assert confirm_reinit(config_path, force=True) is True
+
+
+def test_existing_config_non_tty_refuses(config_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: pytest.fail("must not prompt without a TTY")
+    )
+    assert confirm_reinit(config_path) is False
+    out = capsys.readouterr().out
+    assert "Existing config" in out
+    assert "--force" in out
+
+
+@pytest.mark.parametrize("answer,expected", [
+    ("y", True),
+    ("yes", True),
+    ("Y", True),
+    ("", False),
+    ("n", False),
+    ("no", False),
+])
+def test_existing_config_tty_prompts(config_path, monkeypatch, answer, expected):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a: answer)
+    assert confirm_reinit(config_path) is expected
+
+
+# ── backup_config ───────────────────────────────────────────────
+
+
+def test_backup_creates_timestamped_bak(config_path):
+    backup = backup_config(config_path)
+    assert backup is not None
+    assert backup.parent == config_path.parent
+    assert backup.name.startswith("config.yaml.")
+    assert backup.name.endswith(".bak")
+    assert backup.read_text() == config_path.read_text()
+    # Original stays in place for the subsequent overwrite
+    assert config_path.exists()
+
+
+def test_backup_noop_when_missing(tmp_path):
+    assert backup_config(tmp_path / "config.yaml") is None
+    assert list(tmp_path.iterdir()) == []
+
+
+# ── ensure_machines_file ────────────────────────────────────────
+
+
+def test_machines_created_when_missing(tmp_path):
+    path = tmp_path / "machines.json"
+    assert ensure_machines_file(path) is True
+    assert path.read_text() == '{"machines": []}\n'
+
+
+def test_machines_never_reset(tmp_path):
+    path = tmp_path / "machines.json"
+    existing = '{"machines": [{"name": "dotdev-pc"}]}\n'
+    path.write_text(existing)
+    assert ensure_machines_file(path) is False
+    assert path.read_text() == existing


### PR DESCRIPTION
Re-running `agentwire init` no longer silently destroys user state.

## Changes
- **Existing-config guard** (`confirm_reinit`): if `~/.agentwire/config.yaml` exists, a TTY run prompts `Overwrite existing config? [y/N]` (default no); a non-interactive run no-ops with a clear message pointing at `--force`.
- **`agentwire init --force`**: skips the prompt for deliberate reconfiguration.
- **Timestamped backup** (`backup_config`): any overwrite (prompted or forced) first copies the config to `config.yaml.<YYYYMMDD-HHMMSS>.bak` next to the original.
- **`machines.json` is never reset** (`ensure_machines_file`): created only when missing; an existing registry is left untouched and reported as kept.

## Verification
- New `tests/unit/test_onboarding_reinit.py` (13 tests): existing config + TTY (y/yes/Y/n/no/empty), existing config + non-TTY refusal, `--force` bypass, backup creation/no-op, machines.json create-only-if-missing.
- Updated `tests/unit/test_init_command.py` for the new `force` kwarg.
- Full suite: **2251 passed, 8 skipped**.

Closes #636

Built by [dotdev.dev](https://dotdev.dev)