### PR TITLE
fix(scheduler): harden worktree launch against #739 zombie bare shells

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -847,6 +847,34 @@ def _run_remote(machine_id: str, command: str) -> subprocess.CompletedProcess:
         )
 
 
+def _guarded_launch_command(path_str: str, agent_cmd: str | None) -> str:
+    """Build the pane's ``cd <path> && <agent_cmd>`` line with a missing-dir guard (#739).
+
+    A crashed worktree create can leave ``path_str`` absent by the time the
+    pane actually runs its ``cd`` (race between ``agentwire new`` reporting
+    success and the async pane launch, or an external actor removing the
+    dir). Without a guard, ``cd`` fails, the shell prints an error and
+    carries on, and ``agent_cmd`` (e.g. ``claude``) then launches from the
+    WRONG cwd and crashes — dropping the pane to a bare shell that the
+    idle-reaper never touches (it only reaps a *running* agent going idle),
+    so it lingers forever.
+
+    On a missing dir this instead alerts (emails the owner when
+    ``$AGENTWIRE_UNATTENDED=1`` — set for scheduler dispatches, see
+    ``_with_unattended_env``) and exits the shell, which tears the tmux
+    session down instead of leaving a zombie. ``agent_cmd`` never runs.
+    """
+    quoted_path = shlex.quote(path_str)
+    alert = (
+        f"echo \"agentwire: worktree missing at launch, aborting: {path_str}\" >&2; "
+        '[ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email '
+        f'--subject "agentwire: worktree missing — ${{AGENTWIRE_SESSION_NAME:-unknown session}}" '
+        f'--body "cd failed at launch: {path_str}" >/dev/null 2>&1'
+    )
+    guard = f"cd {quoted_path} || {{ {alert}; exit 1; }}"
+    return f"{guard} && {agent_cmd}" if agent_cmd else guard
+
+
 def _launch_tmux_session(
     session_name: str,
     session_path,
@@ -859,8 +887,9 @@ def _launch_tmux_session(
     The one launch sequence shared by ``new`` / ``recreate`` / ``fork`` (#630):
     `tmux new-session -e K=V` injects *env* into the session environment
     BEFORE the initial shell starts (post-hoc `set-environment` never reaches
-    it), then `send-keys` cd's into place and, if *agent_cmd* is non-empty,
-    starts the agent after a short settle.
+    it), then `send-keys` cd's into place (guarded — see
+    ``_guarded_launch_command``) and, if *agent_cmd* is non-empty, starts the
+    agent after a short settle.
 
     Local (machine_id None): runs subprocess calls with check=True (raises on
     tmux failure) and returns None. Remote: runs one composite shell command
@@ -869,17 +898,14 @@ def _launch_tmux_session(
     import time
 
     path_str = str(session_path)
+    launch_cmd = _guarded_launch_command(path_str, agent_cmd)
     if machine_id:
         env_flags = _build_tmux_env_flags_shell(env)
         create_cmd = (
             f"tmux new-session -d -s {shlex.quote(session_name)} -c {shlex.quote(path_str)} {env_flags}&& "
-            f"tmux send-keys -t {shlex.quote(session_name)} 'cd {shlex.quote(path_str)}' Enter"
+            f"sleep 0.1 && "
+            f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(launch_cmd)} Enter"
         )
-        if agent_cmd:
-            create_cmd += (
-                f" && sleep 0.1 && "
-                f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(agent_cmd)} Enter"
-            )
         return _run_remote(machine_id, create_cmd)
 
     subprocess.run(
@@ -887,16 +913,11 @@ def _launch_tmux_session(
          *_build_tmux_env_flags(env)],
         check=True,
     )
+    time.sleep(0.1)
     subprocess.run(
-        ["tmux", "send-keys", "-t", session_name, f"cd {shlex.quote(path_str)}", "Enter"],
+        ["tmux", "send-keys", "-t", session_name, launch_cmd, "Enter"],
         check=True,
     )
