### PR TITLE
fix(delivery): pasted ≠ submitted — close the swallowed-Enter delivery hole

### DIFF
--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -69,7 +69,9 @@ MAX_ATTEMPTS = 40
 # consecutive sweeps ≈ an unknown placeholder, not an actively-typed draft).
 # Such messages stay pending forever instead of burning toward dead-letter;
 # doctor / worktree --watch surface them, and they deliver once the box frees up.
-_NO_PENALTY_REASONS = frozenset({"target_busy", "queued_placeholder", "box_static"})
+_NO_PENALTY_REASONS = frozenset(
+    {"target_busy", "queued_placeholder", "box_static", "stuck_in_box"}
+)
 
 # Consecutive sweeps the box must show byte-identical content before the defer
 # stops penalizing (see _box_static). Low enough that an unknown placeholder
@@ -766,6 +768,47 @@ def flush_session(session: str, force: bool = False) -> dict:
                 }
 
             if box_content != "":
+                # Our own message sitting in the box = a prior paste whose Enter
+                # was swallowed (#689). Heal it: Enter-only finish_submit — NEVER
+                # a re-paste, so the #621 idempotency dedup keeps holding. Unlink
+                # only once submission is confirmed; otherwise stay pending
+                # without penalty (the target isn't refusing, our own delivery
+                # is wedged).
+                stuck = [
+                    m for m in messages
+                    if "".join(m.render().split()) in "".join(box_content.split())
+                ]
+                if stuck:
+                    from .session_ready import finish_submit
+
+                    if finish_submit(session, stuck[0].render()):
+                        for m in stuck:
+                            if m.path is not None:
+                                m.path.unlink(missing_ok=True)
+                        _log_event(
+                            "stuck_submitted", to=session, count=len(stuck),
+                            kinds=[m.kind for m in stuck],
+                        )
+                        _clear_box_state(session)
+                        remaining = [m for m in messages if m not in stuck]
+                        if remaining:
+                            _bump_attempts(remaining, "target_busy")
+                        return {
+                            "session": session,
+                            "delivered": pre_consumed + len(stuck),
+                            "deferred": bool(remaining),
+                            "reason": "delivered" if not remaining else "target_busy",
+                        }
+                    dead = _bump_attempts(messages, "stuck_in_box")
+                    _log_event(
+                        "deferred", to=session, count=len(messages),
+                        reason="stuck_in_box",
+                    )
+                    return {
+                        "session": session, "delivered": pre_consumed,
+                        "deferred": True, "reason": "stuck_in_box", "dead": dead,
+                    }
+
                 # Box is not empty. We never bypass this to protect human drafts. But
                 # the "queued messages" placeholder is a BUSY signal, not a draft:
                 # defer WITHOUT penalty (like target_busy) so a generating-with-queued

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -447,7 +447,7 @@ def safe_deliver(target_session: str, target_pane: int, text: str) -> "tuple[boo
 
     from .session_ready import send_verified
 
-    ok = send_verified(target_session, text)
+    ok = send_verified(target_session, text, pane_index=target_pane)
     return (ok, "delivered" if ok else "delivery_unverified")
 
 
@@ -749,6 +749,80 @@ def _router_config() -> "tuple[bool, set[str]]":
         return True, set()
 
 
