### PR TITLE
fix(msg): dim-ghost-text-aware drain + static-content no-penalty defer (#669)

### DIFF
--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -64,10 +64,18 @@ MAX_ATTEMPTS = 40
 
 # Defer reasons that DON'T penalize: the target is legitimately busy — running a
 # long command (unparseable box → "target_busy") or generating with human-queued
-# input (the "queued messages" placeholder → "queued_placeholder"). Such messages
-# stay pending forever instead of burning toward dead-letter; doctor /
-# worktree --watch surface them, and they deliver once the box frees up.
-_NO_PENALTY_REASONS = frozenset({"target_busy", "queued_placeholder"})
+# input (the "queued messages" placeholder → "queued_placeholder"), or the box
+# holds unrecognized-but-static content ("box_static": identical across
+# consecutive sweeps ≈ an unknown placeholder, not an actively-typed draft).
+# Such messages stay pending forever instead of burning toward dead-letter;
+# doctor / worktree --watch surface them, and they deliver once the box frees up.
+_NO_PENALTY_REASONS = frozenset({"target_busy", "queued_placeholder", "box_static"})
+
+# Consecutive sweeps the box must show byte-identical content before the defer
+# stops penalizing (see _box_static). Low enough that an unknown placeholder
+# costs only a couple of attempts; high enough that a paused human draft eats
+# at least a few penalty ticks before being classed as static.
+_BOX_STATIC_THRESHOLD = 3
 
 # Load-bearing kinds: a silently-dropped one is a real loss, so on dead-letter it
 # is escalated out-of-band (owner email). note is fire-and-forget and ingest
@@ -182,6 +190,42 @@ def ingest_dir(session: str) -> Path:
     never walks (it's in ``_RESERVED_DIRS`` and below the top-level glob), so
     these wait silently until pulled."""
     return session_dir(session) / "ingest"
+
+
+def _box_state_path(session: str) -> Path:
+    # No .json suffix so pending_files' *.json glob can never pick it up.
+    return session_dir(session) / ".box-state"
+
+
+def _box_static(session: str, content: str) -> bool:
+    """True if this recipient's box has shown identical content ≥ N sweeps.
+
+    Per-recipient last-seen box content persisted next to the inbox. Content
+    unchanged across ``_BOX_STATIC_THRESHOLD`` consecutive drain sweeps is not
+    an actively-typed human draft — most likely an unrecognized placeholder —
+    so the drain defers WITHOUT penalty (like ``target_busy``) instead of
+    burning messages toward dead-letter (#669). Never widens delivery: the
+    box is still non-empty, so nothing pastes — only the penalty changes.
+    """
+    path = _box_state_path(session)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        data = {}
+    count = int(data.get("count", 0)) + 1 if data.get("content") == content else 1
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"content": content, "count": count}))
+    except OSError:
+        pass
+    return count >= _BOX_STATIC_THRESHOLD
+
+
+def _clear_box_state(session: str) -> None:
+    try:
+        _box_state_path(session).unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def _log_event(event: str, **fields) -> None:
@@ -707,8 +751,10 @@ def flush_session(session: str, force: bool = False) -> dict:
                         "deferred": False, "reason": "delivered",
                     }
 
-            visible = prompt_router.capture(session, 0)
-            box_content = prompt_router.input_box_content(visible)
+            # SGR-preserving capture so dim ghost/autosuggest text inside the
+            # box reads as empty instead of starving delivery (#669).
+            visible = prompt_router.capture(session, 0, escapes=True)
+            box_content = prompt_router.input_box_content_sgr(visible)
 
             if box_content is None:
                 # Target is busy (input box not located). Defer.
@@ -725,14 +771,23 @@ def flush_session(session: str, force: bool = False) -> dict:
                 # defer WITHOUT penalty (like target_busy) so a generating-with-queued
                 # session doesn't burn report-backs toward dead-letter. Either way we
                 # never paste — only the penalty decision differs.
-                placeholder = prompt_router.is_queued_placeholder(box_content)
-                reason = "queued_placeholder" if placeholder else "box_not_empty"
+                if prompt_router.is_queued_placeholder(box_content):
+                    reason = "queued_placeholder"
+                elif _box_static(session, box_content):
+                    # Same unrecognized content for N straight sweeps — an
+                    # unknown placeholder, not an active draft. Still deferred
+                    # (never pasted), but no longer burning toward dead-letter.
+                    reason = "box_static"
+                else:
+                    reason = "box_not_empty"
                 dead = _bump_attempts(messages, reason)
                 _log_event("deferred", to=session, count=len(messages), reason=reason)
                 return {
                     "session": session, "delivered": pre_consumed, "deferred": True,
                     "reason": reason, "dead": dead,
                 }
+
+            _clear_box_state(session)  # box is empty — reset the static counter
 
         rendered = "\n".join(m.render() for m in messages)
         delivered, reason = prompt_router.safe_deliver(session, 0, rendered)

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -314,9 +314,76 @@ def input_box_content(visible: str) -> "str | None":
     return text[1:].strip()
 
 
-def capture(target_session: str, target_pane: int = 0) -> str:
-    """Capture the live screen text of a pane."""
-    return _capture(f"{target_session}.{target_pane}")
+# SGR (color/attribute) escape sequences, captured with tmux capture-pane -e.
+_SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+# Non-SGR escapes that may survive an -e capture (OSC titles, cursor moves).
+_NON_SGR_ESCAPES = re.compile(r"\x1b\].*?(?:\x07|\x1b\\)|\x1b\[[0-9;?]*[A-Za-ln-z]")
+
+
+def _non_dim_lines(visible: str) -> list[str]:
+    """Per-line text with dim-rendered (``ESC[2m``) characters removed.
+
+    Walks an SGR-preserved capture tracking the dim/faint attribute (set by
+    param ``2``; cleared by ``0``, empty, or ``22``) — the attribute carries
+    across lines, matching terminal semantics. Ghost/autosuggest text is the
+    dim content; whatever survives is what a human actually typed.
+    """
+    visible = _NON_SGR_ESCAPES.sub("", visible)
+    lines: list[str] = []
+    cur: list[str] = []
+    dim = False
+    pos = 0
+
+    def emit(segment: str) -> None:
+        for ch in segment:
+            if ch == "\n":
+                lines.append("".join(cur))
+                cur.clear()
+            elif not dim:
+                cur.append(ch)
+
+    for m in _SGR_RE.finditer(visible):
+        emit(visible[pos:m.start()])
+        for param in (m.group(1) or "0").split(";"):
+            if param in ("", "0", "22"):
+                dim = False
+            elif param == "2":
+                dim = True
+        pos = m.end()
+    emit(visible[pos:])
+    lines.append("".join(cur))
+    return lines
+
+
+def input_box_content_sgr(visible: str) -> "str | None":
+    """SGR-aware ``input_box_content``: dim-only ghost text reads as empty.
+
+    *visible* must be an SGR-preserving capture (``capture-pane -e``). Claude
+    Code renders ghost/autosuggest text inside the input box dim (``ESC[2m``)
+    and human-typed drafts never dim, so content that is entirely dim is not a
+    draft — the box is deliverable. Any non-dim content is returned as usual
+    (defer). On any ambiguity (line-count mismatch, glyph itself dim, no
+    parseable box) this degrades to the plain parse — never wider than it.
+    """
+    plain = input_box_content(visible)  # ANSI_PATTERN strips SGR: same parse
+    if not plain:
+        return plain  # None (defer) or "" (empty) — nothing to reclassify
+    non_dim = _non_dim_lines(visible)
+    plain_lines = ANSI_PATTERN.sub("", _NON_SGR_ESCAPES.sub("", visible)).split("\n")
+    if len(non_dim) != len(plain_lines):
+        return plain
+    rules = [i for i, ln in enumerate(plain_lines) if _is_rule_line(ln)]
+    if len(rules) < 2:
+        return plain
+    text = "\n".join(non_dim[rules[-2] + 1:rules[-1]]).lstrip()
+    if not text or text[0] not in _PROMPT_GLYPHS:
+        return plain  # prompt glyph rendered dim/odd — stay conservative
+    return text[1:].strip()
+
+
+def capture(target_session: str, target_pane: int = 0, escapes: bool = False) -> str:
+    """Capture the live screen text of a pane (``escapes=True`` keeps SGR)."""
+    return _capture(f"{target_session}.{target_pane}", escapes=escapes)
 
 
 def prompt_is_empty(target_session: str, target_pane: int = 0) -> bool:
@@ -326,9 +393,12 @@ def prompt_is_empty(target_session: str, target_pane: int = 0) -> bool:
     is mid-typing. Conservative by design — any non-empty content (a draft OR
     a busy-state placeholder like "Press up to edit queued messages") and any
     screen we can't parse as a clean empty box returns False (defer). A delayed
-    message is fine; a clobbered human draft is not.
+    message is fine; a clobbered human draft is not. Captures with SGR escapes
+    so dim-rendered ghost/autosuggest text doesn't read as a draft (#669).
     """
-    content = input_box_content(_capture(f"{target_session}.{target_pane}"))
+    content = input_box_content_sgr(
+        _capture(f"{target_session}.{target_pane}", escapes=True)
+    )
     return content == ""
 
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -121,9 +121,15 @@ def _tmux(args: list[str], timeout: float = 5) -> subprocess.CompletedProcess:
     )
 
 
-def _capture(target: str, scrollback: int | None = None) -> str:
-    """Capture pane text. Visible screen only unless ``scrollback`` lines given."""
+def _capture(target: str, scrollback: int | None = None, escapes: bool = False) -> str:
+    """Capture pane text. Visible screen only unless ``scrollback`` lines given.
+
+    ``escapes=True`` adds ``-e`` (preserve SGR escape sequences) so callers can
+    distinguish dim-rendered ghost/autosuggest text from real typed text.
+    """
     cmd = ["capture-pane", "-t", target, "-p"]
+    if escapes:
+        cmd.append("-e")
     if scrollback:
         cmd += ["-S", f"-{scrollback}"]
     try:

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -102,12 +102,111 @@ class TestInputBox:
         assert prompt_router.input_box_content(colored) == ""
 
     def test_prompt_is_empty_gate(self, monkeypatch):
-        monkeypatch.setattr(prompt_router, "_capture", lambda t: EMPTY_BOX)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: EMPTY_BOX)
         assert prompt_router.prompt_is_empty("s", 0) is True
-        monkeypatch.setattr(prompt_router, "_capture", lambda t: DRAFT_BOX)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: DRAFT_BOX)
         assert prompt_router.prompt_is_empty("s", 0) is False
-        monkeypatch.setattr(prompt_router, "_capture", lambda t: DIALOG)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: DIALOG)
         assert prompt_router.prompt_is_empty("s", 0) is False
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: GHOST_BOX)
+        assert prompt_router.prompt_is_empty("s", 0) is True
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: MIXED_BOX)
+        assert prompt_router.prompt_is_empty("s", 0) is False
+
+
+# SGR-preserved captures (tmux capture-pane -e). Claude Code renders the box
+# border colored, ghost/autosuggest text dim (ESC[2m), and typed text plain.
+DIM_RULE = f"\x1b[38;5;244m{RULE}\x1b[39m"
+
+SGR_EMPTY_BOX = f"""\
+some agent output above
+{DIM_RULE}
+❯
+{DIM_RULE}
+  status bar
+"""
+
+GHOST_BOX = f"""\
+some agent output above
+{DIM_RULE}
+❯ \x1b[2mTry "fix lint errors"\x1b[22m
+{DIM_RULE}
+  status bar
+"""
+
+# Ghost styled with a combined dim+color sequence and reset via ESC[0m.
+GHOST_BOX_COMBINED = f"""\
+output
+{DIM_RULE}
+❯ \x1b[2;38;5;242mhow can I help?\x1b[0m
+{DIM_RULE}
+  status bar
+"""
+
+SGR_DRAFT_BOX = f"""\
+output
+{DIM_RULE}
+❯ real typed draft
+{DIM_RULE}
+  status bar
+"""
+
+MIXED_BOX = f"""\
+output
+{DIM_RULE}
+❯ typed prefix\x1b[2m ghost completion tail\x1b[22m
+{DIM_RULE}
+  status bar
+"""
+
+SGR_QUEUED_BOX = f"""\
+output
+{DIM_RULE}
+❯ \x1b[2mPress up to edit queued messages\x1b[22m
+{DIM_RULE}
+  status bar
+"""
+
+
+class TestInputBoxSgr:
+    def test_sgr_empty_box(self):
+        assert prompt_router.input_box_content_sgr(SGR_EMPTY_BOX) == ""
+
+    def test_dim_only_ghost_reads_empty(self):
+        assert prompt_router.input_box_content_sgr(GHOST_BOX) == ""
+
+    def test_combined_dim_color_ghost_reads_empty(self):
+        assert prompt_router.input_box_content_sgr(GHOST_BOX_COMBINED) == ""
+
+    def test_real_draft_still_defers(self):
+        assert prompt_router.input_box_content_sgr(SGR_DRAFT_BOX) == "real typed draft"
+
+    def test_mixed_dim_and_typed_keeps_typed(self):
+        content = prompt_router.input_box_content_sgr(MIXED_BOX)
+        assert content == "typed prefix"
+
+    def test_dim_queued_placeholder_reads_empty(self):
+        # If a future build renders the queued placeholder dim it's ghost text;
+        # today's non-dim render still routes through is_queued_placeholder.
+        assert prompt_router.input_box_content_sgr(SGR_QUEUED_BOX) == ""
+
+    def test_plain_queued_placeholder_unchanged(self):
+        assert (
+            prompt_router.input_box_content_sgr(QUEUED_BOX)
+            == "Press up to edit queued messages"
+        )
+
+    def test_plain_captures_fall_back(self):
+        # No SGR at all — behaves exactly like the plain parse.
+        assert prompt_router.input_box_content_sgr(EMPTY_BOX) == ""
+        assert prompt_router.input_box_content_sgr(DRAFT_BOX).startswith("this is my")
+        assert prompt_router.input_box_content_sgr(DIALOG) is None
+
+    def test_dim_prompt_glyph_falls_back_to_plain(self):
+        # If the glyph itself renders dim the SGR parse can't find the box —
+        # degrade to the plain (conservative, defer-shaped) result.
+        weird = f"output\n{RULE}\n\x1b[2m❯ hint text\x1b[22m\n{RULE}\n status"
+        assert prompt_router.input_box_content_sgr(weird) == "hint text"
 
 
 # =============================================================================
