### PR TITLE
fix(portal): flush-left HUD shade + prune orphaned topology links

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5958,10 +5958,17 @@ body.sidebar-pinned .sidebar-tab {
    mounted into .session-hud-canvas by a later issue (#777, TopologyView).
    ============================================ */
 
+/* Left offset shared by the drawer and its handle so the two never drift.
+   0 = flush to the screen's left edge; the sidebar tab (z 9002) still sits
+   above the shade (z 9001) and stays clickable. Shifts to the sidebar width
+   only while the sidebar is pinned, so the shade never covers an open sidebar. */
+:root { --hud-left: 0px; }
+body.sidebar-pinned { --hud-left: var(--sidebar-width); }
+
 .session-hud-drawer {
     position: fixed;
     top: 0;
-    left: var(--sidebar-tab-width);
+    left: var(--hud-left);
     right: 0;
     height: 33vh;
     background: color-mix(in srgb, var(--background) 78%, transparent);
@@ -5989,10 +5996,6 @@ body.sidebar-pinned .sidebar-tab {
     transition: none;
 }
 
-body.sidebar-pinned .session-hud-drawer {
-    left: var(--sidebar-width);
-}
-
 .session-hud-canvas {
     flex: 1;
     min-height: 0;
@@ -6009,7 +6012,7 @@ body.sidebar-pinned .session-hud-drawer {
 .session-hud-handle {
     position: fixed;
     top: 0;
-    left: 50%;
+    left: calc((100vw + var(--hud-left)) / 2);
     transform: translateX(-50%);
     width: 64px;
     height: var(--sidebar-tab-width);

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -246,6 +246,10 @@ export class TopologyView {
                 clearTimeout(entry.ghostConfirmTimer);
                 entry.card.remove();
                 this._cards.delete(name);
+                // Drop the DOM path too: deleting only the map entry orphans its
+                // <path> in the SVG (it's gone from _links, so _redrawLinks' stale
+                // sweep can't reach it) — a dangling connector after any re-root.
+                this._links.get(name)?.path.remove();
                 this._links.delete(name);
             }
         }


### PR DESCRIPTION
Two bugs surfaced during live narrow-width QA of the Session HUD epic (#775):

## 1. Stale lineage connectors
`TopologyView._pruneCards` deleted a pruned card's entry from the `_links` map but never removed its `<path>` from the SVG — and since it was already gone from `_links`, `_redrawLinks`' stale-sweep couldn't reach it. Result: **dangling connector curves after any re-root/teardown that shrinks the visible set** — i.e. every focus-driven re-root (global tree → a session's subtree). Verified live: 1 card, 3 orphaned paths.

Fix: remove the `<path>` element when the card is pruned.

## 2. Shade mis-positioned at narrow width
The drawer was inset `left: var(--sidebar-tab-width)` while the pull handle was pinned to the **viewport** centre (`left: 50%`), so at ≤768px the shade sat off-centre with a left gap and the handle + Sessions∣Services pill didn't line up with it.

Fix: both the drawer and handle now read one shared `--hud-left` token — `0` (flush to the left edge; the sidebar tab at z-9002 still renders above the z-9001 shade and stays clickable), shifting to the sidebar width only while the sidebar is pinned. The handle centres on the shade via `calc((100vw + var(--hud-left)) / 2)` in every state, so it can't drift from the drawer.

## Test
- [x] `node --check --input-type=module` clean on `topology-render.js`
- [ ] Browser-verify narrow (owner's Chrome crashed mid-QA; to confirm on the live portal once it's back)

Refs #775

Built by [dotdev.dev](https://dotdev.dev)