### PR TITLE
fix(safety): stop AGENTWIRE_UNATTENDED leaking into the shared tmux server

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -78,12 +78,36 @@ class AgentCommand:
 _UNATTENDED_ENV_KEYS = ("AGENTWIRE_UNATTENDED", "AGENTWIRE_UNATTENDED_ALLOW")
 
 
+def _capture_unattended_env() -> dict[str, str]:
+    """Pop the unattended marker OUT of this process's environment.
+
+    The marker must reach new sessions only via the deliberate
+    ``tmux new-session -e K=V`` path (``_with_unattended_env`` below). If it
+    stays in ``os.environ``, a ``tmux`` client we spawn while no server is
+    running boots the shared tmux server WITH the marker in its process env,
+    and from then on every session that server creates — interactive human
+    sessions included — inherits it and gets falsely treated as unattended
+    (#674). Capturing at import time preserves intended propagation while
+    guaranteeing no child process of the CLI can inherit the raw var.
+    """
+    captured: dict[str, str] = {}
+    for key in _UNATTENDED_ENV_KEYS:
+        val = os.environ.pop(key, None)
+        if val:
+            captured[key] = val
+    return captured
+
+
+_UNATTENDED_ENV = _capture_unattended_env()
+
+
 def _with_unattended_env(env: dict[str, str]) -> dict[str, str]:
     """Propagate the unattended marker into a session being created.
 
     The scheduler is the single place that decides a dispatch is unattended —
     it seeds ``AGENTWIRE_UNATTENDED[=1]`` (and any per-task
-    ``AGENTWIRE_UNATTENDED_ALLOW``) into the dispatch subprocess environment.
+    ``AGENTWIRE_UNATTENDED_ALLOW``) into the dispatch subprocess environment,
+    captured here at import (see ``_capture_unattended_env``).
     Every session-creation path funnels its env through here on the way to
     ``tmux new-session -e K=V``, so the marker lands in the new session BEFORE
     the agent launches and the damage-control hook can read it. A child session
@@ -94,7 +118,7 @@ def _with_unattended_env(env: dict[str, str]) -> dict[str, str]:
     """
     merged = dict(env)
     for key in _UNATTENDED_ENV_KEYS:
-        val = os.environ.get(key)
+        val = _UNATTENDED_ENV.get(key)
         if val and key not in merged:
             merged[key] = val
     return merged