@@ -172,13 +271,24 @@ class TestBroadcast:
 # =============================================================================
 
 
-def _patch_delivery(monkeypatch, empty=True, deliver=(True, "delivered")):
+def _patch_delivery(monkeypatch, empty=True, deliver=(True, "delivered"), box=None):
     from agentwire import usage_limit
-    monkeypatch.setattr(usage_limit, "_capture", lambda s: "dummy screen")
-    monkeypatch.setattr(
-        prompt_router, "input_box_content",
-        lambda vis: "" if empty else "draft content",
-    )
+    monkeypatch.setattr(usage_limit, "_capture", lambda s, **kw: "dummy screen")
+    monkeypatch.setattr(prompt_router, "capture", lambda s, p=0, **kw: "dummy screen")
+    # Default non-empty box content VARIES per sweep (an actively-edited draft);
+    # identical content across sweeps is the no-penalty box_static path (#669) —
+    # pass a fixed ``box=`` to exercise it.
+    calls = {"n": 0}
+
+    def _box(vis):
+        if empty:
+            return ""
+        if box is not None:
+            return box
+        calls["n"] += 1
+        return f"draft content {calls['n']}"
+
+    monkeypatch.setattr(prompt_router, "input_box_content_sgr", _box)
     monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
     monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: empty)
     sent = []
