### PR TITLE
feat(portal): toast lifecycle — auto-fade info toasts, sticky high, quiet shim reuse

### DIFF
--- a/agentwire/channels_cli.py
+++ b/agentwire/channels_cli.py
@@ -288,7 +288,10 @@ def cmd_say(args) -> int:
     display = getattr(args, 'display', None)
     # Capture whether the toast actually reached the portal, so the caller can
     # report it honestly rather than claiming "shown" when the portal is down.
-    toast_ok = _post_desktop_notification(display, session=session, priority="high") if display else None
+    # Briefing cards are info, not action items: normal priority, but a longer
+    # fade than the 8s default since the card carries more than the spoken line.
+    toast_ok = _post_desktop_notification(display, session=session, priority="normal",
+                                          timeout=30) if display else None
 
     def _say_result(rc: int, sink: str, clients: int = 0) -> int:
         """Report which sink actually received the audio (#444): browser

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1081,17 +1081,21 @@ def _get_agentwire_path() -> str:
     return os.path.expanduser("~/.local/bin/agentwire")
 
 
-def _post_desktop_notification(text: str, session: str | None = None, priority: str = "normal") -> bool:
+def _post_desktop_notification(text: str, session: str | None = None, priority: str = "normal",
+                               timeout: float | None = None) -> bool:
     """POST a toast to the portal's desktop-notification endpoint. Best-effort.
 
     Shared by `agentwire notify-user` and the `say --display` path. Returns True
     on a 2xx, False on any failure (no portal, network error) — never raises.
+    `timeout` (seconds) overrides the frontend's auto-fade default; 0 = sticky.
     """
     import ssl
 
     body: dict = {"text": text, "priority": priority}
     if session:
         body["session"] = session
+    if timeout is not None:
+        body["timeout"] = timeout
     try:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False

--- a/agentwire/routes/desktop.py
+++ b/agentwire/routes/desktop.py
@@ -6,7 +6,6 @@ They read/write ``self.active_notifications`` and call ``self.broadcast_dashboar
 through the composed server's MRO.
 """
 
-import time
 
 from aiohttp import web
 
@@ -167,33 +166,21 @@ class DesktopRoutesMixin:
         if not text:
             return web.json_response({"success": False, "error": "text required"}, status=400)
 
-        import uuid
-        notification_id = data.get("id") or str(uuid.uuid4())[:8]
-        session = data.get("session")
-        priority = data.get("priority", "normal")
-
-        if session:
-            stale_ids = [
-                nid for nid, n in self.active_notifications.items()
-                if n.get("session") == session
-            ]
-            for nid in stale_ids:
-                self.active_notifications.pop(nid, None)
-                await self.broadcast_dashboard("notification_dismiss", {"id": nid})
-
-        notification = {
-            "id": notification_id,
-            "text": text,
-            "session": session,
-            "priority": priority,
-            "timestamp": time.time(),
-        }
-
-        self.active_notifications[notification_id] = notification
+        timeout = data.get("timeout")
+        if timeout is not None:
+            try:
+                timeout = max(0.0, float(timeout))
+            except (TypeError, ValueError):
+                timeout = None
 
         clients = len(self.dashboard_clients)
