### PR TITLE
fix(portal): remove duplicate header from Session Workspace window

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -4184,26 +4184,6 @@ body .winbox.max {
     color: var(--text);
 }
 
-.workspace-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 10px;
-    background: var(--chrome);
-    border-bottom: 1px solid var(--chrome-border);
-    flex: 0 0 auto;
-}
-
-.workspace-toolbar-icon {
-    font-size: 14px;
-}
-
-.workspace-toolbar-title {
-    font-weight: 600;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
 
 .workspace-window-canvas {
     flex: 1;

--- a/agentwire/static/js/workspace-window.js
+++ b/agentwire/static/js/workspace-window.js
@@ -29,12 +29,6 @@ import { buildSessionId, normalizeMachine } from './session-id.js';
 import { voicePromptWrap } from './voice/prompt.js';
 import { isAutoSend } from './voice/autosend-prefs.js';
 
-function esc(s) {
-    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
-        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
-    }[c]));
-}
-
 export class WorkspaceWindow {
     /**
      * @param {Object} options
@@ -103,11 +97,9 @@ export class WorkspaceWindow {
     _createContainer() {
         const container = document.createElement('div');
         container.className = 'workspace-window-content';
+        // No in-content header — the WinBox title bar already shows the 🛰 icon
+        // + session name; a second toolbar row here just duplicated it.
         container.innerHTML = `
-            <div class="workspace-toolbar">
-                <span class="workspace-toolbar-icon">🛰</span>
-                <span class="workspace-toolbar-title" title="${esc(this.rootSession)}">${esc(this.rootSession)}</span>
-            </div>
             <div class="workspace-window-canvas desktop-dot-grid"></div>
         `;
         return container;


### PR DESCRIPTION
The workspace window (#762) rendered an in-content `.workspace-toolbar` (🛰 + session name) on top of WinBox's native title bar, which already shows the same — so the window had **two identical stacked headers**.

Removed the redundant toolbar row, its now-dead `esc()` helper, and the dead CSS. The WinBox title bar remains as the single header; the canvas + topology cards are unaffected.

Verified live: `.workspace-toolbar` gone, canvas present, single `🛰 agentwire` title.

Built by [dotdev.dev](https://dotdev.dev)