@@ -351,8 +461,8 @@ class TestTick:
 class TestEscalation:
     def test_busy_screen_defers_target_busy(self, isolate, monkeypatch):
         inbox.enqueue("s", "PR done", kind="done", sender="worker")
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: None)
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: None)
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
 
         res = inbox.flush_session("s")
@@ -363,8 +473,8 @@ class TestEscalation:
 
     def test_done_under_threshold_defers_box_not_empty(self, isolate, monkeypatch):
         inbox.enqueue("s", "PR done", kind="done", sender="worker")
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "draft content")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
 
         res = inbox.flush_session("s")
@@ -378,8 +488,8 @@ class TestEscalation:
         msg.attempts = 10
         inbox._write_message(msg.path, msg)
 
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "draft content")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
         sent = []
         monkeypatch.setattr(prompt_router, "safe_deliver", lambda s, p, text: (sent.append(text) or (True, "delivered")))
@@ -396,8 +506,8 @@ class TestEscalation:
         msg.attempts = 10
         inbox._write_message(msg.path, msg)
 
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: None)
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: None)
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
 
         res = inbox.flush_session("s")
@@ -412,8 +522,8 @@ class TestEscalation:
         msg.attempts = 10
         inbox._write_message(msg.path, msg)
 
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "draft content")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: False)
 
         res = inbox.flush_session("s")
