### PR TITLE
fix(notify): route launch-crash + zombie-reap alerts to parent + portal

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -148,15 +148,25 @@ def _build_tmux_env_flags_shell(env: dict[str, str]) -> str:
     return " ".join(parts) + " "
 
 
-def _set_session_name_env(agent: "AgentCommand", session_name: str) -> None:
-    """Stamp ``AGENTWIRE_SESSION_NAME`` onto an ``AgentCommand.env``.
+def _set_session_name_env(agent: "AgentCommand", session_name: str, created_by: str | None = None) -> None:
+    """Stamp ``AGENTWIRE_SESSION_NAME`` (and, when there's a real parent,
+    ``AGENTWIRE_CREATED_BY``) onto an ``AgentCommand.env``.
 
     Every session created via ``cmd_new`` / ``cmd_spawn`` / ``cmd_recreate``
-    / ``cmd_fork`` / scheduler-spawn paths gets this so downstream tooling
-    (notably the worker damage-control rules in ``safety/_core.py``)
-    can identify which agentwire session the running tool is part of.
+    / ``cmd_fork`` / scheduler-spawn paths gets ``AGENTWIRE_SESSION_NAME`` so
+    downstream tooling (notably the worker damage-control rules in
+    ``safety/_core.py``) can identify which agentwire session the running
+    tool is part of.
+
+    ``created_by`` of ``''`` (root/orchestrator) or ``None`` means no
+    parent — ``AGENTWIRE_CREATED_BY`` is deliberately left UNSET rather than
+    set to an empty string, so the bare pre-agent shell's launch-crash guard
+    (``_guarded_launch_command``) can tell "has a parent to escalate to"
+    apart from "root session, email the owner" with a plain ``-n`` test (#743).
     """
     agent.env["AGENTWIRE_SESSION_NAME"] = session_name
+    if created_by:
+        agent.env["AGENTWIRE_CREATED_BY"] = created_by
 
 
 def inject_session_env(session: str, env: dict[str, str], remote_host: str | None = None) -> None:
@@ -859,17 +869,35 @@ def _guarded_launch_command(path_str: str, agent_cmd: str | None) -> str:
     idle-reaper never touches (it only reaps a *running* agent going idle),
     so it lingers forever.
 
-    On a missing dir this instead alerts (emails the owner when
-    ``$AGENTWIRE_UNATTENDED=1`` — set for scheduler dispatches, see
-    ``_with_unattended_env``) and exits the shell, which tears the tmux
-    session down instead of leaving a zombie. ``agent_cmd`` never runs.
+    On a missing dir this instead alerts and exits the shell, which tears the
+    tmux session down instead of leaving a zombie. ``agent_cmd`` never runs.
+
+    Two alert routes, both shell-runtime-gated on env vars stamped at launch
+    (``_set_session_name_env``), so this function stays a pure string builder
+    with no Python-level knowledge of the session's parent (#743):
+    - A real recorded parent (``$AGENTWIRE_CREATED_BY`` set) gets the crash
+      escalated to its msg inbox — in-band, not just an email the human has
+      to forward.
+    - No parent (root/orchestrator sessions, the genuine scheduler-dispatch
+      case) falls back to the original owner email, still gated on
+      ``$AGENTWIRE_UNATTENDED=1`` (see ``_with_unattended_env``).
     """
     quoted_path = shlex.quote(path_str)
+    session_ref = "${AGENTWIRE_SESSION_NAME:-unknown session}"
+    missing_body = f"cd failed at launch: {path_str}"
+    notify_parent = (
+        '[ -n "$AGENTWIRE_CREATED_BY" ] && agentwire msg send --to "$AGENTWIRE_CREATED_BY" '
+        f'--kind escalation --subject "agentwire: worktree missing at launch — {session_ref}" '
+        f'--body "{missing_body}" >/dev/null 2>&1'
+    )
+    notify_owner = (
+        '[ -z "$AGENTWIRE_CREATED_BY" ] && [ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email '
+        f'--subject "agentwire: worktree missing — {session_ref}" '
+        f'--body "{missing_body}" >/dev/null 2>&1'
+    )
     alert = (
         f"echo \"agentwire: worktree missing at launch, aborting: {path_str}\" >&2; "
-        '[ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email '
-        f'--subject "agentwire: worktree missing — ${{AGENTWIRE_SESSION_NAME:-unknown session}}" '
-        f'--body "cd failed at launch: {path_str}" >/dev/null 2>&1'
+        f"{notify_parent}; {notify_owner}"
     )
     guard = f"cd {quoted_path} || {{ {alert}; exit 1; }}"
     return f"{guard} && {agent_cmd}" if agent_cmd else guard

--- a/agentwire/scheduler/zombie.py
+++ b/agentwire/scheduler/zombie.py
@@ -78,8 +78,47 @@ def scan() -> list[dict]:
 
 
 def _notify(session: str, branch: str, command: str) -> None:
-    """Best-effort owner email — reused Resend wiring, mirrors
-    ``dispatch._notify_dispatch_timeout`` (never raises into the caller)."""
+    """Alert on a reaped zombie session (#739 + #743).
+
+    Always posts a portal toast, so the reap is visible in-band rather than
+    only in an email the human has to notice and forward. When the session
+    has a recorded parent (``created_by`` in its metadata — set at
+    ``agentwire new`` time, see ``_record_session_creator``), the crash is
+    ALSO escalated there via the msg inbox (drained by the same watchdog that
+    runs this reap) — a worktree worker's crash reaches its orchestrator, not
+    just the owner's inbox. Owner email — the reused Resend wiring, mirrors
+    ``dispatch._notify_dispatch_timeout`` — is strictly the fallback for a
+    session with no recorded parent (the genuine root/scheduler-dispatch
+    case #739 originally covered). Each channel is independently
+    best-effort; this must never raise into the caller.
+    """
+    text = (
+        f"agentwire: reaped zombie scheduler session `{session}` (branch "
+        f"`{branch}`) — launch crashed at a bare shell (`{command}`) before "
+        "the agent started."
+    )
+
+    try:
+        from ..core import _post_desktop_notification
+        _post_desktop_notification(text, session=session, priority="high")
+    except Exception:
+        pass
+
+    parent = None
+    try:
+        from ..core import load_session_metadata
+        parent = load_session_metadata(session).get("created_by") or None
+    except Exception:
+        parent = None
+
+    if parent:
+        try:
+            from ..inbox import enqueue
+            enqueue(parent, text, kind="escalation", sender="agentwire")
+        except Exception:
+            pass
+        return
+
     try:
         import socket
 

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -455,11 +455,39 @@ def cmd_new(args) -> int:
             # Kind default posture (no global default-role lookup).
             posture, _ = _resolve_posture_from_args(args)
 
+    # Record the creating session as parent for prompt routing. --created-by
+    # overrides (including '' to opt out); otherwise default to the caller
+    # ONLY when the new session is in the caller's own project — a
+    # cross-project spawn gets its own root instead of flattening into the
+    # caller's subtree (#715). --caller-session is the candidate caller for
+    # that check (MCP forwards it; direct CLI use falls back to the current
+    # tmux session). Resolved before building the agent env (#743 needs the
+    # real parent, if any, in AGENTWIRE_CREATED_BY BEFORE `tmux new-session
+    # -e` fires) and before seeding so a failed seed can name its sender.
+    #
+    # Joint default with role (#716): an EXPLICITLY requested orchestrator
+    # roots by default instead — a durable orchestrator shouldn't answer to
+    # whoever happened to spawn it. Gated on the explicit --kind flag (not
+    # the resolved `kind`, which is "orchestrator" by default for any
+    # branchless name) so the ubiquitous plain `agentwire new` case keeps
+    # its existing same-project-inherit behavior untouched. This is the one
+    # place this default lives — cmd_worktree's `_launch_session` forwards
+    # its own `--kind` straight through as `kind` here, so `agentwire
+    # worktree --kind orchestrator` / `agentwire orchestrator` compose with
+    # it for free.
+    created_by = getattr(args, 'created_by', None)
+    caller = None
+    if created_by is None and getattr(args, 'kind', None) == 'orchestrator':
+        created_by = ''
+    elif created_by is None:
+        caller = getattr(args, 'caller_session', None) or pane_manager.get_current_session()
+        created_by = resolve_default_created_by(caller, session_path)
+
     # Build agent command
     model_override = getattr(args, 'model', None)
     agent = build_agent_command(posture, roles if roles else None, model=model_override)
     agent.env.update(parse_env_args(getattr(args, 'env', None)))
-    _set_session_name_env(agent, session_name)
+    _set_session_name_env(agent, session_name, created_by=created_by)
 
     agent_cmd = agent.command
 
@@ -497,33 +525,6 @@ def cmd_new(args) -> int:
                 voice=None,
             )
         save_project_config(project_config, session_path)
