### PR TITLE
feat(portal): card mini-terminal — extract TerminalPane, expandable topology cards

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6691,6 +6691,67 @@ body.sidebar-pinned .sidebar-tab {
     }
 }
 
+/* --- card mini-terminal (#763) — click a card to expand it inline into a
+   live xterm (TerminalPane) + mic. Grows the card to full row width so the
+   terminal has room; the toolbar/terminal live inside .topology-card-expand-slot,
+   guarded (in topology-render.js's click handler) from bubbling into the
+   card's own collapse toggle. */
+.topology-card--expanded {
+    flex: 1 1 100%;
+    max-width: 100%;
+    cursor: default;
+}
+
+.topology-card--expanded:hover {
+    transform: none;
+}
+
+.topology-card-expand-slot {
+    margin-top: 2px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--chrome-border);
+    cursor: default;
+}
+
+.topology-card-mini-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 4px 6px;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--chrome-border);
+}
+
+.topology-card-mini-open {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-left: 6px;
+    border-radius: 4px;
+    border: 1px solid var(--chrome-border);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+    padding: 0;
+}
+
+.topology-card-mini-open:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+/* Fixed height so TerminalPane's FitAddon has something real to measure —
+   overrides .session-window-content's height:100% via a higher-specificity
+   compound selector (TerminalPane adds that class onto this same element). */
+.topology-card-mini-terminal.session-window-content {
+    height: 280px;
+}
+
 /* --- phantom topology overlay (#764) — topology-overlay.js ---
    Transient, non-interactive pop-over of the shared renderer above: the
    instant a child session spawns, TopologyView mounts into the panel below

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -920,9 +920,6 @@ export function openSessionWorkspace(session, machine = null) {
         rootSession: root,
         windowId: id,
         root: elements.desktopArea,
-        onCardClick: (name, cardSession) => {
-            openSessionTerminal(name, 'terminal', normalizeMachine(cardSession?.machine));
-        },
         onClose: () => {
             workspaceWindows.delete(id);
             removeTaskbarButton(id);

--- a/agentwire/static/js/session-window.js
+++ b/agentwire/static/js/session-window.js
@@ -4,23 +4,24 @@
  * SessionWindow class - encapsulates a terminal window for a session.
  * Wraps WinBox window, xterm.js Terminal, and WebSocket connection.
  * Supports two modes: Monitor (read-only) and Terminal (interactive).
+ *
+ * Terminal mode delegates the xterm/WS core to TerminalPane (#763,
+ * terminal-pane.js) — SessionWindow just owns the WinBox chrome, PTT
+ * titlebar button, and activity indicator around it. Monitor mode (a
+ * polling <pre> dump, not xterm) keeps its own WS/status/reconnect
+ * machinery here — it's a different beast, out of scope for TerminalPane.
  */
 
 
 import { apiFetch, wsProtocols } from './api.js';
 import { desktop } from './desktop-manager.js';
 import { sessionIcons } from './icon-manager.js';
-import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
 import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
 import { ansiToHtml } from './utils/ansi.js';
 import { PttController } from './ptt.js';
 import { voicePromptWrap } from './voice/prompt.js';
 import { isAutoSend } from './voice/autosend-prefs.js';
-
-const NARROW_VIEWPORT = '(max-width: 768px)';
-function pickTerminalFontSize() {
-    return getTerminalFontSize();
-}
+import { TerminalPane } from './terminal-pane.js';
 
 // Touch-primary devices (tablets/phones) raise the on-screen keyboard the
 // instant xterm's hidden textarea is focused. Opening or switching to a window
@@ -31,7 +32,7 @@ const TOUCH_PRIMARY = typeof window !== 'undefined'
     && window.matchMedia
     && window.matchMedia('(pointer: coarse)').matches;
 
-// Terminal WS reconnect tuning. A transient drop (portal restart, an
+// Monitor-mode WS reconnect tuning. A transient drop (portal restart, an
 // over-broad bg-process kill, a network blip) should heal silently rather than
 // dump the user onto the manual "Reconnect" wall — the tmux session almost
 // always outlives the WS. Mirrors the dashboard WS backoff in desktop-manager.js.
@@ -59,14 +60,12 @@ export class SessionWindow {
         this.onFocusCallback = options.onFocus || null;
 
         this.winbox = null;
-        this.terminal = null;
-        this.outputEl = null;  // For monitor mode
-        this.fitAddon = null;
-        this.ws = null;
-        this.resizeObserver = null;
+        this.pane = null;       // TerminalPane instance (terminal mode)
+        this.outputEl = null;   // <pre> element (monitor mode)
+        this.ws = null;         // monitor-mode WS
         this.isOpen = false;
 
-        // Silent reconnect state for the terminal/monitor WS.
+        // Silent reconnect state for the monitor-mode WS.
         this._autoReconnectAttempts = 0;
         this._autoReconnectTimer = null;
         this._destroyed = false;       // set in close() so a stray onclose can't re-dial
@@ -85,7 +84,7 @@ export class SessionWindow {
                 if (isAutoSend()) this._sendVoiceText(text);
                 else this._showTranscriptBar(text);
             },
-            onError: (kind, message) => this._updateStatus('error', message),
+            onError: (kind, message) => this.pane?.setStatus('error', message),
         });
 
         // Activity indicator state