--- a/tests/unit/test_unattended_env_isolation.py
+++ b/tests/unit/test_unattended_env_isolation.py
@@ -1,0 +1,90 @@
+"""Unattended-marker isolation (#674).
+
+The scheduler stamps AGENTWIRE_UNATTENDED=1 on the dispatch subprocess. If
+that var stays in the CLI's os.environ, a tmux client that boots the shared
+tmux server leaks it into the server process — after which EVERY session the
+server spawns (interactive ones included) is falsely treated as unattended.
+
+core.py therefore pops the marker out of os.environ at import into a captured
+module-level dict; propagation into new sessions happens only via the
+deliberate `tmux new-session -e` path.
+"""
+
+import os
+import subprocess
+import sys
+
+from agentwire import core
+
+
+class TestCaptureUnattendedEnv:
+    def test_pops_marker_out_of_environ(self, monkeypatch):
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED", "1")
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED_ALLOW", "task.rule-a")
+        captured = core._capture_unattended_env()
+        assert captured == {
+            "AGENTWIRE_UNATTENDED": "1",
+            "AGENTWIRE_UNATTENDED_ALLOW": "task.rule-a",
+        }
+        assert "AGENTWIRE_UNATTENDED" not in os.environ
+        assert "AGENTWIRE_UNATTENDED_ALLOW" not in os.environ
+
+    def test_empty_when_not_dispatched_unattended(self, monkeypatch):
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED", raising=False)
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED_ALLOW", raising=False)
+        assert core._capture_unattended_env() == {}
+
+
+class TestWithUnattendedEnv:
+    def test_reads_captured_copy_not_environ(self, monkeypatch):
+        # Marker in os.environ alone (the leak vector) must NOT propagate...
+        monkeypatch.setenv("AGENTWIRE_UNATTENDED", "1")
+        monkeypatch.setattr(core, "_UNATTENDED_ENV", {})
+        assert "AGENTWIRE_UNATTENDED" not in core._with_unattended_env({})
+
+        # ...while the captured copy (a real scheduler dispatch) does.
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED")
+        monkeypatch.setattr(
+            core, "_UNATTENDED_ENV",
+            {"AGENTWIRE_UNATTENDED": "1", "AGENTWIRE_UNATTENDED_ALLOW": "x.y"},
+        )
+        merged = core._with_unattended_env({"FOO": "bar"})
+        assert merged["AGENTWIRE_UNATTENDED"] == "1"
+        assert merged["AGENTWIRE_UNATTENDED_ALLOW"] == "x.y"
+        assert merged["FOO"] == "bar"
+
+    def test_explicit_env_wins_over_captured(self, monkeypatch):
+        monkeypatch.setattr(core, "_UNATTENDED_ENV", {"AGENTWIRE_UNATTENDED": "1"})
+        merged = core._with_unattended_env({"AGENTWIRE_UNATTENDED": "0"})
+        assert merged["AGENTWIRE_UNATTENDED"] == "0"
+
+    def test_tmux_env_flags_carry_captured_marker(self, monkeypatch):
+        monkeypatch.setattr(core, "_UNATTENDED_ENV", {"AGENTWIRE_UNATTENDED": "1"})
+        flags = core._build_tmux_env_flags({})
+        assert flags == ["-e", "AGENTWIRE_UNATTENDED=1"]
+
+
+class TestImportScrubsEnviron:
+    def test_fresh_process_import_scrubs_marker(self):
+        """End to end: a process started with the marker (like a scheduler's
+        `agentwire ensure` dispatch) drops it from os.environ on import, so
+        any tmux server it boots can't inherit it — but keeps the captured
+        copy for deliberate `-e` propagation."""
+        env = dict(os.environ)
+        env["AGENTWIRE_UNATTENDED"] = "1"
+        env["AGENTWIRE_UNATTENDED_ALLOW"] = "task.rule"
+        code = (
+            "import os\n"
+            "from agentwire import core\n"
+            "assert 'AGENTWIRE_UNATTENDED' not in os.environ\n"
+            "assert 'AGENTWIRE_UNATTENDED_ALLOW' not in os.environ\n"
+            "assert core._UNATTENDED_ENV['AGENTWIRE_UNATTENDED'] == '1'\n"
+            "assert core._UNATTENDED_ENV['AGENTWIRE_UNATTENDED_ALLOW'] == 'task.rule'\n"
+            "m = core._with_unattended_env({})\n"
+            "assert m['AGENTWIRE_UNATTENDED'] == '1'\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], env=env,
+            capture_output=True, text=True, timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Root cause

The scheduler stamps `AGENTWIRE_UNATTENDED=1` on the dispatch subprocess (`agentwire ensure`). If that dispatch's `tmux` client runs while no tmux server exists, it **boots the shared server with the marker in the server's process env**. From then on every session the server spawns — interactive human sessions included — inherits the marker by plain process inheritance, bypassing the deliberate `_with_unattended_env` → `tmux new-session -e` propagation path. All ask-tier damage-control rules then fail closed for a human sitting right there, plus owner-email noise. Invisible to `tmux show-environment`.

## Fix

`core.py` now pops `AGENTWIRE_UNATTENDED` / `AGENTWIRE_UNATTENDED_ALLOW` out of `os.environ` at import into a captured module-level dict (`_capture_unattended_env`). `_with_unattended_env` reads the captured copy, so:

- Intended propagation is unchanged: scheduler dispatches still stamp new sessions via `tmux new-session -e K=V` before the agent launches.
- No child process of the CLI — including a freshly booted tmux server — can inherit the raw var.
- Damage-control hooks are untouched: they run in the agent's process tree and read the env the tmux session gave them.

## Verification

- New `tests/unit/test_unattended_env_isolation.py`: capture pops+returns, `_with_unattended_env` reads captured copy not environ, explicit env wins, `-e` flags carry the marker, and an end-to-end fresh-subprocess import check (marker gone from environ, kept in captured dict).
- Full suite in-worktree: **2352 passed**.

Note for already-poisoned machines: `tmux set-environment -gr AGENTWIRE_UNATTENDED` cleans new panes without a server restart. Doctor drift-check and per-session marker-file redesign left as follow-ups.

Closes #674

Built by [dotdev.dev](https://dotdev.dev)