### PR TITLE
fix(tests): exempt test_channels from the email autouse stub

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(autouse=True)
-def _no_real_outbound_email(monkeypatch):
+def _no_real_outbound_email(request, monkeypatch):
     """No test may send real email — ever.
 
     ``_escalate_dead_letter`` (and friends) call the live Resend wiring, so a
@@ -19,7 +19,12 @@ def _no_real_outbound_email(monkeypatch):
     way: ``test_purge_leaves_ingest_and_dead`` flooded the inbox with
     "undelivered done: x → s" from its fixture names). Tests that assert on
     email re-patch the same target via ``monkeypatch``, which overrides this.
+
+    ``test_channels.py`` is exempt: it tests ``send_email`` itself (against a
+    mocked Resend transport), so stubbing the function would test the stub.
     """
+    if request.node.fspath.basename == "test_channels.py":
+        return
     from types import SimpleNamespace
 
     monkeypatch.setattr(


### PR DESCRIPTION
PR #687's suite-wide send_email stub broke 3 tests in test_channels.py that test send_email itself (against a mocked Resend transport — safe to exempt, no real sends). Spotted by the fix-675 session during its rebase.

Built by [dotdev.dev](https://dotdev.dev)