### PR TITLE
fix: onboarding correctness — PEP 668 install path, CONTRIBUTING, ffmpeg status, Dockerfile pins (#635, #637)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,15 +25,20 @@ Add it automatically with `git commit -s` (use your real name and an email that 
 git clone https://github.com/dotdevdotdev/agentwire-dev.git
 cd agentwire-dev
 
-# Install in development mode
-uv pip install -e .
+# Install dependencies into a project venv (creates .venv automatically)
+uv sync --extra dev
+
+# Run the test suite
+uv run pytest
 
 # Run in development mode (picks up code changes instantly)
-agentwire portal start --dev
+uv run agentwire portal start --dev
 
-# After structural changes (pyproject.toml, new files)
-agentwire rebuild
+# After changing pyproject.toml or adding files, re-sync
+uv sync --extra dev
 ```
+
+If you also have agentwire installed as a tool (`uv tool install agentwire-dev`) and want that install to pick up your source changes, run `agentwire rebuild` (reinstalls from your checkout).
 
 ### Development Workflow
 
@@ -108,20 +113,6 @@ from agentwire.utils import agentwire_dir, config_path, logs_dir
 base = agentwire_dir()  # ~/.agentwire/
 ```
 
-### Error Handling
-
-Use the structured error classes in `agentwire/errors.py`:
-
-```python
-from agentwire.errors import AgentWireError
-
-raise AgentWireError(
-    what="Session not found",
-    why="No tmux session exists with that name",
-    how="Create a new session with 'agentwire new -s name'"
-)
-```
-
 ### Configuration
 
 Use dataclasses for configuration (see `agentwire/config.py`):
@@ -164,7 +155,6 @@ agentwire/
 ├── *_cli.py         # Per-domain command groups, each with a register_<domain>_parser()
 ├── server.py        # WebSocket server
 ├── config.py        # Configuration dataclasses
-├── errors.py        # Structured error classes
 ├── validation.py    # Config validation
 ├── utils/           # Shared utilities
 │   ├── subprocess.py  # Command execution

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -33,8 +33,8 @@ WORKDIR /app
 
 # Install Python dependencies for HTTP server
 RUN pip install --no-cache-dir \
-    torch>=2.0.0 \
-    torchaudio>=2.0.0 \
+    "torch>=2.0.0" \
+    "torchaudio>=2.0.0" \
     fastapi \
     uvicorn[standard] \
     faster-whisper \

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ session to commanding many.
 ## Quick Start
 
 ```bash
-# Install
-pip install agentwire-dev
+# Install (isolated tool env — works on any Python, including Homebrew/Debian PEP 668 setups)
+uv tool install agentwire-dev
 
 # Setup (interactive)
 agentwire init
@@ -89,7 +89,7 @@ agentwire new -s hello -p ~/projects/hello
 
 > **Optional:** clone this repo (`git clone https://github.com/dotdevdotdev/agentwire-dev ~/projects/agentwire-dev`) and `agentwire dev` opens a guided helper session inside it — setup walkthrough, project wiring, issue filing, forking. It requires the source checkout; everything above works without one.
 
-**Requirements:** Python 3.10+, tmux, ffmpeg, Claude Code
+**Requirements:** Python 3.10+, tmux, Claude Code. Optional: ffmpeg (only for host-mic push-to-talk capture and voice cloning — browser voice input works without it).
 
 **Honest setup time:** under a minute to a working voice portal with a genuinely good voice — Kokoro-82M runs on CPU out of the box (one-time ~200 MB model download in the background; the browser voice covers the wait). ~15 minutes for the full experience: cloned voices via a self-hosted TTS shim, Whisper-grade transcription, phone-from-anywhere (certs + token).
 
@@ -115,16 +115,20 @@ Origin checks reject cross-site browser requests on every bind. Keep the portal 
 
 **macOS:**
 ```bash
-brew install tmux ffmpeg
-pip install agentwire-dev
+brew install tmux uv        # ffmpeg optional: only for host-mic PTT + voice cloning
+uv tool install agentwire-dev
 ```
+
+> Bare `pip install agentwire-dev` fails on Homebrew Python 3.12+ with `error: externally-managed-environment` (PEP 668). `uv tool install` (or `pipx install agentwire-dev`) sidesteps that by installing into its own isolated environment.
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt install tmux ffmpeg python3-pip python3-venv
-python3 -m venv ~/.agentwire-venv && source ~/.agentwire-venv/bin/activate
-pip install agentwire-dev
+sudo apt install tmux       # ffmpeg optional: only for host-mic PTT + voice cloning
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv tool install agentwire-dev
 ```
+
+`pipx install agentwire-dev` works everywhere too. Prefer plain pip? Use a venv: `python3 -m venv ~/.agentwire-venv && source ~/.agentwire-venv/bin/activate && pip install agentwire-dev`.
 
 **WSL2:** Same as Ubuntu. Audio is limited; use as remote worker with portal on Windows host.
 

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import urllib.request
 from dataclasses import dataclass, field
@@ -351,27 +352,32 @@ def check_python_version() -> bool:
 
 
 def check_pip_environment() -> bool:
-    """Detect Ubuntu 24.04+ EXTERNALLY-MANAGED marker; return False if user must act."""
-    if not sys.platform.startswith('linux'):
+    """Detect a PEP 668 externally-managed interpreter; return False if user must act.
+
+    Applies to Homebrew Python on macOS and Debian/Ubuntu system Python alike.
+    Inside a virtualenv (or a uv tool / pipx environment) the marker check is
+    skipped — installs there are always fine.
+    """
+    # Virtualenvs are never externally managed.
+    if sys.prefix != sys.base_prefix:
         return True
 
-    # Check for EXTERNALLY-MANAGED marker
-    marker = Path(sys.prefix) / "EXTERNALLY-MANAGED"
+    # PEP 668: the marker lives in the interpreter's stdlib sysconfig dir.
+    marker = Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED"
     if marker.exists():
-        print("⚠️  Externally-managed Python environment detected (Ubuntu 24.04+)")
+        print("⚠️  Externally-managed Python environment detected (PEP 668)")
         print()
-        print("Ubuntu prevents pip from installing packages system-wide to avoid conflicts.")
+        print("This Python (e.g. Homebrew on macOS, Debian/Ubuntu system Python)")
+        print("blocks bare `pip install` to protect its own packages.")
         print()
-        print("Recommended approach - Use venv:")
+        print("Recommended - install as an isolated tool:")
+        print("  uv tool install agentwire-dev")
+        print("  # or: pipx install agentwire-dev")
+        print()
+        print("Alternative - a dedicated venv:")
         print("  python3 -m venv ~/.agentwire-venv")
         print("  source ~/.agentwire-venv/bin/activate")
         print("  pip install agentwire-dev")
-        print()
-        print("  Add to ~/.bashrc for persistence:")
-        print("  echo 'source ~/.agentwire-venv/bin/activate' >> ~/.bashrc")
-        print()
-        print("Alternative (not recommended):")
-        print("  pip3 install --break-system-packages agentwire-dev")
         print()
         return False
 

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -440,7 +440,7 @@ def cmd_doctor(args) -> int:
     if ffmpeg_path:
         print(f"  [ok] ffmpeg: {ffmpeg_path}")
     else:
-        print("  [..] ffmpeg: not found (optional, needed for voice input)")
+        print("  [..] ffmpeg: not found (optional — needed for host-mic push-to-talk and voice cloning; browser voice input works without it)")
         print("     macOS: brew install ffmpeg")
         print("     Ubuntu: sudo apt install ffmpeg")
 

--- a/agentwire/onboarding.py
+++ b/agentwire/onboarding.py
@@ -252,7 +252,7 @@ def run_onboarding(skip_session: bool = True, force: bool = False) -> int:
     # Check ffmpeg (optional)
     ffmpeg_ok, ffmpeg_path = check_ffmpeg()
     if not ffmpeg_ok:
-        print_warning("ffmpeg not found (voice input won't work)")
+        print_warning("ffmpeg not found (optional — needed for host-mic push-to-talk and voice cloning; browser voice input works without it)")
         print_info(f"Install with: {instructions['ffmpeg']}")
     else:
         print_success(f"ffmpeg: {ffmpeg_path}")

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -2,7 +2,7 @@
 
 > Living document. Update this, don't create new versions.
 
-A 5-minute path from `pip install` to "I have a session with voice working." For the conceptual *why*, read [Concepts](concepts.md). For the full feature set, browse the [INDEX](INDEX.md).
+A 5-minute path from install to "I have a session with voice working." For the conceptual *why*, read [Concepts](concepts.md). For the full feature set, browse the [INDEX](INDEX.md).
 
 This page assumes you're on macOS or Linux with Python 3.10+ already installed. If anything errors, jump to [Troubleshooting](internals/troubleshooting.md).
 
@@ -12,14 +12,18 @@ This page assumes you're on macOS or Linux with Python 3.10+ already installed. 
 
 ```bash
 # macOS
-brew install tmux ffmpeg
-pip install agentwire-dev
+brew install tmux uv
+uv tool install agentwire-dev
 
 # Ubuntu / Debian
-sudo apt install tmux ffmpeg python3-pip python3-venv
-python3 -m venv ~/.agentwire-venv && source ~/.agentwire-venv/bin/activate
-pip install agentwire-dev
+sudo apt install tmux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv tool install agentwire-dev
 ```
+
+`uv tool install` (or `pipx install agentwire-dev`) puts agentwire in its own isolated environment, so it works on PEP 668 "externally-managed" Pythons — bare `pip install agentwire-dev` fails there (Homebrew Python 3.12+, Debian/Ubuntu system Python). If you'd rather use pip, do it inside a venv.
+
+ffmpeg is **optional**: browser voice input works without it (WebM/Opus uploads are decoded in-process via PyAV). Install it only if you want host-mic push-to-talk capture (`agentwire listen`) or voice cloning — `brew install ffmpeg` / `sudo apt install ffmpeg`.
 
 You'll also want **Claude Code** installed (`claude --version`) since the default session type runs through it.
 

--- a/tests/unit/test_pip_environment.py
+++ b/tests/unit/test_pip_environment.py
@@ -1,0 +1,58 @@
+"""Tests for the PEP 668 externally-managed environment detector (#635)."""
+
+from unittest.mock import patch
+
+from agentwire.core import check_pip_environment
+
+
+def _patch_stdlib(tmp_path):
+    return patch("agentwire.core.sysconfig.get_path", return_value=str(tmp_path))
+
+
+def _patch_no_venv():
+    # sys.prefix == sys.base_prefix → not inside a virtualenv
+    return patch.multiple("agentwire.core.sys", prefix="/usr", base_prefix="/usr")
+
+
+def test_marker_present_returns_false(tmp_path, capsys):
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("managed")
+    with _patch_stdlib(tmp_path), _patch_no_venv():
+        assert check_pip_environment() is False
+    out = capsys.readouterr().out
+    assert "uv tool install agentwire-dev" in out
+    assert "pipx install agentwire-dev" in out
+
+
+def test_marker_absent_returns_true(tmp_path):
+    with _patch_stdlib(tmp_path), _patch_no_venv():
+        assert check_pip_environment() is True
+
+
+def test_runs_on_macos(tmp_path):
+    """The detector must not short-circuit on darwin — Homebrew Python ships
+    the PEP 668 marker too."""
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("managed")
+    with _patch_stdlib(tmp_path), _patch_no_venv(), \
+            patch("agentwire.core.sys.platform", "darwin"):
+        assert check_pip_environment() is False
+
+
+def test_virtualenv_skips_marker_check(tmp_path):
+    """Inside a venv the interpreter is never externally managed, even if the
+    base interpreter's stdlib carries the marker."""
+    (tmp_path / "EXTERNALLY-MANAGED").write_text("managed")
+    with _patch_stdlib(tmp_path), \
+            patch.multiple("agentwire.core.sys", prefix="/home/x/.venv", base_prefix="/usr"):
+        assert check_pip_environment() is True
+
+
+def test_marker_checked_in_stdlib_dir(tmp_path):
+    """The marker lives in sysconfig's stdlib dir, not sys.prefix (they differ
+    on Homebrew/framework builds)."""
+    stdlib = tmp_path / "lib" / "python3.12"
+    stdlib.mkdir(parents=True)
+    (stdlib / "EXTERNALLY-MANAGED").write_text("managed")
+    with patch("agentwire.core.sysconfig.get_path", return_value=str(stdlib)) as gp, \
+            _patch_no_venv():
+        assert check_pip_environment() is False
+    gp.assert_called_once_with("stdlib")


### PR DESCRIPTION
Onboarding/docs correctness pass fixing both issues in one branch.

## #635 — macOS install path fails on PEP 668
- README + quickstart now document `uv tool install agentwire-dev` (or pipx) as the primary install path on macOS and Ubuntu; venv+pip kept as an explicit fallback. Consistent with the #634 install-parity reality (shims work from installed packages; `agentwire dev` needs only an optional checkout).
- `check_pip_environment()` (agentwire/core.py) now checks the interpreter's actual PEP 668 marker at `sysconfig.get_path("stdlib")/EXTERNALLY-MANAGED` (not `sys.prefix`), runs on macOS too (no darwin short-circuit), skips inside virtualenvs, and recommends uv/pipx first. 5 new unit tests in `tests/unit/test_pip_environment.py`.

## #637
- **(a) CONTRIBUTING.md** — dev setup is now `uv sync --extra dev` + `uv run pytest` / `uv run agentwire portal start --dev` (venv-less `uv pip install -e .` failed on fresh clones); removed the deleted `agentwire/errors.py` section and structure entry.
- **(b) ffmpeg** — README, quickstart, `agentwire init`, and `agentwire doctor` now agree: **optional**, needed only for host-mic push-to-talk capture (`agentwire listen`) and voice cloning; browser voice input decodes WebM/Opus in-process via PyAV.
- **(c) Dockerfile.local** — quoted `"torch>=2.0.0"` / `"torchaudio>=2.0.0"` so the shell no longer parses `>=` as redirection and drops the pins.

## Verification
- Full suite: `uv run pytest` → **2283 passed** (unit + integration)
- Lint: `uv run --no-sync ruff check agentwire/ tests/` → all checks passed

Closes #635
Closes #637

Built by [dotdev.dev](https://dotdev.dev)