### PR TITLE
fix(scheduler): dispatch watchdog — hung ensure can no longer starve the board

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -205,6 +205,7 @@ channels:  # Outbound-only notifications. Only email + quo ship.
 scheduler:
   autostart: true        # Start the scheduler daemon when the portal boots (default: true)
   dispatch_cooldown: 60  # Seconds between task dispatches (default: 60)
+  dispatch_max_runtime: 14400  # Watchdog ceiling per dispatch in seconds; a hung ensure is killed and the task marked timeout (default: 4h, 0 disables)
 
 usage_limit:             # Usage-limit recovery watchdog (docs/wiki/usage-limit-recovery.md)
   enabled: true          # Master switch for dialog detection/parking (default: true)

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -431,6 +431,10 @@ class SchedulerConfig:
     session_create_timeout: int = 30
     max_loop_sleep: int = 60
     dispatch_cooldown: int = 60
+    # Watchdog ceiling for a single dispatch (seconds). A hung `ensure`
+    # (e.g. an unrecognized usage-limit dialog) otherwise holds the single
+    # dispatch slot forever and starves the whole board (#677). 0 disables.
+    dispatch_max_runtime: int = 14400
     # Crash-loop guard: a board that won't parse / has no tasks backs off
     # exponentially from `error_backoff_base` up to `error_backoff_max`
     # instead of tight-looping (#449).

