### PR TITLE
fix(tasks): migration path + doctor guard for #720/#721 task-split (#736)

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -117,6 +117,24 @@ opt-in for your own non-interactive script) — `--yes` only skips the
 confirmation prompt, it never substitutes for that. Run `promote` from your
 own terminal; it cannot be made to run through the agent.
 
+**Migrating legacy inline tasks (#736).** Before #720/#721, tasks lived inline
+in `.agentwire.yml` under a `tasks:` key. That block is now **dead weight** —
+the executor (`agentwire ensure` + the scheduler) reads **only**
+`.agentwire.tasks.yml`, so a project whose tasks never moved fails silently
+(`ensure` exits 6, scheduled runs error). There is no runtime fallback by
+design. Migrate each affected project once:
+
+1. `agentwire tasks migrate` — reads the inline `.agentwire.yml` `tasks:` block
+   and stages it to `.agentwire.tasks.proposed.yml` (never writes the protected
+   live file). Refuses to clobber an existing `.agentwire.tasks.yml`; overwrites
+   an existing proposed draft (and says so).
+2. `agentwire tasks review` then `agentwire tasks promote` — vet and land it.
+3. Delete the now-dead `tasks:` block from `.agentwire.yml`.
+
+`agentwire doctor` flags any project stuck in this state ("tasks defined in
+.agentwire.yml but never migrated to .agentwire.tasks.yml — they will NOT run
+under ensure/scheduler").
+
 ```yaml
 # .agentwire.tasks.yml
 shell: /bin/sh  # Project-level default shell

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ Thumbs.db
 /voices/
 
 .agentwire.yml
+.agentwire.tasks.yml
+.agentwire.tasks.proposed.yml
 
 
 # Test outputs

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -357,6 +357,53 @@ def _render_voice_loop_section(config, ctx) -> int:
     return failures
 
 
+def _find_unmigrated_task_projects() -> list[str]:
+    """Local projects with an inline ``.agentwire.yml`` ``tasks:`` block but no
+    promoted ``.agentwire.tasks.yml`` (#736).
+
+    This is the concrete #720/#721 regression: the task-split relocated where
+    tasks are READ from (``.agentwire.tasks.yml``) without migrating existing
+    task DATA, so these projects' scheduled/ensure tasks silently fail (exit 6)
+    while their config still *looks* task-bearing. Returns the affected project
+    names.
+    """
+    import yaml
+
+    from . import projects as projects_mod
+    from .tasks import TASKS_FILENAME
+
+    unmigrated: list[str] = []
+    for proj in projects_mod.get_projects("local"):
+        proj_dir = Path(proj["path"])
+        cfg_file = proj_dir / ".agentwire.yml"
+        try:
+            cfg = yaml.safe_load(cfg_file.read_text()) or {}
+        except Exception:
+            continue
+        if cfg.get("tasks") and not (proj_dir / TASKS_FILENAME).exists():
+            unmigrated.append(proj["name"])
+    return unmigrated
+
+
+def _render_task_migration_section() -> int:
+    """Doctor section: flag projects whose inline tasks never migrated (#736)."""
+    unmigrated = _find_unmigrated_task_projects()
+    if not unmigrated:
+        print("  [ok] No projects with un-migrated inline tasks")
+        return 0
+    for name in unmigrated:
+        print(
+            f"  [!!] Project {name}: tasks defined in .agentwire.yml but never "
+            "migrated to .agentwire.tasks.yml — they will NOT run under "
+            "ensure/scheduler."
+        )
+    print(
+        "     Run `agentwire tasks migrate` then `agentwire tasks promote` "
+        "in each affected project."
+    )
+    return len(unmigrated)
+
+
 def cmd_doctor(args) -> int:
     """Auto-diagnose and fix common issues."""
     from .hooks_cli import _managed_file_state, _managed_hook_files, get_hooks_source
@@ -867,6 +914,17 @@ def cmd_doctor(args) -> int:
             print("       Assign a parent (agentwire msg send / --created-by) or merge/close the PR yourself.")
     except Exception as e:
         print(f"  [..] Could not check for dangling worktree sessions: {e}")
+
+    # 12. Projects whose inline .agentwire.yml tasks were never migrated to the
+    # promoted .agentwire.tasks.yml (#736). The #720/#721 task-split moved where
+    # tasks are read from without migrating the data, so these tasks silently
+    # fail (exit 6) under ensure/scheduler — the exact regression that went
+    # undetected because nothing surfaced it. Loud here so it can't hide again.
+    print("\nChecking project task migration (#736)...")
+    try:
+        issues_found += _render_task_migration_section()
+    except Exception as e:
+        print(f"  [..] Could not check project task migration: {e}")
 
     # Summary
     print()

--- a/agentwire/tasks_cli.py
+++ b/agentwire/tasks_cli.py
@@ -200,6 +200,80 @@ def cmd_tasks_review(args) -> int:
     return 0
 
 
+def cmd_tasks_migrate(args) -> int:
+    """CLI command: agentwire tasks migrate [session]
+
+    One-shot data migration for the #720/#721 task-split (#736): reads the
+    inline ``tasks:`` block still living in a project's declarative
+    ``.agentwire.yml`` — now dead weight, since the executor only reads
+    ``.agentwire.tasks.yml`` — and STAGES it to the unprotected
+    ``.agentwire.tasks.proposed.yml``. It deliberately never writes the
+    protected live ``.agentwire.tasks.yml``; that is ``promote``'s host-only
+    job. The human then runs ``agentwire tasks review`` and
+    ``agentwire tasks promote``.
+    """
+    json_mode = getattr(args, "json", False)
+    project_path = _resolve_project_path(getattr(args, "session", None))
+
+    config_path = project_path / ".agentwire.yml"
+    proposed_path = project_path / PROPOSED_TASKS_FILENAME
+    active_path = project_path / TASKS_FILENAME
+
+    if not config_path.exists():
+        return _output_result(
+            False, json_mode, f"No .agentwire.yml found in {project_path}"
+        )
+
+    data, err = _load_yaml(config_path)
+    if err:
+        return _output_result(False, json_mode, err)
+
+    tasks = data.get("tasks")
+    if not tasks:
+        return _output_result(
+            False, json_mode,
+            f"No inline 'tasks:' block in {config_path.name} — nothing to migrate.",
+        )
+
+    if active_path.exists():
+        return _output_result(
+            False, json_mode,
+            f"{active_path.name} already exists — tasks look already migrated. "
+            "Refusing to clobber the live task file; reconcile it by hand if you "
+            "really mean to re-migrate.",
+        )
+
+    overwrote = proposed_path.exists()
+    proposed_path.write_text(
+        yaml.safe_dump(
+            {"tasks": tasks}, sort_keys=False, allow_unicode=True, width=100
+        )
+    )
+    ensure_gitignored(project_path, TASKS_FILENAME, ".agentwire.tasks*.yml")
+
+    lines = [
+        f"Staged {len(tasks)} task(s) from {config_path.name} -> {proposed_path.name}"
+    ]
+    if overwrote:
+        lines.append(f"(overwrote an existing {proposed_path.name})")
+    lines += [
+        "",
+        "Next:",
+        "  1. Review:  agentwire tasks review",
+        "  2. Promote: agentwire tasks promote   (host-only)",
+        "",
+        f"After promoting, delete the dead 'tasks:' block from {config_path.name} "
+        "— the executor ignores it.",
+    ]
+    return _output_result(
+        True, json_mode, "\n".join(lines),
+        project=str(project_path),
+        proposed=str(proposed_path),
+        tasks=list(tasks),
+        overwrote=overwrote,
+    )
+
+
 def cmd_tasks_promote(args) -> int:
     """CLI command: agentwire tasks promote [session] [--yes]
 
@@ -282,6 +356,20 @@ def register_tasks_parser(subparsers) -> None:
         ),
     )
     tasks_subparsers = tasks_parser.add_subparsers(dest="tasks_command")
+
+    migrate = tasks_subparsers.add_parser(
+        "migrate",
+        help="Stage a project's inline .agentwire.yml tasks: block as a draft (#736)",
+        description=(
+            "Read the inline 'tasks:' block from the project's .agentwire.yml "
+            "(dead weight since #720/#721 — the executor only reads "
+            ".agentwire.tasks.yml) and stage it to .agentwire.tasks.proposed.yml. "
+            "Then run `agentwire tasks review` and `agentwire tasks promote`."
+        ),
+    )
+    migrate.add_argument("session", nargs="?", help="Session name (default: current directory)")
+    migrate.add_argument("--json", action="store_true", help="Output JSON")
+    migrate.set_defaults(func=cmd_tasks_migrate)
 
     review = tasks_subparsers.add_parser(
         "review", help="Show the diff + every shell command in the staged draft"

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -23,6 +23,8 @@ Define tasks in `.agentwire.tasks.yml` (a sibling of `.agentwire.yml`, split out
 
 `.agentwire.tasks.yml` is **protected control-plane** — a policed agent can't write it directly. Authoring it is propose-and-promote: draft to `.agentwire.tasks.proposed.yml`, then a human runs `agentwire tasks review` and `agentwire tasks promote`. See [Damage control](../internals/damage-control.md#task-execution-config-split-agentwiretasksyml-720).
 
+**Legacy inline tasks are dead weight (#736).** Tasks that predate the #720/#721 split still living under a `tasks:` key in `.agentwire.yml` do **not** run — the executor reads only `.agentwire.tasks.yml`, with no runtime fallback. Migrate once: `agentwire tasks migrate` stages the inline block to `.agentwire.tasks.proposed.yml`, then `agentwire tasks review` + `agentwire tasks promote` lands it; finally delete the dead `tasks:` block from `.agentwire.yml`. `agentwire doctor` flags any project still in the un-migrated state.
+
 ```yaml
 # .agentwire.yml — declarative session config
 posture: auto    # Recommended for unattended work — see auto below

--- a/tests/unit/test_doctor_task_migration.py
+++ b/tests/unit/test_doctor_task_migration.py
@@ -1,0 +1,79 @@
+"""Tests for the doctor task-migration check (#736).
+
+The #720/#721 task-split relocated where tasks are READ from
+(.agentwire.tasks.yml) without migrating existing inline .agentwire.yml
+`tasks:` data, so those projects' scheduled/ensure tasks silently failed
+(exit 6). Doctor must surface exactly that state.
+"""
+
+import agentwire.projects as projects_mod
+from agentwire.doctor_cli import (
+    _find_unmigrated_task_projects,
+    _render_task_migration_section,
+)
+
+
+def _make_project(tmp_path, name, *, inline_tasks: bool, migrated: bool):
+    """Create a fake local project dir and return its get_projects() dict."""
+    proj_dir = tmp_path / name
+    proj_dir.mkdir()
+    cfg = "posture: bypass\n"
+    if inline_tasks:
+        cfg += "tasks:\n  daily:\n    prompt: do the thing\n"
+    (proj_dir / ".agentwire.yml").write_text(cfg)
+    if migrated:
+        (proj_dir / ".agentwire.tasks.yml").write_text(
+            "tasks:\n  daily:\n    prompt: do the thing\n"
+        )
+    return {"name": name, "path": str(proj_dir), "machine": "local"}
+
+
+def _patch_projects(monkeypatch, project_dicts):
+    monkeypatch.setattr(projects_mod, "get_projects", lambda machine=None: project_dicts)
+
+
+def test_flags_unmigrated_project(tmp_path, monkeypatch):
+    p = _make_project(tmp_path, "daily-book-report", inline_tasks=True, migrated=False)
+    _patch_projects(monkeypatch, [p])
+    assert _find_unmigrated_task_projects() == ["daily-book-report"]
+
+
+def test_clean_once_migrated(tmp_path, monkeypatch):
+    p = _make_project(tmp_path, "daily-book-report", inline_tasks=True, migrated=True)
+    _patch_projects(monkeypatch, [p])
+    assert _find_unmigrated_task_projects() == []
+
+
+def test_project_without_inline_tasks_not_flagged(tmp_path, monkeypatch):
+    p = _make_project(tmp_path, "no-tasks", inline_tasks=False, migrated=False)
+    _patch_projects(monkeypatch, [p])
+    assert _find_unmigrated_task_projects() == []
+
+
+def test_mixed_fleet_reports_only_unmigrated(tmp_path, monkeypatch):
+    projects = [
+        _make_project(tmp_path, "broken", inline_tasks=True, migrated=False),
+        _make_project(tmp_path, "fixed", inline_tasks=True, migrated=True),
+        _make_project(tmp_path, "plain", inline_tasks=False, migrated=False),
+    ]
+    _patch_projects(monkeypatch, projects)
+    assert _find_unmigrated_task_projects() == ["broken"]
+
+
+def test_render_section_flags_and_counts(tmp_path, monkeypatch, capsys):
+    p = _make_project(tmp_path, "daily-book-report", inline_tasks=True, migrated=False)
+    _patch_projects(monkeypatch, [p])
+    count = _render_task_migration_section()
+    out = capsys.readouterr().out
+    assert count == 1
+    assert "daily-book-report" in out
+    assert "will NOT run under ensure/scheduler" in out
+    assert "agentwire tasks migrate" in out
+
+
+def test_render_section_ok_when_clean(tmp_path, monkeypatch, capsys):
+    p = _make_project(tmp_path, "fixed", inline_tasks=True, migrated=True)
+    _patch_projects(monkeypatch, [p])
+    count = _render_task_migration_section()
+    assert count == 0
+    assert "No projects with un-migrated inline tasks" in capsys.readouterr().out

--- a/tests/unit/test_tasks_cli.py
+++ b/tests/unit/test_tasks_cli.py
@@ -4,8 +4,9 @@ import argparse
 import json
 
 import pytest
+import yaml
 
-from agentwire.tasks_cli import cmd_tasks_promote, cmd_tasks_review
+from agentwire.tasks_cli import cmd_tasks_migrate, cmd_tasks_promote, cmd_tasks_review
 
 
 def _ns(**kwargs):
@@ -169,3 +170,82 @@ class TestTasksPromoteHardGating:
         rc = cmd_tasks_promote(_ns(yes=True))
         assert rc == 1
         assert not (proj / ".agentwire.tasks.yml").exists()
+
+
+def _write_config(proj, text):
+    (proj / ".agentwire.yml").write_text(text)
+
+
+INLINE = (
+    "posture: bypass\n"
+    "tasks:\n"
+    "  daily:\n"
+    "    prompt: write the report\n"
+    "    post:\n"
+    "      - echo done\n"
+)
+
+
+class TestTasksMigrate:
+    def test_stages_inline_tasks_as_proposed(self, proj):
+        _write_config(proj, INLINE)
+        rc = cmd_tasks_migrate(_ns())
+        assert rc == 0
+        proposed = proj / ".agentwire.tasks.proposed.yml"
+        assert proposed.exists()
+        # Live protected file is NEVER written by migrate.
+        assert not (proj / ".agentwire.tasks.yml").exists()
+        staged = yaml.safe_load(proposed.read_text())
+        assert set(staged.keys()) == {"tasks"}
+        assert staged["tasks"]["daily"]["prompt"] == "write the report"
+        assert staged["tasks"]["daily"]["post"] == ["echo done"]
+
+    def test_migrated_draft_promotes_cleanly(self, proj, capsys):
+        # End-to-end: what migrate stages must survive review with no issues.
+        _write_config(proj, INLINE)
+        assert cmd_tasks_migrate(_ns()) == 0
+        assert cmd_tasks_review(_ns()) == 0
+        assert "No validation issues" in capsys.readouterr().out
+
+    def test_no_inline_tasks_clear_message(self, proj, capsys):
+        _write_config(proj, "posture: bypass\n")
+        rc = cmd_tasks_migrate(_ns())
+        assert rc == 1
+        assert "nothing to migrate" in capsys.readouterr().err
+        assert not (proj / ".agentwire.tasks.proposed.yml").exists()
+
+    def test_no_config_file_fails(self, proj, capsys):
+        rc = cmd_tasks_migrate(_ns())
+        assert rc == 1
+        assert "No .agentwire.yml found" in capsys.readouterr().err
+
+    def test_does_not_clobber_existing_live_tasks_file(self, proj, capsys):
+        _write_config(proj, INLINE)
+        live = proj / ".agentwire.tasks.yml"
+        live.write_text("tasks:\n  existing:\n    prompt: keep me\n")
+        rc = cmd_tasks_migrate(_ns())
+        assert rc == 1
+        assert "already exists" in capsys.readouterr().err
+        # Live file untouched; no proposed draft written.
+        assert "keep me" in live.read_text()
+        assert not (proj / ".agentwire.tasks.proposed.yml").exists()
+
+    def test_overwrites_existing_proposed_with_note(self, proj, capsys):
+        _write_config(proj, INLINE)
+        proposed = proj / ".agentwire.tasks.proposed.yml"
+        proposed.write_text("tasks:\n  stale:\n    prompt: old\n")
+        rc = cmd_tasks_migrate(_ns())
+        assert rc == 0
+        assert "overwrote" in capsys.readouterr().out
+        staged = yaml.safe_load(proposed.read_text())
+        assert "daily" in staged["tasks"]
+        assert "stale" not in staged["tasks"]
+
+    def test_json_mode(self, proj, capsys):
+        _write_config(proj, INLINE)
+        rc = cmd_tasks_migrate(_ns(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["success"] is True
+        assert data["tasks"] == ["daily"]
+        assert data["overwrote"] is False


### PR DESCRIPTION
## Problem

`#720/#721` moved task-exec out of inline `.agentwire.yml` `tasks:` into a separate protected `.agentwire.tasks.yml`, but **existing projects were never migrated** and the gitignore + doctor were never updated. Result: every scheduled/ensure task in those projects silently fails — `ensure` exits 6, scheduled runs error (confirmed live: `daily-book-report`, `cc-dialog-drift`).

## Fix (3 code changes + tests + docs)

1. **`.gitignore`** — ignore `.agentwire.tasks.yml` + `.agentwire.tasks.proposed.yml` next to `.agentwire.yml` (the task files were never added).
2. **`agentwire tasks migrate`** (new subcommand, `tasks_cli.py`) — reads the current project's inline `.agentwire.yml` `tasks:` block and stages it to `.agentwire.tasks.proposed.yml` (`yaml.safe_dump`, `sort_keys=False`). It **never** writes the protected live `.agentwire.tasks.yml` — that's `promote`'s host-only job. Edge cases: no inline block → clear message + exit; live tasks file already present → warn, don't clobber; existing proposed draft → overwrite + note. Then prints the review/promote next steps.
3. **`agentwire doctor`** — flags any local project with inline `.agentwire.yml` `tasks:` but no promoted `.agentwire.tasks.yml`. This is the safety net that would have caught the regression.

## Tests
- `tests/unit/test_tasks_cli.py::TestTasksMigrate` — staging, migrate→review round-trip, no-inline-tasks message, missing config, clobber-protection, proposed-overwrite note, JSON mode.
- `tests/unit/test_doctor_task_migration.py` — flags un-migrated, clean once migrated, mixed fleet.
- `uv run --no-sync ruff check agentwire/ tests/` → clean. Full suite: 2657 passed.

## Docs
- `agentwire-project-config` skill + `docs/wiki/scheduling/scheduled-workloads.md` document `tasks migrate` and that inline `.agentwire.yml` tasks are dead weight.

**No compat shim** — data migration per the no-backwards-compat rule, not a runtime fallback that re-reads inline tasks.

Closes #736

Built by [dotdev.dev](https://dotdev.dev)