-    time.sleep(0.1)
-    if agent_cmd:
-        subprocess.run(
-            ["tmux", "send-keys", "-t", session_name, agent_cmd, "Enter"],
-            check=True,
-        )
     return None
 
 

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -1008,6 +1008,30 @@ def cmd_doctor(args) -> int:
     except Exception as e:
         print(f"  [..] Could not check managed voice shim liveness: {e}")
 
+    # 14. Zombie scheduler sessions (#739): a worktree dispatch whose launch
+    # crashed before the agent started (e.g. the worktree dir went missing
+    # between `agentwire new` reporting success and the pane's `cd`) drops to
+    # a bare shell the idle-reaper never touches. `agentwire limits tick`
+    # self-heals these every minute, so a live one here means the watchdog
+    # isn't installed/running, not that reaping is broken.
+    print("\nChecking for zombie scheduler sessions (#739)...")
+    try:
+        from .scheduler import scan_zombie_sessions
+
+        zombie_sessions = scan_zombie_sessions()
+        if not zombie_sessions:
+            print("  [ok] No zombie scheduler sessions found")
+        else:
+            issues_found += 1
+            print(f"  [!!] {len(zombie_sessions)} scheduler session(s) stuck at a bare shell:")
+            for z in zombie_sessions:
+                print(f"       - {z['session']} ({z['command']}, {z['age_seconds']}s old)")
+            print("       `agentwire limits tick` reaps these automatically — "
+                  "run it now, or check the usage-limit watchdog is installed "
+                  "(`agentwire limits install`).")
+    except Exception as e:
+        print(f"  [..] Could not check for zombie scheduler sessions: {e}")
+
     # Summary
     print()
     print("-" * 60)

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -177,16 +177,20 @@ def cmd_limits_tick(args) -> int:
     """One watchdog pass (called by launchd every minute).
 
     Runs the usage-limit sweep FIRST, then prompt routing (#276), then the
-    polite-message inbox drain (#296), then context auto-management (#442) —
-    the ordering guarantees a usage-limit dialog is parked before any sweep
-    looks at the pane, that the inbox only ever delivers to panes the prompt
-    sweep already cleared, and that auto-``/clear`` runs LAST so it never fights
-    a pending paste/prompt for the same idle, empty box.
+    polite-message inbox drain (#296), then context auto-management (#442),
+    then the zombie-scheduler-session reap (#739) — the ordering guarantees a
+    usage-limit dialog is parked before any sweep looks at the pane, that the
+    inbox only ever delivers to panes the prompt sweep already cleared, that
+    auto-``/clear`` runs before the reap so it never fights a pending
+    paste/prompt for the same idle, empty box, and that the reap runs LAST
+    since it kills sessions outright (nothing later should still be acting on
+    one).
 
     Each stage runs inside :func:`_run_stage` so an exception in one subsystem
     is logged and skipped rather than aborting the whole cycle (#490).
     """
     from agentwire import inbox, prompt_router, session_context
+    from agentwire.scheduler import zombie as scheduler_zombie
 
     result = _run_stage(
         "usage_limit", usage_limit.tick,
@@ -197,9 +201,12 @@ def cmd_limits_tick(args) -> int:
         "inbox", inbox.tick, {"flushed": [], "deferred": []})
     context = _run_stage(
         "session_context", session_context.tick, {"acted": [], "deferred": []})
+    zombies = _run_stage(
+        "scheduler_zombie", scheduler_zombie.tick, {"killed": []})
     if getattr(args, "json", False):
         print(json.dumps({
-            **result, "prompts": prompts, "messages": messages, "context": context,
+            **result, "prompts": prompts, "messages": messages,
+            "context": context, "zombies": zombies,
         }))
         return 0
     if result.get("skipped"):
@@ -237,6 +244,9 @@ def cmd_limits_tick(args) -> int:
     if ctx_deferred:
         print("context deferred: " + ", ".join(
             f"{e['session']}({e['deferred']})" for e in ctx_deferred))
+    killed = zombies.get("killed") or []
+    if killed:
+        print("zombie scheduler sessions reaped: " + ", ".join(killed))
     return 0
 
 

