### PR TITLE
fix(safety): anchor command-prefix rules so quoted content can't false-match (#675)

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -507,6 +507,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -944,6 +947,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -1029,9 +1191,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1051,8 +1216,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -503,6 +503,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -940,6 +943,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -1025,9 +1187,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1047,8 +1212,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -515,6 +515,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -952,6 +955,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -1037,9 +1199,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1059,8 +1224,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -509,6 +509,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -946,6 +949,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -1031,9 +1193,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1053,8 +1218,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/rules/git.yaml
+++ b/agentwire/hooks/damage-control/rules/git.yaml
@@ -7,28 +7,36 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bgit\s+reset\s+--hard\b'
     reason: git reset --hard (use --soft or stash)
+    anchored: true
 
   - pattern: '\bgit\s+clean\s+(-[^\s]*)*-[fd]'
     reason: git clean with force/directory flags
+    anchored: true
 
   # Note: This blocks --force but NOT --force-with-lease
   - pattern: '\bgit\s+push\s+.*--force(?!-with-lease)'
     reason: git push --force (use --force-with-lease)
+    anchored: true
 
   - pattern: '\bgit\s+push\s+(-[^\s]*)*-f\b'
     reason: git push -f (use --force-with-lease)
+    anchored: true
 
   - pattern: '\bgit\s+stash\s+clear\b'
     reason: git stash clear (deletes ALL stashes)
+    anchored: true
 
   - pattern: '\bgit\s+reflog\s+expire\b'
     reason: git reflog expire (destroys recovery mechanism)
+    anchored: true
 
   - pattern: '\bgit\s+gc\s+.*--prune=now'
     reason: git gc --prune=now (can lose dangling commits)
+    anchored: true
 
   - pattern: '\bgit\s+filter-branch\b'
     reason: git filter-branch (rewrites entire history)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # GIT OPERATIONS REQUIRING CONFIRMATION (ask: true)
@@ -36,23 +44,29 @@ bashToolPatterns:
   - pattern: '\bgit\s+checkout\s+--\s*\.'
     reason: Discards all uncommitted changes
     ask: true
+    anchored: true
 
   - pattern: '\bgit\s+restore\s+\.'
     reason: Discards all uncommitted changes
     ask: true
+    anchored: true
 
   - pattern: '\bgit\s+stash\s+drop\b'
     reason: Permanently deletes a stash
     ask: true
+    anchored: true
 
   - pattern: '\bgit\s+branch\s+(-[^\s]*)*-D'
     reason: Force deletes branch (even if unmerged)
     ask: true
+    anchored: true
 
   - pattern: '\bgit\s+push\s+\S+\s+--delete\b'
     reason: Deletes remote branch
     ask: true
+    anchored: true
 
   - pattern: '\bgit\s+push\s+\S+\s+:\S+'
     reason: Deletes remote branch (old syntax)
     ask: true
+    anchored: true

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -502,6 +502,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -939,6 +942,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -1024,9 +1186,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1046,8 +1211,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -471,6 +471,9 @@ def load_write_patterns_from_tooldefs(tooldefs_dir: Optional[Path]) -> List[Dict
                     "pattern": regex,
                     "reason": f"{tool_name}: {cmd_def.get('description', cmd_str)}",
                     "ask": True,
+                    # Command-prefix rule: match command position only, never
+                    # quoted argument/message content (#675).
+                    "anchored": True,
                 }
                 # An explicit ``id:`` on the tooldef command yields a stable
                 # rule ID (e.g. ``git.push``) that survives description edits —
@@ -908,6 +911,165 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
     return subs, None
 
 