-
-    # Record the creating session as parent for prompt routing. --created-by
-    # overrides (including '' to opt out); otherwise default to the caller
-    # ONLY when the new session is in the caller's own project — a
-    # cross-project spawn gets its own root instead of flattening into the
-    # caller's subtree (#715). --caller-session is the candidate caller for
-    # that check (MCP forwards it; direct CLI use falls back to the current
-    # tmux session). Resolved before seeding so a failed seed can name its
-    # sender.
-    #
-    # Joint default with role (#716): an EXPLICITLY requested orchestrator
-    # roots by default instead — a durable orchestrator shouldn't answer to
-    # whoever happened to spawn it. Gated on the explicit --kind flag (not
-    # the resolved `kind`, which is "orchestrator" by default for any
-    # branchless name) so the ubiquitous plain `agentwire new` case keeps
-    # its existing same-project-inherit behavior untouched. This is the one
-    # place this default lives — cmd_worktree's `_launch_session` forwards
-    # its own `--kind` straight through as `kind` here, so `agentwire
-    # worktree --kind orchestrator` / `agentwire orchestrator` compose with
-    # it for free.
-    created_by = getattr(args, 'created_by', None)
-    caller = None
-    if created_by is None and getattr(args, 'kind', None) == 'orchestrator':
-        created_by = ''
-    elif created_by is None:
-        caller = getattr(args, 'caller_session', None) or pane_manager.get_current_session()
-        created_by = resolve_default_created_by(caller, session_path)
 
     # Deliver the first message once the agent is ready (verified paste).
     # Delivery failure doesn't fail the command — the session exists — but it

