### PR TITLE
feat(portal): hierarchy-group the collage by session family (#748)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6293,3 +6293,84 @@ body.sidebar-pinned .sidebar-tab {
       never the resting state.
    Slices append their own subsections below as they ship; this anchor
    intentionally has no rules yet. */
+
+/* Collage hierarchy grouping (#748) — collage.js groups tiles into one grid
+   cell per session family (a parent + its descendants) instead of one per
+   window. A singleton family (no children open) renders as a plain tile
+   with a faint tint hint; a family with children renders as a cluster: the
+   parent tile on top, children nested in a wrapping row below it. Family
+   hue comes from --family-tint, set inline per family by collage.js as an
+   alias of --lineage-tint-1..6 (rule 1 above). overflow:hidden here is load
+   -bearing: it's what keeps a family with many children from ever pushing
+   the grid past the desktop edge — such a family scrolls vertically inside
+   its own cell instead of overflowing horizontally. */
+.collage-family {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    gap: 6px;
+    padding: 6px;
+    border-radius: 10px;
+    border: 1px solid color-mix(in srgb, var(--family-tint) 45%, var(--chrome-border));
+    background: color-mix(in srgb, var(--family-tint) 6%, transparent);
+    overflow: hidden;
+}
+
+.collage-family.is-singleton {
+    padding: 0;
+    border-color: color-mix(in srgb, var(--family-tint) 30%, var(--chrome-border));
+    background: transparent;
+}
+
+.collage-family-parent {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+}
+
+.collage-family-parent .collage-card {
+    flex: 1;
+}
+
+/* Reserve ~42% of the cluster for children so the parent tile — the
+   primary preview — never gets crowded out. A definite flex-basis (not
+   max-height) is load-bearing: with flex:0 0 auto the row would hug its
+   (initially empty-looking) content and collapse to header height only,
+   since each child card's own body has min-height:0. align-content:stretch
+   then splits that 42% evenly across wrapped lines so each child card
+   actually gets a real body, not just its header. Scrolls vertically past
+   that, never horizontally (overflow-x: hidden). */
+.collage-family-children {
+    flex: 0 0 42%;
+    min-height: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: stretch;
+    gap: 4px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.collage-card.is-child {
+    flex: 1 1 96px;
+    min-width: 72px;
+}
+
+.collage-card.is-child .collage-card-header {
+    height: 22px;
+}
+
+.collage-card.is-child .collage-card-label {
+    font-size: calc(var(--collage-label-size, 22px) * 0.62);
+    padding: 0.22em 0.7em;
+}
+
+.collage-family .collage-card {
+    border-color: color-mix(in srgb, var(--family-tint) 55%, var(--chrome-border));
+}
+
+.collage-family .collage-card.is-active {
+    border-color: var(--accent);
+}

--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -39,6 +39,7 @@ import { wsProtocols } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { ansiToHtml } from './utils/ansi.js';
 import { isCommandPaletteOpen } from './command-palette.js';
+import { getAllSessions, ensureSessionsLoaded } from './sidebar/sessions-section.js';
 
 /** Overlay z-index: above all windows (WinBox's focus counter sets inline
  * z-indexes that grow from 10), below notification toasts (1500), modals
@@ -65,6 +66,13 @@ class Collage {
 
         /** @type {function(string): (object|null)} id → window instance lookup */
         this._lookup = () => null;
+
+        // Family grouping (#748) needs session/parent data that only loads
+        // once ensureSessionsLoaded() has resolved at least once (see there
+        // for why getAllSessions() alone isn't reliable at cold start). Once
+        // true, every subsequent build already has fresh data — no need to
+        // re-trigger the one-time post-load rebuild in enter() again.
+        this._sessionsReady = false;
 
         this._onKeydown = this._onKeydown.bind(this);
     }
@@ -127,6 +135,17 @@ class Collage {
             // Grid geometry depends on the desktop area size.
             desktop.on('viewport_resize', () => this._rebuild()),
         );
+
+        // First-ever open this page load: session/parent data may not have
+        // loaded yet (see ensureSessionsLoaded), so the grid above may have
+        // fallen back to ungrouped singletons. Rebuild once real data lands.
+        // A no-op on every later open, since _sessionsReady is already true.
+        if (!this._sessionsReady) {
+            ensureSessionsLoaded().then(() => {
+                this._sessionsReady = true;
+                if (this._active) this._rebuild();
+            });
+        }
     }
 
     /**
@@ -196,14 +215,21 @@ class Collage {
     }
 
     /**
-     * Build the preview grid for the given window ids.
+     * Build the preview grid for the given window ids. Grid cells are
+     * families (a session + its descendants), not raw windows — a family of
+     * one renders as a plain tile, a family with children renders as a
+     * tinted cluster with the parent on top and children nested below it
+     * (#748). This keeps the aspect-fit cols×rows math (proven not to
+     * overflow at 15+ tiles) exactly as it was, just computed over family
+     * count instead of window count.
      * @param {string[]} ids
      */
     _buildGrid(ids) {
         const area = document.getElementById('desktopArea');
         if (!area) return;
         const areaRect = area.getBoundingClientRect();
-        const n = ids.length;
+        const families = this._groupFamilies(ids);
+        const n = families.length;
 
         // Fit cols×rows to the desktop aspect so cells stay window-shaped.
         const aspect = areaRect.width / Math.max(1, areaRect.height);
@@ -226,9 +252,9 @@ class Collage {
         );
 
         const activeId = desktop.getActiveWindow();
-        for (const id of ids) {
-            this._grid.appendChild(this._buildTile(id, id === activeId, areaRect));
-        }
+        families.forEach((familyIds, familyIndex) => {
+            this._grid.appendChild(this._buildFamily(familyIds, familyIndex, activeId, areaRect));
+        });
         this._overlay.appendChild(this._grid);
 
         // Scale each miniature into its tile body. Overlay elements have no
@@ -242,6 +268,99 @@ class Collage {
             );
             mini.style.transform = `translate(-50%, -50%) scale(${scale})`;
         }
