### PR TITLE
fix(safety): close Bash-hook bypasses on protected control-plane files

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -121,6 +121,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -416,7 +435,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -806,7 +829,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -117,6 +117,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -412,7 +431,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -802,7 +825,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -129,6 +129,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -424,7 +443,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -814,7 +837,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -123,6 +123,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -418,7 +437,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -808,7 +831,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -116,6 +116,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -411,7 +430,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -801,7 +824,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -85,6 +85,25 @@ READ_ONLY_BLOCKED = (
 
 NO_DELETE_BLOCKED = DELETE_PATTERNS
 
+# Interpreter programs can write a file without any shell-level write token:
+# ``python3 -c 'open(p, "w")...'``, a heredoc piped into ``python -``, or
+# ``echo 'open(p,"w")' | python3``. The program text is opaque to static
+# matching, so for PROTECTED control-plane paths we fail closed: an interpreter
+# invocation that takes inline code (-c/-e, combined forms like ``perl -pie``),
+# a heredoc/stdin program, or has data piped into it, AND mentions a protected
+# path anywhere in the command, is blocked (#678). Applied ONLY by
+# ``check_protected_command`` — never to user readOnlyPaths rules — so a
+# legitimate read via ``cat``/``grep`` stays allowed.
+_INTERPRETERS = r'(?:python[\d.]*|perl|ruby|node|deno|bun|php)'
+INTERPRETER_WRITE_PATTERNS = [
+    # interpreter ... -c/-e/... or stdin/heredoc marker, path anywhere after
+    (r'\b' + _INTERPRETERS +
+     r'\b[^\n|;&]*(?:\s-\S*[ceE]\b|\s+-\s|\s+-$|<<)(?s:.*){path}',
+     "interpreter program"),
+    # path anywhere before a pipe into an interpreter
+    (r'{path}(?s:.*)\|\s*' + _INTERPRETERS + r'\b', "pipe into interpreter"),
+]
+
 
 # ============================================================================
 # GLOB / PATH HELPERS
@@ -380,7 +399,11 @@ def check_path_patterns(
     Returns ``(matched, reason)`` where reason names the operation that triggered.
     """
     if is_glob_pattern(path):
-        path_regex = glob_to_regex(path)
+        # Allow an optional (possibly quoted) directory prefix: ``*`` in the
+        # glob can't span ``/``, so without this a basename glob like
+        # ``*.agentwire.yml`` never matched an absolute target
+        # (``> /repo/.agentwire.yml`` sailed past every write pattern) (#678).
+        path_regex = r'["\']?(?:[^\s"\';|&<>]*/)?' + glob_to_regex(path)
     else:
         expanded = os.path.expanduser(path)
         if expanded == path:
@@ -770,7 +793,10 @@ def check_protected_command(
     for path in _protected_path_patterns():
         for hay in haystacks:
             matched, reason = check_path_patterns(
-                hay, path, READ_ONLY_BLOCKED, "protected control-plane path"
+                hay,
+                path,
+                READ_ONLY_BLOCKED + INTERPRETER_WRITE_PATTERNS,
+                "protected control-plane path",
             )
             if matched:
                 op = _infer_operation_from_reason(reason)

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -112,7 +112,42 @@ BASH_WRITES = [
     "rm ~/.agentwire/damage-control/core.yaml",
     "sed -i 's/x/y/' ~/.agentwire/hooks/damage-control/bash-tool-damage-control.py",
     "echo 'enabled: false' > .damagecontrol.yml",
+    # #678 — absolute-path targets: basename globs (*.agentwire.yml) must
+    # match through a directory prefix, not just the bare relative form.
+    "echo x >> /some/repo/.agentwire.yml",
+    "echo x > /some/repo/.agentwire.yml",
+    'sed -i "s/a/b/" /some/repo/.agentwire.yml',
+    "cp /tmp/x /some/repo/.agentwire.yml",
+    "mv /tmp/x /some/repo/.agentwire.yml",
+    'tee "/some/repo/.agentwire.yml" < /tmp/x',
+    # #678 — interpreter programs are opaque; fail closed when an inline/
+    # stdin/piped interpreter invocation mentions a protected path.
+    "python3 -c 'open(\".agentwire.yml\", \"w\").write(\"x\")'",
+    "python3 -c 'open(\"/some/repo/.agentwire.yml\", \"a\").write(\"x\")'",
+    "perl -e 'open(F, \">\", \".agentwire.yml\")'",
+    "python3 - <<'EOF'\nopen('/some/repo/.agentwire.yml', 'w').write('x')\nEOF",
+    "echo 'open(\".agentwire.yml\",\"w\")' | python3",
 ]
+
+# Write-shaped-looking but innocent: mentioning the filename in quoted
+# CONTENT (an issue body, a commit message) must NOT block (#675 posture),
+# and plain reads stay allowed.
+BASH_INNOCENT = [
+    'gh issue create --title "bug" --body "edit your .agentwire.yml to fix"',
+    'git commit -m "docs: mention .agentwire.yml"',
+    "cat .agentwire.yml",
+    "grep roles /some/repo/.agentwire.yml",
+    "python3 -m pytest tests/unit",
+]
+
+
+@pytest.mark.parametrize("command", BASH_INNOCENT)
+def test_innocent_mention_or_read_not_blocked(cfg, command):
+    result = check_command(command, cfg)
+    # Some of these hit ordinary ask-tier rules (gh/git) — that's fine; the
+    # assertion is that the PROTECTED control-plane gate doesn't fire.
+    assert result["decision"] != "block", command
+    assert result.get("protected") is not True, command
 
 
 @pytest.mark.parametrize("command", BASH_WRITES)


### PR DESCRIPTION
Closes #678

## Root cause (verified in-worktree)

The Bash-side protected gate (`check_protected_command`) existed but had two holes:

1. **Absolute-path targets slipped past basename globs.** `check_path_patterns` compiled `*.agentwire.yml` to a regex whose `*` can't span `/`, so `echo x > /repo/<project config>`, `mv`/`cp` onto it, etc. matched nothing — only the bare relative form blocked. Fixed by allowing an optional (quoted) directory prefix in the glob branch.
2. **Interpreter programs had zero coverage.** `python3 -c 'open(p, "w")…'`, heredoc/stdin programs, and `echo code | python3` carry no shell-level write token. New `INTERPRETER_WRITE_PATTERNS` fail closed when an inline/stdin/piped interpreter invocation mentions a protected path — applied only in `check_protected_command`, so plain reads (`cat`, `grep`) and filename mentions in quoted content (`gh issue create` bodies, per #675) are unaffected.

On the dispatch-snapshot scope item: the unattended allowlist is already stamped into env at dispatch (`_unattended_env`), so a mid-run self-grant never affects the running task; closing the write path closes the escalation for future runs too.

## Verification

- Reproduced every bypass pre-fix via `check_protected_command` probe; all block post-fix, reads/incidental mentions still allow.
- Hook scripts regenerated via `scripts/regen_damage_control_hooks.py` (sync test guards drift).
- Full suite in-worktree: **2384 passed**.

Built by [dotdev.dev](https://dotdev.dev)