### PR TITLE
feat(portal): shared topology renderer — TopologyView (#761)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6438,6 +6438,263 @@ body.sidebar-pinned .sidebar-tab {
     }
 }
 
+/* --- shared topology renderer (#761) — topology-render.js's TopologyView
+   Mount-agnostic family-card renderer shared by the Session Workspace window
+   (#762) and the phantom overlay (#764) — "one engine, two mounts". Cards
+   stack in normal flex-wrap flow (never absolute-positioned on a wide
+   canvas) so a family packs into a narrow ~1/3-width portal column: one row
+   per lineage depth, 1-2 cards per row once wrapped. --family-tint /
+   --card-tint / --link-tint are set inline per family/card/link, always an
+   alias of --lineage-tint-1..6 (never a hardcoded hex, same rule as the rest
+   of this === topology === section). */
+.topology-view {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 10px;
+}
+
+.topology-view-links {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+}
+
+.topology-family {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.topology-row {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+}
+
+.topology-card {
+    position: relative;
+    flex: 1 1 150px;
+    max-width: 220px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--chrome);
+    border: 1px solid color-mix(in srgb, var(--card-tint, var(--lineage-tint-1)) 45%, var(--chrome-border));
+    border-radius: 10px;
+    padding: 8px 10px;
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.topology-card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--card-tint, var(--lineage-tint-1)) 75%, var(--chrome-border));
+}
+
+/* Overlay mount pops over a live terminal window, so its cards read as
+   glass; the workspace-window mount is a page in its own right and stays
+   solid chrome (the default above). */
+.topology-view--overlay .topology-card {
+    background: color-mix(in srgb, var(--chrome) 74%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.topology-card-top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+
+.topology-status-dot {
+    position: relative;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    background: var(--text-muted);
+    opacity: 0.5;
+}
+
+.topology-status-dot::after {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    border: 1px solid currentColor;
+    opacity: 0;
+}
+
+.topology-card-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.topology-role-chip {
+    flex: 0 0 auto;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 2px 6px;
+    border-radius: 5px;
+    border: 1px solid color-mix(in srgb, var(--neon-blue) 45%, transparent);
+    background: color-mix(in srgb, var(--neon-blue) 8%, transparent);
+    color: var(--neon-blue);
+}
+
+.topology-role-chip--orchestrator {
+    border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    color: var(--accent);
+}
+
+.topology-card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+}
+
+.topology-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 12px;
+}
+
+.topology-spark i {
+    display: block;
+    width: 2px;
+    height: 3px;
+    border-radius: 1px;
+    background: var(--text-muted);
+    opacity: 0.5;
+}
+
+.topology-card-machine {
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* flow (processing/generating/playing) — family-tinted "alive" treatment */
+.topology-card--flow .topology-status-dot {
+    background: var(--card-tint, var(--lineage-tint-1));
+    color: var(--card-tint, var(--lineage-tint-1));
+    opacity: 1;
+}
+.topology-card--flow .topology-status-dot::after {
+    opacity: 0.5;
+    animation: topology-dot-ring 1.8s ease-out infinite;
+}
+.topology-card--flow .topology-spark i {
+    background: var(--card-tint, var(--lineage-tint-1));
+    opacity: 0.9;
+    animation: topology-spark-eq 1s ease-in-out infinite;
+}
+
+/* Failure-state parity (#749): awaiting/stuck override the lineage tint
+   outright, same rule as the connector overlay above — a blocked child must
+   never read as "fine" just because its family hue is calm. */
+.topology-card--awaiting .topology-status-dot {
+    background: var(--topology-awaiting);
+    color: var(--topology-awaiting);
+    opacity: 1;
+}
+.topology-card--awaiting .topology-status-dot::after {
+    opacity: 0.6;
+    animation: topology-dot-ring 1.3s ease-out infinite;
+}
+.topology-card--awaiting .topology-spark i {
+    background: var(--topology-awaiting);
+    opacity: 0.7;
+}
+.topology-card--stuck .topology-status-dot {
+    background: var(--topology-stuck);
+    color: var(--topology-stuck);
+    opacity: 1;
+}
+.topology-card--stuck .topology-status-dot::after {
+    opacity: 0.7;
+    animation: topology-dot-ring 0.9s ease-out infinite;
+}
+.topology-card--stuck .topology-spark i {
+    background: var(--topology-stuck);
+    opacity: 0.7;
+}
+
+@keyframes topology-dot-ring {
+    0% { transform: scale(0.6); opacity: 0.7; }
+    100% { transform: scale(1.9); opacity: 0; }
+}
+@keyframes topology-spark-eq {
+    0%, 100% { height: 3px; }
+    50% { height: 11px; }
+}
+
+.topology-link {
+    fill: none;
+    stroke: var(--link-tint, var(--lineage-tint-1));
+    stroke-width: 2px;
+    stroke-linecap: round;
+    opacity: 0.45;
+    filter: drop-shadow(0 0 3px color-mix(in srgb, var(--link-tint, var(--lineage-tint-1)) 45%, transparent));
+}
+.topology-link--flow {
+    opacity: 0.9;
+    stroke-dasharray: 7 7;
+    animation: topology-link-flow 0.7s linear infinite;
+}
+.topology-link--awaiting {
+    stroke: var(--topology-awaiting);
+    opacity: 0.95;
+    filter: drop-shadow(0 0 5px var(--topology-awaiting-glow));
+    animation: topology-link-pulse 1.3s ease-in-out infinite;
+}
+.topology-link--stuck {
+    stroke: var(--topology-stuck);
+    opacity: 1;
+    filter: drop-shadow(0 0 6px var(--topology-stuck-glow));
+    animation: topology-link-pulse 0.7s ease-in-out infinite;
+}
+
+@keyframes topology-link-flow {
+    to { stroke-dashoffset: -28; }
+}
+@keyframes topology-link-pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .topology-status-dot::after,
+    .topology-card--flow .topology-spark i,
+    .topology-link--flow,
+    .topology-link--awaiting,
+    .topology-link--stuck {
+        animation: none;
+    }
+}
+
 /* --- born-from-parent placement (#745) ---
    Overlay ghost that flies from a parent window's title-bar edge to the
    landing spot; the real WinBox window is only created once the ghost is

--- a/agentwire/static/js/collage.js
+++ b/agentwire/static/js/collage.js
@@ -40,7 +40,7 @@ import { desktop } from './desktop-manager.js';
 import { ansiToHtml } from './utils/ansi.js';
 import { isCommandPaletteOpen } from './command-palette.js';
 import { getAllSessions, ensureSessionsLoaded } from './sidebar/sessions-section.js';
-import { lineageTintVar } from './lineage.js';
+import { lineageTintVar, lineageOf } from './lineage.js';
 
 /** Overlay z-index: above all windows (WinBox's focus counter sets inline
  * z-indexes that grow from 10), below notification toasts (1500), modals
@@ -272,37 +272,17 @@ class Collage {
     }
 
     /**
-     * Resolve a session's family root and its depth below that root, by
-     * walking `.parent` (the same display linkage the sidebar's session
-     * tree uses — see sessions-section.js `buildSessionTree`). A parent
-     * that's absent, self-referential, or not in the current session list
-     * makes `name` its own root. `seen` guards against a parent cycle.
-     * @param {Map<string, object>} byName - session name → session record
-     * @param {string} name
-     * @returns {{root: string, depth: number}}
-     */
-    _lineageOf(byName, name) {
-        let cur = name;
-        let depth = 0;
-        const seen = new Set([name]);
-        while (true) {
-            const parent = byName.get(cur)?.parent;
-            if (!parent || parent === cur || !byName.has(parent) || seen.has(parent)) break;
-            seen.add(parent);
-            cur = parent;
-            depth++;
-        }
-        return { root: cur, depth };
-    }
-
-    /**
      * Group open window ids into families keyed by session-tree root. The
-     * root name is threaded through to _buildFamily so it can look up the
-     * family's hue via lineage.js's lineageTintVar (#755) — the same
-     * assignment placement and the wire overlay use, instead of re-deriving
-     * one here. Non-session windows (artifacts/panels) have no lineage and
-     * each form their own singleton family (rooted at their own id). Within
-     * a family, ids are ordered ancestor-first so nested descendants render
+     * root-resolution walk itself is lineage.js's `lineageOf` (#761 — the
+     * same walk `groupFamilies` and `familyRootName` build on) rather than a
+     * copy kept here; this method only adds the window-id-specific parts:
+     * looking up each id's session name and giving non-session windows
+     * (artifacts/panels) their own singleton family (rooted at their own
+     * id, since they have no lineage to walk). The root name is threaded
+     * through to _buildFamily so it can look up the family's hue via
+     * lineage.js's lineageTintVar (#755) — the same assignment placement and
+     * the wire overlay use, instead of re-deriving one here. Within a
+     * family, ids are ordered ancestor-first so nested descendants render
      * under their parent even across multiple generations.
      * @param {string[]} ids
      * @returns {Array<{root: string, ids: string[]}>} One entry per family.
@@ -314,7 +294,7 @@ class Collage {
             const inst = this._lookup(id);
             const isSession = inst && typeof inst.session === 'string';
             const { root, depth } = isSession
-                ? this._lineageOf(byName, inst.session)
+                ? lineageOf(byName, inst.session)
                 : { root: id, depth: 0 };
             if (!families.has(root)) families.set(root, []);
             families.get(root).push({ id, depth });

--- a/agentwire/static/js/lineage.js
+++ b/agentwire/static/js/lineage.js
@@ -5,9 +5,9 @@
  * `agentwire/static/css/desktop.css` `--lineage-tint-1..6`). A family is a
  * root session plus every descendant reachable by walking `.parent` links;
  * the whole family shares one hue so relatedness reads at a glance without
- * labels. Consumed by the born-from-parent ghost (#745) and meant to be
- * reused by the connector overlay / grouped collage slices rather than each
- * re-deriving its own palette.
+ * labels. Consumed by the born-from-parent ghost (#745) and reused by the
+ * connector overlay, grouped collage slices, and the shared topology
+ * renderer (#761) rather than each re-deriving its own palette or walk.
  *
  * @module lineage
  */
