### PR TITLE
fix(portal): rebind sidebar toggle off Cmd+` to Option/Alt+` (#725)

### DIFF
--- a/agentwire/static/js/dead-key-suppressor.js
+++ b/agentwire/static/js/dead-key-suppressor.js
@@ -51,8 +51,3 @@ export function armDeadKeySuppressor(ms = 700) {
         requestAnimationFrame(() => ae.focus());
     }
 }
-
-/** Cancel an arm() — for hotkeys that turned out to be no-ops. */
-export function disarmDeadKeySuppressor() {
-    suppressUntil = 0;
-}

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -30,7 +30,6 @@ import { councilSection } from './sidebar/council-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { notificationsPanel } from './notifications-panel.js';
 import { scratchpad } from './scratchpad.js';
-import { armDeadKeySuppressor, disarmDeadKeySuppressor } from './dead-key-suppressor.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import { setupHelp, openHelp, isHelpOpen } from './help-modal.js';
 import { PttController } from './ptt.js';
@@ -458,33 +457,22 @@ function isWithinHorizontalScroller(target) {
     return false;
 }
 
-// Collage — tap F3 (like macOS Mission Control) or Alt/Option+` to grid all
-// open windows; tap again, press Esc, or click a window to restore.
-// Dead-key handling (Option+` composes a grave accent) lives in the shared
-// suppressor — see dead-key-suppressor.js.
+// Collage — tap F3 (like macOS Mission Control) to grid all open windows; tap
+// again, press Esc, or click a window to restore. (Option/Alt+` is the sidebar
+// toggle — see sidebar.js.)
 function setupCollage() {
     collage.init(_lookupWindowInstance);
 
     // Capture phase on window + stopPropagation so xterm's <textarea> never
     // sees the keystroke (and the browser default — F3 find-next — is
-    // suppressed). Alt+` is detected via e.code: on macOS the dead key makes
-    // e.key 'Dead', never a backtick. Cmd/Ctrl+` stays the sidebar toggle.
+    // suppressed).
     window.addEventListener('keydown', (e) => {
-        const isF3 = e.code === 'F3';
-        const isAltBacktick = e.altKey && !e.metaKey && !e.ctrlKey && e.code === 'Backquote';
-        if (!isF3 && !isAltBacktick) return;
+        if (e.code !== 'F3') return;
         if (isCommandPaletteOpen() || isHelpOpen()) return;
         e.preventDefault();
         e.stopPropagation();
         if (e.repeat) return;  // ignore auto-repeat while the key is held
-        // Arm BEFORE toggling — the suppressor must be active when the
-        // pending composition finalizes (blur of the focused terminal).
-        if (isAltBacktick) armDeadKeySuppressor();
-        const wasActive = collage.active;
         collage.toggle();
-        // No-op toggle (under 2 windows): disarm so the dead key composes
-        // normally — with no collage there's nothing to protect.
-        if (isAltBacktick && collage.active === wasActive) disarmDeadKeySuppressor();
     }, true);
 }
 

--- a/agentwire/static/js/shortcuts.js
+++ b/agentwire/static/js/shortcuts.js
@@ -39,7 +39,7 @@ export const SHORTCUT_GROUPS = [
         items: [
             { combo: ['Mod', 'K'], desc: 'Open the command palette', where: 'desktop.js setupCommandPalette' },
             { combo: ['F1'], alt: ['?'], desc: 'Show this help', where: 'help-modal.js setupHelp' },
-            { combo: ['Mod', '`'], desc: 'Toggle the sidebar', where: 'sidebar.js' },
+            { combo: ['Alt', '`'], desc: 'Toggle the sidebar', where: 'sidebar.js' },
             { combo: ['Esc'], desc: 'Close the open modal, palette, collage, or sidebar', where: 'various' },
         ],
     },
@@ -53,7 +53,7 @@ export const SHORTCUT_GROUPS = [
         title: 'Windows',
         items: [
             { combo: ['Alt', ']'], alt: ['Alt', '['], desc: 'Cycle to the next / previous window (Tab always goes to the terminal)', where: 'desktop.js setupWindowCycling' },
-            { combo: ['F3'], alt: ['Alt', '`'], desc: 'Window collage — Mission-Control grid of all windows', where: 'desktop.js setupCollage' },
+            { combo: ['F3'], desc: 'Window collage — Mission-Control grid of all windows', where: 'desktop.js setupCollage' },
         ],
     },
     {

--- a/agentwire/static/js/sidebar.js
+++ b/agentwire/static/js/sidebar.js
@@ -6,6 +6,7 @@
  */
 
 import { scratchpad } from './scratchpad.js';
+import { armDeadKeySuppressor } from './dead-key-suppressor.js';
 
 const PIN_KEY = 'sidebar-pinned';
 
@@ -35,17 +36,27 @@ export const sidebar = {
             this.close();
         });
 
