### PR TITLE
feat(portal): parent↔child connector overlay — topology wires

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6374,3 +6374,66 @@ body.sidebar-pinned .sidebar-tab {
 .collage-family .collage-card.is-active {
     border-color: var(--accent);
 }
+
+/* --- connector overlay (#746) — topology-wires.js ---
+   SVG layer of thin wires from each parent session's title bar to each live
+   child's, appended into the same #desktopArea collage.js targets. Read-only:
+   the module only measures window rects, never moves/resizes a real WinBox. */
+.topology-wires-overlay {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+}
+.topology-wires-overlay.hidden { display: none; }
+
+.topology-wire {
+    fill: none;
+    stroke: var(--wire-tint, var(--lineage-tint-1));
+    stroke-width: 2px;
+    stroke-linecap: round;
+    opacity: 0.4;
+    filter: drop-shadow(0 0 3px color-mix(in srgb, var(--wire-tint, var(--lineage-tint-1)) 45%, transparent));
+}
+
+/* processing / generating / playing — a flowing dash reads as "working" */
+.topology-wire--flow {
+    opacity: 0.9;
+    stroke-dasharray: 7 7;
+    animation: topology-wire-flow 0.7s linear infinite;
+}
+
+/* Failure-state parity (#749): awaiting/stuck override the lineage tint
+   outright — amber/red must win over the family hue so a blocked child
+   never reads as "fine". Declared after .topology-wire so equal-specificity
+   cascade order (not !important) decides it. */
+.topology-wire--awaiting {
+    stroke: var(--topology-awaiting);
+    opacity: 0.95;
+    filter: drop-shadow(0 0 5px var(--topology-awaiting-glow));
+    animation: topology-wire-pulse 1.3s ease-in-out infinite;
+}
+.topology-wire--stuck {
+    stroke: var(--topology-stuck);
+    opacity: 1;
+    filter: drop-shadow(0 0 6px var(--topology-stuck-glow));
+    animation: topology-wire-pulse 0.7s ease-in-out infinite;
+}
+
+@keyframes topology-wire-flow {
+    to { stroke-dashoffset: -28; }
+}
+@keyframes topology-wire-pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .topology-wire--flow,
+    .topology-wire--awaiting,
+    .topology-wire--stuck {
+        animation: none;
+    }
+}

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -11,6 +11,7 @@ import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
+import { topologyWires } from './topology-wires.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { ReviewWindow } from './review-window.js';
@@ -101,6 +102,7 @@ async function init() {
     setupWindowCycling();
     setupWindowSwipeCycling();
     setupCollage();
+    setupTopologyWires();
     setupHelp();
 
     // Set up event listeners BEFORE fetching data
@@ -501,6 +503,23 @@ function setupCollage() {
         e.stopPropagation();
         if (e.repeat) return;  // ignore auto-repeat while the key is held
         collage.toggle();
+    }, true);
+}
+
+// Topology wires (#746) — Alt+L toggles the parent↔child connector overlay.
+// Detected via e.code, same capture-phase idiom as F3/Alt+`/Alt+bracket above,
+// so xterm's focused textarea never swallows it.
+function setupTopologyWires() {
+    topologyWires.init();
+
+    window.addEventListener('keydown', (e) => {
+        if (!e.altKey || e.metaKey || e.ctrlKey) return;
+        if (e.code !== 'KeyL') return;
+        if (isCommandPaletteOpen() || isHelpOpen()) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.repeat) return;
+        topologyWires.toggle();
     }, true);
 }
 

--- a/agentwire/static/js/sidebar/config-section.js
+++ b/agentwire/static/js/sidebar/config-section.js
@@ -8,6 +8,7 @@ import {
     getPermission, isMuted, setMuted, enableNotifications,
 } from '../notification-prefs.js';
 import { isAutoSend, setAutoSend, AUTOSEND_EVENT } from '../voice/autosend-prefs.js';