@@ -429,9 +539,9 @@ class TestQueuedPlaceholderDefer:
     The collision guard is untouched: we still never paste into a non-empty box."""
 
     def _placeholder_box(self, monkeypatch):
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
         monkeypatch.setattr(
-            prompt_router, "input_box_content",
+            prompt_router, "input_box_content_sgr",
             lambda vis: "Press up to edit queued messages",
         )
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
@@ -465,14 +575,74 @@ class TestQueuedPlaceholderDefer:
         assert sent == []  # box non-empty → never delivered into
 
 
+class TestBoxStatic:
+    """Unrecognized-but-static box content (#669): identical across N sweeps →
+    defer WITHOUT penalty (like target_busy) instead of burning to dead-letter."""
+
+    def test_static_content_stops_penalizing(self, isolate, monkeypatch):
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        sent = _patch_delivery(monkeypatch, empty=False, box='Try "fix lint errors"')
+        reasons = [
+            inbox.flush_session("s")["reason"]
+            for _ in range(inbox.MAX_ATTEMPTS + 5)
+        ]
+        # Pre-threshold sweeps penalize; from the Nth identical capture on, no penalty.
+        assert reasons[: inbox._BOX_STATIC_THRESHOLD - 1] == ["box_not_empty"] * (
+            inbox._BOX_STATIC_THRESHOLD - 1
+        )
+        assert set(reasons[inbox._BOX_STATIC_THRESHOLD - 1:]) == {"box_static"}
+        pending = inbox.list_messages("s")
+        assert len(pending) == 1
+        assert pending[0].attempts == inbox._BOX_STATIC_THRESHOLD - 1
+        assert inbox.list_dead("s") == []  # never dead-lettered
+        assert sent == []  # and never pasted
+
+    def test_changing_content_keeps_penalizing(self, isolate, monkeypatch):
+        inbox.enqueue("s", "hi", sender="x")
+        _patch_delivery(monkeypatch, empty=False)  # default: varies per sweep
+        for _ in range(inbox.MAX_ATTEMPTS):
+            inbox.flush_session("s")
+        assert inbox.list_messages("s") == []
+        assert len(inbox.list_dead("s")) == 1
+
+    def test_box_static_counter_unit(self, isolate):
+        assert not inbox._box_static("s", "x")
+        assert not inbox._box_static("s", "x")
+        assert inbox._box_static("s", "x")  # third identical sweep
+        assert not inbox._box_static("s", "y")  # content change resets
+        inbox._clear_box_state("s")
+        assert not inbox._box_static("s", "y")
+        assert not inbox._box_static("s", "y")
+        assert inbox._box_static("s", "y")
+
+    def test_state_file_is_not_a_message(self, isolate):
+        inbox._box_static("s", "x")
+        assert inbox.list_messages("s") == []
+
+    def test_empty_box_clears_state(self, isolate, monkeypatch):
+        inbox.enqueue("s", "hi", sender="x")
+        inbox._box_static("s", "stale")
+        _patch_delivery(monkeypatch, empty=True)
+        inbox.flush_session("s")
+        assert not inbox._box_state_path("s").exists()
+
+
 class TestDeadLetterEscalation:
     """A: a load-bearing report-back (done/request/escalation) that dead-letters
     emails the owner out-of-band; note does not. Escalation is best-effort and
     must never break the drain."""
 
     def _occupied_agent(self, monkeypatch):
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "human draft")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        # Varying draft per sweep — identical content would hit the no-penalty
+        # box_static path (#669) and never dead-letter.
+        calls = {"n": 0}
+
+        def _box(vis):
+            calls["n"] += 1
+            return f"human draft {calls['n']}"
+
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", _box)
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
 
     def _capture_email(self, monkeypatch, sink):
@@ -536,7 +706,7 @@ class TestIdempotentDelivery:
     def _patch(self, monkeypatch, deliver, scrollback):
         from agentwire import session_ready, usage_limit
         monkeypatch.setattr(usage_limit, "_capture", lambda s: "dummy screen")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
         sent = []
         monkeypatch.setattr(
@@ -652,8 +822,8 @@ class TestPurgePending:
         inbox.enqueue("s", "active", sender="x")
         inbox.enqueue("s", "passive", kind="ingest", sender="x")
         # dead-letter one
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "draft")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
         msgs = inbox.enqueue("s", "doomed", kind="done", sender="x")
         msgs[0].attempts = inbox.MAX_ATTEMPTS - 1
@@ -673,8 +843,8 @@ class TestPurgePending:
 class TestForceFlush:
     def test_force_pastes_despite_nonempty_box(self, isolate, monkeypatch):
         inbox.enqueue("s", "urgent", kind="done", sender="w")
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "draft")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
         sent = []
         monkeypatch.setattr(

--- a/tests/unit/test_msg_cli.py
+++ b/tests/unit/test_msg_cli.py
@@ -48,8 +48,14 @@ class TestDeadLister:
         from agentwire import prompt_router
 
         inbox.enqueue(session, "stuck", sender="x")
-        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s: "dummy")
-        monkeypatch.setattr(prompt_router, "input_box_content", lambda vis: "draft content")
+        monkeypatch.setattr("agentwire.usage_limit._capture", lambda s, **kw: "dummy")
+        monkeypatch.setattr(prompt_router, "capture", lambda s, p=0, **kw: "dummy")
+        # Box content must CHANGE between sweeps to keep penalizing — identical
+        # content across sweeps is the no-penalty box_static path (#669).
+        drafts = iter(f"draft content {i}" for i in range(inbox.MAX_ATTEMPTS + 1))
+        monkeypatch.setattr(
+            prompt_router, "input_box_content_sgr", lambda vis: next(drafts)
+        )
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
         for _ in range(inbox.MAX_ATTEMPTS):
             inbox.flush_session(session)


### PR DESCRIPTION
## What

Makes the polite-messaging drain immune to ghost/autosuggest text rendered inside the Claude Code input box (latent starvation hazard: every sweep returned `box_not_empty` with penalty → dead-letter in ~40 min).

- **SGR-aware box parse** — `prompt_router.input_box_content_sgr` works on a `tmux capture-pane -e` capture: content rendered entirely dim (`ESC[2m`, incl. combined `2;38;5;…` params; cleared by `0`/`22`/reset) is ghost text → box reads **empty** (deliverable). Any non-dim content is a human draft → defer, exactly as today. Every ambiguity (no parseable box, line mismatch, dim prompt glyph) degrades to the existing plain parse — the safe default never widens.
- **`prompt_is_empty` + `flush_session`** now capture with `-e` and use the SGR-aware parse.
- **`box_static` no-penalty defer** — unrecognized box content that is byte-identical across 3 consecutive drain sweeps (persisted per-recipient in `.box-state`, non-`.json` so the pending glob can't see it; cleared when the box empties) defers like `target_busy` instead of bumping attempts, so unknown future placeholders degrade to delay instead of dead-letter. Still never pastes.

## Verification

- Full suite: **2316 passed**; ruff clean.
- New tests: SGR fixtures (empty box, dim-only ghost, combined dim+color ghost, real draft, mixed dim+typed, queued placeholder, dim-glyph fallback) + box_static penalty/no-penalty/reset/clear paths. Existing dead-letter loop tests updated to vary box content per sweep (fixed content is now, by design, the no-penalty path).
- Live: SGR captures of two real Claude Code panes parse as empty via the new gate; end-to-end `enqueue` + `flush_session` to the idle orchestrator delivered first sweep (`{'delivered': 1, 'reason': 'delivered'}`).

Closes #669

Built by [dotdev.dev](https://dotdev.dev)