### PR TITLE
Unify lineage-tint slot assignment across topology surfaces

### DIFF
--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -40,6 +40,7 @@ import { desktop } from './desktop-manager.js';
 import { ansiToHtml } from './utils/ansi.js';
 import { isCommandPaletteOpen } from './command-palette.js';
 import { getAllSessions, ensureSessionsLoaded } from './sidebar/sessions-section.js';
+import { lineageTintVar } from './lineage.js';
 
 /** Overlay z-index: above all windows (WinBox's focus counter sets inline
  * z-indexes that grow from 10), below notification toasts (1500), modals
@@ -252,8 +253,8 @@ class Collage {
         );
 
         const activeId = desktop.getActiveWindow();
-        families.forEach((familyIds, familyIndex) => {
-            this._grid.appendChild(this._buildFamily(familyIds, familyIndex, activeId, areaRect));
+        families.forEach((family) => {
+            this._grid.appendChild(this._buildFamily(family.ids, family.root, activeId, areaRect));
         });
         this._overlay.appendChild(this._grid);
 
@@ -295,13 +296,16 @@ class Collage {
     }
 
     /**
-     * Group open window ids into families keyed by session-tree root.
-     * Non-session windows (artifacts/panels) have no lineage and each form
-     * their own singleton family. Within a family, ids are ordered
-     * ancestor-first so nested descendants render under their parent even
-     * across multiple generations.
+     * Group open window ids into families keyed by session-tree root. The
+     * root name is threaded through to _buildFamily so it can look up the
+     * family's hue via lineage.js's lineageTintVar (#755) — the same
+     * assignment placement and the wire overlay use, instead of re-deriving
+     * one here. Non-session windows (artifacts/panels) have no lineage and
+     * each form their own singleton family (rooted at their own id). Within
+     * a family, ids are ordered ancestor-first so nested descendants render
+     * under their parent even across multiple generations.
      * @param {string[]} ids
-     * @returns {string[][]} One array of window ids per family.
+     * @returns {Array<{root: string, ids: string[]}>} One entry per family.
      */
     _groupFamilies(ids) {
         const byName = new Map(getAllSessions().map((s) => [s.name || '', s]));
@@ -315,29 +319,31 @@ class Collage {
             if (!families.has(root)) families.set(root, []);
             families.get(root).push({ id, depth });
         }
-        return [...families.values()].map((entries) =>
-            entries.sort((a, b) => a.depth - b.depth).map((e) => e.id),
-        );
+        return [...families.entries()].map(([root, entries]) => ({
+            root,
+            ids: entries.sort((a, b) => a.depth - b.depth).map((e) => e.id),
+        }));
     }
 
     /**
      * Build one grid cell for a family: a lone tile for a singleton family,
      * or a tinted cluster (parent on top, children nested below in a
-     * wrapping row) for a family with descendants. Family hue cycles
-     * through the shared --lineage-tint-1..6 tokens by family index so
-     * lineage reads without labels (#748/#749). `overflow: hidden` on the
-     * cluster (CSS) is what keeps a family with many children from ever
-     * pushing the grid into horizontal overflow — it scrolls vertically
-     * instead.
+     * wrapping row) for a family with descendants. Family hue comes from
+     * lineage.js's `lineageTintVar` (#755) — a root-hash, not grid position,
+     * so a family keeps the same hue here as on placement and the wire
+     * overlay. `overflow: hidden` on the cluster (CSS) is what keeps a
+     * family with many children from ever pushing the grid into horizontal
+     * overflow — it scrolls vertically instead.
      * @param {string[]} familyIds - Ancestor-first window ids for this family.
-     * @param {number} familyIndex - Position among this grid's families.
+     * @param {string} root - Family root session name (or window id, for a
+     *   singleton family rooted at a non-session window).
      * @param {string|null} activeId - Currently-active window id.
      * @param {DOMRect} areaRect
      */