-        await self.broadcast_dashboard("notification", notification)
-        await self._fanout_push(text, session=session, priority=priority)
+        notification_id = await self._post_toast(
+            text,
+            session=data.get("session"),
+            priority=data.get("priority", "normal"),
+            notification_id=data.get("id"),
+            timeout=timeout,
+        )
 
         # Report how many dashboards saw it live. 0 isn't a failure — the toast
         # is persisted in active_notifications and restored on the next page

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -427,10 +427,14 @@ class AgentWireServer(
         try:
             success, result = await self.run_agentwire_cmd(["stt", "start"], json_output=False)
             if success:
-                await self._post_toast(
-                    "Starting host STT (Moonshine) — browser speech until ready",
-                    session="moonshine-stt", priority="normal", id_prefix="moonshine")
-                logger.info("[STT] Ensured managed Moonshine shim")
+                if "already running" in result.get("output", ""):
+                    # Reused an existing shim — nothing launched, stay quiet.
+                    logger.info("[STT] Managed Moonshine shim already running")
+                else:
+                    await self._post_toast(
+                        "Starting host STT (Moonshine) — browser speech until ready",
+                        session="moonshine-stt", priority="normal", id_prefix="moonshine")
+                    logger.info("[STT] Ensured managed Moonshine shim")
             else:
                 logger.warning("[STT] Managed shim start failed: %s", result.get("error"))
         except asyncio.CancelledError:
@@ -455,10 +459,14 @@ class AgentWireServer(
         try:
             success, result = await self.run_agentwire_cmd(["kokoro", "start"], json_output=False)
             if success:
-                await self._post_toast(
-                    "Starting host voice (Kokoro) — browser speech until ready",
-                    session="kokoro-voice", priority="normal", id_prefix="kokoro")
-                logger.info("[TTS] Ensured managed Kokoro shim")
+                if "already running" in result.get("output", ""):
+                    # Reused an existing shim — nothing launched, stay quiet.
+                    logger.info("[TTS] Managed Kokoro shim already running")
+                else:
+                    await self._post_toast(
+                        "Starting host voice (Kokoro) — browser speech until ready",
+                        session="kokoro-voice", priority="normal", id_prefix="kokoro")
+                    logger.info("[TTS] Ensured managed Kokoro shim")
             else:
                 logger.warning("[TTS] Managed shim start failed: %s", result.get("error"))
         except asyncio.CancelledError:
@@ -1783,16 +1791,26 @@ class AgentWireServer(
         except Exception as e:
             logger.warning("[Services] Autostart error: %s", e)
 
-    async def _post_toast(self, text: str, session: str, priority: str = "high",
-                          id_prefix: str = "toast") -> None:
+    async def _post_toast(self, text: str, session: str | None = None,
+                          priority: str = "normal", id_prefix: str = "toast",
+                          notification_id: str | None = None,
+                          timeout: float | None = None) -> str:
         """Post a dashboard toast notification, replacing any stale toast
-        for the same session key."""
-        notification_id = f"{id_prefix}-{str(uuid.uuid4())[:8]}"
-        stale = [nid for nid, n in self.active_notifications.items()
-                 if n.get("session") == session]
-        for nid in stale:
-            self.active_notifications.pop(nid, None)
-            await self.broadcast_dashboard("notification_dismiss", {"id": nid})
+        for the same session key. Single emit path — the HTTP endpoint
+        delegates here too.
+
+        Lifecycle contract (enforced frontend-side): ``normal`` toasts
+        auto-fade after a default timeout, ``high`` toasts stick until
+        dismissed. An explicit ``timeout`` (seconds) overrides the default;
+        0 means sticky. Returns the notification id.
+        """
+        notification_id = notification_id or f"{id_prefix}-{str(uuid.uuid4())[:8]}"
+        if session:
+            stale = [nid for nid, n in self.active_notifications.items()
+                     if n.get("session") == session]
+            for nid in stale:
+                self.active_notifications.pop(nid, None)
+                await self.broadcast_dashboard("notification_dismiss", {"id": nid})
         notification = {
             "id": notification_id,
             "text": text,
@@ -1800,9 +1818,12 @@ class AgentWireServer(
             "priority": priority,
             "timestamp": time.time(),
         }
+        if timeout is not None:
+            notification["timeout"] = timeout
         self.active_notifications[notification_id] = notification
         await self.broadcast_dashboard("notification", notification)
         await self._fanout_push(text, session=session, priority=priority)
+        return notification_id
 
     async def _notify_service_event(self, name: str, text: str, speak: bool):
         """Toast (+ optional TTS) for a service watchdog event."""

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5568,6 +5568,37 @@ body.sidebar-pinned .sidebar-tab {
     border-color: var(--error);
 }
 
+/* Transient info toasts: a thin bar drains over the auto-fade countdown so
+   it's visually obvious the toast is ephemeral. Paused on hover / hidden tab
+   (the .fading class is toggled in sync with the JS timer). */
+.notification-toast.auto-fade {
+    position: relative;
+    overflow: hidden;
+}
+
+.notification-toast.auto-fade::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 2px;
+    width: 100%;
+    background: var(--text-muted);
+    opacity: 0.5;
+    transform-origin: left;
+    transform: scaleX(1);
+}
+
+.notification-toast.auto-fade.fading::after {
+    animation: toast-fade-progress var(--fade-duration, 8s) linear forwards;
+}
+
+@keyframes toast-fade-progress {
+    to {
+        transform: scaleX(0);
+    }
+}
+
 .notification-toast-header {
     display: flex;
     align-items: center;

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -9,11 +9,17 @@ import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 
 const MAX_TOASTS = 8;
+// Lifecycle contract: `normal` toasts are transient info — they auto-fade
+// after this default (server may override per-toast via `timeout` seconds;
+// 0 = sticky). `high` toasts are actionable and stick until dismissed.
+const AUTO_FADE_SECONDS = 8;
 
 class NotificationsPanel {
     constructor() {
         /** @type {Map<string, HTMLElement>} id -> toast element */
         this.toasts = new Map();
+        /** @type {Map<string, number>} id -> auto-fade setTimeout handle */
+        this.fadeTimers = new Map();
         this.container = null;
     }
 
@@ -25,6 +31,16 @@ class NotificationsPanel {
         // Listen for notification events
         desktop.on('notification', (data) => this._addToast(data));
         desktop.on('notification_dismiss', ({ id }) => this._removeToast(id));
+
+        // Auto-fade only counts down while the tab is actually visible —
+        // a toast posted to a background tab shouldn't vanish unseen.
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                for (const [id, toast] of this.toasts) this._scheduleFade(id, toast);
+            } else {
+                for (const id of this.fadeTimers.keys()) this._cancelFade(id);
+            }
+        });
 
         // Restore active notifications on page load
         this._restore();
@@ -45,7 +61,7 @@ class NotificationsPanel {
     }
 
     _addToast(notification) {
-        const { id, text, session, priority, timestamp } = notification;
+        const { id, text, session, priority, timestamp, timeout } = notification;
         if (!id || !text) return;
 
         // Update existing toast if same id
@@ -59,10 +75,20 @@ class NotificationsPanel {
             this._removeToast(oldest, false);
         }
 
+        // Resolve auto-fade: explicit timeout wins (0 = sticky); otherwise
+        // high priority sticks and normal fades after the default.
+        let fadeSeconds = 0;
+        if (timeout !== undefined && timeout !== null) {
+            fadeSeconds = Number(timeout) || 0;
+        } else if (priority !== 'high') {
+            fadeSeconds = AUTO_FADE_SECONDS;
+        }
+
         const toast = document.createElement('div');
-        toast.className = `notification-toast${priority === 'high' ? ' high' : ''}`;
+        toast.className = `notification-toast${priority === 'high' ? ' high' : ''}${fadeSeconds ? ' auto-fade' : ''}`;
         toast.dataset.id = id;
         toast.dataset.session = session || '';
+        toast.dataset.fadeSeconds = String(fadeSeconds);
 
         const timeStr = this._formatTime(timestamp);
 
@@ -89,6 +115,10 @@ class NotificationsPanel {
             this._dismissToast(id);
         });
 
+        // Hovering pauses the auto-fade — the user is reading it.
+        toast.addEventListener('mouseenter', () => this._cancelFade(id));
+        toast.addEventListener('mouseleave', () => this._scheduleFade(id, toast));
+
         // Prepend (newest on top — CSS uses flex-direction: column-reverse)
         this.container.appendChild(toast);
 
@@ -96,9 +126,39 @@ class NotificationsPanel {
         requestAnimationFrame(() => toast.classList.add('visible'));
 
         this.toasts.set(id, toast);
+        this._scheduleFade(id, toast);
+    }
+
+    /**
+     * (Re)start the auto-fade countdown for a transient toast. No-op for
+     * sticky toasts (fadeSeconds 0) or while the tab is hidden. Restarts the
+     * full duration on resume/unhover — simple beats precise here. Fading
+     * routes through _dismissToast: the toast sat on a visible dashboard for
+     * its whole countdown, so the dismissal is persisted server-side.
+     */
+    _scheduleFade(id, toast) {
+        const seconds = Number(toast.dataset.fadeSeconds) || 0;
+        if (!seconds || document.visibilityState !== 'visible') return;
+        this._cancelFade(id);
+        this.fadeTimers.set(id, setTimeout(() => this._dismissToast(id), seconds * 1000));
+        // Restart the fade-progress cue in sync with the timer.
+        toast.style.setProperty('--fade-duration', `${seconds}s`);
+        toast.classList.remove('fading');
+        requestAnimationFrame(() => toast.classList.add('fading'));
+    }
+
+    _cancelFade(id) {
+        const timer = this.fadeTimers.get(id);
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            this.fadeTimers.delete(id);
+        }
+        const toast = this.toasts.get(id);
+        if (toast) toast.classList.remove('fading');
     }
 
     _removeToast(id, animate = true) {
+        this._cancelFade(id);
         const toast = this.toasts.get(id);
         if (!toast) return;
 


### PR DESCRIPTION
## What

Two-tier toast lifecycle for the portal notification system:

- **Normal-priority toasts auto-fade** after 8s with a thin draining progress bar; hovering pauses the countdown, and it only runs while the tab is visible so a toast posted to a background tab is never lost unseen. The fade persists the dismissal server-side (no resurrection on reload).
- **High-priority toasts stay sticky** until explicitly dismissed (service-down watchdog, first-message-failed, `notify_user --priority high`).
- **Per-toast `timeout` override** (seconds; 0 = sticky) flows CLI → endpoint → frontend.
- **Shim startup toasts silenced on reuse**: the portal parses the idempotent `stt/kokoro start` output and only toasts when a shim actually launched — portal restarts no longer look like duplicate processes spawning.
- **Single emit path**: `/api/desktop/notification` now delegates to `_post_toast` instead of duplicating dedup/store/broadcast/push; priority defaults reconciled to `normal`.
- **`say --display` briefing cards**: normal priority with a 30s fade (info, not action items).

## Verification

Full suite: 2346 passed. Verified live: rebuild + portal restart produced no shim toasts (reuse path).

Built by [dotdev.dev](https://dotdev.dev)