### PR TITLE
fix(portal): role chip shows ORCHESTRATOR, not session name, on root cards (#768)

### DIFF
--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -235,7 +235,15 @@ export class TopologyView {
 
         if (entry.nameEl.textContent !== name) entry.nameEl.textContent = name;
 
-        const role = (session.roles && session.roles[0]) || 'worker';
+        // session.roles (plural) is the arbitrary persona/etiquette list from
+        // .agentwire.yml, not the orchestrator/worker axis — do not read it here.
+        // session.role (singular) is that axis but is only recorded for sessions
+        // created after #747, so long-lived root sessions still have it null;
+        // fall back to parentless-ness (this file already treats depth 0 as
+        // "root" for row layout above).
+        const role = session.role === 'worker' || session.role === 'orchestrator'
+            ? session.role
+            : (session.parent ? 'worker' : 'orchestrator');
         if (entry.roleEl.textContent !== role) {
             entry.roleEl.textContent = role;
             entry.roleEl.classList.toggle('topology-role-chip--orchestrator', role === 'orchestrator');


### PR DESCRIPTION
## Summary
- `_renderCard()` in `topology-render.js` read `session.roles[0]` (the arbitrary persona/etiquette list from `.agentwire.yml`) as if it were the orchestrator/worker axis. For long-lived root sessions this coincidentally rendered the session's own name (e.g. the `agentwire` session's persona role is literally named `"agentwire"`).
- Now reads the singular `session.role` field (the real axis) when set, falling back to parentless-ness (root sessions predating #747 never got `role` recorded on disk) — reusing the same depth-0-is-root convention this file already applies to row layout.
- Worker cards are unaffected (`session.role === "worker"` was already correct).

## Root cause (diagnosed against live data before touching code)
Fetched `/api/sessions` live: the `agentwire` root session has `roles: ["agentwire", "voice"]` (persona config) and `role: null` (axis field, unset — feature shipped after this session was created). The worker session has `roles: []`, `role: "worker"`. Two research agents traced both fields to their exact server-side write paths to confirm this before I wrote the fix.

## Test plan
- [x] `node --check --input-type=module < agentwire/static/js/topology-render.js` — clean
- [x] Reproduced the bug live in the real Session Workspace window (`agentwire` root card showed `AGENTWIRE`, worker card showed `WORKER`)
- [x] Verified the fix against real live session data in the same browser: dynamic-imported the live (same-origin) module and monkey-patched `TopologyView.prototype._renderCard` in-memory to the fixed logic (blob-URL module imports are blocked by the portal's CSP), rendered into a scratch container — root card showed `ORCHESTRATOR` (with the accent chip class), worker card still showed `WORKER`. Screenshot confirmed. No files on the owner's checkout were touched; the in-memory patch is gone on next reload.
- [x] Cleaned up: removed the scratch DOM, closed the workspace test window (left the owner's other pre-existing minimized windows untouched), closed and untracked the Chrome tab.

Closes #768