### PR TITLE
fix(sessions): worktree seed failure is loud + recoverable; readiness probes the input handler

### DIFF
--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -52,15 +52,41 @@ def worktree_create(
     caller = get_caller_session()
     if caller:
         args += ["--created-by", caller]
-    # Seeding waits for agent boot (~up to 60s); give the CLI room to finish.
-    data = run_agentwire_cmd(args, timeout=90)
+    # Seeding waits for agent boot (up to 60s) and, on a failed seed, runs the
+    # clear-box + inbox-fallback recovery (#695) — give the CLI room to finish
+    # the loud-failure path instead of masking it with a subprocess timeout.
+    data = run_agentwire_cmd(args, timeout=180)
     if not data.get("success"):
         return f"Failed to create worktree: {data.get('error', 'Unknown error')}"
     session = data.get("session", name)
     path = data.get("path", "")
-    seeded = " (seeded)" if prompt and data.get("first_message_delivered") else ""
     if data.get("reattached"):
-        return f"Reattached to existing worktree session '{session}' at {path}."
+        note = (
+            " NOTE: the session was already live, so the seed prompt was NOT "
+            "pasted — send it with msg_send if still needed."
+            if prompt
+            else ""
+        )
+        return f"Reattached to existing worktree session '{session}' at {path}.{note}"
+    # Seed failure must be LOUD (#695): a silently-missing "(seeded)" suffix is
+    # invisible to an orchestrator skimming results, and the session then sits
+    # idle with the task never delivered.
+    if prompt and not data.get("first_message_delivered"):
+        if data.get("first_message_fallback") == "inbox":
+            return (
+                f"Created worktree session '{session}' at {path}. "
+                "WARNING: seed prompt NOT delivered — the input box was not ready. "
+                "The prompt was queued to the session's msg inbox and the watchdog "
+                "will deliver it once the box is ready; verify with msg_inbox / "
+                "session_output before assuming the task started."
+            )
+        return (
+            f"Created worktree session '{session}' at {path}. "
+            "WARNING: seed prompt NOT delivered and could NOT be queued — the "
+            f"session is idle with no task. Deliver it manually (session_send to "
+            f"'{session}')."
+        )
+    seeded = " (seeded)" if prompt else ""
     return f"Created worktree session '{session}'{seeded} at {path}."
 
 

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -477,11 +477,25 @@ def cmd_new(args) -> int:
             )
         save_project_config(project_config, session_path)
 
+    # Record the creating session as parent for prompt routing. --created-by
+    # overrides; empty string opts out; default = the calling tmux session.
+    # Resolved before seeding so a failed seed can name its sender.
+    created_by = getattr(args, 'created_by', None)
+    if created_by is None:
+        created_by = pane_manager.get_current_session()
+
     # Deliver the first message once the agent is ready (verified paste).
-    # Delivery failure doesn't fail the command — the session exists.
+    # Delivery failure doesn't fail the command — the session exists — but it
+    # must be LOUD (#695): clear the partial paste out of the box and fall
+    # back to the msg inbox so the prompt still arrives once the box is ready.
     first_message_delivered = None
+    first_message_fallback = None
     if first_message and agent_cmd:
-        from agentwire.session_ready import send_verified, wait_for_session_ready
+        from agentwire.session_ready import (
+            recover_failed_seed,
+            send_verified,
+            wait_for_session_ready,
+        )
 
         if not json_mode:
             print("Waiting for agent to deliver first message...")
@@ -489,14 +503,24 @@ def cmd_new(args) -> int:
             wait_for_session_ready(session_name, timeout=60)
             and send_verified(session_name, first_message)
         )
-        if not first_message_delivered and not json_mode:
-            print(f"Warning: first message not delivered to '{session_name}' — paste it manually", file=sys.stderr)
+        if not first_message_delivered:
+            first_message_fallback = recover_failed_seed(
+                session_name, first_message, sender=created_by or "agentwire"
+            )
+            if not json_mode:
+                if first_message_fallback == "inbox":
+                    print(
+                        f"WARNING: first message NOT delivered to '{session_name}' — "
+                        "queued to its msg inbox for delivery once the input box is ready",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"WARNING: first message NOT delivered to '{session_name}' "
+                        "and could not be queued — paste it manually",
+                        file=sys.stderr,
+                    )
 
-    # Record the creating session as parent for prompt routing. --created-by
-    # overrides; empty string opts out; default = the calling tmux session.
-    created_by = getattr(args, 'created_by', None)
-    if created_by is None:
-        created_by = pane_manager.get_current_session()
     _record_session_creator(session_name, created_by, via="new")
 
     if json_mode:
@@ -509,6 +533,10 @@ def cmd_new(args) -> int:
         }
         if first_message:
             result["first_message_delivered"] = bool(first_message_delivered)
+            if not first_message_delivered:
+                # "inbox" (queued for watchdog delivery) or None (fallback
+                # failed too — the prompt is gone; caller must redeliver).
+                result["first_message_fallback"] = first_message_fallback
         _output_json(result)
     else:
         print(f"Created session '{session_name}' in {session_path}")

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -41,6 +41,27 @@ SUBMIT_BUDGET = 20.0
 # can eat the wall-clock before we've pressed Enter enough times).
 MIN_ENTER_ATTEMPTS = 4
 