+# Stuck-box sweeper backstop (#689). Machine-injected message headers whose
+# pasted-but-unsubmitted drafts the sweep may flush with a bare Enter. Human
+# drafts never start with these, so the backstop cannot submit a walked-away
+# human's half-typed message. ``[Pasted text`` is Claude Code's placeholder for
+# a large multi-line paste — the msg drain's coalesced blob renders exactly
+# that way when its Enter is swallowed.
+_MACHINE_HEADER_RE = re.compile(r"^\[(MSG from|NOTIFY from|PROMPT|IDLE|Pasted text)\b")
+# Consecutive sweeps (~60s apart) the identical content must sit in the box
+# before the flush fires — one sweep of settling covers a delivery in flight.
+STUCK_BOX_SWEEPS = 2
+
+
+def _stuck_box_path(session: str, pane_index: int) -> Path:
+    return STATE_DIR / f"{session}.{pane_index}.stuckbox.json"
+
+
+def _flush_stuck_box(session: str, pane_index: int, visible: str) -> bool:
+    """Press Enter on a box stuck holding machine-injected text (#689).
+
+    The last-resort healer behind the verified-submit and drain fixes: any
+    paste-then-submit path that died between paste and Enter (crash, kill,
+    swallowed keystroke that exhausted its budget) leaves a message rendered in
+    the recipient's input box forever. Fires only when ALL of:
+
+      - the box parses and holds non-empty, non-placeholder content,
+      - the content starts with a machine-injected header (never a human draft),
+      - the pane is not mid-generation (no ``esc to interrupt`` footer),
+      - the identical content has sat there for ``STUCK_BOX_SWEEPS``
+        consecutive sweeps (state persisted per-pane next to prompt markers).
+
+    Never pastes — Enter only, so the #621 idempotency dedup keeps holding.
+    """
+    path = _stuck_box_path(session, pane_index)
+    box = input_box_content(visible)
+    if (
+        not box
+        or not _MACHINE_HEADER_RE.match(box)
+        or is_queued_placeholder(box)
+        or "esc to interrupt" in visible.lower()
+    ):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        data = {}
+    count = int(data.get("count", 0)) + 1 if data.get("content") == box else 1
+    if count < STUCK_BOX_SWEEPS:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(path, {"content": box, "count": count})
+        except OSError:
+            pass
+        return False
+
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    try:
+        _tmux(["send-keys", "-t", f"{session}.{pane_index}", "Enter"])
+        _log_event(
+            "stuck_box_flushed", session=session, pane=pane_index,
+            content=box[:120],
+        )
+        return True
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def sweep() -> dict:
     """Scan all agent panes for live interactive prompts and route them.
 
@@ -794,12 +868,17 @@ def sweep() -> dict:
         if session in excluded or _is_parked(session):
             continue
 
-        info = detect_prompt(_capture(f"{session}.{pane_index}"))
+        visible = _capture(f"{session}.{pane_index}")
+        info = detect_prompt(visible)
         marker = read_marker(session, pane_index)
 
         if info is None:
             if marker:
                 clear_marker(session, pane_index)
+            if _flush_stuck_box(session, pane_index, visible):
+                routed.append(
+                    {"session": session, "pane": pane_index, "kind": "stuck_box"}
+                )
             continue
 
         # A fresh hook-routed marker keeps the sweep off this pane entirely.

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -141,7 +141,12 @@ def submitted(capture: str, message: str, marker: str | None = None) -> bool:
     return pane_shows_activity(capture) and message_visible(capture, message)
 
 
-def submit_confirmed(capture: str, message: str, marker: str | None = None) -> bool:
+def submit_confirmed(
+    capture: str,
+    message: str,
+    marker: str | None = None,
+    allow_unparsed: bool = True,
+) -> bool:
     """Phase-2 confirm: did the (already-landed) paste actually *submit*? (#621)
 
     Distinct from :func:`submitted`, which also has to defend Phase 1's "did the
@@ -160,11 +165,19 @@ def submit_confirmed(capture: str, message: str, marker: str | None = None) -> b
       pressing Enter (dismiss-then-submit).
     - Box unparseable (tool output / dialog covering it) → fall back to positive
       evidence: the explicit marker line, the message echoed in scrollback, or
-      visible activity.
+      visible activity. This fallback is inherently permissive — activity glyphs
+      sit in almost every agent pane's scrollback, and the "visible" text may be
+      our paste still sitting in the very box we failed to parse — so it is only
+      trusted once at least one Enter has actually been pressed (#689): callers
+      pass ``allow_unparsed=False`` before the first press, forcing an Enter
+      instead of declaring a busy re-rendering pane submitted with zero
+      keystrokes ever sent.
     """
     box = input_box(capture)
     if box is not None:
         return not message_visible(box, message)
+    if not allow_unparsed:
+        return False
     if marker is not None and marker in capture:
         return True
     return pane_shows_activity(capture) or message_visible(capture, message)
@@ -270,6 +283,33 @@ def message_visible(capture: str, message: str) -> bool:
     return "[Pasted text" in capture
 
 
+def strip_input_box(capture: str) -> "str | None":
+    """*capture* with the input-box region removed, or None if no box parses.
+
+    The #689 building block: "on scrollback" must mean *outside the input box*.
+    A pasted-but-unsubmitted message renders inside the box, which is part of
+    every pane capture — matching against the raw capture reads a swallowed
+    Enter as a delivered message. Mirrors ``prompt_router.input_box_content``'s
+    parse (region between the last two horizontal rules, prompt glyph first);
+    when the box can't be located we return None so callers stay conservative
+    (can't prove the text is outside the box → treat as not on scrollback).
+    """
+    from agentwire import prompt_router
+
+    clean = prompt_router.ANSI_PATTERN.sub("", capture)
+    lines = clean.split("\n")
+    rules = [i for i, ln in enumerate(lines) if prompt_router._is_rule_line(ln)]
+    if len(rules) < 2:
+        return None
+    box = lines[rules[-2] + 1:rules[-1]]
+    if not box:
+        return None
+    text = "\n".join(box).lstrip()
+    if text[:1] not in prompt_router._PROMPT_GLYPHS:
+        return None
+    return "\n".join(lines[:rules[-2] + 1] + lines[rules[-1]:])
+
+
 def message_on_scrollback(capture: str, rendered: str) -> bool:
     """Strict per-message scrollback check for idempotent redelivery (#621).
 
@@ -282,6 +322,12 @@ def message_on_scrollback(capture: str, rendered: str) -> bool:
     message. tmux wraps long lines at pane width, so both sides are
     whitespace-stripped before the substring test.
 
+    The input-box region is EXCLUDED from the match (#689): a message pasted
+    into the box whose Enter was swallowed is landed-but-unsubmitted, and
+    counting it as "on scrollback" is exactly how the drain unlinked messages
+    the recipient never received. When the box can't be parsed at all we return
+    False — can't prove the text is outside it.
+
     Deliberately does NOT fall back to the generic ``"[Pasted text"`` placeholder
     (which would mark EVERY queued message visible). A message that scrolled past
     the window returns False — the safe direction: keep it pending and retry
@@ -290,7 +336,10 @@ def message_on_scrollback(capture: str, rendered: str) -> bool:
     needle = "".join(rendered.split())
     if not needle:
         return False
-    return needle in "".join(capture.split())
+    outside = strip_input_box(capture)
+    if outside is None:
+        return False
+    return needle in "".join(outside.split())
 
 
 def scrollback(session: str, pane_index: int = 0) -> str:
@@ -352,18 +401,35 @@ def _deliver_once(
     if not _poll(landed_or_done, LAND_TIMEOUT):
         return False
 
-    # Phase 2 — press Enter and confirm the box cleared. Re-press is driven by a
-    # wall-clock budget, not a fixed count: a single Enter can be swallowed under
-    # load, a large paste needs a second Enter (dismiss the ``[Pasted text]``
-    # banner, then submit), and on a bogged-down host the box renders slowly. We
-    # keep pressing until the box clears or SUBMIT_BUDGET elapses — an idle Enter
-    # on an already-submitted/empty box is a harmless no-op, so over-pressing is
-    # safe, while a tight count would give up before a laggy box ever caught up.
+    return _submit_phase(session, message, marker, pane_index)
+
+
+def _submit_phase(
+    session: str, message: str, marker: str | None, pane_index: int
+) -> bool:
+    """Phase 2 — press Enter and confirm the box cleared. Enter-only, no paste.
+
+    Re-press is driven by a wall-clock budget, not a fixed count: a single Enter
+    can be swallowed under load, a large paste needs a second Enter (dismiss the
+    ``[Pasted text]`` banner, then submit), and on a bogged-down host the box
+    renders slowly. We keep pressing until the box clears or SUBMIT_BUDGET
+    elapses — an idle Enter on an already-submitted/empty box is a harmless
+    no-op, so over-pressing is safe, while a tight count would give up before a
+    laggy box ever caught up.
+
+    The pre-press confirm is STRICT (``allow_unparsed=False``): before any Enter
+    has been sent, an unparseable box must never read as submitted — that was
+    the #689 zero-keystroke false positive (busy pane + activity glyphs →
+    "delivered" with the Enter never fired). Once at least one Enter is pressed,
+    the permissive fallback is trusted again.
+    """
+    if submit_confirmed(
+        _snapshot(session, pane_index), message, marker, allow_unparsed=False
+    ):
+        return True
     deadline = time.time() + SUBMIT_BUDGET
     attempts = 0
     while True:
-        if submit_confirmed(_snapshot(session, pane_index), message, marker):
-            return True
         press_enter(session, pane_index=pane_index)
         attempts += 1
         if _poll(
@@ -373,6 +439,23 @@ def _deliver_once(
             return True
         if attempts >= MIN_ENTER_ATTEMPTS and time.time() >= deadline:
             return False
+
+
+def finish_submit(
+    session: str, message: str, marker: str | None = None, pane_index: int = 0
+) -> bool:
+    """Enter-only submit retry for a message already sitting in the input box.
+
+    The #689 healing primitive: when a prior delivery pasted the text but its
+    Enter was swallowed, the fix is to press Enter again — NEVER to re-paste
+    (the #621 idempotency dedup must keep holding; a second paste doubles the
+    draft). Runs the same strict-then-press phase-2 loop as a fresh delivery.
+    Returns True only once submission is confirmed; never raises.
+    """
+    try:
+        return _submit_phase(session, message, marker, pane_index)
+    except Exception:
+        return False
 
 
 def send_verified(

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -74,6 +74,23 @@ lands in a durable inbox and is injected only at a safe boundary.
    already sits landed-but-unsubmitted in the box, and if so retries only the
    *submit*, so a whole-send retry can never double the draft.
 
+   **Pasted ≠ submitted (#689).** Three closures for the paste-lands-but-Enter-
+   is-swallowed failure: **(a)** `message_on_scrollback` excludes the input-box
+   region — a message still sitting in the box no longer reads as "on
+   scrollback", so the drain can't unlink a pending file the recipient never
+   received (an unparseable box counts as *not* on scrollback: keep pending).
+   **(b)** `send_verified`'s Phase-2 confirm is strict before the first Enter —
+   an unparseable busy box plus activity glyphs can no longer declare a message
+   submitted with **zero** Enter keystrokes ever sent. **(c)** When the drain
+   finds one of its own pending messages rendered in the recipient's box, it
+   heals via `session_ready.finish_submit` — an **Enter-only** retry (never a
+   re-paste, so the #621 dedup holds), unlinking only once submission confirms
+   and otherwise deferring without penalty (`stuck_in_box`). As a last-resort
+   backstop, the watchdog pane-sweep flushes a bare Enter on any idle pane
+   whose box has held identical **machine-injected** text (`[MSG…`, `[NOTIFY…`,
+   `[Pasted text…`) for two consecutive sweeps — human-looking drafts are never
+   auto-submitted.
+
 4. **Defer or drop.** If either gate fails, the messages stay put, their
    `attempts` counter bumps, and the defer `reason` (`box_not_empty`,
    `target_parked`, …) is stamped on each message. After `MAX_ATTEMPTS`

--- a/tests/integration/test_send_verified_tmux.py
+++ b/tests/integration/test_send_verified_tmux.py
@@ -184,3 +184,34 @@ def test_quiet_submit_is_confirmed_not_false_negatived(emulator_session, monkeyp
     # No activity markers on screen — pure quiet confirm.
     assert not session_ready.pane_shows_activity(box)
     assert "quiet report no spinner here" not in box
+
+
+def test_stuck_paste_finished_enter_only_no_duplicate(emulator_session, monkeypatch):
+    # #689: a prior delivery pasted the message but its Enter was swallowed —
+    # the message sits rendered in the input box. finish_submit must heal it
+    # with Enter ONLY (no re-paste, so the #621 dedup holds: the emulator's
+    # buffer would show the text twice if a second paste happened).
+    session, socket, _ = emulator_session
+    _patch_pane_manager(monkeypatch, socket)
+
+    msg = "[MSG from worker - done] PR 42 drafted  (#deadbe)"
+    # Simulate the stuck state: paste lands, Enter never fires.
+    session_ready.paste_no_enter(session, msg)
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+        if session_ready.text_landed(cap, msg):
+            break
+        time.sleep(0.1)
+    cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    assert session_ready.text_landed(cap, msg), "stuck-state setup failed"
+    # The stuck message must NOT read as delivered/on-scrollback (#689).
+    assert not session_ready.message_on_scrollback(cap, msg)
+
+    assert session_ready.finish_submit(session, msg)
+    cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    box = session_ready.input_box(cap)
+    assert box == "", f"box should be empty after finish_submit, got: {box!r}"
+    # No duplicate: the emulator clears on submit; a re-paste would have left a
+    # second copy sitting in the box.
+    assert msg not in (box or "")

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -705,6 +705,10 @@ class TestIdempotentDelivery:
 
     def _patch(self, monkeypatch, deliver, scrollback):
         from agentwire import session_ready, usage_limit
+        # #689: "on scrollback" now means outside a parseable input box — a bare
+        # rendered line with no box no longer counts (it could be sitting unsent
+        # in the box). Model a real delivered state: text above an EMPTY box.
+        scrollback = f"{scrollback}\n{RULE}\n❯\n{RULE}"
         monkeypatch.setattr(usage_limit, "_capture", lambda s: "dummy screen")
         monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "")
         monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
@@ -948,3 +952,68 @@ class TestSessionNameValidation:
         assert len(msgs) == 1
         assert msgs[0].path.is_relative_to(isolate / "proj" / "child")
         assert [m.text for m in inbox.list_messages("proj/child")] == ["hello"]
+
+
+class TestStuckInBox:
+    """#689 — our own message sitting in the recipient's input box is a
+    swallowed-Enter delivery, not a human draft: the drain must finish it with
+    an Enter-only retry (never a re-paste) and unlink only once submitted."""
+
+    def _patch(self, monkeypatch, box_content, finish_ok):
+        from agentwire import session_ready, usage_limit
+        monkeypatch.setattr(usage_limit, "_capture", lambda s: "dummy screen")
+        monkeypatch.setattr(
+            prompt_router, "input_box_content_sgr", lambda vis: box_content)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
+        # No pre-dedup hits: nothing on scrollback outside the box.
+        monkeypatch.setattr(
+            session_ready, "scrollback", lambda s, p=0: f"{RULE}\n❯\n{RULE}")
+        finishes = []
+        monkeypatch.setattr(
+            session_ready, "finish_submit",
+            lambda s, m, marker=None, pane_index=0:
+                (finishes.append(m) or finish_ok))
+        pasted = []
+        monkeypatch.setattr(
+            prompt_router, "safe_deliver",
+            lambda s, p, text: (pasted.append(text) or (True, "delivered")))
+        return finishes, pasted
+
+    def test_stuck_message_finished_and_unlinked(self, isolate, monkeypatch):
+        m = inbox.enqueue("s", "PR drafted", kind="done", sender="w")[0]
+        finishes, pasted = self._patch(monkeypatch, m.render(), finish_ok=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 1
+        assert finishes == [m.render()]
+        assert pasted == []  # NEVER re-pasted (#621)
+        assert inbox.list_messages("s") == []
+
+    def test_finish_failure_defers_without_penalty(self, isolate, monkeypatch):
+        m = inbox.enqueue("s", "PR drafted", kind="done", sender="w")[0]
+        finishes, pasted = self._patch(monkeypatch, m.render(), finish_ok=False)
+        res = inbox.flush_session("s")
+        assert res["deferred"] and res["reason"] == "stuck_in_box"
+        assert pasted == []
+        msgs = inbox.list_messages("s")
+        assert len(msgs) == 1
+        assert msgs[0].attempts == 0  # no dead-letter penalty — target isn't refusing
+
+    def test_foreign_draft_is_not_stuck(self, isolate, monkeypatch):
+        # Box holds a human draft, not our message: normal defer path, no Enter.
+        inbox.enqueue("s", "PR drafted", kind="done", sender="w")
+        finishes, pasted = self._patch(
+            monkeypatch, "half-typed human thought", finish_ok=True)
+        res = inbox.flush_session("s")
+        assert res["deferred"]
+        assert finishes == []  # never pressed Enter into a foreign draft
+        assert len(inbox.list_messages("s")) == 1
+
+    def test_partial_stuck_unlinks_only_stuck(self, isolate, monkeypatch):
+        a = inbox.enqueue("s", "alpha", kind="done", sender="w")[0]
+        inbox.enqueue("s", "beta", kind="done", sender="w")
+        finishes, pasted = self._patch(monkeypatch, a.render(), finish_ok=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 1 and res["deferred"]
+        remaining = inbox.list_messages("s")
+        assert len(remaining) == 1 and "beta" in remaining[0].text
+        assert pasted == []

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -5,6 +5,8 @@ from Claude Code 2.x panes (fixture-gen session) and from the stuck worker
 incident that motivated #276.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from agentwire import prompt_router
@@ -842,3 +844,108 @@ class TestNotifyPermissionRequest:
         assert info.kind == "question" and source == "hook"
         assert info.question == "Ship it?"
         assert [o["label"] for o in info.options] == ["Yes", "No"]
+
+
+# =============================================================================
+# #689 — stuck-box sweeper backstop
+# =============================================================================
+
+STUCK_RULE = "─" * 60
+
+
+def _stuck_screen(box_text, footer=""):
+    return f"output above\n{STUCK_RULE}\n❯ {box_text}\n{STUCK_RULE}\n{footer}"
+
+
+class TestFlushStuckBox:
+    """The last-resort healer: machine-injected text stuck in an idle pane's
+    input box across consecutive sweeps gets a bare Enter — never a paste."""
+
+    def _patch(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path)
+        keys = []
+
+        def fake_tmux(args, timeout=5):
+            keys.append(args)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(prompt_router, "_tmux", fake_tmux)
+        monkeypatch.setattr(
+            prompt_router, "EVENTS_FILE", tmp_path / "events.jsonl")
+        return keys
+
+    def test_machine_header_flushes_on_second_sweep(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        screen = _stuck_screen("[MSG from worker · done] finished  ⟨#abc123⟩")
+        assert not prompt_router._flush_stuck_box("s", 0, screen)  # sweep 1: arm
+        assert keys == []
+        assert prompt_router._flush_stuck_box("s", 0, screen)  # sweep 2: flush
+        assert keys == [["send-keys", "-t", "s.0", "Enter"]]
+
+    def test_pasted_text_placeholder_flushes(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        screen = _stuck_screen("[Pasted text #1 +12 lines]")
+        prompt_router._flush_stuck_box("s", 0, screen)
+        assert prompt_router._flush_stuck_box("s", 0, screen)
+        assert len(keys) == 1
+
+    def test_human_draft_never_flushed(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        screen = _stuck_screen("my half-typed human thought")
+        for _ in range(5):
+            assert not prompt_router._flush_stuck_box("s", 0, screen)
+        assert keys == []
+
+    def test_changed_content_resets_counter(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        a = _stuck_screen("[MSG from w · done] one  ⟨#aaa111⟩")
+        b = _stuck_screen("[MSG from w · done] two  ⟨#bbb222⟩")
+        assert not prompt_router._flush_stuck_box("s", 0, a)
+        assert not prompt_router._flush_stuck_box("s", 0, b)  # reset, re-armed
+        assert keys == []
+
+    def test_generating_pane_skipped(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        screen = _stuck_screen(
+            "[MSG from w · done] finished  ⟨#abc123⟩",
+            footer="✶ Working… (esc to interrupt)",
+        )
+        for _ in range(3):
+            assert not prompt_router._flush_stuck_box("s", 0, screen)
+        assert keys == []
+
+    def test_queued_placeholder_skipped(self, monkeypatch, tmp_path):
+        keys = self._patch(monkeypatch, tmp_path)
+        screen = _stuck_screen("[MSG queue] Press up to edit queued messages")
+        prompt_router._flush_stuck_box("s", 0, screen)
+        assert not prompt_router._flush_stuck_box("s", 0, screen)
+        assert keys == []
+
+    def test_empty_or_unparseable_clears_state(self, monkeypatch, tmp_path):
+        self._patch(monkeypatch, tmp_path)
+        stuck = _stuck_screen("[MSG from w · done] hi  ⟨#abc123⟩")
+        assert not prompt_router._flush_stuck_box("s", 0, stuck)  # armed
+        prompt_router._flush_stuck_box("s", 0, _stuck_screen(""))  # cleared
+        # Re-stuck: must take TWO sweeps again, not fire immediately.
+        assert not prompt_router._flush_stuck_box("s", 0, stuck)
+
+
+class TestSafeDeliverPane:
+    def test_pane_index_threads_to_send_verified(self, monkeypatch):
+        from agentwire import session_ready
+        monkeypatch.setattr(prompt_router, "_session_exists", lambda s: True)
+        monkeypatch.setattr(prompt_router, "_is_parked", lambda s: False)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p: True)
+        monkeypatch.setattr(
+            prompt_router, "screen_shows_live_menu", lambda v: False)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t: "")
+        seen = {}
+
+        def fake_send(session, text, marker=None, retries=1, settle=2.0,
+                      pane_index=0):
+            seen["pane"] = pane_index
+            return True
+
+        monkeypatch.setattr(session_ready, "send_verified", fake_send)
+        ok, reason = prompt_router.safe_deliver("s", 3, "hello")
+        assert ok and seen["pane"] == 3

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -474,3 +474,115 @@ class TestCouncilDelegation:
         monkeypatch.setattr(session_ready, "send_verified", fake)
         assert cli.send_verified("council-gut", "msg", "[COUNCIL PROMPT #1]")
         assert calls["args"] == ("council-gut", "msg", "[COUNCIL PROMPT #1]", 1)
+
+
+class TestStripInputBox:
+    """#689 — 'on scrollback' must mean OUTSIDE the input box."""
+
+    def test_removes_box_region(self):
+        cap = "history line\n" + render_box("draft text")
+        outside = session_ready.strip_input_box(cap)
+        assert "history line" in outside
+        assert "draft text" not in outside
+
+    def test_unparseable_returns_none(self):
+        assert session_ready.strip_input_box("no rules anywhere") is None
+
+    def test_empty_box(self):
+        outside = session_ready.strip_input_box("above\n" + render_box())
+        assert "above" in outside
+
+
+class TestMessageOnScrollbackBoxAware:
+    """#689 regression — a pasted-but-unsubmitted message sitting in the input
+    box must NOT read as 'on scrollback'. That false positive is exactly how
+    the drain unlinked pending files while the recipient never got the message
+    (2026-07-03 repro)."""
+
+    def test_message_in_box_is_not_on_scrollback(self):
+        msg = "[MSG from w · done] PR drafted  ⟨#abc123⟩"
+        cap = "some history\n" + render_box(msg)
+        assert not session_ready.message_on_scrollback(cap, msg)
+
+    def test_message_above_box_is_on_scrollback(self):
+        msg = "[MSG from w · done] PR drafted  ⟨#abc123⟩"
+        cap = f"{msg}\n" + render_box()
+        assert session_ready.message_on_scrollback(cap, msg)
+
+    def test_unparseable_box_stays_pending(self):
+        # Can't prove the text is outside the box → conservative False.
+        msg = "[MSG from w · done] PR drafted  ⟨#abc123⟩"
+        assert not session_ready.message_on_scrollback(f"junk\n{msg}\njunk", msg)
+
+
+class TestZeroEnterFalsePositive:
+    """#689 root cause 1 — a busy pane whose box is unparseable at phase-2
+    start must NOT be declared submitted before at least one Enter has actually
+    been pressed."""
+
+    def test_strict_confirm_rejects_unparseable_box(self):
+        busy = "⏺ Bash(ls)\n  ⎿ file.py\n✻ Thinking…\nsome text no box"
+        assert not session_ready.submit_confirmed(
+            busy, "our msg", allow_unparsed=False
+        )
+        # Permissive (post-Enter) still accepts activity evidence.
+        assert session_ready.submit_confirmed(busy, "our msg")
+
+    def test_enter_pressed_before_permissive_confirm(self, monkeypatch):
+        # Paste lands (parseable box), then the pane re-renders busily and the
+        # box becomes unparseable with activity glyphs. The old code confirmed
+        # on the FIRST phase-2 snapshot with zero Enters.
+        _fake_clock(monkeypatch)
+        busy = "⏺ Bash(build)\n✶ Working… (esc to interrupt)\nno box parses here"
+
+        def frame(a):
+            if a["enters"] == 0:
+                if a["caps"] <= 2:
+                    return render_box("stuck report")  # landed
+                return busy  # unparseable re-render — must NOT confirm yet
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "stuck report")
+        assert actions["enters"] >= 1, "confirmed with zero Enters pressed"
+
+
+class TestFinishSubmit:
+    """#689 healing primitive — Enter-only, never a paste."""
+
+    def test_submits_stuck_message(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        msg = "[MSG from w · done] PR drafted  ⟨#abc123⟩"
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box(msg)  # stuck in the box
+            return render_box()  # Enter registered
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.finish_submit("s", msg)
+        assert actions["pastes"] == 0  # NEVER pastes (#621 dedup holds)
+        assert actions["enters"] >= 1
+
+    def test_already_clear_box_no_enter(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        actions = _env(monkeypatch, lambda a: render_box())
+        assert session_ready.finish_submit("s", "gone message")
+        assert actions["enters"] == 0
+        assert actions["pastes"] == 0
+
+    def test_wedged_box_returns_false(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        msg = "immovable text"
+        actions = _env(monkeypatch, lambda a: render_box(msg))
+        assert not session_ready.finish_submit("s", msg)
+        assert actions["pastes"] == 0
+
+    def test_never_raises(self, monkeypatch):
+        _fake_clock(monkeypatch)
+
+        def boom(a):
+            raise RuntimeError("gone")
+
+        _env(monkeypatch, boom)
+        assert session_ready.finish_submit("s", "msg") is False


### PR DESCRIPTION
## Root cause (verified against the code, not the hypothesis as written)

The issue's hypothesis was close but the actual escape hatches were:

1. **`inbox._dedup_landed` counted the input box as scrollback.** `session_ready.message_on_scrollback` matched the rendered line against the whole pane capture — which includes the input box. A pasted-but-unsubmitted message therefore read as "already delivered" and the drain unlinked its pending file. This is exactly the 2026-07-03 repro (pending file gone, text sitting unsent for 15+ min).

2. **Phase-2 confirm could pass with zero Enters ever pressed.** `submit_confirmed`'s unparseable-box fallback (`activity OR message visible`) was checked *before* the first Enter (`session_ready._deliver_once`). A pane busy re-rendering at delivery time — the exact under-load scenario — was declared submitted without a single keystroke.

3. `safe_deliver` dropped its `target_pane` argument (always delivered to pane 0).

## Fix (Enter-only retries, never a re-paste — #621 dedup holds)

- **`strip_input_box` / box-aware `message_on_scrollback`**: "on scrollback" now means *outside* the box; unparseable box → not on scrollback (keep pending). Kills the drain's false unlink.
- **Strict pre-Enter confirm**: `submit_confirmed(allow_unparsed=False)` before the first press; the permissive fallback only counts after ≥1 real Enter.
- **`finish_submit`**: Enter-only phase-2 healer. The msg drain uses it when it finds its own pending message rendered in the recipient's box — unlink only on confirmed submit, otherwise defer without penalty (`stuck_in_box`, no dead-letter burn).
- **Sweeper backstop**: the watchdog pane-sweep flushes a bare Enter on an idle pane whose box has held identical machine-injected content (`[MSG from`, `[NOTIFY from`, `[PROMPT`, `[IDLE`, `[Pasted text`) for 2 consecutive sweeps (~2 min). Deviation from the issue spec: it only flushes machine-header content, never arbitrary text — auto-submitting a walked-away human draft is worse than the stall.
- `safe_deliver` threads `pane_index` through.

## Verification

- Unit: box-aware scrollback, zero-Enter regression, `finish_submit` (never pastes), drain stuck-in-box paths, sweeper arming/reset/skip rules, pane threading.
- Real-tmux integration: paste with swallowed Enter → `finish_submit` submits Enter-only, no duplicate, and the stuck state correctly reads as *not* delivered.
- Full suite in-worktree: **2459 passed**.
- Not verifiable in-worktree: live portal/watchdog behavior post-rebuild.

Closes #689

Built by [dotdev.dev](https://dotdev.dev)