### PR TITLE
feat(mcp): standalone param on session_create to spawn non-child sessions (#712)

### DIFF
--- a/agentwire/mcp_session.py
+++ b/agentwire/mcp_session.py
@@ -106,6 +106,7 @@ def session_create(
     base: str | None = None,
     pull_first: bool = True,
     created_by: str = "",
+    standalone: bool = False,
     kind: str = "",
 ) -> str:
     """Create a new AgentWire session.
@@ -138,13 +139,18 @@ def session_create(
         created_by: Force a specific recorded creator/parent, overriding the
             default same-project-only inheritance above — e.g. to parent a
             session in a closely related project. Leave empty for the
-            default behavior; note that empty here is NOT the same as the
-            CLI's `--created-by ''` (force standalone) — there is currently
-            no way to force standalone through this tool. Ignored when
-            kind="orchestrator" is passed explicitly and this is left empty
-            — that combination roots by default instead (a durable
-            orchestrator shouldn't inherit whoever spawned it), regardless
-            of whether name has a branch.
+            default behavior. Wins over `standalone` when both are given.
+            Ignored when kind="orchestrator" is passed explicitly and this
+            is left empty — that combination roots by default instead (a
+            durable orchestrator shouldn't inherit whoever spawned it),
+            regardless of whether name has a branch.
+        standalone: Force a standalone root (no parent) even in your OWN
+            project, passing the CLI's `--created-by ''`. Use this when you're
+            spawning a session in a separate project you're only advising —
+            so its prompts route to the human, not back to you. Cross-project
+            spawns already auto-root (#715), so this is mainly for a
+            same-project session you want detached, or to force standalone
+            explicitly. Ignored when `created_by` is set (that wins).
         kind: Session role — "worker" or "orchestrator". A flat name (no
             branch) already defaults to orchestrator; a project/branch name
             defaults to worker (safety-railed: isolation/verify/draft-PR/
@@ -171,6 +177,13 @@ def session_create(
         args.extend(["--kind", kind])
     if created_by:
         args.extend(["--created-by", created_by])
+    elif standalone:
+        # Force a standalone root even in the caller's own project (#712):
+        # the CLI reads `--created-by ''` (an explicit empty string, which
+        # argparse distinguishes from the flag being absent) as "opt out of
+        # inheritance". Wins over the default caller-forwarding below;
+        # `created_by` above wins over this.
+        args.extend(["--created-by", ""])
     else:
         # Forward the calling session as a CANDIDATE parent — the CLI only
         # inherits it when project_dir turns out to be the caller's own repo

--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -24,6 +24,8 @@ Sessions are tmux sessions running AI agents. You can create, message, and monit
 
 **Polite vs forceful.** Prefer `msg_send` for routine peer updates that must not interrupt — "PR drafted", "picking up the footer". It drops the message into a file inbox and the watchdog injects it only when the recipient's input box is empty (≤60s), so it **never clobbers a human's half-typed draft**. Reach for `session_send` **only** when you must drive a session right now — it pastes + Enter immediately, overwriting any uncommitted draft. `kind` ∈ note|done|request|escalation; `to="@all"` broadcasts to live agent sessions except you.
 
+**Subtask vs standalone.** By default a session you create in **your own project** is recorded as your child — its prompts (permission / plan / AskUserQuestion) route back to you, which is right for a **subtask of your own work**. But when you spin up a session in a **separate project you're only advising or delegating to**, you don't want its prompts routed to you — they should reach the human. Cross-project spawns already auto-root (a genuinely different project becomes its own standalone root, never your child). To force standalone anyway — a same-project session you want detached, or belt-and-suspenders on a cross-project one — pass `session_create(name, standalone=True)`; that opts the new session out of parenting entirely. (Set `created_by` instead to force a *specific* parent; it wins over `standalone`.) To detach a session you already spawned, clear `created_by` from `~/.agentwire/sessions/<name>/metadata.json`.
+
 ## Panes (Workers)
 
 Panes are sub-processes within your session. Pane 0 is you. Panes 1+ are workers.

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -92,6 +92,34 @@ class TestSessionTools:
 
     @patch("agentwire.mcp_session.run_agentwire_cmd")
     @patch("agentwire.mcp_session.get_caller_session", return_value="orchestrator")
+    def test_session_create_standalone_forces_empty_created_by(self, _caller, mock_cmd):
+        # #712 — standalone=True forces `--created-by ''` (an explicit empty
+        # string the CLI reads as "opt out of inheritance") even in the
+        # caller's own project, and skips the default --caller-session
+        # candidate-forwarding entirely.
+        from agentwire.mcp_session import session_create
+        mock_cmd.return_value = _success()
+        session_create(name="test", project_dir="/p", standalone=True)
+        args = mock_cmd.call_args[0][0]
+        assert args == ["new", "-s", "test", "-p", "/p", "--created-by", ""]
+        assert "--caller-session" not in args
+
+    @patch("agentwire.mcp_session.run_agentwire_cmd")
+    @patch("agentwire.mcp_session.get_caller_session", return_value="orchestrator")
+    def test_session_create_created_by_wins_over_standalone(self, _caller, mock_cmd):
+        # #712 — an explicit created_by beats standalone: the caller asked for
+        # a specific parent, so honor it rather than forcing a root.
+        from agentwire.mcp_session import session_create
+        mock_cmd.return_value = _success()
+        session_create(name="test", project_dir="/p", created_by="orchestrator",
+                       standalone=True)
+        args = mock_cmd.call_args[0][0]
+        assert args == ["new", "-s", "test", "-p", "/p",
+                         "--created-by", "orchestrator"]
+        assert "--caller-session" not in args
+
+    @patch("agentwire.mcp_session.run_agentwire_cmd")
+    @patch("agentwire.mcp_session.get_caller_session", return_value="orchestrator")
     def test_session_send_cross_session(self, mock_caller, mock_cmd):
         from agentwire.mcp_session import session_send
         mock_cmd.return_value = _success(verified=True)


### PR DESCRIPTION
## What

Adds `standalone: bool = False` to the MCP `session_create` tool so an agent can spawn a **non-parented** session — one whose prompts route to the human, not back to the caller.

#715 already auto-roots *cross-project* spawns, but there was **no way to force standalone in the caller's OWN project** through MCP: the existing `created_by` param only handled the non-empty case, so an empty value fell through to default inheritance. `standalone=True` closes that gap by passing the CLI's `--created-by ''` (the explicit empty string argparse distinguishes from an absent flag, which `cmd_new` reads as "opt out of inheritance").

**Precedence:** explicit `created_by` > `standalone` > default caller-forwarding.

## Changes

- `agentwire/mcp_session.py` — new `standalone` param + branch; fixed the stale docstring that claimed "there is currently no way to force standalone through this tool".
- `agentwire/roles/agentwire.md` — subtask-vs-standalone framing in the Sessions section (child parenting is right for your own subtasks; `standalone=True` when advising a separate project), noting #715 already auto-roots cross-project spawns.
- `tests/unit/test_mcp_tools_args.py` — `standalone` forces `--created-by ''`; explicit `created_by` wins over `standalone`.

## Verification

- Full suite green: 2575 unit + 118 integration.
- End-to-end (real `_record_session_creator` → `resolve_parent` chain): a `standalone=True` spawn records **no** `created_by` and its pane-0 prompt routes to the human (`resolve_parent → None`); a normal parented spawn still routes back to the caller (positive control).

Closes #712

Built by [dotdev.dev](https://dotdev.dev)