--- a/tests/unit/test_guarded_launch_command.py
+++ b/tests/unit/test_guarded_launch_command.py
@@ -1,6 +1,7 @@
-"""`_guarded_launch_command` (#739) — the pane's cd+agent-launch line must
-guard a missing worktree dir instead of crashing the agent into a bare
-shell nobody reaps."""
+"""`_guarded_launch_command` (#739, #743) — the pane's cd+agent-launch line
+must guard a missing worktree dir instead of crashing the agent into a bare
+shell nobody reaps, and (#743) route the alert to a real parent — not just
+the owner's email — when one is recorded in the launch env."""
 
 from agentwire.core import _guarded_launch_command
 
@@ -20,11 +21,18 @@ class TestGuardedLaunchCommand:
 
     def test_bare_posture_has_no_agent_segment(self):
         cmd = _guarded_launch_command("/tmp/wt", None)
-        assert cmd == 'cd /tmp/wt || { echo "agentwire: worktree missing at launch, ' \
-            'aborting: /tmp/wt" >&2; [ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire ' \
-            'email --subject "agentwire: worktree missing — ' \
-            '${AGENTWIRE_SESSION_NAME:-unknown session}" --body "cd failed at ' \
+        assert cmd == (
+            'cd /tmp/wt || { echo "agentwire: worktree missing at launch, '
+            'aborting: /tmp/wt" >&2; [ -n "$AGENTWIRE_CREATED_BY" ] && agentwire '
+            'msg send --to "$AGENTWIRE_CREATED_BY" --kind escalation --subject '
+            '"agentwire: worktree missing at launch — '
+            '${AGENTWIRE_SESSION_NAME:-unknown session}" --body "cd failed at '
+            'launch: /tmp/wt" >/dev/null 2>&1; [ -z "$AGENTWIRE_CREATED_BY" ] && '
+            '[ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email --subject '
+            '"agentwire: worktree missing — '
+            '${AGENTWIRE_SESSION_NAME:-unknown session}" --body "cd failed at '
             'launch: /tmp/wt" >/dev/null 2>&1; exit 1; }'
+        )
 
     def test_path_with_spaces_is_quoted(self):
         cmd = _guarded_launch_command("/tmp/my wt", "claude")
@@ -33,3 +41,33 @@ class TestGuardedLaunchCommand:
     def test_alert_guarded_on_unattended_env_var(self):
         cmd = _guarded_launch_command("/tmp/wt", "claude")
         assert '[ "$AGENTWIRE_UNATTENDED" = "1" ] && agentwire email' in cmd
