### PR TITLE
feat(portal): Session HUD context-following controller (#778)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6835,6 +6835,16 @@ body.sidebar-pinned .session-hud-drawer {
     gap: 4px;
 }
 
+/* The you-are-here self card (#778) carries a role chip AND a mic button in
+   its header — at the standard 128px shade width those two alone already
+   squeeze the name to ~0px (long words like "ORCHESTRATOR" leave no slack),
+   so it needs more room than a plain card. Same specificity trick as the
+   expanded-card override above (two classes beat the shade card rule's two). */
+.topology-view--shade .topology-card--self {
+    flex: 0 0 210px;
+    max-width: 210px;
+}
+
 /* An expanded (mini-terminal open) card must win over the fixed 128px shade
    card width above — `.topology-view--shade .topology-card` has two class
    selectors to `.topology-card--expanded`'s one, so without this override

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6722,6 +6722,26 @@ body.sidebar-pinned .session-hud-drawer {
     opacity: 0.7;
 }
 
+/* "You-are-here" self/root card (#778) — the Session HUD's re-rooted view
+   dims the focused session itself rather than making it a normal
+   interactive card; click-exemption lives in topology-render.js's card
+   click handler, this is just the visual half. Hover-lift is suppressed
+   too (the card can't be clicked into, so the affordance is misleading). */
+.topology-card--self {
+    opacity: 0.6;
+    cursor: default;
+}
+.topology-card--self:hover {
+    transform: none;
+    border-color: color-mix(in srgb, var(--card-tint, var(--lineage-tint-1)) 45%, var(--chrome-border));
+}
+.topology-card--self .topology-card-name::after {
+    content: " \00b7 here";
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text-muted);
+}
+
 @keyframes topology-dot-ring {
     0% { transform: scale(0.6); opacity: 0.7; }
     100% { transform: scale(1.9); opacity: 0; }
@@ -6813,6 +6833,17 @@ body.sidebar-pinned .session-hud-drawer {
     max-width: 128px;
     padding: 6px 8px;
     gap: 4px;
+}
+
+/* An expanded (mini-terminal open) card must win over the fixed 128px shade
+   card width above — `.topology-view--shade .topology-card` has two class
+   selectors to `.topology-card--expanded`'s one, so without this override
+   the higher-specificity shade rule would keep clamping an open mini-terminal
+   to 128px regardless. Narrow-first: this is still sized for the owner's
+   ~1/3-width portal, not a full desktop canvas. */
+.topology-view--shade .topology-card--expanded {
+    flex: 0 0 340px;
+    max-width: 340px;
 }
 
 /* --- card mini-terminal (#763) — click a card to expand it inline into a

--- a/agentwire/static/js/card-terminal.js
+++ b/agentwire/static/js/card-terminal.js
@@ -1,0 +1,260 @@
+/**
+ * card-terminal.js
+ *
+ * Shared "mount voice/terminal onto a topology card's header" plumbing (#778
+ * extraction) — previously lived only as WorkspaceWindow._mountCardTerminal
+ * (#763), duplicated here would have meant two copies of the record →
+ * transcribe → auto-send/edit-before-send pipeline. Now both the Session
+ * Workspace window (workspace-window.js) and the Session HUD controller
+ * (session-hud-controller.js) import from here.
+ *
+ * Two mount shapes, one shared mic:
+ *   - `mountCardTerminal` — full mini-terminal (TerminalPane) + mic + open-full
+ *     button, for an interactive card's expand slot.
+ *   - `mountSelfMic` — header-only mic, no terminal, no open button, for the
+ *     Session HUD's dimmed "you-are-here" root card (the user is already in
+ *     that session's own window — there's nothing to peek at, but its PTT
+ *     should still be one tap away).
+ * `wirePttMic` is the record/transcribe/send plumbing both share; only where
+ * status is surfaced (a TerminalPane's status bar vs the mic button's title)
+ * and where the edit-before-send transcript bar is anchored differ.
+ */
+
+import { desktop } from './desktop-manager.js';
+import { TerminalPane } from './terminal-pane.js';
+import { PttController } from './ptt.js';
+import { apiFetch } from './api.js';
+import { buildSessionId, normalizeMachine } from './session-id.js';
+import { voicePromptWrap } from './voice/prompt.js';
+import { isAutoSend } from './voice/autosend-prefs.js';
+
+/**
+ * Wire a titlebar-style PTT mic button: press-and-hold to record, transcribe,
+ * then auto-send or show an edit-before-send bar. Shared by `mountCardTerminal`
+ * and `mountSelfMic` below.
+ *
+ * @param {string} name - Session name
+ * @param {object} session - Session record (for machine)
+ * @param {Object} opts
+ * @param {(bar: HTMLElement) => void} opts.insertBar - Insert the transcript-edit bar into the DOM
+ * @param {(kind: string, message: string) => void} opts.setStatus - Status sink
+ * @param {() => void} [opts.afterRemove] - Called whenever the transcript bar is dismissed/sent
+ * @returns {{ pttBtn: HTMLButtonElement, dispose: () => void }}
+ */
+export function wirePttMic(name, session, { insertBar, setStatus, afterRemove }) {
+    const machine = normalizeMachine(session?.machine);
+    const sessionId = buildSessionId(name, machine);
+
+    const pttBtn = document.createElement('button');
+    pttBtn.type = 'button';
+    pttBtn.className = 'wb-title-ptt';
+    pttBtn.title = 'Hold to record voice input';
+    pttBtn.innerHTML = '<span class="ptt-icon">🎤</span>';
+
+    let transcriptBar = null;
+    const removeTranscriptBar = () => {
+        transcriptBar?.remove();
+        transcriptBar = null;
+        afterRemove?.();
+    };
+
+    const sendVoiceText = async (text) => {
+        try {
+            const res = await apiFetch(`/send/${sessionId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: voicePromptWrap(text) }),
+            });
+            const data = await res.json();
+            if (data.error) throw new Error(data.error);
+            setStatus('connected', `Sent: "${text.substring(0, 30)}${text.length > 30 ? '...' : ''}"`);
+        } catch (err) {
+            console.error('[card-terminal] Voice send failed:', err);
+            setStatus('error', err.message || 'Voice input failed');
+        }
+    };
+
+    const showTranscriptBar = (text) => {
+        removeTranscriptBar();
+        const bar = document.createElement('div');
+        bar.className = 'wb-transcript-bar';
+        bar.innerHTML = `
+            <input type="text" class="wb-transcript-input" />
+            <button class="wb-transcript-send" title="Send (Enter)">➤</button>
+            <button class="wb-transcript-dismiss" title="Discard (Esc)">✕</button>
+        `;
+        const input = bar.querySelector('.wb-transcript-input');
+        input.value = text;
+
+        const send = () => {
+            const value = input.value.trim();
+            removeTranscriptBar();
+            if (value) sendVoiceText(value);
+        };
+        bar.querySelector('.wb-transcript-send').addEventListener('click', send);
+        bar.querySelector('.wb-transcript-dismiss').addEventListener('click', removeTranscriptBar);
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); send(); }
+            else if (e.key === 'Escape') { e.preventDefault(); removeTranscriptBar(); }
+            e.stopPropagation();
+        });
+
+        insertBar(bar);
+        transcriptBar = bar;
+        input.focus();
+        input.select();
+    };
+
+    const ptt = new PttController({
+        getVoiceStatus: () => desktop.voiceStatus,
+        onState: (state) => {
+            pttBtn.classList.remove('recording', 'processing');
+            if (state === 'recording') {
+                pttBtn.classList.add('recording');
+                pttBtn.querySelector('.ptt-icon').textContent = '🔴';
+            } else if (state === 'processing') {
+                pttBtn.classList.add('processing');
+                pttBtn.querySelector('.ptt-icon').textContent = '🎤';
+            } else {
+                pttBtn.querySelector('.ptt-icon').textContent = '🎤';
+            }
+        },
+        onResult: (text) => {
+            if (isAutoSend()) sendVoiceText(text);
+            else showTranscriptBar(text);
+        },
+        onError: (kind, message) => setStatus('error', message),
+    });
+
+    // Same pointer-capture pattern as SessionWindow's titlebar PTT button.
+    const onDown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        pttBtn.setPointerCapture?.(e.pointerId);
+        ptt.start();
+    };
+    const onUp = (e) => {
+        e.stopPropagation();
+        pttBtn.releasePointerCapture?.(e.pointerId);
+        if (ptt.state === 'recording') ptt.stop();
+    };
+    const onCancel = (e) => {
+        pttBtn.releasePointerCapture?.(e.pointerId);
+        if (ptt.state === 'recording') ptt.cancel();
+    };
+    pttBtn.addEventListener('pointerdown', onDown, true);
+    pttBtn.addEventListener('pointerup', onUp, true);
+    pttBtn.addEventListener('pointercancel', onCancel);
+
+    return {
+        pttBtn,
+        dispose: () => removeTranscriptBar(),
+    };
+}
+
+/**
+ * Mount a mini-terminal (#763) into a card's expand slot: a TerminalPane over
+ * the session's real WS, plus a titlebar-style mic button wired the same way
+ * SessionWindow's PTT is. Returns a dispose function TopologyView calls on
+ * collapse/prune/view-teardown.
+ *
+ * @param {string} name - Session name
+ * @param {object} session - Session record (for machine)
+ * @param {HTMLElement} slotEl - Empty slot appended into the card
+ * @param {Object} [opts]
+ * @param {import('./topology-render.js').TopologyView} [opts.topologyView] - Notified
+ *   (via `collapseCard`) if the session's terminal reports the underlying session ended
+ * @returns {() => void} cleanup
+ */
+export function mountCardTerminal(name, session, slotEl, { topologyView } = {}) {
+    const machine = normalizeMachine(session?.machine);
+
+    // Actions (mic + open-full) live in the card's own header row next to
+    // the role chip — not a dedicated toolbar row — so the mini-terminal
+    // reclaims that vertical space. topology-render.js's card-click collapse
+    // toggle exempts .topology-card-actions the same way it exempts the slot.
+    const card = slotEl.closest('.topology-card');
+    const headerRow = card?.querySelector('.topology-card-top');
+    const actions = document.createElement('div');
+    actions.className = 'topology-card-actions';
+
+    const termHost = document.createElement('div');
+    termHost.className = 'topology-card-mini-terminal';
+    slotEl.append(termHost);
+
+    const pane = new TerminalPane(termHost, {
+        session: name,
+        machine,
+        // A card is a compact peek — render smaller than the global terminal
+        // pref (16/20px) so more rows are visible; the ⤢ pop-out opens the
+        // full-size window for real work.
+        fontSize: 14,
+        onSessionEnded: () => topologyView?.collapseCard(name),
+    });
+
+    const { pttBtn, dispose: disposePtt } = wirePttMic(name, session, {
+        insertBar: (bar) => termHost.before(bar),
+        setStatus: (kind, message) => {
+            pane.setStatus(kind, message);
+            if (kind === 'connected') setTimeout(() => pane.setStatus('connected', 'Connected'), 3000);
+        },
+        afterRemove: () => pane.focus(),
+    });
+
+    const openBtn = document.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'topology-card-mini-open';
+    openBtn.title = 'Open full terminal';
+    openBtn.textContent = '⤢';
+    openBtn.addEventListener('click', async () => {
+        const { openSessionTerminal } = await import('./desktop.js');
+        openSessionTerminal(name, 'terminal', machine);
+    });
+
+    actions.append(pttBtn, openBtn);
+    headerRow?.appendChild(actions);
+
+    return () => {
+        disposePtt();
+        actions.remove();
+        pane.dispose();
+    };
+}
+
+/**
+ * Mount a header-only PTT mic for a card that never gets a mini-terminal —
+ * the Session HUD's you-are-here self/root card (#778): the user is already
+ * inside that session's own window, so there's nothing to peek at, but its
+ * mic should still be one tap away. Shares `wirePttMic`'s record/transcribe/
+ * send plumbing with `mountCardTerminal`; status surfaces on the mic
+ * button's title (no TerminalPane to show it on) and the transcript-edit bar
+ * lands directly under the header (no terminal to sit above).
+ *
+ * @param {string} name - Session name
+ * @param {object} session - Session record (for machine)
+ * @param {HTMLElement} card - The topology card element (already in the DOM)
+ * @returns {() => void} cleanup
+ */
+export function mountSelfMic(name, session, card) {
+    const headerRow = card?.querySelector('.topology-card-top');
+    const actions = document.createElement('div');
+    actions.className = 'topology-card-actions';
+
+    const { pttBtn, dispose: disposePtt } = wirePttMic(name, session, {
+        insertBar: (bar) => headerRow?.after(bar),
+        setStatus: (kind, message) => {
+            pttBtn.title = message;
+            if (kind === 'connected') {
+                setTimeout(() => { pttBtn.title = 'Hold to record voice input'; }, 3000);
+            }
+        },
+    });
+
+    actions.append(pttBtn);
+    headerRow?.appendChild(actions);
+
+    return () => {
+        disposePtt();
+        actions.remove();
+    };
+}

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -35,6 +35,7 @@ import { servicesSection } from './sidebar/services-section.js';
 import { notificationsPanel } from './notifications-panel.js';
 import { scratchpad } from './scratchpad.js';
 import { sessionHud } from './session-hud.js';
+import { hudController } from './session-hud-controller.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import { setupHelp, openHelp, isHelpOpen } from './help-modal.js';
 import { PttController } from './ptt.js';
@@ -266,9 +267,11 @@ async function init() {
     // Scratch pad drawer (Alt+N, right-edge handle, selection capture)
     scratchpad.init();
 
-    // Session HUD drawer (Alt+T, top-center handle) — chrome only; #777
-    // mounts TopologyView into .session-hud-canvas.
+    // Session HUD drawer (Alt+T, top-center handle) — #776 chrome, #777 shade
+    // layout. #778's controller decides what renders (global tree vs
+    // re-rooted onto the focused session) and mounts TopologyView itself.
     sessionHud.init();
+    hudController.init(sessionHud.canvas, getWindowSession);
 
     // Click on a toast -> open the subject session it's about as interactive terminal.
     // No subject (e.g. a system-level toast) -> no-op, never fall back to the bridge.
@@ -1002,6 +1005,25 @@ function _lookupWindowInstance(id) {
     // active but never raised or un-minimized them.
     return sessionWindows.get(id) || artifactWindows.get(id)
         || reviewWindows.get(id) || workspaceWindows.get(id) || null;
+}
+
+/**
+ * Resolve a desktop window id back to the session name it belongs to, but
+ * only for a real session (terminal/monitor) window — `kind: 'session'`
+ * taskbar records, populated by `_mountSessionWindow` above. Every other
+ * window kind (artifact/review/workspace/council) returns null. This is the
+ * "is a session window focused, and which session" query the Session HUD
+ * controller (#778) re-roots its view on; passed in via DI rather than
+ * imported there, to avoid a static circular import (this module already
+ * imports WorkspaceWindow et al., and would need to import the HUD
+ * controller to call its init()).
+ *
+ * @param {string|null} id - Window id (desktop-manager.js's registry key)
+ * @returns {string|null}
+ */
+export function getWindowSession(id) {
+    const rec = taskbarRecords.get(id);
+    return rec && rec.kind === 'session' ? rec.session : null;
 }
 
 function loadTaskbarState() {

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -772,8 +772,13 @@ export function openSessionTerminal(session, mode, machine = null) {
 
 /** Construct and register the real SessionWindow. The only place `new
  * SessionWindow(...)` is called — both the plain-open and birth-ghost paths
- * above hand off to this once it's safe to create the real WinBox window. */
+ * above hand off to this once it's safe to create the real WinBox window.
+ * `recordTaskbarEntry` runs BEFORE `sw.open()` — a brand-new WinBox can fire
+ * its `onfocus` synchronously during construction (it auto-focuses), which
+ * would call `getWindowSession(id)` (desktop.js, #778) before the record
+ * existed and misread a genuine session window as "no session focused". */
 function _mountSessionWindow(session, mode, machine, id) {
+    recordTaskbarEntry({ kind: 'session', id, session, mode, machine });
     const sw = new SessionWindow({
         session,
         mode,
@@ -800,7 +805,6 @@ function _mountSessionWindow(session, mode, machine, id) {
     sw.open();
     sessionWindows.set(id, sw);
     addTaskbarButton(id, sw);
-    recordTaskbarEntry({ kind: 'session', id, session, mode, machine });
 }
 
 /**

--- a/agentwire/static/js/lineage.js
+++ b/agentwire/static/js/lineage.js
@@ -81,6 +81,43 @@ export function groupFamilies(sessions) {
     }));
 }
 
+/**
+ * Build the subtree rooted at `name`: `name` itself plus every session
+ * reachable by walking descendant `.parent` links from it (ancestors and
+ * siblings excluded). Used by the Session HUD controller (#778) to re-root
+ * the view onto a focused session — passing the result back into
+ * `groupFamilies`/`TopologyView.render()` makes `name` resolve as the root
+ * (its real parent, if any, isn't in the subset so `lineageOf` stops there)
+ * without needing a second "root override" concept anywhere downstream.
+ *
+ * @param {string} name - Session name to re-root onto.
+ * @param {Array<{name: string, parent?: string|null}>} sessions - Full session list.
+ * @returns {Array<object>} The subset of `sessions` in the subtree, root first then descendants.
+ */
+export function subtreeOf(name, sessions) {
+    const list = sessions || [];
+    const byName = new Map(list.map((s) => [s.name, s]));
+    if (!byName.has(name)) return [];
+
+    const childrenOf = new Map();
+    for (const s of list) {
+        if (!s.name || !s.parent || s.parent === s.name) continue;
+        if (!childrenOf.has(s.parent)) childrenOf.set(s.parent, []);
+        childrenOf.get(s.parent).push(s.name);
+    }
+
+    const seen = new Set([name]);
+    const order = [name];
+    for (let i = 0; i < order.length; i++) {
+        for (const child of childrenOf.get(order[i]) || []) {
+            if (seen.has(child)) continue; // cycle-safe
+            seen.add(child);
+            order.push(child);
+        }
+    }
+    return order.map((n) => byName.get(n)).filter(Boolean);
+}
+
 /** Deterministic small-int hash of a string, stable across reloads/renders. */
 function hashIndex(str) {
     let h = 0;

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -1,0 +1,118 @@
+/**
+ * session-hud-controller.js
+ *
+ * The context-following brain behind the Session HUD shade (#778): decides
+ * WHAT the drawer renders, and wires up card-click → mini-terminal the same
+ * way the Session Workspace window does.
+ *
+ * Mounts a `TopologyView(mode:'shade')` (#777) into the HUD's canvas and
+ * subscribes to two feeds:
+ *   - the sessions feed (`onSessionsChanged`, sidebar/sessions-section.js)
+ *   - window-focus changes (`desktop`'s `active_window_changed`, fired by
+ *     every window kind's onFocus → `desktop.setActiveWindow`)
+ *
+ * Context-following view selection:
+ *   - No session window focused → render ALL root families (the global
+ *     tree) — just `render(sessions)`, letting TopologyView's own
+ *     `groupFamilies` call do the grouping.
+ *   - A session window focused → re-root onto that session's family
+ *     (`subtreeOf`, lineage.js) and present it as if its card were clicked:
+ *     the focused session becomes a dimmed, non-interactive "you-are-here"
+ *     root (`TopologyView.setSelfSession`); its descendants are the
+ *     interactive cards.
+ * Focusing an artifact/review/workspace/council window resolves to no
+ * session (`resolveWindowSession` returns null for non-`kind:'session'`
+ * windows) and is therefore a no-op — the last session context is retained,
+ * per spec. `resolveWindowSession` is injected via `init()` rather than
+ * imported from desktop.js directly: desktop.js is the module that boots
+ * this controller, and desktop.js↔session-hud-controller.js would otherwise
+ * be a static circular import (the same reason `card-terminal.js`'s
+ * "open full terminal" button dynamic-imports desktop.js instead).
+ */
+
+import { desktop } from './desktop-manager.js';
+import { TopologyView } from './topology-render.js';
+import { getAllSessions, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
+import { subtreeOf } from './lineage.js';
+import { mountCardTerminal, mountSelfMic } from './card-terminal.js';
+import { sessionHud } from './session-hud.js';
+
+class HudController {
+    constructor() {
+        this._view = null;
+        this._resolveWindowSession = null;
+        /** @type {string|null} focused session name, or null = global tree */
+        this._contextSession = null;
+        /** @type {string|null} window id backing _contextSession, for window_unregistered matching */
+        this._contextWindowId = null;
+    }
+
+    /**
+     * @param {HTMLElement} canvas - `.session-hud-canvas`, sessionHud's mount point
+     * @param {(id: string|null) => string|null} resolveWindowSession - desktop.js's
+     *   getWindowSession — resolves a focused window id to a session name, or null
+     *   for a non-session window (or nothing focused)
+     */
+    init(canvas, resolveWindowSession) {
+        this._resolveWindowSession = resolveWindowSession;
+
+        this._view = new TopologyView(canvas, {
+            mode: 'shade',
+            onCardExpand: (name, session, slotEl) => this._expandCard(name, session, slotEl),
+            onSelfMount: (name, session, cardEl) => mountSelfMic(name, session, cardEl),
+        });
+
+        // Seed from whatever's already focused when the HUD first mounts,
+        // rather than waiting for the next focus change.
+        this._applyFocus(desktop.getActiveWindow());
+
+        ensureSessionsLoaded();
+        this._render();
+        onSessionsChanged(() => this._render());
+
+        desktop.on('active_window_changed', ({ id }) => this._applyFocus(id));
+        // Closing the focused session's own window (with nothing else taking
+        // focus) falls back to the global tree, rather than leaving the HUD
+        // re-rooted onto a session that's no longer open anywhere.
+        desktop.on('window_unregistered', ({ id }) => {
+            if (id && id === this._contextWindowId) {
+                this._contextSession = null;
+                this._contextWindowId = null;
+                this._render();
+            }
+        });
+    }
+
+    _applyFocus(id) {
+        const session = this._resolveWindowSession(id);
+        if (!session || session === this._contextSession) return;
+        this._contextSession = session;
+        this._contextWindowId = id;
+        this._render();
+    }
+
+    _render() {
+        if (!this._view) return;
+        const sessions = getAllSessions();
+        // The context session may have closed/renamed since it was last
+        // focused — fall back to the global tree rather than rendering an
+        // empty subtree for a name nothing matches anymore.
+        if (this._contextSession && !sessions.some((s) => s.name === this._contextSession)) {
+            this._contextSession = null;
+            this._contextWindowId = null;
+        }
+        this._view.setSelfSession(this._contextSession);
+        this._view.render(this._contextSession ? subtreeOf(this._contextSession, sessions) : sessions);
+    }
+
+    _expandCard(name, session, slotEl) {
+        sessionHud.growToHalf();
+        const cleanup = mountCardTerminal(name, session, slotEl, { topologyView: this._view });
+        return () => {
+            cleanup();
+            sessionHud.restoreDetent();
+        };
+    }
+}
+
+export const hudController = new HudController();

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -96,8 +96,12 @@ class HudController {
         const sessions = getAllSessions();
         // The context session may have closed/renamed since it was last
         // focused — fall back to the global tree rather than rendering an
-        // empty subtree for a name nothing matches anymore.
-        if (this._contextSession && !sessions.some((s) => s.name === this._contextSession)) {
+        // empty subtree for a name nothing matches anymore. Gated on
+        // sessions.length: an empty list during the page-boot window (the
+        // sessions fetch hasn't resolved yet, e.g. mid-restoreTaskbarState())
+        // means "no data yet", not "this session is gone" — resetting on
+        // that would wipe a just-restored focus before it ever got to render.
+        if (this._contextSession && sessions.length > 0 && !sessions.some((s) => s.name === this._contextSession)) {
             this._contextSession = null;
             this._contextWindowId = null;
         }

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -38,6 +38,8 @@ class SessionHud {
         this.canvas = null;
         this.open = false;
         this.detent = 'peek';
+        /** @type {string|null} detent to restore on restoreDetent(), set by growToHalf() */
+        this._grownFromDetent = null;
     }
 
     init() {
@@ -150,6 +152,30 @@ class SessionHud {
     _settle(detent) {
         this.detent = detent;
         this.toggle(true);
+    }
+
+    /**
+     * Programmatically grow to the half detent (e.g. a HUD card's mini-terminal
+     * just opened and needs the room) — remembers whatever detent was active
+     * so restoreDetent() can put it back. A no-op if already grown (the
+     * accordion-style switch between two expanded cards collapses the old
+     * one — which calls restoreDetent() — then expands the new one — which
+     * calls this again — within the same tick; only the first grab of a grow
+     * cycle should record what to restore).
+     */
+    growToHalf() {
+        if (this._grownFromDetent !== null) return;
+        this._grownFromDetent = this.detent;
+        if (this.detent !== 'half') this._settle('half');
+    }
+
+    /** Undo growToHalf() — restores the detent that was active before the
+     * grow. No-op if nothing is currently grown. */
+    restoreDetent() {
+        if (this._grownFromDetent === null) return;
+        const prior = this._grownFromDetent;
+        this._grownFromDetent = null;
+        if (this.detent !== prior) this._settle(prior);
     }
 
     // ─── State ──────────────────────────────────────────────────

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -69,6 +69,11 @@ export class TopologyView {
      *   mini-terminal) and optionally return a cleanup function. TopologyView calls that cleanup on
      *   collapse (re-click), when the card is pruned (session disappeared), or on dispose(). Omitting
      *   this makes cards inert (e.g. the non-interactive phantom overlay).
+     * @param {(name: string, session: object, cardEl: HTMLElement) => (() => void)|void} [opts.onSelfMount] -
+     *   Fired whenever a card becomes (or, via its returned cleanup, stops being) the "self" session
+     *   set via `setSelfSession()`. The self-session equivalent of `onCardExpand` minus the
+     *   expand/collapse toggle — used by the Session HUD controller (#778) to mount a header-only PTT
+     *   mic onto the dimmed, non-interactive "you-are-here" root card.
      * @param {boolean} [opts.showLinks=true] - Draw the connector SVG layer.
      * @param {'window'|'overlay'|'shade'} [opts.mode='window'] - Styling hook only — 'overlay'
      *   renders translucent glass cards for popping over a live terminal window; 'shade' renders
@@ -79,11 +84,14 @@ export class TopologyView {
     constructor(container, opts = {}) {
         this._container = container;
         this._onCardExpand = opts.onCardExpand || null;
+        this._onSelfMount = opts.onSelfMount || null;
         this._showLinks = opts.showLinks !== false;
         this._mode = opts.mode === 'overlay' ? 'overlay' : opts.mode === 'shade' ? 'shade' : 'window';
         this._lastSessions = [];
         /** @type {string|null} name of the currently expanded card, if any (accordion — one at a time) */
         this._expandedCard = null;
+        /** @type {string|null} name of the dimmed, non-interactive "you-are-here" root card, if any */
+        this._selfSession = null;
 
         /** @type {Map<string, {familyEl: HTMLElement, rows: Map<number, HTMLElement>}>} */
         this._families = new Map();
@@ -145,9 +153,22 @@ export class TopologyView {
         this._scheduleRedraw();
     }
 
+    /**
+     * Set (or clear) the "you-are-here" self session — a dimmed, non-interactive
+     * root card (no expand/collapse, no mini-terminal) with its own `onSelfMount`
+     * hook (e.g. a header-only mic). Takes effect on the next `render()` call.
+     * @param {string|null} name
+     */
+    setSelfSession(name) {
+        this._selfSession = name || null;
+    }
+
     /** Tear down everything TopologyView appended into its container. */
     dispose() {
         if (this._expandedCard) this._collapseCard(this._expandedCard);
+        for (const entry of this._cards.values()) {
+            if (entry.selfDispose) entry.selfDispose();
+        }
         this._resizeObserver.disconnect();
         window.removeEventListener('resize', this._scheduleRedraw);
         if (this._raf !== null) cancelAnimationFrame(this._raf);
@@ -211,6 +232,7 @@ export class TopologyView {
         for (const [name, entry] of this._cards) {
             if (!seenCards.has(name)) {
                 if (entry.expanded) this._collapseCard(name);
+                if (entry.selfDispose) entry.selfDispose();
                 entry.card.remove();
                 this._cards.delete(name);
                 this._links.delete(name);
@@ -263,6 +285,24 @@ export class TopologyView {
             entry.card.style.setProperty('--card-tint', `var(${tintVar})`);
             entry.tintVar = tintVar;
         }
+
+        const isSelf = name === this._selfSession;
+        if (entry.isSelf !== isSelf) {
+            // A card can arrive already-expanded if it was clicked open before
+            // becoming the self session (e.g. re-rooting after a card's
+            // mini-terminal was opened) — self cards never carry one.
+            if (isSelf && entry.expanded) this._collapseCard(name);
+            entry.isSelf = isSelf;
+            entry.card.classList.toggle('topology-card--self', isSelf);
+            if (entry.selfDispose) {
+                entry.selfDispose();
+                entry.selfDispose = null;
+            }
+            if (isSelf && this._onSelfMount) {
+                const dispose = this._onSelfMount(name, session, entry.card);
+                entry.selfDispose = typeof dispose === 'function' ? dispose : null;
+            }
+        }
     }
 
     _buildCard(name) {
@@ -270,6 +310,9 @@ export class TopologyView {
         card.className = 'topology-card';
         card.dataset.session = name;
         card.addEventListener('click', (e) => {
+            // The dimmed "you-are-here" self card is inert — the user is
+            // already inside that session, so there's nothing to drill into.
+            if (name === this._selfSession) return;
             if (!this._onCardExpand) return;
             // Clicks inside the expanded slot (the mounted mini-terminal, its
             // mic button, etc.) must not bubble into a collapse toggle.
@@ -307,6 +350,7 @@ export class TopologyView {
         return {
             card, dot, nameEl, roleEl, machineEl, sparkEl, state: null, tintVar: null, session: null,
             expanded: false, expandSlot: null, expandDispose: null,
+            isSelf: false, selfDispose: null,
         };
     }
 

--- a/agentwire/static/js/workspace-window.js
+++ b/agentwire/static/js/workspace-window.js
@@ -15,19 +15,15 @@
  * SessionWindow's full terminal window uses) plus a PttController mic,
  * wired the same way SessionWindow's titlebar PTT is. TopologyView owns the
  * expand/collapse DOM lifecycle (including cleanup when a session vanishes
- * mid-expand); this module only supplies what to mount.
+ * mid-expand); the actual mount (#778 extraction, card-terminal.js) is
+ * shared with the Session HUD controller rather than duplicated here.
  */
 
 import { desktop } from './desktop-manager.js';
 import { TopologyView } from './topology-render.js';
 import { getAllSessions, onSessionsChanged, ensureSessionsLoaded } from './sidebar/sessions-section.js';
 import { familyRootName } from './lineage.js';
-import { TerminalPane } from './terminal-pane.js';
-import { PttController } from './ptt.js';
-import { apiFetch } from './api.js';
-import { buildSessionId, normalizeMachine } from './session-id.js';
-import { voicePromptWrap } from './voice/prompt.js';
-import { isAutoSend } from './voice/autosend-prefs.js';
+import { mountCardTerminal } from './card-terminal.js';
 
 export class WorkspaceWindow {
     /**
@@ -60,7 +56,8 @@ export class WorkspaceWindow {
 
         const canvas = container.querySelector('.workspace-window-canvas');
         this._topologyView = new TopologyView(canvas, {
-            onCardExpand: (name, session, slotEl) => this._mountCardTerminal(name, session, slotEl),
+            onCardExpand: (name, session, slotEl) =>
+                mountCardTerminal(name, session, slotEl, { topologyView: this._topologyView }),
             mode: 'window',
         });
 
@@ -140,167 +137,5 @@ export class WorkspaceWindow {
             return name && familyRootName(name, sessions) === this.rootSession;
         });
         this._topologyView.render(members);
-    }
-
-    /**
-     * Mount a mini-terminal (#763) into a card's expand slot: a TerminalPane
-     * over the session's real WS, plus a titlebar-style mic button wired the
-     * same way SessionWindow's PTT is (record → /transcribe → auto-send or
-     * edit-before-send bar). Returns a dispose function TopologyView calls on
-     * collapse/prune/view-teardown.
-     *
-     * @param {string} name - Session name
-     * @param {object} session - Session record (for machine)
-     * @param {HTMLElement} slotEl - Empty slot appended into the card
-     * @returns {() => void} cleanup
-     */
-    _mountCardTerminal(name, session, slotEl) {
-        const machine = normalizeMachine(session?.machine);
-        const sessionId = buildSessionId(name, machine);
-
-        // Actions (mic + open-full) live in the card's own header row next to
-        // the role chip — not a dedicated toolbar row — so the mini-terminal
-        // reclaims that vertical space. topology-render.js's card-click collapse
-        // toggle exempts .topology-card-actions the same way it exempts the slot.
-        const card = slotEl.closest('.topology-card');
-        const headerRow = card?.querySelector('.topology-card-top');
-        const actions = document.createElement('div');
-        actions.className = 'topology-card-actions';
-
-        const pttBtn = document.createElement('button');
-        pttBtn.type = 'button';
-        pttBtn.className = 'wb-title-ptt';
-        pttBtn.title = 'Hold to record voice input';
-        pttBtn.innerHTML = '<span class="ptt-icon">🎤</span>';
-
-        const openBtn = document.createElement('button');
-        openBtn.type = 'button';
-        openBtn.className = 'topology-card-mini-open';
-        openBtn.title = 'Open full terminal';
-        openBtn.textContent = '⤢';
-        openBtn.addEventListener('click', async () => {
-            const { openSessionTerminal } = await import('./desktop.js');
-            openSessionTerminal(name, 'terminal', machine);
-        });
-
-        actions.append(pttBtn, openBtn);
-        headerRow?.appendChild(actions);
-
-        const termHost = document.createElement('div');
-        termHost.className = 'topology-card-mini-terminal';
-
-        slotEl.append(termHost);
-
-        const pane = new TerminalPane(termHost, {
-            session: name,
-            machine,
-            // A card is a compact peek — render smaller than the global terminal
-            // pref (16/20px) so more rows are visible; the ⤢ pop-out opens the
-            // full-size window for real work.
-            fontSize: 14,
-            onSessionEnded: () => this._topologyView?.collapseCard(name),
-        });
-
-        let transcriptBar = null;
-        const removeTranscriptBar = () => {
-            transcriptBar?.remove();
-            transcriptBar = null;
-            pane.focus();
-        };
-
-        const sendVoiceText = async (text) => {
-            try {
-                const res = await apiFetch(`/send/${sessionId}`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ text: voicePromptWrap(text) }),
-                });
-                const data = await res.json();
-                if (data.error) throw new Error(data.error);
-                pane.setStatus('connected', `Sent: "${text.substring(0, 30)}${text.length > 30 ? '...' : ''}"`);
-                setTimeout(() => pane.setStatus('connected', 'Connected'), 3000);
-            } catch (err) {
-                console.error('[WorkspaceWindow] Voice send failed:', err);
-                pane.setStatus('error', err.message || 'Voice input failed');
-            }
-        };
-
-        const showTranscriptBar = (text) => {
-            removeTranscriptBar();
-            const bar = document.createElement('div');
-            bar.className = 'wb-transcript-bar';
-            bar.innerHTML = `
-                <input type="text" class="wb-transcript-input" />
-                <button class="wb-transcript-send" title="Send (Enter)">➤</button>
-                <button class="wb-transcript-dismiss" title="Discard (Esc)">✕</button>
-            `;
-            const input = bar.querySelector('.wb-transcript-input');
-            input.value = text;
-
-            const send = () => {
-                const value = input.value.trim();
-                removeTranscriptBar();
-                if (value) sendVoiceText(value);
-            };
-            bar.querySelector('.wb-transcript-send').addEventListener('click', send);
-            bar.querySelector('.wb-transcript-dismiss').addEventListener('click', removeTranscriptBar);
-            input.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') { e.preventDefault(); send(); }
-                else if (e.key === 'Escape') { e.preventDefault(); removeTranscriptBar(); }
-                e.stopPropagation();
-            });
-
-            termHost.before(bar);
-            transcriptBar = bar;
-            input.focus();
-            input.select();
-        };
-
-        const ptt = new PttController({
-            getVoiceStatus: () => desktop.voiceStatus,
-            onState: (state) => {
-                pttBtn.classList.remove('recording', 'processing');
-                if (state === 'recording') {
-                    pttBtn.classList.add('recording');
-                    pttBtn.querySelector('.ptt-icon').textContent = '🔴';
-                } else if (state === 'processing') {
-                    pttBtn.classList.add('processing');
-                    pttBtn.querySelector('.ptt-icon').textContent = '🎤';
-                } else {
-                    pttBtn.querySelector('.ptt-icon').textContent = '🎤';
-                }
-            },
-            onResult: (text) => {
-                if (isAutoSend()) sendVoiceText(text);
-                else showTranscriptBar(text);
-            },
-            onError: (kind, message) => pane.setStatus('error', message),
-        });
-
-        // Same pointer-capture pattern as SessionWindow's titlebar PTT button.
-        const onDown = (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            pttBtn.setPointerCapture?.(e.pointerId);
-            ptt.start();
-        };
-        const onUp = (e) => {
-            e.stopPropagation();
-            pttBtn.releasePointerCapture?.(e.pointerId);
-            if (ptt.state === 'recording') ptt.stop();
-        };
-        const onCancel = (e) => {
-            pttBtn.releasePointerCapture?.(e.pointerId);
-            if (ptt.state === 'recording') ptt.cancel();
-        };
-        pttBtn.addEventListener('pointerdown', onDown, true);
-        pttBtn.addEventListener('pointerup', onUp, true);
-        pttBtn.addEventListener('pointercancel', onCancel);
-
-        return () => {
-            removeTranscriptBar();
-            actions.remove();
-            pane.dispose();
-        };
     }
 }


### PR DESCRIPTION
## Summary
- Mounts `TopologyView(mode:'shade')` into the Session HUD canvas, driven by a new `session-hud-controller.js`: no session window focused → global tree (all root families); a session window focused → re-root onto that session's family (`subtreeOf()`, lineage.js) with the focused session rendered as a dimmed, non-interactive "you-are-here" root (`TopologyView.setSelfSession`/`onSelfMount`) and its descendants as interactive cards.
- Re-roots live via `desktop`'s `active_window_changed`, resolved to a session name through a new `getWindowSession(id)` (desktop.js, DI'd into the controller to avoid a static circular import). Non-session windows (artifact/review/workspace/council) and "nothing focused" are no-ops that retain the last context; closing the focused session's own window falls back to the global tree.
- Card click mounts a mini-terminal and auto-grows the shade to the half detent (`sessionHud.growToHalf()`/`restoreDetent()`), remembering the prior detent for collapse.
- Extracted `WorkspaceWindow._mountCardTerminal` into shared `card-terminal.js` (`mountCardTerminal`), so the HUD and the 🛰 Session Workspace window share one mount instead of duplicating ~150 lines. Factored the mic-wiring further into `wirePttMic`, reused by the new `mountSelfMic` (header-only mic for the you-are-here root — no mini-terminal, since the user is already in that session).
- Header + mic stacking falls out of the existing family row layout (self at depth 0, children below) — both stay visible and reachable with the child terminal open, each PTT wired to its own session.
- Fixed a real ordering bug found during verification: `_mountSessionWindow` recorded its taskbar entry *after* `sw.open()`, but a brand-new WinBox auto-focuses synchronously during construction — so a fresh session-window open could misread as "nothing focused" on the very first focus event. Also hardened the HUD controller against resetting context during the page-boot window before the sessions fetch resolves, and widened `.topology-card--self` in shade mode (the role chip + mic left no room for the name at the standard 128px width).

## Test plan
- [x] `node --check --input-type=module` clean on all changed/new JS
- [x] Browser-verified end-to-end against a live throwaway portal instance (port 8199, this worktree's source) on a visually-narrowed window, with 4 real test tmux sessions forming 2 families (one with 2 children)
- [x] Focusing session A then B re-roots the HUD to each family live; the focused session renders dimmed as root and isn't clickable-into
- [x] Nothing focused (all windows closed) → global tree (all families)
- [x] Clicking a child card opens its mini-terminal and bumps the shade from peek to half; collapsing restores peek
- [x] With a child terminal open, both the self/root card's mic and the child card's mic are present, each wired to its own session name (verified via DOM inspection — self card has no open-full button/terminal, child card has both)
- [x] 🛰 Session Workspace window (#762) card expansion regression-checked — still works after the `card-terminal.js` extraction

Closes #778