### PR TITLE
ci: pin uvx tools, drop stale snapshot config, un-skip Kokoro shim contract tests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,7 +55,7 @@ jobs:
       # asserts), and we fail only on high-severity high-confidence findings.
       # Green on the clean tree today; red only on NEW genuinely-dangerous code.
       - name: Run bandit
-        run: uvx bandit -c pyproject.toml -r agentwire --severity-level high --confidence-level high
+        run: uvx bandit==1.9.4 -c pyproject.toml -r agentwire --severity-level high --confidence-level high
 
   pip-audit:
     name: pip-audit (advisory)
@@ -87,7 +87,7 @@ jobs:
       # chatterbox-tts relax the ceiling. See docs/wiki/security/pip-audit.md.
       - name: Audit runtime dependencies
         run: >
-          uvx pip-audit -r requirements.txt
+          uvx pip-audit==2.10.1 -r requirements.txt
           --ignore-vuln PYSEC-2026-161
           --ignore-vuln CVE-2026-48818
           --ignore-vuln CVE-2026-48817
@@ -101,4 +101,4 @@ jobs:
         run: uv export --no-emit-project --all-extras --format requirements-txt -o requirements-all.txt
       - name: Full audit (weekly cron, optional extras)
         if: github.event_name == 'schedule'
-        run: uvx pip-audit -r requirements-all.txt
+        run: uvx pip-audit==2.10.1 -r requirements-all.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,10 +222,6 @@ exclude = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-norecursedirs = ["tests/snapshot/apps"]
-# Default: skip snapshot tests in the main run. Snapshots leave asyncio
-# state polluted in a way that breaks subsequent tests when interleaved.
-# Run them separately via `pytest tests/snapshot/ -m snapshots`.
 markers = [
     "slow: marks tests as slow",
     "integration: requires subprocess mocking",

--- a/tests/unit/test_tts_local.py
+++ b/tests/unit/test_tts_local.py
@@ -6,7 +6,6 @@ tier dispatch. No real model files or network involved.
 """
 
 import hashlib
-import importlib.util
 import subprocess
 import sys
 import wave
@@ -311,10 +310,6 @@ class TestLocalSayDispatch:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("fastapi") is None,
-    reason="fastapi only ships in the stt/tts extras (the shim runs from the source venv)",
-)
 class TestKokoroServer:
     """The shim wraps one LocalKokoro and serves the contract envelope.
 


### PR DESCRIPTION
## What

**#641a — pinned uvx tool versions in `security.yml`.** `uvx bandit` → `uvx bandit==1.9.4` (the currently-passing version; verified exit 0 locally against this tree). Also pinned the two `uvx pip-audit` invocations to `2.10.1` — same determinism argument; a pinned tool still pulls fresh advisory data.

**#641b — removed stale `tests/snapshot/` references from `pyproject.toml`.** Dead `norecursedirs = ["tests/snapshot/apps"]` entry plus the misleading "run them separately" comment; that tree was deleted with the SDK/snapshot removal.

**#642 — `TestKokoroServer` shim contract tests now run, not skip.** Key finding: `fastapi` moved into the **base** dependencies in #634 (PR #661), so `uv sync --extra dev` already installs it — the `skipif(find_spec("fastapi") is None)` guard and its "fastapi only ships in the stt/tts extras" message were stale. Rather than keep a guard that could silently re-skip, I deleted it: fastapi is a hard base dep, so a missing import should fail loudly. No workflow change needed.

## Proof the tests RUN (CI-equivalent local invocation)

```
$ uv sync --extra dev && uv run --no-sync pytest -q -m "not requires_tmux" tests/unit/test_tts_local.py -k KokoroServer -rs
tests/unit/test_tts_local.py::TestKokoroServer::test_health_reports_loading_state PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_health_ok_when_ready PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_health_surfaces_error PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_tts_503_until_ready PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_tts_400_on_empty_text PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_tts_returns_wav_when_ready PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_voices_empty_until_ready_then_presets PASSED
tests/unit/test_tts_local.py::TestKokoroServer::test_capabilities_shape PASSED
8 passed, 26 deselected
```

## Verification

- Full suite: `uv run --no-sync pytest -q` → **2278 passed** (unit + integration)
- `uv run --no-sync ruff check agentwire/ tests/` → all checks passed
- `uvx bandit==1.9.4 -c pyproject.toml -r agentwire --severity-level high --confidence-level high` → exit 0

Closes #641
Closes #642

Built by [dotdev.dev](https://dotdev.dev)