### PR TITLE
fix(portal): shade cards show the session name, not the role chip

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6838,14 +6838,22 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     gap: 4px;
 }
 
-/* The you-are-here self card (#778) carries a role chip AND a mic button in
-   its header — at the standard 128px shade width those two alone already
-   squeeze the name to ~0px (long words like "ORCHESTRATOR" leave no slack),
-   so it needs more room than a plain card. Same specificity trick as the
-   expanded-card override above (two classes beat the shade card rule's two). */
+/* Narrow shade cards (fixed 128px) can't fit both the session name and the
+   role word — "ORCHESTRATOR" (a non-shrinking chip) starves the name to an
+   "age…" ellipsis. The name is the identifier that matters, so it takes the
+   whole row; role still shows on the expanded card + the standalone
+   workspace window (non-shade), where there's room. */
+.topology-view--shade .topology-role-chip {
+    display: none;
+}
+
+/* The you-are-here self card (#778) carries a mic button in its header (the
+   role chip is hidden in shade — see the rule above), and it's the focused
+   root, so give its name + mic a little more room than a plain 128px card.
+   Same two-class specificity trick as the expanded-card override below. */
 .topology-view--shade .topology-card--self {
-    flex: 0 0 210px;
-    max-width: 210px;
+    flex: 0 0 168px;
+    max-width: 168px;
 }
 
 /* An expanded (mini-terminal open) card must win over the fixed 128px shade


### PR DESCRIPTION
On the tiny fixed-128px shade cards, the non-shrinking role chip (`ORCHESTRATOR`) always won the row and starved the session **name** to an `age…` ellipsis. The name is the identifier that matters, so in shade mode the role chip is hidden and the name takes the row. Role still shows on the expanded (mini-terminal) card and the standalone workspace window, which have room.

Also trims the you-are-here self card 210→168px — it was widened specifically to fit that role chip, which is now hidden.

Verified: CSS brace-balanced; scoped to `.topology-view--shade` only (non-shade mounts keep the chip). Visual confirm pending on the live portal — automated browser-driving keeps crashing the owner's Chrome, so leaving the visual check to the owner.

Refs #775

Built by [dotdev.dev](https://dotdev.dev)