### PR TITLE
feat(portal): mode:'shade' TopologyView layout for the Session HUD (#777)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5996,6 +5996,13 @@ body.sidebar-pinned .session-hud-drawer {
 .session-hud-canvas {
     flex: 1;
     min-height: 0;
+    /* TopologyView's mode:'shade' root grows to its natural content width
+       (families flow left-to-right, never wrap) instead of clipping itself —
+       this ancestor is the one that scrolls, so cards and their SVG links
+       (both positioned off getBoundingClientRect) move together as a rigid
+       block and never need a scroll-triggered redraw. */
+    overflow-x: auto;
+    overflow-y: auto;
 }
 
 /* Pull handle — top-center twin of the sidebar/scratchpad edge handles */
@@ -6512,7 +6519,8 @@ body.sidebar-pinned .session-hud-drawer {
 
 /* --- shared topology renderer (#761) — topology-render.js's TopologyView
    Mount-agnostic family-card renderer shared by the Session Workspace window
-   (#762) and the phantom overlay (#764) — "one engine, two mounts". Cards
+   (#762), the phantom overlay (#764), and the Session HUD shade (#777) —
+   "one engine, three mounts". Cards
    stack in normal flex-wrap flow (never absolute-positioned on a wide
    canvas) so a family packs into a narrow ~1/3-width portal column: one row
    per lineage depth, 1-2 cards per row once wrapped. --family-tint /
@@ -6765,6 +6773,46 @@ body.sidebar-pinned .session-hud-drawer {
     .topology-link--stuck {
         animation: none;
     }
+}
+
+/* --- shade mount (#777) — mode:'shade', the Session HUD's compact layout.
+   Window mode centers one family column top-to-bottom; the shade is the
+   opposite shape (full desktop width, only 33-50vh tall), so families flow
+   left-to-right as columns instead, each starting flush at the left edge and
+   extending right — "top-level roots starting at the left" per the owner's
+   spec. Within a family, depth rows stay stacked top-down (parent above
+   child, unchanged) but never wrap, trading the scarce vertical budget for
+   the abundant (scrollable) horizontal one. .topology-view--shade itself
+   never clips — it grows to natural content width so the mount container
+   (.session-hud-canvas) is the one that scrolls; see the comment there for
+   why that split matters for link redraw correctness. Card sizing/chrome is
+   otherwise inherited from the window-mode defaults above (only alignment/
+   flow changes), just denser: smaller fixed width, tighter gaps. */
+.topology-view--shade {
+    flex-direction: row;
+    align-items: flex-start;
+    width: max-content;
+    min-width: 100%;
+    gap: 20px;
+    padding: 8px 12px;
+}
+
+.topology-view--shade .topology-family {
+    flex: 0 0 auto;
+    gap: 6px;
+}
+
+.topology-view--shade .topology-row {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    gap: 6px;
+}
+
+.topology-view--shade .topology-card {
+    flex: 0 0 128px;
+    max-width: 128px;
+    padding: 6px 8px;
+    gap: 4px;
 }
 
 /* --- card mini-terminal (#763) — click a card to expand it inline into a

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -2,7 +2,8 @@
  * topology-render.js
  *
  * Mount-agnostic session-family renderer (#761) — the shared engine behind
- * the Session Workspace window (#762) and the phantom overlay (#764).
+ * the Session Workspace window (#762), the phantom overlay (#764), and the
+ * Session HUD shade (#777, `mode:'shade'`).
  * Given a container element and a session list, TopologyView renders one
  * block per family (root + descendants, grouped by lineage.js's
  * `groupFamilies`): a card per session (status dot, name, role chip,
@@ -69,15 +70,17 @@ export class TopologyView {
      *   collapse (re-click), when the card is pruned (session disappeared), or on dispose(). Omitting
      *   this makes cards inert (e.g. the non-interactive phantom overlay).
      * @param {boolean} [opts.showLinks=true] - Draw the connector SVG layer.
-     * @param {'window'|'overlay'} [opts.mode='window'] - Styling hook only — 'overlay' renders
-     *   translucent glass cards for popping over a live terminal window; 'window' (default)
-     *   renders solid chrome for a first-class workspace window.
+     * @param {'window'|'overlay'|'shade'} [opts.mode='window'] - Styling hook only — 'overlay'
+     *   renders translucent glass cards for popping over a live terminal window; 'shade' renders
+     *   full-width, left-anchored compact family clusters for the short/narrow Session HUD shade
+     *   (#777); 'window' (default) renders solid chrome, centered, for a first-class workspace
+     *   window.
      */
     constructor(container, opts = {}) {
         this._container = container;
         this._onCardExpand = opts.onCardExpand || null;
         this._showLinks = opts.showLinks !== false;
-        this._mode = opts.mode === 'overlay' ? 'overlay' : 'window';
+        this._mode = opts.mode === 'overlay' ? 'overlay' : opts.mode === 'shade' ? 'shade' : 'window';
         this._lastSessions = [];
         /** @type {string|null} name of the currently expanded card, if any (accordion — one at a time) */
         this._expandedCard = null;


### PR DESCRIPTION
## Summary
- Adds `mode:'shade'` to `TopologyView` (`agentwire/static/js/topology-render.js`) — a one-line ternary, no engine changes.
- Adds `.topology-view--shade` layout in `desktop.css`: families flow left-to-right as compact, non-wrapping columns (instead of window mode's centered single column), left-anchored, denser card sizing/gaps.
- `.session-hud-canvas` gets `overflow-x/y: auto` and is the scroll container — `.topology-view--shade` grows to natural content width rather than clipping itself, so cards and their SVG links (both driven by `getBoundingClientRect`) scroll together as one rigid block with no scroll-triggered redraw needed.
- `mode:'window'` is untouched — no base `.topology-view`/`.topology-family`/`.topology-row`/`.topology-card` rules were modified, only new `--shade`-scoped overrides added.

## Test plan
- [x] `node --check --input-type=module < agentwire/static/js/topology-render.js` — clean
- [x] Browser-verified with a throwaway harness (multi-family mock data, real `topology-render.js` + `lineage.js`, served via `python3 -m http.server` on a non-default port — not part of this PR) at a 600px-wide mock (owner's ~1/3-screen narrow browser) and 33vh/50vh shade heights:
  - Cards start at the left edge, flow rightward — no page-level horizontal scroll; the shade canvas scrolls internally once families overflow the width.
  - Scrolled the internal canvas horizontally and confirmed lineage links stay correctly attached to their cards (validates the scroll-the-ancestor architecture).
  - `mode:'window'` mock rendered identical centered/wrapped layout — no regression.

Closes #777