+    }
+
+    /**
+     * Resolve a session's family root and its depth below that root, by
+     * walking `.parent` (the same display linkage the sidebar's session
+     * tree uses — see sessions-section.js `buildSessionTree`). A parent
+     * that's absent, self-referential, or not in the current session list
+     * makes `name` its own root. `seen` guards against a parent cycle.
+     * @param {Map<string, object>} byName - session name → session record
+     * @param {string} name
+     * @returns {{root: string, depth: number}}
+     */
+    _lineageOf(byName, name) {
+        let cur = name;
+        let depth = 0;
+        const seen = new Set([name]);
+        while (true) {
+            const parent = byName.get(cur)?.parent;
+            if (!parent || parent === cur || !byName.has(parent) || seen.has(parent)) break;
+            seen.add(parent);
+            cur = parent;
+            depth++;
+        }
+        return { root: cur, depth };
+    }
+
+    /**
+     * Group open window ids into families keyed by session-tree root.
+     * Non-session windows (artifacts/panels) have no lineage and each form
+     * their own singleton family. Within a family, ids are ordered
+     * ancestor-first so nested descendants render under their parent even
+     * across multiple generations.
+     * @param {string[]} ids
+     * @returns {string[][]} One array of window ids per family.
+     */
+    _groupFamilies(ids) {
+        const byName = new Map(getAllSessions().map((s) => [s.name || '', s]));
+        const families = new Map();  // root key → [{id, depth}]
+        for (const id of ids) {
+            const inst = this._lookup(id);
+            const isSession = inst && typeof inst.session === 'string';
+            const { root, depth } = isSession
+                ? this._lineageOf(byName, inst.session)
+                : { root: id, depth: 0 };
+            if (!families.has(root)) families.set(root, []);
+            families.get(root).push({ id, depth });
+        }
+        return [...families.values()].map((entries) =>
+            entries.sort((a, b) => a.depth - b.depth).map((e) => e.id),
+        );
+    }
+
+    /**
+     * Build one grid cell for a family: a lone tile for a singleton family,
+     * or a tinted cluster (parent on top, children nested below in a
+     * wrapping row) for a family with descendants. Family hue cycles
+     * through the shared --lineage-tint-1..6 tokens by family index so
+     * lineage reads without labels (#748/#749). `overflow: hidden` on the
+     * cluster (CSS) is what keeps a family with many children from ever
+     * pushing the grid into horizontal overflow — it scrolls vertically
+     * instead.
+     * @param {string[]} familyIds - Ancestor-first window ids for this family.
+     * @param {number} familyIndex - Position among this grid's families.
+     * @param {string|null} activeId - Currently-active window id.
+     * @param {DOMRect} areaRect
+     */
+    _buildFamily(familyIds, familyIndex, activeId, areaRect) {
+        const wrap = document.createElement('div');
+        wrap.className = 'collage-family';
+        wrap.style.setProperty('--family-tint', `var(--lineage-tint-${(familyIndex % 6) + 1})`);
+
+        if (familyIds.length === 1) {
+            wrap.classList.add('is-singleton');
+            wrap.appendChild(this._buildTile(familyIds[0], familyIds[0] === activeId, areaRect));
+            return wrap;
+        }
+
+        const [parentId, ...childIds] = familyIds;
+        const parentWrap = document.createElement('div');
+        parentWrap.className = 'collage-family-parent';
+        parentWrap.appendChild(this._buildTile(parentId, parentId === activeId, areaRect));
+        wrap.appendChild(parentWrap);
+
+        const childrenWrap = document.createElement('div');
+        childrenWrap.className = 'collage-family-children';
+        for (const id of childIds) {
+            const tile = this._buildTile(id, id === activeId, areaRect);
+            tile.classList.add('is-child');
+            childrenWrap.appendChild(tile);
+        }
+        wrap.appendChild(childrenWrap);
+
+        return wrap;
     }
 
     /**

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -30,6 +30,21 @@ const collapsedParents = new Set();
 export function getAllSessions() { return allSessions; }
 export function onSessionsChanged(fn) { listeners.add(fn); }
 
+// getAllSessions() is only backed by a live fetch once something has called
+// initData()+fetchSessions() — normally sessionsSection.mount(), which only
+// runs once the sidebar's Sessions accordion is expanded. A consumer that
+// needs session data (parent linkage, etc.) without depending on that UI
+// state — e.g. the collage's family grouping, #748 — calls this instead.
+// Memoized: the first call fetches once and wires the live 'sessions' event
+// subscription (via initData); later calls reuse the same promise, so this
+// never becomes a second parallel poller.
+let sessionsLoadPromise = null;
+export function ensureSessionsLoaded() {
+    initData();
+    if (!sessionsLoadPromise) sessionsLoadPromise = fetchSessions();
+    return sessionsLoadPromise;
+}
+
 function notifyListeners() { for (const fn of listeners) fn(); }
 
 function renderCloseButton(name) {


### PR DESCRIPTION
## Summary
- Collage grid cells are now session families (parent + descendants) instead of raw windows — a family with children renders as one tinted cluster: parent tile on top, children nested in a wrapping row below it.
- Family hue cycles through `--lineage-tint-1..6` by family index, derived via `color-mix()` per the design tokens from #749. Singleton families (no open children) keep the outer aspect-fit grid math unchanged, just with a faint tint hint.
- `overflow: hidden` + vertical-only scroll on the children row guarantees a family with many children can never push the grid into horizontal overflow — verified at 20 open windows / 16 families with no `document.body` horizontal overflow.
- Click-to-focus still works on nested child tiles (verified: clicking a child tile exits the collage and focuses the real underlying window, no mutation of any real WinBox window).
- Fixes a cold-start race found during verification: family grouping needs session `.parent` data that previously only loaded once the sidebar's Sessions accordion was expanded, so opening the collage before ever touching the sidebar silently degraded to ungrouped tiles. Added `ensureSessionsLoaded()` (memoized, reuses the existing fetch/subscribe logic) so collage.js can trigger that load itself and rebuild once real data lands.

## Test plan
- [x] Verified in a worktree-local dev portal (`uv run python -m agentwire portal serve --port 8799`) via Chrome: opened F3 with a real family (`agentwire` + 4 worktree children) plus 3 singleton sessions — cluster nests correctly, tints distinct per family, labels/previews legible.
- [x] Verified cold-start path (fresh page load, F3 before ever opening the sidebar) now grouping still resolves correctly after the one-time rebuild.
- [x] Stress-tested 20 open windows (16 families) — grid wraps cleanly, `document.body.scrollWidth === document.body.clientWidth` (no horizontal overflow).
- [x] Verified click-to-focus on a nested child tile focuses the real window without moving/resizing/minimizing it.

Closes #748

Built by [dotdev.dev](https://dotdev.dev)