--- a/agentwire/scheduler/__init__.py
+++ b/agentwire/scheduler/__init__.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 import yaml
 
 from ..core import _atomic_write
+from . import zombie
 from .dispatch import (
     _WORKFLOW_STATUS_TO_SCHED,
     _apply_max_runs,
@@ -110,3 +111,6 @@ from .state import (
     load_board,
     save_board,
 )
+from .zombie import reap as reap_zombie_sessions
+from .zombie import scan as scan_zombie_sessions
+from .zombie import tick as zombie_tick

--- a/agentwire/scheduler/zombie.py
+++ b/agentwire/scheduler/zombie.py
@@ -1,0 +1,121 @@
+"""Reap bare-shell scheduler sessions (#739).
+
+``_dispatch_worktree_task`` names every worktree branch
+``scheduler-<task>-<ts>``. If the session's launch crashes before the agent
+starts (e.g. the worktree directory went missing between ``agentwire new``
+reporting success and the pane's ``cd``), the tmux session drops to a bare
+shell — which the idle-reaper correctly never touches, since it only reaps a
+*running* agent that goes idle. Nothing else would ever clean that up, so it
+lingers indefinitely. This module finds and kills those sessions.
+
+Detected by branch naming rather than ``worktree_registry`` — scheduler
+dispatch goes through ``agentwire new``, which (unlike ``agentwire
+worktree``) never registers there.
+"""
+
+import subprocess
+import time
+
+from ..worktree import parse_session_name
+
+BRANCH_PREFIX = "scheduler-"
+
+# tmux `session_created` is whole seconds. A healthy launch's pre-agent shell
+# moment lasts well under a second (see `_launch_tmux_session`'s 0.1s
+# settle), but this gives a slow `claude` cold start real headroom before a
+# session still mid-launch could be mistaken for a zombie.
+MIN_AGE_SECONDS = 60
+
+_SHELL_COMMANDS = frozenset({"zsh", "bash", "sh", "fish", "tcsh", "csh", "dash"})
+
+
+def _is_bare_shell(command: str) -> bool:
+    """True if *command* (a ``pane_current_command`` value) is a login shell."""
+    return command.strip().lstrip("-") in _SHELL_COMMANDS
+
+
+def scan() -> list[dict]:
+    """Live scheduler-dispatched worktree sessions stuck at a bare shell.
+
+    Each entry: ``session``, ``branch``, ``command``, ``age_seconds``.
+    """
+    result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}\t#{session_created}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return []
+
+    now = time.time()
+    zombies = []
+    for line in result.stdout.strip().splitlines():
+        if "\t" not in line:
+            continue
+        session, created = line.split("\t", 1)
+        _, branch, machine = parse_session_name(session)
+        if machine or not branch or not branch.startswith(BRANCH_PREFIX):
+            continue
+        try:
+            age = now - float(created)
+        except ValueError:
+            continue
+        if age < MIN_AGE_SECONDS:
+            continue
+
+        panes = subprocess.run(
+            ["tmux", "list-panes", "-t", f"={session}", "-F", "#{pane_current_command}"],
+            capture_output=True, text=True,
+        )
+        if panes.returncode != 0:
+            continue
+        commands = [p for p in panes.stdout.strip().splitlines() if p]
+        if len(commands) == 1 and _is_bare_shell(commands[0]):
+            zombies.append({
+                "session": session, "branch": branch,
+                "command": commands[0], "age_seconds": int(age),
+            })
+    return zombies
+
+
+def _notify(session: str, branch: str, command: str) -> None:
+    """Best-effort owner email — reused Resend wiring, mirrors
+    ``dispatch._notify_dispatch_timeout`` (never raises into the caller)."""
+    try:
+        import socket
+
+        from ..channels.email import send_email
+        send_email(
+            subject=f"[agentwire] reaped zombie scheduler session: {session}",
+            body=(
+                f"Scheduler dispatch session `{session}` (branch `{branch}`) "
+                f"on `{socket.gethostname()}` never reached its agent — the "
+                f"pane was stuck at a bare shell (`{command}`), the #739 "
+                "failure mode where the worktree launch crashes before "
+                "`claude` starts (e.g. a missing worktree directory). The "
+                "watchdog killed the session so it can't linger.\n\n"
+                "Check the scheduler events log for the originating "
+                "dispatch failure."
+            ),
+        )
+    except Exception:
+        pass
+
+
+def reap() -> dict:
+    """Kill every detected zombie session, logging + emailing each one."""
+    from agentwire import scheduler as _sched
+
+    killed = []
+    for z in scan():
+        _sched._kill_session(z["session"])
+        _sched._log_event("zombie_session_reaped", session=z["session"],
+                          branch=z["branch"], command=z["command"],
+                          age_seconds=z["age_seconds"])
+        _notify(z["session"], z["branch"], z["command"])
+        killed.append(z["session"])
+    return {"killed": killed}
+
+
+def tick() -> dict:
+    """Watchdog stage entry point — same ``{"killed": [...]}`` shape as ``reap()``."""
+    return reap()

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -402,7 +402,17 @@ def cmd_new(args) -> int:
                 return _output_result(False, json_mode, hint)
 
     if not session_path.exists():
