### PR TITLE
fix(messaging): route idle report-backs through the msg inbox + full-message delivery identity (#667)

### DIFF
--- a/agentwire/hooks/idle-handler.sh
+++ b/agentwire/hooks/idle-handler.sh
@@ -380,7 +380,15 @@ complete | incomplete | error
         # (whose parent lives in metadata, not config) never notified anyone.
         # TMUX_PANE is inherited, so the CLI knows which session this is; a
         # top-level session resolves to no parent and this is a harmless no-op.
-        $AGENTWIRE notify-parent --on-idle -q "is idle and done working" 2>/dev/null &
+        # --queued (#667): ride the polite msg inbox (kind=done) instead of a
+        # direct paste — a busy orchestrator defers the message instead of
+        # accumulating unsubmitted notify lines in its input box, and an
+        # undeliverable one dead-letters + emails the owner instead of
+        # vanishing. Failures are logged, never discarded.
+        (
+          out=$($AGENTWIRE notify-parent --on-idle --queued -q "is idle and done working" 2>&1) \
+            || log "notify-parent --queued failed: $out"
+        ) &
       fi
     fi
   fi

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -127,9 +127,9 @@ class Message:
         rendered line on scrollback; without a unique tail a shorter message
         whose text is a prefix of a longer same-sender/kind one (or two
         identical-text report-backs) would substring-collide and be consumed
-        without delivery. The token is appended at the END so the prefix-based
-        landing checks (``derive_check_fragment`` / ``message_visible``) are
-        unchanged.
+        without delivery. Landing checks (``message_visible``) key on the full
+        whitespace-normalized message (#667), so the tail participates in the
+        match rather than weakening it.
         """
         return f"[MSG from {self.sender} · {self.kind}] {self.text}  ⟨#{self.short_id()}⟩"
 

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -96,6 +96,36 @@ def cmd_notify_parent(args) -> int:
             False, json_mode,
             "No target session (set 'parent' in .agentwire.yml or use --to)")
 
+    # --queued (#667): route through the polite msg inbox (kind=done) instead
+    # of a direct paste. The drain owns everything the direct path lacks — the
+    # empty-box gate (never appends to a busy orchestrator's draft), busy
+    # deferral without dead-letter penalty, full-line scrollback dedup, and
+    # email-on-dead-letter — so an idle report-back can neither pile up
+    # unsubmitted nor vanish silently. Non-queued callers are unchanged.
+    if getattr(args, 'queued', False):
+        from agentwire import inbox
+
+        try:
+            msgs = inbox.enqueue(
+                to=target_session, text=text, kind="done",
+                sender=current_session or "unknown",
+            )
+        except (ValueError, OSError) as e:
+            if json_mode:
+                _output_json({"success": False, "target": target_session,
+                              "queued": False, "error": str(e)})
+                return 1
+            print(f"Failed to queue notification for {target_session}: {e}",
+                  file=sys.stderr)
+            return 1
+        if json_mode:
+            _output_json({"success": True, "target": target_session,
+                          "queued": True, "id": msgs[0].id if msgs else None})
+            return 0
+        if not getattr(args, 'quiet', False):
+            print(f"Queued for {target_session}")
+        return 0
+
     # safe_deliver refuses targets where a paste could do damage (live
     # dialog on screen, bare shell, parked session) and verifies the paste
     # actually landed. Callers (queue processor) retry on failure.
@@ -271,6 +301,10 @@ def register_notify_parser(subparsers) -> None:
     notify_cmd_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     notify_cmd_parser.add_argument("--raw", action="store_true",
                                    help="Send the message verbatim (no [NOTIFY from ...] prefix)")
+    notify_cmd_parser.add_argument("--queued", action="store_true",
+                                   help="Deliver via the polite msg inbox (kind=done) instead of a direct "
+                                        "paste — waits for an empty input box, defers while the target is "
+                                        "busy, dead-letters + emails the owner on exhaustion (#667)")
     notify_cmd_parser.add_argument("--on-idle", dest="on_idle", action="store_true",
                                    help="Idle-hook mode: suppress the notify if the current session "
                                         "is an infrastructure service (they cycle idle constantly)")

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -361,9 +361,10 @@ def safe_deliver(target_session: str, target_pane: int, text: str) -> "tuple[boo
       target_not_agent  pane runs a shell/editor — pasted text could EXECUTE
       target_dialog     pane shows its own live menu — Enter would answer it
 
-    Delivery itself is session_ready.send_verified (marker = the message's
-    own [PROMPT ...] prefix line), so a silent tmux paste failure reports
-    as not-delivered instead of being assumed sent.
+    Delivery itself is session_ready.send_verified, keyed on the FULL
+    whitespace-normalized message (#667) — never a fixed-length prefix, which
+    collided across same-prefix ``[NOTIFY from …]`` pile-ups — so a silent
+    tmux paste failure reports as not-delivered instead of being assumed sent.
     """
     if not _session_exists(target_session):
         return False, "target_gone"
@@ -374,10 +375,9 @@ def safe_deliver(target_session: str, target_pane: int, text: str) -> "tuple[boo
     if screen_shows_live_menu(_capture(f"{target_session}.{target_pane}")):
         return False, "target_dialog"
 
-    from .session_ready import derive_check_fragment, send_verified
+    from .session_ready import send_verified
 
-    marker = derive_check_fragment(text)
-    ok = send_verified(target_session, text, marker=marker or None)
+    ok = send_verified(target_session, text)
     return (ok, "delivered" if ok else "delivery_unverified")
 
 

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -249,29 +249,23 @@ def wait_for_session_ready(
     return False
 
 
-def derive_check_fragment(message: str, length: int = 32) -> str:
-    """A distinctive fragment of *message* to look for in pane output.
-
-    First non-empty line, first *length* characters.
-    """
-    for line in message.splitlines():
-        line = line.strip()
-        if line:
-            return line[:length]
-    return ""
-
-
 def message_visible(capture: str, message: str) -> bool:
     """Did *message* land in the pane?
 
-    Whitespace-normalized substring check — tmux ``capture-pane`` wraps long
-    lines at pane width mid-word, so both sides are compared with all
-    whitespace stripped. Large multiline pastes may render only as Claude's
-    ``[Pasted text #N +M lines]`` placeholder, which counts as landed (the
-    failure mode being defended against is the paste vanishing entirely).
+    Keys on the **full** whitespace-normalized message, never a fixed-length
+    prefix (#667): all worktree idle notifications share a long
+    ``[NOTIFY from agentwire-dev-issue-…`` prefix, so a 32-char fragment
+    false-matched a *pile* of other sessions' notifications sitting in the box
+    — Phase 1 passed against text that wasn't ours, and Phase 2's
+    "box no longer shows our text" could never come true. tmux
+    ``capture-pane`` wraps long lines at pane width mid-word, so both sides
+    are compared with all whitespace stripped. Large multiline pastes may
+    render only as Claude's ``[Pasted text #N +M lines]`` placeholder, which
+    counts as landed (the failure mode being defended against is the paste
+    vanishing entirely).
     """
-    frag = derive_check_fragment(message)
-    if frag and "".join(frag.split()) in "".join(capture.split()):
+    needle = "".join(message.split())
+    if needle and needle in "".join(capture.split()):
         return True
     return "[Pasted text" in capture
 
@@ -314,7 +308,22 @@ def _deliver_once(
     session: str, message: str, marker: str | None, pane_index: int
 ) -> bool:
     """One adaptive paste→land→submit attempt. True iff the message submitted."""
-    paste_no_enter(session, message, pane_index=pane_index)
+    # Idempotent paste guard (#667): a previous attempt (an earlier whole-send
+    # retry, or a prior tick) may have left this exact message sitting in the
+    # box — landed but unsubmitted. Blindly pasting again doubles the draft
+    # (the observed "issue-659 twice" pile). So first look: already submitted →
+    # done; already landed → skip the paste and retry only the SUBMIT.
+    already_landed = False
+    try:
+        cap = _snapshot(session, pane_index)
+        if submitted(cap, message, marker):
+            return True
+        already_landed = text_landed(cap, message)
+    except Exception:
+        pass
+
+    if not already_landed:
+        paste_no_enter(session, message, pane_index=pane_index)
 
     # Phase 1 — wait for the paste to actually land in the input box (or for a
     # very fast bypass agent to have already consumed AND submitted it). If it

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -311,14 +311,31 @@ def _deliver_once(
     # Idempotent paste guard (#667): a previous attempt (an earlier whole-send
     # retry, or a prior tick) may have left this exact message sitting in the
     # box — landed but unsubmitted. Blindly pasting again doubles the draft
-    # (the observed "issue-659 twice" pile). So first look: already submitted →
-    # done; already landed → skip the paste and retry only the SUBMIT.
+    # (the observed "issue-659 twice" pile).
+    #
+    # The short-circuit demands POSITIVE full-message identity — the full
+    # whitespace-normalized message visible in the box (→ landed: skip the
+    # paste, retry only the submit) or on scrollback outside the box
+    # (→ already submitted). Nothing weaker counts before we have pasted:
+    # NOT empty-box+activity (real agent panes show ⏺/⎿/spinner glyphs in
+    # scrollback almost always — accepting that as "delivered" makes the msg
+    # drain unlink queued messages that were never sent: silent deletion),
+    # NOT the ``[Pasted text]`` placeholder (pre-paste it can only be someone
+    # ELSE's draft — skipping our paste and pressing Enter would force-submit
+    # a foreign draft; see message_on_scrollback), and NOT the caller marker
+    # (markers like council's are constant across messages, so a hit may be
+    # the PREVIOUS message). When identity is not provable, paste again — the
+    # existing full-line dedup makes duplicates recoverable; deletions aren't.
     already_landed = False
     try:
         cap = _snapshot(session, pane_index)
-        if submitted(cap, message, marker):
-            return True
-        already_landed = text_landed(cap, message)
+        box = input_box(cap)
+        needle = "".join(message.split())
+        if box is not None and needle:
+            if needle in "".join(box.split()):
+                already_landed = True
+            elif message_on_scrollback(cap, message):
+                return True
     except Exception:
         pass
 

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -64,6 +64,16 @@ lands in a durable inbox and is injected only at a safe boundary.
    That one fix covers the polite-msg loop, `notify-parent` (which also routes
    through `safe_deliver` → `send_verified`), and `session_send`.
 
+   Two further #667 hardenings live in the same layer, for every
+   `send_verified` caller: **(a) full-message identity** — the land/confirm
+   checks key on the full whitespace-normalized message, never a fixed-length
+   prefix (all worktree idle notifications share a >32-char
+   `[NOTIFY from agentwire-dev-issue-…` prefix, so a fragment false-matched a
+   *pile* of other sessions' notifications sitting in the box); and **(b) no
+   blind re-paste** — before pasting, each attempt checks whether the message
+   already sits landed-but-unsubmitted in the box, and if so retries only the
+   *submit*, so a whole-send retry can never double the draft.
+
 4. **Defer or drop.** If either gate fails, the messages stay put, their
    `attempts` counter bumps, and the defer `reason` (`box_not_empty`,
    `target_parked`, …) is stamped on each message. After `MAX_ATTEMPTS`
@@ -114,7 +124,7 @@ collision detector simple and the no-clobber guarantee absolute.
 | kind | meaning |
 |---|---|
 | `note` | default — informational |
-| `done` | a worker finished |
+| `done` | a worker finished — also what idle report-backs ride: `agentwire notify-parent --queued` (used by `idle-handler.sh`, #667) enqueues here instead of direct-pasting |
 | `request` | asking for something |
 | `escalation` | needs attention |
 | `ingest` | **passive** — awareness only; never auto-delivered (see below) |

--- a/docs/wiki/sessions/prompt-routing.md
+++ b/docs/wiki/sessions/prompt-routing.md
@@ -38,8 +38,15 @@ each machine's own watchdog sweeps its panes; cross-machine delivery falls
 back to human-only.
 
 **Idle notifications use the same resolution.** When a pane-0 session goes idle,
-`idle-handler.sh` calls `agentwire notify-parent --on-idle`, which resolves the
-parent through the precedence above — so a worktree / `agentwire new` child whose
+`idle-handler.sh` calls `agentwire notify-parent --on-idle --queued`, which
+resolves the parent through the precedence above and then (#667) **enqueues the
+report-back on the [polite msg inbox](messaging.md) as `kind=done`** instead of
+direct-pasting: the drain's empty-box gate means a busy orchestrator defers the
+message rather than accumulating unsubmitted `[NOTIFY …]` lines in its input
+box, busy deferral carries no dead-letter penalty, and an undeliverable
+report-back dead-letters + emails the owner instead of vanishing (the hook logs
+CLI failures instead of discarding them). Non-queued `notify-parent` calls
+still direct-paste via `safe_deliver`. Resolution itself is unchanged — so a worktree / `agentwire new` child whose
 parent lives in **creator metadata** (not `.agentwire.yml`) now correctly pings
 its spawner on completion. Earlier the idle hook read only the `.agentwire.yml`
 `parent:` field and silently dropped the notification when it was empty.
@@ -60,7 +67,11 @@ Every delivery goes through `safe_deliver()` (also used by
 - **target_parked** — usage-limit parked; a paste would corrupt the resume.
 - **target_gone** — session died.
 - Sends are verified (`send_verified`): a silent tmux paste failure reports
-  as undelivered and retries.
+  as undelivered and retries. Verification keys on the **full**
+  whitespace-normalized message (#667), never a fixed-length prefix — so a
+  pile of same-prefix drafts can't false-match — and a retry that finds its
+  own copy already landed in the box retries only the *submit*, never pasting
+  a duplicate.
 
 The message itself is paraphrased — no `❯`, no option block, no dialog footer
 text — so it can never be re-detected as a dialog.

--- a/tests/unit/test_notify_cli.py
+++ b/tests/unit/test_notify_cli.py
@@ -1,0 +1,95 @@
+"""Tests for ``agentwire notify-parent`` — the --queued msg-inbox path (#667).
+
+Idle report-backs ride the polite msg rail (kind=done): empty-box gate, busy
+deferral without dead-letter penalty, full-line scrollback dedup, and
+email-on-dead-letter. Direct-paste behavior for non-queued callers is
+unchanged and covered by test_prompt_router's safe_deliver tests.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import inbox, pane_manager, prompt_router
+from agentwire.notify_cli import cmd_notify_parent
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    root = tmp_path / "inbox"
+    monkeypatch.setattr(inbox, "INBOX_ROOT", root)
+    monkeypatch.setattr(inbox, "EVENTS_FILE", tmp_path / "inbox-events.jsonl")
+    return root
+
+
+def _args(**kw):
+    defaults = dict(
+        text=["is", "idle", "and", "done", "working"],
+        to=None, json=False, quiet=True, raw=False, on_idle=False, queued=True,
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def worktree_child(monkeypatch):
+    """A pane-0 worktree child whose parent resolves via creator metadata."""
+    monkeypatch.setattr(pane_manager, "get_current_session", lambda: "agentwire-dev-issue-661-bar")
+    monkeypatch.setattr(pane_manager, "get_current_pane_index", lambda: 0)
+    monkeypatch.setattr(prompt_router, "resolve_parent", lambda s, p: ("orch", 0))
+
+
+class TestQueuedMode:
+    def test_enqueues_done_kind_to_resolved_parent(self, isolate, worktree_child):
+        assert cmd_notify_parent(_args()) == 0
+        msgs = inbox.list_messages("orch")
+        assert len(msgs) == 1
+        assert msgs[0].kind == "done"
+        assert msgs[0].sender == "agentwire-dev-issue-661-bar"
+        assert msgs[0].text == "is idle and done working"
+
+    def test_no_direct_paste_in_queued_mode(self, isolate, worktree_child, monkeypatch):
+        def boom(*a, **kw):
+            raise AssertionError("queued mode must never call safe_deliver")
+
+        monkeypatch.setattr(prompt_router, "safe_deliver", boom)
+        assert cmd_notify_parent(_args()) == 0
+
+    def test_explicit_to_target(self, isolate, worktree_child):
+        assert cmd_notify_parent(_args(to="boss")) == 0
+        assert len(inbox.list_messages("boss")) == 1
+
+    def test_enqueue_failure_is_surfaced_not_silent(self, isolate, worktree_child, monkeypatch):
+        def fail(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(inbox, "enqueue", fail)
+        assert cmd_notify_parent(_args()) == 1
+
+    def test_no_parent_still_errors(self, isolate, monkeypatch):
+        monkeypatch.setattr(pane_manager, "get_current_session", lambda: "solo")
+        monkeypatch.setattr(pane_manager, "get_current_pane_index", lambda: 0)
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda s, p: None)
+        assert cmd_notify_parent(_args()) == 1
+        assert inbox.list_messages("solo") == []
+
+    def test_on_idle_service_session_skips(self, isolate, worktree_child, monkeypatch):
+        from agentwire import services
+
+        monkeypatch.setattr(services, "is_service_session", lambda s: True)
+        assert cmd_notify_parent(_args(on_idle=True)) == 0
+        assert inbox.list_messages("orch") == []
+
+
+class TestQueuedRendersUniquely:
+    def test_rendered_lines_are_distinct_for_same_prefix_senders(self, isolate, monkeypatch):
+        """Two worktree children with a shared long name prefix and identical
+        text must produce distinct rendered lines (the ⟨#id6⟩ tail), so the
+        full-line dedup can never cross-match them (#621/#667)."""
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda s, p: ("orch", 0))
+        monkeypatch.setattr(pane_manager, "get_current_pane_index", lambda: 0)
+        for name in ("agentwire-dev-issue-659-a", "agentwire-dev-issue-659-b"):
+            monkeypatch.setattr(pane_manager, "get_current_session", lambda n=name: n)
+            assert cmd_notify_parent(_args()) == 0
+        rendered = [m.render() for m in inbox.list_messages("orch")]
+        assert len(rendered) == 2 and rendered[0] != rendered[1]

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -347,6 +347,81 @@ class TestNoDoublePaste:
         assert actions["enters"] == 0
 
 
+class TestPrePasteGuardIdentity:
+    """#668 review — the pre-paste short-circuit may fire ONLY on positive
+    full-message identity. Ambient evidence (activity glyphs beside an empty
+    box, a foreign [Pasted text] placeholder, a constant caller marker) must
+    never count as delivery before we have pasted: a false 'submitted' makes
+    the msg drain unlink queued messages that were never sent."""
+
+    def test_empty_box_with_transcript_glyphs_does_not_short_circuit(self, monkeypatch):
+        # A real agent pane: 200-line scrollback full of tool glyphs/spinner,
+        # empty input box. The old guard called submitted() pre-paste, which
+        # returned True on empty-box+activity → nothing pasted, reported sent.
+        _fake_clock(monkeypatch)
+        transcript = "⏺ Bash(ls)\n  ⎿ file.py\n✻ Thinking…\n· 1.2k tokens\n"
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return transcript + render_box()  # busy-looking, empty box
+            if a["enters"] == 0:
+                return transcript + render_box("fresh report")  # our paste landed
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "fresh report")
+        assert actions["pastes"] == 1  # the guard did NOT skip the paste
+
+    def test_constant_marker_on_scrollback_does_not_short_circuit(self, monkeypatch):
+        # Council-style constant marker already on scrollback from the PREVIOUS
+        # nudge: pre-paste it proves nothing about THIS message. The paste must
+        # happen (Phase 1 may then legitimately confirm via the marker).
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            return "[COUNCIL FOLLOW-UP]\nold nudge text\n" + render_box()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "second nudge", "[COUNCIL FOLLOW-UP]")
+        assert actions["pastes"] == 1
+
+    def test_foreign_pasted_placeholder_is_not_our_landing(self, monkeypatch):
+        # A human's half-composed large paste sits in the target box as
+        # [Pasted text ...]. Pre-paste that placeholder can only be someone
+        # ELSE's draft: we must not skip our paste, and we must never press
+        # Enter before pasting (which would force-submit the foreign draft).
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return render_box("[Pasted text #1 +57 lines]")
+            if a["enters"] == 0:
+                return render_box("our own report")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+
+        real_enter = session_ready.press_enter
+
+        def guarded_enter(s, pane_index=0):
+            assert actions["pastes"] > 0, "Enter pressed into a foreign draft before pasting"
+            real_enter(s, pane_index=pane_index)
+
+        monkeypatch.setattr(session_ready, "press_enter", guarded_enter)
+        assert session_ready.send_verified("s", "our own report")
+        assert actions["pastes"] == 1
+
+    def test_full_message_on_scrollback_short_circuits_as_submitted(self, monkeypatch):
+        # Positive identity: our FULL rendered message already on scrollback
+        # (not in the box) → a prior attempt submitted it. No paste, no Enter.
+        _fake_clock(monkeypatch)
+        msg = "[MSG from worker · done] finished  ⟨#abc123⟩"
+        actions = _env(monkeypatch, lambda a: f"{msg}\n" + render_box())
+        assert session_ready.send_verified("s", msg)
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 0
+
+
 class TestSubmitConfirmed:
     """#621 — Phase-2 confirm keys on 'the box no longer holds our text', since
     Phase 1 already proved the paste landed. The old `submitted` additionally

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -67,17 +67,6 @@ class TestWaitForSessionReady:
         assert session_ready.wait_for_session_ready("s", timeout=10)
 
 
-class TestDeriveCheckFragment:
-    def test_first_nonempty_line(self):
-        assert session_ready.derive_check_fragment("\n\n  hello world  \nmore") == "hello world"
-
-    def test_truncates(self):
-        assert session_ready.derive_check_fragment("x" * 100) == "x" * 32
-
-    def test_empty_message(self):
-        assert session_ready.derive_check_fragment("   \n  ") == ""
-
-
 class TestMessageVisible:
     def test_exact_match(self):
         msg = "build a voice diary app"
@@ -95,6 +84,26 @@ class TestMessageVisible:
 
     def test_miss(self):
         assert not session_ready.message_visible("❯ \nBypassing Permissions", "my unique idea")
+
+    def test_same_prefix_pile_does_not_false_match(self):
+        # #667 fragment-collision repro: every worktree idle notification
+        # shares a >32-char prefix. A pile of OTHER sessions' notifications
+        # sitting in the box must NOT read as ours landing.
+        pile = (
+            "❯ [NOTIFY from agentwire-dev-issue-655-foo] is idle and done working\n"
+            "[NOTIFY from agentwire-dev-issue-659-shift-tab] is idle and done working"
+        )
+        ours = "[NOTIFY from agentwire-dev-issue-661-bar] is idle and done working"
+        assert not session_ready.message_visible(pile, ours)
+        # ...while the actual message in the pile still matches.
+        theirs = "[NOTIFY from agentwire-dev-issue-655-foo] is idle and done working"
+        assert session_ready.message_visible(pile, theirs)
+
+    def test_full_message_keying_not_prefix(self):
+        # Two messages identical for well past 32 chars, differing in the tail.
+        a = "[NOTIFY from agentwire-dev-issue-100] finished task alpha"
+        b = "[NOTIFY from agentwire-dev-issue-100] finished task bravo"
+        assert not session_ready.message_visible(f"❯ {a}", b)
 
 
 RULE = "─" * 20
@@ -191,7 +200,9 @@ class TestSendVerified:
 
         def frame(a):
             if a["enters"] == 0:
-                return render_box("hi there")
+                # Empty until the paste actually happens (the #667 pre-paste
+                # guard skips the paste if the text already sits in the box).
+                return render_box("hi there") if a["pastes"] else render_box()
             return render_working()
 
         actions = _env(monkeypatch, frame)
@@ -287,6 +298,53 @@ class TestSendVerifiedAdaptive:
         actions = _env(monkeypatch, lambda a: render_working())
         session_ready.send_verified("s", "anything")
         assert actions["cap_lines"] == session_ready.VERIFY_SCROLLBACK_LINES
+
+
+class TestNoDoublePaste:
+    """#667 — a landed-but-unsubmitted copy means retry the SUBMIT, not the
+    paste. The whole-send retry must never blindly paste a second copy on top
+    of one already sitting in the box (the observed 'issue-659 twice' pile)."""
+
+    def test_retry_skips_paste_when_copy_already_in_box(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        msg = "[NOTIFY from agentwire-dev-issue-659-shift-tab] is idle and done working"
+        # After the first paste the box permanently holds our text and Enter
+        # never registers: the retry sees the landed copy and does NOT paste
+        # again.
+        actions = _env(
+            monkeypatch, lambda a: render_box(msg) if a["pastes"] else render_box()
+        )
+        assert not session_ready.send_verified("s", msg, retries=1)
+        assert actions["pastes"] == 1
+        assert actions["enters"] > 0  # it kept retrying the SUBMIT
+
+    def test_no_paste_at_all_when_already_landed(self, monkeypatch):
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box("leftover from a prior attempt")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "leftover from a prior attempt")
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 1
+
+    def test_pile_of_other_notifications_is_not_our_landing(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        pile = (
+            "[NOTIFY from agentwire-dev-issue-655-foo] is idle and done working "
+            "[NOTIFY from agentwire-dev-issue-663-tab] is idle and done working"
+        )
+        ours = "[NOTIFY from agentwire-dev-issue-661-bar] is idle and done working"
+        # Box shows only OTHER sessions' same-prefix notifications, ours never
+        # renders: Phase 1 must fail (no false landing) and Enter must never be
+        # pressed into the pile (the old 32-char fragment matched instantly and
+        # then hammered Enter for 20s against a pile that could never clear).
+        actions = _env(monkeypatch, lambda a: render_box(pile))
+        assert not session_ready.send_verified("s", ours)
+        assert actions["enters"] == 0
 
 
 class TestSubmitConfirmed:


### PR DESCRIPTION
Fixes the notify pile-up: worker idle notifications accumulating unsubmitted in a busy orchestrator's input box. All four compounding defects from the issue diagnosis:

1. **Idle report-backs ride the msg rail.** `idle-handler.sh` now calls `agentwire notify-parent --on-idle --queued`; the new `--queued` mode resolves the parent exactly as before, then enqueues on the polite msg inbox as `kind=done` — empty-box gate, busy deferral without dead-letter penalty, full-line scrollback dedup, email-on-dead-letter. Non-queued `notify-parent` uses (queue processor `--raw`, explicit `--to`) keep the direct `safe_deliver` paste unchanged.
2. **Full-message identity.** `session_ready.message_visible` (used by `text_landed`/`submitted`/`submit_confirmed`) now keys on the full whitespace-normalized message, never the first-32-chars fragment that collided across every `[NOTIFY from agentwire-dev-issue-…]` message. `safe_deliver` stops passing a fragment marker; `derive_check_fragment` is deleted (council's explicit markers unaffected).
3. **No blind re-paste.** `_deliver_once` gets an idempotent pre-paste guard: already-submitted → done; landed-but-unsubmitted copy in the box → skip the paste and retry only the submit. A whole-send retry can no longer double the draft.
4. **No silent discard.** The hook drops `2>/dev/null`: CLI failures log to the hook debug log, and once enqueued, delivery failure lands in the dead-letter machinery (which emails the owner for `done`).

Docs: `messaging.md` + `prompt-routing.md` contract descriptions updated.

**Verification:** full suite `uv run --extra dev pytest` → **2298 passed**; `ruff check` clean; `bash -n` on the hook. New unit coverage: same-prefix pile fragment-collision repro, retry-does-not-double-paste, pile-never-gets-Enter, `--queued` enqueue semantics (kind/sender/target, no safe_deliver, failure surfaced, service-session skip, unique rendered lines). Busy-target deferral and dead-letter-on-exhaustion were already covered in `test_inbox.py` and remain green.

Closes #667

Built by [dotdev.dev](https://dotdev.dev)