### PR TITLE
feat(portal): born-from-parent window placement (#745)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6437,3 +6437,42 @@ body.sidebar-pinned .sidebar-tab {
         animation: none;
     }
 }
+
+/* --- born-from-parent placement (#745) ---
+   Overlay ghost that flies from a parent window's title-bar edge to the
+   landing spot; the real WinBox window is only created once the ghost is
+   at rest (see spawn-ghost.js). --ghost-tint is set inline per-spawn to a
+   --lineage-tint-N value (lineage.js) — never a hardcoded hex. */
+.spawn-ghost-root {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+}
+
+.spawn-ghost {
+    position: fixed;
+    border-radius: var(--r, 9px);
+    background: color-mix(in srgb, var(--ghost-tint) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ghost-tint) 65%, transparent);
+    box-shadow: 0 0 28px color-mix(in srgb, var(--ghost-tint) 55%, transparent);
+    opacity: 0;
+    filter: brightness(2.2);
+    transition:
+        left 0.48s cubic-bezier(0.2, 0.9, 0.25, 1),
+        top 0.48s cubic-bezier(0.2, 0.9, 0.25, 1),
+        width 0.48s cubic-bezier(0.2, 0.9, 0.25, 1),
+        height 0.48s cubic-bezier(0.2, 0.9, 0.25, 1),
+        opacity 0.3s ease-out,
+        filter 0.42s ease-out;
+}
+
+.spawn-ghost--fly {
+    opacity: 1;
+    filter: brightness(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .spawn-ghost {
+        transition: none !important;
+    }
+}

--- a/agentwire/static/js/desktop-manager.js
+++ b/agentwire/static/js/desktop-manager.js
@@ -220,11 +220,16 @@ class DesktopManager {
                 break;
 
             case 'session_created':
+                // machine is undefined on today's payload (server only ever
+                // creates local sessions this way) — forwarded ahead of time
+                // so the born-from-parent placement (#745) is ready the
+                // moment a remote-creation path starts sending it too.
                 this.emit('session_created', {
                     session: msg.session,
                     name: msg.name,
                     parent: msg.parent,
                     role: msg.role,
+                    machine: msg.machine,
                 });
                 break;
 

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -12,6 +12,8 @@ import { desktop } from './desktop-manager.js';
 import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
 import { topologyWires } from './topology-wires.js';
+import { flyGhost } from './spawn-ghost.js';
+import { lineageTintVar } from './lineage.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { ReviewWindow } from './review-window.js';
@@ -43,6 +45,21 @@ const sessionWindows = new Map();  // sessionId -> SessionWindow instance
 const artifactWindows = new Map();  // artifactId -> ArtifactWindow instance
 const reviewWindows = new Map();  // windowId -> ReviewWindow instance
 let councilWindow = null;  // single CouncilWindow instance (one board at a time)
+
+// Born-from-parent placement (#745): sessions we've noticed appear (via the
+// poll-driven `sessions` event, or the optional live `session_created` event
+// upgrade from #747) that haven't been placed yet. One-shot AND time-boxed —
+// consumed (or expired) by the next openSessionTerminal() call for that id,
+// so a session only ever gets one chance at the birth ghost, and only while
+// it's genuinely fresh. Without the TTL, a child created hours ago while its
+// parent was closed would still "materialize" the first time someone happens
+// to click it later — that's just a normal reopen, not a birth.
+const recentBirths = new Map();  // childId -> { parentName, tintVar, ts }
+const BIRTH_TTL_MS = 15000;
+// Baseline session-name snapshot for diffing new arrivals. Null until the
+// first `sessions` event, so page load never treats the existing world as
+// "newly born".
+let knownSessionNames = null;
 
 // Global PTT state
 let globalPttState = 'idle';  // idle | recording | processing (mirrors globalPttCtl)
@@ -115,6 +132,10 @@ async function init() {
     desktop.on('pane_died', handlePaneDied);
     desktop.on('session_renamed', handleSessionRenamed);
     desktop.on('window_activity', handleWindowActivity);
+    // Born-from-parent placement (#745) — poll-driven detection of newly
+    // arrived child sessions. Primary path; session_created above is an
+    // optional accelerant on top of it, never a hard dependency.
+    desktop.on('sessions', handleSessionsListUpdate);
 
     // Handle TTS/audio events for voice indicator
     desktop.on('tts_start', ({ session }) => {
@@ -296,11 +317,20 @@ function handleSessionClosed({ session }) {
 }
 
 /**
- * Handle session_created event (#747) — pushed the instant a session is
- * created (agentwire new / worktree / portal), instead of waiting for the
- * sessions_update broadcast that follows moments later.
+ * Handle session_created event — pushed the instant a session is created
+ * (agentwire new / worktree / portal, #747) instead of waiting for the
+ * sessions_update broadcast that follows moments later. Two independent
+ * jobs share this one event:
+ *  - #747: merge the new session into the live list immediately (dedup by
+ *    name) so the sidebar shows the birth without poll lag.
+ *  - #745: register the birth (registerBirth() below) so a currently-open,
+ *    non-minimized parent gets the ghost-fly placement — the exact function
+ *    the poll-driven handleSessionsListUpdate() also calls, so either
+ *    source lands in the same place; this is a pure accelerant, never a
+ *    hard dependency (today's payload always carries parent/role, but the
+ *    fields are read defensively in case a future creation path omits them).
  */
-function handleSessionCreated({ session, name, parent, role }) {
+function handleSessionCreated({ session, name, parent, role, machine }) {
     const sessionName = name || session;
     if (!sessionName) return;
 
@@ -309,26 +339,105 @@ function handleSessionCreated({ session, name, parent, role }) {
     // that follows always wins with the authoritative record (full-array
     // replace), so this placeholder just needs to not double up before then.
     const sessions = desktop.sessions || [];
-    if (!sessions.some((s) => s.name === sessionName)) {
-        desktop.sessions = [...sessions, {
+    const alreadyKnown = sessions.some((s) => s.name === sessionName);
+    let sessionsWithChild = sessions;
+    if (!alreadyKnown) {
+        sessionsWithChild = [...sessions, {
             name: sessionName,
             parent: parent || null,
             roles: role ? [role] : [],
             windows: 1,
             path: '',
-            machine: null,
+            machine: machine || null,
         }];
-        desktop.emit('sessions', desktop.sessions);
+        desktop.sessions = sessionsWithChild;
+        // This synchronously re-enters handleSessionsListUpdate() (below),
+        // which is what actually calls registerBirth() for a session it's
+        // never seen before — the whole point of the emit is to let that
+        // one diff-driven path pick it up, not to trigger it twice. Do NOT
+        // also call registerBirth() directly here: openSessionTerminal()
+        // consumes (deletes) the recentBirths ticket the instant it's
+        // *called*, well before the ghost settles and the real window
+        // mounts, so a second call this tick would sail past every guard
+        // and fly a second ghost onto a second real window.
+        desktop.emit('sessions', sessionsWithChild);
+        return;
     }
 
-    // If the parent's window is already open, reveal the child beside it
-    // immediately — openSessionTerminal dedupes by session id internally
-    // (sessionWindows.has(id)), so this is a no-op if a window for this
-    // session is already open or gets opened again once sessions_update
-    // (or a later poll) reports the same session.
-    if (parent && sessionWindows.has(buildSessionId(parent, null))) {
-        openSessionTerminal(sessionName, 'monitor');
+    // Already merged — e.g. a sessions_update poll beat this event to it —
+    // so the diff-driven path above won't fire for it again. registerBirth()
+    // checks the parent is genuinely open (not just present — not minimized
+    // either) before flying the ghost + revealing the child; it's a no-op
+    // fallback (no auto-open at all) otherwise, matching #745's graceful-
+    // fallback requirement.
+    if (parent) {
+        registerBirth({ name: sessionName, parent, machine: machine || null }, sessionsWithChild);
     }
+}
+
+/**
+ * Diff the latest session list against the last-known snapshot and register
+ * a birth for anything that just appeared with a recorded parent (#745).
+ * The very first snapshot after page load is a baseline, not a batch of
+ * births — the whole existing world shouldn't fly out of the parent window.
+ */
+function handleSessionsListUpdate(sessions) {
+    const currentNames = new Set(sessions.map((s) => s.name));
+    if (knownSessionNames === null) {
+        knownSessionNames = currentNames;
+        return;
+    }
+    for (const s of sessions) {
+        if (knownSessionNames.has(s.name) || !s.parent) continue;
+        registerBirth(s, sessions);
+    }
+    knownSessionNames = currentNames;
+}
+
+/**
+ * Record that `session` was just born to `session.parent`, and — if the
+ * parent's window happens to be open right now — birth it immediately
+ * rather than waiting for the user to notice it in the sidebar. "Watch it
+ * get born" only works while you're already looking at the parent.
+ */
+function registerBirth(session, allSessions) {
+    const machine = normalizeMachine(session.machine);
+    const id = buildSessionId(session.name, machine);
+    if (sessionWindows.has(id)) return;  // already open — nothing to place
+    // handleSessionCreated's desktop.emit('sessions', ...) can synchronously
+    // re-enter here via handleSessionsListUpdate before the ghost it may have
+    // just kicked off has settled (sessionWindows.has(id) is still false
+    // mid-flight) — without this guard that's a second ghost + a second
+    // openSessionTerminal() call for the same id.
+    if (recentBirths.has(id)) return;
+
+    recentBirths.set(id, {
+        parentName: session.parent,
+        tintVar: lineageTintVar(session.name, allSessions || desktop.sessions),
+        ts: Date.now(),
+    });
+
+    const parentSW = sessionWindows.get(session.parent);
+    if (parentSW && parentTitleBarRect(parentSW)) {
+        openSessionTerminal(session.name, 'monitor', machine);
+    }
+}
+
+/**
+ * The parent window's title-bar rect (viewport coords), or null when it's
+ * not open/minimized/not yet rendered — the graceful fallback signal for the
+ * birth ghost (#745). Anchored near the bar's right edge so the ghost reads
+ * as "growing out of" the parent, not "replacing" it.
+ */
+function parentTitleBarRect(parentSW) {
+    if (!parentSW || parentSW.isMinimized) return null;
+    const win = parentSW.winbox && parentSW.winbox.window;
+    const header = win && win.querySelector('.wb-header');
+    if (!header) return null;
+    const bar = header.getBoundingClientRect();
+    if (!bar.width || !bar.height) return null;
+    const w = Math.min(220, Math.max(80, bar.width * 0.35));
+    return new DOMRect(bar.right - w, bar.top, w, bar.height);
 }
 
 /**
@@ -634,9 +743,39 @@ export function openSessionTerminal(session, mode, machine = null) {
         return;
     }
 
+    // Born-from-parent placement (#745): a one-shot, time-boxed birth ticket,
+    // whether this open was auto-triggered by registerBirth() or is a manual
+    // click that happened to land on a session just born to a currently-open
+    // parent. Consumed immediately so a later reopen never re-animates, and
+    // dropped outright once stale so an old, never-opened child doesn't fly
+    // out of a parent window it wasn't actually just born next to.
+    const birth = recentBirths.get(id);
+    recentBirths.delete(id);
+    const freshBirth = birth && (Date.now() - birth.ts <= BIRTH_TTL_MS) ? birth : null;
+
+    if (freshBirth) {
+        const parentSW = sessionWindows.get(freshBirth.parentName);
+        const fromRect = parentSW ? parentTitleBarRect(parentSW) : null;
+        const toRect = elements.desktopArea.getBoundingClientRect();
+        // flyGhost() itself handles the graceful fallback (no fromRect, or
+        // prefers-reduced-motion): it calls onSettle immediately, no ghost
+        // shown, same as the plain-open path below.
+        flyGhost(fromRect, toRect, freshBirth.tintVar, () => {
+            desktop.minimizeAllExcept(null);
+            _mountSessionWindow(session, mode, machine, id);
+        });
+        return;
+    }
+
     // Minimize all other session windows before opening new one
     desktop.minimizeAllExcept(null);
+    _mountSessionWindow(session, mode, machine, id);
+}
 
+/** Construct and register the real SessionWindow. The only place `new
+ * SessionWindow(...)` is called — both the plain-open and birth-ghost paths
+ * above hand off to this once it's safe to create the real WinBox window. */
+function _mountSessionWindow(session, mode, machine, id) {
     const sw = new SessionWindow({
         session,
         mode,

--- a/agentwire/static/js/lineage.js
+++ b/agentwire/static/js/lineage.js
@@ -1,0 +1,60 @@
+/**
+ * lineage.js
+ *
+ * Maps a session to its family's lineage-tint CSS variable (#749 SSOT —
+ * `agentwire/static/css/desktop.css` `--lineage-tint-1..6`). A family is a
+ * root session plus every descendant reachable by walking `.parent` links;
+ * the whole family shares one hue so relatedness reads at a glance without
+ * labels. Consumed by the born-from-parent ghost (#745) and meant to be
+ * reused by the connector overlay / grouped collage slices rather than each
+ * re-deriving its own palette.
+ *
+ * @module lineage
+ */
+
+const TINT_COUNT = 6;
+
+/**
+ * Walk `.parent` links from `name` up to its root ancestor.
+ * Tolerant of missing sessions, self-referencing parents, and cycles (caps
+ * the walk depth rather than looping forever).
+ *
+ * @param {string} name - Session name to resolve.
+ * @param {Array<{name: string, parent?: string|null}>} sessions - Full session list.
+ * @returns {string} The root ancestor's name (or `name` itself if it has no parent).
+ */
+export function familyRootName(name, sessions) {
+    const byName = new Map((sessions || []).map((s) => [s.name, s]));
+    let current = byName.get(name);
+    let depth = 0;
+    while (
+        current &&
+        current.parent &&
+        current.parent !== current.name &&
+        byName.has(current.parent) &&
+        depth < 32
+    ) {
+        current = byName.get(current.parent);
+        depth++;
+    }
+    return current ? current.name : name;
+}
+
+/** Deterministic small-int hash of a string, stable across reloads/renders. */
+function hashIndex(str) {
+    let h = 0;
+    for (let i = 0; i < str.length; i++) {
+        h = (h * 31 + str.charCodeAt(i)) | 0;
+    }
+    return Math.abs(h) % TINT_COUNT;
+}
+
+/**
+ * @param {string} name - Session name.
+ * @param {Array<{name: string, parent?: string|null}>} sessions - Full session list.
+ * @returns {string} A `--lineage-tint-N` custom property name (1-indexed).
+ */
+export function lineageTintVar(name, sessions) {
+    const root = familyRootName(name, sessions);
+    return `--lineage-tint-${hashIndex(root) + 1}`;
+}

--- a/agentwire/static/js/spawn-ghost.js
+++ b/agentwire/static/js/spawn-ghost.js
@@ -1,0 +1,92 @@
+/**
+ * spawn-ghost.js
+ *
+ * "Born from parent" placement (#745): flies a plain overlay div from a
+ * parent window's title-bar edge to the landing spot, then hands off to the
+ * real (already-settled) session window. This module never touches a real
+ * WinBox window's geometry — same shadow-layer invariant as collage.js, and
+ * for the same reason (#235): transforming a real window mid-open corrupts
+ * WinBox's internal stack and fires ResizeObserver into tmux PTY resize
+ * storms. The ghost is the only thing that moves; the real window is only
+ * ever created once the ghost has already settled at rest.
+ *
+ * @module spawn-ghost
+ */
+
+/** Above windows (WinBox's focus counter grows z-index from 10), below
+ * toasts (1500) — same band as collage.js's OVERLAY_Z (1400). */
+const GHOST_Z = 1420;
+
+const FLY_MS = 480;
+
+let root = null;
+
+function ensureRoot() {
+    if (root) return root;
+    root = document.createElement('div');
+    root.className = 'spawn-ghost-root';
+    root.style.zIndex = String(GHOST_Z);
+    document.body.appendChild(root);
+    return root;
+}
+
+function prefersReducedMotion() {
+    return typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Fly a ghost from `fromRect` to `toRect`, then invoke `onSettle`.
+ *
+ * Skips the animation and calls `onSettle` synchronously when there's no
+ * usable start rect (parent window not open/minimized — the graceful
+ * fallback) or the user prefers reduced motion — in both cases placement
+ * still happens, just instantly.
+ *
+ * @param {DOMRect|null} fromRect - Parent's title-bar rect, viewport coords.
+ * @param {DOMRect} toRect - Landing spot (the desktop area), viewport coords.
+ * @param {string} tintVar - A `--lineage-tint-N` custom property name.
+ * @param {Function} onSettle - Called once the ghost is at rest (or immediately if skipped).
+ */
+export function flyGhost(fromRect, toRect, tintVar, onSettle) {
+    if (!fromRect || !toRect || prefersReducedMotion()) {
+        onSettle();
+        return;
+    }
+
+    const el = document.createElement('div');
+    el.className = 'spawn-ghost';
+    el.style.setProperty('--ghost-tint', `var(${tintVar})`);
+    el.style.left = `${fromRect.left}px`;
+    el.style.top = `${fromRect.top}px`;
+    el.style.width = `${fromRect.width}px`;
+    el.style.height = `${fromRect.height}px`;
+
+    ensureRoot().appendChild(el);
+
+    // Force the browser to commit the start rect before the end-rect write
+    // below, or both writes coalesce into one frame and nothing transitions.
+    void el.getBoundingClientRect();
+
+    requestAnimationFrame(() => {
+        el.classList.add('spawn-ghost--fly');
+        el.style.left = `${toRect.left}px`;
+        el.style.top = `${toRect.top}px`;
+        el.style.width = `${toRect.width}px`;
+        el.style.height = `${toRect.height}px`;
+    });
+
+    let done = false;
+    const finish = () => {
+        if (done) return;
+        done = true;
+        el.remove();
+        onSettle();
+    };
+    el.addEventListener('transitionend', finish, { once: true });
+    // Safety net — transitionend can fail to fire (tab backgrounded mid-fly,
+    // a property that didn't actually change); never leave the ghost or the
+    // caller hanging.
+    setTimeout(finish, FLY_MS + 250);
+}


### PR DESCRIPTION
## Summary
- On child-session creation, auto-open its window beside its recorded parent — only when the parent's window is currently open, so the "watch it get born" moment only fires while you're actually looking at the parent.
- The birth animates via an overlay ghost (`spawn-ghost.js`) that flies from the parent's title-bar edge to the desktop landing spot, then hands off to the real `SessionWindow` once it's at rest. The real WinBox window is never transformed mid-open — same shadow-layer invariant the #235 collage rewrite established (transforming a real window mid-open corrupts WinBox's internal stack and fires `ResizeObserver` into tmux PTY resize storms).
- Graceful fallback to an instant, undecorated open: when the parent window isn't open, when `prefers-reduced-motion` is set, or once a birth ticket goes stale (15s TTL — an old, never-opened child shouldn't fly out of a window it wasn't actually just born next to).
- Placement is driven by the existing poll-driven `sessions_update` broadcast (primary path, works today). The `session_created` websocket event (#747) is wired as an optional accelerant — forwarded with `name`/`parent`/`role`/`machine` ahead of time so it upgrades to instant the moment #747's payload is enriched, but nothing here hard-depends on it (today's `{session}`-only payload is a no-op through this path).
- Ghost tint reuses the #749 lineage-tint CSS tokens via a new `lineage.js` helper (family-root resolution by walking `.parent` chains + a deterministic hash-to-hue), meant to be reused by the connector-overlay and grouped-collage slices rather than each re-deriving its own palette.

## Test plan
- [x] Full pytest suite passes (2713 passed) — no Python touched, sanity check only.
- [x] Verified live in an isolated dev portal instance (`agentwire portal serve --port 8845`, this worktree's source) via Chrome: created parent/child test sessions, simulated the tmux hook's `session_created` notify against the dev instance, and confirmed:
  - Child window auto-opens and lands beside the parent when the parent's window is open (ghost created, animated, cleaned up; no console errors).
  - No auto-open when the parent's window is minimized/closed (graceful fallback — child is discoverable in the sidebar as before, no fly-out).
  - A manual click on a session with a stale (>15s) birth ticket opens instantly with no ghost, even if the parent is open by then.
  - `prefers-reduced-motion` skips the ghost entirely and settles instantly (verified via direct module import + `matchMedia` override in the page console).
  - `lineageTintVar` assigns the same tint to a parent and its child, and a different tint to an unrelated family.

Closes #745