### PR TITLE
fix(sessions): nest worktrees at ~/worktrees/<project>/<name>/ (#703)

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -219,7 +219,8 @@ session_context:         # Context-bloat observability (Phase 0, observe-only â€
 worktree:                         # `agentwire worktree <name>` orchestration (WorktreeConfig).
                                   # Distinct from projects.worktrees above (the legacy
                                   # project/branch layout).
-  worktree_dir: ~/worktrees       # Where worktrees are created (one dir per session)
+  worktree_dir: ~/worktrees       # Root for worktrees, nested per project:
+                                  # <worktree_dir>/<project>/<name>/ (mirrors ~/projects/)
   default_base: develop           # Base branch new worktrees fork from. OMIT to derive from
                                   # the repo's actual default branch (origin/HEAD, fallback to
                                   # current branch) â€” no hardcoded 'main'. --base always wins.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The `agentwire-mcp-tools` skill has the full reference (sessions, panes, voice, 
 
 | Term | Command | What you get |
 |------|---------|--------------|
-| **Worktree session** | `agentwire worktree <name> -p <repo>` | **Standalone tmux session** named `{project}-<name>`, new branch `<name>` from origin/main, worktree under `~/worktrees/`. Survives independently; report-back via `agentwire notify-parent --to <orchestrator>`. Etiquette (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) is intrinsic — the `worktree-session` role is auto-injected by the verb, so first prompts only need the task. |
+| **Worktree session** | `agentwire worktree <name> -p <repo>` | **Standalone tmux session** named `{project}-<name>`, new branch `<name>` from origin/main, worktree at `~/worktrees/<project>/<name>/` (nested per project, mirroring `~/projects/`). Survives independently; report-back via `agentwire notify-parent --to <orchestrator>`. Etiquette (isolation, no rebuild/restart, verify in-worktree, draft PR + notify-back) is intrinsic — the `worktree-session` role is auto-injected by the verb, so first prompts only need the task. |
 | **Worker pane** | `agentwire spawn --branch <name>` | A **pane inside the current session** (pane 1+), worktree on `<name>`. Inherits the session's dashboard; idle hook reaps it. |
 
 When the owner says "worktree session", they mean the standalone session (`agentwire worktree`), **never** `spawn` panes. Worker panes are for small subtasks watched by the orchestrator; worktree sessions are for parallel autonomous work. The verb sets the posture: `worktree`/`new` default to the bypass posture (full access), `spawn` to restricted — no `--type` needed for the common case.

--- a/agentwire/channels_cli.py
+++ b/agentwire/channels_cli.py
@@ -57,9 +57,11 @@ def _infer_session_from_path() -> str | None:
 
     ~/projects/myapp -> myapp
     ~/projects/myapp-worktrees/feature -> myapp/feature
+    ~/worktrees/myapp/fix-bug -> myapp-fix-bug (worktree session)
     """
     cwd = Path.cwd()
     projects_dir = Path.home() / "projects"
+    worktrees_dir = Path.home() / "worktrees"
 
     try:
         rel = cwd.relative_to(projects_dir)
@@ -73,6 +75,15 @@ def _infer_session_from_path() -> str | None:
             return f"{base}/{parts[1]}"
         elif len(parts) >= 2:
             return f"{parts[0]}/{parts[1]}"
+    except ValueError:
+        pass
+
+    try:
+        # Worktree sessions live at ~/worktrees/<project>/<name>/ with a flat
+        # tmux session name {project}-{name}.
+        parts = cwd.relative_to(worktrees_dir).parts
+        if len(parts) >= 2:
+            return f"{parts[0]}-{parts[1]}"
     except ValueError:
         pass
 

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -84,7 +84,16 @@ class ServerConfig:
 
 @dataclass
 class WorktreesConfig:
-    """Git worktrees configuration for parallel sessions."""
+    """Git worktrees configuration for `project/branch` sessions.
+
+    Governs the legacy ``project/branch`` session layout under
+    ``~/projects/<project>-worktrees/``. Still ALIVE (#703): the scheduler's
+    worktree+PR dispatch creates its sessions via
+    ``agentwire new -s <project>/<branch>``, and ``copy_files`` seeds every
+    fresh worktree (including scheduler dispatches). Standalone
+    ``agentwire worktree`` sessions use :class:`WorktreeConfig` instead
+    (``~/worktrees/<project>/<name>/``).
+    """
 
     enabled: bool = True
     suffix: str = "-worktrees"
@@ -128,7 +137,9 @@ class WorktreeConfig:
         default_project: Repo path used when ``--project`` is omitted and
             cwd is not inside a git repo. ``None`` → infer from cwd's git
             root, else cwd.
-        worktree_dir: Where worktrees live (one dir per session).
+        worktree_dir: Root under which worktrees are created, nested per
+            project — ``<worktree_dir>/<project>/<name>/`` — mirroring
+            ``~/projects/<project>/``.
         naming: Optional branch-name template applied in default (new-branch)
             mode, e.g. ``"{user}/{slug}"`` or ``"feature-{slug}"``.
             Placeholders: ``{name}`` (raw), ``{slug}`` (slugified),

--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -19,9 +19,9 @@ def worktree_create(
 
     The spawn half of the worktree lifecycle (paired with worktree_status /
     worktree_list / worktree_remove). Creates a branch off origin/<base>, a
-    worktree under ~/worktrees/, and a tmux session running an agent with the
-    worktree-session safety etiquette auto-injected. This is how a Briefing Mode
-    anchor fans out correspondents.
+    worktree at ~/worktrees/<project>/<name>/, and a tmux session running an
+    agent with the worktree-session safety etiquette auto-injected. This is how
+    a Briefing Mode anchor fans out correspondents.
 
     Args:
         name: Worktree/branch name (becomes the branch + session suffix).

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -809,7 +809,7 @@ def cmd_worktree(args) -> int:
     if getattr(args, 'watch', False):
         return _worktree_watch(args, project_path, json_mode)
     if getattr(args, 'prune', False):
-        return _worktree_prune(args, project_path, json_mode)
+        return _worktree_prune(args, project_path, worktree_dir, json_mode)
     if getattr(args, 'status', False):
         return _worktree_status(args, project_path, worktree_dir, json_mode)
     if getattr(args, 'remove', False):
@@ -826,10 +826,12 @@ def cmd_worktree(args) -> int:
 
     project_name = project_path.name
     # Session/worktree-dir key stays the raw CLI name made tmux-safe; the git
-    # branch may be templated separately via worktree.naming.
+    # branch may be templated separately via worktree.naming. The worktree
+    # nests per project — ~/worktrees/<project>/<name>/ — mirroring
+    # ~/projects/<project>/; the tmux session name stays flat {project}-{name}.
     safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
     session_name = f"{project_name}-{safe_name}"
-    worktree_path = worktree_dir / session_name
+    worktree_path = worktree_dir / project_name / safe_name
 
     # --base wins; else config default; else the repo's actual default branch
     # (origin/HEAD, not a hardcoded 'main'). --current handled per-mode below.
@@ -945,7 +947,7 @@ def cmd_worktree(args) -> int:
             return _output_result(False, json_mode, f"Failed to fetch origin/{base_branch}: {fetch_result.stderr.strip()}")
 
     # Create worktree
-    worktree_dir.mkdir(parents=True, exist_ok=True)
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
     wt_cmd = ["git", "-C", str(project_path), "worktree", "add"]
     if new_branch:
         wt_cmd += [str(worktree_path), git_ref, "--detach", "--quiet"]
@@ -973,6 +975,7 @@ def cmd_worktree(args) -> int:
                     ["git", "-C", str(project_path), "worktree", "remove", str(worktree_path), "--force"],
                     capture_output=True,
                 )
+            _cleanup_empty_project_dir(worktree_path, worktree_dir)
             return _output_result(False, json_mode, f"Failed to create branch '{new_branch}': {branch_result.stderr.strip()}")
 
     # Record the branch↔session association in the local registry.
@@ -1099,28 +1102,48 @@ def _git_badge(git: dict | None) -> str:
     return " ".join(parts)
 
 
+def _resolve_worktree_entry(name: str, project_path: Path, worktree_dir: Path) -> tuple[str, Path]:
+    """Resolve a name/session/branch to (session_name, worktree_path).
+
+    Registry first; falls back to the conventional layout — session
+    ``{project}-{name}``, worktree ``worktree_dir/<project>/<name>/`` — so
+    recovery still works on hand-created or pre-registry worktrees.
+    """
+    project_name = project_path.name
+    candidates = {name, f"{project_name}-{name}"}
+    for e in worktree_registry.entries(project_path):
+        if e.get("session") in candidates or e.get("branch") == name or Path(e.get("worktree_path", "")).name in candidates:
+            return e.get("session"), Path(e.get("worktree_path"))
+
+    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+    if safe_name.startswith(f"{project_name}-"):
+        safe_name = safe_name[len(project_name) + 1:]
+    return f"{project_name}-{safe_name}", worktree_dir / project_name / safe_name
+
+
+def _cleanup_empty_project_dir(worktree_path: Path, worktree_dir: Path) -> None:
+    """Remove now-empty per-project dirs under ``worktree_dir``.
+
+    Removing a project's last worktree should not leave an empty
+    ``~/worktrees/<project>/`` behind. Walks up from the worktree's parent,
+    rmdir'ing while empty, stopping at ``worktree_dir`` itself.
+    """
+    parent = worktree_path.parent
+    while parent != worktree_dir and parent.is_relative_to(worktree_dir):
+        try:
+            parent.rmdir()  # only succeeds when empty
+        except OSError:
+            break
+        parent = parent.parent
+
+
 def _worktree_status(args, project_path: Path, worktree_dir: Path, json_mode: bool) -> int:
     """Read-only git status for one worktree session (--status). Never mutates."""
     name = getattr(args, 'name', None)
     if not name:
         return _output_result(False, json_mode, "Usage: agentwire worktree --status <name|session>")
 
-    project_name = project_path.name
-    candidates = {name, f"{project_name}-{name}"}
-    entry = None
-    for e in worktree_registry.entries(project_path):
-        if e.get("session") in candidates or e.get("branch") == name or Path(e.get("worktree_path", "")).name in candidates:
-            entry = e
-            break
-
-    if entry:
-        session_name = entry.get("session")
-        worktree_path = Path(entry.get("worktree_path"))
-    else:
-        safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
-        session_name = name if name.startswith(f"{project_name}-") else f"{project_name}-{safe_name}"
-        worktree_path = worktree_dir / session_name
-
+    session_name, worktree_path = _resolve_worktree_entry(name, project_path, worktree_dir)
     git = worktree_status(worktree_path)
 
     if json_mode:
@@ -1136,12 +1159,13 @@ def _worktree_status(args, project_path: Path, worktree_dir: Path, json_mode: bo
     return 0
 
 
-def _worktree_prune(args, project_path: Path, json_mode: bool) -> int:
+def _worktree_prune(args, project_path: Path, worktree_dir: Path, json_mode: bool) -> int:
     """Drop registry entries whose worktree path is gone; git worktree prune."""
     removed = []
     for e in worktree_registry.entries(project_path):
         if not Path(e.get("worktree_path", "")).exists():
             worktree_registry.unregister(project_path, session=e.get("session"))
+            _cleanup_empty_project_dir(Path(e.get("worktree_path", "")), worktree_dir)
             removed.append(e.get("session"))
     subprocess.run(["git", "-C", str(project_path), "worktree", "prune"],
                    capture_output=True)
@@ -1161,23 +1185,7 @@ def _worktree_remove(args, project_path: Path, worktree_dir: Path, json_mode: bo
     if not name:
         return _output_result(False, json_mode, "Usage: agentwire worktree --remove <name|session>")
 
-    project_name = project_path.name
-    candidates = {name, f"{project_name}-{name}"}
-    entry = None
-    for e in worktree_registry.entries(project_path):
-        if e.get("session") in candidates or e.get("branch") == name or Path(e.get("worktree_path", "")).name in candidates:
-            entry = e
-            break
-
-    if entry:
-        session_name = entry.get("session")
-        worktree_path = Path(entry.get("worktree_path"))
-    else:
-        # Not in registry — fall back to the conventional layout so recovery
-        # still works on hand-created or pre-registry worktrees.
-        safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
-        session_name = name if name.startswith(f"{project_name}-") else f"{project_name}-{safe_name}"
-        worktree_path = worktree_dir / session_name
+    session_name, worktree_path = _resolve_worktree_entry(name, project_path, worktree_dir)
 
     # Kill the tmux session if it's alive.
     killed = False
@@ -1193,6 +1201,11 @@ def _worktree_remove(args, project_path: Path, worktree_dir: Path, json_mode: bo
             capture_output=True,
         )
         removed = not worktree_path.exists()
+
+    # Removing a project's last worktree also removes the now-empty
+    # ~/worktrees/<project>/ dir.
+    if not worktree_path.exists():
+        _cleanup_empty_project_dir(worktree_path, worktree_dir)
 
     worktree_registry.unregister(project_path, session=session_name, worktree_path=worktree_path)
 

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -136,23 +136,6 @@ def is_git_repo(path: Path) -> bool:
     return (path / ".git").exists()
 
 
-def get_session_path(
-    name: str,
-    projects_dir: Path,
-    worktree_suffix: str = "-worktrees",
-) -> Path:
-    """Get filesystem path for a session.
-
-    For "project" -> projects_dir / project
-    For "project/branch" -> projects_dir / f"{project}{worktree_suffix}" / branch
-    """
-    project, branch, _ = parse_session_name(name)
-
-    if branch:
-        return projects_dir / f"{project}{worktree_suffix}" / branch
-    return projects_dir / project
-
-
 def ensure_worktree(
     project_path: Path,
     branch: str,

--- a/agentwire/worktree_registry.py
+++ b/agentwire/worktree_registry.py
@@ -13,7 +13,7 @@ the repo's absolute path. Each file holds a list of entries:
       "project": "/Users/me/projects/monorepo",
       "entries": [
         {"branch": "fix-bug", "session": "monorepo-fix-bug",
-         "base": "develop", "worktree_path": "/Users/me/worktrees/monorepo-fix-bug",
+         "base": "develop", "worktree_path": "/Users/me/worktrees/monorepo/fix-bug",
          "created_at": "2026-06-14T10:30:00-04:00"}
       ]
     }

--- a/docs/wiki/sessions/worktree-sessions.md
+++ b/docs/wiki/sessions/worktree-sessions.md
@@ -6,7 +6,7 @@
 agentwire worktree fix-bug          # new branch from the repo's default base + standalone session
 ```
 
-A worktree session is a **standalone tmux session** (`{project}-{name}`) running on its own git worktree under `worktree_dir` (default `~/worktrees/`). It survives independently of its creator and carries the intrinsic **worktree-session etiquette** (isolation, no live-tool rebuild/restart, in-worktree verification, draft PR + notify-back) — that role is injected by the spawn verb, so first prompts only need the task itself. `--roles` / `.agentwire.yml roles:` **add** to it; they never replace it.
+A worktree session is a **standalone tmux session** (`{project}-{name}`) running on its own git worktree at `<worktree_dir>/<project>/<name>/` (default `~/worktrees/<project>/<name>/` — nested per project, mirroring `~/projects/<project>/`; the tmux session name stays flat). It survives independently of its creator and carries the intrinsic **worktree-session etiquette** (isolation, no live-tool rebuild/restart, in-worktree verification, draft PR + notify-back) — that role is injected by the spawn verb, so first prompts only need the task itself. `--roles` / `.agentwire.yml roles:` **add** to it; they never replace it.
 
 > "Worktree session" **always** means this command — never `agentwire spawn --branch` (that makes a worker *pane* inside the current session). See the [glossary](../glossary.md).
 
@@ -48,13 +48,13 @@ agentwire worktree --remove name   # kill the session + remove the worktree + un
 agentwire worktree --prune         # drop entries whose worktree is gone + `git worktree prune`
 ```
 
-`--list` annotates each entry: **live** (tmux session running), **orphan** (worktree on disk, no session), **stale** (registry entry, worktree gone). `--remove` is the cleanup/recovery path; it still works on hand-created worktrees not in the registry by falling back to the conventional `{project}-{name}` layout.
+`--list` annotates each entry: **live** (tmux session running), **orphan** (worktree on disk, no session), **stale** (registry entry, worktree gone). `--remove` is the cleanup/recovery path; it still works on hand-created worktrees not in the registry by falling back to the conventional `<worktree_dir>/<project>/<name>/` layout. Removing (or pruning) a project's last worktree also removes the now-empty `<worktree_dir>/<project>/` dir.
 
 ## Config
 
 ```yaml
 worktree:
-  worktree_dir: ~/worktrees
+  worktree_dir: ~/worktrees       # worktrees nest per project: <worktree_dir>/<project>/<name>/
   default_base: develop           # omit → repo-derived (origin/HEAD)
   default_project: ~/projects/my-repo
   naming: "{user}/{slug}"

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -85,7 +85,7 @@ def test_default_base_is_repo_derived(tmp_path, monkeypatch, wt_env):
     rc = _run(monkeypatch, cfg, name="fix-bug", project=str(clone))
     assert rc == 0
 
-    wt_path = wt_dir / "clone-repo-fix-bug"
+    wt_path = wt_dir / "clone-repo" / "fix-bug"
     assert wt_path.exists()
     # New branch's parent is origin/develop's tip.
     base_sha = _git(clone, "rev-parse", "origin/develop").stdout.strip()
@@ -145,7 +145,7 @@ def test_invalid_branch_name_fails_clean_no_orphan(tmp_path, monkeypatch, wt_env
     rc = _run(monkeypatch, _config(wt_dir), name="Auth V2", project=str(clone))
     assert rc != 0
     # No orphaned worktree, nothing registered, nothing launched.
-    assert not (wt_dir / "clone-repo-Auth-V2").exists()
+    assert not (wt_dir / "clone-repo" / "Auth-V2").exists()
     assert reg.entries(clone.resolve()) == []
     # git agrees there's only the main worktree.
     wt_list = _git(clone, "worktree", "list").stdout
@@ -175,7 +175,7 @@ def test_naming_template_applied_to_branch(tmp_path, monkeypatch, wt_env):
     rc = _run(monkeypatch, cfg, name="Auth V2", project=str(clone))
     assert rc == 0
     # Branch is templated; session/worktree key stays the tmux-safe raw name.
-    wt_path = wt_dir / "clone-repo-Auth-V2"  # spaces → '-' for tmux safety
+    wt_path = wt_dir / "clone-repo" / "Auth-V2"  # spaces → '-' for tmux safety
     assert wt_path.exists()
     branch = _git(wt_path, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
     assert branch == "feature-auth-v2"
@@ -191,7 +191,7 @@ def test_project_inferred_from_cwd_git_root(tmp_path, monkeypatch, wt_env):
     wt_dir = tmp_path / "worktrees"
     rc = _run(monkeypatch, _config(wt_dir), name="thing")  # no --project
     assert rc == 0
-    assert (wt_dir / "clone-repo-thing").exists()
+    assert (wt_dir / "clone-repo" / "thing").exists()
     assert reg.entries(clone.resolve())[0]["session"] == "clone-repo-thing"
 
 
@@ -205,7 +205,7 @@ def test_monorepo_many_sessions_one_repo(tmp_path, monkeypatch, wt_env):
     sessions = {e["session"] for e in reg.entries(clone.resolve())}
     assert sessions == {"clone-repo-one", "clone-repo-two", "clone-repo-three"}
     for n in ("one", "two", "three"):
-        assert (wt_dir / f"clone-repo-{n}").exists()
+        assert (wt_dir / "clone-repo" / n).exists()
 
 
 def test_remove_cleans_worktree_and_registry(tmp_path, monkeypatch, wt_env):
@@ -213,12 +213,45 @@ def test_remove_cleans_worktree_and_registry(tmp_path, monkeypatch, wt_env):
     wt_dir = tmp_path / "worktrees"
     cfg = _config(wt_dir)
     assert _run(monkeypatch, cfg, name="kill-me", project=str(clone)) == 0
-    wt_path = wt_dir / "clone-repo-kill-me"
+    wt_path = wt_dir / "clone-repo" / "kill-me"
     assert wt_path.exists()
 
     rc = _run(monkeypatch, cfg, name="kill-me", project=str(clone), remove=True)
     assert rc == 0
     assert not wt_path.exists()
+    assert reg.entries(clone.resolve()) == []
+    # Last worktree gone → the empty per-project dir goes with it.
+    assert not (wt_dir / "clone-repo").exists()
+    assert wt_dir.exists()  # the root itself is never removed
+
+
+def test_remove_keeps_project_dir_while_siblings_remain(tmp_path, monkeypatch, wt_env):
+    """Removing one of two worktrees must NOT sweep the project dir."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    assert _run(monkeypatch, cfg, name="one", project=str(clone)) == 0
+    assert _run(monkeypatch, cfg, name="two", project=str(clone)) == 0
+
+    assert _run(monkeypatch, cfg, name="one", project=str(clone), remove=True) == 0
+    assert not (wt_dir / "clone-repo" / "one").exists()
+    assert (wt_dir / "clone-repo" / "two").exists()
+    assert (wt_dir / "clone-repo").exists()
+
+    assert _run(monkeypatch, cfg, name="two", project=str(clone), remove=True) == 0
+    assert not (wt_dir / "clone-repo").exists()
+
+
+def test_remove_by_full_session_name(tmp_path, monkeypatch, wt_env):
+    """--remove accepts the full {project}-{name} session name too."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    assert _run(monkeypatch, cfg, name="fix-bug", project=str(clone)) == 0
+
+    rc = _run(monkeypatch, cfg, name="clone-repo-fix-bug", project=str(clone), remove=True)
+    assert rc == 0
+    assert not (wt_dir / "clone-repo").exists()
     assert reg.entries(clone.resolve()) == []
 
 
@@ -229,7 +262,7 @@ def test_prune_drops_stale_entries(tmp_path, monkeypatch, wt_env):
     assert _run(monkeypatch, cfg, name="gone", project=str(clone)) == 0
 
     # Simulate an externally-removed worktree.
-    wt_path = wt_dir / "clone-repo-gone"
+    wt_path = wt_dir / "clone-repo" / "gone"
     subprocess.run(["git", "-C", str(clone), "worktree", "remove", str(wt_path), "--force"],
                    capture_output=True)
     assert not wt_path.exists()
@@ -238,3 +271,5 @@ def test_prune_drops_stale_entries(tmp_path, monkeypatch, wt_env):
     rc = _run(monkeypatch, cfg, prune=True, project=str(clone))
     assert rc == 0
     assert reg.entries(clone.resolve()) == []
+    # Pruning the project's last worktree sweeps the empty per-project dir.
+    assert not (wt_dir / "clone-repo").exists()

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -1,7 +1,6 @@
 """Tests for agentwire/worktree.py — Session name parsing, paths."""
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -10,7 +9,6 @@ from agentwire.worktree import (
     default_base_branch,
     ensure_worktree,
     get_project_type,
-    get_session_path,
     git_root,
     is_git_repo,
     is_valid_branch_name,
@@ -58,30 +56,6 @@ class TestParseSessionName:
         assert project == "myapp"
         assert branch == "feat/sub"
         assert machine is None
-
-
-# --- get_session_path ---
-
-class TestGetSessionPath:
-    def test_simple_project(self):
-        projects = Path("/home/user/projects")
-        result = get_session_path("myapp", projects)
-        assert result == Path("/home/user/projects/myapp")
-
-    def test_worktree_with_suffix(self):
-        projects = Path("/home/user/projects")
-        result = get_session_path("myapp/feature", projects)
-        assert result == Path("/home/user/projects/myapp-worktrees/feature")
-
-    def test_custom_suffix(self):
-        projects = Path("/home/user/projects")
-        result = get_session_path("myapp/branch", projects, worktree_suffix="-wt")
-        assert result == Path("/home/user/projects/myapp-wt/branch")
-
-    def test_machine_ignored_in_path(self):
-        projects = Path("/home/user/projects")
-        result = get_session_path("myapp@server", projects)
-        assert result == Path("/home/user/projects/myapp")
 
 
 # --- is_git_repo ---

--- a/tests/unit/test_worktree_layout.py
+++ b/tests/unit/test_worktree_layout.py
@@ -1,0 +1,89 @@
+"""Unit tests for the nested worktree layout (#703).
+
+Worktrees live at ``<worktree_dir>/<project>/<name>/`` — nested per project,
+mirroring ``~/projects/<project>/`` — while tmux session names stay flat
+``{project}-{name}``. Covers fallback path construction (registry miss) and
+the empty-project-dir sweep after the last worktree is removed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from agentwire import worktree_registry as reg
+from agentwire.session_cli import _cleanup_empty_project_dir, _resolve_worktree_entry
+
+
+@pytest.fixture
+def iso_registry(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "REGISTRY_DIR", tmp_path / "registry")
+
+
+# --- _resolve_worktree_entry: fallback (registry miss) path construction ---
+
+class TestResolveFallback:
+    def test_short_name(self, tmp_path, iso_registry):
+        project = tmp_path / "myapp"
+        wt_dir = tmp_path / "worktrees"
+        session, path = _resolve_worktree_entry("fix-bug", project, wt_dir)
+        assert session == "myapp-fix-bug"
+        assert path == wt_dir / "myapp" / "fix-bug"
+
+    def test_full_session_name_strips_project_prefix(self, tmp_path, iso_registry):
+        project = tmp_path / "myapp"
+        wt_dir = tmp_path / "worktrees"
+        session, path = _resolve_worktree_entry("myapp-fix-bug", project, wt_dir)
+        assert session == "myapp-fix-bug"
+        assert path == wt_dir / "myapp" / "fix-bug"
+
+    def test_unsafe_chars_sanitized(self, tmp_path, iso_registry):
+        project = tmp_path / "myapp"
+        wt_dir = tmp_path / "worktrees"
+        session, path = _resolve_worktree_entry("feat/auth v2", project, wt_dir)
+        assert session == "myapp-feat-auth-v2"
+        assert path == wt_dir / "myapp" / "feat-auth-v2"
+
+    def test_registry_entry_wins_over_convention(self, tmp_path, iso_registry):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        wt_dir = tmp_path / "worktrees"
+        custom = tmp_path / "elsewhere" / "fix-bug"
+        reg.register(project, branch="fix-bug", session="myapp-fix-bug",
+                     base="main", worktree_path=custom)
+        session, path = _resolve_worktree_entry("fix-bug", project, wt_dir)
+        assert session == "myapp-fix-bug"
+        assert path == custom
+
+
+# --- _cleanup_empty_project_dir ---
+
+class TestCleanupEmptyProjectDir:
+    def test_removes_empty_project_dir(self, tmp_path):
+        wt_dir = tmp_path / "worktrees"
+        wt_path = wt_dir / "myapp" / "fix-bug"
+        wt_path.parent.mkdir(parents=True)  # worktree itself already gone
+        _cleanup_empty_project_dir(wt_path, wt_dir)
+        assert not (wt_dir / "myapp").exists()
+        assert wt_dir.exists()
+
+    def test_keeps_project_dir_with_siblings(self, tmp_path):
+        wt_dir = tmp_path / "worktrees"
+        (wt_dir / "myapp" / "other").mkdir(parents=True)
+        _cleanup_empty_project_dir(wt_dir / "myapp" / "fix-bug", wt_dir)
+        assert (wt_dir / "myapp" / "other").exists()
+
+    def test_never_removes_worktree_root(self, tmp_path):
+        wt_dir = tmp_path / "worktrees"
+        wt_dir.mkdir()
+        _cleanup_empty_project_dir(wt_dir / "myapp" / "fix-bug", wt_dir)
+        assert wt_dir.exists()
+
+    def test_ignores_paths_outside_worktree_dir(self, tmp_path):
+        wt_dir = tmp_path / "worktrees"
+        outside = tmp_path / "elsewhere" / "fix-bug"
+        outside.parent.mkdir(parents=True)
+        _cleanup_empty_project_dir(outside, wt_dir)
+        assert outside.parent.exists()  # untouched — not under worktree_dir
+
+    def test_empty_path_is_noop(self, tmp_path):
+        _cleanup_empty_project_dir(Path(""), tmp_path / "worktrees")


### PR DESCRIPTION
## What

Worktree sessions now create their worktree at `<worktree_dir>/<project>/<name>/` — nested per project, mirroring `~/projects/<project>/` — instead of the flat `~/worktrees/<project>-<name>`. Tmux session names are unchanged (`{project}-{name}`); only the path nests. Pre-launch no-backwards-compat: no flat-layout fallback anywhere.

## Changes

- **Create** (`cmd_worktree`): builds `worktree_dir/<project>/<name>`, mkdirs parents. A failed branch-create now also sweeps the empty per-project dir it may have created.
- **Resolve** (`--status`/`--remove`): the duplicated registry-lookup-plus-fallback block is consolidated into one `_resolve_worktree_entry` helper; the registry-miss fallback resolves the nested layout (accepts short name, full `{project}-{name}` session name, or branch).
- **Cleanup**: new `_cleanup_empty_project_dir` — removing or pruning a project's **last** worktree removes the now-empty `~/worktrees/<project>/` dir (walks up rmdir-while-empty, never touches the worktree root or paths outside it).
- **`channels_cli` inference**: `~/worktrees/<project>/<name>/` cwd now infers session `{project}-{name}` (alongside the existing `~/projects/…` parsing).
- **Dead code deleted**: `worktree.get_session_path()` had zero production callers — removed with its tests, per no-BC.
- **Docs/skills**: `docs/wiki/sessions/worktree-sessions.md`, `CLAUDE.md` dispatch table, `agentwire-config` skill, registry/MCP/config docstrings all show the nested convention.

## Legacy `projects.worktrees` investigation (per issue)

**ALIVE — kept, with the live consumers documented on the `WorktreesConfig` dataclass:**

- The scheduler's worktree+PR dispatch spawns via `agentwire new -s <project>/<branch>` (`scheduler/dispatch.py:750`), which lands in `~/projects/<project>-worktrees/<branch>` and reads `suffix`/`auto_create_branch`.
- `copy_files` seeds every fresh worktree (`ensure_worktree` → `_seed_worktree_files`), including scheduler dispatches — this is the mechanism that carries `.env`/`.agentwire.yml` into worktree runs.
- `cmd_new`/`cmd_recreate`/`cmd_fork` `project/branch` flows (local + remote) also consume it.

Unifying that layout onto `~/worktrees/<project>/<branch>` would be a separate, larger change (remote-machine paths, scheduler reaper's suffix-based canonical-path derivation) — happy to file a follow-up issue if wanted.

## Verification

- New unit tests: fallback path construction (`_resolve_worktree_entry`) + empty-project-dir sweep (`_cleanup_empty_project_dir`) — `tests/unit/test_worktree_layout.py`.
- Integration tests updated to the nested layout, plus new: last-worktree removal sweeps the project dir, sibling worktrees keep it, remove-by-full-session-name round-trips, prune sweeps the empty dir.
- **Full suite: 2512 passed.**
- Live `agentwire worktree foo -p …` verification needs a rebuild post-merge (this session runs the installed tool, per worktree-session etiquette).

Closes #703

Built by [dotdev.dev](https://dotdev.dev)