### PR TITLE
fix(scheduler): due-but-gated task no longer busy-loops the daemon (sleep floor)

### DIFF
--- a/agentwire/scheduler/schedule.py
+++ b/agentwire/scheduler/schedule.py
@@ -14,6 +14,11 @@ from .models import (
     _parse_time,
 )
 
+# Minimum sleep when the board has a DUE task that isn't runnable (gate
+# failed). Without it, pick_next_task returns (None, 0.0) and the main loop
+# spins at time.sleep(0) — see #691.
+GATE_RETRY_FLOOR = 30.0
+
 
 def _dt_to_ts(dt: datetime | None) -> float:
     """Convert a datetime to a Unix timestamp (0 if None)."""
@@ -258,9 +263,14 @@ def pick_next_task(board: Board) -> tuple[str | None, float]:
         if _sched._check_gate(board, name):
             return name, 0.0
 
-    # Nothing to run now — calculate sleep until earliest task is due
+    # Nothing to run now — calculate sleep until earliest task is due. A task
+    # can be DUE yet not runnable (gate failed, above), which makes
+    # seconds_until_next_due return 0.0 — without a floor the main loop does
+    # time.sleep(0) and spins hard: gate command re-run + portal notify
+    # ~12×/sec until the gate ever passes (#691). Floor to GATE_RETRY_FLOOR so
+    # a due-but-gated board re-checks at loop cadence instead.
     wait = seconds_until_next_due(board)
-    return None, wait
+    return None, max(wait, GATE_RETRY_FLOOR)
 
 
 def seconds_until_next_due(board: Board) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,22 @@ def _no_real_outbound_email(request, monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _no_live_portal_stt_query(monkeypatch):
+    """Keep tests off the RUNNING portal's /api/voice-status.
+
+    #683 made ``resolve_stt_status`` prefer the live portal's effective STT
+    backend over the file config — correct in production, but it makes any
+    status test environment-dependent (a portal running ``--no-stt`` on the
+    dev box flips every configured-backend assertion to the ``none`` tier;
+    test_doctor_voice broke exactly this way). Tests that exercise the live
+    override re-patch this attribute themselves.
+    """
+    import agentwire.voice_status as vs
+
+    monkeypatch.setattr(vs, "_portal_effective_stt_backend", lambda: None)
+
+
 @pytest.fixture
 def tmp_config_dir(tmp_path):
     """Temporary ~/.agentwire/ equivalent."""

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -324,6 +324,21 @@ class TestPickNextTask:
         assert name is None
         assert wait > 0
 
+    @patch("agentwire.scheduler._check_gate", return_value=False)
+    def test_due_but_gate_blocked_sleeps_not_spins(self, mock_gate):
+        """#691: a due task whose gate fails must NOT yield (None, 0.0) —
+        time.sleep(0) makes the daemon busy-loop (gate re-run + portal notify
+        ~12×/sec) until the gate ever passes."""
+        from agentwire.scheduler.schedule import GATE_RETRY_FLOOR
+
+        now = time.time()
+        board = self._make_board([
+            ("gated-task", "1h", True, False, now - 7200),  # overdue, gate fails
+        ])
+        name, wait = pick_next_task(board)
+        assert name is None
+        assert wait >= GATE_RETRY_FLOOR
+
     @patch("agentwire.scheduler._check_gate", return_value=True)
     def test_never_run_task_is_overdue(self, mock_gate):
         board = self._make_board([


### PR DESCRIPTION
Closes #691. A due task with a failing gate made pick_next_task return (None, 0.0) → time.sleep(0) busy-loop: gate re-run + portal notify ~12×/sec until the gate ever passes. Observed live: cc-dialog-drift's failing gate spun the daemon at ~50% CPU for ~20h and flooded /api/notify hard enough that the portal appeared down.

Fix: GATE_RETRY_FLOOR (30s) on the nothing-picked sleep, so a due-but-gated board re-checks at loop cadence. Regression test included; full unit suite green.

Built by [dotdev.dev](https://dotdev.dev)