### PR TITLE
Portal: topology design tokens + failure-parity gate

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentwire-desktop-ui
-description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`), window collage (preview overlay — NEVER mutate real WinBox windows). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, or adding sidebar sections.
+description: Portal desktop UI patterns — left sidebar (click-toggle tab handle, accordion sections, session grouping into Sessions/Services via explicit allowlist, keyboard nav), session window modes (Monitor `<pre>` vs Terminal xterm.js — Monitor MUST NOT use xterm), artifact windows (sandboxed iframes from `~/.agentwire/artifacts/`), window collage (preview overlay — NEVER mutate real WinBox windows), topology design tokens (lineage-tint hue families + failure-state parity for placement/connector/collage). Use when editing portal static files (`static/js/sidebar/*`, `desktop.js`, `desktop.css`), changing window behavior, adding sidebar sections, or building session-topology UI (parent/child visualization).
 ---
 
 # Portal Desktop UI Patterns
@@ -56,6 +56,15 @@ Why this is load-bearing (each broke a previous implementation — full autopsy 
 - `registerWindow`/`setActiveWindow` auto-minimize all others (single-window mode) → any window event mid-overlay fights manual layouts.
 
 **Z-index landscape:** WinBox windows (inline, grows from 10) < collage overlay (1400) < toasts (1500) < modals (2000) < command palette (3000) < sidebar (9001) < tile drag overlay (99999).
+
+## Topology Design Tokens (#749)
+
+Session-family visualization (born-from-parent placement, connector overlay, hierarchy-grouped collage) is a design gate on top of two rules, enforced via shared CSS tokens in `desktop.css` `:root` — the `/* === topology === */` anchor near the end of the file is where those three slices append their rules.
+
+1. **Lineage tint** — a family (a parent + all its descendants) shares one hue, never re-derived per surface. `--lineage-tint-1` through `--lineage-tint-6` are the SSOT palette (assign by `family-index % 6`); derive fills/borders/glows from the base var via `color-mix()` rather than hardcoding a family hex anywhere else. Red and amber are reserved for state (below) — never assign them as a lineage tint.
+2. **Failure-state parity** — every "alive" treatment (glow, pulse, flowing wire) ships an equally salient blocked/crashed/awaiting-input counterpart. `--topology-awaiting` (amber, aliases `--orb-awaiting`) and `--topology-stuck` (red, aliases `--neon-red`, covers blocked + crashed alike) are the shared vocabulary — a green pulse must never be the only signal while a child is stuck on a permission prompt.
+
+**Also:** any live-pane content peek (e.g. a collage tile showing a child's actual terminal output) must default off/blurred — surfacing it by default is a screen-share / credential-exposure risk the moment topology becomes something people demo. Peeks are opt-in reveals, never the resting state.
 
 ## Artifact Windows
 

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -44,6 +44,35 @@
        neon purple (#c06cf0). */
     --neon-red: #ff5449;
     --neon-purple: #c06cf0;
+
+    /* Lineage-tint family palette (#749) — SSOT for the topology slices
+       (born-from-parent placement, connector overlay, hierarchy-grouped
+       collage). A session family (a parent + all its descendants) is
+       assigned ONE hue by family index (index % 6) so lineage reads at a
+       glance without labels. Every surface derives fills/borders/glows
+       from these base vars via color-mix() rather than re-deriving its
+       own palette — do not hardcode a family hex anywhere else.
+       Red and amber are reserved for failure/awaiting state (below) and
+       must never be assigned as a lineage tint. */
+    --lineage-tint-1: #00ff66; /* green  */
+    --lineage-tint-2: #00bfff; /* blue   */
+    --lineage-tint-3: #c06cf0; /* purple */
+    --lineage-tint-4: #f472b6; /* pink   */
+    --lineage-tint-5: #fb923c; /* orange */
+    --lineage-tint-6: #22d3ee; /* cyan   */
+    --lineage-tint-count: 6;   /* keep in sync with the numbered set above */
+
+    /* Failure-state parity (#749) — every "alive" treatment (glow, pulse,
+       flowing wire) a topology surface ships MUST have an equally salient
+       counterpart here. These alias the existing orb vocabulary so wires,
+       placement badges, and collage borders never invent a second color
+       language for state: amber = awaiting-input, red = stuck (blocked or
+       crashed alike). A green pulse must never be the only signal — a
+       stuck/awaiting child needs to read as loud as an active one. */
+    --topology-awaiting: var(--orb-awaiting);
+    --topology-awaiting-glow: color-mix(in srgb, var(--orb-awaiting) 50%, transparent);
+    --topology-stuck: var(--neon-red);
+    --topology-stuck-glow: color-mix(in srgb, var(--neon-red) 50%, transparent);
 }
 
 * {
@@ -6249,3 +6278,18 @@ body.sidebar-pinned .sidebar-tab {
     font-size: 9px; font-weight: 700; letter-spacing: 0.1em; padding: 2px 6px; border-radius: 4px;
     background: rgba(255,255,255,0.06); color: var(--text-muted); border: 1px solid var(--chrome-border);
 }
+
+/* === topology ===
+   Session-family visualization (#749 slate: placement, connector overlay,
+   hierarchy-grouped collage). Every rule appended here must:
+   1. Pull its family color from --lineage-tint-1..6 (never a hardcoded hex)
+      so a parent and its descendants read as one hue family everywhere.
+   2. Pair any "alive" treatment (glow/pulse/flowing wire) with an equally
+      salient counterpart using --topology-awaiting / --topology-stuck —
+      a stuck or awaiting-input child must never look "fine".
+   3. Default any live-pane content peek OFF or blurred — surfacing a
+      child's live terminal by default is a screen-share / credential
+      exposure risk (council flag, issue #749). Peeks are opt-in reveals,
+      never the resting state.
+   Slices append their own subsections below as they ship; this anchor
+   intentionally has no rules yet. */


### PR DESCRIPTION
## Summary
- Foundation-only design gate for #749 (`visual-topology` council slate) — tokens + docs, no behavior change.
- Adds a `--lineage-tint-1..6` hue-family palette in `desktop.css` `:root` as the SSOT for lineage color, so a session family (parent + descendants) shares one hue across the placement/connector/collage slices instead of each surface re-deriving its own.
- Adds `--topology-awaiting` / `--topology-stuck` aliasing the existing orb vocabulary (`--orb-awaiting`, `--neon-red`) so blocked/crashed/awaiting-input states have a shared, equally-salient counterpart to "alive" glow/pulse/wire treatments.
- Adds a `/* === topology === */` section anchor at the end of `desktop.css` where the placement, connector-overlay, and hierarchy-grouped collage slices will append their rules.
- Documents both rules (lineage tint, failure-state parity) plus the live-pane-peek-defaults-off council flag in the `agentwire-desktop-ui` skill.

## Test plan
- [x] Brace-balance check on `desktop.css` (1092 open / 1092 close)
- [x] Served `desktop.css` over HTTP from the worktree source (`uv run python -m agentwire portal serve --port 8977`) and confirmed the new tokens/anchor are present
- [x] Loaded the portal in Chrome — page renders clean (auth modal, dark theme, sidebar), no new console errors attributable to CSS
- [ ] Downstream slices (placement/connector/collage) to consume these tokens and exercise them visually

Closes #749