@@ -114,19 +113,18 @@ export class SessionWindow {
         this._createWinBox(container);
         // Now create terminal - fit addon will have actual dimensions to work with
         this._createTerminal(container);
-        // Re-trigger resize after terminal is created — onmaximize fired before terminal
-        // existed so the initial fit was a no-op; now fit with real dimensions
+
         if (this.mode === 'terminal') {
-            this._handleResizeAfterAnimation();
-        }
-        this._connectWebSocket();
-        this._setupResizeObserver(container);
-        // Set up PTT button for terminal mode
-        if (this.mode === 'terminal') {
+            // Re-trigger fit after the WinBox maximize animation settles — the
+            // very first onmaximize fired before the pane existed (see
+            // _createWinBox's onmaximize), so that fit was a no-op.
+            this.pane.fit({ afterAnimation: true, watchEl: this.winbox.window });
             this._setupPTT(container);
+        } else {
+            this._connectWebSocket();
+            this._setupReconnectButton(container);
         }
-        // Set up reconnect button handler
-        this._setupReconnectButton(container);
+
         // Set up activity indicator in title bar
         this._setupActivityIndicator();
 
@@ -139,7 +137,7 @@ export class SessionWindow {
         // the user taps the terminal to type.
         if (this.mode === 'terminal' && !TOUCH_PRIMARY) {
             requestAnimationFrame(() => {
-                if (this.terminal) this.terminal.focus();
+                this.pane?.focus();
             });
         }
     }
@@ -163,23 +161,6 @@ export class SessionWindow {
         if (this._visibilityHandler) {
             document.removeEventListener('visibilitychange', this._visibilityHandler);
             this._visibilityHandler = null;
-        }
-
-        // Clean up resize observer
-        if (this.resizeObserver) {
-            this.resizeObserver.disconnect();
-            this.resizeObserver = null;
-        }
-
-        // Clean up viewport breakpoint listener
-        if (this._narrowMedia && this._narrowMediaHandler) {
-            this._narrowMedia.removeEventListener('change', this._narrowMediaHandler);
-            this._narrowMedia = null;
-            this._narrowMediaHandler = null;
-        }
-        if (this._fontPrefHandler) {
-            window.removeEventListener(FONT_SIZE_EVENT, this._fontPrefHandler);
-            this._fontPrefHandler = null;
         }
 
         // Clean up PTT keyboard handler
@@ -216,26 +197,19 @@ export class SessionWindow {
             this._cancelRecording();
         }
 
-        // Close WebSocket
+        // Terminal mode: the pane owns its own ws/xterm/resize/reconnect state.
+        if (this.pane) {
+            this.pane.dispose();
+            this.pane = null;
+        }
+
+        // Monitor mode: close its own WS
         if (this.ws) {
             this.ws.onclose = null; // _destroyed already guards, but don't even fire
             this.ws.close();
             this.ws = null;
         }
-
-        // Remove the two-finger touch-scroll listeners
-        if (this._touchScrollCleanup) {
-            this._touchScrollCleanup();
-            this._touchScrollCleanup = null;
-        }
-
-        // Dispose terminal (terminal mode) or output element (monitor mode)
-        if (this.terminal) {
-            this.terminal.dispose();
-            this.terminal = null;
-        }
         this.outputEl = null;
-        this.fitAddon = null;
 
         // Close WinBox (if not already closed)
         if (this.winbox) {
@@ -267,8 +241,8 @@ export class SessionWindow {
         // raises the soft keyboard on every window switch. Bring the window
         // forward only; tapping the terminal focuses it (and shows the keyboard)
         // when the user actually wants to type.
-        if (this.terminal && !TOUCH_PRIMARY) {
-            this.terminal.focus();
+        if (this.mode === 'terminal' && !TOUCH_PRIMARY) {
+            this.pane?.focus();
         }
     }
 
@@ -326,24 +300,9 @@ export class SessionWindow {
                     <span class="status-text">Connecting...</span>
                 </div>
             `;
-        } else {
-            // Terminal mode: xterm.js for interactive terminal. PTT button lives in the
-            // WinBox titlebar (see _setupPTTInTitlebar), not inside the content area.
-            container.innerHTML = `
-                <div class="session-terminal"></div>
-                <div class="session-disconnect-overlay hidden">
-                    <div class="disconnect-content">
-                        <div class="disconnect-message">Session Disconnected</div>
-                        <button class="btn btn-primary reconnect-btn">Reconnect</button>
-                        <div class="disconnect-hint">or press any key</div>
-                    </div>
-                </div>
-                <div class="session-status-bar">
-                    <span class="status-indicator connecting"></span>
-                    <span class="status-text">Connecting...</span>
-                </div>
-            `;
         }
+        // Terminal mode: TerminalPane builds its own DOM directly into this
+        // container (it's already sized and classed by WinBox's mount).
         return container;
     }
 
@@ -354,256 +313,17 @@ export class SessionWindow {
             return;
         }
 
-        // Terminal mode: full xterm.js setup
-        const terminalEl = container.querySelector('.session-terminal');
-        this._terminalEl = terminalEl;
-
-        const initialFontSize = pickTerminalFontSize();
-        terminalEl.style.setProperty('--terminal-font-size', `${initialFontSize}px`);
-
-        this.terminal = new Terminal({
-            cursorBlink: true,
-            fontSize: initialFontSize,
-            fontFamily: '"FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace',
-            altClickMovesCursor: false,
-            macOptionClickForcesSelection: true,  // Allow Option/Alt+drag for native selection (bypasses tmux mouse mode)
-            theme: {
-                background: '#000',
-                foreground: '#e6edf3',
-                cursor: '#2ea043',
-                selection: 'rgba(46, 160, 67, 0.3)',
+        // Terminal mode: the xterm + WS core lives in TerminalPane. PTT button
+        // lives in the WinBox titlebar (see _setupPTT), not inside the pane.
+        this.pane = new TerminalPane(container, {
+            session: this.session,
+            machine: this.machine,
+            onActivity: () => this._markActivity(),
+            onSessionEnded: () => {
+                this._sessionEnded = true;
+                this.close();
             },
         });
-
-        this.fitAddon = new FitAddon.FitAddon();
-        this.terminal.loadAddon(this.fitAddon);
-
-        // Add WebGL addon for performance (optional). Keep a reference: after a
-        // large container resize (tile grid→max) the WebGL renderer can leave
-        // the newly-exposed area transparent until its texture atlas is rebuilt.
-        this.webglAddon = null;
-        try {
-            if (typeof WebglAddon !== 'undefined') {
-                this.webglAddon = new WebglAddon.WebglAddon();
-                this.terminal.loadAddon(this.webglAddon);
-            }
-        } catch (e) {
-            console.warn('[SessionWindow] WebGL not available:', e);
-        }
-
-        this.terminal.open(terminalEl);
-
-        // xterm selections are canvas/WebGL-rendered, not DOM selections, so
-        // the scratch pad's selectionchange-based popover can't see them.
-        // Surface them via a custom event on mouseup (where the pointer is).
-        terminalEl.addEventListener('mouseup', (e) => {
-            const text = this.terminal?.getSelection();
-            if (text && text.trim()) {
-                window.dispatchEvent(new CustomEvent('terminal-selection', {
-                    detail: { text, x: e.clientX, y: e.clientY, session: this.session },
-                }));
-            }
-        });
-
-        // Touch devices emit no `wheel` events, so xterm's wheel-driven
-        // scrolling (tmux copy-mode / the app's own scroll) is unreachable on a
-        // tablet. Translate a two-finger vertical pan into synthetic wheel
-        // events so touch scrolls history exactly like a desktop mouse wheel.
-        // One finger stays free for tap/selection.
-        this._setupTouchScroll(terminalEl);
-
-        // Fit after font loads and layout is complete
-        const fontFamily = '"FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace';
-        const fontSize = pickTerminalFontSize();
-
-        // Re-pick font size on viewport breakpoint changes (mobile rotation, window resize)
-        // and on user override via the sidebar Config slider.
-        const applyNewSize = () => {
-            if (!this.terminal) return;
-            const newSize = pickTerminalFontSize();
-            this._terminalEl?.style.setProperty('--terminal-font-size', `${newSize}px`);
-            this.terminal.options.fontSize = newSize;
-            this._handleResize();
-        };
-        this._narrowMedia = window.matchMedia(NARROW_VIEWPORT);
-        this._narrowMediaHandler = applyNewSize;
-        this._fontPrefHandler = applyNewSize;
-        this._narrowMedia.addEventListener('change', this._narrowMediaHandler);
-        window.addEventListener(FONT_SIZE_EVENT, this._fontPrefHandler);
-
-        const doInitialFit = (fontLoaded) => {
-            requestAnimationFrame(() => {
-                if (fontLoaded) {
-                    // Force xterm to recalculate cell dimensions by re-setting font
-                    // This triggers internal re-measurement with the now-loaded font
-                    this.terminal.options.fontFamily = fontFamily;
-                    this.terminal.options.fontSize = fontSize;
-                }
-                this._handleResize();
-                setTimeout(() => this._handleResize(), 100);
-            });
-        };
-
-        if (document.fonts && document.fonts.load) {
-            // Wait for font to load, then fit
-            document.fonts.load(`${fontSize}px ${fontFamily}`).then(() => {
-                doInitialFit(true);
-            }).catch(() => {
-                // Font load failed, fit anyway with fallback font
-                doInitialFit(false);
-            });
-        } else {
-            // Font loading API not available, use delayed fit
-            doInitialFit(false);
-        }
-    }
-
-    /**
-     * Translate a two-finger vertical pan into tmux mouse-wheel scroll.
-     *
-     * Touch devices emit no `wheel` events, so the desktop scroll path (mouse
-     * wheel → xterm encodes an SGR mouse event → tmux enters copy-mode and
-     * scrolls) never fires on a tablet. Rather than fake a WheelEvent and hope
-     * xterm's mouse encoder picks it up, we send the exact bytes a real wheel
-     * produces — the SGR-1006 mouse sequence — straight down the input
-     * WebSocket. tmux runs with `mouse on`, so it consumes these and scrolls
-     * history. One finger is left untouched for tap/selection.
-     *
-     * SGR wheel: ESC [ < Btn ; Col ; Row M  — Btn 64 = wheel-up, 65 = wheel-down
-     * (1-based Col/Row; any point inside the pane works for scroll).
-     */
-    _setupTouchScroll(terminalEl) {
-        // Finger travel, in text lines, that advances one tmux wheel tick. tmux
-        // scrolls 5 lines per wheel tick (its WheelUp/DownPane `-N 5` binding),
-        // so a strict 1:1 mapping would need 5 lines of finger travel per tick —
-        // on a short window that's nearly the whole draggable height, so you get
-        // one tick then nothing. Firing a tick every ~1.5 lines keeps it ticking
-        // continuously across the whole stroke; momentum then covers distance.
-        const FINGER_LINES_PER_TICK = 1.5;
-        // Cap ticks emitted per animation frame so a fast flick can't flood tmux
-        // faster than it can redraw (the source of the laggy/stuttery feel).
-        const MAX_TICKS_PER_FRAME = 8;
-        // First tick of a gesture fires after only this fraction of a full tick
-        // of travel, so the start feels immediate instead of dead until ~5 lines.
-        const FIRST_TICK_FRACTION = 0.35;
-        // Momentum: after lift, keep scrolling and decay velocity each frame.
-        const FRICTION = 0.94;          // per-frame velocity multiplier
-        const FLING_MIN_V = 0.04;       // px/ms at release needed to start a fling
-        const MOMENTUM_STOP_V = 0.012;  // px/ms below which momentum ends
-
-        let active = false;
-        let lastMidY = 0;
-        let accum = 0;        // unconsumed finger travel (px), sign = direction
-        let rafId = null;
-        let emitted = false;  // has any tick fired this gesture? (first-tick boost)
-        let velocity = 0;     // px/ms, smoothed — drives momentum
-        let lastMoveT = 0;
-        let lastFrameT = 0;
-        let momentum = false;
-
-        const midY = (touches) => (touches[0].clientY + touches[1].clientY) / 2;
-
-        // Finger pixels per tick = lines-per-tick × measured cell height.
-        const pxPerTick = () => {
-            const rows = this.terminal?.rows || 24;
-            const h = terminalEl.getBoundingClientRect().height;
-            const cell = rows > 0 && h > 0 ? h / rows : 18;
-            return FINGER_LINES_PER_TICK * cell;
-        };
-
-        // dir < 0 → wheel-up (older history); dir > 0 → wheel-down (newer).
-        const wheelSeq = (dir) => {
-            const col = Math.max(1, Math.floor(this.terminal.cols / 2));
-            const row = Math.max(1, Math.floor(this.terminal.rows / 2));
-            return `\x1b[<${dir < 0 ? 64 : 65};${col};${row}M`;
-        };
-
-        const sendTicks = (ticks) => {
-            if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.terminal) return;
-            this.ws.send(JSON.stringify({ type: 'input', data: wheelSeq(ticks).repeat(Math.abs(ticks)) }));
-        };
-
-        // One frame: advance momentum, then batch all due ticks into one message.
-        const flush = (now) => {
-            rafId = null;
-
-            if (momentum) {
-                const dt = Math.min(now - lastFrameT, 50);
-                lastFrameT = now;
-                accum += velocity * dt;
-                velocity *= FRICTION;
-                if (Math.abs(velocity) < MOMENTUM_STOP_V) momentum = false;
-            }
-            if (active || momentum) rafId = requestAnimationFrame(flush);
-
-            const step = pxPerTick();
-            // Snappier first tick: lower the threshold until the gesture moves.
-            const threshold = emitted ? step : step * FIRST_TICK_FRACTION;
-            let ticks = Math.trunc(accum / threshold);
-            if (ticks === 0) return;
-            if (ticks > MAX_TICKS_PER_FRAME) ticks = MAX_TICKS_PER_FRAME;
-            else if (ticks < -MAX_TICKS_PER_FRAME) ticks = -MAX_TICKS_PER_FRAME;
-            accum -= ticks * threshold;
-            emitted = true;
-            sendTicks(ticks);
-        };
-
-        const startRaf = () => { if (rafId === null) { lastFrameT = performance.now(); rafId = requestAnimationFrame(flush); } };
-        const stopRaf = () => { if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; } };
-
-        const onTouchStart = (e) => {
-            if (e.touches.length !== 2) { active = false; momentum = false; stopRaf(); return; }
-            active = true;
-            momentum = false;
-            emitted = false;
-            velocity = 0;
-            accum = 0;
-            lastMidY = midY(e.touches);
-            lastMoveT = performance.now();
-            e.preventDefault();  // stop the page/WinBox from claiming the gesture
-            startRaf();
-        };
-
-        const onTouchMove = (e) => {
-            if (!active || e.touches.length !== 2) return;
-            e.preventDefault();
-            const now = performance.now();
-            const y = midY(e.touches);
-            // Fingers up (y decreases) → newer/down; fingers down → older/up.
-            const dy = lastMidY - y;
-            accum += dy;
-            const dt = now - lastMoveT;
-            if (dt > 0) velocity = 0.6 * velocity + 0.4 * (dy / dt);  // smoothed px/ms
-            lastMidY = y;
-            lastMoveT = now;
-        };
-
-        const onTouchEnd = (e) => {
-            if (e.touches.length >= 2) return;
-            active = false;
-            // Carry a fast lift into a decaying fling; otherwise stop clean.
-            if (Math.abs(velocity) >= FLING_MIN_V) {
-                momentum = true;
-                lastFrameT = performance.now();
-                startRaf();
-            } else {
-                velocity = 0;
-                accum = 0;
-            }
-        };
-
-        terminalEl.addEventListener('touchstart', onTouchStart, { passive: false });
-        terminalEl.addEventListener('touchmove', onTouchMove, { passive: false });
-        terminalEl.addEventListener('touchend', onTouchEnd);
-        terminalEl.addEventListener('touchcancel', onTouchEnd);
-
-        this._touchScrollCleanup = () => {
-            stopRaf();
-            terminalEl.removeEventListener('touchstart', onTouchStart);
-            terminalEl.removeEventListener('touchmove', onTouchMove);
-            terminalEl.removeEventListener('touchend', onTouchEnd);
-            terminalEl.removeEventListener('touchcancel', onTouchEnd);
-        };
     }
 
     _createWinBox(container) {
@@ -632,11 +352,16 @@ export class SessionWindow {
                 }
             },
             onresize: () => {
-                this._handleResize();
+                if (this.mode === 'terminal') this.pane?.fit();
             },
             onmaximize: () => {
-                // WinBox animates maximize - wait for animation to complete
-                this._handleResizeAfterAnimation();
+                // WinBox animates maximize - wait for animation to complete.
+                // (Fires once synchronously during _createWinBox, before the
+                // pane exists yet — pane?. no-ops that first call; open()
+                // re-triggers once the pane is actually created.)
+                if (this.mode === 'terminal') {
+                    this.pane?.fit({ afterAnimation: true, watchEl: this.winbox.window });
+                }
                 // Update taskbar tab to active style
                 if (this.onFocusCallback) {
                     this.onFocusCallback(this);
@@ -649,10 +374,12 @@ export class SessionWindow {
             onrestore: () => {
                 // Emit restored event so tile manager can re-apply position
                 desktop.emit('window_restored', { id: this.sessionId });
-                // Restore from minimize animates
-                this._handleResizeAfterAnimation();
-                // Reconnect if disconnected
-                if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+                if (this.mode === 'terminal') {
+                    // Restore from minimize animates
+                    this.pane?.fit({ afterAnimation: true, watchEl: this.winbox.window });
+                    // Reconnect if disconnected while minimized
+                    this.pane?.reconnectIfNeeded();
+                } else if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
                     this._connectWebSocket();
                 }
                 // Update taskbar tab to active style
@@ -669,28 +396,12 @@ export class SessionWindow {
         desktop.registerWindow(this.sessionId, this.winbox);
     }
 
+    /** Monitor-mode WS: /ws/{session} — JSON messages (output frames, audio,
+     * lifecycle) rendered into a <pre>. Terminal mode's WS lives entirely in
+     * TerminalPane; this method is monitor-only. */
     _connectWebSocket() {
         const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const sessionPath = this.sessionId;
-
-        // Choose endpoint based on mode
-        // Terminal mode: /ws/terminal/{session} - bidirectional
-        // Monitor mode: /ws/{session} - JSON messages
-        let endpoint;
-        if (this.mode === 'terminal') {
-            // Force layout reflow so fitAddon.fit() gets real container dimensions,
-            // then pass cols/rows as query params so the server creates the PTY at
-            // the correct size from the start (avoids dots on first render).
-            if (this.fitAddon && this.terminal) {
-                try { this.fitAddon.fit(); } catch (e) {}
-            }
-            const cols = this.terminal ? this.terminal.cols : 80;
-            const rows = this.terminal ? this.terminal.rows : 24;
-            endpoint = `/ws/terminal/${sessionPath}?cols=${cols}&rows=${rows}`;
-        } else {
-            endpoint = `/ws/${sessionPath}`;
-        }
-
+        const endpoint = `/ws/${this.sessionId}`;
         const url = `${protocol}//${location.host}${endpoint}`;
 
         // Close any existing WS (even if still CONNECTING) to avoid orphaned
@@ -701,11 +412,6 @@ export class SessionWindow {
         }
 
         this.ws = new WebSocket(url, wsProtocols());
-
-        if (this.mode === 'terminal') {
-            // Binary data for terminal mode
-            this.ws.binaryType = 'arraybuffer';
-        }
 
         this.ws.onopen = () => {
             this._updateStatus('connected', 'Connected');
@@ -718,15 +424,6 @@ export class SessionWindow {
                 this._autoReconnectTimer = null;
             }
 
-            // Re-fit terminal before sending size — the maximize animation may have
-            // completed while the socket was connecting, so fit now to get current dims
-            if (this.mode === 'terminal' && this.fitAddon && this.terminal) {
-                this.fitAddon.fit();
-            }
-
-            // Send initial terminal size (both modes need it for proper display)
-            this._sendResize();
-
             // Report tab visibility so the server backs off polling when the
             // tab is hidden (#628). Listener registered once per window.
             this._sendVisibility();
@@ -737,85 +434,31 @@ export class SessionWindow {
         };
 
         this.ws.onmessage = (event) => {
-            if (this.mode === 'terminal') {
-                // Terminal mode: binary data or string to xterm
-                // But first check for JSON messages (audio, tts_start, etc.)
-                const data = event.data;
-
-                // Check if this looks like a JSON message from the server
-                if (typeof data === 'string') {
-                    // Check for JSON audio/control messages
-                    if (data.includes('"type"')) {
-                        try {
-                            const msg = JSON.parse(data);
-
-                            if (msg.type === 'audio' && msg.data) {
-                                desktop._playAudio(msg.data, this.sessionId);
-                                return;
-                            } else if (msg.type === 'speak_text' && msg.text) {
-                                desktop._speakText(msg.text, this.sessionId);
-                                return;
-                            } else if (msg.type === 'tts_start') {
-                                return;
-                            } else if (msg.type === 'session_unlocked' || msg.type === 'session_locked') {
-                                return; // Ignore lock messages
-                            } else if (msg.type === 'remote_session_ended' || msg.type === 'local_session_ended') {
-                                // Clean exit - tmux session truly ended, close window
-                                this._sessionEnded = true;
-                                this.close();
-                                return;
-                            } else if (msg.type === 'remote_disconnected' || msg.type === 'local_disconnected') {
-                                // Transient drop (bg process side effect, portal restart, etc) -
-                                // retry silently with backoff instead of dropping the user onto
-                                // the manual wall. The onclose that follows is deduped by the
-                                // scheduler's timer guard.
-                                this._scheduleAutoReconnect();
-                                return;
-                            }
-                            // Other JSON messages - don't write to terminal
-                            return;
-                        } catch (e) {
-                            // Fall through to terminal
-                        }
-                    }
+            if (!this.outputEl) return;
+            try {
+                const msg = JSON.parse(event.data);
+                if (msg.type === 'audio' && msg.data) {
+                    desktop._playAudio(msg.data, this.sessionId);
+                } else if (msg.type === 'speak_text' && msg.text) {
+                    desktop._speakText(msg.text, this.sessionId);
+                } else if (msg.type === 'remote_session_ended' || msg.type === 'local_session_ended') {
+                    // tmux session truly ended (e.g. monitor-loop eviction) —
+                    // close the window instead of auto-reconnecting forever
+                    this._sessionEnded = true;
+                    this.close();
+                    return;
+                } else if (msg.type === 'output' && msg.data) {
+                    // Incremental line-diff render (#628) — only changed
+                    // lines touch the DOM instead of a full innerHTML swap
+                    this._renderOutput(msg.data);
+                    this.outputEl.scrollTop = this.outputEl.scrollHeight;
+                    // Mark activity when output received
+                    this._markActivity();
                 }
-
-                if (!this.terminal) return;
-                if (data instanceof ArrayBuffer) {
-                    this.terminal.write(new Uint8Array(data));
-                } else {
-                    this.terminal.write(data);
-                }
-                // Mark activity when terminal data received
-                this._markActivity();
-            } else {
-                // Monitor mode: JSON messages to pre element
-                if (!this.outputEl) return;
-                try {
-                    const msg = JSON.parse(event.data);
-                    if (msg.type === 'audio' && msg.data) {
-                        desktop._playAudio(msg.data, this.sessionId);
-                    } else if (msg.type === 'speak_text' && msg.text) {
-                        desktop._speakText(msg.text, this.sessionId);
-                    } else if (msg.type === 'remote_session_ended' || msg.type === 'local_session_ended') {
-                        // tmux session truly ended (e.g. monitor-loop eviction) —
-                        // close the window instead of auto-reconnecting forever
-                        this._sessionEnded = true;
-                        this.close();
-                        return;
-                    } else if (msg.type === 'output' && msg.data) {
-                        // Incremental line-diff render (#628) — only changed
-                        // lines touch the DOM instead of a full innerHTML swap
-                        this._renderOutput(msg.data);
-                        this.outputEl.scrollTop = this.outputEl.scrollHeight;
-                        // Mark activity when output received
-                        this._markActivity();
-                    }
-                } catch (e) {
-                    // Fallback: display as plain text
-                    this.outputEl.textContent = event.data;
-                    this._renderedLines = null;
-                }
+            } catch (e) {
+                // Fallback: display as plain text
+                this.outputEl.textContent = event.data;
+                this._renderedLines = null;
             }
         };
 
@@ -836,18 +479,6 @@ export class SessionWindow {
             // (Deduped against the *_disconnected branch by the scheduler's timer guard.)
             this._scheduleAutoReconnect();
         };
-
-        // For terminal mode, send input to WebSocket. Only attach once — xterm.js
-        // stacks onData listeners, so re-attaching on every _connectWebSocket()
-        // (initial + reconnects) would multiply each keystroke.
-        if (this.mode === 'terminal' && this.terminal && !this._inputBound) {
-            this._inputBound = true;
-            this.terminal.onData((data) => {
-                if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-                    this.ws.send(JSON.stringify({ type: 'input', data }));
-                }
-            });
-        }
     }
 
     /**
@@ -874,111 +505,14 @@ export class SessionWindow {
             } else if (prev && i < prev.length && prev[i] === lines[i]) {
                 continue;  // unchanged line — skip the DOM entirely
             }
-            div.innerHTML = lines[i] ? ansiToHtml(lines[i]) : '<span> </span>';
+            div.innerHTML = lines[i] ? ansiToHtml(lines[i]) : '<span> </span>';
         }
         this._renderedLines = lines;
     }
 
     _sendVisibility() {
-        if (this.mode !== 'terminal' && this.ws && this.ws.readyState === WebSocket.OPEN) {
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             this.ws.send(JSON.stringify({ type: 'visibility', visible: !document.hidden }));
-        }
-    }
-
-    _setupResizeObserver(container) {
-        const terminalEl = container.querySelector('.session-terminal');
-        if (!terminalEl) return;
-
-        // Only observe resize for terminal mode
-        if (terminalEl) {
-            this.resizeObserver = new ResizeObserver(() => {
-                this._handleResize();
-            });
-            this.resizeObserver.observe(terminalEl);
-        }
-    }
-
-    _handleResize() {
-        if (this.mode === 'terminal' && this.fitAddon && this.terminal) {
-            requestAnimationFrame(() => {
-                try {
-                    // Ensure font options are correct before fitting
-                    const fontFamily = '"FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace';
-                    const fontSize = pickTerminalFontSize();
-                    this.terminal.options.fontFamily = fontFamily;
-                    this.terminal.options.fontSize = fontSize;
-
-                    this.fitAddon.fit();
-                    this._sendResize();
-                } catch (e) {
-                    console.error('[_handleResize] error:', e);
-                }
-            });
-        }
-    }
-
-    /**
-     * Force a full WebGL repaint. fit() resizes the buffer but doesn't redraw, so
-     * after a large container resize (tile grid → maximized) the newly-exposed
-     * canvas can stay transparent until interaction. The WebGL renderer needs its
-     * stale texture atlas rebuilt; then a full viewport refresh repaints every cell.
-     */
-    _forceRepaint() {
-        try { this.webglAddon?.clearTextureAtlas(); } catch (e) {}
-        this.terminal.refresh(0, this.terminal.rows - 1);
-    }
-
-    _handleResizeAfterAnimation() {
-        // Listen for CSS transition to complete before fitting terminal
-        if (this.mode !== 'terminal' || !this.fitAddon || !this.terminal || !this.winbox) return;
-
-        const doFit = () => {
-            try {
-                // Ensure font options are set before fitting (in case they weren't applied correctly)
-                const fontFamily = '"FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace';
-                const fontSize = pickTerminalFontSize();
-                this.terminal.options.fontFamily = fontFamily;
-                this.terminal.options.fontSize = fontSize;
-
-                this.fitAddon.fit();
-                this._sendResize();
-                this._forceRepaint();
-            } catch (err) {
-                console.error('[SessionWindow] Fit error:', err);
-            }
-        };
-
-        const winboxEl = this.winbox.window;
-        let handled = false;
-
-        const onTransitionEnd = (e) => {
-            if (e.target === winboxEl && (e.propertyName === 'width' || e.propertyName === 'height')) {
-                handled = true;
-                winboxEl.removeEventListener('transitionend', onTransitionEnd);
-                doFit();
-            }
-        };
-
-        winboxEl.addEventListener('transitionend', onTransitionEnd);
-
-        // Fallback: if transitionend doesn't fire within 500ms, force fit
-        setTimeout(() => {
-            if (!handled) {
-                winboxEl.removeEventListener('transitionend', onTransitionEnd);
-                doFit();
-            }
-        }, 500);
-    }
-
-    _sendResize() {
-        // Only terminal mode sends resize (monitor doesn't need it)
-        if (this.mode === 'terminal' && this.ws && this.ws.readyState === WebSocket.OPEN && this.terminal) {
-            const msg = {
-                type: 'resize',
-                cols: this.terminal.cols,
-                rows: this.terminal.rows,
-            };
-            this.ws.send(JSON.stringify(msg));
         }
     }
 
@@ -1025,12 +559,11 @@ export class SessionWindow {
     }
 
     /**
-     * Schedule a silent reconnect with exponential backoff. The terminal heals
-     * itself when the WS comes back (portal restart, transient kill side-effect)
-     * instead of forcing a manual click. The manual "Reconnect" overlay surfaces
-     * only after TERM_RECONNECT_OVERLAY_AFTER silent attempts have failed, so a
-     * brief blip never throws up the wall. Re-entrant calls (e.g. a *_disconnected
-     * message immediately followed by onclose) are coalesced by the timer guard.
+     * Schedule a silent reconnect with exponential backoff (monitor-mode WS).
+     * The window heals itself when the WS comes back (portal restart,
+     * transient kill side-effect) instead of forcing a manual click. The
+     * manual "Reconnect" overlay surfaces only after TERM_RECONNECT_OVERLAY_AFTER
+     * silent attempts have failed, so a brief blip never throws up the wall.
      */
     _scheduleAutoReconnect() {
         if (this._destroyed || this._sessionEnded) return;
@@ -1100,11 +633,6 @@ export class SessionWindow {
             this.ws = null;
         }
 
-        // Clear terminal to avoid escape sequence garbage on reconnect
-        if (this.terminal) {
-            this.terminal.clear();
-        }
-
         // Reconnect
         this._connectWebSocket();
     }
@@ -1127,7 +655,7 @@ export class SessionWindow {
         return div.innerHTML;
     }
 
-    // Reconnect button handler
+    // Reconnect button handler (monitor mode; terminal mode's lives in TerminalPane)
 
     _setupReconnectButton(container) {
         const reconnectBtn = container.querySelector('.reconnect-btn');
@@ -1276,7 +804,7 @@ export class SessionWindow {
         this._transcriptBar?.remove();
         this._transcriptBar = null;
         // Hand focus back to the terminal so typing resumes naturally
-        this.terminal?.focus();
+        this.pane?.focus();
     }
 
     async _sendVoiceText(text) {
@@ -1288,13 +816,13 @@ export class SessionWindow {
             });
             const sendData = await sendRes.json();
             if (sendData.error) throw new Error(sendData.error);
-            this._updateStatus('connected', `Sent: "${text.substring(0, 30)}${text.length > 30 ? '...' : ''}"`);
+            this.pane?.setStatus('connected', `Sent: "${text.substring(0, 30)}${text.length > 30 ? '...' : ''}"`);
             setTimeout(() => {
-                if (this.pttState === 'idle') this._updateStatus('connected', 'Connected');
+                if (this.pttState === 'idle') this.pane?.setStatus('connected', 'Connected');
             }, 3000);
         } catch (err) {
             console.error('[SessionWindow] Voice send failed:', err);
-            this._updateStatus('error', err.message || 'Voice input failed');
+            this.pane?.setStatus('error', err.message || 'Voice input failed');
         }
     }
 

--- a/agentwire/static/js/terminal-pane.js
+++ b/agentwire/static/js/terminal-pane.js
@@ -1,0 +1,775 @@
+/**
+ * terminal-pane.js
+ *
+ * TerminalPane — the terminal CORE extracted from SessionWindow (#763): xterm.js
+ * Terminal + FitAddon, the WS connect/attach/resize/reconnect logic, and the
+ * mouse-wheel/copy-mode (touch two-finger scroll) handling. Mountable into ANY
+ * container — SessionWindow's full terminal window and the Session Workspace
+ * card's mini-terminal both wrap the same `new TerminalPane(container, opts)`.
+ *
+ * Builds its own DOM (`.session-terminal` + `.session-disconnect-overlay` +
+ * `.session-status-bar`) directly inside the given container, adding the
+ * `session-window-content` class so the existing flex-column/status-bar CSS
+ * applies regardless of host — the container just needs a definite size.
+ *
+ * Owns the WS lifecycle end to end: connect, silent auto-reconnect with
+ * backoff, the manual "Reconnect" overlay + any-key-to-reconnect (scoped to
+ * this pane's own DOM via a capture-phase listener, so multiple panes never
+ * cross-trigger each other), and audio/speak_text passthrough. Session-ended
+ * and activity are surfaced to the host via callbacks rather than handled
+ * here, since what to DO about them (close a window vs. collapse a card) is
+ * host-specific.
+ */
+
+import { apiFetch, wsProtocols } from './api.js';
+import { desktop } from './desktop-manager.js';
+import { getTerminalFontSize, FONT_SIZE_EVENT } from './terminal-font-prefs.js';
+import { buildSessionId, normalizeMachine, sameMachine } from './session-id.js';
+
+const NARROW_VIEWPORT = '(max-width: 768px)';
+const TERMINAL_FONT_FAMILY = '"FiraMono Nerd Font Mono", Menlo, Monaco, "Courier New", monospace';
+
+function pickTerminalFontSize() {
+    return getTerminalFontSize();
+}
+
+// Terminal WS reconnect tuning — mirrors the dashboard WS backoff in
+// desktop-manager.js. A transient drop should heal silently rather than dump
+// the user onto the manual "Reconnect" wall; the tmux session almost always
+// outlives the WS.
+const TERM_RECONNECT_INITIAL = 500;     // ms before first silent retry
+const TERM_RECONNECT_MAX = 10000;       // ms backoff ceiling
+const TERM_RECONNECT_MULTIPLIER = 1.6;
+const TERM_RECONNECT_OVERLAY_AFTER = 4; // show the manual wall only after N silent retries fail
+
+export class TerminalPane {
+    /**
+     * @param {HTMLElement} container - Mount point. Must have a definite size;
+     *   TerminalPane appends `session-window-content` and builds its DOM inside it.
+     * @param {Object} opts
+     * @param {string} opts.session - Session name
+     * @param {string|null} [opts.machine] - Remote machine ID
+     * @param {Function} [opts.onActivity] - Fired when terminal data is received
+     * @param {Function} [opts.onSessionEnded] - Fired when the tmux session truly
+     *   ended (clean exit message) or a remote session no longer exists on manual
+     *   reconnect. The host decides what to do (close a window, collapse a card).
+     */
+    constructor(container, opts = {}) {
+        this.container = container;
+        this.session = opts.session;
+        this.machine = normalizeMachine(opts.machine);
+        this.onActivity = opts.onActivity || (() => {});
+        this.onSessionEnded = opts.onSessionEnded || (() => {});
+
+        this.terminal = null;
+        this.fitAddon = null;
+        this.webglAddon = null;
+        this.ws = null;
+        this.resizeObserver = null;
+        this._inputBound = false;
+
+        this._autoReconnectAttempts = 0;
+        this._autoReconnectTimer = null;
+        this._destroyed = false;
+        this._sessionEnded = false;
+        this._overlayKeyHandler = null;
+
+        this._narrowMedia = null;
+        this._narrowMediaHandler = null;
+        this._fontPrefHandler = null;
+        this._touchScrollCleanup = null;
+
+        this._buildDom();
+        this._createTerminal();
+        this._setupResizeObserver();
+        this._setupReconnectButton();
+        this._connectWebSocket();
+    }
+
+    get sessionId() {
+        return buildSessionId(this.session, this.machine);
+    }
+
+    focus() {
+        this.terminal?.focus();
+    }
+
+    /**
+     * @param {Object} [opts]
+     * @param {boolean} [opts.afterAnimation=false] - Wait for a CSS width/height
+     *   transition on `opts.watchEl` to settle before fitting (e.g. a WinBox
+     *   maximize animation), falling back to a 500ms timer if it never fires.
+     * @param {HTMLElement} [opts.watchEl] - Element to watch for transitionend.
+     *   Required when afterAnimation is true (the host knows which element, if
+     *   any, is actually animating — e.g. the WinBox window, not this pane's
+     *   own container).
+     */
+    fit({ afterAnimation = false, watchEl = null } = {}) {
+        if (afterAnimation && watchEl) {
+            this._fitAfterAnimation(watchEl);
+        } else {
+            this._handleResize();
+        }
+    }
+
+    /** Reconnect if the WS isn't currently open — e.g. on window restore, when
+     * the socket may have dropped while minimized. */
+    reconnectIfNeeded() {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            this._connectWebSocket();
+        }
+    }
+
+    /** Push a status message into this pane's own status bar (e.g. a PTT
+     * "Sent: ..." flash). The pane manages its own connect/error states
+     * internally; this is for host-driven, transient notices. */
+    setStatus(state, message) {
+        this._updateStatus(state, message);
+    }
+
+    dispose() {
+        this._destroyed = true;
+        if (this._autoReconnectTimer) {
+            clearTimeout(this._autoReconnectTimer);
+            this._autoReconnectTimer = null;
+        }
+        if (this._overlayKeyHandler) {
+            this._root.removeEventListener('keydown', this._overlayKeyHandler, true);
+            this._overlayKeyHandler = null;
+        }
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
+        if (this._narrowMedia && this._narrowMediaHandler) {
+            this._narrowMedia.removeEventListener('change', this._narrowMediaHandler);
+            this._narrowMedia = null;
+            this._narrowMediaHandler = null;
+        }
+        if (this._fontPrefHandler) {
+            window.removeEventListener(FONT_SIZE_EVENT, this._fontPrefHandler);
+            this._fontPrefHandler = null;
+        }
+        if (this._touchScrollCleanup) {
+            this._touchScrollCleanup();
+            this._touchScrollCleanup = null;
+        }
+        if (this.ws) {
+            // Belt-and-suspenders: an onmessage task already queued before
+            // close() can still fire once more (the browser doesn't retract
+            // an already-scheduled event dispatch) — null the handler too so
+            // it can't reach a torn-down terminal even in that window.
+            this.ws.onclose = null;
+            this.ws.onmessage = null;
+            this.ws.close();
+            this.ws = null;
+        }
+        if (this.terminal) {
+            // A just-processed write can leave xterm.js with its OWN internal
+            // render/write-buffer flush scheduled for a later animation frame,
+            // independent of anything here. Disposing synchronously can tear
+            // the renderer down before that frame runs, and xterm's internal
+            // code then throws (uncatchable from here — different task).
+            // Null the reference now so every guard in this class stops
+            // touching it immediately, but defer the actual dispose() one
+            // frame so xterm's own pending internal work runs first, against
+            // a still-valid instance, before its DOM disappears underneath it.
+            const term = this.terminal;
+            this.terminal = null;
+            requestAnimationFrame(() => {
+                try { term.dispose(); } catch (e) {}
+            });
+        }
+        this.fitAddon = null;
+        this._root = null;
+    }
+
+    // Private methods
+
+    _buildDom() {
+        this._root = this.container;
+        this._root.classList.add('session-window-content');
+        this._root.innerHTML = `
+            <div class="session-terminal"></div>
+            <div class="session-disconnect-overlay hidden">
+                <div class="disconnect-content">
+                    <div class="disconnect-message">Session Disconnected</div>
+                    <button class="btn btn-primary reconnect-btn">Reconnect</button>
+                    <div class="disconnect-hint">or press any key</div>
+                </div>
+            </div>
+            <div class="session-status-bar">
+                <span class="status-indicator connecting"></span>
+                <span class="status-text">Connecting...</span>
+            </div>
+        `;
+        this._terminalEl = this._root.querySelector('.session-terminal');
+    }
+
+    _createTerminal() {
+        const terminalEl = this._terminalEl;
+        const initialFontSize = pickTerminalFontSize();
+        terminalEl.style.setProperty('--terminal-font-size', `${initialFontSize}px`);
+
+        this.terminal = new Terminal({
+            cursorBlink: true,
+            fontSize: initialFontSize,
+            fontFamily: TERMINAL_FONT_FAMILY,
+            altClickMovesCursor: false,
+            macOptionClickForcesSelection: true,  // Allow Option/Alt+drag for native selection (bypasses tmux mouse mode)
+            theme: {
+                background: '#000',
+                foreground: '#e6edf3',
+                cursor: '#2ea043',
+                selection: 'rgba(46, 160, 67, 0.3)',
+            },
+        });
+
+        this.fitAddon = new FitAddon.FitAddon();
+        this.terminal.loadAddon(this.fitAddon);
+
+        // Add WebGL addon for performance (optional). Keep a reference: after a
+        // large container resize (tile grid→max) the WebGL renderer can leave
+        // the newly-exposed area transparent until its texture atlas is rebuilt.
+        this.webglAddon = null;
+        try {
+            if (typeof WebglAddon !== 'undefined') {
+                this.webglAddon = new WebglAddon.WebglAddon();
+                this.terminal.loadAddon(this.webglAddon);
+            }
+        } catch (e) {
+            console.warn('[TerminalPane] WebGL not available:', e);
+        }
+
+        this.terminal.open(terminalEl);
+
+        // xterm selections are canvas/WebGL-rendered, not DOM selections, so
+        // the scratch pad's selectionchange-based popover can't see them.
+        // Surface them via a custom event on mouseup (where the pointer is).
+        terminalEl.addEventListener('mouseup', (e) => {
+            const text = this.terminal?.getSelection();
+            if (text && text.trim()) {
+                window.dispatchEvent(new CustomEvent('terminal-selection', {
+                    detail: { text, x: e.clientX, y: e.clientY, session: this.session },
+                }));
+            }
+        });
+
+        // Touch devices emit no `wheel` events, so xterm's wheel-driven
+        // scrolling (tmux copy-mode / the app's own scroll) is unreachable on a
+        // tablet. Translate a two-finger vertical pan into synthetic wheel
+        // events so touch scrolls history exactly like a desktop mouse wheel.
+        // One finger stays free for tap/selection.
+        this._setupTouchScroll(terminalEl);
+
+        // Re-pick font size on viewport breakpoint changes (mobile rotation, window resize)
+        // and on user override via the sidebar Config slider.
+        const applyNewSize = () => {
+            if (!this.terminal) return;
+            const newSize = pickTerminalFontSize();
+            terminalEl.style.setProperty('--terminal-font-size', `${newSize}px`);
+            this.terminal.options.fontSize = newSize;
+            this._handleResize();
+        };
+        this._narrowMedia = window.matchMedia(NARROW_VIEWPORT);
+        this._narrowMediaHandler = applyNewSize;
+        this._fontPrefHandler = applyNewSize;
+        this._narrowMedia.addEventListener('change', this._narrowMediaHandler);
+        window.addEventListener(FONT_SIZE_EVENT, this._fontPrefHandler);
+
+        const doInitialFit = (fontLoaded) => {
+            requestAnimationFrame(() => {
+                // dispose() may have run while waiting on font load/this frame.
+                if (!this.terminal) return;
+                if (fontLoaded) {
+                    // Force xterm to recalculate cell dimensions by re-setting font
+                    // This triggers internal re-measurement with the now-loaded font
+                    this.terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
+                    this.terminal.options.fontSize = initialFontSize;
+                }
+                this._handleResize();
+                setTimeout(() => this._handleResize(), 100);
+            });
+        };
+
+        if (document.fonts && document.fonts.load) {
+            // Wait for font to load, then fit
+            document.fonts.load(`${initialFontSize}px ${TERMINAL_FONT_FAMILY}`).then(() => {
+                doInitialFit(true);
+            }).catch(() => {
+                // Font load failed, fit anyway with fallback font
+                doInitialFit(false);
+            });
+        } else {
+            // Font loading API not available, use delayed fit
+            doInitialFit(false);
+        }
+    }
+
+    /**
+     * Translate a two-finger vertical pan into tmux mouse-wheel scroll.
+     *
+     * Touch devices emit no `wheel` events, so the desktop scroll path (mouse
+     * wheel → xterm encodes an SGR mouse event → tmux enters copy-mode and
+     * scrolls) never fires on a tablet. Rather than fake a WheelEvent and hope
+     * xterm's mouse encoder picks it up, we send the exact bytes a real wheel
+     * produces — the SGR-1006 mouse sequence — straight down the input
+     * WebSocket. tmux runs with `mouse on`, so it consumes these and scrolls
+     * history. One finger is left untouched for tap/selection.
+     *
+     * SGR wheel: ESC [ < Btn ; Col ; Row M  — Btn 64 = wheel-up, 65 = wheel-down
+     * (1-based Col/Row; any point inside the pane works for scroll).
+     */
+    _setupTouchScroll(terminalEl) {
+        // Finger travel, in text lines, that advances one tmux wheel tick. tmux
+        // scrolls 5 lines per wheel tick (its WheelUp/DownPane `-N 5` binding),
+        // so a strict 1:1 mapping would need 5 lines of finger travel per tick —
+        // on a short window that's nearly the whole draggable height, so you get
+        // one tick then nothing. Firing a tick every ~1.5 lines keeps it ticking
+        // continuously across the whole stroke; momentum then covers distance.
+        const FINGER_LINES_PER_TICK = 1.5;
+        // Cap ticks emitted per animation frame so a fast flick can't flood tmux
+        // faster than it can redraw (the source of the laggy/stuttery feel).
+        const MAX_TICKS_PER_FRAME = 8;
+        // First tick of a gesture fires after only this fraction of a full tick
+        // of travel, so the start feels immediate instead of dead until ~5 lines.
+        const FIRST_TICK_FRACTION = 0.35;
+        // Momentum: after lift, keep scrolling and decay velocity each frame.
+        const FRICTION = 0.94;          // per-frame velocity multiplier
+        const FLING_MIN_V = 0.04;       // px/ms at release needed to start a fling
+        const MOMENTUM_STOP_V = 0.012;  // px/ms below which momentum ends
+
+        let active = false;
+        let lastMidY = 0;
+        let accum = 0;        // unconsumed finger travel (px), sign = direction
+        let rafId = null;
+        let emitted = false;  // has any tick fired this gesture? (first-tick boost)
+        let velocity = 0;     // px/ms, smoothed — drives momentum
+        let lastMoveT = 0;
+        let lastFrameT = 0;
+        let momentum = false;
+
+        const midY = (touches) => (touches[0].clientY + touches[1].clientY) / 2;
+
+        // Finger pixels per tick = lines-per-tick × measured cell height.
+        const pxPerTick = () => {
+            const rows = this.terminal?.rows || 24;
+            const h = terminalEl.getBoundingClientRect().height;
+            const cell = rows > 0 && h > 0 ? h / rows : 18;
+            return FINGER_LINES_PER_TICK * cell;
+        };
+
+        // dir < 0 → wheel-up (older history); dir > 0 → wheel-down (newer).
+        const wheelSeq = (dir) => {
+            const col = Math.max(1, Math.floor(this.terminal.cols / 2));
+            const row = Math.max(1, Math.floor(this.terminal.rows / 2));
+            return `\x1b[<${dir < 0 ? 64 : 65};${col};${row}M`;
+        };
+
+        const sendTicks = (ticks) => {
+            if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.terminal) return;
+            this.ws.send(JSON.stringify({ type: 'input', data: wheelSeq(ticks).repeat(Math.abs(ticks)) }));
+        };
+
+        // One frame: advance momentum, then batch all due ticks into one message.
+        const flush = (now) => {
+            rafId = null;
+
+            if (momentum) {
+                const dt = Math.min(now - lastFrameT, 50);
+                lastFrameT = now;
+                accum += velocity * dt;
+                velocity *= FRICTION;
+                if (Math.abs(velocity) < MOMENTUM_STOP_V) momentum = false;
+            }
+            if (active || momentum) rafId = requestAnimationFrame(flush);
+
+            const step = pxPerTick();
+            // Snappier first tick: lower the threshold until the gesture moves.
+            const threshold = emitted ? step : step * FIRST_TICK_FRACTION;
+            let ticks = Math.trunc(accum / threshold);
+            if (ticks === 0) return;
+            if (ticks > MAX_TICKS_PER_FRAME) ticks = MAX_TICKS_PER_FRAME;
+            else if (ticks < -MAX_TICKS_PER_FRAME) ticks = -MAX_TICKS_PER_FRAME;
+            accum -= ticks * threshold;
+            emitted = true;
+            sendTicks(ticks);
+        };
+
+        const startRaf = () => { if (rafId === null) { lastFrameT = performance.now(); rafId = requestAnimationFrame(flush); } };
+        const stopRaf = () => { if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; } };
+
+        const onTouchStart = (e) => {
+            if (e.touches.length !== 2) { active = false; momentum = false; stopRaf(); return; }
+            active = true;
+            momentum = false;
+            emitted = false;
+            velocity = 0;
+            accum = 0;
+            lastMidY = midY(e.touches);
+            lastMoveT = performance.now();
+            e.preventDefault();  // stop the page/WinBox from claiming the gesture
+            startRaf();
+        };
+
+        const onTouchMove = (e) => {
+            if (!active || e.touches.length !== 2) return;
+            e.preventDefault();
+            const now = performance.now();
+            const y = midY(e.touches);
+            // Fingers up (y decreases) → newer/down; fingers down → older/up.
+            const dy = lastMidY - y;
+            accum += dy;
+            const dt = now - lastMoveT;
+            if (dt > 0) velocity = 0.6 * velocity + 0.4 * (dy / dt);  // smoothed px/ms
+            lastMidY = y;
+            lastMoveT = now;
+        };
+
+        const onTouchEnd = (e) => {
+            if (e.touches.length >= 2) return;
+            active = false;
+            // Carry a fast lift into a decaying fling; otherwise stop clean.
+            if (Math.abs(velocity) >= FLING_MIN_V) {
+                momentum = true;
+                lastFrameT = performance.now();
+                startRaf();
+            } else {
+                velocity = 0;
+                accum = 0;
+            }
+        };
+
+        terminalEl.addEventListener('touchstart', onTouchStart, { passive: false });
+        terminalEl.addEventListener('touchmove', onTouchMove, { passive: false });
+        terminalEl.addEventListener('touchend', onTouchEnd);
+        terminalEl.addEventListener('touchcancel', onTouchEnd);
+
+        this._touchScrollCleanup = () => {
+            stopRaf();
+            terminalEl.removeEventListener('touchstart', onTouchStart);
+            terminalEl.removeEventListener('touchmove', onTouchMove);
+            terminalEl.removeEventListener('touchend', onTouchEnd);
+            terminalEl.removeEventListener('touchcancel', onTouchEnd);
+        };
+    }
+
+    _connectWebSocket() {
+        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const sessionPath = this.sessionId;
+
+        // Force layout reflow so fitAddon.fit() gets real container dimensions,
+        // then pass cols/rows as query params so the server creates the PTY at
+        // the correct size from the start (avoids dots on first render).
+        if (this.fitAddon && this.terminal) {
+            try { this.fitAddon.fit(); } catch (e) {}
+        }
+        const cols = this.terminal ? this.terminal.cols : 80;
+        const rows = this.terminal ? this.terminal.rows : 24;
+        const endpoint = `/ws/terminal/${sessionPath}?cols=${cols}&rows=${rows}`;
+        const url = `${protocol}//${location.host}${endpoint}`;
+
+        // Close any existing WS (even if still CONNECTING) to avoid orphaned
+        // attaches that would receive duplicate broadcast output from tmux.
+        if (this.ws) {
+            try { this.ws.onclose = null; this.ws.close(); } catch (e) {}
+            this.ws = null;
+        }
+
+        this.ws = new WebSocket(url, wsProtocols());
+        this.ws.binaryType = 'arraybuffer';
+
+        this.ws.onopen = () => {
+            this._updateStatus('connected', 'Connected');
+            this._hideDisconnectOverlay();
+
+            // Healed — clear any pending silent-retry state.
+            this._autoReconnectAttempts = 0;
+            if (this._autoReconnectTimer) {
+                clearTimeout(this._autoReconnectTimer);
+                this._autoReconnectTimer = null;
+            }
+
+            // Re-fit terminal before sending size — the maximize animation may have
+            // completed while the socket was connecting, so fit now to get current dims
+            if (this.fitAddon && this.terminal) {
+                this.fitAddon.fit();
+            }
+            this._sendResize();
+        };
+
+        this.ws.onmessage = (event) => {
+            const data = event.data;
+
+            // Check if this looks like a JSON message from the server
+            if (typeof data === 'string' && data.includes('"type"')) {
+                try {
+                    const msg = JSON.parse(data);
+
+                    if (msg.type === 'audio' && msg.data) {
+                        desktop._playAudio(msg.data, this.sessionId);
+                        return;
+                    } else if (msg.type === 'speak_text' && msg.text) {
+                        desktop._speakText(msg.text, this.sessionId);
+                        return;
+                    } else if (msg.type === 'tts_start') {
+                        return;
+                    } else if (msg.type === 'session_unlocked' || msg.type === 'session_locked') {
+                        return; // Ignore lock messages
+                    } else if (msg.type === 'remote_session_ended' || msg.type === 'local_session_ended') {
+                        // Clean exit - tmux session truly ended
+                        this._sessionEnded = true;
+                        this.onSessionEnded();
+                        return;
+                    } else if (msg.type === 'remote_disconnected' || msg.type === 'local_disconnected') {
+                        // Transient drop (bg process side effect, portal restart, etc) -
+                        // retry silently with backoff instead of dropping the user onto
+                        // the manual wall. The onclose that follows is deduped by the
+                        // scheduler's timer guard.
+                        this._scheduleAutoReconnect();
+                        return;
+                    }
+                    // Other JSON messages - don't write to terminal
+                    return;
+                } catch (e) {
+                    // Fall through to terminal
+                }
+            }
+
+            if (!this.terminal) return;
+            if (data instanceof ArrayBuffer) {
+                this.terminal.write(new Uint8Array(data));
+            } else {
+                this.terminal.write(data);
+            }
+            this.onActivity();
+        };
+
+        this.ws.onerror = (error) => {
+            console.error('[TerminalPane] WebSocket error:', error);
+            this._updateStatus('error', 'Connection error');
+        };
+
+        this.ws.onclose = () => {
+            // The session truly ended (host already tearing down) or we're
+            // disposing — nothing to recover.
+            if (this._sessionEnded || this._destroyed) return;
+
+            // Any other close — clean (1000) or abrupt — is treated as a transient drop:
+            // a bg-process kill, portal hot-reload, or network blip. Retry silently with
+            // backoff rather than destroying the terminal or throwing up the manual
+            // wall; the overlay only appears once several silent retries have failed.
+            this._scheduleAutoReconnect();
+        };
+
+        // Only attach once — xterm.js stacks onData listeners, so re-attaching
+        // on every _connectWebSocket() (initial + reconnects) would multiply
+        // each keystroke.
+        if (this.terminal && !this._inputBound) {
+            this._inputBound = true;
+            this.terminal.onData((data) => {
+                if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                    this.ws.send(JSON.stringify({ type: 'input', data }));
+                }
+            });
+        }
+    }
+
+    _setupResizeObserver() {
+        if (!this._terminalEl) return;
+        this.resizeObserver = new ResizeObserver(() => this._handleResize());
+        this.resizeObserver.observe(this._terminalEl);
+    }
+
+    _handleResize() {
+        if (!this.fitAddon || !this.terminal) return;
+        requestAnimationFrame(() => {
+            // dispose() may have run between scheduling and this frame (e.g. a
+            // card collapsed while its resize was in flight) — re-check rather
+            // than trusting the guard taken before the async hop.
+            if (!this.fitAddon || !this.terminal) return;
+            try {
+                this.terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
+                this.terminal.options.fontSize = pickTerminalFontSize();
+                this.fitAddon.fit();
+                this._sendResize();
+            } catch (e) {
+                console.error('[TerminalPane] resize error:', e);
+            }
+        });
+    }
+
+    /**
+     * Force a full WebGL repaint. fit() resizes the buffer but doesn't redraw, so
+     * after a large container resize (tile grid → maximized) the newly-exposed
+     * canvas can stay transparent until interaction. The WebGL renderer needs its
+     * stale texture atlas rebuilt; then a full viewport refresh repaints every cell.
+     */
+    _forceRepaint() {
+        try { this.webglAddon?.clearTextureAtlas(); } catch (e) {}
+        this.terminal.refresh(0, this.terminal.rows - 1);
+    }
+
+    _fitAfterAnimation(watchEl) {
+        if (!this.fitAddon || !this.terminal) return;
+
+        const doFit = () => {
+            // dispose() may have run while waiting on the transition/timeout.
+            if (!this.fitAddon || !this.terminal) return;
+            try {
+                this.terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
+                this.terminal.options.fontSize = pickTerminalFontSize();
+                this.fitAddon.fit();
+                this._sendResize();
+                this._forceRepaint();
+            } catch (err) {
+                console.error('[TerminalPane] Fit error:', err);
+            }
+        };
+
+        let handled = false;
+        const onTransitionEnd = (e) => {
+            if (e.target === watchEl && (e.propertyName === 'width' || e.propertyName === 'height')) {
+                handled = true;
+                watchEl.removeEventListener('transitionend', onTransitionEnd);
+                doFit();
+            }
+        };
+        watchEl.addEventListener('transitionend', onTransitionEnd);
+
+        // Fallback: if transitionend doesn't fire within 500ms, force fit
+        setTimeout(() => {
+            if (!handled) {
+                watchEl.removeEventListener('transitionend', onTransitionEnd);
+                doFit();
+            }
+        }, 500);
+    }
+
+    _sendResize() {
+        if (this.ws && this.ws.readyState === WebSocket.OPEN && this.terminal) {
+            this.ws.send(JSON.stringify({ type: 'resize', cols: this.terminal.cols, rows: this.terminal.rows }));
+        }
+    }
+
+    _updateStatus(state, message) {
+        if (!this._root) return;
+        const statusBar = this._root.querySelector('.session-status-bar');
+        if (!statusBar) return;
+        const indicator = statusBar.querySelector('.status-indicator');
+        const text = statusBar.querySelector('.status-text');
+        if (indicator) indicator.className = `status-indicator ${state}`;
+        if (text) text.textContent = message;
+    }
+
+    _showDisconnectOverlay() {
+        const overlay = this._root?.querySelector('.session-disconnect-overlay');
+        if (overlay) overlay.classList.remove('hidden');
+    }
+
+    _hideDisconnectOverlay() {
+        const overlay = this._root?.querySelector('.session-disconnect-overlay');
+        if (overlay) overlay.classList.add('hidden');
+    }
+
+    /**
+     * Schedule a silent reconnect with exponential backoff. The terminal heals
+     * itself when the WS comes back (portal restart, transient kill side-effect)
+     * instead of forcing a manual click. The manual "Reconnect" overlay surfaces
+     * only after TERM_RECONNECT_OVERLAY_AFTER silent attempts have failed, so a
+     * brief blip never throws up the wall.
+     */
+    _scheduleAutoReconnect() {
+        if (this._destroyed || this._sessionEnded) return;
+        if (this._autoReconnectTimer) return; // already pending — dedupe
+
+        const delay = Math.min(
+            TERM_RECONNECT_INITIAL * Math.pow(TERM_RECONNECT_MULTIPLIER, this._autoReconnectAttempts),
+            TERM_RECONNECT_MAX
+        );
+        this._autoReconnectAttempts++;
+
+        if (this._autoReconnectAttempts > TERM_RECONNECT_OVERLAY_AFTER) {
+            this._updateStatus('disconnected', 'Connection lost');
+            this._showDisconnectOverlay();
+        } else {
+            this._updateStatus('connecting', 'Reconnecting…');
+        }
+
+        this._autoReconnectTimer = setTimeout(() => {
+            this._autoReconnectTimer = null;
+            if (this._destroyed || this._sessionEnded) return;
+            this._connectWebSocket();
+        }, delay);
+    }
+
+    async _reconnect() {
+        // Manual reconnect (button or any-keystroke) — cancel any pending silent
+        // retry and reset backoff so this fires immediately.
+        if (this._autoReconnectTimer) {
+            clearTimeout(this._autoReconnectTimer);
+            this._autoReconnectTimer = null;
+        }
+        this._autoReconnectAttempts = 0;
+
+        this._updateStatus('connecting', 'Checking session...');
+
+        // For remote sessions, check if the session still exists before reconnecting
+        if (this.machine) {
+            try {
+                const response = await apiFetch(`/api/sessions/remote`);
+                const data = await response.json();
+                const allSessions = (data.machines || []).flatMap(m => m.sessions || []);
+                const sessionExists = allSessions.some(s =>
+                    s.name === this.session && sameMachine(s.machine, this.machine)
+                );
+
+                if (!sessionExists) {
+                    this._sessionEnded = true;
+                    this.onSessionEnded();
+                    return;
+                }
+            } catch (err) {
+                console.error('[TerminalPane] Failed to check session:', err);
+                // Continue with reconnect attempt anyway
+            }
+        }
+
+        this._hideDisconnectOverlay();
+        this._updateStatus('connecting', 'Reconnecting...');
+
+        if (this.ws) {
+            this.ws.onclose = null; // Prevent triggering overlay again
+            this.ws.close();
+            this.ws = null;
+        }
+
+        this.terminal?.clear();
+        this._connectWebSocket();
+    }
+
+    _setupReconnectButton() {
+        const reconnectBtn = this._root.querySelector('.reconnect-btn');
+        if (reconnectBtn) {
+            reconnectBtn.addEventListener('click', () => this._reconnect());
+        }
+
+        // Any-keystroke fallback: while the disconnect overlay is up, any key
+        // reconnects — no need to aim for the small button. Capture phase on
+        // this pane's own root so xterm.js (still focused under the overlay)
+        // can't swallow the keydown, and so it's inherently scoped to THIS
+        // pane — a keypress in another pane's terminal never reaches here.
+        this._overlayKeyHandler = (e) => {
+            const overlay = this._root.querySelector('.session-disconnect-overlay');
+            if (!overlay || overlay.classList.contains('hidden')) return;
+            // Bare modifier presses (Shift/Ctrl/Alt/Meta) and OS shortcuts like
+            // Cmd-Tab shouldn't count as the "any key".
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) return;
+            e.preventDefault();
+            e.stopPropagation();
+            this._reconnect();
+        };
+        this._root.addEventListener('keydown', this._overlayKeyHandler, true);
+    }
+}

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -62,7 +62,12 @@ export class TopologyView {
     /**
      * @param {HTMLElement} container - Mount point; TopologyView owns everything appended under it.
      * @param {object} [opts]
-     * @param {(name: string, session: object) => void} [opts.onCardClick] - Fired on card click.
+     * @param {(name: string, session: object, slotEl: HTMLElement) => (() => void)|void} [opts.onCardExpand] -
+     *   Fired when a card is clicked and expands inline. Receives the session name, record, and an
+     *   empty slot element appended into the card — mount whatever content belongs there (e.g. a
+     *   mini-terminal) and optionally return a cleanup function. TopologyView calls that cleanup on
+     *   collapse (re-click), when the card is pruned (session disappeared), or on dispose(). Omitting
+     *   this makes cards inert (e.g. the non-interactive phantom overlay).
      * @param {boolean} [opts.showLinks=true] - Draw the connector SVG layer.
      * @param {'window'|'overlay'} [opts.mode='window'] - Styling hook only — 'overlay' renders
      *   translucent glass cards for popping over a live terminal window; 'window' (default)
@@ -70,10 +75,12 @@ export class TopologyView {
      */
     constructor(container, opts = {}) {
         this._container = container;
-        this._onCardClick = opts.onCardClick || null;
+        this._onCardExpand = opts.onCardExpand || null;
         this._showLinks = opts.showLinks !== false;
         this._mode = opts.mode === 'overlay' ? 'overlay' : 'window';
         this._lastSessions = [];
+        /** @type {string|null} name of the currently expanded card, if any (accordion — one at a time) */
+        this._expandedCard = null;
 
         /** @type {Map<string, {familyEl: HTMLElement, rows: Map<number, HTMLElement>}>} */
         this._families = new Map();
@@ -137,6 +144,7 @@ export class TopologyView {
 
     /** Tear down everything TopologyView appended into its container. */
     dispose() {
+        if (this._expandedCard) this._collapseCard(this._expandedCard);
         this._resizeObserver.disconnect();
         window.removeEventListener('resize', this._scheduleRedraw);
         if (this._raf !== null) cancelAnimationFrame(this._raf);
@@ -199,6 +207,7 @@ export class TopologyView {
     _pruneCards(seenCards) {
         for (const [name, entry] of this._cards) {
             if (!seenCards.has(name)) {
+                if (entry.expanded) this._collapseCard(name);
                 entry.card.remove();
                 this._cards.delete(name);
                 this._links.delete(name);
@@ -249,9 +258,12 @@ export class TopologyView {
         const card = document.createElement('div');
         card.className = 'topology-card';
         card.dataset.session = name;
-        card.addEventListener('click', () => {
-            const entry = this._cards.get(name);
-            this._onCardClick?.(name, entry?.session);
+        card.addEventListener('click', (e) => {
+            if (!this._onCardExpand) return;
+            // Clicks inside the expanded slot (the mounted mini-terminal, its
+            // mic button, etc.) must not bubble into a collapse toggle.
+            if (e.target.closest('.topology-card-expand-slot')) return;
+            this._toggleExpand(name);
         });
 
         const top = document.createElement('div');
@@ -281,7 +293,58 @@ export class TopologyView {
 
         card.append(top, meta);
 
-        return { card, dot, nameEl, roleEl, machineEl, sparkEl, state: null, tintVar: null, session: null };
+        return {
+            card, dot, nameEl, roleEl, machineEl, sparkEl, state: null, tintVar: null, session: null,
+            expanded: false, expandSlot: null, expandDispose: null,
+        };
+    }
+
+    _toggleExpand(name) {
+        const entry = this._cards.get(name);
+        if (!entry) return;
+        if (entry.expanded) this._collapseCard(name);
+        else this._expandCard(name);
+    }
+
+    _expandCard(name) {
+        const entry = this._cards.get(name);
+        if (!entry || entry.expanded || !this._onCardExpand) return;
+        // Accordion — only one card's mini-terminal (and its live WS) is open
+        // at a time, to keep resource use and visual noise bounded.
+        if (this._expandedCard && this._expandedCard !== name) {
+            this._collapseCard(this._expandedCard);
+        }
+
+        const slot = document.createElement('div');
+        slot.className = 'topology-card-expand-slot';
+        entry.card.appendChild(slot);
+        entry.card.classList.add('topology-card--expanded');
+        entry.expanded = true;
+        entry.expandSlot = slot;
+        this._expandedCard = name;
+
+        const dispose = this._onCardExpand(name, entry.session, slot);
+        entry.expandDispose = typeof dispose === 'function' ? dispose : null;
+        this._scheduleRedraw(); // card grew — links may need repositioning
+    }
+
+    _collapseCard(name) {
+        const entry = this._cards.get(name);
+        if (!entry || !entry.expanded) return;
+        entry.expandDispose?.();
+        entry.expandDispose = null;
+        entry.expandSlot?.remove();
+        entry.expandSlot = null;
+        entry.card.classList.remove('topology-card--expanded');
+        entry.expanded = false;
+        if (this._expandedCard === name) this._expandedCard = null;
+        this._scheduleRedraw();
+    }
+
+    /** Programmatically collapse an expanded card — e.g. the mounted content
+     * (a mini-terminal) signals its session ended. No-op if not expanded. */
+    collapseCard(name) {
+        this._collapseCard(name);
     }
 
     _scheduleRedraw() {

--- a/agentwire/static/js/workspace-window.js
+++ b/agentwire/static/js/workspace-window.js
@@ -9,12 +9,25 @@
  * always lands on the same window regardless of which member opened it.
  * Mirrors ReviewWindow's WinBox lifecycle (register/unregister via
  * desktop-manager.js, `_createWinBox` + guarded close).
+ *
+ * Card interaction (#763): clicking a card expands it inline into a mini
+ * terminal — a TerminalPane (terminal-pane.js, the same xterm+WS core
+ * SessionWindow's full terminal window uses) plus a PttController mic,
+ * wired the same way SessionWindow's titlebar PTT is. TopologyView owns the
+ * expand/collapse DOM lifecycle (including cleanup when a session vanishes
+ * mid-expand); this module only supplies what to mount.
  */
 
 import { desktop } from './desktop-manager.js';
 import { TopologyView } from './topology-render.js';
 import { getAllSessions, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
 import { familyRootName } from './lineage.js';
+import { TerminalPane } from './terminal-pane.js';
+import { PttController } from './ptt.js';
+import { apiFetch } from './api.js';
+import { buildSessionId, normalizeMachine } from './session-id.js';
+import { voicePromptWrap } from './voice/prompt.js';
+import { isAutoSend } from './voice/autosend-prefs.js';
 
 function esc(s) {
     return String(s ?? '').replace(/[&<>"']/g, (c) => ({
@@ -28,7 +41,6 @@ export class WorkspaceWindow {
      * @param {string} options.rootSession - Family root session name (the window's identity)
      * @param {string} options.windowId - Unique window identifier
      * @param {HTMLElement} options.root - Parent element for WinBox
-     * @param {(name: string, session: object) => void} [options.onCardClick] - Fired on card click
      * @param {Function} options.onClose - Callback when window closes
      * @param {Function} options.onFocus - Callback when window gains focus
      */
@@ -37,7 +49,6 @@ export class WorkspaceWindow {
         this.windowId = options.windowId;
         this.root = options.root || document.body;
         this.title = `🛰 ${this.rootSession}`;
-        this.onCardClickCallback = options.onCardClick || null;
         this.onCloseCallback = options.onClose || null;
         this.onFocusCallback = options.onFocus || null;
 
@@ -55,7 +66,7 @@ export class WorkspaceWindow {
 
         const canvas = container.querySelector('.workspace-window-canvas');
         this._topologyView = new TopologyView(canvas, {
-            onCardClick: (name, session) => this.onCardClickCallback?.(name, session),
+            onCardExpand: (name, session, slotEl) => this._mountCardTerminal(name, session, slotEl),
             mode: 'window',
         });
 
@@ -137,5 +148,155 @@ export class WorkspaceWindow {
             return name && familyRootName(name, sessions) === this.rootSession;
         });
         this._topologyView.render(members);
+    }
+
+    /**
+     * Mount a mini-terminal (#763) into a card's expand slot: a TerminalPane
+     * over the session's real WS, plus a titlebar-style mic button wired the
+     * same way SessionWindow's PTT is (record → /transcribe → auto-send or
+     * edit-before-send bar). Returns a dispose function TopologyView calls on
+     * collapse/prune/view-teardown.
+     *
+     * @param {string} name - Session name
+     * @param {object} session - Session record (for machine)
+     * @param {HTMLElement} slotEl - Empty slot appended into the card
+     * @returns {() => void} cleanup
+     */
+    _mountCardTerminal(name, session, slotEl) {
+        const machine = normalizeMachine(session?.machine);
+        const sessionId = buildSessionId(name, machine);
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'topology-card-mini-toolbar';
+
+        const pttBtn = document.createElement('button');
+        pttBtn.type = 'button';
+        pttBtn.className = 'wb-title-ptt';
+        pttBtn.title = 'Hold to record voice input';
+        pttBtn.innerHTML = '<span class="ptt-icon">🎤</span>';
+
+        const openBtn = document.createElement('button');
+        openBtn.type = 'button';
+        openBtn.className = 'topology-card-mini-open';
+        openBtn.title = 'Open full terminal';
+        openBtn.textContent = '⤢';
+        openBtn.addEventListener('click', async () => {
+            const { openSessionTerminal } = await import('./desktop.js');
+            openSessionTerminal(name, 'terminal', machine);
+        });
+
+        toolbar.append(pttBtn, openBtn);
+
+        const termHost = document.createElement('div');
+        termHost.className = 'topology-card-mini-terminal';
+
+        slotEl.append(toolbar, termHost);
+
+        const pane = new TerminalPane(termHost, {
+            session: name,
+            machine,
+            onSessionEnded: () => this._topologyView?.collapseCard(name),
+        });
+
+        let transcriptBar = null;
+        const removeTranscriptBar = () => {
+            transcriptBar?.remove();
+            transcriptBar = null;
+            pane.focus();
+        };
+
+        const sendVoiceText = async (text) => {
+            try {
+                const res = await apiFetch(`/send/${sessionId}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text: voicePromptWrap(text) }),
+                });
+                const data = await res.json();
+                if (data.error) throw new Error(data.error);
+                pane.setStatus('connected', `Sent: "${text.substring(0, 30)}${text.length > 30 ? '...' : ''}"`);
+                setTimeout(() => pane.setStatus('connected', 'Connected'), 3000);
+            } catch (err) {
+                console.error('[WorkspaceWindow] Voice send failed:', err);
+                pane.setStatus('error', err.message || 'Voice input failed');
+            }
+        };
+
+        const showTranscriptBar = (text) => {
+            removeTranscriptBar();
+            const bar = document.createElement('div');
+            bar.className = 'wb-transcript-bar';
+            bar.innerHTML = `
+                <input type="text" class="wb-transcript-input" />
+                <button class="wb-transcript-send" title="Send (Enter)">➤</button>
+                <button class="wb-transcript-dismiss" title="Discard (Esc)">✕</button>
+            `;
+            const input = bar.querySelector('.wb-transcript-input');
+            input.value = text;
+
+            const send = () => {
+                const value = input.value.trim();
+                removeTranscriptBar();
+                if (value) sendVoiceText(value);
+            };
+            bar.querySelector('.wb-transcript-send').addEventListener('click', send);
+            bar.querySelector('.wb-transcript-dismiss').addEventListener('click', removeTranscriptBar);
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') { e.preventDefault(); send(); }
+                else if (e.key === 'Escape') { e.preventDefault(); removeTranscriptBar(); }
+                e.stopPropagation();
+            });
+
+            toolbar.after(bar);
+            transcriptBar = bar;
+            input.focus();
+            input.select();
+        };
+
+        const ptt = new PttController({
+            getVoiceStatus: () => desktop.voiceStatus,
+            onState: (state) => {
+                pttBtn.classList.remove('recording', 'processing');
+                if (state === 'recording') {
+                    pttBtn.classList.add('recording');
+                    pttBtn.querySelector('.ptt-icon').textContent = '🔴';
+                } else if (state === 'processing') {
+                    pttBtn.classList.add('processing');
+                    pttBtn.querySelector('.ptt-icon').textContent = '🎤';
+                } else {
+                    pttBtn.querySelector('.ptt-icon').textContent = '🎤';
+                }
+            },
+            onResult: (text) => {
+                if (isAutoSend()) sendVoiceText(text);
+                else showTranscriptBar(text);
+            },
+            onError: (kind, message) => pane.setStatus('error', message),
+        });
+
+        // Same pointer-capture pattern as SessionWindow's titlebar PTT button.
+        const onDown = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            pttBtn.setPointerCapture?.(e.pointerId);
+            ptt.start();
+        };
+        const onUp = (e) => {
+            e.stopPropagation();
+            pttBtn.releasePointerCapture?.(e.pointerId);
+            if (ptt.state === 'recording') ptt.stop();
+        };
+        const onCancel = (e) => {
+            pttBtn.releasePointerCapture?.(e.pointerId);
+            if (ptt.state === 'recording') ptt.cancel();
+        };
+        pttBtn.addEventListener('pointerdown', onDown, true);
+        pttBtn.addEventListener('pointerup', onUp, true);
+        pttBtn.addEventListener('pointercancel', onCancel);
+
+        return () => {
+            removeTranscriptBar();
+            pane.dispose();
+        };
     }
 }

--- a/docs/wiki/internals/session-topology.md
+++ b/docs/wiki/internals/session-topology.md
@@ -9,6 +9,7 @@ Mechanisms, shipped across #745–#749 and #761–#764, that make the parent→c
 | **Born-from-parent placement** | `static/js/spawn-ghost.js` (+ wiring in `desktop.js`) | A child session appears while its parent's window is open |
 | **Shared topology renderer** | `static/js/topology-render.js` (`TopologyView`) | Mounted by the two surfaces below — not triggered directly |
 | **Session Workspace window** | `static/js/workspace-window.js` | 🛰 launcher on a session card, or `openSessionWorkspace()` |
+| **Card mini-terminal** | `static/js/terminal-pane.js` (`TerminalPane`) + `workspace-window.js` | Click a card in the Workspace window |
 | **Phantom overlay** | `static/js/topology-overlay.js` | The live `session_created` event (a child spawns), or the Config sidebar "Topology overlay" checkbox |
 | **Grouped + tinted collage** | `static/js/collage.js` | F3 / `desktop_collage` MCP / command palette |
 | **Live appearance** | `desktop.js` `handleSessionCreated` + server `notify_portal_session_created` | A session is created via `agentwire new` / `worktree` / the portal |
@@ -37,6 +38,14 @@ Birth detection has two independent paths that land in the same place (`register
 `wireStateFor(name, record)` is the one shared status mapping ('idle' | 'flow' | 'awaiting' | 'stuck') every card (and the phantom overlay below) reads, so a card and the sidebar dot never disagree on what "awaiting"/"stuck" means.
 
 **`workspace-window.js`'s `WorkspaceWindow`** (#762) hosts `TopologyView` in `mode: 'window'` (solid chrome) as a first-class WinBox window — the 🛰 launcher on any session card in a family opens (or focuses) the one window for that family, keyed by family root so it doesn't matter which member you launched it from. Opens with `desktop.minimizeAllExcept(null)` maximized, re-renders on every `onSessionsChanged` tick, and disposes its `TopologyView` on close.
+
+## Card mini-terminal
+
+`TopologyView` (#763) supports an optional `onCardExpand(name, session, slotEl)` callback: clicking a card toggles an inline expand — the card grows to full row width, TopologyView appends an empty `.topology-card-expand-slot` into it, and calls `onCardExpand`, which mounts whatever content belongs there and returns a cleanup function. TopologyView owns the DOM lifecycle end to end: it calls that cleanup on re-click (collapse), when the underlying session disappears from a `render()` pass (pruned mid-expand), or when the whole view is disposed — the mounting code never has to track that itself. Only one card is expanded at a time (accordion), so at most one extra live WS connection is open. Clicks inside the slot are guarded (`e.target.closest('.topology-card-expand-slot')`) so interacting with the mounted content never bubbles into a collapse toggle.
+
+`workspace-window.js` is the only consumer today: its `_mountCardTerminal(name, session, slotEl)` mounts a `TerminalPane` (`terminal-pane.js` — the xterm + WS core extracted out of `SessionWindow`'s full terminal window, `new TerminalPane(container, {session, machine})` with `focus()`/`fit()`/`dispose()`) plus a titlebar-style mic button wired the same way `SessionWindow._setupPTT`'s is (`PttController` → `/transcribe` → auto-send or an edit-before-send `.wb-transcript-bar`). A small "⤢" button pops out to the full `SessionWindow` via a dynamic `import('./desktop.js')` (avoids a circular import — `desktop.js` is what constructs `WorkspaceWindow`). `SessionWindow` itself now just wraps `TerminalPane` with WinBox chrome, the titlebar PTT button, and the activity indicator — Monitor mode (a polling `<pre>` dump, not xterm) is untouched and keeps its own WS/reconnect machinery in `session-window.js`, since it's a different beast entirely.
+
+**Satisfies the live-pane-peek safety flag** ([Design tokens](#design-tokens) below): the mini-terminal only mounts on an explicit card click — opening the Workspace window itself shows no live terminal content, so the resting state stays inert and the peek is always an opt-in reveal, never automatic.
 
 ## Phantom overlay
 


### PR DESCRIPTION
## Summary
- Extracts the xterm.js + WebSocket core out of `SessionWindow` into a new, reusable `TerminalPane` (`terminal-pane.js`) — `new TerminalPane(container, {session, machine})` with `focus()`/`fit()`/`dispose()`, mountable into any sized container. `SessionWindow` now wraps it (WinBox chrome + titlebar PTT + activity indicator); Monitor mode is untouched (its own WS/status/reconnect machinery, simplified to drop now-dead terminal-mode branches).
- `TopologyView` (`topology-render.js`) gains an `onCardExpand(name, session, slotEl)` hook: clicking a workspace card expands it inline, TopologyView owns the DOM lifecycle (collapse on re-click, on session-prune, on view dispose), accordion (one expanded card at a time).
- `WorkspaceWindow` mounts a `TerminalPane` + a titlebar-style mic (`PttController`, wired the same as `SessionWindow._setupPTT`) into the expand slot, plus a "⤢" button to pop out to the full terminal window.
- Fixed a real race found during manual testing: rapid expand/collapse cycling could leave a pending resize or an xterm-internal deferred write/refresh firing after `dispose()` had torn the terminal down. Guards now re-check post-dispose, and `terminal.dispose()` itself is deferred one animation frame (with the reference nulled immediately) so xterm's own in-flight internal work settles against a still-valid instance first.

## Test plan
- [x] `node --check --input-type=module` clean on every touched module
- [x] Manual e2e via a local `agentwire portal serve` (non-default port, worktree source): full `SessionWindow` terminal opens/types/minimizes/restores correctly (unchanged behavior)
- [x] Card click → mini-terminal expands over the real session WS, typing works, mic button renders
- [x] Accordion: expanding a second card collapses the first; both show genuinely distinct live sessions
- [x] "⤢" pop-out opens the full `SessionWindow` with identical content
- [x] Stress-tested rapid expand/collapse cycling — no console errors after the race fix
- [x] No duplicate xterm/WS setup left anywhere outside `terminal-pane.js`

Closes #763