--- a/agentwire/scheduler/__init__.py
+++ b/agentwire/scheduler/__init__.py
@@ -37,6 +37,7 @@ from .dispatch import (
     _is_worktree_task,
     _kill_process_tree,
     _kill_session,
+    _notify_dispatch_timeout,
     _parse_ensure_summary,
     _pr_number_from_url,
     _pr_state,

--- a/agentwire/scheduler/dispatch.py
+++ b/agentwire/scheduler/dispatch.py
@@ -13,6 +13,7 @@ from .gates import _gated_tasks
 from .models import (
     _EXIT_FAILED,
     _EXIT_LOCK_CONFLICT,
+    _EXIT_TIMEOUT,
     _EXIT_TO_STATUS,
     Board,
     SchedulerTask,
@@ -512,8 +513,46 @@ def _unattended_env(task: SchedulerTask) -> dict[str, str]:
     return env
 
 
+# How often the dispatch watchdog wakes to check on its child. Bounds how
+# long a dead-child-with-held-pipes wedge can last (see _run_ensure).
+_WATCHDOG_POLL = 30.0
+# How long to wait for pipe drain after the child is known dead/killed.
+_DRAIN_TIMEOUT = 10.0
+
+
+def _drain_pipes(proc: "subprocess.Popen") -> tuple[str, str]:
+    """Best-effort read of remaining stdout/stderr after the child is dead.
+
+    Grandchildren (tmux, agents) inherit the pipe fds and can hold them open
+    past the child's exit, so even this drain gets a bounded timeout; on
+    expiry the pipes are closed and output is abandoned.
+    """
+    try:
+        return proc.communicate(timeout=_DRAIN_TIMEOUT)
+    except Exception:
+        for stream in (proc.stdout, proc.stderr):
+            try:
+                if stream:
+                    stream.close()
+            except Exception:
+                pass
+        return "", ""
+
+
 def _run_ensure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[int, "subprocess.CompletedProcess | None", int]:
-    """Run an `agentwire ensure` subprocess; return (exit_code, result, duration_s)."""
+    """Run an `agentwire ensure` subprocess; return (exit_code, result, duration_s).
+
+    Watchdogged (#677): a single dispatch may run at most
+    ``dispatch_max_runtime`` seconds (0 disables) — on expiry the whole
+    process group is SIGKILLed and the task reports ``timeout``, so one hung
+    ensure can never starve the board. The wait also polls the child's exit
+    directly: ``communicate()`` blocks on pipe EOF, not child exit, so a
+    child killed externally while grandchildren hold the pipes open would
+    otherwise wedge the daemon forever.
+    """
+    from agentwire import scheduler as _sched
+
+    max_runtime = getattr(_sched._sched_config(), "dispatch_max_runtime", 14400)
     start_time = time.time()
     result = None
     try:
@@ -521,12 +560,75 @@ def _run_ensure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[int,
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             text=True, start_new_session=True, env=env,
         )
-        stdout, stderr = proc.communicate()
-        exit_code = proc.returncode
+        while True:
+            try:
+                stdout, stderr = proc.communicate(timeout=_WATCHDOG_POLL)
+                exit_code = proc.returncode
+                break
+            except subprocess.TimeoutExpired:
+                if proc.poll() is not None:
+                    # Child already exited but orphaned grandchildren hold the
+                    # pipes open — reap what's left and take the real exit code.
+                    # killpg still reaches group members reparented to init.
+                    try:
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except OSError:
+                        pass
+                    _kill_process_tree(proc.pid)
+                    stdout, stderr = _drain_pipes(proc)
+                    exit_code = proc.returncode
+                    break
+                if max_runtime and (time.time() - start_time) >= max_runtime:
+                    # Watchdog ceiling: kill the entire process group
+                    # (start_new_session=True makes pgid == pid), then any
+                    # stragglers that escaped it.
+                    try:
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except OSError:
+                        pass
+                    _kill_process_tree(proc.pid)
+                    stdout, stderr = _drain_pipes(proc)
+                    print(f"[{_ts()}] Dispatch watchdog: killed hung ensure "
+                          f"(pid {proc.pid}) after {int(time.time() - start_time)}s")
+                    exit_code = _EXIT_TIMEOUT
+                    break
         result = subprocess.CompletedProcess(cmd, exit_code, stdout, stderr)
     except Exception:
         exit_code = _EXIT_FAILED
     return exit_code, result, int(time.time() - start_time)
+
+
+def _notify_dispatch_timeout(task: SchedulerTask, session: str, duration: int) -> None:
+    """Surface a watchdog kill: distinct event + best-effort owner email.
+
+    Reuses the outbound email channel (same wiring as usage-limit parks and
+    unattended blocks) so a killed dispatch is never a silent failure.
+    """
+    from agentwire import scheduler as _sched
+
+    _sched._log_event("dispatch_timeout", task=task.name, session=session,
+                      duration=duration)
+    try:
+        import socket
+
+        from ..channels.email import send_email
+        hours = duration / 3600
+        send_email(
+            subject=f"[agentwire] scheduler watchdog killed hung task: {task.name}",
+            body=(
+                f"Dispatch of **{task.name}** (session `{session}`) on "
+                f"`{socket.gethostname()}` exceeded the dispatch_max_runtime "
+                f"ceiling and was killed after {hours:.1f}h.\n\n"
+                f"- **Project:** {task.project}\n"
+                f"- **Task:** {task.task}\n\n"
+                "The task was marked `timeout` and the scheduler moved on. "
+                "Common cause: the agent session wedged on an unrecognized "
+                "interactive dialog (e.g. a usage-limit variant) — check "
+                "`agentwire limits status` and the session scrollback."
+            ),
+        )
+    except Exception:
+        pass
 
 
 def _apply_max_runs(board: Board, task: SchedulerTask, new_state: TaskState,
@@ -603,6 +705,14 @@ def _dispatch_inplace_task(board: Board, task: SchedulerTask, existing_state: Ta
             last_duration=duration,
             run_count=existing_state.run_count,
         )
+
+    if exit_code == _EXIT_TIMEOUT:
+        # Watchdog kill — the agent session is wedged, not working. Tear it
+        # down (persistent sessions excepted — they double as interactive
+        # receivers) and make the failure loud.
+        if not persistent:
+            _sched._kill_session(task.session)
+        _sched._notify_dispatch_timeout(task, task.session, duration)
 
     summary, files_modified, blockers_list = _sched._parse_ensure_summary(task, result)
 
@@ -701,6 +811,13 @@ def _dispatch_worktree_task(board: Board, task: SchedulerTask, existing_state: T
             last_run=existing_state.last_run, last_status="lock_conflict",
             last_duration=duration, run_count=existing_state.run_count,
         )
+
+    if exit_code == _EXIT_TIMEOUT:
+        # Watchdog kill — tear down the wedged worktree session and make the
+        # failure loud. The worktree itself flows into _finalize_worktree_pr
+        # below, so any partial work is preserved as a draft PR.
+        _sched._kill_session(wt_session)
+        _sched._notify_dispatch_timeout(task, wt_session, duration)
 
     summary, files_modified, blockers_list = _sched._parse_ensure_summary(
         task, result, project=worktree_path, session=wt_session)

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -566,3 +566,113 @@ class TestPersistentSessionDispatch:
         self._dispatch(proj, type="claude-bypass")
         assert killed == ["persist-s"]
         assert precreated == ["persist-s"]
+
+
+class TestDispatchWatchdog:
+    """#677: a hung ensure must never starve the board. _run_ensure gets a
+    max-runtime ceiling, self-heals from a dead child whose pipes are held
+    open by grandchildren, and the timeout aftermath is loud (session kill +
+    owner notification)."""
+
+    def _fast_watchdog(self, monkeypatch, max_runtime):
+        from types import SimpleNamespace
+
+        from agentwire import scheduler
+        from agentwire.scheduler import dispatch
+        monkeypatch.setattr(dispatch, "_WATCHDOG_POLL", 0.1)
+        monkeypatch.setattr(
+            scheduler, "_sched_config",
+            lambda: SimpleNamespace(dispatch_max_runtime=max_runtime))
+
+    # --- _run_ensure ---
+
+    def test_hung_child_killed_at_ceiling(self, monkeypatch):
+        from agentwire import scheduler
+        from agentwire.scheduler import _EXIT_TIMEOUT
+        self._fast_watchdog(monkeypatch, 1)
+        start = time.time()
+        exit_code, result, duration = scheduler._run_ensure(["sleep", "60"])
+        assert exit_code == _EXIT_TIMEOUT
+        assert time.time() - start < 15  # nowhere near 60s
+        assert result is not None and result.returncode == _EXIT_TIMEOUT
+
+    def test_dead_child_with_held_pipes_reaped(self, monkeypatch):
+        # Child exits immediately but a background grandchild inherits the
+        # stdout pipe — bare communicate() would block on pipe EOF forever.
+        import subprocess as sp
+        self._fast_watchdog(monkeypatch, 3600)
+        from agentwire import scheduler
+        start = time.time()
+        exit_code, result, duration = scheduler._run_ensure(
+            ["sh", "-c", "echo hi; sleep 60 & exit 0"])
+        assert exit_code == 0
+        assert time.time() - start < 30  # reaped by the poll, not pipe EOF
+
+    def test_normal_completion_unaffected(self, monkeypatch):
+        from agentwire import scheduler
+        self._fast_watchdog(monkeypatch, 3600)
+        exit_code, result, duration = scheduler._run_ensure(
+            ["sh", "-c", "echo done"])
+        assert exit_code == 0
+        assert "done" in result.stdout
+
+    def test_zero_ceiling_disables_watchdog_kill(self, monkeypatch):
+        from agentwire import scheduler
+        self._fast_watchdog(monkeypatch, 0)
+        exit_code, result, duration = scheduler._run_ensure(
+            ["sh", "-c", "sleep 0.3; echo ok"])
+        assert exit_code == 0
+
+    # --- dispatch aftermath ---
+
+    def _patch_dispatch(self, monkeypatch, proj):
+        import agentwire.locking
+        from agentwire import scheduler
+        from agentwire.scheduler import _EXIT_TIMEOUT
+        killed, notified = [], []
+        monkeypatch.setattr(agentwire.locking, "remove_stale_lock", lambda s: None)
+        monkeypatch.setattr(scheduler, "_kill_session", lambda s: killed.append(s))
+        monkeypatch.setattr(scheduler, "_pre_create_session", lambda t: None)
+        monkeypatch.setattr(scheduler, "_run_ensure",
+                            lambda cmd, env=None: (_EXIT_TIMEOUT, None, 999))
+        monkeypatch.setattr(scheduler, "_parse_ensure_summary",
+                            lambda t, r, **kw: ("", [], []))
+        monkeypatch.setattr(scheduler, "_notify_dispatch_timeout",
+                            lambda t, s, d: notified.append((t.name, s, d)))
+        monkeypatch.setattr(scheduler, "_log_event", lambda *a, **k: None)
+        monkeypatch.setattr(scheduler, "_notify_portal", lambda *a, **k: None)
+        monkeypatch.setattr(scheduler, "_capture_head", lambda p: "")
+        monkeypatch.setattr(scheduler, "save_board", lambda b: None)
+        return killed, notified
+
+    def _project(self, tmp_path, task_yaml):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / ".agentwire.yml").write_text(task_yaml)
+        return proj
+
+    def _dispatch(self, proj, **task_kwargs):
+        from agentwire import scheduler
+        task = SchedulerTask(name="t", project=str(proj), session="wd-s",
+                             task="t", schedule=Schedule(every="1h"), **task_kwargs)
+        board = Board()
+        board.tasks["t"] = task
+        return scheduler._dispatch_inplace_task(board, task, TaskState())
+
+    def test_timeout_kills_session_and_notifies(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path, "tasks:\n  t:\n    prompt: do\n")
+        killed, notified = self._patch_dispatch(monkeypatch, proj)
+        state = self._dispatch(proj)
+        assert state.last_status == "timeout"
+        # killed once pre-dispatch (fresh session) and once post-timeout
+        assert killed.count("wd-s") == 2
+        assert notified == [("t", "wd-s", 999)]
+
+    def test_timeout_spares_persistent_session_but_still_notifies(self, tmp_path, monkeypatch):
+        proj = self._project(tmp_path,
+                             "tasks:\n  t:\n    prompt: do\n    exit_on_complete: false\n")
+        killed, notified = self._patch_dispatch(monkeypatch, proj)
+        state = self._dispatch(proj)
+        assert state.last_status == "timeout"
+        assert killed == []
+        assert notified == [("t", "wd-s", 999)]

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -599,7 +599,6 @@ class TestDispatchWatchdog:
     def test_dead_child_with_held_pipes_reaped(self, monkeypatch):
         # Child exits immediately but a background grandchild inherits the
         # stdout pipe — bare communicate() would block on pipe EOF forever.
-        import subprocess as sp
         self._fast_watchdog(monkeypatch, 3600)
         from agentwire import scheduler
         start = time.time()


### PR DESCRIPTION
## Root cause (verified)

`scheduler/dispatch.py::_run_ensure` ran `proc.communicate()` with **no timeout** — the daemon's single dispatch slot waits on the ensure child forever. Two aggravators:

1. `ensure`'s completion poll does check `check_and_park` each iteration, but `detect_dialog` requires an exact `PARK_OPTION` + `MENU_FOOTER` match with nothing rendered below — dialog-text drift slips past it, and then nothing bounds the wait.
2. Manually killing the hung ensure PID didn't unwedge the daemon because `communicate()` blocks on **pipe EOF, not child exit** — grandchildren (tmux, agents) inherit the stdout/stderr fds and hold them open past the child's death.

## Fix

- **Watchdog ceiling:** new `SchedulerConfig.dispatch_max_runtime` (default 4h, `0` disables). `_run_ensure` waits in a bounded loop; on expiry it SIGKILLs the whole process group (`start_new_session` → pgid == pid) plus any stragglers, drains pipes with a bounded timeout, and returns exit 5 → task status `timeout`. The board advances.
- **Daemon self-heal:** the wait loop polls `proc.poll()` every 30s, so a child that dies while orphaned grandchildren hold the pipes is reaped within ~30s instead of never.
- **Loud failure:** on timeout the wedged tmux session is killed (persistent `exit_on_complete: false` sessions spared), a `dispatch_timeout` event is logged, and the owner gets a best-effort email via the existing outbound channel — same wiring as usage-limit parks.

Worktree dispatches flow the timeout through `_finalize_worktree_pr`, so partial work still lands as a draft PR rather than being lost.

## Verification

- 8 new unit tests (`TestDispatchWatchdog`): hung child killed at ceiling, dead-child-with-held-pipes reaped promptly, normal completion untouched, `0` disables, in-place timeout kills session + notifies, persistent session spared but still notified.
- Full suite in-worktree: **2339 passed** (unit + integration).

Not in scope (deliberately): hardening `detect_dialog` itself — dialog drift is already surfaced via `unmatched_dialog` events from the limits sweep; the watchdog now bounds the blast radius of any future miss.

Closes #677

Built by [dotdev.dev](https://dotdev.dev)