### PR TITLE
feat(portal): Session HUD D — Services tab (#779)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -7069,3 +7069,65 @@ body.sidebar-pinned .session-hud-drawer {
     opacity: 0.35;
     filter: none;
 }
+
+/* ============================================
+   Session HUD — Sessions|Services header segments (#779)
+   Compact pill segmented control in the drawer's top strip. Only one of
+   .session-hud-canvas / .session-hud-services is visible at a time, driven
+   by [data-segment] on the drawer — the hidden one keeps rendering/updating
+   underneath so switching back never re-mounts anything.
+   ============================================ */
+
+.session-hud-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 8px 4px;
+}
+
+.session-hud-segmented {
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    border-radius: 999px;
+}
+
+.session-hud-segment-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    padding: 4px 14px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 150ms ease, color 150ms ease;
+}
+
+.session-hud-segment-btn:hover {
+    color: var(--text);
+}
+
+.session-hud-segment-btn.active {
+    background: var(--accent);
+    color: var(--background);
+}
+
+.session-hud-services {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 4px 12px 12px;
+}
+
+.session-hud-drawer[data-segment="services"] .session-hud-canvas {
+    display: none;
+}
+
+.session-hud-drawer[data-segment="sessions"] .session-hud-services {
+    display: none;
+}

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -6,18 +6,28 @@
  * top-center pull handle, which snaps to the nearest of closed/peek/half on
  * release. Clicking the handle (no drag) toggles open/closed.
  *
