### PR TITLE
fix(stt): --no-stt fully disables STT — stop leftover shim, report 'none' tier

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -446,6 +446,26 @@ class AgentWireServer(
             # shim's /health and surfaces server_transcribe promptly.
             self._voice_status_cache = None
 
+    async def stop_managed_stt(self) -> None:
+        """Stop the managed Moonshine shim when server STT is disabled.
+
+        ``--no-stt`` / ``stt.backend: none`` must actually silence the ``:8101``
+        shim, not just skip spawning a new one (#679) — otherwise a shim left
+        over from a previous portal run keeps serving. Delegates to the CLI
+        (single source of truth): ``agentwire stt stop`` kills the
+        ``agentwire-stt`` tmux session and is a quiet no-op (exit 1,
+        "not running") when there is nothing to stop.
+        """
+        try:
+            success, result = await self.run_agentwire_cmd(["stt", "stop"], json_output=False)
+            if success:
+                logger.info("[STT] Stopped managed Moonshine shim (STT disabled)")
+            # Failure here almost always means "not running" — nothing to do.
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("[STT] Managed shim stop error: %s", e)
+
     async def ensure_managed_tts(self) -> None:
         """Ensure the default-tier Kokoro TTS shim subprocess is running.
 
@@ -2964,6 +2984,10 @@ async def run_server(config: Config):
 
     if config.stt.backend == "default" and moonshine_importable():
         asyncio.create_task(server.ensure_managed_stt())
+    elif config.stt.backend == "none":
+        # --no-stt / stt.backend: none — actually turn STT off: stop a shim
+        # left running by a previous portal, don't just skip the spawn (#679).
+        asyncio.create_task(server.stop_managed_stt())
 
     # Cleanup old uploads on startup
     await server.cleanup_old_uploads()

--- a/agentwire/voice_status.py
+++ b/agentwire/voice_status.py
@@ -201,18 +201,65 @@ def resolve_tts_status(config: Any | None = None, *, probe: bool = True) -> Voic
 # === STT ===================================================================
 
 
+def _portal_effective_stt_backend() -> str | None:
+    """The RUNNING portal's effective ``stt.backend``, or None if unreachable.
+
+    ``--no-stt`` is a runtime override — it flips the portal process's config
+    to ``backend: none`` without touching ``config.yaml``, so status surfaces
+    reading the file alone would still report "default" (#679). The portal's
+    ``/api/voice-status`` reports its post-override config; ask it and let the
+    live answer win. Fail-open (return None) when the portal isn't running.
+    """
+    try:
+        from .core import _get_portal_url, portal_request
+        resp = portal_request("GET", f"{_get_portal_url()}/api/voice-status", timeout=2)
+        if resp.ok:
+            return (resp.json().get("stt") or {}).get("backend")
+    except Exception:
+        pass
+    return None
+
+
 def resolve_stt_status(config: Any | None = None, *, probe: bool = True) -> VoiceStatus:
     """Resolve the active STT path.
 
-    ``cloud`` uploads audio to an OpenAI-compatible API server-side — no shim,
-    so readiness is "is the API key set". ``default`` transcribes via the
-    portal-managed Moonshine ``:8101`` shim when Moonshine is importable, else
-    falls back to in-browser SpeechRecognition (no host shim to probe).
-    ``custom`` uploads to the configured shim, which is probed.
+    ``none`` means server STT is disabled (``stt.backend: none`` or the portal
+    was started with ``--no-stt``) — browser SpeechRecognition still works
+    client-side. ``cloud`` uploads audio to an OpenAI-compatible API
+    server-side — no shim, so readiness is "is the API key set". ``default``
+    transcribes via the portal-managed Moonshine ``:8101`` shim when Moonshine
+    is importable, else falls back to in-browser SpeechRecognition (no host
+    shim to probe). ``custom`` uploads to the configured shim, which is probed.
     """
     cfg = _load_typed_config(config)
     stt = getattr(cfg, "stt", None)
     tier = getattr(stt, "backend", "default") if stt is not None else "default"
+
+    # A running portal's effective backend beats the file: --no-stt only
+    # exists inside the portal process (#679).
+    if probe and tier != "none":
+        live = _portal_effective_stt_backend()
+        if live == "none":
+            tier = "none"
+
+    if tier == "none":
+        from .stt import DEFAULT_STT_URL
+
+        warnings: list[str] = []
+        if probe:
+            url = getattr(stt, "url", None) or DEFAULT_STT_URL
+            up, _ = _probe(url)
+            if up:
+                warnings.append(
+                    f"an STT shim is up at {url} but server STT is disabled — "
+                    f"it is unused (stop it: agentwire stt stop)."
+                )
+        return VoiceStatus(
+            "stt", "none", "server STT disabled (browser SpeechRecognition only)",
+            True,
+            "STT disabled (stt.backend 'none' or portal --no-stt)",
+            warnings=warnings,
+        )
 
     if tier == "cloud":
         cloud = getattr(stt, "cloud", None) or {}

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -970,6 +970,32 @@ class TestEnsureManagedStt:
         assert moonshine_importable() is True
 
 
+class TestStopManagedStt:
+    """--no-stt must stop a shim left running by a previous portal (#679)."""
+
+    async def test_delegates_to_stt_stop_cli(self, portal_client):
+        client, server = portal_client
+        calls = []
+
+        async def fake_cmd(args, json_output=True):
+            calls.append((args, json_output))
+            return True, {"output": "STT server stopped."}
+
+        server.run_agentwire_cmd = fake_cmd
+        await server.stop_managed_stt()
+        assert calls == [(["stt", "stop"], False)]
+
+    async def test_not_running_is_soft(self, portal_client):
+        client, server = portal_client
+
+        async def fake_cmd(args, json_output=True):
+            return False, {"error": "STT server is not running."}
+
+        server.run_agentwire_cmd = fake_cmd
+        # Must not raise — nothing to stop is the common case.
+        await server.stop_managed_stt()
+
+
 # ---------------------------------------------------------------------------
 # CLI overrides (--no-stt / --no-tts) — apply_cli_overrides
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_voice_status.py
+++ b/tests/unit/test_voice_status.py
@@ -7,7 +7,16 @@ flag an orphaned engine server (running but unused).
 
 from types import SimpleNamespace
 
+import pytest
+
 import agentwire.voice_status as vs
+
+
+@pytest.fixture(autouse=True)
+def _no_live_portal(monkeypatch):
+    """Keep the resolver off the network: no running portal unless a test
+    overrides this (the #679 effective-backend query)."""
+    monkeypatch.setattr(vs, "_portal_effective_stt_backend", lambda: None)
 
 
 def _cfg(tts_backend="default", tts_url=None, stt_backend="default",
@@ -102,3 +111,62 @@ def test_stt_default_probes_shim_when_moonshine_present(monkeypatch):
     assert st.ready is True
     assert st.server_url is not None
     assert "8101" in st.server_url
+
+
+# === STT disabled (none tier, #679) ========================================
+
+
+def test_stt_none_reports_disabled(monkeypatch):
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "refused"))
+    st = vs.resolve_stt_status(_cfg(stt_backend="none"))
+    assert st.tier == "none"
+    assert st.ready is True
+    assert st.server_url is None
+    assert "disabled" in st.detail.lower()
+    assert st.warnings == []
+
+
+def test_stt_none_flags_orphan_shim(monkeypatch):
+    """A shim still answering on :8101 while STT is disabled is an orphan."""
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
+    st = vs.resolve_stt_status(_cfg(stt_backend="none"))
+    assert st.tier == "none"
+    assert any("unused" in w for w in st.warnings)
+
+
+def test_stt_none_skips_probe_when_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(vs, "_probe", lambda *a, **k: calls.append(1) or (True, None))
+    st = vs.resolve_stt_status(_cfg(stt_backend="none"), probe=False)
+    assert st.tier == "none"
+    assert calls == []
+
+
+def test_stt_portal_runtime_no_stt_wins_over_config(monkeypatch):
+    """`portal start --no-stt` flips the RUNNING portal's backend to none
+    without touching config.yaml — the live answer must win (#679)."""
+    monkeypatch.setattr(vs, "_portal_effective_stt_backend", lambda: "none")
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (False, "refused"))
+    st = vs.resolve_stt_status(_cfg(stt_backend="default"))
+    assert st.tier == "none"
+    assert "disabled" in st.detail.lower()
+
+
+def test_stt_portal_unreachable_falls_back_to_config(monkeypatch):
+    monkeypatch.setattr(vs, "_portal_effective_stt_backend", lambda: None)
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    monkeypatch.setattr(vs, "_probe", lambda url, endpoint="/health", timeout=2.0: (True, None))
+    st = vs.resolve_stt_status(_cfg(stt_backend="default"))
+    assert st.tier == "default"
+
+
+def test_stt_no_portal_query_when_probe_off(monkeypatch):
+    """probe=False must not hit the portal either (used by fast paths)."""
+    def boom():
+        raise AssertionError("portal queried with probe=False")
+    monkeypatch.setattr(vs, "_portal_effective_stt_backend", boom)
+    import agentwire.stt as stt_mod
+    monkeypatch.setattr(stt_mod, "moonshine_importable", lambda: True)
+    st = vs.resolve_stt_status(_cfg(stt_backend="default"), probe=False)
+    assert st.tier == "default"


### PR DESCRIPTION
## What

Completes the `--no-stt` fix started in #652 (which only gated the spawn):

- **Stop, not just skip**: `run_server` now calls `agentwire stt stop` (CLI SSOT, quiet no-op when nothing is running) when `stt.backend == "none"`, so a Moonshine shim left over from a previous portal run stops serving on :8101.
- **Status honesty**: `resolve_stt_status` gets a `none` tier branch — reports "server STT disabled (browser SpeechRecognition only)" and warns about an orphaned shim still answering.
- **Runtime flag visibility**: `--no-stt` never touches `config.yaml`, so `stt_status`/`doctor` used to keep reporting "default". The resolver now asks the running portal's `/api/voice-status` for its effective backend (2s timeout, fail-open to config).

## Verification

- Full suite in-worktree: 2354 passed.
- New unit tests: `none` tier reporting + orphan warning, portal-effective-backend override + fallback, `stop_managed_stt` delegation + soft-failure.
- Live check (`portal start --dev --no-stt` → no :8101 listener, `stt_status` disabled) needs a portal restart — deferred to post-merge, per worktree isolation rules.

Closes #679

Built by [dotdev.dev](https://dotdev.dev)