### PR TITLE
fix(messaging): confirm delivery only against a parseable input box; rescue stuck boxes mid-generation (#698)

### DIFF
--- a/agentwire/pane_manager.py
+++ b/agentwire/pane_manager.py
@@ -280,7 +280,14 @@ def send_to_target(target: str, text: str, enter: bool = True) -> None:
             result = run_command(["tmux", "load-buffer", temp_path], timeout=5)
             if not result.success:
                 raise RuntimeError(f"Failed to load buffer: {result.stderr.strip()}")
-            result = run_command(["tmux", "paste-buffer", "-t", target], timeout=5)
+            # -p wraps the paste in bracketed-paste delimiters when the app has
+            # requested them (Claude Code always does; tmux falls back to a
+            # plain paste otherwise). Without the explicit end-of-paste marker,
+            # Claude Code detects the paste heuristically as an input burst,
+            # and an Enter arriving inside that window is coalesced INTO the
+            # paste as a newline instead of submitting — the swallowed-Enter
+            # root cause behind the #698 stress-test failures.
+            result = run_command(["tmux", "paste-buffer", "-p", "-t", target], timeout=5)
             if not result.success:
                 raise RuntimeError(f"Target '{target}' not found: {result.stderr.strip()}")
         finally:

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -775,20 +775,26 @@ def _flush_stuck_box(session: str, pane_index: int, visible: str) -> bool:
 
       - the box parses and holds non-empty, non-placeholder content,
       - the content starts with a machine-injected header (never a human draft),
-      - the pane is not mid-generation (no ``esc to interrupt`` footer),
+      - no live select-menu is on screen (Enter would answer the dialog),
       - the identical content has sat there for ``STUCK_BOX_SWEEPS``
         consecutive sweeps (state persisted per-pane next to prompt markers).
+
+    A mid-generation pane is deliberately NOT skipped (#698): Enter on a
+    generating Claude Code pane QUEUES the draft (Esc interrupts, Enter never
+    does), while the old ``esc to interrupt`` gate both refused the flush AND
+    reset the counter every sweep — so a stuck box on a busy orchestrator was
+    never rescued for as long as it kept working (the 2026-07-04 12:40
+    incident, where the owner watched the message sit and pressed Enter
+    manually). Frames we can't judge (unparseable box, live menu) HOLD the
+    counter instead of resetting it, for the same reason.
 
     Never pastes — Enter only, so the #621 idempotency dedup keeps holding.
     """
     path = _stuck_box_path(session, pane_index)
     box = input_box_content(visible)
-    if (
-        not box
-        or not _MACHINE_HEADER_RE.match(box)
-        or is_queued_placeholder(box)
-        or "esc to interrupt" in visible.lower()
-    ):
+    if box is None or screen_shows_live_menu(visible):
+        return False  # can't judge this frame / Enter unsafe — hold the counter
+    if not box or not _MACHINE_HEADER_RE.match(box) or is_queued_placeholder(box):
         try:
             path.unlink(missing_ok=True)
         except OSError:

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -138,70 +138,37 @@ def text_landed(capture: str, message: str) -> bool:
     return message_visible(box, message)
 
 
-def submitted(capture: str, message: str, marker: str | None = None) -> bool:
-    """Did the paste actually get *submitted* (Enter registered)?
-
-    The discriminating signal is the input box: if our text still sits in a
-    readable box, it is NOT submitted — this is the exact false-positive the old
-    check made (treating "text visible anywhere" as success while it sat unsent).
-
-    Once the box no longer holds our text, we confirm with positive evidence:
-      - *marker* given → the marker line is present in scrollback.
-      - empty box → the pane shows activity OR the message scrolled into history
-        (an empty box with neither is the idle/never-received vanish case).
-      - unparseable box (tool output / dialog covering it) → activity AND the
-        message visible in scrollback.
-    """
-    box = input_box(capture)
-    if box is not None and message_visible(box, message):
-        return False  # still sitting unsent in the box
-    if marker is not None:
-        return marker in capture
-    if box == "":
-        return pane_shows_activity(capture) or message_visible(capture, message)
-    return pane_shows_activity(capture) and message_visible(capture, message)
-
-
-def submit_confirmed(
-    capture: str,
-    message: str,
-    marker: str | None = None,
-    allow_unparsed: bool = True,
-) -> bool:
+def submit_confirmed(capture: str, message: str) -> bool:
     """Phase-2 confirm: did the (already-landed) paste actually *submit*? (#621)
 
-    Distinct from :func:`submitted`, which also has to defend Phase 1's "did the
-    paste even land?" question and so demands positive activity/scrollback
-    evidence before trusting an empty box. By Phase 2 we have ALREADY proven the
-    text landed in the input box, so the submission signal is simply: **the box
-    no longer holds our text.** Requiring a spinner or the echoed turn on top of
-    that is what false-negatived a landed-and-submitted paste under a quiet or
-    very fast agent — reporting ``delivery_unverified`` (→ inbox redelivery loop)
-    or an unconfirmed Enter (→ notify-parent "sat there unsent").
+    By Phase 2 the text has been proven to land in the input box, so the
+    submission signal is: **a parseable box no longer holds our text.** An
+    empty box, or a box now showing a different/next prompt, both count —
+    including the submitted-while-generating case, where the text queues
+    invisibly and never echoes until the turn ends. While a multi-line paste's
+    ``[Pasted text …]`` placeholder (or the expanded text) still occupies the
+    box, it reads as not-yet-submitted, so the caller keeps pressing Enter
+    (dismiss-then-submit).
 
-    - Box parseable → submitted iff our message is no longer visible in it. An
-      empty box, or a box now showing a different/next prompt, both count. While
-      a multi-line paste's ``[Pasted text …]`` placeholder (or the expanded text)
-      still occupies the box, it reads as not-yet-submitted, so the caller keeps
-      pressing Enter (dismiss-then-submit).
-    - Box unparseable (tool output / dialog covering it) → fall back to positive
-      evidence: the explicit marker line, the message echoed in scrollback, or
-      visible activity. This fallback is inherently permissive — activity glyphs
-      sit in almost every agent pane's scrollback, and the "visible" text may be
-      our paste still sitting in the very box we failed to parse — so it is only
-      trusted once at least one Enter has actually been pressed (#689): callers
-      pass ``allow_unparsed=False`` before the first press, forcing an Enter
-      instead of declaring a busy re-rendering pane submitted with zero
-      keystrokes ever sent.
+    An UNPARSEABLE box (mid-redraw frame, tool output / dialog covering it) is
+    never confirmed (#698). The old fallback accepted activity glyphs, a
+    caller marker, or the message visible in the raw capture — all of which a
+    stuck paste satisfies, because activity glyphs sit in every agent pane's
+    scrollback, the marker is part of the pasted text, and the raw capture
+    *includes* the very box we failed to parse. One garbled snapshot during
+    the confirm poll was enough to log ``delivered`` for a message still
+    sitting unsent (the 2026-07-04 12:40 loss, #698). Proving the text is
+    *outside* the box requires the same box parse that just failed, so nothing
+    can be proven: not confirmed. The caller keeps pressing Enter (a no-op on
+    an already-submitted box) until a parseable frame decides, and a genuinely
+    landed-but-scrolled message is consumed by the next drain tick's box-aware
+    dedup instead — a duplicate press is recoverable, a false ``delivered``
+    deletes the message.
     """
     box = input_box(capture)
-    if box is not None:
-        return not message_visible(box, message)
-    if not allow_unparsed:
+    if box is None:
         return False
-    if marker is not None and marker in capture:
-        return True
-    return pane_shows_activity(capture) or message_visible(capture, message)
+    return not message_visible(box, message)
 
 
 def _poll(predicate, timeout: float) -> bool:
@@ -379,6 +346,13 @@ def strip_input_box(capture: str) -> "str | None":
     parse (region between the last two horizontal rules, prompt glyph first);
     when the box can't be located we return None so callers stay conservative
     (can't prove the text is outside the box → treat as not on scrollback).
+
+    Only lines strictly ABOVE the box's top border count as outside (#698).
+    A mid-redraw frame can drop the box's bottom border, making the last two
+    rules bracket some other region — in which case the real box (and the
+    stuck text in it) sits BELOW the last rule, where the old version happily
+    matched it as "scrollback". Below the top border nothing but the box and
+    the footer hints ever renders, so excluding it all loses no real echo.
     """
     from agentwire import prompt_router
 
@@ -393,7 +367,7 @@ def strip_input_box(capture: str) -> "str | None":
     text = "\n".join(box).lstrip()
     if text[:1] not in prompt_router._PROMPT_GLYPHS:
         return None
-    return "\n".join(lines[:rules[-2] + 1] + lines[rules[-1]:])
+    return "\n".join(lines[:rules[-2] + 1])
 
 
 def message_on_scrollback(capture: str, rendered: str) -> bool:
@@ -471,28 +445,47 @@ def _deliver_once(
                 already_landed = True
             elif message_on_scrollback(cap, message):
                 return True
+        if not already_landed:
+            # A live select-menu owns the pane's keystrokes: pasted text (or
+            # the digits in it) could SELECT an option. safe_deliver gates the
+            # first attempt, but the whole-send retry re-enters here after the
+            # target's state may have changed (#698) — refuse, defer to the
+            # next tick.
+            from agentwire import prompt_router
+
+            if prompt_router.screen_shows_live_menu(cap):
+                return False
     except Exception:
         pass
 
     if not already_landed:
         paste_no_enter(session, message, pane_index=pane_index)
 
-    # Phase 1 — wait for the paste to actually land in the input box (or for a
-    # very fast bypass agent to have already consumed AND submitted it). If it
-    # never lands, the paste vanished — let the caller retry the whole send.
+    # Phase 1 — wait for the paste to actually land in the input box, or for
+    # positive proof it already submitted: the message (or the caller's
+    # marker) echoed on scrollback OUTSIDE the box. Ambient evidence must
+    # never end this wait (#698): the old check accepted "empty box +
+    # activity glyphs" as already-submitted, which is what every agent pane
+    # looks like in the instants BEFORE a paste renders — Phase 2 then
+    # confirmed against the same still-empty box and reported ``delivered``
+    # with zero Enter presses, seconds before the paste appeared and stuck
+    # (the 2026-07-04 12:40 loss). If the paste never renders, it vanished —
+    # let the caller retry the whole send.
     def landed_or_done() -> bool:
         cap = _snapshot(session, pane_index)
-        return submitted(cap, message, marker) or text_landed(cap, message)
+        if text_landed(cap, message):
+            return True
+        if message_on_scrollback(cap, message):
+            return True
+        return marker is not None and message_on_scrollback(cap, marker)
 
     if not _poll(landed_or_done, LAND_TIMEOUT):
         return False
 
-    return _submit_phase(session, message, marker, pane_index)
+    return _submit_phase(session, message, pane_index)
 
 
-def _submit_phase(
-    session: str, message: str, marker: str | None, pane_index: int
-) -> bool:
+def _submit_phase(session: str, message: str, pane_index: int) -> bool:
     """Phase 2 — press Enter and confirm the box cleared. Enter-only, no paste.
 
     Re-press is driven by a wall-clock budget, not a fixed count: a single Enter
@@ -503,33 +496,37 @@ def _submit_phase(
     no-op, so over-pressing is safe, while a tight count would give up before a
     laggy box ever caught up.
 
-    The pre-press confirm is STRICT (``allow_unparsed=False``): before any Enter
-    has been sent, an unparseable box must never read as submitted — that was
-    the #689 zero-keystroke false positive (busy pane + activity glyphs →
-    "delivered" with the Enter never fired). Once at least one Enter is pressed,
-    the permissive fallback is trusted again.
+    ``submit_confirmed`` only ever trusts a parseable box (#698), so every
+    exit path — including the pre-press short-circuit — has positively seen a
+    box that no longer holds our text. A live select-menu appearing on the
+    target (a permission dialog the recipient's own work raised) aborts the
+    loop instead of pressing Enter into it, which would CONFIRM the
+    highlighted option; the delivery reports unverified and the next tick's
+    ``safe_deliver`` dialog guard + box-aware dedup take it from there.
     """
-    if submit_confirmed(
-        _snapshot(session, pane_index), message, marker, allow_unparsed=False
-    ):
+    cap = _snapshot(session, pane_index)
+    if submit_confirmed(cap, message):
         return True
+    from agentwire import prompt_router
+
     deadline = time.time() + SUBMIT_BUDGET
     attempts = 0
     while True:
+        if prompt_router.screen_shows_live_menu(cap):
+            return False
         press_enter(session, pane_index=pane_index)
         attempts += 1
         if _poll(
-            lambda: submit_confirmed(_snapshot(session, pane_index), message, marker),
+            lambda: submit_confirmed(_snapshot(session, pane_index), message),
             SUBMIT_TIMEOUT,
         ):
             return True
         if attempts >= MIN_ENTER_ATTEMPTS and time.time() >= deadline:
             return False
+        cap = _snapshot(session, pane_index)
 
 
-def finish_submit(
-    session: str, message: str, marker: str | None = None, pane_index: int = 0
-) -> bool:
+def finish_submit(session: str, message: str, pane_index: int = 0) -> bool:
     """Enter-only submit retry for a message already sitting in the input box.
 
     The #689 healing primitive: when a prior delivery pasted the text but its
@@ -539,7 +536,7 @@ def finish_submit(
     Returns True only once submission is confirmed; never raises.
     """
     try:
-        return _submit_phase(session, message, marker, pane_index)
+        return _submit_phase(session, message, pane_index)
     except Exception:
         return False
 
@@ -560,8 +557,9 @@ def send_verified(
     1. Paste WITHOUT Enter, then poll the input box (bounded, ``LAND_TIMEOUT``)
        until the pasted text is actually visible there — never press Enter on a
        box that hasn't received the paste yet.
-    2. Press Enter and poll (bounded, ``SUBMIT_TIMEOUT``) until the box clears.
-       If a keystroke is swallowed, re-press up to ``MAX_ENTER_ATTEMPTS`` times.
+    2. Press Enter and poll (bounded, ``SUBMIT_TIMEOUT`` per press) until the
+       box clears. If a keystroke is swallowed, re-press until ``SUBMIT_BUDGET``
+       elapses (at least ``MIN_ENTER_ATTEMPTS`` presses).
 
     Returns True once submission is confirmed. Returns False — a hard, surfaced
     failure the caller must handle — only after exhausting *retries* whole-send

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -74,22 +74,35 @@ lands in a durable inbox and is injected only at a safe boundary.
    already sits landed-but-unsubmitted in the box, and if so retries only the
    *submit*, so a whole-send retry can never double the draft.
 
-   **Pasted ≠ submitted (#689).** Three closures for the paste-lands-but-Enter-
-   is-swallowed failure: **(a)** `message_on_scrollback` excludes the input-box
-   region — a message still sitting in the box no longer reads as "on
-   scrollback", so the drain can't unlink a pending file the recipient never
-   received (an unparseable box counts as *not* on scrollback: keep pending).
-   **(b)** `send_verified`'s Phase-2 confirm is strict before the first Enter —
-   an unparseable busy box plus activity glyphs can no longer declare a message
-   submitted with **zero** Enter keystrokes ever sent. **(c)** When the drain
-   finds one of its own pending messages rendered in the recipient's box, it
-   heals via `session_ready.finish_submit` — an **Enter-only** retry (never a
-   re-paste, so the #621 dedup holds), unlinking only once submission confirms
-   and otherwise deferring without penalty (`stuck_in_box`). As a last-resort
-   backstop, the watchdog pane-sweep flushes a bare Enter on any idle pane
+   **Pasted ≠ submitted (#689, hardened by #698).** Closures for the
+   paste-lands-but-Enter-is-swallowed failure: **(a)** `message_on_scrollback`
+   excludes the input-box region — only lines strictly *above* the box's top
+   border count, so a message still sitting in the box (even on a mid-redraw
+   frame missing the bottom border) never reads as "on scrollback" and the
+   drain can't unlink a pending file the recipient never received (an
+   unparseable box counts as *not* on scrollback: keep pending). **(b)**
+   `send_verified` only ever trusts a **parseable box** (#698): Phase 1 ends
+   only when the text renders in the box or the message/marker is echoed
+   *outside* it (empty box + ambient activity glyphs is what a pane looks like
+   in the instants before a paste renders — the old check confirmed there with
+   zero Enter presses), and the Phase-2 confirm is "a parseable box no longer
+   holds our text" with garbled/unparseable frames never confirming (activity
+   glyphs and raw-capture matches are satisfied by a stuck paste inside the
+   very box that failed to parse). A live select-menu appearing mid-send
+   aborts both the paste and the Enter loop. **(c)** When the drain finds one
+   of its own pending messages rendered in the recipient's box, it heals via
+   `session_ready.finish_submit` — an **Enter-only** retry (never a re-paste,
+   so the #621 dedup holds), unlinking only once submission confirms and
+   otherwise deferring without penalty (`stuck_in_box`). As a last-resort
+   backstop, the watchdog pane-sweep flushes a bare Enter on any pane —
+   including a mid-generation one, where Enter merely queues the draft (#698;
+   the old spinner gate left a stuck box on a busy orchestrator unrescued) —
    whose box has held identical **machine-injected** text (`[MSG…`, `[NOTIFY…`,
-   `[Pasted text…`) for two consecutive sweeps — human-looking drafts are never
-   auto-submitted.
+   `[Pasted text…`) for two consecutive sweeps; unjudgeable frames (garbled
+   box, live dialog) hold the counter rather than resetting it, and
+   human-looking drafts are never auto-submitted. Pastes themselves go out
+   with bracketed-paste delimiters (`paste-buffer -p`), so a trailing Enter
+   can't be coalesced into the paste burst as a newline.
 
 4. **Defer or drop.** If either gate fails, the messages stay put, their
    `attempts` counter bumps, and the defer `reason` (`box_not_empty`,

--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -904,15 +904,19 @@ class TestFlushStuckBox:
         assert not prompt_router._flush_stuck_box("s", 0, b)  # reset, re-armed
         assert keys == []
 
-    def test_generating_pane_skipped(self, monkeypatch, tmp_path):
+    def test_generating_pane_still_flushes(self, monkeypatch, tmp_path):
+        # #698 regression (the 12:40 incident): Enter on a generating pane
+        # QUEUES the draft — it never interrupts — so a stuck machine message
+        # on a busy orchestrator must be rescued on the normal two-sweep
+        # cadence, not starved (and counter-reset) until the turn ends.
         keys = self._patch(monkeypatch, tmp_path)
         screen = _stuck_screen(
             "[MSG from w · done] finished  ⟨#abc123⟩",
             footer="✶ Working… (esc to interrupt)",
         )
-        for _ in range(3):
-            assert not prompt_router._flush_stuck_box("s", 0, screen)
-        assert keys == []
+        assert not prompt_router._flush_stuck_box("s", 0, screen)  # arm
+        assert prompt_router._flush_stuck_box("s", 0, screen)  # rescue
+        assert keys == [["send-keys", "-t", "s.0", "Enter"]]
 
     def test_queued_placeholder_skipped(self, monkeypatch, tmp_path):
         keys = self._patch(monkeypatch, tmp_path)
@@ -921,13 +925,38 @@ class TestFlushStuckBox:
         assert not prompt_router._flush_stuck_box("s", 0, screen)
         assert keys == []
 
-    def test_empty_or_unparseable_clears_state(self, monkeypatch, tmp_path):
+    def test_empty_box_clears_state(self, monkeypatch, tmp_path):
         self._patch(monkeypatch, tmp_path)
         stuck = _stuck_screen("[MSG from w · done] hi  ⟨#abc123⟩")
         assert not prompt_router._flush_stuck_box("s", 0, stuck)  # armed
         prompt_router._flush_stuck_box("s", 0, _stuck_screen(""))  # cleared
         # Re-stuck: must take TWO sweeps again, not fire immediately.
         assert not prompt_router._flush_stuck_box("s", 0, stuck)
+
+    def test_unparseable_frame_holds_counter(self, monkeypatch, tmp_path):
+        # #698 — a transient mid-redraw frame (no box parses) must not reset
+        # the stuck counter; the next stuck sighting completes the pair and
+        # rescues within that one sweep.
+        keys = self._patch(monkeypatch, tmp_path)
+        stuck = _stuck_screen("[MSG from w · done] hi  ⟨#abc123⟩")
+        assert not prompt_router._flush_stuck_box("s", 0, stuck)  # armed
+        assert not prompt_router._flush_stuck_box("s", 0, "garbled, no rules")
+        assert prompt_router._flush_stuck_box("s", 0, stuck)  # rescued
+        assert len(keys) == 1
+
+    def test_live_menu_holds_and_never_enters(self, monkeypatch, tmp_path):
+        # A live dialog owns Enter — never flush into it, but keep the counter
+        # so the rescue fires once the dialog is gone.
+        keys = self._patch(monkeypatch, tmp_path)
+        stuck = _stuck_screen("[MSG from w · done] hi  ⟨#abc123⟩")
+        menu = _stuck_screen(
+            "[MSG from w · done] hi  ⟨#abc123⟩", footer="Esc to cancel"
+        )
+        assert not prompt_router._flush_stuck_box("s", 0, stuck)  # armed
+        assert not prompt_router._flush_stuck_box("s", 0, menu)  # held
+        assert keys == []
+        assert prompt_router._flush_stuck_box("s", 0, stuck)  # rescued
+        assert len(keys) == 1
 
 
 class TestSafeDeliverPane:

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -323,12 +323,15 @@ class TestSendVerifiedAdaptive:
         assert session_ready.send_verified("s", "resilient prompt")
         assert actions["enters"] == 2
 
-    def test_fast_agent_already_submitted(self, monkeypatch):
-        # A fast bypass agent consumed+submitted before our first poll: empty
-        # box + visible activity → delivered, no Enter needed.
+    def test_already_submitted_needs_the_echo_not_ambient_activity(self, monkeypatch):
+        # "Already submitted" is only provable by the message echoed on
+        # scrollback OUTSIDE the box. An empty box + ambient activity glyphs is
+        # what every agent pane looks like in the instants BEFORE a paste
+        # renders (#698) — it must NOT read as delivered.
         _fake_clock(monkeypatch)
-        actions = _env(monkeypatch, lambda a: render_working())
-        assert session_ready.send_verified("s", "my unique multiline prompt")
+        msg = "my unique multiline prompt"
+        actions = _env(monkeypatch, lambda a: f"> {msg}\n" + render_working())
+        assert session_ready.send_verified("s", msg)
         assert actions["enters"] == 0
 
     def test_large_paste_placeholder_lands(self, monkeypatch):
@@ -486,26 +489,27 @@ class TestPrePasteGuardIdentity:
 
 class TestSubmitConfirmed:
     """#621 — Phase-2 confirm keys on 'the box no longer holds our text', since
-    Phase 1 already proved the paste landed. The old `submitted` additionally
-    demanded a spinner or the echoed turn, which false-negatived a landed-and-
-    submitted paste under a quiet/fast agent (→ inbox redelivery loop / notify
-    'sat there unsent')."""
+    Phase 1 already proved the paste landed. #698 — ONLY a parseable box may
+    decide: activity glyphs, markers, and raw-capture visibility are all
+    satisfied by a stuck paste sitting inside a box we failed to parse."""
 
     def test_quiet_cleared_box_is_confirmed(self):
         # Box cleared, NO activity marker, message already scrolled out of view.
         cap = render_box()  # empty box, nothing else
         assert session_ready.submit_confirmed(cap, "report text")
-        # The old, over-strict check would NOT confirm this — the regression.
-        assert not session_ready.submitted(cap, "report text")
 
     def test_text_still_in_box_is_not_confirmed(self):
         cap = render_box("report text")
         assert not session_ready.submit_confirmed(cap, "report text")
 
-    def test_unparseable_box_falls_back_to_marker(self):
-        cap = "tool output everywhere, no box at all\n[MARKER-LINE]"
-        assert session_ready.submit_confirmed(cap, "zzz", marker="[MARKER-LINE]")
-        assert not session_ready.submit_confirmed(cap, "zzz", marker="[ABSENT]")
+    def test_unparseable_box_is_never_confirmed(self):
+        # #698 — no box parse, no confirm. The old fallback trusted a marker
+        # or activity glyphs in the raw capture, but the capture INCLUDES the
+        # box region, so a stuck paste satisfied both and got its inbox file
+        # deleted while the recipient never received it.
+        cap = "⏺ tool output everywhere, no box at all\n[MARKER-LINE]"
+        assert not session_ready.submit_confirmed(cap, "zzz")
+        assert not session_ready.submit_confirmed(cap, "[MARKER-LINE]")
 
     def test_quiet_submit_no_activity_delivers(self, monkeypatch):
         # End-to-end: paste lands in the box, one Enter clears it, and the pane
@@ -554,6 +558,18 @@ class TestStripInputBox:
         outside = session_ready.strip_input_box("above\n" + render_box())
         assert "above" in outside
 
+    def test_below_last_rule_is_never_outside(self):
+        # #698 — a mid-redraw frame can drop the box's bottom border, so the
+        # "last two rules" bracket an echoed '> …' line while the REAL box
+        # (holding the stuck text) sits below the last rule. Nothing below the
+        # top border may ever count as scrollback.
+        msg = "[MSG from w · done] stuck  ⟨#abc123⟩"
+        garbled = f"history\n{RULE}\n> some old echoed turn\n{RULE}\n❯ {msg}"
+        outside = session_ready.strip_input_box(garbled)
+        assert outside is not None
+        assert msg not in outside
+        assert not session_ready.message_on_scrollback(garbled, msg)
+
 
 class TestMessageOnScrollbackBoxAware:
     """#689 regression — a pasted-but-unsubmitted message sitting in the input
@@ -578,22 +594,20 @@ class TestMessageOnScrollbackBoxAware:
 
 
 class TestZeroEnterFalsePositive:
-    """#689 root cause 1 — a busy pane whose box is unparseable at phase-2
-    start must NOT be declared submitted before at least one Enter has actually
-    been pressed."""
+    """#689/#698 — a pane whose box is unparseable must NEVER be declared
+    submitted, no matter how many Enters have been pressed: activity glyphs sit
+    in every agent pane's scrollback, and the raw capture includes the very box
+    that failed to parse."""
 
-    def test_strict_confirm_rejects_unparseable_box(self):
+    def test_confirm_rejects_unparseable_box(self):
         busy = "⏺ Bash(ls)\n  ⎿ file.py\n✻ Thinking…\nsome text no box"
-        assert not session_ready.submit_confirmed(
-            busy, "our msg", allow_unparsed=False
-        )
-        # Permissive (post-Enter) still accepts activity evidence.
-        assert session_ready.submit_confirmed(busy, "our msg")
+        assert not session_ready.submit_confirmed(busy, "our msg")
 
-    def test_enter_pressed_before_permissive_confirm(self, monkeypatch):
+    def test_enter_pressed_and_confirm_waits_for_parseable_frame(self, monkeypatch):
         # Paste lands (parseable box), then the pane re-renders busily and the
         # box becomes unparseable with activity glyphs. The old code confirmed
-        # on the FIRST phase-2 snapshot with zero Enters.
+        # on the FIRST phase-2 snapshot with zero Enters; post-#698 the confirm
+        # holds out for a parseable frame that no longer shows our text.
         _fake_clock(monkeypatch)
         busy = "⏺ Bash(build)\n✶ Working… (esc to interrupt)\nno box parses here"
 
@@ -607,6 +621,39 @@ class TestZeroEnterFalsePositive:
         actions = _env(monkeypatch, frame)
         assert session_ready.send_verified("s", "stuck report")
         assert actions["enters"] >= 1, "confirmed with zero Enters pressed"
+
+    def test_garbled_frames_after_enter_never_confirm(self, monkeypatch):
+        # #698 stress-test root cause: Enter pressed but swallowed, and every
+        # subsequent confirm snapshot is a garbled busy frame. The old
+        # permissive fallback confirmed on the first such frame (activity
+        # glyphs) → 'delivered' logged, message file unlinked, text stuck in
+        # the box until a human noticed. Must report failure instead.
+        _fake_clock(monkeypatch)
+        busy = "⏺ Bash(build)\n✶ Working… (esc to interrupt)\nno box parses here"
+
+        def frame(a):
+            if a["caps"] <= 2:
+                return render_box("stress report")  # landed
+            return busy  # garbled forever after — swallowed Enter never proven
+
+        actions = _env(monkeypatch, frame)
+        assert not session_ready.send_verified("s", "stress report")
+        assert actions["enters"] >= 1
+
+    def test_zero_press_race_paste_not_yet_rendered(self, monkeypatch):
+        # #698 12:40 incident: the tick pasted, and BEFORE the paste rendered
+        # the old Phase 1 read 'empty box + activity' as already-submitted and
+        # Phase 2 confirmed against the same still-empty box — 'delivered' in
+        # under a second with ZERO Enter presses, then the paste appeared and
+        # sat there forever. An empty box with no echo must keep polling and,
+        # if the paste never renders, fail the send — never report delivered.
+        _fake_clock(monkeypatch)
+        transcript = "⏺ Bash(ls)\n  ⎿ file.py\n✻ Thinking…\n· 1.2k tokens\n"
+        actions = _env(monkeypatch, lambda a: transcript + render_box())
+        assert not session_ready.send_verified(
+            "s", "[MSG from fix-696 · done] PR ready  ⟨#95556e⟩"
+        )
+        assert actions["enters"] == 0  # never pressed into a box with no paste
 
 
 class TestFinishSubmit:
@@ -752,3 +799,36 @@ class TestRecoverFailedSeed:
 
         monkeypatch.setattr(inbox, "enqueue", boom)
         assert session_ready.recover_failed_seed("sess", "x") is None
+
+
+class TestLiveMenuAbort:
+    """#698 hardening — a live select-menu appearing on the target mid-send
+    owns the pane's keystrokes: Enter would confirm the highlighted option and
+    pasted text could select one. Both the re-press loop and the retry paste
+    must refuse and defer to the next tick's safe_deliver gate."""
+
+    MENU = (
+        "Do you want to proceed?\n"
+        "❯ 1. Yes\n"
+        "  2. No\n"
+        "Esc to cancel"
+    )
+
+    def test_no_enter_pressed_into_live_menu(self, monkeypatch):
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["caps"] <= 2:
+                return render_box("report text")  # landed
+            return self.MENU  # dialog replaced the screen mid-submit
+
+        actions = _env(monkeypatch, frame)
+        assert not session_ready.send_verified("s", "report text")
+        assert actions["enters"] == 0
+
+    def test_retry_never_pastes_into_live_menu(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        actions = _env(monkeypatch, lambda a: self.MENU)
+        assert not session_ready.send_verified("s", "report text", retries=2)
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 0


### PR DESCRIPTION
## What

Fixes the three #698 defects behind the 2026-07-04 swallowed-Enter losses (12:40 UTC incident + 5 stress-test stuck boxes).

### 1. Delivery confirm false positives (`session_ready.py`)

Log forensics: every one of the 5 stress-window `stuck_box_flushed` recoveries was preceded by a false `delivered` — the window contains **zero** `delivery_unverified` / `stuck_in_box` / `delivered_dedup` events. `send_verified` lied on every swallowed-Enter case, so the #689/#690 defenses (stuck-heal, dedup) never even engaged. And the 12:40 `delivered` landed in the **same second** the tick started — the Enter was never pressed at all: Phase 1 read "empty box + activity glyphs" as already-submitted *before the paste rendered*, and Phase 2's pre-check confirmed against the same still-empty box. Zero keystrokes, file unlinked, paste rendered a moment later and sat there until the owner pressed Enter by hand.

- **Phase 1** now ends only on positive evidence: the text rendered in the box (`text_landed`) or the message/marker echoed on scrollback **outside** the box (`message_on_scrollback`). Ambient activity can no longer end the land-wait. `submitted()` is deleted.
- **`submit_confirmed`** trusts only a **parseable box** ("box no longer holds our text", the #621 semantics, incl. submitted-while-generating → queued). Unparseable/garbled frames never confirm: the old fallback accepted activity glyphs / marker / raw-capture visibility, all of which a stuck paste satisfies because the raw capture *includes* the box that failed to parse. One garbled snapshot during the confirm poll used to produce `delivered`.
- **`strip_input_box`** counts only lines strictly above the box's top border as "outside" — a mid-redraw frame missing the bottom border can no longer leak real box content into the dedup's "scrollback".
- `delivered` / `delivered_dedup` / `stuck_submitted` all sit behind these confirms, so **'delivered' can no longer be logged while the text is inside the box region**.

### 2. Enter swallowing hardened (`pane_manager.py`, `session_ready.py`)

- `paste-buffer` now passes `-p` (bracketed paste; tmux falls back to plain paste when the app hasn't requested it). Claude Code gets an explicit end-of-paste marker, so a trailing Enter can't be coalesced into the heuristically-detected paste burst as a newline — the mechanism by which genuinely-pressed Enters were eaten under load.
- The re-press loop is no longer neutered after the first press by the phase-2 false positive — it now genuinely presses until a parseable frame clears (budget-bounded; idle Enters are no-ops).
- New safety: a live select-menu appearing on the target mid-send aborts the Enter loop (Enter would confirm the highlighted option), and the whole-send retry refuses to paste into a menu-covered pane (digits in the text could select an option; previously only the first attempt was gated by `safe_deliver`).

### 3. Stuck-box flusher gap (`prompt_router.py`)

The 12:40 stuck box was never rescued because the recipient (the `agentwire` orchestrator) was mid-turn: the `esc to interrupt` gate both refused the flush **and reset the counter every sweep**. Enter on a generating Claude Code pane *queues* the draft (Esc interrupts; Enter never does), so the flusher now fires mid-generation on the normal two-sweep cadence. Unjudgeable frames (unparseable box, live dialog) hold the counter instead of resetting it; a live menu is never Entered into.

## Regression tests

- 12:40 zero-press race: empty box + activity + no echo → **not** delivered, zero Enters (`test_zero_press_race_paste_not_yet_rendered`).
- Stress root cause: Enter pressed, all confirm frames garbled → failure reported, never `delivered` (`test_garbled_frames_after_enter_never_confirm`).
- Stuck-paste-in-box never counted delivered (`test_unparseable_box_is_never_confirmed`, `test_below_last_rule_is_never_outside`).
- Flusher rescues a stuck box within one sweep once armed, even mid-generation (`test_generating_pane_still_flushes`) and across garbled/menu frames (`test_unparseable_frame_holds_counter`, `test_live_menu_holds_and_never_enters`).
- Live-menu aborts (`TestLiveMenuAbort`).

## Verification

Full suite in-worktree: **2470 passed**. Live-portal behavior (real tmux paste timing with `-p`) can only be validated after merge + rebuild — flagging rather than claiming it.

Notes: diff kept surgical because fix-693-694 / fix-695 are concurrently touching `inbox.py` / `session_ready.py`; no `inbox.py` product changes were needed (its stuck-heal/dedup paths were already sound once `send_verified` stopped lying). `pane_shows_activity` is retained (still used by the integration fixture) though it no longer feeds delivery decisions.

Closes #698

Built by [dotdev.dev](https://dotdev.dev)