-        if args.force or path:
+        if branch:
+            # #739: a worktree session's path is only ever meant to come from
+            # `_spawn_worktree`/`ensure_worktree` above. Reaching here with it
+            # still missing means that creation silently didn't happen (or
+            # the dir vanished right after) — mkdir-ing an empty placeholder
+            # would launch the agent into a directory with no git checkout at
+            # all. Fail loud instead of returning a `path` that doesn't back
+            # a real worktree.
+            return _output_result(False, json_mode,
+                                   f"Worktree path does not exist after creation: {session_path}")
+        elif args.force or path:
             # Auto-create directory with -f flag or when custom path explicitly provided
             session_path.mkdir(parents=True, exist_ok=True)
         else:
@@ -452,6 +462,15 @@ def cmd_new(args) -> int:
     _set_session_name_env(agent, session_name)
 
     agent_cmd = agent.command
+
+    # #739: re-verify right before launch — closes the window between the
+    # earlier worktree-creation check and this point (shared-dir probe,
+    # posture/agent-command resolution) during which an external actor could
+    # still remove the directory. `agentwire new --json` must never report
+    # success with a `path` that doesn't exist on disk.
+    if not session_path.exists():
+        return _output_result(False, json_mode,
+                               f"Session path vanished before launch: {session_path}")
 
     # Create new tmux session with env vars injected at creation time, cd
     # into place, and start the agent (skipped when bare).

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -337,6 +337,83 @@ class TestCmdNewSeedFallback:
         assert "recover" not in calls  # recovery never runs on success
 
 