@@ -15,9 +15,34 @@
 const TINT_COUNT = 6;
 
 /**
- * Walk `.parent` links from `name` up to its root ancestor.
- * Tolerant of missing sessions, self-referencing parents, and cycles (caps
- * the walk depth rather than looping forever).
+ * Walk `.parent` links from `name` to its root ancestor, tracking depth.
+ * Cycle-safe via an exact `seen` set (a 2-cycle stops immediately rather than
+ * spinning for a fixed number of iterations). The one shared implementation
+ * of "resolve a session's family root" — `familyRootName` below and
+ * `groupFamilies` both build on it, and `collage.js`'s window-id family
+ * grouping calls it directly, so there is exactly one root-resolution walk
+ * in the codebase, not a copy per consumer.
+ *
+ * @param {Map<string, {name?: string, parent?: string|null}>} byName - Session name → record.
+ * @param {string} name - Session name to resolve.
+ * @returns {{root: string, depth: number}} Root ancestor's name and hop count to it.
+ */
+export function lineageOf(byName, name) {
+    let cur = name;
+    let depth = 0;
+    const seen = new Set([name]);
+    while (true) {
+        const parent = byName.get(cur)?.parent;
+        if (!parent || parent === cur || !byName.has(parent) || seen.has(parent)) break;
+        seen.add(parent);
+        cur = parent;
+        depth++;
+    }
+    return { root: cur, depth };
+}
+
+/**
+ * Tolerant of missing sessions, self-referencing parents, and cycles.
  *
  * @param {string} name - Session name to resolve.
  * @param {Array<{name: string, parent?: string|null}>} sessions - Full session list.
@@ -25,19 +50,35 @@ const TINT_COUNT = 6;
  */
 export function familyRootName(name, sessions) {
     const byName = new Map((sessions || []).map((s) => [s.name, s]));
-    let current = byName.get(name);
-    let depth = 0;
-    while (
-        current &&
-        current.parent &&
-        current.parent !== current.name &&
-        byName.has(current.parent) &&
-        depth < 32
-    ) {
-        current = byName.get(current.parent);
-        depth++;
+    return lineageOf(byName, name).root;
+}
+
+/**
+ * Group a session list into families (a root + every descendant reachable
+ * via `.parent`), each family's members ordered ancestor-first (root, then
+ * descendants by increasing depth) so parent-before-child render/layout
+ * order falls out for free. Shared by the topology renderer (#761) for its
+ * card layout; `collage.js` groups *window ids* instead (some of which are
+ * non-session windows with no lineage) so it calls `lineageOf` directly
+ * rather than this session-list form.
+ *
+ * @param {Array<{name: string, parent?: string|null}>} sessions
+ * @returns {Array<{root: string, members: Array<{name: string, depth: number}>}>}
+ */
+export function groupFamilies(sessions) {
+    const byName = new Map((sessions || []).map((s) => [s.name, s]));
+    const families = new Map(); // root name → [{name, depth}]
+    for (const s of sessions || []) {
+        const name = s.name;
+        if (!name) continue;
+        const { root, depth } = lineageOf(byName, name);
+        if (!families.has(root)) families.set(root, []);
+        families.get(root).push({ name, depth });
     }
-    return current ? current.name : name;
+    return [...families.entries()].map(([root, members]) => ({
+        root,
+        members: members.sort((a, b) => a.depth - b.depth),
+    }));
 }
 
 /** Deterministic small-int hash of a string, stable across reloads/renders. */

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -1,0 +1,351 @@
+/**
+ * topology-render.js
+ *
+ * Mount-agnostic session-family renderer (#761) — the shared engine behind
+ * the Session Workspace window (#762) and the phantom overlay (#764).
+ * Given a container element and a session list, TopologyView renders one
+ * block per family (root + descendants, grouped by lineage.js's
+ * `groupFamilies`): a card per session (status dot, name, role chip,
+ * activity sparkline, machine tag) plus curved SVG links from each card to
+ * its parent's, tinted by the family's `lineageTintVar`. `render()` is
+ * idempotent — repeat calls diff cards/rows/links against the previous pass
+ * instead of tearing down and rebuilding the DOM, so a spawn or kill
+ * mid-view doesn't flash the whole tree.
+ *
+ * Deliberately narrow-first: cards lay out in normal document flow
+ * (flex-wrap rows, 1-2 cards per row), never an absolutely-positioned wide
+ * canvas — the owner runs the portal in a narrow ~1/3-width window, which is
+ * exactly why the previous connector overlay (#746, topology-wires.js,
+ * wiring title bars of spread-out windows) read as a stray line slashing
+ * across terminal text. `wireStateFor` below is that overlay's status
+ * mapping, extracted here as the one shared copy so a card, a wire, and the
+ * sidebar dot never disagree on what "awaiting"/"stuck" means.
+ *
+ * @module topology-render
+ */
+
+import { groupFamilies, lineageTintVar } from './lineage.js';
+import { activityStates } from './sidebar/sessions-section.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * 'idle' | 'flow' (processing/generating/playing) | 'awaiting' | 'stuck'.
+ * `state`/`state_kind` (needs_input/off) only land on the session record
+ * right after an /api/sessions/local fetch — not on every periodic
+ * sessions_update push — so treat them as a best-effort overlay on top of
+ * the always-live activityStates map (same source the sidebar dot uses).
+ *
+ * @param {string} name - Session name.
+ * @param {{state?: string, activity?: string}} [record] - Session record.
+ * @returns {'idle'|'flow'|'awaiting'|'stuck'}
+ */
+export function wireStateFor(name, record) {
+    if (record?.state === 'needs_input') return 'awaiting';
+    if (record?.state === 'off') return 'stuck';
+    const activity = activityStates.get(name) || record?.activity || 'idle';
+    if (activity === 'processing' || activity === 'generating' || activity === 'playing' || activity === 'active') {
+        return 'flow';
+    }
+    return 'idle';
+}
+
+/** Vertical S-curve from a parent card's bottom edge to a child card's top
+ * edge — reads sensibly whether the pair ends up side by side or stacked
+ * across a row wrap. Same shape as topology-wires.js's bezierPath. */
+function bezierPath(x1, y1, x2, y2) {
+    const bend = Math.max(Math.abs(y2 - y1), 24) * 0.5;
+    return `M ${x1} ${y1} C ${x1} ${y1 + bend}, ${x2} ${y2 - bend}, ${x2} ${y2}`;
+}
+
+export class TopologyView {
+    /**
+     * @param {HTMLElement} container - Mount point; TopologyView owns everything appended under it.
+     * @param {object} [opts]
+     * @param {(name: string, session: object) => void} [opts.onCardClick] - Fired on card click.
+     * @param {boolean} [opts.showLinks=true] - Draw the connector SVG layer.
+     * @param {'window'|'overlay'} [opts.mode='window'] - Styling hook only — 'overlay' renders
+     *   translucent glass cards for popping over a live terminal window; 'window' (default)
+     *   renders solid chrome for a first-class workspace window.
+     */
+    constructor(container, opts = {}) {
+        this._container = container;
+        this._onCardClick = opts.onCardClick || null;
+        this._showLinks = opts.showLinks !== false;
+        this._mode = opts.mode === 'overlay' ? 'overlay' : 'window';
+        this._lastSessions = [];
+
+        /** @type {Map<string, {familyEl: HTMLElement, rows: Map<number, HTMLElement>}>} */
+        this._families = new Map();
+        /** @type {Map<string, object>} card entries keyed by session name */
+        this._cards = new Map();
+        /** @type {Map<string, {path: SVGPathElement, stateClass: string|null, tintVar: string|null}>} */
+        this._links = new Map();
+        this._raf = null;
+
+        this._root = document.createElement('div');
+        this._root.className = `topology-view topology-view--${this._mode}`;
+        container.appendChild(this._root);
+
+        if (this._showLinks) {
+            this._svg = document.createElementNS(SVG_NS, 'svg');
+            this._svg.setAttribute('class', 'topology-view-links');
+            this._root.appendChild(this._svg);
+        } else {
+            this._svg = null;
+        }
+
+        this._scheduleRedraw = this._scheduleRedraw.bind(this);
+        this._resizeObserver = new ResizeObserver(this._scheduleRedraw);
+        this._resizeObserver.observe(this._root);
+        window.addEventListener('resize', this._scheduleRedraw);
+    }
+
+    /**
+     * Render (or re-render) the family tree for the given session list.
+     * Idempotent: existing family/row/card DOM nodes are reused and only
+     * their content/classes are patched, so repeated calls diff in place.
+     * @param {Array<object>} sessions
+     */
+    render(sessions) {
+        this._lastSessions = sessions || [];
+        const byName = new Map(this._lastSessions.map((s) => [s.name || '', s]));
+        const families = groupFamilies(this._lastSessions);
+
+        const seenFamilies = new Set();
+        const seenCards = new Set();
+
+        for (const family of families) {
+            seenFamilies.add(family.root);
+            const entry = this._ensureFamily(family.root);
+            const seenRows = new Set();
+            for (const member of family.members) {
+                const session = byName.get(member.name);
+                if (!session) continue;
+                seenCards.add(member.name);
+                seenRows.add(member.depth);
+                const row = this._ensureRow(entry, member.depth);
+                this._renderCard(row, session, family.root);
+            }
+            this._pruneRows(entry, seenRows);
+        }
+
+        this._pruneFamilies(seenFamilies);
+        this._pruneCards(seenCards);
+        this._scheduleRedraw();
+    }
+
+    /** Tear down everything TopologyView appended into its container. */
+    dispose() {
+        this._resizeObserver.disconnect();
+        window.removeEventListener('resize', this._scheduleRedraw);
+        if (this._raf !== null) cancelAnimationFrame(this._raf);
+        this._root.remove();
+        this._families.clear();
+        this._cards.clear();
+        this._links.clear();
+    }
+
+    _ensureFamily(root) {
+        let entry = this._families.get(root);
+        if (!entry) {
+            const familyEl = document.createElement('div');
+            familyEl.className = 'topology-family';
+            familyEl.dataset.familyRoot = root;
+            this._root.appendChild(familyEl);
+            entry = { familyEl, rows: new Map() };
+            this._families.set(root, entry);
+        }
+        entry.familyEl.style.setProperty('--family-tint', `var(${lineageTintVar(root, this._lastSessions)})`);
+        return entry;
+    }
+
+    /** Depth-ordered rows within a family so "parent on top" holds even as
+     * rows are added/removed across renders — a new row is inserted before
+     * the first existing row with a greater depth rather than appended. */
+    _ensureRow(entry, depth) {
+        let row = entry.rows.get(depth);
+        if (!row) {
+            row = document.createElement('div');
+            row.className = 'topology-row' + (depth === 0 ? ' topology-row--root' : '');
+            const deeper = [...entry.rows.entries()]
+                .filter(([d]) => d > depth)
+                .sort((a, b) => a[0] - b[0])[0];
+            if (deeper) entry.familyEl.insertBefore(row, deeper[1]);
+            else entry.familyEl.appendChild(row);
+            entry.rows.set(depth, row);
+        }
+        return row;
+    }
+
+    _pruneRows(entry, seenRows) {
+        for (const [depth, row] of entry.rows) {
+            if (!seenRows.has(depth)) {
+                row.remove();
+                entry.rows.delete(depth);
+            }
+        }
+    }
+
+    _pruneFamilies(seenFamilies) {
+        for (const [root, entry] of this._families) {
+            if (!seenFamilies.has(root)) {
+                entry.familyEl.remove();
+                this._families.delete(root);
+            }
+        }
+    }
+
+    _pruneCards(seenCards) {
+        for (const [name, entry] of this._cards) {
+            if (!seenCards.has(name)) {
+                entry.card.remove();
+                this._cards.delete(name);
+                this._links.delete(name);
+            }
+        }
+    }
+
+    _renderCard(row, session, familyRoot) {
+        const name = session.name || '';
+        let entry = this._cards.get(name);
+        if (!entry) {
+            entry = this._buildCard(name);
+            this._cards.set(name, entry);
+        }
+        if (entry.card.parentElement !== row) row.appendChild(entry.card);
+
+        entry.session = session;
+
+        const state = wireStateFor(name, session);
+        if (entry.state !== state) {
+            if (entry.state) entry.card.classList.remove(`topology-card--${entry.state}`);
+            entry.card.classList.add(`topology-card--${state}`);
+            entry.state = state;
+        }
+
+        if (entry.nameEl.textContent !== name) entry.nameEl.textContent = name;
+
+        const role = (session.roles && session.roles[0]) || 'worker';
+        if (entry.roleEl.textContent !== role) {
+            entry.roleEl.textContent = role;
+            entry.roleEl.classList.toggle('topology-role-chip--orchestrator', role === 'orchestrator');
+        }
+
+        const machine = session.machine ? `⌂ ${session.machine}` : '';
+        if (entry.machineEl.textContent !== machine) {
+            entry.machineEl.textContent = machine;
+            entry.machineEl.hidden = !machine;
+        }
+
+        const tintVar = lineageTintVar(familyRoot, this._lastSessions);
+        if (entry.tintVar !== tintVar) {
+            entry.card.style.setProperty('--card-tint', `var(${tintVar})`);
+            entry.tintVar = tintVar;
+        }
+    }
+
+    _buildCard(name) {
+        const card = document.createElement('div');
+        card.className = 'topology-card';
+        card.dataset.session = name;
+        card.addEventListener('click', () => {
+            const entry = this._cards.get(name);
+            this._onCardClick?.(name, entry?.session);
+        });
+
+        const top = document.createElement('div');
+        top.className = 'topology-card-top';
+        const dot = document.createElement('span');
+        dot.className = 'topology-status-dot';
+        const nameEl = document.createElement('span');
+        nameEl.className = 'topology-card-name';
+        const roleEl = document.createElement('span');
+        roleEl.className = 'topology-role-chip';
+        top.append(dot, nameEl, roleEl);
+
+        const sparkEl = document.createElement('div');
+        sparkEl.className = 'topology-spark';
+        for (let i = 0; i < 5; i++) {
+            const bar = document.createElement('i');
+            bar.style.animationDelay = `${i * 90}ms`;
+            sparkEl.appendChild(bar);
+        }
+        const machineEl = document.createElement('span');
+        machineEl.className = 'topology-card-machine';
+        machineEl.hidden = true;
+
+        const meta = document.createElement('div');
+        meta.className = 'topology-card-meta';
+        meta.append(sparkEl, machineEl);
+
+        card.append(top, meta);
+
+        return { card, dot, nameEl, roleEl, machineEl, sparkEl, state: null, tintVar: null, session: null };
+    }
+
+    _scheduleRedraw() {
+        if (this._raf !== null) return;
+        this._raf = requestAnimationFrame(() => {
+            this._raf = null;
+            this._redrawLinks();
+        });
+    }
+
+    _redrawLinks() {
+        if (!this._svg) return;
+        const rootRect = this._root.getBoundingClientRect();
+        const byName = new Map(this._lastSessions.map((s) => [s.name || '', s]));
+        const seen = new Set();
+
+        for (const [name, session] of byName) {
+            const parentName = session.parent;
+            if (!name || !parentName || parentName === name || !byName.has(parentName)) continue;
+            const childEntry = this._cards.get(name);
+            const parentEntry = this._cards.get(parentName);
+            if (!childEntry || !parentEntry) continue;
+
+            const parentRect = parentEntry.card.getBoundingClientRect();
+            const childRect = childEntry.card.getBoundingClientRect();
+            if (!parentRect.width || !childRect.width) continue; // not laid out (e.g. hidden) yet
+            seen.add(name);
+
+            const x1 = parentRect.left + parentRect.width / 2 - rootRect.left;
+            const y1 = parentRect.bottom - rootRect.top;
+            const x2 = childRect.left + childRect.width / 2 - rootRect.left;
+            const y2 = childRect.top - rootRect.top;
+            const d = bezierPath(x1, y1, x2, y2);
+
+            let entry = this._links.get(name);
+            if (!entry) {
+                const path = document.createElementNS(SVG_NS, 'path');
+                path.setAttribute('class', 'topology-link');
+                this._svg.appendChild(path);
+                entry = { path, stateClass: null, tintVar: null };
+                this._links.set(name, entry);
+            }
+            if (entry.path.getAttribute('d') !== d) entry.path.setAttribute('d', d);
+
+            const state = wireStateFor(name, session);
+            const stateClass = state === 'idle' ? null : `topology-link--${state}`;
+            if (entry.stateClass !== stateClass) {
+                if (entry.stateClass) entry.path.classList.remove(entry.stateClass);
+                if (stateClass) entry.path.classList.add(stateClass);
+                entry.stateClass = stateClass;
+            }
+
+            const tintVar = lineageTintVar(name, this._lastSessions);
+            if (entry.tintVar !== tintVar) {
+                entry.path.style.setProperty('--link-tint', `var(${tintVar})`);
+                entry.tintVar = tintVar;
+            }
+        }
+
+        for (const [name, entry] of this._links) {
+            if (!seen.has(name)) {
+                entry.path.remove();
+                this._links.delete(name);
+            }
+        }
+    }
+}

--- a/agentwire/static/js/topology-wires.js
+++ b/agentwire/static/js/topology-wires.js
@@ -13,15 +13,19 @@
  * (also used by collage.js's #748 family grouping). Colors come from
  * lineage.js's `lineageTintVar` (#755 — the same family → hue assignment
  * placement and collage use) plus the failure-state-parity tokens (#749) in
- * desktop.css; never a hardcoded hex.
+ * desktop.css; never a hardcoded hex. Status mapping (`wireStateFor`) lives
+ * in topology-render.js (#761) — the shared card renderer this module is
+ * slated to be superseded by (#764) — so this overlay and the cards agree
+ * on what "awaiting"/"stuck" means from one implementation, not two.
  *
  * @module topology-wires
  */
 
 import { desktop } from './desktop-manager.js';
 import { buildSessionId, normalizeMachine } from './session-id.js';
-import { getAllSessions, activityStates, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
+import { getAllSessions, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
 import { lineageTintVar } from './lineage.js';
+import { wireStateFor } from './topology-render.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -32,21 +36,6 @@ const WIRES_Z = 900;
 
 const VISIBLE_KEY = 'aw-topology-wires-visible';
 export const TOPOLOGY_WIRES_EVENT = 'topology-wires-change';
-
-/** 'idle' | 'flow' (processing/generating/playing) | 'awaiting' | 'stuck'.
- * `state`/`state_kind` (needs_input/off) only land on the session record
- * right after an /api/sessions/local fetch — not on every periodic
- * sessions_update push — so treat them as a best-effort overlay on top of
- * the always-live activityStates map (same source the sidebar dot uses). */
-function wireStateFor(name, record) {
-    if (record?.state === 'needs_input') return 'awaiting';
-    if (record?.state === 'off') return 'stuck';
-    const activity = activityStates.get(name) || record?.activity || 'idle';
-    if (activity === 'processing' || activity === 'generating' || activity === 'playing' || activity === 'active') {
-        return 'flow';
-    }
-    return 'idle';
-}
 
 /**
  * A minimized WinBox is `display: none` (this app hides WinBox's own min-bar

--- a/agentwire/static/topology-harness.html
+++ b/agentwire/static/topology-harness.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>topology-render.js harness</title>
+<link rel="stylesheet" href="css/desktop.css">
+<style>
+  /* Harness chrome only — everything inside #stage is styled by desktop.css
+     tokens, same as the real app. Deliberately narrow: this proves the
+     renderer packs a family into a ~1/3-screen-width column, not a wide
+     canvas (see feedback_owner_runs_portal_narrow). */
+  body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 24px 16px 60px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  }
+  h1 { font-size: 15px; color: var(--text); margin: 0; }
+  p { font-size: 12.5px; color: var(--text-muted); max-width: 60ch; text-align: center; margin: 0; }
+  .controls { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+  button {
+    font-family: inherit;
+    font-size: 12px;
+    padding: 7px 12px;
+    border-radius: 7px;
+    border: 1px solid var(--chrome-border);
+    background: var(--chrome);
+    color: var(--text);
+    cursor: pointer;
+  }
+  button:hover { border-color: var(--accent); color: var(--accent); }
+  #stage {
+    width: min(360px, 92vw);
+    border: 1px solid var(--chrome-border);
+    border-radius: 12px;
+    background: #05070a;
+    max-height: 70vh;
+    overflow: auto;
+  }
+  #log { font-size: 11px; color: var(--text-muted); min-height: 1.4em; }
+</style>
+</head>
+<body>
+  <h1>topology-render.js — TopologyView harness</h1>
+  <p>Mock family only, no live portal data. Proves cards + lineage-tinted links render inside a
+    narrow column, and that add/remove/state-change re-renders diff the existing DOM
+    instead of tearing it down.</p>
+  <div class="controls">
+    <button id="add">+ spawn child</button>
+    <button id="remove">- kill last</button>
+    <button id="cycle">cycle states</button>
+  </div>
+  <div id="stage"></div>
+  <div id="log"></div>
+
+<script type="module">
+import { TopologyView } from './js/topology-render.js';
+
+let sessions = [
+  { name: 'agentwire', parent: null, roles: ['orchestrator'], machine: 'jordans-mini', activity: 'idle' },
+  { name: 'feat-login-ui', parent: 'agentwire', roles: ['worker'], machine: 'jordans-mini', activity: 'processing' },
+  { name: 'docs-audit', parent: 'agentwire', roles: ['worker'], machine: 'popos', activity: 'idle' },
+  { name: 'api-rate-limit', parent: 'feat-login-ui', roles: ['worker'], machine: 'jordans-mini', state: 'needs_input' },
+];
+
+const logEl = document.getElementById('log');
+const log = (msg) => { logEl.textContent = msg; };
+
+const stage = document.getElementById('stage');
+const topo = new TopologyView(stage, {
+  mode: 'window',
+  onCardClick: (name) => log(`clicked: ${name}`),
+});
+topo.render(sessions);
+log(`rendered ${sessions.length} sessions`);
+
+let n = 0;
+document.getElementById('add').onclick = () => {
+  n++;
+  const parents = sessions.map((s) => s.name);
+  sessions.push({
+    name: `worker-${n}`,
+    parent: parents[Math.floor(Math.random() * parents.length)],
+    roles: ['worker'],
+    machine: n % 2 ? 'popos' : 'jordans-mini',
+    activity: 'processing',
+  });
+  topo.render(sessions);
+  log(`added worker-${n} (${sessions.length} total)`);
+};
+
+document.getElementById('remove').onclick = () => {
+  if (sessions.length <= 1) return;
+  const removed = sessions.pop();
+  // Drop anything whose parent no longer exists — a killed session takes
+  // its own children with it, same as the real teardown does.
+  const byName = new Set(sessions.map((s) => s.name));
+  sessions = sessions.filter((s) => !s.parent || byName.has(s.parent));
+  topo.render(sessions);
+  log(`removed ${removed.name} (${sessions.length} total)`);
+};
+
+document.getElementById('cycle').onclick = () => {
+  const pool = ['idle', 'processing', 'needs_input', 'off'];
+  sessions = sessions.map((s) => {
+    const pick = pool[Math.floor(Math.random() * pool.length)];
+    if (pick === 'needs_input' || pick === 'off') {
+      return { ...s, state: pick, activity: undefined };
+    }
+    return { ...s, state: undefined, activity: pick };
+  });
+  topo.render(sessions);
+  log('cycled states');
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `agentwire/static/js/topology-render.js` — a mount-agnostic `TopologyView`: given a container + session list, renders family cards (status dot, role chip, activity sparkline, machine tag) plus lineage-tinted curved SVG links, packed into a narrow flex-wrap column (never a wide-canvas layout).
- `render(sessions)` is idempotent — diffs cards/rows/links in place instead of tearing down the DOM on re-render.
- Consolidates existing plumbing rather than reinventing it:
  - `lineage.js` gains the shared `lineageOf`/`groupFamilies` walk; `collage.js`'s window-id family grouping now calls `lineageOf` instead of its own private copy of the walk.
  - `wireStateFor` (idle/flow/awaiting/stuck) moves out of `topology-wires.js` into `topology-render.js` as the one shared status mapping; the wire overlay now imports it instead of keeping a duplicate.
  - Tokens only — `--lineage-tint-1..6`, `--topology-awaiting`/`--topology-stuck`, `--chrome`/`--chrome-border`/`--accent`/`--neon-blue` etc.; `prefers-reduced-motion` respected.
- Adds `agentwire/static/topology-harness.html`, a standalone harness proving the renderer against a mock family (add/remove/cycle-state buttons), reachable via the portal's existing `/static/{path}` route.

## Test plan
- [x] `node --check --input-type=module` clean on every touched/added JS module (`lineage.js`, `collage.js`, `topology-wires.js`, `topology-render.js`)
- [x] Served `agentwire/static/` via a throwaway local static server and drove `topology-harness.html` in a real Chrome tab: initial family renders (parent + 2 children + 1 grandchild) with correct role chips, status-dot colors, and lineage-tinted links; "spawn child" adds nested cards without disturbing existing ones; "cycle states" flips status/link colors (including failure-state-parity red for `stuck`) in place; "kill last" prunes cards/rows/families cleanly; card click fires `onCardClick` with the right session name. No console errors.

Closes #761

Built by dotdev.dev