### PR TITLE
feat(portal): Session HUD shell — top-edge frosted drawer (#776)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5952,6 +5952,102 @@ body.sidebar-pinned .sidebar-tab {
     color: var(--background);
 }
 
+/* ============================================
+   Session HUD — top-edge frosted drawer (#776, foundation shell)
+   Two detents (peek 33vh / half 50vh), top-center pull handle. Content is
+   mounted into .session-hud-canvas by a later issue (#777, TopologyView).
+   ============================================ */
+
+.session-hud-drawer {
+    position: fixed;
+    top: 0;
+    left: var(--sidebar-tab-width);
+    right: 0;
+    height: 33vh;
+    background: color-mix(in srgb, var(--background) 78%, transparent);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--accent);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+    z-index: 9001; /* same tier as the sidebar / scratchpad drawer — above WinBoxes */
+    display: flex;
+    flex-direction: column;
+    transform: translateY(-100%);
+    transition: transform var(--sidebar-transition), height 180ms ease;
+    overflow: hidden;
+}
+
+.session-hud-drawer.open {
+    transform: translateY(0);
+}
+
+.session-hud-drawer.detent-half {
+    height: 50vh;
+}
+
+.session-hud-drawer.dragging {
+    transition: none;
+}
+
+body.sidebar-pinned .session-hud-drawer {
+    left: var(--sidebar-width);
+}
+
+.session-hud-canvas {
+    flex: 1;
+    min-height: 0;
+}
+
+/* Pull handle — top-center twin of the sidebar/scratchpad edge handles */
+.session-hud-handle {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 64px;
+    height: var(--sidebar-tab-width);
+    z-index: 9002;
+    background: transparent;
+    border: 1px solid var(--primary-subtle);
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent);
+    opacity: 0.5;
+    cursor: grab;
+    touch-action: none;
+    transition: opacity 150ms ease, top var(--sidebar-transition), background 150ms ease;
+    padding: 0;
+}
+
+.session-hud-handle:hover {
+    opacity: 1;
+    background: var(--hover);
+}
+
+.session-hud-handle.drawer-open {
+    top: 33vh;
+}
+
+.session-hud-handle.drawer-open.detent-half {
+    top: 50vh;
+}
+
+.session-hud-handle.dragging {
+    cursor: grabbing;
+    transition: none;
+}
+
+.session-hud-grip {
+    width: 28px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--accent);
+    opacity: 0.8;
+}
+
 /* ── Mobile (≤768px): sidebar tab gets a real tap target, and the open
    sidebar leaves a tap-outside strip so it can always be closed
    (close tab would otherwise sit off-screen past a 400px sidebar).

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -34,6 +34,7 @@ import { councilSection } from './sidebar/council-section.js';
 import { servicesSection } from './sidebar/services-section.js';
 import { notificationsPanel } from './notifications-panel.js';
 import { scratchpad } from './scratchpad.js';
+import { sessionHud } from './session-hud.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import { setupHelp, openHelp, isHelpOpen } from './help-modal.js';
 import { PttController } from './ptt.js';
@@ -264,6 +265,10 @@ async function init() {
 
     // Scratch pad drawer (Alt+N, right-edge handle, selection capture)
     scratchpad.init();
+
+    // Session HUD drawer (Alt+T, top-center handle) — chrome only; #777
+    // mounts TopologyView into .session-hud-canvas.
+    sessionHud.init();
 
     // Click on a toast -> open the subject session it's about as interactive terminal.
     // No subject (e.g. a system-level toast) -> no-op, never fall back to the bridge.

--- a/agentwire/static/js/scratchpad.js
+++ b/agentwire/static/js/scratchpad.js
@@ -14,6 +14,7 @@
 
 import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
+import { sessionHud } from './session-hud.js';
 import { armDeadKeySuppressor } from './dead-key-suppressor.js';
 
 const SAVE_DEBOUNCE_MS = 600;
@@ -182,6 +183,9 @@ class ScratchPad {
         this.open = force ?? !this.open;
         this.drawer.classList.toggle('open', this.open);
         this.handle.classList.toggle('drawer-open', this.open);
+        // Mutually exclusive with the top-edge Session HUD — mirrors
+        // sidebar.js's coordination with this drawer.
+        if (this.open && sessionHud.open) sessionHud.toggle(false);
     }
 
     _pulseHandle() {

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -1,0 +1,177 @@
+/**
+ * Session HUD — top-edge frosted drawer (foundation shell, #776).
+ *
+ * Slides down from the top edge of the desktop area (right of the sidebar).
+ * Two detents — peek (~33vh) and half (~50vh) — set by dragging the
+ * top-center pull handle, which snaps to the nearest of closed/peek/half on
+ * release. Clicking the handle (no drag) toggles open/closed.
+ *
+ * Chrome only for now: `.session-hud-canvas` is an empty mount point that a
+ * later issue (#777) fills with TopologyView. Mirrors scratchpad.js's
+ * create-once drawer lifecycle (`.open` class, keyboard toggle, teardown).
+ *
+ * Toggle: Alt+T or the handle. Mutually exclusive with the left sidebar and
+ * the right scratchpad drawer — mirrors their existing coordination
+ * (sidebar.js:72): opening the HUD closes both, and opening either of them
+ * closes the HUD.
+ */
+
+import { sidebar } from './sidebar.js';
+import { scratchpad } from './scratchpad.js';
+
+const PEEK_VH = 0.33;
+const HALF_VH = 0.50;
+const CLOSE_THRESHOLD = PEEK_VH / 2;
+const MID_THRESHOLD = (PEEK_VH + HALF_VH) / 2;
+const DRAG_MIN_VH = 0.12;
+const DRAG_MAX_VH = 0.66;
+const CLICK_TOLERANCE_PX = 3;
+
+function clamp(v, min, max) {
+    return Math.min(Math.max(v, min), max);
+}
+
+class SessionHud {
+    constructor() {
+        this.drawer = null;
+        this.handle = null;
+        this.canvas = null;
+        this.open = false;
+        this.detent = 'peek';
+    }
+
+    init() {
+        this._buildDrawer();
+
+        // Alt+T toggles the drawer. Capture phase + stopPropagation so xterm
+        // never sees the keystroke — mirrors scratchpad.js's Alt+N binding.
+        // e.code (not e.key): physical-key detection, consistent with every
+        // other Alt combo in the portal. Option+T isn't a macOS dead key (it
+        // types a literal † rather than composing), so no suppressor arm is
+        // needed here — same reasoning as the Alt+bracket window-cycle combo.
+        window.addEventListener('keydown', (e) => {
+            if (e.altKey && !e.metaKey && !e.ctrlKey && e.code === 'KeyT') {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.repeat) return;
+                this.toggle();
+            }
+        }, true);
+    }
+
+    // ─── DOM ────────────────────────────────────────────────────
+
+    _buildDrawer() {
+        const drawer = document.createElement('div');
+        drawer.className = 'session-hud-drawer';
+        drawer.innerHTML = '<div class="session-hud-canvas"></div>';
+        document.body.appendChild(drawer);
+        this.drawer = drawer;
+        this.canvas = drawer.querySelector('.session-hud-canvas');
+
+        const handle = document.createElement('button');
+        handle.className = 'session-hud-handle';
+        handle.title = 'Session HUD (Alt+T)';
+        handle.innerHTML = '<span class="session-hud-grip" aria-hidden="true"></span>';
+        document.body.appendChild(handle);
+        this.handle = handle;
+
+        this._wireHandleDrag();
+    }
+
+    _wireHandleDrag() {
+        const handle = this.handle;
+        let dragging = false;
+        let moved = false;
+        let startY = 0;
+        let startHeight = 0;
+
+        const onMove = (e) => {
+            if (!dragging) return;
+            const dy = e.clientY - startY;
+            if (!moved && Math.abs(dy) <= CLICK_TOLERANCE_PX) return;
+            moved = true;
+            const heightPx = clamp(
+                startHeight + dy,
+                window.innerHeight * DRAG_MIN_VH,
+                window.innerHeight * DRAG_MAX_VH,
+            );
+            this._applyDragHeight(heightPx);
+        };
+
+        const onUp = (e) => {
+            if (!dragging) return;
+            dragging = false;
+            handle.classList.remove('dragging');
+            this.drawer.classList.remove('dragging');
+            handle.releasePointerCapture?.(e.pointerId);
+            window.removeEventListener('pointermove', onMove);
+            window.removeEventListener('pointerup', onUp);
+
+            if (!moved) {
+                this.toggle();
+                return;
+            }
+            const fraction = this.drawer.getBoundingClientRect().height / window.innerHeight;
+            if (fraction < CLOSE_THRESHOLD) {
+                this.toggle(false);
+            } else if (fraction < MID_THRESHOLD) {
+                this._settle('peek');
+            } else {
+                this._settle('half');
+            }
+        };
+
+        handle.addEventListener('pointerdown', (e) => {
+            if (e.button !== undefined && e.button !== 0) return;
+            e.preventDefault();
+            dragging = true;
+            moved = false;
+            startY = e.clientY;
+            startHeight = this.open ? this.drawer.getBoundingClientRect().height : 0;
+            handle.classList.add('dragging');
+            this.drawer.classList.add('dragging');
+            handle.setPointerCapture?.(e.pointerId);
+            window.addEventListener('pointermove', onMove);
+            window.addEventListener('pointerup', onUp);
+        });
+    }
+
+    _applyDragHeight(heightPx) {
+        if (!this.open) {
+            this.open = true;
+            this.drawer.classList.add('open');
+            this.handle.classList.add('drawer-open');
+        }
+        this.drawer.style.height = `${heightPx}px`;
+        this.handle.style.top = `${heightPx}px`;
+    }
+
+    _settle(detent) {
+        this.detent = detent;
+        this.toggle(true);
+    }
+
+    // ─── State ──────────────────────────────────────────────────
+
+    toggle(force = null) {
+        const next = force ?? !this.open;
+        this.drawer.style.height = '';
+        this.handle.style.top = '';
+        if (next) {
+            this.drawer.classList.toggle('detent-half', this.detent === 'half');
+            this.handle.classList.toggle('detent-half', this.detent === 'half');
+            this.open = true;
+            this.drawer.classList.add('open');
+            this.handle.classList.add('drawer-open');
+            sidebar.close();
+            if (scratchpad.open) scratchpad.toggle(false);
+        } else {
+            this.open = false;
+            this.drawer.classList.remove('open');
+            this.handle.classList.remove('drawer-open');
+        }
+    }
+}
+
+export const sessionHud = new SessionHud();

