### PR TITLE
fix(portal): move blocking subprocess calls off the asyncio event loop

### DIFF
--- a/agentwire/routes/permission.py
+++ b/agentwire/routes/permission.py
@@ -15,7 +15,6 @@ imported lazily inside the handlers to avoid a circular import.
 
 import asyncio
 import logging
-import subprocess
 from pathlib import Path
 
 from aiohttp import web
@@ -127,7 +126,7 @@ class PermissionRoutesMixin:
 
             # Ensure session exists
             if name not in self.active_sessions:
-                self.active_sessions[name] = Session(name=name, config=self._get_session_config(name))
+                self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
 
             session = self.active_sessions[name]
 
@@ -146,29 +145,25 @@ class PermissionRoutesMixin:
                     # Only send keystroke for Bash commands (say)
                     # AskUserQuestion doesn't need permission keystroke
                     if tool_name == "Bash":
-                        try:
-                            # Use CLI for consistent behavior (handles local and remote)
-                            # Send "1" to select "Yes" option in permission prompt
-                            session_target = f"{tmux_session}@{machine}" if machine else tmux_session
-                            subprocess.run(
-                                ["agentwire", "send-keys", "-s", session_target, "1"],
-                                check=True, capture_output=True
-                            )
-                        except Exception as e:
-                            logger.error(f"[{name}] Failed to send allow keystroke: {e}")
+                        # Use CLI for consistent behavior (handles local and remote)
+                        # Send "1" to select "Yes" option in permission prompt
+                        session_target = f"{tmux_session}@{machine}" if machine else tmux_session
+                        result = await self._run_subprocess(
+                            ["agentwire", "send-keys", "-s", session_target, "1"]
+                        )
+                        if result is None or result[0] != 0:
+                            logger.error(f"[{name}] Failed to send allow keystroke")
                     return web.json_response({"decision": "allow_always"})
                 else:
                     # Auto-deny: send "Escape" keystroke (deny silently)
                     logger.info(f"[{name}] Restricted mode: auto-denying {tool_name}")