+# Readiness hardening (#695). Two identical 500ms frames proved too weak a
+# stability signal: a render pause while a notice panel / effort banner loads
+# (or model-init on a high effort tier) yields an identical pair with the input
+# handler still unwired, and the premature paste fragments + its Enters are
+# swallowed. Require a longer identical run, then demand POSITIVE proof the
+# handler consumes keystrokes: type a probe char, watch it render in the input
+# box, erase it. Only then is the real paste allowed.
+READY_STABLE_SNAPSHOTS = 3  # consecutive identical frames (~1s of stability)
+PROBE_CHAR = "."
+# Per-probe wait for the typed char to render in the box. Short: an unwired
+# handler swallows (or buffers) the keystroke, and the outer loop re-sends.
+PROBE_APPEAR_TIMEOUT = 3.0
+# Wait for backspace(s) to clear the rendered probe(s) out of the box.
+PROBE_ERASE_TIMEOUT = 3.0
+
+# Seed-failure recovery (#695): bounded attempts at clearing a partial paste
+# out of the input box (Escape clears Claude Code's current input, including a
+# large paste's ``[Pasted text]`` chip), and the per-attempt confirm budget.
+CLEAR_BOX_ATTEMPTS = 3
+CLEAR_BOX_TIMEOUT = 3.0
+
 # Substrings that mean "Claude is actively working" — a spinner footer, the
 # token counter, the esc-to-interrupt hint, or tool-output glyphs. A
 # submitted-and-working agent is the success case the old check mistook for a
@@ -197,27 +218,86 @@ def _poll(predicate, timeout: float) -> bool:
         time.sleep(POLL_INTERVAL)
 
 
+def _box_is_probe(box: "str | None") -> bool:
+    """Is the input box showing nothing but our probe char(s)?
+
+    Swallowed-then-buffered keystrokes can pile up, so any run of probe chars
+    counts. Ghost/placeholder hint text (a sentence) never matches, and a
+    leftover draft never matches — both correctly read as "probe not proven".
+    """
+    if not box:
+        return False
+    s = "".join(box.split())
+    return bool(s) and set(s) == {PROBE_CHAR}
+
+
+def _probe_input_handler(session: str, pane_index: int, deadline: float) -> bool:
+    """Positive proof the input handler consumes keystrokes (#695).
+
+    Types PROBE_CHAR, polls the input box until the char actually renders,
+    then erases it and confirms the box moved on. A banner-up-but-unwired
+    session swallows (or buffers) the keystroke, so the probe never confirms
+    and we re-send until *deadline* — failing safe instead of pasting into a
+    session that would fragment the paste and swallow its Enters.
+    """
+    from agentwire import pane_manager
+
+    target = f"{session}.{pane_index}"
+
+    def box() -> "str | None":
+        return input_box(capture_session(session, pane_index=pane_index))
+
+    while time.time() < deadline:
+        pane_manager.run_command(
+            ["tmux", "send-keys", "-t", target, "-l", PROBE_CHAR], timeout=5
+        )
+        appear_budget = min(
+            PROBE_APPEAR_TIMEOUT, max(deadline - time.time(), POLL_INTERVAL)
+        )
+        if not _poll(lambda: _box_is_probe(box()), appear_budget):
+            continue  # swallowed — handler not wired yet; re-send and re-check
+        # Erase: buffered keystrokes may have piled up ("..."), so backspace
+        # what's visible and confirm the box no longer shows probe chars.
+        while time.time() < deadline:
+            try:
+                visible = box() or ""
+            except Exception:
+                visible = ""
+            for _ in range(len("".join(visible.split())) or 1):
+                pane_manager.run_command(
+                    ["tmux", "send-keys", "-t", target, "BSpace"], timeout=5
+                )
+            if _poll(lambda: not _box_is_probe(box()), PROBE_ERASE_TIMEOUT):
+                return True
+        return False
+    return False
+
+
 def wait_for_session_ready(
     session_full_name: str, timeout: float = 30.0, pane_index: int = 0
 ) -> bool:
     """Poll a session's pane until Claude is fully ready to accept input.
 
-    Two-phase wait:
+    Three-phase wait:
 
     1. Detect the Claude prompt banner (``❯`` or ``Bypassing Permissions``).
-    2. Wait until the screen is *stable* — two consecutive 500ms snapshots
-       are identical. This catches the case where Claude has rendered its
-       banner but is still wiring its input handler. A premature paste at
-       that point gets fragmented into multiple ``[Pasted text +N]`` chunks
-       and Enter keys land in a state where Claude can't process them —
-       the prompt sits in the input box, never submitted.
+    2. Wait until the screen is *stable* — READY_STABLE_SNAPSHOTS consecutive
+       500ms snapshots are identical. Two identical frames proved too weak
+       (#695): a render pause while a notice panel / effort banner loads
+       yields an identical pair with the input handler still unwired.
+    3. Probe the input handler (:func:`_probe_input_handler`): type a char,
+       confirm it renders in the input box, erase it. Without this positive
+       proof, a premature paste gets fragmented into multiple
+       ``[Pasted text +N]`` chunks and Enter keys land in a state where
+       Claude can't process them — the prompt sits in the input box, never
+       submitted.
 
     Also auto-accepts the first-time "trust this folder" prompt, which a
     fresh project directory always triggers (and which contains neither
     banner string, so it would otherwise stall the wait until timeout).
 
-    Returns True once the screen is stable after banner-detection. False on
-    timeout.
+    Returns True once the probe round-trips after banner + stability. False
+    on timeout.
     """
     from agentwire import pane_manager
 
