### PR TITLE
Portal: push session_created event with name/parent/role (#747)

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -740,6 +740,54 @@ def _record_session_creator(session_name: str, created_by: str | None, via: str)
     store_session_metadata(session_name, metadata)
 
 
+def _record_session_role(session_name: str, role: str | None) -> None:
+    """Record the session's ROLE axis (orchestrator/worker) to disk (merge-preserving).
+
+    Distinct from the etiquette/persona ``roles:`` list in ``.agentwire.yml`` —
+    this is the fundamental authority axis derived at creation time (``kind``
+    in cmd_new, ``effective_kind`` in cmd_worktree, "worker" for cmd_spawn).
+    Read back by list_local_sessions() and the session_created notify lookup.
+    """
+    if not role:
+        return
+    metadata = load_session_metadata(session_name)
+    metadata["role"] = role
+    store_session_metadata(session_name, metadata)
+
+
+def notify_portal_session_created(session_name: str, parent: str | None, role: str | None) -> None:
+    """Tell the portal a session was just created, with topology context (#747).
+
+    Fires immediately from the creating process instead of relying solely on
+    the global tmux ``session-created`` hook, which only knows the bare
+    session name (no parent/role) and can race a slow first-message delivery
+    before metadata is written. Fire-and-forget — failures are silently
+    ignored since the portal may not be running.
+    """
+    import ssl
+
+    payload: dict = {"event": "session_created", "session": session_name}
+    if parent:
+        payload["parent"] = parent
+    if role:
+        payload["role"] = role
+
+    try:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        req = urllib.request.Request(
+            f"{_default_portal_url()}/api/notify",
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json", **_portal_auth_headers()},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=3, context=ctx)
+    except Exception:
+        pass
+
+
 def _display_parent(session_name: str, path: str = "") -> "str | None":
     """The session that should visually own this one in the sidebar.
 

--- a/agentwire/pane_cli.py
+++ b/agentwire/pane_cli.py
@@ -37,6 +37,7 @@ from .core import (
     build_agent_command,
     inject_session_env,
     load_config,
+    load_session_metadata,
     parse_env_args,
     tmux_session_exists,
 )
@@ -172,6 +173,7 @@ def list_local_sessions(show_context: bool = False) -> list[dict]:
             "posture": cfg.get("posture"),
             "roles": cfg.get("roles", []),
             "parent": _display_parent(parts[0], path),
+            "role": load_session_metadata(parts[0]).get("role"),
         }
         if usage_limit_parked(parts[0]):
             session_info["usage_limit"] = True

--- a/agentwire/routes/notify.py
+++ b/agentwire/routes/notify.py
@@ -66,9 +66,20 @@ class NotifyRoutesMixin:
                 await self.broadcast_dashboard("sessions_update", {"sessions": sessions_data})
 
             elif event == "session_created":
+                # #747: name/parent/role travel in the payload when the
+                # creating process (cmd_new et al.) posts this explicitly —
+                # that's authoritative, no race. The bare global tmux hook
+                # (session-created, any tmux session) carries only the name,
+                # so fall back to a fresh lookup for that case (metadata may
+                # not be written yet on a very fast reattach — best-effort).
                 self._invalidate_session_caches()
-                await self.broadcast_dashboard("session_created", {"session": session})
                 sessions_data = await self._get_sessions_data()
+                entry = next((s for s in sessions_data if s.get("name") == session), None)
+                parent = data.get("parent") or (entry.get("parent") if entry else None)
+                role = data.get("role") or (entry.get("role") if entry else None)
+                await self.broadcast_dashboard("session_created", {
+                    "session": session, "name": session, "parent": parent, "role": role,
+                })
                 await self.broadcast_dashboard("sessions_update", {"sessions": sessions_data})
 
             elif event == "pane_died":

--- a/agentwire/routes/sessions_admin.py
+++ b/agentwire/routes/sessions_admin.py
@@ -183,10 +183,10 @@ class SessionsAdminRoutesMixin:
                 yaml_config["voice"] = voice
                 await self._write_agentwire_yaml(session_path, yaml_config, machine_id)
 
-            # Broadcast session created to dashboard clients
-            await self.broadcast_dashboard("session_created", {"session": session_name})
-            sessions_data = await self._get_sessions_data()
-            await self.broadcast_dashboard("sessions_update", {"sessions": sessions_data})
+            # No manual broadcast here (#747): the `agentwire new` subprocess
+            # just awaited above already posted the enriched session_created
+            # (name/parent/role) + sessions_update to this same portal from
+            # inside cmd_new, before returning.
 
             # Wait until the tmux pane has actually rendered something. The CLI
             # returns the moment `tmux send-keys` *queues* the agent command, so

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -29,12 +29,14 @@ from .core import (
     _output_json,
     _output_result,
     _record_session_creator,
+    _record_session_role,
     _resolve_posture_from_args,
     _resolve_posture_or_config,
     _run_remote,
     _set_session_name_env,
     build_agent_command,
     load_config,
+    notify_portal_session_created,
     parse_env_args,
     resolve_default_created_by,
     tmux_session_exists,
@@ -504,6 +506,14 @@ def cmd_new(args) -> int:
     # into place, and start the agent (skipped when bare).
     _launch_tmux_session(session_name, session_path, agent.env, agent_cmd)
 
+    # Record creator/role and push the enriched session_created event (#747)
+    # as early as possible — before the potentially slow first-message wait
+    # below — so the portal broadcast carries real parent/role instead of
+    # racing the metadata write against the async global tmux hook.
+    _record_session_creator(session_name, created_by, via="new")
+    _record_session_role(session_name, kind)
+    notify_portal_session_created(session_name, created_by, kind)
+
     # Update project config (.agentwire.yml) - only if --persist is given.
     # Persist USER roles (--roles) only — the intrinsic etiquette and soul are
     # derived/auto-appended each run, never written into project config.
@@ -566,8 +576,6 @@ def cmd_new(args) -> int:
                         "and could not be queued — paste it manually",
                         file=sys.stderr,
                     )
-
-    _record_session_creator(session_name, created_by, via="new")
 
     if json_mode:
         result = {

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -220,7 +220,12 @@ class DesktopManager {
                 break;
 
             case 'session_created':
-                this.emit('session_created', { session: msg.session });
+                this.emit('session_created', {
+                    session: msg.session,
+                    name: msg.name,
+                    parent: msg.parent,
+                    role: msg.role,
+                });
                 break;
 
             case 'session_closed':

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -294,11 +294,39 @@ function handleSessionClosed({ session }) {
 }
 
 /**
- * Handle session_created event from tmux hook.
- * Sessions list will be updated automatically via sessions_update.
+ * Handle session_created event (#747) — pushed the instant a session is
+ * created (agentwire new / worktree / portal), instead of waiting for the
+ * sessions_update broadcast that follows moments later.
  */
-function handleSessionCreated({ session }) {
-    // Sessions list will be updated by the sessions_update event
+function handleSessionCreated({ session, name, parent, role }) {
+    const sessionName = name || session;
+    if (!sessionName) return;
+
+    // Merge into the live list right away so the sidebar shows the birth
+    // without poll lag. Dedupe by session id (name): the sessions_update
+    // that follows always wins with the authoritative record (full-array
+    // replace), so this placeholder just needs to not double up before then.
+    const sessions = desktop.sessions || [];
+    if (!sessions.some((s) => s.name === sessionName)) {
+        desktop.sessions = [...sessions, {
+            name: sessionName,
+            parent: parent || null,
+            roles: role ? [role] : [],
+            windows: 1,
+            path: '',
+            machine: null,
+        }];
+        desktop.emit('sessions', desktop.sessions);
+    }
+
+    // If the parent's window is already open, reveal the child beside it
+    // immediately — openSessionTerminal dedupes by session id internally
+    // (sessionWindows.has(id)), so this is a no-op if a window for this
+    // session is already open or gets opened again once sessions_update
+    // (or a later poll) reports the same session.
+    if (parent && sessionWindows.has(buildSessionId(parent, null))) {
+        openSessionTerminal(sessionName, 'monitor');
+    }
 }
 
 /**

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -240,6 +240,74 @@ def test_record_session_creator_persists_creator(tmp_path, monkeypatch):
     assert core._display_parent("clone-repo-fix-bug") == "orchestrator"
 
 
+def test_record_session_role_persists_and_merges_with_creator(tmp_path, monkeypatch):
+    """#747 — role (orchestrator/worker) is a separate merge-preserving field
+    alongside created_by, so the session_created broadcast can carry both."""
+    from agentwire import core
+
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path / "agentwire")
+
+    core._record_session_creator("clone-repo-fix-bug", "orchestrator", via="worktree")
+    core._record_session_role("clone-repo-fix-bug", "worker")
+
+    metadata = core.load_session_metadata("clone-repo-fix-bug")
+    assert metadata["created_by"] == "orchestrator"
+    assert metadata["role"] == "worker"
+
+    # A falsy role is a no-op — never clobbers an already-recorded role.
+    core._record_session_role("clone-repo-fix-bug", None)
+    assert core.load_session_metadata("clone-repo-fix-bug")["role"] == "worker"
+
+
+def test_notify_portal_session_created_posts_enriched_payload(monkeypatch):
+    """#747 — the creating process posts name/parent/role to /api/notify
+    directly, rather than relying solely on the racy global tmux hook."""
+    import json as _json
+    import urllib.request
+
+    from agentwire import core
+
+    seen = {}
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None, context=None):
+        seen["url"] = req.full_url
+        seen["payload"] = _json.loads(req.data.decode())
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    core.notify_portal_session_created("clone-repo-fix-bug", "orchestrator", "worker")
+
+    assert seen["url"].endswith("/api/notify")
+    assert seen["payload"] == {
+        "event": "session_created",
+        "session": "clone-repo-fix-bug",
+        "parent": "orchestrator",
+        "role": "worker",
+    }
+
+
+def test_notify_portal_session_created_swallows_failures(monkeypatch):
+    """Fire-and-forget: the portal may not be running — never raise."""
+    import urllib.request
+
+    from agentwire import core
+
+    def fail(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fail)
+
+    core.notify_portal_session_created("proj", None, None)  # must not raise
+
+
 def test_base_flag_overrides(tmp_path, monkeypatch, wt_env):
     _, clone = _origin_and_clone(tmp_path, default_branch="develop")
     # Add a second branch on origin to base off of.

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -284,6 +284,8 @@ class TestCmdNewSeedFallback:
             lambda *a, **k: SimpleNamespace(command="claude", env={}))
         monkeypatch.setattr(m, "_launch_tmux_session", lambda *a, **k: None)
         monkeypatch.setattr(m, "_record_session_creator", lambda *a, **k: None)
+        monkeypatch.setattr(m, "_record_session_role", lambda *a, **k: None)
+        monkeypatch.setattr(m, "notify_portal_session_created", lambda *a, **k: None)
         monkeypatch.setattr(m, "_notify_portal_sessions_changed", lambda: None)
 
         calls = {}
@@ -440,6 +442,8 @@ class TestCmdNewDefaultCreatedByRooting:
             lambda *a, **k: SimpleNamespace(command="claude", env={}))
         monkeypatch.setattr(m, "_launch_tmux_session", lambda *a, **k: None)
         monkeypatch.setattr(m, "_notify_portal_sessions_changed", lambda: None)
+        monkeypatch.setattr(m, "_record_session_role", lambda *a, **k: None)
+        monkeypatch.setattr(m, "notify_portal_session_created", lambda *a, **k: None)
         monkeypatch.setattr(m.pane_manager, "get_current_session", lambda: None)
         monkeypatch.setattr(core, "_live_session_cwd", lambda s: caller_project_path)
 

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -550,6 +550,57 @@ class TestApiNotify:
         resp = await client.post("/api/notify", json={"session": "test"})
         assert resp.status == 400
 
+    async def test_session_created_broadcasts_explicit_parent_and_role(self, portal_client):
+        """#747 — when the creating process (cmd_new) posts parent/role
+        explicitly, those values are authoritative and travel straight
+        through to the broadcast, no lookup needed."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        server._get_sessions_data = AsyncMock(return_value=[])
+        resp = await client.post("/api/notify", json={
+            "event": "session_created", "session": "fix-auth-812",
+            "parent": "orchestrator", "role": "worker",
+        })
+        assert resp.status == 200
+        server.broadcast_dashboard.assert_any_call("session_created", {
+            "session": "fix-auth-812", "name": "fix-auth-812",
+            "parent": "orchestrator", "role": "worker",
+        })
+
+    async def test_session_created_falls_back_to_sessions_data_lookup(self, portal_client):
+        """A bare tmux-hook-triggered session_created (no parent/role in the
+        payload) falls back to looking the session up in the fresh sessions
+        list — the same data the immediately-following sessions_update
+        carries, so both events describe the session identically."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        server._get_sessions_data = AsyncMock(return_value=[
+            {"name": "fix-auth-812", "parent": "orchestrator", "role": "worker"},
+        ])
+        resp = await client.post("/api/notify", json={
+            "event": "session_created", "session": "fix-auth-812",
+        })
+        assert resp.status == 200
+        server.broadcast_dashboard.assert_any_call("session_created", {
+            "session": "fix-auth-812", "name": "fix-auth-812",
+            "parent": "orchestrator", "role": "worker",
+        })
+
+    async def test_session_created_unknown_session_has_null_parent_and_role(self, portal_client):
+        """A manually-created (non-agentwire) tmux session degrades to
+        null/null rather than erroring — it genuinely has no topology."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        server._get_sessions_data = AsyncMock(return_value=[])
+        resp = await client.post("/api/notify", json={
+            "event": "session_created", "session": "some-manual-tmux-session",
+        })
+        assert resp.status == 200
+        server.broadcast_dashboard.assert_any_call("session_created", {
+            "session": "some-manual-tmux-session", "name": "some-manual-tmux-session",
+            "parent": None, "role": None,
+        })
+
     async def test_generic_event_reports_client_count(self, portal_client):
         """#444: a broadcast reports how many dashboards received it, so the
         caller knows whether anything actually saw the ephemeral event."""


### PR DESCRIPTION
## Summary
- `agentwire new` / `agentwire worktree` (funnels through `cmd_new`) now post an enriched `session_created` websocket event — `{name, parent, role}` — the instant the tmux session exists, instead of relying solely on the async global tmux hook (which only knows the bare session name and can race a slow first-message delivery before parent/role metadata is written).
- `routes/notify.py`'s `session_created` handler broadcasts the payload's `parent`/`role` when the creating process supplied them (authoritative, no race); falls back to a fresh `sessions_data` lookup for the bare tmux-hook case (e.g. a manually-created, non-agentwire tmux session).
- `api_create_session` (portal-initiated creation) no longer manually broadcasts — the `agentwire new` subprocess it awaits already posts the enriched event from inside `cmd_new` before returning, so the old broadcast was redundant.
- Client: `handleSessionCreated` in `desktop.js` merges the new session into `desktop.sessions` immediately (deduped by name) so the sidebar reflects it without waiting for the `sessions_update` broadcast/poll that follows, and reveals a child window beside an already-open parent window via the existing `openSessionTerminal` dedupe (`sessionWindows.has(id)`).

## Scoping note
`agentwire spawn` creates a **pane** inside an existing tmux session, not a new session — CLAUDE.md's own topology model treats worker panes as inheriting their parent's dashboard/window, and the sessions list (`list_local_sessions`) enumerates tmux sessions, not panes. Forcing `session_created` semantics onto pane spawns would misrepresent the data model; panes already get their own `pane_created` event automatically via the pre-existing `after-split-window` global tmux hook. Also out of scope: the "born from parent" adjacent-placement + birth animation (tracked separately in #745) — this PR only reveals the child using the existing default window placement when its parent is already open.

## Test plan
- [x] Full unit + integration suite: `uv run pytest` — 2719 passed (2713 baseline + 6 new tests covering `_record_session_role`, `notify_portal_session_created`'s payload/failure handling, and the enriched/fallback/unknown-session branches of the `session_created` notify handler)
- [x] `ruff check` clean on all touched files
- [x] Manual E2E verification: a real `agentwire new`-driven tmux session creation (via `cmd_new`, off-thread) against a real in-process portal (`aiohttp` `TestServer`, ephemeral port) — confirmed a connected websocket client receives `session_created` with the correct `name`/`parent`/`role` before the subsequent `sessions_update`
- [ ] Live browser verification — not run. I'm barred from `agentwire portal start`/`restart` in this worktree (live-service safety rail), so the client-side reaction (`handleSessionCreated`) was verified by code review + `node --check` syntax check + reuse of already-tested dedupe primitives (`sessionWindows.has`, `openSessionTerminal`), not exercised in a live DOM.

Closes #747

Built by dotdev.dev