+
+
+class TestParentEscalation:
+    """#743: a real parent (`$AGENTWIRE_CREATED_BY`, stamped by
+    `_set_session_name_env` only for a non-root session) gets the crash
+    routed to its msg inbox; the owner-email fallback still fires only when
+    there's no parent."""
+
+    def test_parent_notify_clause_present(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude")
+        assert (
+            '[ -n "$AGENTWIRE_CREATED_BY" ] && agentwire msg send '
+            '--to "$AGENTWIRE_CREATED_BY" --kind escalation'
+        ) in cmd
+
+    def test_email_fallback_branch_still_present(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude")
+        assert (
+            '[ -z "$AGENTWIRE_CREATED_BY" ] && [ "$AGENTWIRE_UNATTENDED" = "1" ] '
+            '&& agentwire email'
+        ) in cmd
+
+    def test_path_still_quoted_with_parent_escalation_present(self):
+        cmd = _guarded_launch_command("/tmp/my wt", "claude")
+        assert "cd '/tmp/my wt'" in cmd
+        assert '$AGENTWIRE_CREATED_BY' in cmd
+
+    def test_agent_still_gated_behind_successful_cd(self):
+        cmd = _guarded_launch_command("/tmp/wt", "claude --flag")
+        assert cmd.endswith("; exit 1; } && claude --flag")

--- a/tests/unit/test_scheduler_zombie.py
+++ b/tests/unit/test_scheduler_zombie.py
@@ -160,9 +160,110 @@ class TestReap:
         assert zombie.tick() == {"killed": []}
 
     def test_notify_never_raises_on_email_failure(self, monkeypatch):
+        import agentwire.core as core_mod
+
         def boom(**kwargs):
             raise RuntimeError("resend down")
 
         import agentwire.channels.email as email_mod
         monkeypatch.setattr(email_mod, "send_email", boom)
+        monkeypatch.setattr(core_mod, "_post_desktop_notification", lambda *a, **k: False)
+        monkeypatch.setattr(core_mod, "load_session_metadata", lambda s: {})
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")  # must not raise
+
+
+class TestNotifyRouting:
+    """#743: reap alerts must reach the portal + parent, not just email."""
+
+    def _no_op_toast(self, monkeypatch):
+        import agentwire.core as core_mod
+        posted = []
+        monkeypatch.setattr(
+            core_mod, "_post_desktop_notification",
+            lambda text, **kw: posted.append((text, kw)) or True,
+        )
+        return posted
+
+    def test_always_posts_a_portal_toast(self, monkeypatch):
+        import agentwire.core as core_mod
+        posted = self._no_op_toast(monkeypatch)
+        monkeypatch.setattr(core_mod, "load_session_metadata", lambda s: {})
+        monkeypatch.setattr("agentwire.channels.email.send_email", lambda **k: None)
+
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")
+
+        assert len(posted) == 1
+        assert "proj/scheduler-a-1" in posted[0][0]
+        assert posted[0][1].get("session") == "proj/scheduler-a-1"
+
+    def test_routes_to_parent_via_msg_when_created_by_recorded(self, monkeypatch):
+        import agentwire.core as core_mod
+        import agentwire.inbox as inbox_mod
+        self._no_op_toast(monkeypatch)
+        monkeypatch.setattr(
+            core_mod, "load_session_metadata",
+            lambda s: {"created_by": "orchestrator"},
+        )
+        emailed = []
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: emailed.append(k),
+        )
+        sent = []
+        monkeypatch.setattr(
+            inbox_mod, "enqueue",
+            lambda to, text, **kw: sent.append((to, text, kw)),
+        )
+
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")
+
+        assert len(sent) == 1
+        to, text, kw = sent[0]
+        assert to == "orchestrator"
+        assert kw.get("kind") == "escalation"
+        assert not emailed  # email is the no-parent fallback only
+
+    def test_falls_back_to_email_when_no_parent_recorded(self, monkeypatch):
+        import agentwire.core as core_mod
+        import agentwire.inbox as inbox_mod
+        self._no_op_toast(monkeypatch)
+        monkeypatch.setattr(core_mod, "load_session_metadata", lambda s: {})
+        sent = []
+        monkeypatch.setattr(inbox_mod, "enqueue", lambda *a, **k: sent.append((a, k)))
+        emailed = []
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: emailed.append(k),
+        )
+
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")
+
+        assert not sent
+        assert len(emailed) == 1
+        assert "proj/scheduler-a-1" in emailed[0]["subject"]
+
+    def test_never_raises_when_msg_send_fails(self, monkeypatch):
+        import agentwire.core as core_mod
+        import agentwire.inbox as inbox_mod
+        self._no_op_toast(monkeypatch)
+        monkeypatch.setattr(
+            core_mod, "load_session_metadata",
+            lambda s: {"created_by": "orchestrator"},
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("inbox write failed")
+
+        monkeypatch.setattr(inbox_mod, "enqueue", boom)
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")  # must not raise
+
+    def test_never_raises_when_toast_fails(self, monkeypatch):
+        import agentwire.core as core_mod
+
+        def boom(*a, **k):
+            raise RuntimeError("portal unreachable")
+
+        monkeypatch.setattr(core_mod, "_post_desktop_notification", boom)
+        monkeypatch.setattr(core_mod, "load_session_metadata", lambda s: {})
+        monkeypatch.setattr("agentwire.channels.email.send_email", lambda **k: None)
         zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")  # must not raise

--- a/tests/unit/test_session_created_by_env.py
+++ b/tests/unit/test_session_created_by_env.py
@@ -1,0 +1,56 @@
+"""`_set_session_name_env` stamping `AGENTWIRE_CREATED_BY` (#743).
+
+The bare pre-agent shell's launch-crash guard (`_guarded_launch_command`)
+needs a real parent name in the tmux env to route an alert there instead of
+just emailing the owner. A `created_by` of '' (root/orchestrator) or None
+must NOT set the var at all — its mere presence is the guard's signal that
+there's a parent to escalate to.
+"""
+
+from agentwire.core import AgentCommand, _build_tmux_env_flags, _set_session_name_env
+
+
+class TestSetSessionNameEnv:
+    def test_session_name_always_stamped(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch")
+        assert agent.env["AGENTWIRE_SESSION_NAME"] == "proj/branch"
+
+    def test_real_parent_sets_created_by(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch", created_by="orchestrator")
+        assert agent.env["AGENTWIRE_CREATED_BY"] == "orchestrator"
+
+    def test_empty_string_created_by_is_not_stamped(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch", created_by="")
+        assert "AGENTWIRE_CREATED_BY" not in agent.env
+
+    def test_none_created_by_is_not_stamped(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch", created_by=None)
+        assert "AGENTWIRE_CREATED_BY" not in agent.env
+
+    def test_default_omits_created_by(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch")
+        assert "AGENTWIRE_CREATED_BY" not in agent.env
+
+
+class TestEnvReachesTmuxFlags:
+    """`tmux new-session -e K=V` is the only path that lands a var in the
+    initial pane's shell (post-hoc `set-environment` misses it) — confirm the
+    stamped var actually flows into that flag list, not just `agent.env`."""
+
+    def test_created_by_reaches_new_session_flags(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch", created_by="orchestrator")
+        flags = _build_tmux_env_flags(agent.env)
+        assert "-e" in flags
+        assert "AGENTWIRE_CREATED_BY=orchestrator" in flags
+
+    def test_no_parent_means_no_flag(self):
+        agent = AgentCommand(command="claude")
+        _set_session_name_env(agent, "proj/branch")
+        flags = _build_tmux_env_flags(agent.env)
+        assert not any(f.startswith("AGENTWIRE_CREATED_BY=") for f in flags)


### PR DESCRIPTION
## Summary
- **Reap** (`agentwire/scheduler/zombie.py`, `_notify`): always posts a portal toast; resolves the reaped session's recorded parent from `load_session_metadata(...).get("created_by")` and escalates there via the msg inbox (`agentwire.inbox.enqueue`, `kind="escalation"`); owner email is now strictly the fallback for a parentless (root/scheduler-dispatch) session. Each channel is independently best-effort — `_notify` still never raises.
- **Guard** (`agentwire/core.py`): `_set_session_name_env` now stamps `AGENTWIRE_CREATED_BY` into the launch env alongside `AGENTWIRE_SESSION_NAME`, but only for a real parent (`''`/`None` leave it unset). `cmd_new` (`session_cli.py`) resolves `created_by` before building the agent env instead of after `_launch_tmux_session`, so the var is present at `tmux new-session -e` time. `_guarded_launch_command` now emits both a parent-notify clause (`agentwire msg send --to "$AGENTWIRE_CREATED_BY" --kind escalation`, gated on `[ -n "$AGENTWIRE_CREATED_BY" ]`) and the original owner-email fallback (now additionally gated on `[ -z "$AGENTWIRE_CREATED_BY" ]`).

## Test plan
- [x] `uv run --no-sync ruff check agentwire/ tests/` — clean
- [x] `uv run --no-sync pytest -q` — 2713 passed
- [x] New/updated unit tests: `test_session_created_by_env.py` (env stamp presence/absence by `created_by`), `test_guarded_launch_command.py` (parent-notify clause + email fallback both present, path quoting, `&&` gating preserved), `test_scheduler_zombie.py` (`_notify` routes to portal + parent-msg when `created_by` is set, falls back to email otherwise, never raises on any channel failure)
- [x] No live email/msg/portal calls made during testing — all channels mocked
- Not verified (out of worktree scope): live portal toast rendering and actual `agentwire msg send` delivery end-to-end — would require the running portal/watchdog outside this isolated worktree.

Closes #743

Built by [dotdev.dev](https://dotdev.dev)