-    _buildFamily(familyIds, familyIndex, activeId, areaRect) {
+    _buildFamily(familyIds, root, activeId, areaRect) {
         const wrap = document.createElement('div');
         wrap.className = 'collage-family';
-        wrap.style.setProperty('--family-tint', `var(--lineage-tint-${(familyIndex % 6) + 1})`);
+        wrap.style.setProperty('--family-tint', `var(${lineageTintVar(root, getAllSessions())})`);
 
         if (familyIds.length === 1) {
             wrap.classList.add('is-singleton');

--- a/agentwire/static/js/topology-wires.js
+++ b/agentwire/static/js/topology-wires.js
@@ -10,9 +10,10 @@
  * Parent/child pairing reuses sessions-section.js's `s.parent` linkage (the
  * same data the sidebar's nested tree renders from) rather than re-deriving
  * it — see ensureSessionsLoaded()/getAllSessions()/activityStates there
- * (also used by collage.js's #748 family grouping). Colors pull from the
- * lineage-tint + failure-state-parity tokens (#749) in desktop.css; never a
- * hardcoded hex.
+ * (also used by collage.js's #748 family grouping). Colors come from
+ * lineage.js's `lineageTintVar` (#755 — the same family → hue assignment
+ * placement and collage use) plus the failure-state-parity tokens (#749) in
+ * desktop.css; never a hardcoded hex.
  *
  * @module topology-wires
  */
@@ -20,6 +21,7 @@
 import { desktop } from './desktop-manager.js';
 import { buildSessionId, normalizeMachine } from './session-id.js';
 import { getAllSessions, activityStates, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
+import { lineageTintVar } from './lineage.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -30,29 +32,6 @@ const WIRES_Z = 900;
 
 const VISIBLE_KEY = 'aw-topology-wires-visible';
 export const TOPOLOGY_WIRES_EVENT = 'topology-wires-change';
-
-/** Stable, order-independent family color: hash the family's root session
- * name into one of the 6 lineage-tint slots (#749 SSOT palette). Avoids
- * re-deriving a palette here — only picks which of the shared vars applies. */
-function tintIndexForRoot(root) {
-    let h = 0;
-    for (let i = 0; i < root.length; i++) h = (h * 31 + root.charCodeAt(i)) >>> 0;
-    return (h % 6) + 1;
-}
-
-/** Walk `s.parent` up to the family root, guarding against cycles the same
- * way sessions-section.js's buildSessionTree does. */
-function familyRootName(name, byName) {
-    const guard = new Set();
-    let cur = name;
-    for (;;) {
-        const rec = byName.get(cur);
-        const parent = rec && rec.parent;
-        if (!parent || parent === cur || !byName.has(parent) || guard.has(parent)) return cur;
-        guard.add(parent);
-        cur = parent;
-    }
-}
 
 /** 'idle' | 'flow' (processing/generating/playing) | 'awaiting' | 'stuck'.
  * `state`/`state_kind` (needs_input/off) only land on the session record
@@ -98,7 +77,7 @@ class TopologyWires {
     constructor() {
         /** @type {SVGSVGElement|null} */
         this._svg = null;
-        /** @type {Map<string, {path: SVGPathElement, stateClass: string|null, tintIdx: number|null}>} */
+        /** @type {Map<string, {path: SVGPathElement, stateClass: string|null, tintVar: string|null}>} */
         this._paths = new Map();
         /** @type {number|null} */
         this._raf = null;
@@ -198,7 +177,7 @@ class TopologyWires {
                 key: `${parentId}=>${childId}`,
                 parentWin,
                 childWin,
-                tintIdx: tintIndexForRoot(familyRootName(name, byName)),
+                tintVar: lineageTintVar(name, sessions),
                 state: wireStateFor(name, s),
             });
         }
@@ -229,7 +208,7 @@ class TopologyWires {
                 const path = document.createElementNS(SVG_NS, 'path');
                 path.setAttribute('class', 'topology-wire');
                 this._svg.appendChild(path);
-                entry = { path, stateClass: null, tintIdx: null };
+                entry = { path, stateClass: null, tintVar: null };
                 this._paths.set(pair.key, entry);
             }
             if (entry.path.getAttribute('d') !== d) entry.path.setAttribute('d', d);
@@ -240,9 +219,9 @@ class TopologyWires {
                 if (stateClass) entry.path.classList.add(stateClass);
                 entry.stateClass = stateClass;
             }
-            if (entry.tintIdx !== pair.tintIdx) {
-                entry.path.style.setProperty('--wire-tint', `var(--lineage-tint-${pair.tintIdx})`);
-                entry.tintIdx = pair.tintIdx;
+            if (entry.tintVar !== pair.tintVar) {
+                entry.path.style.setProperty('--wire-tint', `var(${pair.tintVar})`);
+                entry.tintVar = pair.tintVar;
             }
         }
 


### PR DESCRIPTION
## Summary
- `collage.js` and `topology-wires.js` each derived a family's hue independently (collage: positional `familyIndex % 6`; wires: hash of session name into 6 slots), so the same family could render a different color on placement vs. wires vs. collage.
- Both now call `lineageTintVar(root, sessions)` from `lineage.js` — the same shared primitive placement (#745) already uses — so one family gets one stable hue everywhere.
- Deleted the now-dead per-surface assignment functions (`topology-wires.js`'s `tintIndexForRoot`/`familyRootName`, `collage.js`'s `familyIndex % 6` calc). `collage.js`'s `_lineageOf`/`_groupFamilies` walk stays — it's needed for depth-based tile ordering, a separate concern from hue assignment — but now threads the resolved family root through to `_buildFamily` for the tint lookup.

## Test plan
- [x] `node --check --input-type=module < file.js` on all three touched files (`lineage.js`, `topology-wires.js`, `collage.js`)
- [x] Node sanity check confirming `lineageTintVar` returns the same `--lineage-tint-N` for every member of a family and different values across families
- [ ] Visual check in the portal: open a parent + child session pair and confirm placement ghost, connector wire, and collage tile all render the same hue (not verified live in this worktree — no dev server running here)

Closes #755

Built by dotdev.dev