### PR TITLE
chore(docs): clean up final type→posture remnants after #733

### DIFF
--- a/agentwire/roles/agentwire.md
+++ b/agentwire/roles/agentwire.md
@@ -36,7 +36,7 @@ Workers are for: large refactors touching many files, parallel independent subta
 
 | Tool | What it does |
 |------|-------------|
-| `pane_spawn(pane_type, roles)` | Spawn a worker pane |
+| `pane_spawn(posture, roles)` | Spawn a worker pane |
 | `pane_send(pane, message)` | Send a task to a worker |
 | `pane_output(pane)` | Read worker output |
 | `panes_list()` | List all panes |

--- a/agentwire/roles/contributor.md
+++ b/agentwire/roles/contributor.md
@@ -18,7 +18,7 @@ You're the helper session for someone getting started with **agentwire** (the ag
 
 - Install is `uv tool install agentwire-dev` (or `pip install agentwire-dev`); the entry point is the `agentwire` command. Config lives under `~/.agentwire/` — `config.yaml` (main), `.env` (all API keys/secrets, `chmod 600`), and per-project `.agentwire.yml`.
 - First run: `agentwire init` walks through setup; `agentwire portal start` launches the web portal. `agentwire doctor` diagnoses a broken install.
-- **Their own projects**: a project gets an `.agentwire.yml` at its root (session type, roles) — plus a separate, protected `.agentwire.tasks.yml` for scheduled tasks (authored via `agentwire tasks review`/`promote`). Keep both gitignored — personal config. Spin up a session with `agentwire new -s <name> -p <path>`.
+- **Their own projects**: a project gets an `.agentwire.yml` at its root (posture, roles) — plus a separate, protected `.agentwire.tasks.yml` for scheduled tasks (authored via `agentwire tasks review`/`promote`). Keep both gitignored — personal config. Spin up a session with `agentwire new -s <name> -p <path>`.
 - **Sessions vs panes**: a *session* is a tmux session running an agent (orchestrator = pane 0); *worker panes* are sub-agents spawned inside it for parallel subtasks. Explain this when they ask how to delegate work.
 
 ## Knowing this repo

--- a/scripts/benchmark-models.sh
+++ b/scripts/benchmark-models.sh
@@ -34,7 +34,7 @@ run_model() {
 
   # Create session with model override
   agentwire new -s "$session" -p "$project" \
-    --type claude-bypass --roles task-runner \
+    --posture bypass --roles task-runner \
     --model "$model" -f 2>/dev/null || true
 
   # Run the task


### PR DESCRIPTION
Post-#733 audit for old session-type remnants. Three stragglers referencing the deleted vocabulary:

- `roles/agentwire.md` — `pane_spawn(pane_type, roles)` → `pane_spawn(posture, roles)` (the MCP tool now takes `posture=`; this is an injected agent prompt, so it was actively misleading agents).
- `scripts/benchmark-models.sh` — `--type claude-bypass` → `--posture bypass`. The `--type` flag was cut in #733, so this script was **broken**.
- `roles/contributor.md` — ".agentwire.yml (session type, roles)" → "(posture, roles)".

The rest of the audit was clean: **zero** `pi`/`harness`/`glm` leftovers (#730/#731 was thorough), and no `restricted`/`readonly`-as-posture remnants. Docs/script only — no logic, no tests affected.

Built by [dotdev.dev](https://dotdev.dev)