- * Chrome only for now: `.session-hud-canvas` is an empty mount point that a
- * later issue (#777) fills with TopologyView. Mirrors scratchpad.js's
- * create-once drawer lifecycle (`.open` class, keyboard toggle, teardown).
+ * `.session-hud-canvas` is the mount point session-hud-controller.js (#778)
+ * fills with TopologyView. Mirrors scratchpad.js's create-once drawer
+ * lifecycle (`.open` class, keyboard toggle, teardown).
  *
  * Toggle: Alt+T or the handle. Mutually exclusive with the left sidebar and
  * the right scratchpad drawer — mirrors their existing coordination
  * (sidebar.js:72): opening the HUD closes both, and opening either of them
  * closes the HUD.
+ *
+ * Header (#779): a Sessions|Services segmented control sits above the
+ * canvas. Sessions is the topology mounted into `.session-hud-canvas`;
+ * Services reuses sidebar/services-section.js's singleton, mounted into the
+ * sibling `.session-hud-services` container — same fetch/render/start-stop
+ * logic as the sidebar's Services accordion, no duplication. Switching
+ * segments only toggles CSS visibility (`data-segment` on the drawer); the
+ * topology is never unmounted, so its live state and focus-rerooting
+ * survive a round trip. Last-selected segment persists in localStorage.
  */
 
 import { sidebar } from './sidebar.js';
 import { scratchpad } from './scratchpad.js';
+import { servicesSection } from './sidebar/services-section.js';
 
 const PEEK_VH = 0.33;
 const HALF_VH = 0.50;
@@ -26,6 +36,9 @@ const MID_THRESHOLD = (PEEK_VH + HALF_VH) / 2;
 const DRAG_MIN_VH = 0.12;
 const DRAG_MAX_VH = 0.66;
 const CLICK_TOLERANCE_PX = 3;
+
+/** localStorage key for the last-selected header segment (#779). */
+const SEGMENT_KEY = 'aw-hud-segment';
 
 function clamp(v, min, max) {
     return Math.min(Math.max(v, min), max);
@@ -40,6 +53,13 @@ class SessionHud {
         this.detent = 'peek';
         /** @type {string|null} detent to restore on restoreDetent(), set by growToHalf() */
         this._grownFromDetent = null;
+        /** @type {HTMLElement|null} header strip hosting the Sessions|Services segmented control (#779) */
+        this.header = null;
+        /** @type {HTMLElement|null} sibling mount point for the Services segment's content */
+        this.servicesCanvas = null;
+        /** @type {'sessions'|'services'} currently active header segment */
+        this.segment = 'sessions';
+        this._servicesMounted = false;
     }
 
     init() {
@@ -66,10 +86,26 @@ class SessionHud {
     _buildDrawer() {
         const drawer = document.createElement('div');
         drawer.className = 'session-hud-drawer';
-        drawer.innerHTML = '<div class="session-hud-canvas"></div>';
+        drawer.innerHTML = `
+            <div class="session-hud-header">
+                <div class="session-hud-segmented" role="tablist" aria-label="Session HUD view">
+                    <button type="button" class="session-hud-segment-btn" data-segment="sessions" role="tab">Sessions</button>
+                    <button type="button" class="session-hud-segment-btn" data-segment="services" role="tab">Services</button>
+                </div>
+            </div>
+            <div class="session-hud-canvas"></div>
+            <div class="session-hud-services"></div>
+        `;
         document.body.appendChild(drawer);
         this.drawer = drawer;
+        this.header = drawer.querySelector('.session-hud-header');
         this.canvas = drawer.querySelector('.session-hud-canvas');
+        this.servicesCanvas = drawer.querySelector('.session-hud-services');
+
+        this.header.querySelectorAll('.session-hud-segment-btn').forEach((btn) => {
+            btn.addEventListener('click', () => this.setSegment(btn.dataset.segment));
+        });
+        this._applySegment(this._loadSegment());
 
         const handle = document.createElement('button');
         handle.className = 'session-hud-handle';
@@ -191,6 +227,51 @@ class SessionHud {
         this.detent = 'peek';
         this.toggle(true);
         return true;
+    }
+
+    // ─── Header segments (#779) ────────────────────────────────
+
+    _loadSegment() {
+        try {
+            return localStorage.getItem(SEGMENT_KEY) === 'services' ? 'services' : 'sessions';
+        } catch (e) {
+            return 'sessions';
+        }
+    }
+
+    /**
+     * Switch the HUD header between the Sessions topology and the Services
+     * list. Swaps visibility only (`data-segment` on the drawer drives the
+     * CSS) — the topology canvas is never unmounted, so session-hud-controller's
+     * live render/focus-rerooting keeps running underneath and is exactly as
+     * it was when the user switches back.
+     */
+    setSegment(segment) {
+        if (segment !== 'sessions' && segment !== 'services') return;
+        try { localStorage.setItem(SEGMENT_KEY, segment); } catch (e) {}
+        this._applySegment(segment);
+    }
+
+    _applySegment(segment) {
+        this.segment = segment;
+        this.drawer.dataset.segment = segment;
+        this.header.querySelectorAll('.session-hud-segment-btn').forEach((btn) => {
+            const active = btn.dataset.segment === segment;
+            btn.classList.toggle('active', active);
+            btn.setAttribute('aria-selected', String(active));
+        });
+        if (segment !== 'services') return;
+        // Reuse the sidebar's servicesSection singleton (SSOT for the
+        // fetch/render/start-stop logic) — mount once into our own
+        // container, then just re-render on every subsequent visit since
+        // its onSessionsChanged subscription already keeps content live
+        // while hidden.
+        if (!this._servicesMounted) {
+            this._servicesMounted = true;
+            servicesSection.mount(this.servicesCanvas);
+        } else {
+            servicesSection.refresh(this.servicesCanvas);
+        }
     }
 
     // ─── State ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a compact **Sessions | Services** pill segmented control to the Session HUD's header strip (`session-hud.js`).
- Services segment reuses `sidebar/services-section.js`'s `servicesSection` singleton — same fetch/render/start-stop logic as the sidebar's Services accordion, mounted into a sibling `.session-hud-services` container. No duplicated fetch logic (verified: `services-section.js` is imported only by `session-hud.js` and `desktop.js`).
- Switching segments only toggles CSS visibility via `data-segment` on the drawer — the topology canvas is never unmounted, so `session-hud-controller.js`'s live render + focus-rerooting survive a round trip through Services and back.
- Last-selected segment persists in `localStorage` (`aw-hud-segment`), default Sessions.
- New CSS appended to the end of `desktop.css` (compact pill styling using existing `--chrome`/`--accent`/`--text-muted` tokens).

## Test plan
- [x] `node --check --input-type=module` clean on `session-hud.js`
- [x] Browser-verified at 640px width against an isolated `agentwire portal serve` instance (own worktree checkout, non-default port, HTTP-only config, torn down after): segmented control renders in the HUD header, Services list matches the sidebar's Services section exactly (same 3 service cards, same actions)
- [x] Toggle Services → Sessions → Services round-trips without reload or re-mount
- [x] Opened a real session window to trigger focus-rerooting, then round-tripped through Services — the re-rooted "you-are-here" self-card was intact on return (no regression)
- [x] Reloaded the page — HUD reopened directly on the last-selected segment (Services), confirming localStorage persistence
- [x] No console errors during the full flow

Closes #779

Built by dotdev.dev