+import { topologyWires, TOPOLOGY_WIRES_EVENT } from '../topology-wires.js';
 
 function renderDisplayPrefs() {
     const current = getTerminalFontSize();
@@ -105,6 +106,38 @@ function bindAutoSendPref(body) {
     body._autoSendRepaint = repaint;
 }
 
+function renderTopologyWiresPref() {
+    const on = topologyWires.visible;
+    return `<div class="sidebar-display-prefs" data-topology-wires-block>
+        <div class="sidebar-display-row">
+            <label class="sidebar-config-key">Topology wires</label>
+            <label class="sidebar-notif-mute"><input type="checkbox" data-action="topology-wires"${on ? ' checked' : ''}/> ${on ? 'on' : 'off'}</label>
+        </div>
+        <div class="sidebar-display-row">
+            <span class="sidebar-display-hint">Parent↔child connector lines (Alt+L)</span>
+        </div>
+    </div>`;
+}
+
+function bindTopologyWiresPref(body) {
+    const repaint = () => {
+        const block = body.querySelector('[data-topology-wires-block]');
+        if (!block) return;
+        const tmp = document.createElement('div');
+        tmp.innerHTML = renderTopologyWiresPref();
+        block.replaceWith(tmp.firstElementChild);
+        wire();
+    };
+    function wire() {
+        body.querySelector('[data-action="topology-wires"]')?.addEventListener('change', (e) => {
+            topologyWires.setVisible(e.target.checked);
+        });
+    }
+    wire();
+    window.addEventListener(TOPOLOGY_WIRES_EVENT, repaint);
+    body._topologyWiresRepaint = repaint;
+}
+
 function bindDisplayPrefs(body) {
     const slider = body.querySelector('#termFontSize');
     const valueEl = body.querySelector('[data-display="size"]');
@@ -139,15 +172,17 @@ export const configSection = {
                 else if (typeof value === 'object') display = `<code>${JSON.stringify(value)}</code>`;
                 return `<div class="sidebar-config-item"><span class="sidebar-config-key">${key}</span><span class="sidebar-config-val">${display}</span></div>`;
             }).join('');
-            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + itemHtml;
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + renderTopologyWiresPref() + itemHtml;
             bindDisplayPrefs(body);
             bindNotificationPrefs(body);
             bindAutoSendPref(body);
+            bindTopologyWiresPref(body);
         } catch (e) {
-            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + '<div class="sidebar-empty">Failed to load config</div>';
+            body.innerHTML = renderDisplayPrefs() + renderNotificationPrefs() + renderAutoSendPref() + renderTopologyWiresPref() + '<div class="sidebar-empty">Failed to load config</div>';
             bindDisplayPrefs(body);
             bindNotificationPrefs(body);
             bindAutoSendPref(body);
+            bindTopologyWiresPref(body);
         }
     },
 };

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -231,10 +231,13 @@ async function handleCloseClick(session) {
     }
 }
 
-// Data fetching + WebSocket events (registered once by sessionsSection)
+// Data fetching + WebSocket events (registered once by sessionsSection, but
+// exported so other consumers of getAllSessions()/activityStates — e.g.
+// topology-wires.js — can guarantee the pipeline is live without depending on
+// the Sessions sidebar accordion ever being expanded).
 let dataInitialized = false;
 