+class TestCmdNewWorktreeMissingDirFailsLoud:
+    """#739 — `agentwire new --json` must never report success with a `path`
+    that doesn't back a real worktree on disk. Two guards, two failure
+    windows: (1) worktree creation reports ok but the dir never landed, (2)
+    the dir existed right after creation but vanished before the pane
+    actually launches."""
+
+    def _base_args(self, project_path):
+        return argparse.Namespace(
+            session="proj/mybranch", path=str(project_path), force=False,
+            json=True, base=None, pull_first=False, roles=None, no_soul=True,
+        )
+
+    def test_ensure_worktree_lies_about_success(self, capsys, monkeypatch, tmp_path):
+        """`ensure_worktree` returns True without the dir existing (the #739
+        symptom: `agentwire new` proceeded past worktree creation with a path
+        whose directory was never actually created)."""
+        from agentwire import session_cli as m
+
+        project_path = tmp_path / "proj"
+        project_path.mkdir()
+
+        monkeypatch.setattr(m, "_check_tmux_installed", lambda: True)
+        monkeypatch.setattr(
+            m.subprocess, "run", lambda *a, **k: MagicMock(returncode=1, stdout=""))
+        monkeypatch.setattr(m, "ensure_worktree", lambda *a, **k: True)
+        monkeypatch.setattr(m, "load_config", lambda *a, **k: {})
+
+        rc = m.cmd_new(self._base_args(project_path))
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["success"] is False
+        assert "does not exist" in payload["error"]
+
+    def test_dir_vanishes_between_creation_and_launch(self, capsys, monkeypatch, tmp_path):
+        """The dir is real right after `ensure_worktree`, but something
+        removes it before `_launch_tmux_session` runs — the pre-launch guard
+        must catch this instead of launching the agent into an ENOENT."""
+        import shutil
+        from types import SimpleNamespace
+
+        from agentwire import session_cli as m
+
+        project_path = tmp_path / "proj"
+        project_path.mkdir()
+        session_path = tmp_path / "proj-worktrees" / "mybranch"
+
+        def fake_ensure_worktree(proj, branch, wt_path, **kw):
+            wt_path.mkdir(parents=True)
+            return True
+
+        monkeypatch.setattr(m, "_check_tmux_installed", lambda: True)
+        monkeypatch.setattr(
+            m.subprocess, "run", lambda *a, **k: MagicMock(returncode=1, stdout=""))
+        monkeypatch.setattr(m, "ensure_worktree", fake_ensure_worktree)
+        monkeypatch.setattr(m, "load_config", lambda *a, **k: {})
+        monkeypatch.setattr(m, "resolve_roles", lambda *a, **k: [])
+        monkeypatch.setattr(m, "inject_soul", lambda names, cfg, no_soul=False: [])
+        monkeypatch.setattr(
+            m, "_resolve_posture_from_args", lambda a, **kw: ("bypass", None))
+
+        def vanish_then_build(*a, **k):
+            shutil.rmtree(str(session_path))
+            return SimpleNamespace(command="claude", env={})
+
+        monkeypatch.setattr(m, "build_agent_command", vanish_then_build)
+        launched = []
+        monkeypatch.setattr(m, "_launch_tmux_session", lambda *a, **k: launched.append(True))
+
+        rc = m.cmd_new(self._base_args(project_path))
+        assert rc == 1
+        assert not launched
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["success"] is False
+        assert "vanished before launch" in payload["error"]
+
+
 class TestCmdNewDefaultCreatedByRooting:
     """#715 — with --created-by unset, cmd_new should only default to the
     caller when the new session is in the caller's own project; a genuinely

--- a/tests/unit/test_guarded_launch_command.py
+++ b/tests/unit/test_guarded_launch_command.py
@@ -1,0 +1,35 @@
+"""`_guarded_launch_command` (#739) — the pane's cd+agent-launch line must
+guard a missing worktree dir instead of crashing the agent into a bare
+shell nobody reaps."""
+
+from agentwire.core import _guarded_launch_command
+
+
+class TestGuardedLaunchCommand:
+    def test_cd_success_runs_agent(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude --flag")
+        assert cmd.startswith("cd /tmp/wt || {")
+        assert cmd.endswith("&& claude --flag")
+
+    def test_cd_failure_exits_without_running_agent(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude --flag")
+        # The guard clause exits the shell on cd failure — the agent segment
+        # is only reachable via the `&&` after a successful cd.
+        assert "exit 1" in cmd
+        assert 'AGENTWIRE_UNATTENDED' in cmd
+
+    def test_bare_posture_has_no_agent_segment(self):
+        cmd = _guarded_launch_command("/tmp/wt", None)
+        assert cmd == 'cd /tmp/wt || { echo "agentwire: worktree missing at launch, ' \
+            'aborting: /tmp/wt" >&2; [ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire ' \
+            'email --subject "agentwire: worktree missing — ' \
+            '${AGENTWIRE_SESSION_NAME:-unknown session}" --body "cd failed at ' \
+            'launch: /tmp/wt" >/dev/null 2>&1; exit 1; }'
+
+    def test_path_with_spaces_is_quoted(self):
+        cmd = _guarded_launch_command("/tmp/my wt", "claude")
+        assert "cd '/tmp/my wt'" in cmd
+
+    def test_alert_guarded_on_unattended_env_var(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude")
+        assert '[ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email' in cmd

--- a/tests/unit/test_limits_tick_isolation.py
+++ b/tests/unit/test_limits_tick_isolation.py
@@ -1,6 +1,6 @@
 """Watchdog stage isolation (agentwire/limits_cli.py, #490).
 
-The 60s watchdog runs four ``*.tick()`` stages sequentially. A raise in one
+The 60s watchdog runs five ``*.tick()`` stages sequentially. A raise in one
 must be logged and skipped, not propagate out and starve the rest of the cycle.
 """
 
@@ -24,7 +24,8 @@ def stub_stages(monkeypatch):
     when that stage actually runs, so the test can assert which stages ran.
     """
     ran: dict[str, list] = {k: [] for k in
-                            ("usage_limit", "prompt_router", "inbox", "session_context")}
+                            ("usage_limit", "prompt_router", "inbox", "session_context",
+                             "scheduler_zombie")}
 
     def make(name, result):
         def _tick():
@@ -35,6 +36,7 @@ def stub_stages(monkeypatch):
     import agentwire.inbox as inbox_mod
     import agentwire.prompt_router as pr_mod
     import agentwire.session_context as sc_mod
+    from agentwire.scheduler import zombie as zombie_mod
 
     monkeypatch.setattr(limits_cli.usage_limit, "tick",
                         make("usage_limit",
@@ -42,6 +44,7 @@ def stub_stages(monkeypatch):
     monkeypatch.setattr(pr_mod, "tick", make("prompt_router", {"routed": [], "deferred": []}))
     monkeypatch.setattr(inbox_mod, "tick", make("inbox", {"flushed": [], "deferred": []}))
     monkeypatch.setattr(sc_mod, "tick", make("session_context", {"acted": [], "deferred": []}))
+    monkeypatch.setattr(zombie_mod, "tick", make("scheduler_zombie", {"killed": []}))
     return ran
 
 

--- a/tests/unit/test_scheduler_zombie.py
+++ b/tests/unit/test_scheduler_zombie.py
@@ -1,0 +1,168 @@
+"""Zombie scheduler session detection + reap (#739).
+
+`_dispatch_worktree_task` names every worktree branch `scheduler-<task>-<ts>`.
+If the launch crashes before the agent starts, the tmux session drops to a
+bare shell that the idle-reaper never touches. `agentwire.scheduler.zombie`
+finds and kills those.
+"""
+
+from unittest.mock import MagicMock
+
+from agentwire.scheduler import zombie
+
+
+class TestIsBareShell:
+    def test_recognizes_common_shells(self):
+        for cmd in ("zsh", "-zsh", "bash", "-bash", "sh", "fish"):
+            assert zombie._is_bare_shell(cmd), cmd
+
+    def test_rejects_agent_and_daemon_commands(self):
+        for cmd in ("claude", "node", "2.1.185", "python3.13", "uv"):
+            assert not zombie._is_bare_shell(cmd), cmd
+
+
+def _fake_run(sessions_line, panes_by_session):
+    """Build a subprocess.run stand-in serving list-sessions / list-panes."""
+
+    def _run(args, **kwargs):
+        if "list-sessions" in args:
+            return MagicMock(returncode=0, stdout=sessions_line)
+        if "list-panes" in args:
+            target = next(a for a in args if a.startswith("=")).lstrip("=")
+            panes = panes_by_session.get(target)
+            if panes is None:
+                return MagicMock(returncode=1, stdout="")
+            return MagicMock(returncode=0, stdout="\n".join(panes) + "\n")
+        raise AssertionError(f"unexpected tmux invocation: {args}")
+
+    return _run
+
+
+class TestScan:
+    def test_flags_bare_shell_scheduler_session(self, monkeypatch):
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        session = "proj/scheduler-mytask-20260101-090000"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{old}\n", {session: ["zsh"]}),
+        )
+        zombies = zombie.scan()
+        assert len(zombies) == 1
+        assert zombies[0]["session"] == session
+        assert zombies[0]["branch"] == "scheduler-mytask-20260101-090000"
+        assert zombies[0]["command"] == "zsh"
+        assert zombies[0]["age_seconds"] == 120
+
+    def test_ignores_non_scheduler_branches(self, monkeypatch):
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        session = "proj/some-feature-branch"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{old}\n", {session: ["zsh"]}),
+        )
+        assert zombie.scan() == []
+
+    def test_ignores_sessions_without_a_branch(self, monkeypatch):
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"proj\t{old}\n", {"proj": ["zsh"]}),
+        )
+        assert zombie.scan() == []
+
+    def test_ignores_remote_sessions(self, monkeypatch):
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        session = "proj/scheduler-mytask-20260101-090000@gpu"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{old}\n", {}),
+        )
+        assert zombie.scan() == []
+
+    def test_running_agent_is_not_a_zombie(self, monkeypatch):
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        session = "proj/scheduler-mytask-20260101-090000"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{old}\n", {session: ["claude"]}),
+        )
+        assert zombie.scan() == []
+
+    def test_too_young_is_skipped(self, monkeypatch):
+        """A dispatch mid-launch briefly shows a bare shell before the agent
+        starts — must not be reaped before it's had a chance to run."""
+        created = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: created + 5)
+        session = "proj/scheduler-mytask-20260101-090000"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{created}\n", {session: ["zsh"]}),
+        )
+        assert zombie.scan() == []
+
+    def test_multiple_panes_are_not_flagged(self, monkeypatch):
+        """A human may have attached and split panes — don't treat that as a
+        zombie shell."""
+        old = 1000.0
+        monkeypatch.setattr(zombie.time, "time", lambda: old + 120)
+        session = "proj/scheduler-mytask-20260101-090000"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            _fake_run(f"{session}\t{old}\n", {session: ["zsh", "zsh"]}),
+        )
+        assert zombie.scan() == []
+
+    def test_no_tmux_server_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            lambda *a, **k: MagicMock(returncode=1, stdout=""))
+        assert zombie.scan() == []
+
+
+class TestReap:
+    def test_kills_logs_and_notifies_each_zombie(self, monkeypatch):
+        zombies = [
+            {"session": "proj/scheduler-a-1", "branch": "scheduler-a-1",
+             "command": "zsh", "age_seconds": 90},
+            {"session": "proj/scheduler-b-2", "branch": "scheduler-b-2",
+             "command": "bash", "age_seconds": 200},
+        ]
+        monkeypatch.setattr(zombie, "scan", lambda: zombies)
+
+        killed = []
+        logged = []
+        notified = []
+        import agentwire.scheduler as sched_pkg
+        monkeypatch.setattr(sched_pkg, "_kill_session", lambda s: killed.append(s))
+        monkeypatch.setattr(sched_pkg, "_log_event",
+                            lambda event, **f: logged.append((event, f)))
+        monkeypatch.setattr(zombie, "_notify",
+                            lambda session, branch, command: notified.append(session))
+
+        result = zombie.reap()
+
+        assert killed == ["proj/scheduler-a-1", "proj/scheduler-b-2"]
+        assert notified == ["proj/scheduler-a-1", "proj/scheduler-b-2"]
+        assert [e for e, _ in logged] == ["zombie_session_reaped", "zombie_session_reaped"]
+        assert result == {"killed": ["proj/scheduler-a-1", "proj/scheduler-b-2"]}
+
+    def test_no_zombies_is_a_noop(self, monkeypatch):
+        monkeypatch.setattr(zombie, "scan", lambda: [])
+        assert zombie.reap() == {"killed": []}
+
+    def test_tick_is_reap(self, monkeypatch):
+        monkeypatch.setattr(zombie, "scan", lambda: [])
+        assert zombie.tick() == {"killed": []}
+
+    def test_notify_never_raises_on_email_failure(self, monkeypatch):
+        def boom(**kwargs):
+            raise RuntimeError("resend down")
+
+        import agentwire.channels.email as email_mod
+        monkeypatch.setattr(email_mod, "send_email", boom)
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")  # must not raise