@@ -225,6 +305,7 @@ def wait_for_session_ready(
     banner_seen = False
     trust_accepted = False
     last_snapshot: str | None = None
+    stable_count = 0
 
     while time.time() < deadline:
         try:
@@ -232,6 +313,7 @@ def wait_for_session_ready(
         except Exception:
             time.sleep(0.5)
             last_snapshot = None
+            stable_count = 0
             continue
 
         if not banner_seen:
@@ -253,10 +335,14 @@ def wait_for_session_ready(
             time.sleep(0.5)
             continue
 
-        # Banner is up; wait for two consecutive identical snapshots.
+        # Banner is up; require READY_STABLE_SNAPSHOTS identical snapshots.
         if last_snapshot is not None and out == last_snapshot:
-            return True
+            stable_count += 1
+        else:
+            stable_count = 0
         last_snapshot = out
+        if stable_count >= READY_STABLE_SNAPSHOTS - 1:
+            return _probe_input_handler(session_full_name, pane_index, deadline)
         time.sleep(0.5)
 
     return False
@@ -494,3 +580,64 @@ def send_verified(
         except Exception:
             pass
     return False
+
+
+def clear_input_box(session: str, pane_index: int = 0) -> bool:
+    """Best-effort: clear whatever sits unsubmitted in the input box (#695).
+
+    A failed seed can leave a partial paste in the box, which (a) confuses a
+    human attaching to the session and (b) blocks the msg-inbox fallback
+    forever — the drain only pastes into an EMPTY box. Sends Escape (Claude
+    Code: clears the current input, including a large paste's ``[Pasted
+    text]`` chip) and confirms emptiness with the drain's own SGR-aware gate
+    (``prompt_router.prompt_is_empty``), so "cleared" here means exactly
+    "the drain will deliver". Returns True iff the box ends up empty.
+    """
+    from agentwire import pane_manager, prompt_router
+
+    target = f"{session}.{pane_index}"
+
+    def empty() -> bool:
+        return prompt_router.prompt_is_empty(session, pane_index)
+
+    for _ in range(CLEAR_BOX_ATTEMPTS):
+        try:
+            if empty():
+                return True
+            pane_manager.run_command(
+                ["tmux", "send-keys", "-t", target, "Escape"], timeout=5
+            )
+            if _poll(empty, CLEAR_BOX_TIMEOUT):
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def recover_failed_seed(
+    session: str, message: str, sender: "str | None" = None, pane_index: int = 0
+) -> "str | None":
+    """Recover a first-message seed that failed to deliver (#695).
+
+    1. Clear the partial paste out of the input box (it would block the
+       inbox drain's empty-box gate indefinitely).
+    2. Enqueue the prompt as a ``request`` into the session's msg inbox —
+       the watchdog delivers it once the box is truly ready, and a request
+       that can never deliver dead-letters LOUDLY (owner email) instead of
+       vanishing.
+
+    Returns ``"inbox"`` when the prompt was queued, None when even the
+    fallback failed (the caller must tell the user to deliver manually).
+    Never raises.
+    """
+    try:
+        clear_input_box(session, pane_index=pane_index)
+    except Exception:
+        pass
+    try:
+        from agentwire import inbox
+
+        inbox.enqueue(session, message, kind="request", sender=sender or "agentwire")
+        return "inbox"
+    except Exception:
+        return None

--- a/tests/integration/test_send_verified_tmux.py
+++ b/tests/integration/test_send_verified_tmux.py
@@ -32,9 +32,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 # A self-contained emulator — written to a temp file and run as the pane's
-# command. Reads stdin byte-by-byte in raw mode; \r submits, \n is literal.
+# command. Reads stdin byte-by-byte in raw mode; \r submits, \n is literal,
+# \x7f (backspace) erases. An optional argv[1] delay renders the banner+box
+# immediately but leaves stdin unconsumed for that many seconds — the #695
+# "input handler not wired yet" window (keystrokes buffer in the PTY).
 EMULATOR = r'''
-import os, sys, tty
+import os, sys, time, tty
 RULE = "─" * 20
 buf = ""
 
@@ -55,6 +58,12 @@ sys.stdout.write("\x1b[?2004h")
 sys.stdout.flush()
 tty.setraw(sys.stdin.fileno())
 draw()
+
+# Simulated late input wiring (#695): the screen is up (banner + box) but
+# nothing consumes stdin yet — keystrokes sent now buffer in the PTY and are
+# dumped into the loop all at once when the "handler" finally wires.
+if len(sys.argv) > 1:
+    time.sleep(float(sys.argv[1]))
 
 data = b""
 in_paste = False
@@ -82,6 +91,8 @@ while True:
         elif ch == "\r":             # real Enter keystroke -> submit
             if buf:
                 buf = ""
+        elif ch == "\x7f":           # backspace keystroke -> erase one char
+            buf = buf[:-1]
         elif ch == "\x03":
             sys.exit(0)
         else:
@@ -99,34 +110,53 @@ def _capture(session):
 
 
 @pytest.fixture
-def emulator_session(tmp_path):
+def emulator_factory(tmp_path):
+    """Spawn emulator panes on a private tmux socket; kill them on teardown.
+
+    ``make(wire_delay=N)`` renders the banner+box immediately but leaves the
+    emulator's stdin unconsumed for N seconds — the #695 unwired window.
+    """
     script = tmp_path / "claude_box_emulator.py"
     script.write_text(EMULATOR)
-    session = f"awtest-{uuid.uuid4().hex[:8]}"
-    # Dedicated server socket so we never touch the user's live tmux. The socket
-    # path MUST be short — macOS caps Unix-domain socket paths at ~104 bytes, and
-    # pytest's tmp_path easily blows past that (silently failing new-session), so
-    # keep it in a short temp dir keyed by a tiny uuid.
-    sock_dir = Path(tempfile.mkdtemp(prefix="awt-"))
-    socket = str(sock_dir / "s")
+    created = []
 
-    def tmux_s(*args):
-        return subprocess.run(
-            ["tmux", "-S", socket, *args], capture_output=True, text=True
-        )
+    def make(wire_delay: float = 0.0):
+        session = f"awtest-{uuid.uuid4().hex[:8]}"
+        # Dedicated server socket so we never touch the user's live tmux. The
+        # socket path MUST be short — macOS caps Unix-domain socket paths at
+        # ~104 bytes, and pytest's tmp_path easily blows past that (silently
+        # failing new-session), so keep it in a short temp dir.
+        sock_dir = Path(tempfile.mkdtemp(prefix="awt-"))
+        socket = str(sock_dir / "s")
 
-    tmux_s("new-session", "-d", "-s", session, "-x", "120", "-y", "40",
-           f"{sys.executable} {script}")
-    # Wait for the box to render.
-    deadline = time.time() + 5
-    while time.time() < deadline:
-        if "❯" in subprocess.run(
-            ["tmux", "-S", socket, "capture-pane", "-t", f"{session}.0", "-p"],
-            capture_output=True, text=True).stdout:
-            break
-        time.sleep(0.1)
-    yield session, socket, tmux_s
-    tmux_s("kill-session", "-t", session)
+        def tmux_s(*args):
+            return subprocess.run(
+                ["tmux", "-S", socket, *args], capture_output=True, text=True
+            )
+
+        cmd = f"{sys.executable} {script}"
+        if wire_delay:
+            cmd += f" {wire_delay}"
+        tmux_s("new-session", "-d", "-s", session, "-x", "120", "-y", "40", cmd)
+        # Wait for the box to render.
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if "❯" in subprocess.run(
+                ["tmux", "-S", socket, "capture-pane", "-t", f"{session}.0", "-p"],
+                capture_output=True, text=True).stdout:
+                break
+            time.sleep(0.1)
+        created.append((session, tmux_s))
+        return session, socket, tmux_s
+
+    yield make
+    for session, tmux_s in created:
+        tmux_s("kill-session", "-t", session)
+
+
+@pytest.fixture
+def emulator_session(emulator_factory):
+    return emulator_factory()
 
 
 def _patch_pane_manager(monkeypatch, socket):
@@ -215,3 +245,34 @@ def test_stuck_paste_finished_enter_only_no_duplicate(emulator_session, monkeypa
     # No duplicate: the emulator clears on submit; a re-paste would have left a
     # second copy sitting in the box.
     assert msg not in (box or "")
+
+
+def test_wait_ready_probe_roundtrip_real_tmux(emulator_factory, monkeypatch):
+    # #695: against a wired pane, readiness confirms via the probe round-trip
+    # (type a char, see it render, erase it) and leaves the box clean for the
+    # real paste — which then delivers end-to-end.
+    session, socket, _ = emulator_factory()
+    _patch_pane_manager(monkeypatch, socket)
+
+    assert session_ready.wait_for_session_ready(session, timeout=15)
+    cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    assert session_ready.input_box(cap) == "", "probe left residue in the box"
+    assert session_ready.send_verified(session, "the seed prompt")
+
+
+def test_wait_ready_holds_until_input_handler_wired(emulator_factory, monkeypatch):
+    # #695 live repro shape: banner + input box render immediately, but stdin
+    # is not consumed for 3s (keystrokes buffer in the PTY — the unwired
+    # window). The pre-#695 rule (two identical 500ms frames) declared ready
+    # ~1s in and pasted into the void; the probe must hold readiness until the
+    # handler actually consumes keystrokes, then clean up every buffered probe.
+    session, socket, _ = emulator_factory(wire_delay=3.0)
+    _patch_pane_manager(monkeypatch, socket)
+
+    t0 = time.time()
+    assert session_ready.wait_for_session_ready(session, timeout=30)
+    assert time.time() - t0 >= 2.5, "declared ready inside the unwired window"
+    cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    assert session_ready.input_box(cap) == "", "buffered probes not erased"
+    # The seed that used to fragment/sit unsubmitted now delivers.
+    assert session_ready.send_verified(session, "seed after late wiring")

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -259,6 +259,83 @@ class TestCmdNewFirstMessage:
         assert "local-only" in payload["error"]
 
 
+class TestCmdNewSeedFallback:
+    """#695 — cmd_new's JSON contract on a failed seed: recovery runs (clear
+    box + msg-inbox fallback) and `first_message_fallback` tells the caller
+    (mcp_worktree) which fallback fired, so the failure is never silent."""
+
+    def _run_cmd_new(self, monkeypatch, tmp_path, *, ready, verified, fallback):
+        from types import SimpleNamespace
+        from agentwire import session_cli as m
+        from agentwire import session_ready
+
+        # Hermetic stubs: no tmux, no roles from disk, no portal.
+        monkeypatch.setattr(m, "_check_tmux_installed", lambda: True)
+        monkeypatch.setattr(
+            m.subprocess, "run", lambda *a, **k: MagicMock(returncode=1, stdout=""))
+        monkeypatch.setattr(m, "load_config", lambda *a, **k: {})
+        monkeypatch.setattr(m, "resolve_roles", lambda *a, **k: [])
+        monkeypatch.setattr(m, "inject_soul", lambda names, cfg, no_soul=False: [])
+        monkeypatch.setattr(
+            m, "_resolve_session_type_from_args", lambda a, k: ("claude-bypass", None))
+        monkeypatch.setattr(
+            m, "build_agent_command",
+            lambda *a, **k: SimpleNamespace(command="claude", env={}))
+        monkeypatch.setattr(m, "_launch_tmux_session", lambda *a, **k: None)
+        monkeypatch.setattr(m, "_record_session_creator", lambda *a, **k: None)
+        monkeypatch.setattr(m, "_notify_portal_sessions_changed", lambda: None)
+
+        calls = {}
+        monkeypatch.setattr(
+            session_ready, "wait_for_session_ready",
+            lambda s, timeout=30.0, pane_index=0: ready)
+        monkeypatch.setattr(
+            session_ready, "send_verified",
+            lambda s, msg, **k: verified)
+
+        def fake_recover(session, message, sender=None, pane_index=0):
+            calls["recover"] = (session, message, sender)
+            return fallback
+
+        monkeypatch.setattr(session_ready, "recover_failed_seed", fake_recover)
+
+        args = argparse.Namespace(
+            session="proj", path=str(tmp_path), force=False, json=True,
+            first_message="do the thing", created_by="orch",
+        )
+        rc = m.cmd_new(args)
+        return rc, calls
+
+    def test_seed_failure_runs_recovery_and_reports_fallback(
+            self, capsys, monkeypatch, tmp_path):
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=False, verified=False, fallback="inbox")
+        assert rc == 0  # the session exists; seeding failure doesn't fail the cmd
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["success"] is True
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] == "inbox"
+        # Recovery got the prompt and the creator as sender.
+        assert calls["recover"] == ("proj", "do the thing", "orch")
+
+    def test_seed_failure_fallback_also_failed(self, capsys, monkeypatch, tmp_path):
+        rc, _ = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=False, fallback=None)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] is None
+
+    def test_seed_success_no_fallback_key(self, capsys, monkeypatch, tmp_path):
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=True, fallback="inbox")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is True
+        assert "first_message_fallback" not in payload
+        assert "recover" not in calls  # recovery never runs on success
+
+
 # --- cmd_recreate / cmd_fork route through resolve_roles (#311) ---
 #
 # Both commands used to copy `project_config.roles` raw, bypassing

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -393,3 +393,66 @@ class TestSchedulerHistory:
         # Should only show 3 most recent
         lines = [line for line in result.split("\n") if line.startswith("  ")]
         assert len(lines) == 3
+
+
+# ---------------------------------------------------------------------------
+# Worktree tools
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateSeedResult:
+    """#695 — a failed seed must be LOUD in the tool result. The old contract
+    (silently omitting ' (seeded)') left orchestrators believing the task was
+    delivered while the session sat idle."""
+
+    def _create(self, mock_cmd, data, prompt="do the task"):
+        from agentwire.mcp_worktree import worktree_create
+        mock_cmd.return_value = data
+        return worktree_create("x", prompt=prompt)
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_seeded_success(self, mock_cmd, _caller):
+        result = self._create(mock_cmd, _success(
+            session="proj-x", path="/w/proj-x", first_message_delivered=True))
+        assert "(seeded)" in result
+        assert "WARNING" not in result
+        # The failure path (recovery) needs headroom past the 60s boot wait.
+        assert mock_cmd.call_args.kwargs["timeout"] >= 180
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_seed_failure_with_inbox_fallback_is_loud(self, mock_cmd, _caller):
+        result = self._create(mock_cmd, _success(
+            session="proj-x", path="/w/proj-x",
+            first_message_delivered=False, first_message_fallback="inbox"))
+        assert "WARNING" in result
+        assert "NOT delivered" in result
+        assert "msg inbox" in result
+        assert "(seeded)" not in result
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_seed_failure_without_fallback_is_loud(self, mock_cmd, _caller):
+        result = self._create(mock_cmd, _success(
+            session="proj-x", path="/w/proj-x",
+            first_message_delivered=False, first_message_fallback=None))
+        assert "WARNING" in result
+        assert "could NOT be queued" in result
+        assert "session_send" in result
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_no_prompt_no_seed_talk(self, mock_cmd, _caller):
+        result = self._create(
+            mock_cmd, _success(session="proj-x", path="/w/proj-x"), prompt="")
+        assert "(seeded)" not in result
+        assert "WARNING" not in result
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_reattach_with_prompt_notes_undelivered_seed(self, mock_cmd, _caller):
+        result = self._create(mock_cmd, _success(
+            session="proj-x", path="/w/proj-x", reattached=True))
+        assert "Reattached" in result
+        assert "NOT" in result  # the seed prompt was not pasted — say so

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -5,6 +5,25 @@ from agentwire import session_ready
 BANNER = "❯ \nBypassing Permissions"
 TRUST = "Do you trust this folder?\nPress Enter to confirm"
 
+RULE = "─" * 20
+
+
+def render_box(content: str = "") -> str:
+    """A parseable Claude input box wrapped in horizontal rules."""
+    glyph = f"❯ {content}" if content else "❯"
+    return f"{RULE}\n{glyph}\n{RULE}"
+
+
+def render_working(content: str = "") -> str:
+    """An empty input box plus a visible activity marker (submitted+working)."""
+    return "✶ Working… (esc to interrupt)\n" + render_box(content)
+
+
+# Readiness frames (#695): banner up with a parseable input box, empty or
+# holding the rendered probe char.
+READY = "Bypassing Permissions\n" + render_box()
+READY_PROBE = "Bypassing Permissions\n" + render_box(session_ready.PROBE_CHAR)
+
 
 def _scripted_capture(monkeypatch, frames):
     """Make capture_pane return successive frames (last one repeats)."""
@@ -28,43 +47,100 @@ class TestWaitForSessionReady:
     def _no_sleep(self, monkeypatch):
         monkeypatch.setattr(session_ready.time, "sleep", lambda s: self._sleeps.append(s))
 
-    def test_banner_then_stable_returns_true(self, monkeypatch):
+    def _keys(self, monkeypatch):
+        """Stub tmux key sends (trust-Enter + readiness probe); returns the log."""
+        sent = []
+        from agentwire import pane_manager
+        monkeypatch.setattr(
+            pane_manager, "run_command",
+            lambda cmd, timeout=5: sent.append(cmd))
+        return sent
+
+    def _fake_time(self, monkeypatch, step=0.1):
+        clock = {"t": 0.0}
+
+        def fake_time():
+            clock["t"] += step
+            return clock["t"]
+
+        monkeypatch.setattr(session_ready.time, "time", fake_time)
+
+    # Happy-path frames: banner, READY_STABLE_SNAPSHOTS identical frames, the
+    # probe char rendering in the box (poll + erase-count captures), erased.
+    HAPPY = ["booting...", READY, READY, READY, READY_PROBE, READY_PROBE, READY]
+
+    def test_banner_stable_then_probe_roundtrip_returns_true(self, monkeypatch):
         self._no_sleep(monkeypatch)
-        _scripted_capture(monkeypatch, ["booting...", BANNER, BANNER])
+        sent = self._keys(monkeypatch)
+        _scripted_capture(monkeypatch, self.HAPPY)
         assert session_ready.wait_for_session_ready("s", timeout=10)
+        # The probe was typed and erased — never left in the box.
+        assert any(c[-2:] == ["-l", session_ready.PROBE_CHAR] for c in sent)
+        assert any(c[-1] == "BSpace" for c in sent)
 
     def test_churning_screen_times_out(self, monkeypatch):
         self._no_sleep(monkeypatch)
         # Banner up but screen never stabilizes: every frame differs
         frames = [BANNER + f"\nline{i}" for i in range(1000)]
         _scripted_capture(monkeypatch, frames)
-        # Fake clock: advance time per capture so the deadline passes
-        clock = {"t": 0.0}
-
-        def fake_time():
-            clock["t"] += 0.1
-            return clock["t"]
-
-        monkeypatch.setattr(session_ready.time, "time", fake_time)
+        self._fake_time(monkeypatch)
         assert not session_ready.wait_for_session_ready("s", timeout=5)
 
     def test_trust_prompt_accepted_then_ready(self, monkeypatch):
         self._no_sleep(monkeypatch)
-        pressed = []
-        from agentwire import pane_manager
-        monkeypatch.setattr(
-            pane_manager, "run_command",
-            lambda cmd, timeout=5: pressed.append(cmd))
-        _scripted_capture(monkeypatch, [TRUST, BANNER, BANNER])
+        sent = self._keys(monkeypatch)
+        _scripted_capture(monkeypatch, [TRUST] + self.HAPPY[1:])
         assert session_ready.wait_for_session_ready("s", timeout=10)
-        assert len(pressed) == 1
-        assert pressed[0][:2] == ["tmux", "send-keys"]
-        assert pressed[0][-1] == "Enter"
+        assert sent[0][:2] == ["tmux", "send-keys"]
+        assert sent[0][-1] == "Enter"
 
     def test_capture_exception_tolerated(self, monkeypatch):
         self._no_sleep(monkeypatch)
-        _scripted_capture(monkeypatch, [RuntimeError("no session"), BANNER, BANNER])
+        sent = self._keys(monkeypatch)
+        _scripted_capture(
+            monkeypatch, [RuntimeError("no session")] + self.HAPPY[1:])
         assert session_ready.wait_for_session_ready("s", timeout=10)
+        assert sent  # probe ran
+
+    def test_unwired_input_handler_never_ready(self, monkeypatch):
+        # #695 live repro: banner up, screen stable, input box parseable and
+        # empty — but the input handler is not wired yet, so the probe char
+        # never renders. The old two-identical-frames rule declared ready here
+        # and the seed paste fragmented/sat unsubmitted; now the wait must
+        # keep re-probing and ultimately fail instead of green-lighting.
+        self._no_sleep(monkeypatch)
+        sent = self._keys(monkeypatch)
+        _scripted_capture(monkeypatch, [READY])  # stable forever, box empty
+        self._fake_time(monkeypatch)
+        assert not session_ready.wait_for_session_ready("s", timeout=20)
+        probes = [c for c in sent if c[-2:] == ["-l", session_ready.PROBE_CHAR]]
+        assert len(probes) >= 2  # kept re-probing, never trusted the screen
+
+    def test_render_pause_two_identical_frames_not_ready(self, monkeypatch):
+        # #695: a render pause (notice panel / effort banner loading) yields
+        # exactly two identical frames before the screen changes again. The
+        # pre-#695 rule returned ready at frame two; now nothing may be typed
+        # or pasted at the pane at all.
+        self._no_sleep(monkeypatch)
+        sent = self._keys(monkeypatch)
+        frames = [READY, READY] + [READY + f"\nnotice {i}" for i in range(1000)]
+        _scripted_capture(monkeypatch, frames)
+        self._fake_time(monkeypatch)
+        assert not session_ready.wait_for_session_ready("s", timeout=5)
+        assert sent == []  # probe never reached — no keystrokes sent
+
+    def test_buffered_probes_all_erased(self, monkeypatch):
+        # Keystrokes swallowed during wiring can be buffered and dumped into
+        # the box all at once ("..."); every one must be backspaced away so
+        # the real paste lands in a clean box.
+        self._no_sleep(monkeypatch)
+        sent = self._keys(monkeypatch)
+        piled = "Bypassing Permissions\n" + render_box(session_ready.PROBE_CHAR * 3)
+        _scripted_capture(
+            monkeypatch, [READY, READY, READY, piled, piled, READY])
+        assert session_ready.wait_for_session_ready("s", timeout=10)
+        bspaces = [c for c in sent if c[-1] == "BSpace"]
+        assert len(bspaces) == 3
 
 
 class TestMessageVisible:
@@ -104,20 +180,6 @@ class TestMessageVisible:
         a = "[NOTIFY from agentwire-dev-issue-100] finished task alpha"
         b = "[NOTIFY from agentwire-dev-issue-100] finished task bravo"
         assert not session_ready.message_visible(f"❯ {a}", b)
-
-
-RULE = "─" * 20
-
-
-def render_box(content: str = "") -> str:
-    """A parseable Claude input box wrapped in horizontal rules."""
-    glyph = f"❯ {content}" if content else "❯"
-    return f"{RULE}\n{glyph}\n{RULE}"
-
-
-def render_working(content: str = "") -> str:
-    """An empty input box plus a visible activity marker (submitted+working)."""
-    return "✶ Working… (esc to interrupt)\n" + render_box(content)
 
 
 def _fake_clock(monkeypatch, step: float = 0.5):
@@ -586,3 +648,107 @@ class TestFinishSubmit:
 
         _env(monkeypatch, boom)
         assert session_ready.finish_submit("s", "msg") is False
+
+
+class TestClearInputBox:
+    """#695 — seed recovery clears the partial paste out of the box, keyed on
+    the drain's own SGR-aware emptiness gate (so 'cleared' means exactly 'the
+    inbox fallback can deliver')."""
+
+    def _wire(self, monkeypatch, empty_after: int):
+        """prompt_is_empty flips True after N Escapes; returns the key log."""
+        from agentwire import pane_manager, prompt_router
+        state = {"escapes": 0}
+        monkeypatch.setattr(
+            prompt_router, "prompt_is_empty",
+            lambda s, p=0: state["escapes"] >= empty_after)
+
+        def run(cmd, timeout=5):
+            if cmd[-1] == "Escape":
+                state["escapes"] += 1
+
+        monkeypatch.setattr(pane_manager, "run_command", run)
+        return state
+
+    def test_already_empty_sends_nothing(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        state = self._wire(monkeypatch, empty_after=0)
+        assert session_ready.clear_input_box("s")
+        assert state["escapes"] == 0
+
+    def test_escape_clears_partial_paste(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        state = self._wire(monkeypatch, empty_after=1)
+        assert session_ready.clear_input_box("s")
+        assert state["escapes"] == 1
+
+    def test_wedged_box_returns_false_bounded(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        state = self._wire(monkeypatch, empty_after=10**9)
+        assert not session_ready.clear_input_box("s")
+        assert state["escapes"] == session_ready.CLEAR_BOX_ATTEMPTS
+
+    def test_capture_failure_returns_false(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        from agentwire import pane_manager, prompt_router
+
+        def boom(*a, **k):
+            raise RuntimeError("gone")
+
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", boom)
+        monkeypatch.setattr(pane_manager, "run_command", lambda *a, **k: None)
+        assert session_ready.clear_input_box("s") is False
+
+
+class TestRecoverFailedSeed:
+    """#695 — a failed seed must never be silent: the prompt falls back to the
+    msg inbox (watchdog delivery, dead-letter escalation) and the caller learns
+    which fallback fired."""
+
+    def test_clears_box_then_queues_request(self, monkeypatch):
+        from agentwire import inbox
+        calls = {}
+        monkeypatch.setattr(
+            session_ready, "clear_input_box",
+            lambda s, pane_index=0: calls.setdefault("cleared", (s, pane_index)) or True)
+
+        def fake_enqueue(to, text, kind="note", sender=None, ref=""):
+            calls["enqueue"] = (to, text, kind, sender)
+            return []
+
+        monkeypatch.setattr(inbox, "enqueue", fake_enqueue)
+        result = session_ready.recover_failed_seed("sess", "the seed prompt", sender="orch")
+        assert result == "inbox"
+        assert calls["cleared"] == ("sess", 0)
+        assert calls["enqueue"] == ("sess", "the seed prompt", "request", "orch")
+
+    def test_default_sender(self, monkeypatch):
+        from agentwire import inbox
+        seen = {}
+        monkeypatch.setattr(session_ready, "clear_input_box", lambda s, pane_index=0: True)
+        monkeypatch.setattr(
+            inbox, "enqueue",
+            lambda to, text, kind="note", sender=None, ref="": seen.update(sender=sender) or [])
+        assert session_ready.recover_failed_seed("sess", "x") == "inbox"
+        assert seen["sender"] == "agentwire"
+
+    def test_clear_failure_still_queues(self, monkeypatch):
+        from agentwire import inbox
+
+        def boom(*a, **k):
+            raise RuntimeError("no pane")
+
+        monkeypatch.setattr(session_ready, "clear_input_box", boom)
+        monkeypatch.setattr(
+            inbox, "enqueue", lambda to, text, kind="note", sender=None, ref="": [])
+        assert session_ready.recover_failed_seed("sess", "x") == "inbox"
+
+    def test_enqueue_failure_returns_none_never_raises(self, monkeypatch):
+        from agentwire import inbox
+        monkeypatch.setattr(session_ready, "clear_input_box", lambda s, pane_index=0: True)
+
+        def boom(*a, **k):
+            raise OSError("inbox unwritable")
+
+        monkeypatch.setattr(inbox, "enqueue", boom)
+        assert session_ready.recover_failed_seed("sess", "x") is None


### PR DESCRIPTION
## What

Fixes the silent half-pasted-seed failure from the 2026-07-04 messaging stress test: `worktree_create`'s seeded prompt could land fragmented and unsubmitted in a freshly booted Claude session, and the MCP result merely omitted "(seeded)".

### 1. Loud failure + recovery (issue fix part 1)
- `cmd_new` on seed failure now runs `session_ready.recover_failed_seed`: **clears the partial paste** out of the input box (Escape, confirmed via the msg drain's own SGR-aware `prompt_is_empty` gate — so "cleared" means exactly "the drain can deliver"), then **enqueues the prompt as a `request` in the session's msg inbox**. The watchdog delivers it once the box is truly ready; if it never can, `request` is a load-bearing kind, so dead-letter escalates with an owner email instead of vanishing.
- JSON result grows `first_message_fallback` (`"inbox"` | `null`) alongside `first_message_delivered`.
- `worktree_create` (MCP) renders a **WARNING** on failed seed (naming the fallback and how to verify), instructs manual delivery when even the fallback failed, and notes when a reattach-to-live-session drops the prompt. Subprocess timeout widened 90→180s so the recovery path isn't masked by a timeout.

### 2. Hardened readiness (part 2)
`wait_for_session_ready` is now three-phase:
- banner detection (unchanged, incl. trust-prompt auto-accept),
- stability: **3** consecutive identical 500ms frames (was 2 — a render pause while the notice panel / effort banner loads yields an identical pair with the input handler still unwired),
- **input-handler probe**: type a probe char, poll until it actually renders in the input box, backspace it away (including swallowed-then-buffered pile-ups). Positive proof keystrokes are consumed before the real paste; fails safe into the inbox fallback otherwise.

All `wait_for_session_ready` consumers (`worktree --prompt` / `new --first-message`, `ensure`, `send --wait-ready`, portal first-message) inherit the hardening.

### 3. Regression tests (part 3)
- Unit: unwired-handler probe timeout, render-pause two-identical-frames no longer ready, buffered-probe erase, `clear_input_box`, `recover_failed_seed`, `cmd_new` JSON contract, `worktree_create` warning rendering.
- Real-tmux integration: the input-box emulator gained backspace handling and a **wire-delay mode** (banner+box render immediately, stdin unconsumed for 3s — the exact #695 window); tests prove readiness holds through the unwired window, cleans up every buffered probe, and the seed then delivers end-to-end.

## Verification

- Full suite: **2481 passed** (`uv run --extra dev pytest`), including the new real-tmux integration tests.
- Live `worktree_create`-against-cold-session behavior can only be exercised after merge + `agentwire rebuild` (this worktree must not rebuild the live tool); the emulator integration tests reproduce the failure shape faithfully in the meantime.

Closes #695

Built by [dotdev.dev](https://dotdev.dev)