-function initData() {
+export function initData() {
     if (dataInitialized) return;
     dataInitialized = true;
 

--- a/agentwire/static/js/topology-wires.js
+++ b/agentwire/static/js/topology-wires.js
@@ -9,16 +9,17 @@
  *
  * Parent/child pairing reuses sessions-section.js's `s.parent` linkage (the
  * same data the sidebar's nested tree renders from) rather than re-deriving
- * it — see initData()/getAllSessions()/activityStates there. Colors pull
- * from the lineage-tint + failure-state-parity tokens (#749) in desktop.css;
- * never a hardcoded hex.
+ * it — see ensureSessionsLoaded()/getAllSessions()/activityStates there
+ * (also used by collage.js's #748 family grouping). Colors pull from the
+ * lineage-tint + failure-state-parity tokens (#749) in desktop.css; never a
+ * hardcoded hex.
  *
  * @module topology-wires
  */
 
 import { desktop } from './desktop-manager.js';
 import { buildSessionId, normalizeMachine } from './session-id.js';
-import { getAllSessions, activityStates, onSessionsChanged, initData as ensureSessionsData } from './sidebar/sessions-section.js';
+import { getAllSessions, activityStates, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -136,8 +137,10 @@ class TopologyWires {
 
         // The shared session/activity pipeline (sessions-section.js) only goes
         // live once the Sessions sidebar accordion is expanded — ensure it's
-        // live regardless, so wires render on a fresh page load.
-        ensureSessionsData();
+        // live regardless, so wires render on a fresh page load. Same helper
+        // collage.js's #748 family grouping uses; memoized there so this
+        // isn't a second parallel fetch.
+        ensureSessionsLoaded();
 
         this._svg = document.createElementNS(SVG_NS, 'svg');
         this._svg.setAttribute('class', 'topology-wires-overlay' + (this._visible ? '' : ' hidden'));

--- a/agentwire/static/js/topology-wires.js
+++ b/agentwire/static/js/topology-wires.js
@@ -1,0 +1,261 @@
+/**
+ * Topology wires — read-only SVG connector overlay from each parent session's
+ * title bar to each live child's title bar (#746).
+ *
+ * Strictly read-only, same discipline as collage.js: it only *reads* window
+ * geometry via getBoundingClientRect to anchor wires, and never writes to a
+ * real WinBox window (no move/resize/minimize/restore). The overlay is a
+ * plain SVG layered into the same #desktopArea collage.js appends into.
+ *
+ * Parent/child pairing reuses sessions-section.js's `s.parent` linkage (the
+ * same data the sidebar's nested tree renders from) rather than re-deriving
+ * it — see initData()/getAllSessions()/activityStates there. Colors pull
+ * from the lineage-tint + failure-state-parity tokens (#749) in desktop.css;
+ * never a hardcoded hex.
+ *
+ * @module topology-wires
+ */
+
+import { desktop } from './desktop-manager.js';
+import { buildSessionId, normalizeMachine } from './session-id.js';
+import { getAllSessions, activityStates, onSessionsChanged, initData as ensureSessionsData } from './sidebar/sessions-section.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** Overlay z-index: above WinBox windows (inline z-indexes grow from 10),
+ * below the collage overlay (1400 — see collage.js) so entering collage
+ * always wins. */
+const WIRES_Z = 900;
+
+const VISIBLE_KEY = 'aw-topology-wires-visible';
+export const TOPOLOGY_WIRES_EVENT = 'topology-wires-change';
+
+/** Stable, order-independent family color: hash the family's root session
+ * name into one of the 6 lineage-tint slots (#749 SSOT palette). Avoids
+ * re-deriving a palette here — only picks which of the shared vars applies. */
+function tintIndexForRoot(root) {
+    let h = 0;
+    for (let i = 0; i < root.length; i++) h = (h * 31 + root.charCodeAt(i)) >>> 0;
+    return (h % 6) + 1;
+}
+
+/** Walk `s.parent` up to the family root, guarding against cycles the same
+ * way sessions-section.js's buildSessionTree does. */
+function familyRootName(name, byName) {
+    const guard = new Set();
+    let cur = name;
+    for (;;) {
+        const rec = byName.get(cur);
+        const parent = rec && rec.parent;
+        if (!parent || parent === cur || !byName.has(parent) || guard.has(parent)) return cur;
+        guard.add(parent);
+        cur = parent;
+    }
+}
+
+/** 'idle' | 'flow' (processing/generating/playing) | 'awaiting' | 'stuck'.
+ * `state`/`state_kind` (needs_input/off) only land on the session record
+ * right after an /api/sessions/local fetch — not on every periodic
+ * sessions_update push — so treat them as a best-effort overlay on top of
+ * the always-live activityStates map (same source the sidebar dot uses). */
+function wireStateFor(name, record) {
+    if (record?.state === 'needs_input') return 'awaiting';
+    if (record?.state === 'off') return 'stuck';
+    const activity = activityStates.get(name) || record?.activity || 'idle';
+    if (activity === 'processing' || activity === 'generating' || activity === 'playing' || activity === 'active') {
+        return 'flow';
+    }
+    return 'idle';
+}
+
+/**
+ * A minimized WinBox is `display: none` (this app hides WinBox's own min-bar
+ * stack in favor of the sidebar's taskbar list — desktop.css `.winbox.min`),
+ * which collapses getBoundingClientRect to an all-zero rect rather than some
+ * corner position. Treat that as "no anchor" so the pair's wire is dropped
+ * instead of hanging from the desktop's top-left corner; it reappears the
+ * next tick after restore, which is what "redraw on minimize/restore" means
+ * for a window that currently has nowhere sensible to point to.
+ */
+function headerRect(winbox) {
+    const el = winbox && winbox.window;
+    if (!el || winbox.min) return null;
+    const header = el.querySelector('.wb-header') || el;
+    const rect = header.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return null;
+    return rect;
+}
+
+/** Vertical S-curve hanging from each header's bottom edge — reads sensibly
+ * whether the two windows are tiled side by side or stacked. */
+function bezierPath(x1, y1, x2, y2) {
+    const bend = Math.max(Math.abs(x2 - x1), Math.abs(y2 - y1), 20) * 0.4;
+    return `M ${x1} ${y1} C ${x1} ${y1 + bend}, ${x2} ${y2 + bend}, ${x2} ${y2}`;
+}
+
+class TopologyWires {
+    constructor() {
+        /** @type {SVGSVGElement|null} */
+        this._svg = null;
+        /** @type {Map<string, {path: SVGPathElement, stateClass: string|null, tintIdx: number|null}>} */
+        this._paths = new Map();
+        /** @type {number|null} */
+        this._raf = null;
+        /** @type {boolean} */
+        this._hasPairs = false;
+        this._visible = localStorage.getItem(VISIBLE_KEY) !== '0';
+
+        this._tick = this._tick.bind(this);
+    }
+
+    get visible() {
+        return this._visible;
+    }
+
+    /** Toggle. Alt+L in desktop.js, and the Config sidebar checkbox, both call this. */
+    toggle() {
+        this.setVisible(!this._visible);
+    }
+
+    setVisible(v) {
+        this._visible = v;
+        if (v) localStorage.removeItem(VISIBLE_KEY);
+        else localStorage.setItem(VISIBLE_KEY, '0');
+        this._svg?.classList.toggle('hidden', !v);
+        window.dispatchEvent(new CustomEvent(TOPOLOGY_WIRES_EVENT));
+        if (v) this._wake();
+    }
+
+    /**
+     * Create the overlay SVG inside #desktopArea and start listening for
+     * anything that could move a title bar. Call once from desktop.js init.
+     */
+    init() {
+        const area = document.getElementById('desktopArea');
+        if (!area) return;
+
+        // The shared session/activity pipeline (sessions-section.js) only goes
+        // live once the Sessions sidebar accordion is expanded — ensure it's
+        // live regardless, so wires render on a fresh page load.
+        ensureSessionsData();
+
+        this._svg = document.createElementNS(SVG_NS, 'svg');
+        this._svg.setAttribute('class', 'topology-wires-overlay' + (this._visible ? '' : ' hidden'));
+        this._svg.style.zIndex = String(WIRES_Z);
+        area.appendChild(this._svg);
+
+        const wake = () => this._wake();
+        onSessionsChanged(wake);
+        desktop.on('window_registered', wake);
+        desktop.on('window_unregistered', wake);
+        desktop.on('window_minimized', wake);
+        desktop.on('window_restored', wake);
+        desktop.on('window_tiled', wake);
+        desktop.on('viewport_resize', wake);
+        desktop.on('session_activity', wake);
+        desktop.on('tts_start', wake);
+        desktop.on('audio', wake);
+        desktop.on('audio_ended', wake);
+
+        this._wake();
+    }
+
+    /** Kick the redraw loop if it isn't already running. Self-stops once
+     * there's nothing to draw, so it doesn't spin forever in the common
+     * single-session case. */
+    _wake() {
+        if (!this._visible || this._raf !== null) return;
+        this._raf = requestAnimationFrame(this._tick);
+    }
+
+    _tick() {
+        this._raf = null;
+        this._redraw();
+        if (this._visible && this._hasPairs) {
+            this._raf = requestAnimationFrame(this._tick);
+        }
+    }
+
+    _computePairs() {
+        const sessions = getAllSessions();
+        const byName = new Map(sessions.map((s) => [s.name || '', s]));
+        const pairs = [];
+        for (const s of sessions) {
+            const name = s.name || '';
+            const parentName = s.parent;
+            if (!name || !parentName || parentName === name || !byName.has(parentName)) continue;
+            const parentRec = byName.get(parentName);
+            const childId = buildSessionId(name, normalizeMachine(s.machine));
+            const parentId = buildSessionId(parentName, normalizeMachine(parentRec.machine));
+            const parentWin = desktop.getWindow(parentId);
+            const childWin = desktop.getWindow(childId);
+            if (!parentWin || !childWin) continue; // only wire up live (open) windows on both ends
+
+            pairs.push({
+                key: `${parentId}=>${childId}`,
+                parentWin,
+                childWin,
+                tintIdx: tintIndexForRoot(familyRootName(name, byName)),
+                state: wireStateFor(name, s),
+            });
+        }
+        return pairs;
+    }
+
+    _redraw() {
+        const area = document.getElementById('desktopArea');
+        if (!area || !this._svg) return;
+        const areaRect = area.getBoundingClientRect();
+        const pairs = this._computePairs();
+
+        const seen = new Set();
+        for (const pair of pairs) {
+            const parentRect = headerRect(pair.parentWin);
+            const childRect = headerRect(pair.childWin);
+            if (!parentRect || !childRect) continue;
+            seen.add(pair.key);
+
+            const x1 = parentRect.left + parentRect.width / 2 - areaRect.left;
+            const y1 = parentRect.bottom - areaRect.top;
+            const x2 = childRect.left + childRect.width / 2 - areaRect.left;
+            const y2 = childRect.bottom - areaRect.top;
+            const d = bezierPath(x1, y1, x2, y2);
+
+            let entry = this._paths.get(pair.key);
+            if (!entry) {
+                const path = document.createElementNS(SVG_NS, 'path');
+                path.setAttribute('class', 'topology-wire');
+                this._svg.appendChild(path);
+                entry = { path, stateClass: null, tintIdx: null };
+                this._paths.set(pair.key, entry);
+            }
+            if (entry.path.getAttribute('d') !== d) entry.path.setAttribute('d', d);
+
+            const stateClass = pair.state === 'idle' ? null : `topology-wire--${pair.state}`;
+            if (entry.stateClass !== stateClass) {
+                if (entry.stateClass) entry.path.classList.remove(entry.stateClass);
+                if (stateClass) entry.path.classList.add(stateClass);
+                entry.stateClass = stateClass;
+            }
+            if (entry.tintIdx !== pair.tintIdx) {
+                entry.path.style.setProperty('--wire-tint', `var(--lineage-tint-${pair.tintIdx})`);
+                entry.tintIdx = pair.tintIdx;
+            }
+        }
+
+        for (const [key, entry] of this._paths) {
+            if (!seen.has(key)) {
+                entry.path.remove();
+                this._paths.delete(key);
+            }
+        }
+
+        // Drives whether _tick keeps looping: at least one wire actually on
+        // screen right now (not just logically paired — e.g. both minimized
+        // in this app's default single-window mode counts as nothing to
+        // follow). window_restored/_tiled events re-wake the loop later.
+        this._hasPairs = seen.size > 0;
+    }
+}
+
+export const topologyWires = new TopologyWires();


### PR DESCRIPTION
## Summary
- New read-only overlay module `agentwire/static/js/topology-wires.js`: draws a thin SVG bezier wire from each parent session's title bar to each live child's, anchored via `getBoundingClientRect` on `.wb-header` — never writes window geometry (same discipline as `collage.js`).
- Pairing reuses `s.parent` already client-side in `sessions-section.js` (exported `initData`/`getAllSessions`/`activityStates` so the pipeline is live even if the Sessions sidebar accordion is never opened).
- Color/pulse: lineage tint (`--lineage-tint-1..6`, hashed from the family root name) for idle/flowing wires; `--topology-awaiting`/`--topology-stuck` override the tint outright for a child blocked on input or with no running agent (failure-state parity, #749).
- Lives at z-index 900 — above WinBox windows, below the collage overlay (1400).
- Toggle via **Alt+L** or the new "Topology wires" checkbox in the Config sidebar section; state persists in localStorage.
- `prefers-reduced-motion` disables the dash-flow/pulse animations, leaving static wires.
- Continuous rAF redraw loop only runs while at least one wire is actually on screen (both endpoints un-minimized) — self-pauses in this app's default single-window mode, self-wakes on window/session events (register/unregister/minimize/restore/tile/viewport-resize/activity).

## Notes for reviewer
- `state`/`state_kind` (`needs_input`/`off`, used for the awaiting/stuck override) only land on a session record right after an `/api/sessions/local` fetch — the periodic `sessions_update` WS push doesn't recompute them — so that part of the coloring is best-effort/refreshes on each sidebar Sessions fetch rather than being fully live. No backend changes were made, per the issue's scope.
- The family-root→tint-index hash (`tintIndexForRoot`/`familyRootName`) is local to this module since it's currently the only consumer on `main`. Other in-flight topology-slate PRs (placement, hierarchy-grouped collage) may want the identical formula — worth extracting to a shared helper once more than one slice has landed, so families tint identically across surfaces.

## Test plan
- [x] Verified in an isolated dev-portal instance (`uv run python -m agentwire portal serve --port 8877`, separate from the live portal) against real parent/child worktree sessions on this host via the Chrome extension: wire renders correctly anchored to both title bars, colored by lineage tint, dashed for an actively-processing child (confirmed via DOM inspection: `d`, `class`, `--wire-tint`).
- [x] Manually verified `--awaiting` (amber) and `--stuck` (red) CSS states render with the correct glow/pulse.
- [x] Verified Alt+L toggle and the Config sidebar checkbox both flip the overlay and stay in sync (shared `TOPOLOGY_WIRES_EVENT`), state persists across the toggle in localStorage.
- [x] Confirmed closing/reopening windows and toggling correctly adds/removes wire elements with no console errors.
- [ ] Drag-to-reposition and minimize/restore during an active drag were exercised implicitly (rAF loop rereads rects every frame while visible) but not screen-recorded — the continuous-loop design should cover it structurally.

Closes #746