### PR TITLE
fix(portal): workspace + review windows missing from window-instance lookup (cycling/taskbar focus)

### DIFF
--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -990,7 +990,13 @@ let restoringTaskbar = false;
 
 function _lookupWindowInstance(id) {
     if (id === COUNCIL_WINDOW_ID && councilWindow) return councilWindow;
-    return sessionWindows.get(id) || artifactWindows.get(id) || null;
+    // Every registered window map must be here or the window can't be focused/
+    // restored via the taskbar-button click (:1116) or Alt+] cycling (:505),
+    // which resolve the live instance through this lookup. Workspace (#762) and
+    // review windows were both missing, so cycling/taskbar-click marked them
+    // active but never raised or un-minimized them.
+    return sessionWindows.get(id) || artifactWindows.get(id)
+        || reviewWindows.get(id) || workspaceWindows.get(id) || null;
 }
 
 function loadTaskbarState() {


### PR DESCRIPTION
The Session Workspace window (#762) — and review windows — were missing from `_lookupWindowInstance`, which `cycleWindow` (Alt+] cycling) and the taskbar-button click handler use to resolve the live window instance. Result: cycling or clicking the taskbar tab for a workspace window marked it active but never raised or un-minimized it.

Fix: add `reviewWindows` + `workspaceWindows` to the lookup. Tiling/maximize were already fine (they go through the WinBox registry + events, not this lookup).

Surfaced by manual verification of window-management integration after the Session Workspace epic (#765).

Built by [dotdev.dev](https://dotdev.dev)