### PR TITLE
feat(portal): Session Workspace window + 🛰 launcher

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -4154,6 +4154,65 @@ body .winbox.max {
 .review-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* ============================================
+   Workspace Window (#762) — hosts topology-render.js's TopologyView as a
+   first-class window, the "home base" for a session family.
+   ============================================ */
+
+/* Reusable full-bleed dot-grid canvas token — any surface that hosts the
+   shared topology renderer on open space (this window; the phantom overlay
+   in #764) composes this alongside its own layout class rather than
+   redefining the pattern. Tokens only, no hardcoded hex. */
+.desktop-dot-grid {
+    background-color: var(--background);
+    background-image: radial-gradient(circle, var(--chrome-border) 1px, transparent 1px);
+    background-size: 22px 22px;
+}
+
+.workspace-window .wb-body {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.workspace-window-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    background: var(--background);
+    color: var(--text);
+}
+
+.workspace-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--chrome-border);
+    flex: 0 0 auto;
+}
+
+.workspace-toolbar-icon {
+    font-size: 14px;
+}
+
+.workspace-toolbar-title {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.workspace-window-canvas {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* ============================================
    Scheduler Panel
    ============================================ */
 

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -13,10 +13,11 @@ import { tileManager } from './tile-manager.js';
 import { collage } from './collage.js';
 import { topologyWires } from './topology-wires.js';
 import { flyGhost } from './spawn-ghost.js';
-import { lineageTintVar } from './lineage.js';
+import { lineageTintVar, familyRootName } from './lineage.js';
 import { SessionWindow } from './session-window.js';
 import { ArtifactWindow } from './artifact-window.js';
 import { ReviewWindow } from './review-window.js';
+import { WorkspaceWindow } from './workspace-window.js';
 import { CouncilWindow, COUNCIL_WINDOW_ID } from './council-window.js';
 import { sidebar } from './sidebar.js';
 import { buildSessionId, normalizeMachine, isLocalMachine } from './session-id.js';
@@ -26,7 +27,7 @@ import { configSection } from './sidebar/config-section.js';
 import { safetySection } from './sidebar/safety-section.js';
 import { artifactsSection } from './sidebar/artifacts-section.js';
 import { machinesSection } from './sidebar/machines-section.js';
-import { sessionsSection } from './sidebar/sessions-section.js';
+import { sessionsSection, getAllSessions } from './sidebar/sessions-section.js';
 import { projectsSection } from './sidebar/projects-section.js';
 import { schedulerSection } from './sidebar/scheduler-section.js';
 import { councilSection } from './sidebar/council-section.js';
@@ -44,6 +45,7 @@ import { initAnnouncements } from './announcement-modal.js';
 const sessionWindows = new Map();  // sessionId -> SessionWindow instance
 const artifactWindows = new Map();  // artifactId -> ArtifactWindow instance
 const reviewWindows = new Map();  // windowId -> ReviewWindow instance
+const workspaceWindows = new Map();  // windowId (workspace-<familyRoot>) -> WorkspaceWindow instance
 let councilWindow = null;  // single CouncilWindow instance (one board at a time)
 
 // Born-from-parent placement (#745): sessions we've noticed appear (via the
@@ -900,6 +902,58 @@ export function openReviewWindow(session) {
 }
 
 /**
+ * Open (or focus) the Session Workspace window for a session's family — the
+ * shared topology renderer (#761) hosted as a first-class window (#762).
+ * Keyed off the family ROOT, not the clicked session, so the 🛰 launcher on
+ * any member (and taskbar restore) always lands on the one window for that
+ * family. Re-opening focuses (and live-updates) the existing window.
+ *
+ * @param {string} session - Any session in the family to open the workspace for
+ * @param {string|null} machine - Remote machine ID (unused for dedupe — a family is grouped by lineage, not machine)
+ */
+export function openSessionWorkspace(session, machine = null) {
+    const root = familyRootName(session, getAllSessions());
+    const id = `workspace-${root}`;
+
+    if (workspaceWindows.has(id)) {
+        const existing = workspaceWindows.get(id);
+        if (existing.isMinimized) {
+            if (!desktop.isTiled(id)) desktop.minimizeAllExcept(id);
+            existing.restore();
+        } else {
+            existing.focus();
+        }
+        return;
+    }
+
+    desktop.minimizeAllExcept(null);
+
+    const ww = new WorkspaceWindow({
+        rootSession: root,
+        windowId: id,
+        root: elements.desktopArea,
+        onCardClick: (name, cardSession) => {
+            openSessionTerminal(name, 'terminal', normalizeMachine(cardSession?.machine));
+        },
+        onClose: () => {
+            workspaceWindows.delete(id);
+            removeTaskbarButton(id);
+            unrecordTaskbarEntry(id);
+        },
+        onFocus: () => {
+            updateTaskbarActive(id);
+            desktop.setActiveWindow(id);
+            saveTaskbarState();
+        },
+    });
+
+    ww.open();
+    workspaceWindows.set(id, ww);
+    addTaskbarButton(id, ww);
+    recordTaskbarEntry({ kind: 'workspace', id, session: root, machine });
+}
+
+/**
  * Open the council workspace window. Registers through the same desktop path as
  * a session window (single-window maximize + taskbar tab), so it opens
  * maximized, appears in the open-sessions area, and is tabbable. Only one board
@@ -1006,6 +1060,8 @@ function _openByRecord(rec) {
         openCouncilWindow(rec.sitting || null);
     } else if (rec.kind === 'review') {
         openReviewWindow(rec.session);
+    } else if (rec.kind === 'workspace') {
+        openSessionWorkspace(rec.session, rec.machine || null);
     }
 }
 

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -28,7 +28,14 @@ const killingSessions = new Set();
 const collapsedParents = new Set();
 
 export function getAllSessions() { return allSessions; }
-export function onSessionsChanged(fn) { listeners.add(fn); }
+// Returns an unsubscribe function — load-bearing for consumers with a
+// lifecycle shorter than the page (e.g. workspace-window.js opens/closes
+// many times), unlike the permanent sidebar-section/topology-wires
+// subscribers that never need to unhook.
+export function onSessionsChanged(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+}
 
 // getAllSessions() is only backed by a live fetch once something has called
 // initData()+fetchSessions() — normally sessionsSection.mount(), which only
@@ -111,6 +118,7 @@ export function renderCard(s, opts = {}) {
             <button class="sidebar-list-item-btn" data-action="connect" title="Connect">▸</button>
             <button class="sidebar-list-item-btn" data-action="monitor" title="Monitor">👁</button>
             <button class="sidebar-list-item-btn" data-action="review" title="Review diff (approve/deny)">🔍</button>
+            <button class="sidebar-list-item-btn" data-action="workspace" title="Open workspace">🛰</button>
             ${opts.closable ? renderCloseButton(name) : ''}
         </div>
         ${path ? `<div class="sidebar-session-row2"><span class="sidebar-session-path">${path}</span></div>` : ''}
@@ -190,6 +198,11 @@ export async function handleSessionClick(e) {
     if (action === 'review') {
         const { openReviewWindow } = await import('../desktop.js');
         openReviewWindow(session);
+        return;
+    }
+    if (action === 'workspace') {
+        const { openSessionWorkspace } = await import('../desktop.js');
+        openSessionWorkspace(session, machine);
         return;
     }
     const { openSessionTerminal } = await import('../desktop.js');

--- a/agentwire/static/js/workspace-window.js
+++ b/agentwire/static/js/workspace-window.js
@@ -1,0 +1,141 @@
+/**
+ * workspace-window.js
+ *
+ * WorkspaceWindow — the "home base" surface for a session family (#762):
+ * a first-class WinBox window that hosts the shared topology renderer
+ * (topology-render.js's TopologyView, #761) on a canvas. One window per
+ * root family — identity is the family's root session name, not the
+ * particular session the launcher was clicked from, so the 🛰 button
+ * always lands on the same window regardless of which member opened it.
+ * Mirrors ReviewWindow's WinBox lifecycle (register/unregister via
+ * desktop-manager.js, `_createWinBox` + guarded close).
+ */
+
+import { desktop } from './desktop-manager.js';
+import { TopologyView } from './topology-render.js';
+import { getAllSessions, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
+import { familyRootName } from './lineage.js';
+
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+}
+
+export class WorkspaceWindow {
+    /**
+     * @param {Object} options
+     * @param {string} options.rootSession - Family root session name (the window's identity)
+     * @param {string} options.windowId - Unique window identifier
+     * @param {HTMLElement} options.root - Parent element for WinBox
+     * @param {(name: string, session: object) => void} [options.onCardClick] - Fired on card click
+     * @param {Function} options.onClose - Callback when window closes
+     * @param {Function} options.onFocus - Callback when window gains focus
+     */
+    constructor(options) {
+        this.rootSession = options.rootSession;
+        this.windowId = options.windowId;
+        this.root = options.root || document.body;
+        this.title = `🛰 ${this.rootSession}`;
+        this.onCardClickCallback = options.onCardClick || null;
+        this.onCloseCallback = options.onClose || null;
+        this.onFocusCallback = options.onFocus || null;
+
+        this.winbox = null;
+        this.isOpen = false;
+        this._topologyView = null;
+        this._unsubscribe = null;
+    }
+
+    open() {
+        if (this.isOpen) { this.focus(); return; }
+        const container = this._createContainer();
+        this._createWinBox(container);
+        this.isOpen = true;
+
+        const canvas = container.querySelector('.workspace-window-canvas');
+        this._topologyView = new TopologyView(canvas, {
+            onCardClick: (name, session) => this.onCardClickCallback?.(name, session),
+            mode: 'window',
+        });
+
+        ensureSessionsLoaded();
+        this._render();
+        this._unsubscribe = onSessionsChanged(() => this._render());
+    }
+
+    close() {
+        if (!this.isOpen) return;
+        if (this._unsubscribe) {
+            this._unsubscribe();
+            this._unsubscribe = null;
+        }
+        if (this._topologyView) {
+            this._topologyView.dispose();
+            this._topologyView = null;
+        }
+        if (this.winbox) {
+            const wb = this.winbox;
+            this.winbox = null;
+            wb.close();
+        }
+        desktop.unregisterWindow(this.windowId);
+        this.isOpen = false;
+        if (this.onCloseCallback) this.onCloseCallback(this);
+    }
+
+    focus() { if (this.winbox) this.winbox.focus(); }
+    minimize() { if (this.winbox) this.winbox.minimize(); }
+    restore() { if (this.winbox) this.winbox.restore(); }
+    get isMinimized() { return this.winbox ? this.winbox.min : false; }
+
+    _createContainer() {
+        const container = document.createElement('div');
+        container.className = 'workspace-window-content';
+        container.innerHTML = `
+            <div class="workspace-toolbar">
+                <span class="workspace-toolbar-icon">🛰</span>
+                <span class="workspace-toolbar-title" title="${esc(this.rootSession)}">${esc(this.rootSession)}</span>
+            </div>
+            <div class="workspace-window-canvas desktop-dot-grid"></div>
+        `;
+        return container;
+    }
+
+    _createWinBox(container) {
+        this.winbox = new WinBox({
+            title: this.title,
+            icon: '<span style="font-size:14px">&#x1F6F0;</span>',
+            mount: container,
+            root: this.root,
+            width: '80%',
+            height: '80%',
+            x: 'center',
+            y: 'center',
+            minwidth: 320,
+            minheight: 320,
+            class: ['workspace-window'],
+            onclose: () => { this.winbox = null; this.close(); return false; },
+            onfocus: () => { if (this.onFocusCallback) this.onFocusCallback(this); },
+            onminimize: () => desktop.emit('window_minimized', { id: this.windowId }),
+            onrestore: () => {
+                desktop.emit('window_restored', { id: this.windowId });
+                if (this.onFocusCallback) this.onFocusCallback(this);
+            },
+        });
+        desktop.registerWindow(this.windowId, this.winbox);
+    }
+
+    /** Re-render the family against the latest session list. Called on open
+     * and whenever onSessionsChanged fires (poll update or the session_created
+     * accelerant, both funneled through the same sessions-section.js feed). */
+    _render() {
+        if (!this._topologyView) return;
+        const sessions = getAllSessions();
+        const members = sessions.filter((s) => {
+            const name = s.name || '';
+            return name && familyRootName(name, sessions) === this.rootSession;
+        });
+        this._topologyView.render(members);
+    }
+}


### PR DESCRIPTION
## Summary
- New `WorkspaceWindow` class (`agentwire/static/js/workspace-window.js`) mirrors `ReviewWindow`'s WinBox lifecycle and hosts #761's `TopologyView` on the desktop dotted-grid canvas — a first-class window rendering a session's family (root + descendants), one window per family root (dedupe keyed on `familyRootName`, not the clicked session).
- `openSessionWorkspace(session, machine)` in `desktop.js`, peer to `openSessionTerminal()`, with the same registerWindow/taskbar dedupe plumbing (appears in `desktop_windows_list`, survives minimize/restore/reload via taskbar persistence).
- 🛰 workspace action button on the session row in `sidebar/sessions-section.js`, beside connect/monitor/review.
- Live updates: wired to `onSessionsChanged` (extended to return an unsubscribe fn, since a window that opens/closes repeatedly needs to unhook — the existing singleton consumers never did). That feed already carries the `session_created` accelerant, so a spawned child appears without poll lag or reload.
- `desktop.css`: new `.desktop-dot-grid` reusable canvas background token (didn't exist yet — introduced here so #764's phantom overlay can reuse it) plus workspace window chrome. Tokens only, no hardcoded colors.

## Test plan
- [x] `node --check --input-type=module` clean on all 4 touched files
- [x] Verified live in the dev portal (non-default port, isolated from the live :8765 instance): 🛰 button opens the workspace window, renders the family (root + worktree child) with correct role chips/status dots/lineage-tinted connector line, card click opens that session's terminal, window survives minimize + restore via the taskbar, dotted-grid canvas renders
- [ ] Narrow-viewport (~1/3 screen) resize check was inconclusive in the sandboxed browser (window resize didn't propagate to the screenshot) — the underlying renderer's flex-wrap layout was already validated narrow-first in #761, and WinBox uses percentage sizing here, so this should hold, but a manual check on landing is worth a glance

Closes #762