-                    try:
-                        # Use CLI for consistent behavior (handles local and remote)
-                        session_target = f"{tmux_session}@{machine}" if machine else tmux_session
-                        subprocess.run(
-                            ["agentwire", "send-keys", "-s", session_target, "Escape"],
-                            check=True, capture_output=True
-                        )
-                    except Exception as e:
-                        logger.error(f"[{name}] Failed to send deny keystroke: {e}")
+                    # Use CLI for consistent behavior (handles local and remote)
+                    session_target = f"{tmux_session}@{machine}" if machine else tmux_session
+                    result = await self._run_subprocess(
+                        ["agentwire", "send-keys", "-s", session_target, "Escape"]
+                    )
+                    if result is None or result[0] != 0:
+                        logger.error(f"[{name}] Failed to send deny keystroke")
                     return web.json_response({
                         "decision": "deny",
                         "message": "Restricted mode: only say commands are allowed"
@@ -276,8 +271,6 @@ class PermissionRoutesMixin:
             # input box, and a late Escape would abort the child's next turn.
             # Re-capture and only send if a live menu is still on screen.
             try:
-                import subprocess
-
                 dialog_live = await asyncio.get_event_loop().run_in_executor(
                     None,
                     lambda: prompt_router.screen_shows_live_menu(
@@ -293,11 +286,12 @@ class PermissionRoutesMixin:
                     custom_message = data.get("message", "")
                     if custom_message:
                         # send-keys handles pauses between key groups
-                        subprocess.run(
+                        result = await self._run_subprocess(
                             ["agentwire", "send-keys", "-s", tmux_name,
-                             "--pane", str(pane_index), "3", custom_message, "Enter"],
-                            check=True, capture_output=True
+                             "--pane", str(pane_index), "3", custom_message, "Enter"]
                         )
+                        if result is None or result[0] != 0:
+                            raise RuntimeError("send-keys failed")
                         logger.info(f"[{name}] Sent custom feedback: {custom_message[:50]}...")
                 else:
                     # Map decision to keystroke: allow=1, allow_always=2, deny=Escape
@@ -307,11 +301,12 @@ class PermissionRoutesMixin:
                         "deny": "Escape",
                     }
                     keystroke = keystroke_map.get(decision, "Escape")
-                    subprocess.run(
+                    result = await self._run_subprocess(
                         ["agentwire", "send-keys", "-s", tmux_name,
-                         "--pane", str(pane_index), keystroke],
-                        check=True, capture_output=True
+                         "--pane", str(pane_index), keystroke]
                     )
+                    if result is None or result[0] != 0:
+                        raise RuntimeError("send-keys failed")
                     logger.info(f"[{name}] Sent keystroke '{keystroke}' to {tmux_name}.{pane_index}")
             except Exception as e:
                 logger.error(f"[{name}] Failed to send keystroke: {e}")

--- a/agentwire/routes/permission.py
+++ b/agentwire/routes/permission.py
@@ -8,7 +8,7 @@ Part of the #560 server.py split. Handlers moved verbatim from
 server class.
 
 Review and permission are grouped because the Review window's ``_live_prompt``
-helper is unique to ``api_review``. ``Session`` / ``PendingPermission`` /
+helper is unique to ``api_review``. ``PendingPermission`` /
 ``_is_allowed_in_restricted_mode`` live on the base server module and are
 imported lazily inside the handlers to avoid a circular import.
 """
@@ -113,7 +113,7 @@ class PermissionRoutesMixin:
         In restricted mode, only say commands are auto-allowed,
         everything else is auto-denied silently.
         """
-        from ..server import PendingPermission, Session, _is_allowed_in_restricted_mode
+        from ..server import PendingPermission, _is_allowed_in_restricted_mode
 
         name = request.match_info["name"]
         try:
@@ -125,10 +125,7 @@ class PermissionRoutesMixin:
             logger.info(f"[{name}] Permission request: {tool_name}")
 
             # Ensure session exists
-            if name not in self.active_sessions:
-                self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
-
-            session = self.active_sessions[name]
+            session = await self._get_or_create_session(name)
 
             # Check restricted mode - auto-handle without user interaction
             if session.config.type == "claude-restricted":

--- a/agentwire/routes/sessions_admin.py
+++ b/agentwire/routes/sessions_admin.py
@@ -186,9 +186,9 @@ class SessionsAdminRoutesMixin:
                     _, machine_id = session_name.rsplit("@", 1)
 
                 # Read and update .agentwire.yml
-                yaml_config = self._read_agentwire_yaml(session_path, machine_id) or {}
+                yaml_config = await self._read_agentwire_yaml(session_path, machine_id) or {}
                 yaml_config["voice"] = voice
-                self._write_agentwire_yaml(session_path, yaml_config, machine_id)
+                await self._write_agentwire_yaml(session_path, yaml_config, machine_id)
 
             # Broadcast session created to dashboard clients
             await self.broadcast_dashboard("session_created", {"session": session_name})
@@ -273,18 +273,18 @@ class SessionsAdminRoutesMixin:
                 base_name, machine_id = name.rsplit("@", 1)
 
             # Get session's working directory
-            cwd = self._get_session_cwd(base_name, machine_id)
+            cwd = await self._get_session_cwd(base_name, machine_id)
             if not cwd:
                 return web.json_response({"error": "Session working directory not found"}, status=404)
 
             # Read existing .agentwire.yml (or create new)
-            yaml_config = self._read_agentwire_yaml(cwd, machine_id) or {}
+            yaml_config = await self._read_agentwire_yaml(cwd, machine_id) or {}
 
             # Update voice
             yaml_config["voice"] = voice
 
             # Write back
-            if not self._write_agentwire_yaml(cwd, yaml_config, machine_id):
+            if not await self._write_agentwire_yaml(cwd, yaml_config, machine_id):
                 return web.json_response({"error": "Failed to write .agentwire.yml"}, status=500)
 
             # Update live session if exists
@@ -322,7 +322,7 @@ class SessionsAdminRoutesMixin:
             logger.info(f"[{name}] Recreating session...")
 
             # Get old config for inheriting settings (before CLI deletes it)
-            old_config = self._get_session_config(name)
+            old_config = await self._get_session_config(name)
 
             # Build CLI args
             args = ["recreate", "-s", name]
@@ -351,9 +351,9 @@ class SessionsAdminRoutesMixin:
                 machine_id = None
                 if "@" in new_session_name:
                     _, machine_id = new_session_name.rsplit("@", 1)
-                yaml_config = self._read_agentwire_yaml(session_path, machine_id) or {}
+                yaml_config = await self._read_agentwire_yaml(session_path, machine_id) or {}
                 yaml_config["voice"] = old_config.voice
-                self._write_agentwire_yaml(session_path, yaml_config, machine_id)
+                await self._write_agentwire_yaml(session_path, yaml_config, machine_id)
 
             logger.info(f"[{name}] Session recreated as '{new_session_name}'")
             return web.json_response({"success": True, "session": new_session_name})
@@ -379,7 +379,7 @@ class SessionsAdminRoutesMixin:
             project, _, machine = parse_session_name(name)
 
             # Get old config for inheriting settings
-            old_config = self._get_session_config(name)
+            old_config = await self._get_session_config(name)
 
             # Build new session name: project/session-<timestamp>[@machine]
             new_branch = f"session-{int(time.time())}"
@@ -405,9 +405,9 @@ class SessionsAdminRoutesMixin:
             # CLI writes .agentwire.yml with type; update voice if the old session had one
             if session_path and old_config.voice != self.config.tts.default_voice:
                 machine_id = machine
-                yaml_config = self._read_agentwire_yaml(session_path, machine_id) or {}
+                yaml_config = await self._read_agentwire_yaml(session_path, machine_id) or {}
                 yaml_config["voice"] = old_config.voice
-                self._write_agentwire_yaml(session_path, yaml_config, machine_id)
+                await self._write_agentwire_yaml(session_path, yaml_config, machine_id)
 
             logger.info(f"[{name}] Sibling session created: '{session_name}'")
             return web.json_response({"success": True, "session": session_name})
@@ -427,7 +427,7 @@ class SessionsAdminRoutesMixin:
         name = request.match_info["name"]
         try:
             # Get current session config for inheriting settings
-            session_config = self._get_session_config(name)
+            session_config = await self._get_session_config(name)
 
             logger.info(f"[{name}] Forking session...")
 
@@ -469,9 +469,9 @@ class SessionsAdminRoutesMixin:
             # CLI writes .agentwire.yml with type; update voice if the old session had one
             if session_path and session_config.voice != self.config.tts.default_voice:
                 machine_id = machine
-                yaml_config = self._read_agentwire_yaml(session_path, machine_id) or {}
+                yaml_config = await self._read_agentwire_yaml(session_path, machine_id) or {}
                 yaml_config["voice"] = session_config.voice
-                self._write_agentwire_yaml(session_path, yaml_config, machine_id)
+                await self._write_agentwire_yaml(session_path, yaml_config, machine_id)
 
             logger.info(f"[{name}] Session forked as '{session_name}'")
             return web.json_response({"success": True, "session": session_name})
@@ -499,7 +499,7 @@ class SessionsAdminRoutesMixin:
         # Find or create a session object to broadcast through
         session = self.active_sessions.get(name)
         if not session:
-            session = Session(name=name, config=self._get_session_config(name))
+            session = Session(name=name, config=await self._get_session_config(name))
             self.active_sessions[name] = session
 
         await self._broadcast(session, data)
@@ -535,20 +535,17 @@ class SessionsAdminRoutesMixin:
                     await asyncio.sleep(1)
                     logger.info("Portal restarting...")
                     # Kill the tmux session (which kills us)
-                    subprocess.run(
-                        ["tmux", "kill-session", "-t", portal_session],
-                        capture_output=True
+                    await self._run_subprocess(
+                        ["tmux", "kill-session", "-t", portal_session]
                     )
                     await asyncio.sleep(0.5)
                     # Create new tmux session with portal serve command
-                    subprocess.run(
-                        ["tmux", "new-session", "-d", "-s", portal_session],
-                        capture_output=True
+                    await self._run_subprocess(
+                        ["tmux", "new-session", "-d", "-s", portal_session]
                     )
-                    subprocess.run(
+                    await self._run_subprocess(
                         ["tmux", "send-keys", "-t", portal_session,
-                         "agentwire portal serve", "Enter"],
-                        capture_output=True
+                         "agentwire portal serve", "Enter"]
                     )
 
                 asyncio.create_task(delayed_restart())
@@ -559,10 +556,7 @@ class SessionsAdminRoutesMixin:
 
             elif base_name == tts_session:
                 # Restart TTS server
-                subprocess.run(
-                    ["agentwire", "tts", "stop"],
-                    capture_output=True, text=True
-                )
+                await self._run_subprocess(["agentwire", "tts", "stop"])
                 await asyncio.sleep(0.5)
                 subprocess.Popen(
                     ["agentwire", "tts", "start"],

--- a/agentwire/routes/sessions_admin.py
+++ b/agentwire/routes/sessions_admin.py
@@ -488,8 +488,6 @@ class SessionsAdminRoutesMixin:
         Request body: JSON with at least a "type" field.
         Common types: "alert" (text), "question" (question, options), "audio" (audio base64).
         """
-        from ..server import Session
-
         name = request.match_info["name"]
         try:
             data = await request.json()
@@ -497,10 +495,7 @@ class SessionsAdminRoutesMixin:
             return web.json_response({"error": "Invalid JSON"}, status=400)
 
         # Find or create a session object to broadcast through
-        session = self.active_sessions.get(name)
-        if not session:
-            session = Session(name=name, config=await self._get_session_config(name))
-            self.active_sessions[name] = session
+        session = await self._get_or_create_session(name)
 
         await self._broadcast(session, data)
         return web.json_response({"success": True})

--- a/agentwire/routes/voice.py
+++ b/agentwire/routes/voice.py
@@ -254,7 +254,7 @@ class VoiceRoutesMixin:
             if name not in self.active_sessions:
                 from ..server import Session
 
-                self.active_sessions[name] = Session(name=name, config=self._get_session_config(name))
+                self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
 
             session = self.active_sessions[name]
 
@@ -299,7 +299,7 @@ class VoiceRoutesMixin:
                 clean = strip_speech_tags(text)
                 if await self._kokoro_shim_ready():
                     try:
-                        session_config = self._get_session_config(name)
+                        session_config = await self._get_session_config(name)
                         wav = await self._tts_generate(
                             clean, voice or session_config.voice
                         )
@@ -318,7 +318,7 @@ class VoiceRoutesMixin:
                 )
 
             # Get session config for defaults
-            session_config = self._get_session_config(name)
+            session_config = await self._get_session_config(name)
             if voice is None:
                 voice = session_config.voice
             exaggeration = session_config.exaggeration

--- a/agentwire/routes/voice.py
+++ b/agentwire/routes/voice.py
@@ -251,12 +251,7 @@ class VoiceRoutesMixin:
                 return web.json_response({"error": "No text provided"}, status=400)
 
             # Ensure session exists (create if not)
-            if name not in self.active_sessions:
-                from ..server import Session
-
-                self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
-
-            session = self.active_sessions[name]
+            session = await self._get_or_create_session(name)
 
             # Track this text to avoid duplicate TTS from output polling
             session.played_says.add(text)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -659,6 +659,24 @@ class AgentWireServer(
             voice=yaml_config.get("voice", self.config.tts.default_voice),
         )
 
+    async def _get_or_create_session(self, name: str) -> "Session":
+        """Get-or-create an active_sessions entry without a TOCTOU race.
+
+        The config fetch awaits (possibly a 5s SSH probe), so a naive
+        check-then-assign around it lets a concurrent handler register the
+        same session first — clobbering its clients and pending_permission.
+        Re-check after the await and keep whichever Session landed first.
+        """
+        session = self.active_sessions.get(name)
+        if session is not None:
+            return session
+        config = await self._get_session_config(name)
+        session = self.active_sessions.get(name)
+        if session is None:
+            session = Session(name=name, config=config)
+            self.active_sessions[name] = session
+        return session
+
     async def _get_session_cwd(self, session_name: str, machine_id: str | None = None) -> str | None:
         """Get working directory of a tmux session.
 
@@ -1731,10 +1749,7 @@ class AgentWireServer(
         await ws.prepare(request)
 
         # Get or create session
-        if name not in self.active_sessions:
-            self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
-
-        session = self.active_sessions[name]
+        session = await self._get_or_create_session(name)
         client_id = str(id(ws))
         session.clients.add(ws)
         logger.info(f"[{name}] Client connected (total: {len(session.clients)})")
@@ -1795,9 +1810,7 @@ class AgentWireServer(
         ws_to_tmux_task = None
 
         # Track this connection for TTS routing (so audio goes to browser, not local speakers)
-        if session_name not in self.active_sessions:
-            self.active_sessions[session_name] = Session(name=session_name, config=await self._get_session_config(session_name))
-        session = self.active_sessions[session_name]
+        session = await self._get_or_create_session(session_name)
         session.clients.add(ws)
         logger.info(f"[Terminal] Client connected to {session_name} (total: {len(session.clients)})")
 
@@ -2608,12 +2621,7 @@ class AgentWireServer(
             True if audio was sent to clients, False if no clients connected.
         """
         # Get or create session
-        if session_name not in self.active_sessions:
-            self.active_sessions[session_name] = Session(
-                name=session_name, config=await self._get_session_config(session_name)
-            )
-
-        session = self.active_sessions[session_name]
+        session = await self._get_or_create_session(session_name)
 
         # Notifications session: fan out to whichever session(s) the user
         # currently has open, since this session itself rarely has listeners.

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -20,7 +20,6 @@ import signal
 import socket
 import ssl
 import struct
-import subprocess
 import tempfile
 import termios
 import time
@@ -603,7 +602,32 @@ class AgentWireServer(
         if cleaned > 0:
             logger.info(f"Cleaned up {cleaned} old upload(s)")
 
-    def _get_session_config(self, name: str) -> SessionConfig:
+    async def _run_subprocess(
+        self, argv: list[str], timeout: float | None = None
+    ) -> tuple[int, str, str] | None:
+        """Run a subprocess without blocking the event loop.
+
+        Returns (returncode, stdout, stderr), or None on timeout/spawn failure.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            return proc.returncode, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:
+                pass
+            return None
+        except Exception:
+            return None
+
+    async def _get_session_config(self, name: str) -> SessionConfig:
         """Get session config dynamically from .agentwire.yml in session's working directory.
 
         Uses cached config from active_sessions if available, otherwise looks up
@@ -620,12 +644,12 @@ class AgentWireServer(
             base_name, machine_id = name.rsplit("@", 1)
 
         # Get working directory from tmux
-        cwd = self._get_session_cwd(base_name, machine_id)
+        cwd = await self._get_session_cwd(base_name, machine_id)
         if not cwd:
             return SessionConfig(voice=self.config.tts.default_voice)
 
         # Read .agentwire.yml from that path
-        yaml_config = self._read_agentwire_yaml(cwd, machine_id)
+        yaml_config = await self._read_agentwire_yaml(cwd, machine_id)
         if not yaml_config:
             return SessionConfig(voice=self.config.tts.default_voice)
 
@@ -635,7 +659,7 @@ class AgentWireServer(
             voice=yaml_config.get("voice", self.config.tts.default_voice),
         )
 
-    def _get_session_cwd(self, session_name: str, machine_id: str | None = None) -> str | None:
+    async def _get_session_cwd(self, session_name: str, machine_id: str | None = None) -> str | None:
         """Get working directory of a tmux session.
 
         Args:
@@ -652,13 +676,11 @@ class AgentWireServer(
 
         if is_local:
             # Local tmux lookup
-            result = subprocess.run(
+            result = await self._run_subprocess(
                 ["tmux", "display-message", "-t", session_name, "-p", "#{pane_current_path}"],
-                capture_output=True,
-                text=True,
             )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
+            if result and result[0] == 0 and result[1].strip():
+                return result[1].strip()
             return None
         else:
             # Remote tmux lookup via SSH
@@ -670,18 +692,13 @@ class AgentWireServer(
             user = machine.get("user", "")
             ssh_target = f"{user}@{host}" if user else host
 
-            try:
-                cmd = f"tmux display-message -t {shlex.quote(session_name)} -p '#{{pane_current_path}}'"
-                result = subprocess.run(
-                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                if result.returncode == 0 and result.stdout.strip():
-                    return result.stdout.strip()
-            except (subprocess.TimeoutExpired, Exception):
-                pass
+            cmd = f"tmux display-message -t {shlex.quote(session_name)} -p '#{{pane_current_path}}'"
+            result = await self._run_subprocess(
+                ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
+                timeout=5,
+            )
+            if result and result[0] == 0 and result[1].strip():
+                return result[1].strip()
             return None
 
     def _get_machine_config(self, machine_id: str) -> dict | None:
@@ -692,7 +709,7 @@ class AgentWireServer(
                     return m
         return None
 
-    def _read_agentwire_yaml(self, cwd: str, machine_id: str | None = None) -> dict | None:
+    async def _read_agentwire_yaml(self, cwd: str, machine_id: str | None = None) -> dict | None:
         """Read .agentwire.yml from a directory.
 
         Args:
@@ -726,21 +743,19 @@ class AgentWireServer(
             user = machine.get("user", "")
             ssh_target = f"{user}@{host}" if user else host
 
-            try:
-                yaml_path = f"{cwd}/.agentwire.yml"
-                result = subprocess.run(
-                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, f"cat {shlex.quote(yaml_path)}"],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                if result.returncode == 0 and result.stdout.strip():
-                    return yaml.safe_load(result.stdout) or {}
-            except (subprocess.TimeoutExpired, Exception):
-                pass
+            yaml_path = f"{cwd}/.agentwire.yml"
+            result = await self._run_subprocess(
+                ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, f"cat {shlex.quote(yaml_path)}"],
+                timeout=5,
+            )
+            if result and result[0] == 0 and result[1].strip():
+                try:
+                    return yaml.safe_load(result[1]) or {}
+                except Exception:
+                    pass
             return None
 
-    def _write_agentwire_yaml(self, cwd: str, data: dict, machine_id: str | None = None) -> bool:
+    async def _write_agentwire_yaml(self, cwd: str, data: dict, machine_id: str | None = None) -> bool:
         """Write .agentwire.yml to a directory.
 
         Args:
@@ -777,22 +792,19 @@ class AgentWireServer(
             user = machine.get("user", "")
             ssh_target = f"{user}@{host}" if user else host
 
-            try:
-                yaml_content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
-                yaml_path = f"{cwd}/.agentwire.yml"
-                # Use base64 encoding for safe content transmission (avoids heredoc injection)
-                encoded = base64.b64encode(yaml_content.encode()).decode()
-                cmd = f"echo {shlex.quote(encoded)} | base64 -d > {shlex.quote(yaml_path)}"
-                result = subprocess.run(
-                    ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                return result.returncode == 0
-            except (subprocess.TimeoutExpired, Exception) as e:
-                logger.warning(f"Failed to write remote yaml: {e}")
+            yaml_content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+            yaml_path = f"{cwd}/.agentwire.yml"
+            # Use base64 encoding for safe content transmission (avoids heredoc injection)
+            encoded = base64.b64encode(yaml_content.encode()).decode()
+            cmd = f"echo {shlex.quote(encoded)} | base64 -d > {shlex.quote(yaml_path)}"
+            result = await self._run_subprocess(
+                ["ssh", *ssh_base_opts(), "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", ssh_target, cmd],
+                timeout=5,
+            )
+            if result is None:
+                logger.warning("Failed to write remote yaml: ssh timed out or failed to spawn")
                 return False
+            return result[0] == 0
 
     async def _get_voices(self) -> list[str]:
         """Available TTS voices: Kokoro presets on the default tier (once
@@ -1720,7 +1732,7 @@ class AgentWireServer(
 
         # Get or create session
         if name not in self.active_sessions:
-            self.active_sessions[name] = Session(name=name, config=self._get_session_config(name))
+            self.active_sessions[name] = Session(name=name, config=await self._get_session_config(name))
 
         session = self.active_sessions[name]
         client_id = str(id(ws))
@@ -1784,7 +1796,7 @@ class AgentWireServer(
 
         # Track this connection for TTS routing (so audio goes to browser, not local speakers)
         if session_name not in self.active_sessions:
-            self.active_sessions[session_name] = Session(name=session_name, config=self._get_session_config(session_name))
+            self.active_sessions[session_name] = Session(name=session_name, config=await self._get_session_config(session_name))
         session = self.active_sessions[session_name]
         session.clients.add(ws)
         logger.info(f"[Terminal] Client connected to {session_name} (total: {len(session.clients)})")
@@ -2598,7 +2610,7 @@ class AgentWireServer(
         # Get or create session
         if session_name not in self.active_sessions:
             self.active_sessions[session_name] = Session(
-                name=session_name, config=self._get_session_config(session_name)
+                name=session_name, config=await self._get_session_config(session_name)
             )
 
         session = self.active_sessions[session_name]

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -1167,7 +1167,8 @@ class TestPermissionRouting:
             return_value=True,
         ), patch(
             "agentwire.server.prompt_router._capture", return_value=""
-        ), patch("subprocess.run") as run:
+        ):
+            run = server._run_subprocess = AsyncMock(return_value=(0, "", ""))
             task, sess = await self._start_request(client, server)
             assert sess.pending_permission.pane_index == 2
 
@@ -1208,7 +1209,8 @@ class TestPermissionRouting:
             return_value=False,
         ), patch(
             "agentwire.server.prompt_router._capture", return_value=""
-        ), patch("subprocess.run") as run:
+        ):
+            run = server._run_subprocess = AsyncMock(return_value=(0, "", ""))
             task, sess = await self._start_request(client, server)
             resp = await client.post(
                 "/api/permission/myproj/respond", json={"decision": "deny"}
@@ -1242,7 +1244,8 @@ class TestPermissionRouting:
             return_value=True,
         ), patch(
             "agentwire.server.prompt_router._capture", return_value=""
-        ), patch("subprocess.run"):
+        ):
+            server._run_subprocess = AsyncMock(return_value=(0, "", ""))
             task, sess = await self._start_request(client, server)
             requests = [m for m in broadcasts if m.get("type") == "permission_request"]
             assert requests and requests[0]["parent_notified"] == "orch"
@@ -1534,7 +1537,7 @@ class TestMonitorInProcessCapture:
         server.broadcast_dashboard = AsyncMock()
 
         # "watched" has an open window; "headless" does not. Both must broadcast.
-        sess = Session(name="watched", config=server._get_session_config("watched"))
+        sess = Session(name="watched", config=await server._get_session_config("watched"))
         sess.clients.add(object())
         server.active_sessions["watched"] = sess
 

--- a/tests/unit/test_server_async.py
+++ b/tests/unit/test_server_async.py
@@ -228,7 +228,7 @@ class TestSpeakDefaultTier:
         server.broadcast_dashboard = AsyncMock()
         # Session with a connected client
         from agentwire.server import Session
-        session = Session(name="dev", config=server._get_session_config("dev"))
+        session = Session(name="dev", config=await server._get_session_config("dev"))
         session.clients.add(_client())
         server.active_sessions["dev"] = session
 
@@ -278,7 +278,7 @@ class TestSpeakDefaultTier:
         server._kokoro_shim_ready = AsyncMock(return_value=True)
         server._tts_generate = AsyncMock(return_value=wav)
         from agentwire.server import Session
-        session = Session(name="dev", config=server._get_session_config("dev"))
+        session = Session(name="dev", config=await server._get_session_config("dev"))
         session.clients.add(_client())
         server.active_sessions["dev"] = session
 
@@ -299,7 +299,7 @@ class TestSpeakDefaultTier:
         server._kokoro_shim_ready = AsyncMock(return_value=True)
         server._tts_generate = AsyncMock(return_value=None)
         from agentwire.server import Session
-        session = Session(name="dev", config=server._get_session_config("dev"))
+        session = Session(name="dev", config=await server._get_session_config("dev"))
         session.clients.add(_client())
         server.active_sessions["dev"] = session
 
@@ -311,7 +311,7 @@ class TestSpeakDefaultTier:
         server._broadcast = AsyncMock()
         server.broadcast_dashboard = AsyncMock()
         from agentwire.server import Session
-        other = Session(name="dev", config=server._get_session_config("dev"))
+        other = Session(name="dev", config=await server._get_session_config("dev"))
         other.clients.add(_client())
         server.active_sessions["dev"] = other
 


### PR DESCRIPTION
## Summary

The portal's async handlers called blocking `subprocess.run` (tmux + SSH, up to 5s each), parking the entire event loop. This converts every blocking subprocess call on an async path to non-blocking `asyncio.create_subprocess_exec`.

- New `AgentWireServer._run_subprocess(argv, timeout)` helper: `create_subprocess_exec` + `asyncio.wait_for`, kills the child on timeout, returns `(returncode, stdout, stderr)` or `None`.
- `_get_session_config`, `_get_session_cwd`, `_read_agentwire_yaml`, `_write_agentwire_yaml` are now `async`; all call sites await them (`server.py` websocket/terminal/TTS handlers, `routes/permission.py`, `routes/voice.py`, `routes/sessions_admin.py`).
- `routes/permission.py`: the four blocking `agentwire send-keys` calls (restricted-mode auto-allow/deny, respond keystrokes) are now async; failure logging semantics preserved.
- `routes/sessions_admin.py`: restart-service tmux/tts `subprocess.run` calls converted (`subprocess.Popen` for tts start left as-is — fire-and-forget, non-blocking).
- `routes/projects.py` already used `asyncio.to_thread` — untouched.
- Unused `import subprocess` removed from `server.py` and `routes/permission.py`.

## TOCTOU fix (review follow-up)

Making the config fetch awaitable opened a race in the `if name not in active_sessions: active_sessions[name] = Session(...)` pattern — the coroutine suspends mid-check, so two concurrent handlers for the same untracked session could both create it and the later would clobber the earlier (orphaned ws clients, lost `pending_permission`). Fixed with a shared `_get_or_create_session(name)` helper that fetches config first, re-checks after the await, and keeps whichever `Session` landed first. All six get-or-create sites use it.

Out of scope per issue partitioning: monitor-tick internals (#627), session-window streaming (#628), active_sessions lifecycle (#629), static/js.

## Verification

Full suite in-worktree: `uv run --extra dev pytest` → **2238 passed, 8 skipped** (after both commits). Permission-routing tests mock `server._run_subprocess` instead of patching `subprocess.run`.

Closes #626

Built by [dotdev.dev](https://dotdev.dev)