### PR DESCRIPTION
## Problem

Scheduler worktree dispatches could zombie into a bare shell that never self-closes: `agentwire new` reported success with a worktree `path`, but the directory wasn't actually there when the pane's `cd` ran, so `claude` launched from the wrong cwd and crashed. The idle-reaper correctly never touches a bare shell (it only reaps a running agent going idle), so nothing ever cleaned it up.

## Root cause

I traced the create → launch path (`_dispatch_worktree_task` → `agentwire new` → `cmd_new` → `_launch_tmux_session`) end to end and found **no automatic background process in this codebase** that races with fresh worktree creation to delete a directory (no periodic prune tied to `agentwire limits tick`, no lock-file collision — locks are keyed by the full unique `project/branch` session name — and `_kill_session`'s scheduler "paranoia" call only touches tmux/processes, never the filesystem). So I can't prove from code alone what deleted the directory in the observed incidents.

I did find one real, always-reachable bug along the way: in `cmd_new`, when a worktree session's directory doesn't exist after the create step, the code fell through to a fallback meant for plain custom-path sessions and **silently `mkdir`'d an empty placeholder** instead of failing — so `ensure_worktree` reporting success with no real directory behind it would sail through unnoticed. Fixed, but it doesn't explain an ENOENT (mkdir would have made `cd` succeed, just into a broken empty dir) — so it's not proven to be *the* trigger for these two incidents either.

Leading hypothesis given the fixed early-morning dispatch times (08:00/09:00) and the total absence of an internal cause: an external actor on the host — backup, sync, or a maintenance cron unrelated to agentwire — removing the just-created directory in the narrow window between `ensure_worktree` succeeding and the pane's `cd` executing. Unconfirmed; the hardening below closes the failure mode regardless of the exact trigger.

## Fix — three layers, all independently valuable

1. **`agentwire new` never returns a `path` that doesn't exist** (`session_cli.py`):
   - the worktree/branch case now fails loud instead of silently `mkdir`-ing an empty placeholder when the directory is missing after creation
   - a final existence check right before `_launch_tmux_session` closes the window against anything that removes the directory afterward — win or lose, `cmd_new` never proceeds to launch against a path it hasn't just re-verified

2. **The pane's `cd` is now guarded** (`core.py`, `_guarded_launch_command`): `cd <path> || { alert; exit 1; }`. A missing directory alerts (emails the owner when `$AGENTWIRE_UNATTENDED=1` — already set for scheduler dispatches — reusing the existing `agentwire email`/Resend wiring) and exits the shell instead of launching the agent into an ENOENT crash. The session tears itself down instead of leaving a bare-shell zombie. Applies to every `_launch_tmux_session` caller (`new`/`recreate`/`fork`, local and remote).

3. **GC for anything that still slips through** (`agentwire/scheduler/zombie.py`): detects a live tmux session on a `scheduler-*`-branch name whose sole pane is a bare shell (not the agent), aged past a 60s safety margin so an in-flight launch's brief pre-agent moment is never mistaken for one.
   - `agentwire doctor` surfaces any live zombie
   - `agentwire limits tick` (the existing 60s watchdog) auto-reaps every cycle: kills the session, logs `zombie_session_reaped`, and emails the owner

## Test plan

- [x] `uv run --no-sync ruff check agentwire/ tests/` — clean
- [x] `uv run --no-sync pytest` — 2694 passed (full suite, in-worktree)
- [x] New tests: `tests/unit/test_guarded_launch_command.py` (guard command construction), `tests/unit/test_scheduler_zombie.py` (scan/reap detection, age/pane-count/command heuristics), `tests/unit/test_cli_commands.py::TestCmdNewWorktreeMissingDirFailsLoud` (both failure windows — `ensure_worktree` lying about success, and the dir vanishing between creation and launch)
- [x] Manually executed the built guard command under both `bash` and `zsh` for the exists/missing-dir cases to confirm real shell semantics (agent runs on success; alert + clean exit, no zombie, on failure)
- Not verifiable in-worktree: the live watchdog/doctor behavior against a real tmux server (per worktree-session etiquette, no portal/service restarts here)

Built by [dotdev.dev](https://dotdev.dev)