### PR TITLE
feat(mcp): add standalone param to session_create for non-child spawns

### DIFF
--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -32,7 +32,7 @@ description: Reference for the `mcp__agentwire__*` MCP tools — session/pane ma
 
 **Passive `ingest` messages (Briefing Mode):** `kind="ingest"` is **never auto-delivered** — it lands silently and waits until the recipient calls `msg_pull()`. Use it for "output ready" awareness signals that must NOT drive the recipient into a turn. Pair with `ref="<path>"` so the pointer is machine-readable. `msg_flush` forces a (still-gated) drain of the *driving* queue; it never touches passive messages.
 
-**Note:** `session_create` (via `agentwire new`) records the calling session as the new session's creator — interactive prompts (permission/plan/AskUserQuestion) in the child then route back to you as `[PROMPT from ...]` messages. Answer them with `agentwire prompts answer -s <session> --expect <hash> <key>` via Bash (guarded compare-and-send), NEVER with raw `session_send_keys` — a late keystroke races the portal and can type into the child's input or abort its turn.
+**Note:** `session_create` (via `agentwire new`) records the calling session as the new session's creator — interactive prompts (permission/plan/AskUserQuestion) in the child then route back to you as `[PROMPT from ...]` messages. Answer them with `agentwire prompts answer -s <session> --expect <hash> <key>` via Bash (guarded compare-and-send), NEVER with raw `session_send_keys` — a late keystroke races the portal and can type into the child's input or abort its turn. Spawning a session for a **separate standalone project** you're only advising, not your own subtask? Pass `session_create(..., standalone=True)` so its prompts route to the human instead of you.
 
 ## Pane Management (9 tools)
 

--- a/agentwire/mcp_session.py
+++ b/agentwire/mcp_session.py
@@ -105,6 +105,7 @@ def session_create(
     session_type: str | None = None,
     base: str | None = None,
     pull_first: bool = True,
+    standalone: bool = False,
 ) -> str:
     """Create a new AgentWire session.
 
@@ -128,6 +129,13 @@ def session_create(
             default 'main'). Ignored for flat names.
         pull_first: Fetch origin/<base> before branching (worktree mode only,
             default True). Set False to branch off the local <base> as-is.
+        standalone: Set True when spawning a session in a SEPARATE standalone
+            project you're only advising or delegating to — not a subtask of
+            your own work. Skips recording you as its creator, so its prompts
+            (permission/plan/AskUserQuestion) route to the human instead of
+            back to you and it doesn't nest under you in the sidebar. Leave
+            False (default) for spawning your own subtasks — that's when
+            child parenting is correct.
 
     Returns:
         Success message or error description.
@@ -144,6 +152,8 @@ def session_create(
         args.extend(["--base", base])
     if not pull_first:
         args.append("--no-pull-first")
+    if standalone:
+        args.extend(["--created-by", ""])
 
     data = run_agentwire_cmd(args)
     if data.get("success"):

--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -24,6 +24,8 @@ Sessions are tmux sessions running AI agents. You can create, message, and monit
 
 **Polite vs forceful.** Prefer `msg_send` for routine peer updates that must not interrupt — "PR drafted", "picking up the footer". It drops the message into a file inbox and the watchdog injects it only when the recipient's input box is empty (≤60s), so it **never clobbers a human's half-typed draft**. Reach for `session_send` **only** when you must drive a session right now — it pastes + Enter immediately, overwriting any uncommitted draft. `kind` ∈ note|done|request|escalation; `to="@all"` broadcasts to live agent sessions except you.
 
+**Parenting — subtask vs standalone project.** A session you create is recorded as your **child** by default: its permission/plan/AskUserQuestion prompts route back to you and it nests under you in the sidebar. That's correct when the new session is a **subtask of your own work**. If instead you're spawning a session for a **separate standalone project** you're only advising or delegating to, use `session_create(..., standalone=True)` (or CLI `agentwire new ... --created-by ''`) so its prompts route to the human instead of you. An already-spawned session can be detached after the fact by clearing `created_by` from `~/.agentwire/sessions/<name>/metadata.json`.
+
 ## Panes (Workers)
 
 Panes are sub-processes within your session. Pane 0 is you. Panes 1+ are workers.

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -51,6 +51,22 @@ class TestSessionTools:
         assert args == ["new", "-s", "x", "-p", "/p", "--roles", "voice,worker", "--type", "bare"]
 
     @patch("agentwire.mcp_session.run_agentwire_cmd")
+    def test_session_create_standalone(self, mock_cmd):
+        from agentwire.mcp_session import session_create
+        mock_cmd.return_value = _success()
+        session_create(name="x", standalone=True)
+        args = mock_cmd.call_args[0][0]
+        assert args == ["new", "-s", "x", "--created-by", ""]
+
+    @patch("agentwire.mcp_session.run_agentwire_cmd")
+    def test_session_create_not_standalone_by_default(self, mock_cmd):
+        from agentwire.mcp_session import session_create
+        mock_cmd.return_value = _success()
+        session_create(name="x")
+        args = mock_cmd.call_args[0][0]
+        assert "--created-by" not in args
+
+    @patch("agentwire.mcp_session.run_agentwire_cmd")
     @patch("agentwire.mcp_session.get_caller_session", return_value="orchestrator")
     def test_session_send_cross_session(self, mock_caller, mock_cmd):
         from agentwire.mcp_session import session_send


### PR DESCRIPTION
## Summary
- `session_create` (MCP) gains `standalone: bool = False` — when `True`, forwards `--created-by ''` to `agentwire new` so the spawned session isn't recorded as the caller's child (its prompts route to the human instead of the spawner, and it doesn't nest in the sidebar).
- Documents the subtask-vs-standalone distinction in `agentwire/roles/agentwire.md` ("Sessions" section) and the `agentwire-mcp-tools` skill, including how to detach an already-spawned session by clearing `created_by` from its `metadata.json`.
- Adds unit tests covering both the `standalone=True` arg-building and the unchanged default (no `--created-by` forwarded).

## Test plan
- [x] `uv run --extra dev pytest tests/unit -q` — 2450 passed
- [x] Verified via the live MCP `session_create` tool: default (non-standalone) call correctly records `created_by` as the calling session in `~/.agentwire/sessions/<name>/metadata.json`
- [x] Verified `standalone=True` (both via direct CLI `--created-by ''` and via the MCP wrapper routed through the worktree's own source) produces no `created_by` in metadata
- [x] Adversarial review pass (2 independent finder agents) — sole shared concern (whether the default path forwards the caller correctly across the MCP process boundary, per the #578 precedent in `worktree_create`) was directly tested and refuted: `session_create`'s default path works correctly, unlike `worktree_create`'s pre-#578 bug
- [x] Killed all throwaway verification sessions

Closes #712

Built by [dotdev.dev](https://dotdev.dev)