### PR TITLE
docs: document session-topology feature, sync stale collage/portal pages

### DIFF
--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -47,6 +47,8 @@ Both share session data from `sessions-section.js` (single fetch, shared activit
 
 F3 or Alt/Option+` / `desktop_collage` MCP / command palette → grid of live previews of every open window; click a tile to focus, Esc to exit.
 
+**Grid cells are families, not windows (#748):** `collage.js#_groupFamilies()` walks each window's `.parent` chain to a root and clusters every open descendant under it — a singleton family (no open children) is a plain tile, a family with children renders as a tinted cluster (parent tile on top, children in a wrapping row below). Hue cycles `--lineage-tint-1..6` by the family's position in the current grid.
+
 **The one rule: tiles are overlay-local previews — NEVER mutate the real WinBox windows.** Session tiles stream pane content over a second monitor WS (`/ws/{sessionId}`, rendered via shared `utils/ansi.js`); artifact tiles are cloned iframes. Real windows are never moved/resized/transformed/un-minimized, so exit has nothing to restore.
 
 Why this is load-bearing (each broke a previous implementation — full autopsy in `docs/wiki/internals/window-collage.md`):
@@ -56,6 +58,15 @@ Why this is load-bearing (each broke a previous implementation — full autopsy 
 - `registerWindow`/`setActiveWindow` auto-minimize all others (single-window mode) → any window event mid-overlay fights manual layouts.
 
 **Z-index landscape:** WinBox windows (inline, grows from 10) < collage overlay (1400) < toasts (1500) < modals (2000) < command palette (3000) < sidebar (9001) < tile drag overlay (99999).
+
+## Session Topology (#745–#749)
+
+Four mechanisms make the parent→child session tree visible and alive on the desktop (full reference: `docs/wiki/internals/session-topology.md`):
+
+- **Born-from-parent placement** (`spawn-ghost.js`, #745) — when a child session's parent window is open, the child's window flies out of the parent's title bar (a disposable overlay ghost, `flyGhost()`) before the real WinBox window is constructed in `onSettle` — never transform a real window mid-open (same #235 discipline as the collage). Falls back to instant placement with no ghost when the parent isn't open/minimized or `prefers-reduced-motion` is set.
+- **Connector overlay** (`topology-wires.js`, #746) — **Alt+L** (`e.code === 'KeyL'`, capture phase, same idiom as F3/Alt+`/Alt+bracket) toggles a read-only SVG of wires from each open parent's title bar to each open child's; also toggleable from the Config sidebar's "Topology wires" checkbox. Only reads `getBoundingClientRect()` on `.wb-header` elements, never writes window geometry. Wire color is family lineage tint; wire state (idle/flow/awaiting/stuck) mirrors the child's activity, with awaiting/stuck overriding the tint per failure-state parity. z-index 900 — above windows, below the collage (1400).
+- **Grouped + tinted collage** (`collage.js`, #748) — see "Window Collage" above.
+- **Live appearance** (`desktop.js` `handleSessionCreated` + `agentwire/core.py` `notify_portal_session_created`, #747) — `agentwire new`/`worktree` posts a `session_created` event as soon as the session exists, so the desktop merges it into the live list (and can trigger born-from-parent placement) without waiting for the next `sessions_update` poll.
 
 ## Topology Design Tokens (#749)
 

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -89,6 +89,7 @@ and `custom` (any model behind a small HTTP shim).
 Implementation reference for contributors and advanced users.
 
 - **[Portal](internals/portal.md)** — modes, REST API, WebSocket events
+- **[Session topology](internals/session-topology.md)** — parent→child visualization: born-from-parent ghost placement, the Alt+L connector overlay, lineage-tinted/hierarchy-grouped collage, live `session_created` appearance, and the shared design tokens behind all four
 - **[Large parallel refactors](internals/parallel-refactor.md)** — splitting a huge file across parallel worktrees: positional-interleaving conflicts, regenerate-against-fresh-base + sequential merges, foundation-first, verification discipline
 - **[Window collage](internals/window-collage.md)** — Mission Control overlay: preview-tile architecture + why mutating real WinBox windows can never work
 - **[Shell escaping](internals/shell-escaping.md)** — how complex strings cross tmux boundaries

--- a/docs/wiki/internals/portal.md
+++ b/docs/wiki/internals/portal.md
@@ -47,6 +47,8 @@ async def api_create_session(self, request):
 
 The portal provides an OS-like desktop interface using WinBox.js for window management. Clean desktop by default with sessions opened as draggable, resizable windows.
 
+**Session topology:** the parent→child session tree is visible and live on the desktop, not just in the sidebar's nested list — a child session born while its parent's window is open flies out of the parent's title bar into place (born-from-parent placement) instead of just popping into existence, sessions created via `agentwire new`/`worktree`/the portal appear instantly rather than waiting for the next poll (live appearance, `session_created` event), and **Alt+L** toggles a read-only connector overlay wiring each open parent to its open children, activity-colored. Full reference: **[Session topology](session-topology.md)**.
+
 ### Menu Bar
 
 | Menu | Items |
@@ -118,7 +120,7 @@ Sessions can be opened from the Sessions dropdown in two modes:
 
 ### Window Collage
 
-F3 (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**.
+F3 (or the `desktop_collage` MCP tool / command palette) shows a Mission Control-style grid of live previews of every open window — click a tile to focus, Esc to dismiss. Grid cells are grouped by session family (a parent + its open descendants) and lineage-tinted rather than one cell per window. The tiles are overlay-local live views (monitor WebSockets / cloned iframes); the real windows are never moved or resized. Architecture and the hard-won "never mutate real WinBox windows" lessons: **[Window collage](window-collage.md)**. Family grouping + the connector overlay's **Alt+L** toggle: **[Session topology](session-topology.md)**.
 
 ### Simultaneous Operation
 

--- a/docs/wiki/internals/session-topology.md
+++ b/docs/wiki/internals/session-topology.md
@@ -1,0 +1,82 @@
+# Session Topology (parent → child visualization)
+
+> Living wiki. Update this page, don't create new versions.
+
+Four mechanisms, shipped across #745–#749, that make the parent→child session tree visible and alive on the desktop instead of only existing in the sidebar's nested list:
+
+| Mechanism | Module | Trigger |
+|-----------|--------|---------|
+| **Born-from-parent placement** | `static/js/spawn-ghost.js` (+ wiring in `desktop.js`) | A child session appears while its parent's window is open |
+| **Connector overlay** | `static/js/topology-wires.js` | Alt+L, or the Config sidebar "Topology wires" checkbox |
+| **Grouped + tinted collage** | `static/js/collage.js` | F3 / `desktop_collage` MCP / command palette |
+| **Live appearance** | `desktop.js` `handleSessionCreated` + server `notify_portal_session_created` | A session is created via `agentwire new` / `worktree` / the portal |
+
+All four share one palette (`--lineage-tint-1..6`) and one state vocabulary (`--topology-awaiting`, `--topology-stuck`) — see [Design tokens](#design-tokens) below. Static reference for those tokens (with the enforcement rules) also lives in the `agentwire-desktop-ui` skill's "Topology Design Tokens" section.
+
+## Born-from-parent placement
+
+When a session's parent window is open and a child of it is created, the child's window doesn't just pop into existence — it "flies" out of the parent's title bar to its landing spot, then mounts as a real window. Two modules split the job:
+
+- **`desktop.js`** tracks *who was just born* (`recentBirths`, a one-shot, 15-second-TTL ticket per child id — `BIRTH_TTL_MS`) and computes the two rects: `parentTitleBarRect()` (a slice of the parent's `.wb-header`, clamped to 80–220px wide) as the start, and the desktop area as the end.
+- **`spawn-ghost.js`**'s `flyGhost(fromRect, toRect, tintVar, onSettle)` animates a plain overlay `<div>` (`.spawn-ghost`, tinted via `--ghost-tint`) between those two rects over 480ms (`FLY_MS`), then calls `onSettle`.
+
+**The real WinBox window is only constructed in `onSettle`** — never transformed mid-flight. This mirrors the discipline `window-collage.md`'s autopsy documents for the collage (#235): animating or resizing a *real* WinBox window mid-transition corrupts its internal geometry/min-stack bookkeeping and fires its `ResizeObserver` into a PTY resize storm. The ghost is a disposable DOM node with no WinBox state to protect, so it's the only thing that ever moves.
+
+**Graceful fallback, in two independent layers:**
+- `flyGhost()` itself skips the animation and calls `onSettle()` synchronously whenever there's no usable `fromRect` (parent not open, or minimized — `parentTitleBarRect()` returns `null` for both) or the browser reports `prefers-reduced-motion: reduce`. Placement still happens — just instantly, no ghost shown.
+- If the parent isn't open at all, `registerBirth()` never calls `openSessionTerminal()` in the first place — the child is just recorded in `desktop.sessions` and shows up in the sidebar list like any other session, with no auto-open and no ghost. "Watch it get born" only fires while you're already looking at the parent.
+
+Birth detection has two independent paths that land in the same place (`registerBirth()`): the poll-driven `sessions` event diff (`handleSessionsListUpdate`, comparing against a baseline snapshot so page-load's existing world is never treated as a batch of births) and the live `session_created` push (see [Live appearance](#live-appearance) below) as a pure accelerant on top of it — session creation still gets a birth ghost even if the live event never arrives.
+
+## Connector overlay
+
+**Alt+L** toggles a read-only SVG overlay (`.topology-wires-overlay`, `topology-wires.js`) drawing a bezier "wire" from each open parent window's title bar down to each of its open children's title bars. It's also toggleable from the Config sidebar's "Topology wires" checkbox (same `topologyWires.setVisible()` call); the on/off state persists across reloads in `localStorage['aw-topology-wires-visible']` (visible by default).
+
+Verified in `desktop.js`'s `setupTopologyWires()`: bound on `keydown` in the capture phase, gated on `e.altKey && !e.metaKey && !e.ctrlKey && e.code === 'KeyL'`, with the command palette / help modal open as an escape hatch and `e.repeat` ignored — the same idiom as the F3 collage toggle and the Alt+]/Alt+[ window-cycling bindings.
+
+**Strictly read-only**, the same discipline as the collage: it only calls `getBoundingClientRect()` on each window's `.wb-header` to anchor a wire's endpoints, and never writes to a window's geometry. A minimized window (`display: none` via this app's `.winbox.min` override) collapses its rect to all-zero, which the module treats as "no anchor" — the wire for that pair is simply dropped until the window is restored, rather than hanging off the desktop's top-left corner.
+
+**Wire state** mirrors each child's activity, reusing the same `activityStates` map the sidebar's status dot reads:
+- **idle** — the default, no state class, plain lineage-tinted line at low opacity.
+- **flow** — `processing`/`generating`/`playing`/`active` — a dashed line animates along its length (`topology-wire-flow`).
+- **awaiting** — the child's `state === 'needs_input'` — overrides the lineage tint with `--topology-awaiting` (amber) and pulses.
+- **stuck** — `state === 'off'` — overrides with `--topology-stuck` (red) and pulses faster.
+
+Failure-state parity is enforced in the CSS cascade order, not `!important`: the `--awaiting`/`--stuck` classes are declared after the base `.topology-wire` rule specifically so an equal-specificity override wins and a blocked/awaiting child's wire can never read as "fine" just because its family tint happens to look calm.
+
+**Wire color** is a stable per-family hash (`tintIndexForRoot`, hashing the family-root session name into one of the 6 `--lineage-tint-N` slots) — the same 6-slot palette the collage and the birth-ghost use, computed independently rather than imported from `lineage.js` (see the open follow-up below).
+
+**Z-band:** the overlay sits at z-index 900 — above WinBox windows (whose inline z-indexes grow from 10) but below the collage overlay (1400), so entering the collage always wins and the wires never bleed through it.
+
+The redraw loop is a self-stopping `requestAnimationFrame` tick: it only keeps scheduling itself while at least one wire is actually on-screen (`_hasPairs`), and is woken by session/window/activity events (`onSessionsChanged`, `window_registered/unregistered/minimized/restored/tiled`, `viewport_resize`, `session_activity`, TTS/audio events) rather than polling on a timer.
+
+## Grouped + tinted collage
+
+F3 (or the `desktop_collage` MCP tool, or the command palette) still enters the same Mission Control-style preview overlay documented in [Window collage](window-collage.md) — but the grid cells are now **families** (a session + its descendants), not raw windows (#748). `collage.js#_groupFamilies()` walks each window's `.parent` chain (via `_lineageOf()`, sessions-section.js's tree-linkage data) to a root, and groups every open window under that root. A singleton family (no open children) renders as a plain tile with a faint tint hint (`.collage-family.is-singleton`); a family with open children renders as a tinted cluster (`.collage-family`) — the parent's tile on top (`.collage-family-parent`), its children nested in a wrapping row below (`.collage-family-children`, reserved ~42% of the cluster height, scrolling vertically rather than ever overflowing the grid horizontally).
+
+Family hue cycles through `--lineage-tint-1..6` by **family index within the current grid** (`familyIndex % 6`), set inline as `--family-tint` — a different hashing scheme than the connector overlay's per-root hash (see the open follow-up below). The grid's cols×rows fitting and the underlying preview-tile mechanics (live monitor WebSocket per session tile, cloned iframe per artifact tile, the "never touch a real WinBox window" invariant) are unchanged — see `window-collage.md` for that architecture and its autopsy.
+
+## Live appearance
+
+A newly created session used to only appear once the next `sessions_update` poll landed. `agentwire new` (and `agentwire worktree`, which delegates into the same `cmd_new` code path) now posts an extra event as early as possible during session creation — before the potentially slow first-message wait — so the desktop can react immediately (#747):
+
+1. **CLI side** (`session_cli.py cmd_new` → `agentwire/core.py notify_portal_session_created(session_name, created_by, kind)`): fire-and-forget POST to the portal's `/api/notify` with `{"event": "session_created", "session": ..., "parent": ..., "role": ...}` (`parent`/`role` omitted from the payload entirely when not set, rather than sent as null).
+2. **Server side** (`agentwire/routes/notify.py api_notify`, the `session_created` branch): looks up the session's fresh record as a fallback for `parent`/`role` if the payload didn't carry them (covers the plain global tmux `session-created` hook, which only ever knows the bare session name), then broadcasts `session_created` with `{session, name, parent, role}` to every connected dashboard, immediately followed by a full `sessions_update`.
+3. **Client side** (`desktop.js handleSessionCreated`): merges a placeholder record into `desktop.sessions` right away (deduped by name; the `sessions_update` that follows moments later always wins with the authoritative record) and re-emits `sessions`, which is what actually drives `registerBirth()` for the born-from-parent placement above. This is a pure accelerant on top of the poll-driven diff path — a session still gets placed correctly if this event is dropped or arrives late, just with poll lag.
+
+Note: `handleSessionCreated`'s destructuring includes a `machine` field, read defensively for a future creation path — as of this writing neither `notify_portal_session_created` nor the server's `session_created` broadcast actually populates `machine` in the payload, so it's always `undefined` today.
+
+## Design tokens
+
+Both design rules that gate every rule appended to `desktop.css`'s `/* === topology === */` anchor:
+
+1. **Lineage tint SSOT** — `--lineage-tint-1` through `--lineage-tint-6` (green/blue/purple/pink/orange/cyan) are the one palette every topology surface derives fills/borders/glows from via `color-mix()`, rather than hardcoding a family hex anywhere else. Red and amber are reserved for state (below) and must never be assigned as a lineage tint.
+2. **Failure-state parity** — `--topology-awaiting` (amber, aliases `--orb-awaiting`) and `--topology-stuck` (red, aliases `--neon-red`) are the shared state vocabulary; every "alive" treatment a surface ships (glow, pulse, flowing wire) must have an equally salient blocked/awaiting counterpart, so a stuck or awaiting-input child never reads as "fine" next to an active sibling.
+
+**Live-pane-peek safety flag:** any live-pane content peek (e.g. a collage tile rendering a child's actual terminal output) must default off or blurred — surfacing a child session's live terminal by default is a screen-share / credential-exposure risk the moment topology becomes something people demo (council flag, #749). Peeks are opt-in reveals, never the resting state. Today's collage tiles already stream live content by design (see `window-collage.md`) — this rule governs any *future* peek surface layered on top of the topology visualization, not a retrofit of the existing collage.
+
+Both rules, plus `prefers-reduced-motion` handling for the wire animations, live in the CSS comment block at `desktop.css`'s `/* === topology === */` anchor.
+
+## Open follow-up
+
+**#755** — unify lineage-tint slot assignment across the three surfaces. #749 made the tint *palette* SSOT but not the *assignment*, so all three still pick a family's slot differently: placement calls `lineage.js`'s `lineageTintVar()` (string-hash of the family root), the connector overlay has its own near-identical hash in `tintIndexForRoot()`, and the collage instead keys on the family's *position in the current grid* (`familyIndex % 6`, which isn't even stable across rebuilds). Nothing is broken by this today (each surface's own tint is internally consistent), but the same family can render a different hue in the collage than on its connector wire or its birth ghost. The proposed fix points `topology-wires.js` and `collage.js` at `lineage.js` instead of each re-deriving its own assignment.

--- a/docs/wiki/internals/window-collage.md
+++ b/docs/wiki/internals/window-collage.md
@@ -4,6 +4,8 @@
 
 F3 (or the `desktop_collage` MCP tool, or the command palette → "Window collage") lays a live preview of every open window into a grid so the whole desktop can be scanned at once. Click a tile to focus that window; Esc, the hotkey again, or clicking the backdrop exits.
 
+Grid cells are **families** (a session + its descendants), not raw windows (#748): a session with no open children renders as a plain singleton tile, one with open children renders as a tinted cluster — parent tile on top, children nested in a wrapping row below, hued from the shared `--lineage-tint-1..6` palette so relatedness reads at a glance. See [Session topology](session-topology.md) for the grouping mechanics and the sibling placement/connector-overlay/live-appearance features it shares a palette with.
+
 Module: `agentwire/static/js/collage.js`. Styles: the `.collage-*` block in `agentwire/static/css/desktop.css`. Hotkey wiring: `setupCollage()` in `agentwire/static/js/desktop.js`.
 
 ## The one rule
@@ -19,7 +21,8 @@ Any future feature that wants to show multiple windows at once — exposé varia
 | Piece | Implementation |
 |-------|----------------|
 | **Backdrop** | `.collage-overlay`, a fully opaque (`#0a0c10`) layer over the desktop area. Opaque is deliberate: any translucency lets the maximized window behind ghost through the gaps (bright artifact pages especially). No `backdrop-filter` — a blur here leaves a stale compositor layer that renders windows translucent after exit. |
-| **Grid** | cols = `round(sqrt(n × aspect))` fitted to the desktop area aspect, CSS Grid with `1fr` tracks. Rebuilt (not patched) on any churn. |
+| **Grid** | One cell per **family** (a session + its open descendants, grouped by walking `.parent` — `_groupFamilies()`/`_lineageOf()`), not per window. cols = `round(sqrt(n × aspect))` over family count, fitted to the desktop area aspect, CSS Grid with `1fr` tracks. Rebuilt (not patched) on any churn. |
+| **Family clusters** | A family with open children renders as `.collage-family` — parent tile (`.collage-family-parent`) on top, children (`.collage-family-children`, `is-child`) in a wrapping row below reserving ~42% of the cluster height, scrolling vertically rather than overflowing the grid. Tinted via `--family-tint` (an alias of `--lineage-tint-1..6`) so a family reads as one hue without labels. |
 | **Session tiles** | A second *monitor* WebSocket per tile (`/ws/{sessionId}`) — the server pushes the current pane content on connect and re-broadcasts on change (500ms poll). Rendered as ANSI→HTML via the shared `utils/ansi.js` into a `<pre>` sized at full desktop dimensions, then `transform: scale()`d into the tile (overlay-local element, so the transform is harmless). Bottom-anchored so the visible part is the live screen. Audio messages on tile sockets play through `desktop._playAudio` (device-level dedupe prevents double-play with a real window attached). |
 | **Artifact tiles** | A cloned `<iframe>` with the live window's `src` and sandbox attributes, scaled the same way, `pointer-events: none`. |
 | **Other windows** | Title-only fallback card ("no preview"). |


### PR DESCRIPTION
## Summary
- New `docs/wiki/internals/session-topology.md` documenting the four topology mechanisms shipped in #745-#749 (born-from-parent ghost placement, the Alt+L connector overlay, lineage-tinted/hierarchy-grouped collage, live `session_created` appearance) and the shared design tokens — every claim grounded in `spawn-ghost.js`, `topology-wires.js`, `lineage.js`, `collage.js`, `desktop.js`, `desktop.css`, `core.py`/`routes/notify.py`.
- Fixed `window-collage.md`'s stale "every open window" intro to describe the #748 family grouping; kept the "never mutate real windows" autopsy intact.
- Updated `portal.md`'s Desktop UI + Window Collage sections with Alt+L, born-from-parent placement, and instant live-appear.
- Added a "Session Topology" behavioral subsection to the `agentwire-desktop-ui` skill (next to the existing Topology Design Tokens section) and noted family grouping under Window Collage.
- Linked the new page from `INDEX.md`.

Verified against source (not invented): Alt+L is `e.code === 'KeyL'` in `setupTopologyWires()` (desktop.js); the `session_created` payload actually sent by `core.py`/`routes/notify.py` omits `machine` even though `desktop.js` destructures it defensively; collage tint keys on grid position while wires/placement hash the family root (the real divergence #755 tracks).

## Test plan
- [x] Docs-only change — no code touched.
- [x] Every shortcut/behavior cross-checked against the merged source cited above.

Closes #758