+#
+# CONTENT MASKING (#675)
+#
+# Tooldef rules are COMMAND-PREFIX rules (``\bgh\s+pr\s+comment\b``), but the
+# haystacks above include quoted argument text — so a commit message that
+# merely *mentions* "gh pr comment" false-matches the rule. Anchored rules are
+# therefore matched against MASKED subcommands instead: quoted spans that can
+# only be content (a quoted token containing whitespace — a message, an echo
+# string, a heredoc body) are replaced with a placeholder, while quoted
+# single words are kept (``"gh" pr comment`` is still a real command) and
+# ``sh -c "…"`` payloads are recursively re-scanned as commands.
+
+_MASK = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+_ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
+    m = _HEREDOC_RE.search(command)
+    if not m:
+        return command
+    delim = m.group(2)
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return command
+    lines = command[nl + 1:].split("\n")
+    for i, line in enumerate(lines):
+        if line.strip() == delim:
+            rest = "\n".join(lines[i + 1:])
+            return command[:nl + 1] + _strip_heredoc_bodies(rest)
+    # Unterminated heredoc: everything after the marker is body.
+    return command[:nl + 1]
+
+
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
+    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+
+    Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
+    ``fully_quoted`` is True when no character of the token was unquoted.
+    """
+    subs: List[List[Tuple[str, bool]]] = []
+    cur: List[Tuple[str, bool]] = []
+    buf: List[str] = []
+    has_unquoted = False
+    has_any = False
+
+    def end_token() -> None:
+        nonlocal buf, has_unquoted, has_any
+        if has_any:
+            cur.append(("".join(buf), not has_unquoted))
+        buf, has_unquoted, has_any = [], False, False
+
+    def end_sub() -> None:
+        nonlocal cur
+        end_token()
+        if cur:
+            subs.append(cur)
+            cur = []
+
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "'":
+            j = command.find("'", i + 1)
+            if j == -1:
+                j = n
+            buf.append(command[i + 1:j])
+            has_any = True
+            i = j + 1
+        elif c == '"':
+            j = i + 1
+            out: List[str] = []
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n and command[j + 1] in '"\\$`':
+                    out.append(command[j + 1])
+                    j += 2
+                else:
+                    out.append(command[j])
+                    j += 1
+            buf.append("".join(out))
+            has_any = True
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            buf.append(command[i + 1])
+            has_unquoted = True
+            has_any = True
+            i += 2
+        elif c in " \t":
+            end_token()
+            i += 1
+        elif c in ";\n":
+            end_sub()
+            i += 1
+        elif c in "&|":
+            end_sub()
+            while i < n and command[i] in "&|":
+                i += 1
+        else:
+            buf.append(c)
+            has_unquoted = True
+            has_any = True
+            i += 1
+    end_sub()
+    return subs
+
+
+def masked_subcommands(command: str) -> List[str]:
+    """Return per-subcommand strings with content-only quoted spans masked.
+
+    Used for command-prefix (``anchored``) rules so quoted argument text —
+    commit messages, echo strings, heredoc bodies — cannot false-match a
+    command rule, while quoting obfuscation of the command itself still
+    normalizes to the literal form.
+    """
+    command = _strip_heredoc_bodies(command)
+
+    assigns: Dict[str, str] = {}
+    for m in _ASSIGN_RE.finditer(command):
+        assigns[m.group(1)] = m.group(2).strip("'\"")
+
+    def _resolve(tok: str) -> str:
+        for name, val in assigns.items():
+            tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
+        return tok
+
+    results: List[str] = []
+    for toks in _scan_masked_tokens(command):
+        words: List[str] = []
+        prev = ""
+        for text, fully_quoted in toks:
+            resolved = _resolve(text)
+            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            if not words and _ASSIGN_TOKEN_RE.match(resolved):
+                # Leading VAR=value assignment — its value is data here (the
+                # assigns table already handles later ``$VAR`` expansion).
+                words.append(_MASK)
+                prev = _MASK
+                continue
+            if is_content:
+                # A ``sh -c "…"`` payload is a command, not content — rescan.
+                if (
+                    words
+                    and prev.startswith("-")
+                    and "c" in prev
+                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                ):
+                    results.extend(masked_subcommands(resolved))
+                words.append(_MASK)
+                prev = _MASK
+            else:
+                words.append(resolved)
+                prev = resolved
+        if words and any(w != _MASK for w in words):
+            results.append(" ".join(words))
+    return results
+
+
 # ============================================================================
 # DECISION LADDERS
 # ============================================================================
@@ -993,9 +1155,12 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # ``ask`` at the end (the unattended resolver turns that into a block).
     subcommands, ambiguous = normalize_subcommands(command)
     haystacks = [command] + [s for s in subcommands if s and s != command]
+    # Anchored (command-prefix) rules match only masked subcommands, so quoted
+    # argument text — commit messages, echo strings — can't false-match (#675).
+    masked_haystacks = masked_subcommands(command)
 
-    def _search(pat: str) -> bool:
-        for hay in haystacks:
+    def _search(pat: str, hays: List[str]) -> bool:
+        for hay in hays:
             try:
                 if re.search(pat, hay, re.IGNORECASE):
                     return True
@@ -1015,8 +1180,9 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         reason = pattern_obj.get("reason", "Matched pattern")
         should_ask = pattern_obj.get("ask", False)
         bypassable = pattern_obj.get("bypassable", False)
+        anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern):
+            if _search(pattern, masked_haystacks if anchored else haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -149,6 +149,97 @@ class TestBashHookCheckCommand:
 
 
 # ---------------------------------------------------------------------------
+# bash-tool-damage-control.py: anchored (command-prefix) rules — #675
+# ---------------------------------------------------------------------------
+
+
+class TestAnchoredRules:
+    """Anchored rules match command position only, never quoted content."""
+
+    GH_RULE = {
+        "pattern": r"\bgh\s+pr\s+comment\b",
+        "reason": "GitHub CLI: Add a comment to a PR",
+        "ask": True,
+        "anchored": True,
+    }
+
+    @staticmethod
+    def _config(patterns):
+        return {
+            "bashToolPatterns": patterns,
+            "zeroAccessPaths": [],
+            "readOnlyPaths": [],
+            "noDeletePaths": [],
+            "allowedPaths": [],
+        }
+
+    def _check(self, bash_hook, command):
+        return bash_hook.check_command(command, self._config([self.GH_RULE]))
+
+    def test_quoted_message_mention_not_matched(self, bash_hook):
+        r = self._check(
+            bash_hook,
+            'git commit -m "document that gh pr comment was blocked"',
+        )
+        assert r["decision"] == "allow"
+
+    def test_quoted_echo_mention_not_matched(self, bash_hook):
+        r = self._check(bash_hook, 'echo "gh pr comment was blocked" >> notes.md')
+        assert r["decision"] == "allow"
+
+    def test_heredoc_body_mention_not_matched(self, bash_hook):
+        r = self._check(
+            bash_hook, 'git commit -F - <<EOF\nnotes about gh pr comment\nEOF'
+        )
+        assert r["decision"] == "allow"
+
+    def test_real_command_still_matched(self, bash_hook):
+        r = self._check(bash_hook, "gh pr comment 5 --body hi")
+        assert r["decision"] == "ask"
+
+    def test_real_command_in_chain_still_matched(self, bash_hook):
+        r = self._check(bash_hook, "git status && gh pr comment 5 --body hi")
+        assert r["decision"] == "ask"
+
+    def test_quote_obfuscated_command_still_matched(self, bash_hook):
+        assert self._check(bash_hook, 'g"h" pr comment 5')["decision"] == "ask"
+        assert self._check(bash_hook, '"gh" pr comment 5')["decision"] == "ask"
+
+    def test_var_indirection_still_matched(self, bash_hook):
+        r = self._check(bash_hook, "G=gh; $G pr comment 5")
+        assert r["decision"] == "ask"
+
+    def test_shell_dash_c_payload_still_matched(self, bash_hook):
+        r = self._check(bash_hook, 'bash -c "gh pr comment 5 --body hi"')
+        assert r["decision"] == "ask"
+
+    def test_unanchored_rule_still_matches_content(self, bash_hook):
+        # Content-based rules keep whole-command semantics.
+        rule = dict(self.GH_RULE)
+        del rule["anchored"]
+        r = bash_hook.check_command(
+            'git commit -m "mentions gh pr comment"', self._config([rule])
+        )
+        assert r["decision"] == "ask"
+
+    def test_tooldef_rules_are_anchored(self, bash_hook, tmp_path):
+        (tmp_path / "gh.yaml").write_text(
+            "name: GitHub CLI\ncommands:\n"
+            "  - cmd: gh pr comment <pr>\n"
+            "    access: write\n"
+            "    description: Add a comment to a PR\n"
+        )
+        patterns = bash_hook.load_write_patterns_from_tooldefs(tmp_path)
+        assert patterns and all(p.get("anchored") for p in patterns)
+
+    def test_masked_subcommands_masks_quoted_content(self, bash_hook):
+        subs = bash_hook.masked_subcommands('git commit -m "a b c" && echo hi')
+        assert subs[0].startswith("git commit -m ")
+        assert "a b c" not in subs[0]
+        assert subs[1] == "echo hi"
+
+
+# ---------------------------------------------------------------------------
 # bash-tool-damage-control.py: helper functions
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`check_command` regex-searched every rule pattern over the raw command string and its shlex-normalized subcommands — both include quoted argument text. So `git commit -m "document that gh pr comment was blocked"` was misclassified as **GitHub CLI: Add a comment to a PR** (repro in #675; the live hook even blocked this branch's own test script and this PR body for quoting the git force-push phrase).

## Fix

New `masked_subcommands()` in `agentwire/safety/_core.py`: a quote-aware tokenizer that splits on `&&`/`;`/`|`/newline and masks quoted tokens containing whitespace (message/echo/heredoc content) while:
- keeping quoted single words, so `"gh" pr comment` / `g"h" pr comment` obfuscation still normalizes to the literal command
- recursively rescanning `sh|bash|zsh -c "…"` payloads as commands
- resolving simple `VAR=x; $VAR` indirection (parity with `normalize_subcommands`)
- stripping heredoc bodies

Rules opt into this via `anchored: true`. Tooldef-generated prefix rules get it automatically; `git.yaml`'s pure command+flag rules are flagged too. Content-based rules (rm/path patterns etc.) keep whole-command matching, and the obfuscation → fail-closed-`ask` ladder is unchanged. Hooks regenerated via `scripts/regen_damage_control_hooks.py`.

## Verification

- 12 new unit tests in `tests/unit/test_damage_control_hooks.py` (false-match cases; real-command/chain/obfuscation/`-c`-payload still caught; tooldef anchoring)
- Full suite: 2357 passed in-worktree
- Manual matrix against bundled rules+tooldefs: quoted mentions now allow (or fall through to the honest `Git: Create a commit` ask), real invocations still ask/block

Closes #675

Built by [dotdev.dev](https://dotdev.dev)