### PR TITLE
fix(portal): move window cycling to unconditional Alt+]/Alt+[ — Tab is never intercepted

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -22,7 +22,7 @@ The portal uses a left sidebar with a floating tab handle instead of hover hotzo
 
 Both share session data from `sessions-section.js` (single fetch, shared activity state, pub-sub via `onSessionsChanged`).
 
-**Keyboard:** Tab cycles forward through open windows, Shift+Tab cycles backward. Works inside terminals (captured on `window` in capture phase before xterm).
+**Keyboard:** Alt+] cycles forward through open windows, Alt+[ cycles backward — works everywhere including inside terminals (captured on `window` in capture phase before xterm, detected via `e.code` bracket keys). Tab and Shift+Tab are NEVER intercepted by the desktop; they always pass through to the focused terminal (Claude Code uses Tab for completion and Shift+Tab for permission modes — #659/#696).
 
 **Files:** `static/js/sidebar.js` (shell + click-toggle), `static/js/sidebar/<name>-section.js` (per-section modules), `static/css/desktop.css` (sidebar-* classes).
 

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -347,7 +347,7 @@ function handleWindowActivity({ session }) {
 }
 
 // Move focus to the next (+1) / previous (-1) open window, wrapping around.
-// Shared by Tab/Shift+Tab and the two-finger swipe gesture.
+// Shared by Alt+]/Alt+[ and the two-finger swipe gesture.
 function cycleWindow(direction) {
     const items = Array.from(elements.taskbarWindows.querySelectorAll('.sidebar-open-item'));
     if (items.length === 0) return;
@@ -367,39 +367,32 @@ function cycleWindow(direction) {
     saveTaskbarState();
 }
 
-// Tab / Shift+Tab to cycle open windows.
-// Terminal input wins: when focus is inside an xterm (its hidden
-// .xterm-helper-textarea) or any other text-input context, both Tab and
-// Shift+Tab pass through untouched — Claude Code uses Shift+Tab to cycle
-// permission modes and Tab for completion cycling (#659).
+// Alt+] / Alt+[ to cycle open windows (#696).
 //
-// One wrinkle: cycling itself focuses the landed-on terminal (cycleWindow →
-// SessionWindow.focus() → terminal.focus()), so without a carve-out the guard
-// would end every cycle chain after one hop — and a second Shift+Tab would
-// silently flip that Claude session's permission mode. So cycling is "sticky":
-// for a short grace window after a keyboard cycle, further Tab/Shift+Tab keep
-// cycling even though a terminal holds focus. Pause longer than the grace
-// window and the keys belong to the terminal again.
-const CYCLE_GRACE_MS = 1500;
-let lastKeyboardCycleTs = -Infinity;
-
-function tabBelongsToFocusedInput() {
-    const el = document.activeElement;
-    if (!el) return false;
-    if (el.closest('.xterm')) return true;  // xterm-helper-textarea et al.
-    const tag = el.tagName;
-    return tag === 'TEXTAREA' || tag === 'INPUT' || el.isContentEditable;
-}
-
+// Tab and Shift+Tab are NEVER intercepted by the desktop — they always pass
+// through to the focused terminal or input. Claude Code needs Shift+Tab to
+// cycle permission modes and Tab for completion cycling (#659); the earlier
+// focus-gated Tab binding (#663) could sustain a cycle chain but never start
+// one, because every window-activation path auto-focuses the terminal (#696).
+// Cycling therefore lives on a dedicated chord that works unconditionally,
+// terminal focus or not.
+//
+// Why Alt+bracket: Cmd+Tab (macOS app switcher), Alt+Tab (Windows/Linux app
+// switcher) and Ctrl+Tab / Ctrl+Shift+Tab (browser tab switching) never
+// reliably reach the page; Ctrl+Alt+Left/Right is workspace switching on
+// common Linux desktops; Alt+` is already the collage toggle. Alt+] / Alt+[
+// is unclaimed by OS, browser, and Claude Code, encodes direction in the key,
+// and matches the Alt+` / Alt+N chord idiom used elsewhere in the portal.
+// Detected via e.code (physical key) because on macOS Option composes e.key
+// into “ / ‘ — same trick as setupCollage's Alt+`.
 function setupWindowCycling() {
     window.addEventListener('keydown', (e) => {
-        if (e.key !== 'Tab') return;
-        const inCycleChain = performance.now() - lastKeyboardCycleTs < CYCLE_GRACE_MS;
-        if (!inCycleChain && tabBelongsToFocusedInput()) return;
+        if (!e.altKey || e.metaKey || e.ctrlKey) return;
+        if (e.code !== 'BracketRight' && e.code !== 'BracketLeft') return;
+        if (isCommandPaletteOpen() || isHelpOpen()) return;
         e.preventDefault();
         e.stopPropagation();
-        lastKeyboardCycleTs = performance.now();
-        cycleWindow(e.shiftKey ? -1 : 1);
+        cycleWindow(e.code === 'BracketRight' ? 1 : -1);
     }, true);  // capture phase — runs before xterm's handlers
 }
 

--- a/agentwire/static/js/shortcuts.js
+++ b/agentwire/static/js/shortcuts.js
@@ -52,7 +52,7 @@ export const SHORTCUT_GROUPS = [
     {
         title: 'Windows',
         items: [
-            { combo: ['Tab'], alt: ['Shift', 'Tab'], desc: 'Cycle to the next / previous window', where: 'desktop.js setupWindowCycling' },
+            { combo: ['Alt', ']'], alt: ['Alt', '['], desc: 'Cycle to the next / previous window (Tab always goes to the terminal)', where: 'desktop.js setupWindowCycling' },
             { combo: ['F3'], alt: ['Alt', '`'], desc: 'Window collage — Mission-Control grid of all windows', where: 'desktop.js setupCollage' },
         ],
     },

--- a/tests/unit/test_window_cycling_binding.py
+++ b/tests/unit/test_window_cycling_binding.py
@@ -1,0 +1,65 @@
+"""Guard the #696 window-cycling keyboard contract in the portal static JS.
+
+Owner decision on #696: Tab and Shift+Tab are NEVER intercepted by the desktop
+(Claude Code needs Tab for completion and Shift+Tab for permission modes, #659);
+window cycling lives on a dedicated unconditional Alt+] / Alt+[ chord instead.
+There is no JS test runner in this repo, so these are source-level assertions
+tying desktop.js's real binding to the shortcuts.js catalogue that feeds the
+F1 help modal (the two must stay in sync — see shortcuts.js header).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+STATIC_JS = Path(__file__).resolve().parents[2] / "agentwire" / "static" / "js"
+
+
+@pytest.fixture(scope="module")
+def desktop_js():
+    return (STATIC_JS / "desktop.js").read_text()
+
+
+@pytest.fixture(scope="module")
+def shortcuts_js():
+    return (STATIC_JS / "shortcuts.js").read_text()
+
+
+@pytest.fixture(scope="module")
+def cycling_handler(desktop_js):
+    """The setupWindowCycling function body (up to the next top-level function)."""
+    match = re.search(
+        r"function setupWindowCycling\(\).*?(?=\nfunction )", desktop_js, re.DOTALL
+    )
+    assert match, "setupWindowCycling missing from desktop.js"
+    return match.group(0)
+
+
+def test_cycling_never_intercepts_tab(cycling_handler, desktop_js):
+    assert "'Tab'" not in cycling_handler, (
+        "setupWindowCycling must not handle Tab — Tab/Shift+Tab always pass "
+        "through to the terminal (#696 owner decision)"
+    )
+    # The #663 focus-gate + sticky-chain machinery must stay deleted, not dormant.
+    for relic in ("tabBelongsToFocusedInput", "CYCLE_GRACE_MS", "lastKeyboardCycleTs"):
+        assert relic not in desktop_js, f"{relic} is #663 machinery removed by #696"
+
+
+def test_cycling_bound_to_alt_brackets(cycling_handler):
+    # e.code (physical key), not e.key — macOS Option composes e.key into “ / ‘.
+    assert "e.code" in cycling_handler
+    assert "'BracketRight'" in cycling_handler
+    assert "'BracketLeft'" in cycling_handler
+    assert "e.altKey" in cycling_handler
+    assert "cycleWindow" in cycling_handler
+
+
+def test_help_catalogue_documents_the_chord(shortcuts_js):
+    row = re.search(r"\{[^{}]*setupWindowCycling[^{}]*\}", shortcuts_js)
+    assert row, "shortcuts.js must keep a row pointing at setupWindowCycling"
+    assert "['Alt', ']']" in row.group(0)
+    assert "['Alt', '[']" in row.group(0)
+    assert "['Tab']" not in row.group(0), (
+        "help modal must not advertise Tab window-cycling (#696)"
+    )


### PR DESCRIPTION
## Problem

Window cycling was still bound to Tab / Shift+Tab, but the #663 focus gate made it unreachable in normal use: the 1500 ms sticky-chain grace could *sustain* a chain, never *start* one (`lastKeyboardCycleTs` starts `-Infinity`), and every window-activation path auto-focuses the terminal — so the first Tab always belonged to the terminal and the chain never began. Full analysis in #696.

## Fix (owner decision, superseding the chord-starts-chain option in the issue)

**No conditional Tab handling at all.**

- Tab and Shift+Tab are **never** intercepted by the desktop — they pass through to the focused terminal/input unconditionally, preserving Claude Code's Tab completion and Shift+Tab permission-mode cycling (#659). The #663 focus-gate + sticky-chain machinery (`CYCLE_GRACE_MS`, `lastKeyboardCycleTs`, `tabBelongsToFocusedInput`) is deleted, not extended.
- Window cycling moves entirely to a dedicated chord: **Alt+] = next, Alt+[ = previous**, capture-phase on `window` so it works regardless of focus (including inside terminals). Detected via `e.code` (`BracketRight`/`BracketLeft`) because macOS Option composes `e.key` into curly quotes — same trick as the collage Alt+` handler. Suppressed while the command palette or help modal is open. Swipe cycling (trackpad + touch) is untouched.

## Chord evaluation

| Candidate | Verdict |
|---|---|
| Cmd+Tab | macOS app switcher — never reaches the page |
| Alt+Tab / Alt+Shift+Tab | Windows/Linux app switcher — OS-eaten |
| Ctrl+Tab / Ctrl+Shift+Tab | Browser tab switching — browser-eaten in Chrome/Safari/Firefox |
| Ctrl+Alt+Tab | Windows sticky task switcher |
| Alt+\` / Alt+Shift+\` | Already the collage toggle in this portal (`setupCollage` doesn't gate on Shift, so both variants collide) |
| Ctrl+Alt+Left/Right | Workspace switching on common Linux desktops (Cinnamon/MATE/Xfce), legacy Intel display-rotation hotkey on Windows |
| **Alt+] / Alt+[** | **Unclaimed by OS, browser, and Claude Code; encodes direction in the key; matches the portal's existing Alt+\` / Alt+N chord idiom** |

## Also

- `shortcuts.js` help-modal row updated (it previously advertised unconditional Tab cycling — misleading since #663).
- `.claude/skills/agentwire-desktop-ui` keyboard section updated to match.
- New `tests/unit/test_window_cycling_binding.py` — no JS runner exists in this repo, so it source-asserts the contract: `setupWindowCycling` handles no Tab, the #663 relics stay deleted, the Alt+bracket binding exists, and the shortcuts catalogue documents the same chord.

## Verification

Full suite: **2463 passed** (`uv run --extra dev pytest`). Live-portal behavior (actual keypress in a real browser) can only be checked after merge + rebuild — this worktree doesn't touch the running portal.

Closes #696

Built by [dotdev.dev](https://dotdev.dev)