-        // ESC closes (unless pinned). Cmd/Ctrl + ` toggles.
+        // ESC closes (unless pinned).
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && this.isOpen() && !this.isPinned()) {
                 this.close();
-                return;
-            }
-            if ((e.metaKey || e.ctrlKey) && (e.key === '`' || e.code === 'Backquote')) {
-                e.preventDefault();
-                this.toggle();
             }
         });
+
+        // Option/Alt + ` toggles. Capture phase on window + stopPropagation so
+        // xterm's <textarea> never sees the keystroke; arm the shared dead-key
+        // suppressor so the grave-accent composition (Option+` on macOS) never
+        // leaks into the focused terminal. Mirrors desktop.js setupCollage's
+        // alt-backquote idiom — e.code (not e.key) because the macOS dead key
+        // makes e.key 'Dead', never a backtick.
+        window.addEventListener('keydown', (e) => {
+            if (!(e.altKey && !e.metaKey && !e.ctrlKey && e.code === 'Backquote')) return;
+            e.preventDefault();
+            e.stopPropagation();
+            if (e.repeat) return;  // ignore auto-repeat while the key is held
+            armDeadKeySuppressor();
+            this.toggle();
+        }, true);
 
         // Pin toggle
         this.pinBtn?.addEventListener('click', (e) => {

--- a/docs/wiki/internals/portal.md
+++ b/docs/wiki/internals/portal.md
@@ -118,7 +118,7 @@ Sessions can be opened from the Sessions dropdown in two modes:
 
 ### Window Collage
 
-F3 or Alt/Option+` (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
+F3 (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
 
 ### Simultaneous Operation
 

--- a/docs/wiki/internals/window-collage.md
+++ b/docs/wiki/internals/window-collage.md
@@ -2,7 +2,7 @@
 
 > Living wiki. Update this page, don't create new versions.
 
-F3 or Alt/Option+` (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, the hotkey again, or clicking the backdrop exits.
+F3 (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, the hotkey again, or clicking the backdrop exits.
 
 Module: `agentwire/static/js/collage.js`. Styles: the `.collage-*` block in `agentwire/static/css/desktop.css`. Hotkey wiring: `setupCollage()` in `agentwire/static/js/desktop.js`.
 


### PR DESCRIPTION
## What

The portal's sidebar toggle was bound to **Cmd/Ctrl+`**, which on macOS **shadows the system "cycle windows" shortcut** — you couldn't cycle browser windows while the portal tab was focused. Rebind it to **Option/Alt+`**.

Alt+` was Window Collage's *secondary* binding, so this drops that alt (collage keeps its **F3** primary) to avoid a collision.

## Cross-platform decision

**Unified on Alt/Option+` everywhere** (vs Mac-only Option / others keep Ctrl) — it's simpler, Alt+` collides with nothing on Windows/Linux, the dead-key composition issue is macOS-only anyway, and the codebase already had the `altKey && !metaKey && !ctrlKey` idiom + an `Alt` registry token that renders ⌥ on Mac / Alt elsewhere.

## Changes

- **`sidebar.js`** — toggle now fires on `altKey && !metaKey && !ctrlKey && code==='Backquote'`, in a capture-phase window listener with `stopPropagation` (xterm never sees it) that arms the shared dead-key suppressor (the macOS Option+` grave-accent composition would otherwise leak into the focused terminal — a new concern, since Cmd/Ctrl don't compose dead keys).
- **`desktop.js`** — collage is now **F3-only**; dropped the Alt+` branch, its dead-key plumbing, and the stale comment.
- **`shortcuts.js`** — registry updated (the F1 help modal renders from it): sidebar → `Alt ` `` `` ``, collage → F3 only.
- **`dead-key-suppressor.js`** — removed the now-unused `disarmDeadKeySuppressor` export (its only consumer was collage's no-op path).
- **wiki** — `portal.md` + `window-collage.md` no longer list collage's Alt/Option+` secondary.

## Verification (Chrome, isolated worktree portal on :8799)

- Cmd+`, Ctrl+`, and Cmd+Alt+` **no longer toggle** the sidebar → macOS window-cycle works again.
- Alt+` **toggles** the sidebar open/closed.
- F1 help modal shows **⌥ `** for "Toggle the sidebar" and **F3** only for "Window collage".
- Confirmed the served JS was the worktree build, not the live install.

Closes #725