### PR TITLE
feat(portal): denser card mini-terminal (14px font, header actions, trimmed chrome)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6714,13 +6714,23 @@ body.sidebar-pinned .sidebar-tab {
     cursor: default;
 }
 
-.topology-card-mini-toolbar {
+/* Mini-terminal actions (mic + open-full) live in the card's header row next
+   to the role chip (workspace-window.js appends .topology-card-actions there),
+   so there's no separate toolbar row stealing terminal height. */
+.topology-card-actions {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    padding: 4px 6px;
-    background: var(--chrome);
-    border-bottom: 1px solid var(--chrome-border);
+    gap: 4px;
+    flex: 0 0 auto;
+    margin-left: 4px;
+}
+
+.topology-card-actions .wb-title-ptt,
+.topology-card-actions .topology-card-mini-open {
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+    padding: 0;
 }
 
 .topology-card-mini-open {
@@ -6749,8 +6759,14 @@ body.sidebar-pinned .sidebar-tab {
    overrides .session-window-content's height:100% via a higher-specificity
    compound selector (TerminalPane adds that class onto this same element). */
 .topology-card-mini-terminal.session-window-content {
-    height: 280px;
+    height: 320px;
 }
+
+/* Expanded card hosts a live terminal — the activity sparkline is redundant
+   and just steals a row, so hide it, and tighten the card's gap. Reclaims
+   vertical space for terminal rows (the card was mostly chrome above it). */
+.topology-card--expanded .topology-card-meta { display: none; }
+.topology-card--expanded { gap: 4px; }
 
 /* --- phantom topology overlay (#764) — topology-overlay.js ---
    Transient, non-interactive pop-over of the shared renderer above: the

--- a/agentwire/static/js/terminal-pane.js
+++ b/agentwire/static/js/terminal-pane.js
@@ -58,6 +58,10 @@ export class TerminalPane {
         this.container = container;
         this.session = opts.session;
         this.machine = normalizeMachine(opts.machine);
+        // Per-instance font override: the card mini-terminal renders a smaller
+        // fixed size than the global terminal pref so more rows fit. null →
+        // follow the global pref + responsive default like the full window.
+        this._fontSizeOverride = opts.fontSize ?? null;
         this.onActivity = opts.onActivity || (() => {});
         this.onSessionEnded = opts.onSessionEnded || (() => {});
 
@@ -208,7 +212,7 @@ export class TerminalPane {
 
     _createTerminal() {
         const terminalEl = this._terminalEl;
-        const initialFontSize = pickTerminalFontSize();
+        const initialFontSize = this._fontSizeOverride ?? pickTerminalFontSize();
         terminalEl.style.setProperty('--terminal-font-size', `${initialFontSize}px`);
 
         this.terminal = new Terminal({
@@ -266,7 +270,7 @@ export class TerminalPane {
         // and on user override via the sidebar Config slider.
         const applyNewSize = () => {
             if (!this.terminal) return;
-            const newSize = pickTerminalFontSize();
+            const newSize = this._fontSizeOverride ?? pickTerminalFontSize();
             terminalEl.style.setProperty('--terminal-font-size', `${newSize}px`);
             this.terminal.options.fontSize = newSize;
             this._handleResize();
@@ -590,7 +594,7 @@ export class TerminalPane {
             if (!this.fitAddon || !this.terminal) return;
             try {
                 this.terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
-                this.terminal.options.fontSize = pickTerminalFontSize();
+                this.terminal.options.fontSize = this._fontSizeOverride ?? pickTerminalFontSize();
                 this.fitAddon.fit();
                 this._sendResize();
             } catch (e) {
@@ -618,7 +622,7 @@ export class TerminalPane {
             if (!this.fitAddon || !this.terminal) return;
             try {
                 this.terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
-                this.terminal.options.fontSize = pickTerminalFontSize();
+                this.terminal.options.fontSize = this._fontSizeOverride ?? pickTerminalFontSize();
                 this.fitAddon.fit();
                 this._sendResize();
                 this._forceRepaint();

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -262,7 +262,7 @@ export class TopologyView {
             if (!this._onCardExpand) return;
             // Clicks inside the expanded slot (the mounted mini-terminal, its
             // mic button, etc.) must not bubble into a collapse toggle.
-            if (e.target.closest('.topology-card-expand-slot')) return;
+            if (e.target.closest('.topology-card-expand-slot, .topology-card-actions')) return;
             this._toggleExpand(name);
         });
 

--- a/agentwire/static/js/workspace-window.js
+++ b/agentwire/static/js/workspace-window.js
@@ -166,8 +166,14 @@ export class WorkspaceWindow {
         const machine = normalizeMachine(session?.machine);
         const sessionId = buildSessionId(name, machine);
 
-        const toolbar = document.createElement('div');
-        toolbar.className = 'topology-card-mini-toolbar';
+        // Actions (mic + open-full) live in the card's own header row next to
+        // the role chip — not a dedicated toolbar row — so the mini-terminal
+        // reclaims that vertical space. topology-render.js's card-click collapse
+        // toggle exempts .topology-card-actions the same way it exempts the slot.
+        const card = slotEl.closest('.topology-card');
+        const headerRow = card?.querySelector('.topology-card-top');
+        const actions = document.createElement('div');
+        actions.className = 'topology-card-actions';
 
         const pttBtn = document.createElement('button');
         pttBtn.type = 'button';
@@ -185,16 +191,21 @@ export class WorkspaceWindow {
             openSessionTerminal(name, 'terminal', machine);
         });
 
-        toolbar.append(pttBtn, openBtn);
+        actions.append(pttBtn, openBtn);
+        headerRow?.appendChild(actions);
 
         const termHost = document.createElement('div');
         termHost.className = 'topology-card-mini-terminal';
 
-        slotEl.append(toolbar, termHost);
+        slotEl.append(termHost);
 
         const pane = new TerminalPane(termHost, {
             session: name,
             machine,
+            // A card is a compact peek — render smaller than the global terminal
+            // pref (16/20px) so more rows are visible; the ⤢ pop-out opens the
+            // full-size window for real work.
+            fontSize: 14,
             onSessionEnded: () => this._topologyView?.collapseCard(name),
         });
 
@@ -247,7 +258,7 @@ export class WorkspaceWindow {
                 e.stopPropagation();
             });
 
-            toolbar.after(bar);
+            termHost.before(bar);
             transcriptBar = bar;
             input.focus();
             input.select();
@@ -296,6 +307,7 @@ export class WorkspaceWindow {
 
         return () => {
             removeTranscriptBar();
+            actions.remove();
             pane.dispose();
         };
     }


### PR DESCRIPTION
Follow-up polish on the Session Workspace card mini-terminal (#763): it showed only ~11 rows in the narrow portal, most of the card was chrome (header + sparkline row + toolbar row), and the font matched the chunky global terminal pref.

**Changes**
- `TerminalPane` gains an `opts.fontSize` override (honored across the font-pref + viewport re-fit paths). The card mini-terminal passes a fixed **14px** vs the global 16/20px, so more rows fit. The full terminal window is unchanged.
- Mic 🎤 + open-full ⤢ move into the card's **header row** (`.topology-card-actions`), removing the dedicated toolbar row; the card click/collapse toggle exempts them like the expand slot.
- **Sparkline hidden** when a card is expanded (redundant next to a live terminal); box grown **280→320px**.

**Net:** chrome above the terminal drops from 3 rows to 1; visible rows ~11 → ~17.

Verified live in the browser (font size, row count, mic/⤢ in header, toolbar gone, collapse still works).

Built by [dotdev.dev](https://dotdev.dev)