--- a/agentwire/static/js/shortcuts.js
+++ b/agentwire/static/js/shortcuts.js
@@ -60,6 +60,7 @@ export const SHORTCUT_GROUPS = [
         title: 'Panels',
         items: [
             { combo: ['Alt', 'N'], desc: 'Toggle the scratchpad drawer', where: 'scratchpad.js' },
+            { combo: ['Alt', 'T'], desc: 'Toggle the Session HUD', where: 'session-hud.js' },
         ],
     },
     {

--- a/agentwire/static/js/sidebar.js
+++ b/agentwire/static/js/sidebar.js
@@ -6,6 +6,7 @@
  */
 
 import { scratchpad } from './scratchpad.js';
+import { sessionHud } from './session-hud.js';
 import { armDeadKeySuppressor } from './dead-key-suppressor.js';
 
 const PIN_KEY = 'sidebar-pinned';
@@ -69,10 +70,12 @@ export const sidebar = {
         if (!this.el) return;
         this.el.classList.add('open');
         document.body.classList.add('sidebar-open');
-        // Mutually exclusive with the right-edge scratchpad drawer — opening
-        // the sidebar closes the pad (mirrors how clicking the pad's handle
-        // closes the sidebar via the click-away handler below).
+        // Mutually exclusive with the right-edge scratchpad drawer and the
+        // top-edge Session HUD — opening the sidebar closes both (mirrors how
+        // clicking the pad's handle closes the sidebar via the click-away
+        // handler below).
         if (scratchpad.open) scratchpad.toggle(false);
+        if (sessionHud.open) sessionHud.toggle(false);
     },
 
     close() {


### PR DESCRIPTION
## Summary
Foundation shell for the **Session HUD** (epic #775) — the top-edge frosted drawer that a later issue (#777) fills with `TopologyView`.

- New `session-hud.js`: create-once drawer mirroring `scratchpad.js`. Two detents — peek (33vh) / half (50vh) — via a top-center pull handle that snaps to closed/peek/half on release; a click (no drag) toggles. **Alt+T** toggles (capture-phase, `e.code` KeyT, repeat-guarded — same idiom as the other portal Alt combos).
- **Bidirectional mutual-exclusion**: opening the HUD closes the sidebar + scratchpad; opening either of them closes the HUD (`sidebar.js` / `scratchpad.js` hooks, mirroring their existing coordination).
- `desktop.js` wires `sessionHud.init()`; `shortcuts.js` documents Alt+T; `desktop.css` adds 96 lines of fully-tokenized styling (frosted `backdrop-filter`, `--accent` border, `--sidebar-*` offsets incl. `body.sidebar-pinned`, z-index 9001/9002).
- Exposes an empty `.session-hud-canvas` mount point — no topology content yet (that's #777).

## Recovery note
The worktree worker implemented and browser-verified this in a harness, then its `claude` process died to a **Bun segfault** before committing. The orchestrator reviewed every diff and re-verified the harness (drawer, detents, Alt+T, sidebar/scratchpad coordination) before committing the intact work. The throwaway `*-harness.html` files are intentionally left uncommitted.

## Test plan
- [x] `node --check --input-type=module` clean on all changed/added JS
- [x] Harness-verified on a narrow window: drawer opens/closes, Alt+T toggles, detents snap, sidebar+scratchpad mutual-exclusion all work
- [ ] Post-merge: confirm on the live desktop (empty canvas is expected — content lands in #777)

Closes #776