### PR TITLE
feat(sessions): per-project worktree overrides in .agentwire.yml (dir + base) (#705)

### DIFF
--- a/.claude/skills/agentwire-config/SKILL.md
+++ b/.claude/skills/agentwire-config/SKILL.md
@@ -219,6 +219,10 @@ session_context:         # Context-bloat observability (Phase 0, observe-only �
 worktree:                         # `agentwire worktree <name>` orchestration (WorktreeConfig).
                                   # Distinct from projects.worktrees above (the legacy
                                   # project/branch layout).
+                                  # PRECEDENCE (#705): a project's .agentwire.yml `worktree:`
+                                  # block (dir/base) overrides these for that repo; a
+                                  # per-invocation --base flag beats both. Chain: flag →
+                                  # project .agentwire.yml → this global block → built-ins.
   worktree_dir: ~/worktrees       # Root for worktrees, nested per project:
                                   # <worktree_dir>/<project>/<name>/ (mirrors ~/projects/)
   default_base: develop           # Base branch new worktrees fork from. OMIT to derive from

--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -45,8 +45,30 @@ session:
 | `parent` | Session name | Parent session for hierarchical notifications |
 | `shell` | `/bin/sh`, `/bin/bash`, etc. | Default shell for task commands |
 | `tasks` | Task definitions | Scheduled workload configurations |
+| `worktree` | `dir` / `base` mapping | Per-project overrides for `agentwire worktree` (see below) |
 
 For pi sessions (`pi-*`, e.g. `pi-zai`, `pi-deepseek`), see the `agentwire-pi` skill.
+
+## Worktree overrides (#705)
+
+A project can override where `agentwire worktree` puts its worktrees and which
+branch they fork from, without touching the global config — the
+monorepo/develop-base shop is the canonical case:
+
+```yaml
+worktree:
+  dir: ~/work-trees     # overrides global worktree.worktree_dir for THIS project
+  base: develop         # overrides global worktree.default_base for THIS project
+```
+
+Precedence (most specific wins): per-invocation CLI/MCP `--base` flag →
+project `.agentwire.yml` `worktree:` block → global `~/.agentwire/config.yaml`
+`worktree:` → built-ins (`~/worktrees`, repo origin/HEAD). The nesting shape is
+unchanged — `dir` only moves the root: `<dir>/<project>/<name>/`. ALL worktree
+subcommands (create/list/status/remove/prune) resolve through the same
+project-scoped dir, and registry entries record the resolved path, so existing
+worktrees survive an override change. Unknown keys in the block warn to stderr
+but don't fail.
 
 > **No safety config in `.agentwire.yml` (#466/#467).** `.agentwire.yml` is
 > agent-writable, so it carries **zero** damage-control policy. The kill switch,

--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -5,6 +5,7 @@ This file lives in project directories and is the source of truth for session co
 """
 
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -139,6 +140,47 @@ def compose_session_type(harness: str, posture: str) -> str:
 
 
 @dataclass
+class WorktreeOverrides:
+    """Per-project overrides for `agentwire worktree` (the `worktree:` block).
+
+    Sits between per-invocation flags and the global config in the
+    precedence chain (#705): CLI/MCP flag → this block → global `worktree:`
+    in config.yaml → built-ins. ``dir`` only moves the root — the nesting
+    shape is unchanged: ``<dir>/<project>/<name>/``.
+    """
+    dir: Optional[Path] = None   # overrides worktree.worktree_dir for this project
+    base: Optional[str] = None   # overrides worktree.default_base for this project
+
+
+_WORKTREE_OVERRIDE_KEYS = {"dir", "base"}
+
+
+def _parse_worktree_overrides(data: Any) -> WorktreeOverrides:
+    """Parse the optional ``worktree:`` block. Unknown keys warn, never fail."""
+    if not isinstance(data, dict):
+        if data is not None:
+            print(
+                f"Warning: .agentwire.yml `worktree:` should be a mapping "
+                f"with dir/base keys, got {type(data).__name__} — ignoring",
+                file=sys.stderr,
+            )
+        return WorktreeOverrides()
+    unknown = sorted(set(data) - _WORKTREE_OVERRIDE_KEYS)
+    if unknown:
+        print(
+            f"Warning: unknown key(s) in .agentwire.yml `worktree:` block: "
+            f"{', '.join(unknown)} (expected: dir, base)",
+            file=sys.stderr,
+        )
+    dir_val = data.get("dir")
+    base_val = data.get("base")
+    return WorktreeOverrides(
+        dir=Path(str(dir_val)).expanduser() if dir_val else None,
+        base=str(base_val) if base_val else None,
+    )
+
+
+@dataclass
 class ProjectConfig:
     """Project-level configuration for a project directory.
 
@@ -154,6 +196,7 @@ class ProjectConfig:
     parent: Optional[str] = None  # Parent session for hierarchical notifications
     shell: Optional[str] = None  # Default shell for task commands (default: /bin/sh)
     tasks: dict[str, Any] = field(default_factory=dict)  # Task definitions (raw dict, parsed by tasks.py)
+    worktree: WorktreeOverrides = field(default_factory=WorktreeOverrides)  # `agentwire worktree` overrides (#705)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -170,6 +213,13 @@ class ProjectConfig:
             d["shell"] = self.shell
         if self.tasks:
             d["tasks"] = self.tasks
+        if self.worktree.dir or self.worktree.base:
+            wt: dict[str, Any] = {}
+            if self.worktree.dir:
+                wt["dir"] = str(self.worktree.dir)
+            if self.worktree.base:
+                wt["base"] = self.worktree.base
+            d["worktree"] = wt
         return d
 
     @classmethod
@@ -189,6 +239,7 @@ class ProjectConfig:
             parent=parent,
             shell=shell,
             tasks=tasks if isinstance(tasks, dict) else {},
+            worktree=_parse_worktree_overrides(data.get("worktree")),
         )
 
 

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -41,6 +41,7 @@ from .project_config import (
     POSTURES,
     ProjectConfig,
     SessionType,
+    WorktreeOverrides,
     compose_session_type,
     detect_default_agent_type,
     load_project_config,
@@ -801,7 +802,17 @@ def cmd_worktree(args) -> int:
         project_base = Path(os.getcwd())
     project_path = git_root(project_base) or project_base
 
-    worktree_dir = wt_config.worktree_dir
+    # Per-project overrides (#705): the repo's .agentwire.yml `worktree:` block
+    # (dir/base) beats the global config for THIS project. Precedence:
+    # per-invocation flag → project .agentwire.yml → global config.yaml →
+    # built-ins. Resolved BEFORE the subcommand dispatch so create / list /
+    # status / remove / prune all scope to the same dir — remove/prune must
+    # find what create made. (Registry entries record the resolved path, so
+    # already-created worktrees survive an override change regardless.)
+    project_config = load_project_config(project_path)
+    project_wt = project_config.worktree if project_config else WorktreeOverrides()
+
+    worktree_dir = project_wt.dir or wt_config.worktree_dir
 
     # Registry management flags (name is optional for these).
     if getattr(args, 'list', False):
@@ -833,9 +844,10 @@ def cmd_worktree(args) -> int:
     session_name = f"{project_name}-{safe_name}"
     worktree_path = worktree_dir / project_name / safe_name
 
-    # --base wins; else config default; else the repo's actual default branch
-    # (origin/HEAD, not a hardcoded 'main'). --current handled per-mode below.
-    default_base = getattr(args, 'base', None) or wt_config.default_base
+    # --base wins; else project override; else global config default; else the
+    # repo's actual default branch (origin/HEAD, not a hardcoded 'main').
+    # --current handled per-mode below.
+    default_base = getattr(args, 'base', None) or project_wt.base or wt_config.default_base
 
     # The branch created in default mode honors the naming template.
     templated_branch = apply_naming(wt_config.naming, name)
@@ -903,8 +915,8 @@ def cmd_worktree(args) -> int:
         new_branch = None
         mode_label = f"existing branch {name}"
     else:
-        # Default mode: new branch from base.
-        # Precedence: explicit --base > --current > config default > repo-derived.
+        # Default mode: new branch from base. Precedence: explicit --base >
+        # --current > project .agentwire.yml > global config > repo-derived.
         explicit_base = getattr(args, 'base', None)
         if explicit_base:
             base_branch = explicit_base
@@ -916,6 +928,8 @@ def cmd_worktree(args) -> int:
             if result.returncode != 0 or not result.stdout.strip():
                 return _output_result(False, json_mode, f"Failed to detect current branch in {project_path}")
             base_branch = result.stdout.strip()
+        elif project_wt.base:
+            base_branch = project_wt.base
         elif wt_config.default_base:
             base_branch = wt_config.default_base
         else:

--- a/docs/wiki/sessions/worktree-sessions.md
+++ b/docs/wiki/sessions/worktree-sessions.md
@@ -16,8 +16,9 @@ The branch a new worktree forks from is resolved in this order:
 
 1. `--base/-b <branch>` (explicit, always wins)
 2. `--current/-c` (the repo's currently checked-out branch)
-3. config `worktree.default_base`
-4. **the repo's actual default branch** — `git symbolic-ref refs/remotes/origin/HEAD` (e.g. a monorepo defaulting to `develop`), falling back to the current branch, finally `main`
+3. the project's `.agentwire.yml` `worktree.base` (per-project override, #705)
+4. global config `worktree.default_base`
+5. **the repo's actual default branch** — `git symbolic-ref refs/remotes/origin/HEAD` (e.g. a monorepo defaulting to `develop`), falling back to the current branch, finally `main`
 
 So `agentwire worktree foo` in a repo whose default is `develop` branches off `origin/develop` with no flags and no config. (If `origin/HEAD` isn't set locally, run `git remote set-head origin -a` once to populate it; until then the current-branch fallback applies.)
 
@@ -61,6 +62,21 @@ worktree:
 ```
 
 Distinct from `projects.worktrees` (the legacy `project/branch` session layout under `~/projects/<project>-worktrees/`). See the `agentwire-config` skill for the full field reference.
+
+### Per-project overrides (#705)
+
+A repo's `.agentwire.yml` can override the worktree root and base for **that project only**, so the global layout isn't a lock-in (the monorepo/develop-base shop is the canonical case):
+
+```yaml
+# .agentwire.yml at the repo root
+worktree:
+  dir: ~/work-trees     # overrides worktree.worktree_dir for this project
+  base: develop         # overrides worktree.default_base for this project
+```
+
+Precedence (most specific wins): per-invocation `--base` flag → project `.agentwire.yml` `worktree:` block → global `config.yaml` `worktree:` → built-ins (`~/worktrees`, repo origin/HEAD). The nesting shape is unchanged — `dir` only moves the root: `<dir>/<project>/<name>/`.
+
+All subcommands (create/list/status/remove/prune) resolve through the same project-scoped dir, so `--remove` always finds what create made. Registry entries record the **resolved** worktree path, so worktrees created before an override change remain listable and removable afterwards. Unknown keys in the block warn to stderr but never fail the config load.
 
 ## Other modes
 

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -255,6 +255,130 @@ def test_remove_by_full_session_name(tmp_path, monkeypatch, wt_env):
     assert reg.entries(clone.resolve()) == []
 
 
+# --- Per-project overrides via .agentwire.yml `worktree:` block (#705) ---
+
+def _write_project_override(repo, **kv):
+    import yaml
+    (repo / ".agentwire.yml").write_text(yaml.safe_dump({"worktree": kv}))
+
+
+def test_project_dir_override_creates_under_project_dir(tmp_path, monkeypatch, wt_env):
+    """`worktree.dir` in .agentwire.yml moves the root for THIS repo only;
+    the nesting shape <dir>/<project>/<name>/ is unchanged."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    global_dir = tmp_path / "global-worktrees"
+    project_dir = tmp_path / "project-worktrees"
+    _write_project_override(clone, dir=str(project_dir))
+
+    rc = _run(monkeypatch, _config(global_dir), name="fix-bug", project=str(clone))
+    assert rc == 0
+    assert (project_dir / "clone-repo" / "fix-bug").exists()
+    assert not global_dir.exists()
+    # Registry records the RESOLVED path, so the entry survives override changes.
+    entries = reg.entries(clone.resolve())
+    assert entries[0]["worktree_path"] == str(project_dir / "clone-repo" / "fix-bug")
+
+
+def test_project_dir_override_remove_round_trip(tmp_path, monkeypatch, wt_env):
+    """--remove resolves through the same project-scoped dir as create."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    global_dir = tmp_path / "global-worktrees"
+    project_dir = tmp_path / "project-worktrees"
+    _write_project_override(clone, dir=str(project_dir))
+    cfg = _config(global_dir)
+
+    assert _run(monkeypatch, cfg, name="fix-bug", project=str(clone)) == 0
+    wt_path = project_dir / "clone-repo" / "fix-bug"
+    assert wt_path.exists()
+
+    assert _run(monkeypatch, cfg, name="fix-bug", project=str(clone), remove=True) == 0
+    assert not wt_path.exists()
+    assert reg.entries(clone.resolve()) == []
+    # Last worktree gone → empty per-project dir swept under the OVERRIDE root.
+    assert not (project_dir / "clone-repo").exists()
+
+
+def test_project_base_override_beats_global(tmp_path, monkeypatch, wt_env):
+    """`worktree.base` in .agentwire.yml wins over config default_base."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    origin = tmp_path / "origin"
+    _git(origin, "branch", "release")
+    _git(clone, "fetch", "-q", "origin")
+    _write_project_override(clone, base="release")
+
+    wt_dir = tmp_path / "worktrees"
+    rc = _run(monkeypatch, _config(wt_dir, default_base="develop"),
+              name="hot", project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve())[0]["base"] == "release"
+    # The new branch actually forked from origin/release.
+    base_sha = _git(clone, "rev-parse", "origin/release").stdout.strip()
+    head = _git(wt_dir / "clone-repo" / "hot", "rev-parse", "HEAD").stdout.strip()
+    assert head == base_sha
+
+
+def test_invocation_base_beats_project_override(tmp_path, monkeypatch, wt_env):
+    """Per-invocation --base is the most specific — beats the project block."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    origin = tmp_path / "origin"
+    _git(origin, "branch", "release")
+    _git(clone, "fetch", "-q", "origin")
+    _write_project_override(clone, base="release")
+
+    rc = _run(monkeypatch, _config(tmp_path / "worktrees"),
+              name="hot", base="develop", project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve())[0]["base"] == "develop"
+
+
+def test_current_flag_beats_project_base(tmp_path, monkeypatch, wt_env):
+    """--current is per-invocation too — beats the project block."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    origin = tmp_path / "origin"
+    _git(origin, "branch", "release")
+    _git(clone, "fetch", "-q", "origin")
+    _write_project_override(clone, base="release")
+    # Current branch differs from both develop and release... but must exist
+    # on origin for the fetch — keep it on develop and just assert the pick.
+    rc = _run(monkeypatch, _config(tmp_path / "worktrees"),
+              name="hot", current=True, project=str(clone))
+    assert rc == 0
+    assert reg.entries(clone.resolve())[0]["base"] == "develop"  # the checked-out branch
+
+
+def test_no_override_falls_through_to_global(tmp_path, monkeypatch, wt_env):
+    """An .agentwire.yml WITHOUT a worktree block changes nothing — global
+    dir/base apply as before."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    (clone / ".agentwire.yml").write_text("type: claude-bypass\n")
+
+    global_dir = tmp_path / "global-worktrees"
+    rc = _run(monkeypatch, _config(global_dir), name="fix-bug", project=str(clone))
+    assert rc == 0
+    assert (global_dir / "clone-repo" / "fix-bug").exists()
+    assert reg.entries(clone.resolve())[0]["base"] == "develop"  # repo-derived
+
+
+def test_entries_survive_override_change(tmp_path, monkeypatch, wt_env):
+    """A worktree created under the old dir stays removable after the
+    override changes: the registry stores the resolved path."""
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    old_dir = tmp_path / "old-trees"
+    new_dir = tmp_path / "new-trees"
+    _write_project_override(clone, dir=str(old_dir))
+    cfg = _config(tmp_path / "global-worktrees")
+
+    assert _run(monkeypatch, cfg, name="fix-bug", project=str(clone)) == 0
+    wt_path = old_dir / "clone-repo" / "fix-bug"
+    assert wt_path.exists()
+
+    # Override moves — the already-created worktree must still resolve.
+    _write_project_override(clone, dir=str(new_dir))
+    assert _run(monkeypatch, cfg, name="fix-bug", project=str(clone), remove=True) == 0
+    assert not wt_path.exists()
+    assert reg.entries(clone.resolve()) == []
+
+
 def test_prune_drops_stale_entries(tmp_path, monkeypatch, wt_env):
     _, clone = _origin_and_clone(tmp_path, default_branch="develop")
     wt_dir = tmp_path / "worktrees"

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -1,12 +1,15 @@
 """Tests for agentwire/project_config.py — SessionType, ProjectConfig, normalize."""
 
 
+from pathlib import Path
+
 import pytest
 import yaml
 
 from agentwire.project_config import (
     ProjectConfig,
     SessionType,
+    WorktreeOverrides,
     compose_session_type,
     ensure_gitignored,
     find_project_config,
@@ -262,6 +265,62 @@ class TestProjectConfigIO:
         assert config is not None
         assert config.type == SessionType.CLAUDE_BYPASS
         assert config.roles == ["contributor"]
+
+
+# --- worktree: block — per-project overrides for `agentwire worktree` (#705) ---
+
+class TestWorktreeOverrides:
+    def test_full_block(self):
+        config = ProjectConfig.from_dict({
+            "worktree": {"dir": "/tmp/my-trees", "base": "develop"},
+        })
+        assert config.worktree.dir == Path("/tmp/my-trees")
+        assert config.worktree.base == "develop"
+
+    def test_dir_tilde_expanded(self):
+        config = ProjectConfig.from_dict({"worktree": {"dir": "~/work-trees"}})
+        assert config.worktree.dir == Path.home() / "work-trees"
+        assert config.worktree.base is None
+
+    def test_base_only(self):
+        config = ProjectConfig.from_dict({"worktree": {"base": "develop"}})
+        assert config.worktree.dir is None
+        assert config.worktree.base == "develop"
+
+    def test_absent_block_defaults_empty(self):
+        config = ProjectConfig.from_dict({})
+        assert config.worktree == WorktreeOverrides()
+        assert config.worktree.dir is None
+        assert config.worktree.base is None
+
+    def test_unknown_keys_warn_but_parse(self, capsys):
+        config = ProjectConfig.from_dict({
+            "worktree": {"dir": "/tmp/t", "bogus": 1, "naming": "x"},
+        })
+        assert config.worktree.dir == Path("/tmp/t")  # known keys still land
+        err = capsys.readouterr().err
+        assert "bogus" in err and "naming" in err
+
+    def test_non_mapping_block_ignored_with_warning(self, capsys):
+        config = ProjectConfig.from_dict({"worktree": "develop"})
+        assert config.worktree == WorktreeOverrides()
+        assert "worktree" in capsys.readouterr().err
+
+    def test_null_values_treated_as_unset(self):
+        config = ProjectConfig.from_dict({"worktree": {"dir": None, "base": None}})
+        assert config.worktree.dir is None
+        assert config.worktree.base is None
+
+    def test_to_dict_round_trip(self):
+        original = ProjectConfig.from_dict({
+            "type": "claude-bypass",
+            "worktree": {"dir": "/tmp/my-trees", "base": "develop"},
+        })
+        restored = ProjectConfig.from_dict(original.to_dict())
+        assert restored.worktree == original.worktree
+
+    def test_to_dict_omits_empty_block(self):
+        assert "worktree" not in ProjectConfig().to_dict()
 
 
 # --- ProjectConfig holds no safety config (#466/#467) ---


### PR DESCRIPTION
## What

Adds an optional per-project `worktree:` block to `.agentwire.yml` so the nested-layout default from #703 isn't a lock-in:

```yaml
worktree:
  dir: ~/work-trees     # overrides global worktree.worktree_dir for THIS project
  base: develop         # overrides global worktree.default_base for THIS project
```

Precedence (most specific wins): per-invocation CLI/MCP `--base` flag → project `.agentwire.yml` `worktree:` block → global `~/.agentwire/config.yaml` `worktree:` → built-ins (`~/worktrees`, repo origin/HEAD). Nesting shape is unchanged — `dir` only moves the root: `<dir>/<project>/<name>/`.

## How

- **`project_config.py`**: new `WorktreeOverrides` dataclass + `_parse_worktree_overrides` — `dir` is ~-expanded, `base` is a plain string, unknown keys warn to stderr but never fail the config load, and `to_dict`/`from_dict` round-trip.
- **`session_cli.py` `cmd_worktree`**: the project override is resolved right after `project_path` and BEFORE the subcommand dispatch, so create/list/status/remove/prune all resolve the same project-scoped dir — `--remove` always finds what create made. Base slots into both resolution sites (the create-mode chain and the reattach-path `default_base`), with `--current` still per-invocation: `--base` > `--current` > project > global > repo-derived.
- **Registry**: verified (not assumed) that entries record the **resolved** `worktree_path` — worktrees created under an old override stay listable/removable after the override changes; there's a regression test for exactly that.
- MCP `worktree_*` tools shell out to the CLI, so they inherit the resolution with no changes.

## Docs

- `agentwire-project-config` skill: new "Worktree overrides" section + field-table row.
- `agentwire-config` skill: precedence note on the global `worktree:` block.
- `docs/wiki/sessions/worktree-sessions.md`: base-resolution order updated + "Per-project overrides" section.

## Tests

- Unit: `worktree:` block parsing (full/partial/absent, ~-expansion, unknown-key + non-mapping warnings, null values, round-trip).
- Integration: create lands under the project dir (global root untouched); create→remove round-trip under an override; project base beats global (fork-point SHA asserted); per-invocation `--base` and `--current` beat the project block; `.agentwire.yml` without the block falls through to global; entries survive an override change.
- Full suite: **2528 passed**.

Closes #705

Built by [dotdev.dev](https://dotdev.dev)