### PR TITLE
feat(hud): wider shade cards, distinguishing child names, per-card ⋯ menu

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6679,6 +6679,100 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     text-overflow: ellipsis;
 }
 
+/* --- per-card ⋯ actions menu (#792) --- the button rides the header row next
+   to the name (flex 0 0 auto so it never steals name width), stays out of the
+   way at rest (opacity 0), and fades in on card hover or while its menu is
+   open. Wired only for live, non-self cards in the HUD (topology-render.js). */
+.topology-card-menu-btn {
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 2px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+
+.topology-card:hover .topology-card-menu-btn,
+.topology-card-menu-btn.is-open {
+    opacity: 0.75;
+}
+
+.topology-card-menu-btn:hover,
+.topology-card-menu-btn.is-open {
+    opacity: 1;
+    color: var(--text);
+    background: var(--hover);
+}
+
+/* Popover positioned `fixed` (top/left set inline in JS from the ⋯ button's
+   rect) so it escapes the HUD canvas's `overflow:auto` clip — a bottom-row
+   card's menu must never get cut off. z above the drawer (9001) + sidebar tab. */
+.topology-card-menu {
+    position: fixed;
+    z-index: 9050;
+    min-width: 136px;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 4px;
+    border-radius: 8px;
+    border: 1px solid var(--chrome-border);
+    background: var(--chrome);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.topology-card-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text);
+    font-size: 12px;
+    font-family: inherit;
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.12s ease;
+}
+
+.topology-card-menu-item:hover {
+    background: var(--hover);
+}
+
+.topology-card-menu-icon {
+    flex: 0 0 14px;
+    text-align: center;
+    opacity: 0.8;
+}
+
+.topology-card-menu-item--danger {
+    color: var(--error);
+}
+
+.topology-card-menu-item--danger:hover,
+.topology-card-menu-item--danger.is-armed {
+    background: color-mix(in srgb, var(--error) 14%, transparent);
+}
+
+.topology-card-menu-item--danger.is-armed {
+    justify-content: center;
+    font-weight: 600;
+}
+
 /* flow (processing/generating/playing) — family-tinted "alive" treatment */
 .topology-card--flow .topology-status-dot {
     background: var(--card-tint, var(--lineage-tint-1));
@@ -6832,16 +6926,17 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
 }
 
 .topology-view--shade .topology-card {
-    flex: 0 0 128px;
-    max-width: 128px;
+    flex: 0 0 176px;
+    max-width: 176px;
     padding: 6px 8px;
     gap: 4px;
 }
 
-/* Narrow shade cards (fixed 128px) can't fit both the session name and the
+/* Even widened (176px, #792), a shade card can't fit the session name AND the
    role word — "ORCHESTRATOR" (a non-shrinking chip) starves the name to an
-   "age…" ellipsis. The name is the identifier that matters, so it takes the
-   whole row; role still shows on the expanded card + the standalone
+   "age…" ellipsis, and the extra room now goes to the un-truncated child
+   branch name + the ⋯ menu. The name is the identifier that matters, so it
+   takes the row; role still shows on the expanded card + the standalone
    workspace window (non-shade), where there's room. */
 .topology-view--shade .topology-role-chip {
     display: none;
@@ -6852,15 +6947,15 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
    root, so give its name + mic a little more room than a plain 128px card.
    Same two-class specificity trick as the expanded-card override below. */
 .topology-view--shade .topology-card--self {
-    flex: 0 0 168px;
-    max-width: 168px;
+    flex: 0 0 208px;
+    max-width: 208px;
 }
 
-/* An expanded (mini-terminal open) card must win over the fixed 128px shade
+/* An expanded (mini-terminal open) card must win over the fixed 176px shade
    card width above — `.topology-view--shade .topology-card` has two class
    selectors to `.topology-card--expanded`'s one, so without this override
    the higher-specificity shade rule would keep clamping an open mini-terminal
-   to 128px regardless. Narrow-first: this is still sized for the owner's
+   to 176px regardless. Narrow-first: this is still sized for the owner's
    ~1/3-width portal, not a full desktop canvas. */
 .topology-view--shade .topology-card--expanded {
     flex: 0 0 340px;

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -50,6 +50,7 @@ import { subtreeOf } from './lineage.js';
 import { mountCardTerminal, mountSelfMic } from './card-terminal.js';
 import { sessionHud } from './session-hud.js';
 import { apiFetch } from './api.js';
+import { normalizeMachine } from './session-id.js';
 import { toastSuccess, toastError } from './toast.js';
 
 const GHOST_POLL_MS = 20000;
@@ -82,6 +83,8 @@ class HudController {
             onSelfMount: (name, session, cardEl) => mountSelfMic(name, session, cardEl),
             onGhostCleanup: (name, session) => this._cleanupGhost(name, session),
             onGhostAdopt: (name, session) => this._adoptGhost(name, session),
+            onCardOpen: (name, session) => this._openSession(name, session),
+            onCardKill: (name, session) => this._killSession(name, session),
         });
 
         // Seed from whatever's already focused when the HUD first mounts,
@@ -142,6 +145,36 @@ class HudController {
             cleanup();
             sessionHud.restoreDetent();
         };
+    }
+
+    // ⋯ menu "Open window" — pop the session into its own full terminal window.
+    // Dynamic-imports desktop.js for the same reason card-terminal.js does: it's
+    // the module that boots this controller, so a static import would be circular.
+    async _openSession(name, session) {
+        try {
+            const { openSessionTerminal } = await import('./desktop.js');
+            openSessionTerminal(name, 'terminal', normalizeMachine(session?.machine));
+        } catch (e) {
+            toastError(`Couldn't open ${name}: ${e.message}`);
+        }
+    }
+
+    // ⋯ menu "Kill session" — the two-step confirm already happened in-menu
+    // (topology-render.js), so this fires straight through. DELETE /api/sessions
+    // is the same thin `agentwire kill` wrapper the sidebar close button uses; the
+    // resulting lifecycle push re-renders the tree without this card.
+    async _killSession(name, session) {
+        try {
+            const res = await apiFetch(`/api/sessions/${encodeURIComponent(name)}`, { method: 'DELETE' });
+            if (!res.ok) {
+                const reason = await res.text().catch(() => '') || `HTTP ${res.status}`;
+                toastError(`Kill failed for ${name}: ${reason}`);
+                return;
+            }
+            toastSuccess(`Killed ${name}`);
+        } catch (e) {
+            toastError(`Kill failed for ${name}: ${e.message}`);
+        }
     }
 
     // Ghosts (#781) aren't sessions — no WS push tells us when a worktree dir

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -51,6 +51,34 @@ export function wireStateFor(name, record) {
     return 'idle';
 }
 
+/**
+ * The label a card should show for a session. Roots keep their full name;
+ * children show their distinguishing branch/worktree tail instead of the
+ * project-prefixed full name — under the narrow shade the full name truncated
+ * every sibling to the same "project…" ellipsis, so children were
+ * indistinguishable (#792). Two signals, cwd-immune first:
+ *   1. strip the parent's name as a leading prefix — worktree sessions are
+ *      named "{project}-{branch}" and the parent ≈ the project — leaving the
+ *      branch tail (survives a `cd` inside the session);
+ *   2. else the worktree folder basename (path is ~/worktrees/<proj>/<branch>).
+ * Falls back to the full bare name when neither yields a distinct tail.
+ *
+ * @param {{name?: string, parent?: string, path?: string, worktreePath?: string}} session
+ * @returns {string}
+ */
+export function cardDisplayName(session) {
+    const raw = (session?.name || '').split('@')[0];
+    if (!session?.parent) return raw;
+    const parent = String(session.parent).split('@')[0];
+    if (parent && raw.length > parent.length && raw.startsWith(parent)) {
+        const tail = raw.slice(parent.length).replace(/^[-/_.:\s]+/, '');
+        if (tail) return tail;
+    }
+    const base = (session.path || session.worktreePath || '').replace(/\/+$/, '').split('/').pop();
+    if (base && base !== parent && base !== raw) return base;
+    return raw;
+}
+
 /** Vertical S-curve from a parent card's bottom edge to a child card's top
  * edge — reads sensibly whether the pair ends up side by side or stacked
  * across a row wrap. */
@@ -81,6 +109,12 @@ export class TopologyView {
      *   underlying worktree is actually gone).
      * @param {(name: string, session: object) => Promise<{error?: string}>|void} [opts.onGhostAdopt] -
      *   Fired when a ghost card's "Adopt" button is confirmed. Same contract as `onGhostCleanup`.
+     * @param {(name: string, session: object) => void} [opts.onCardOpen] -
+     *   Fired from a card's ⋯ menu "Open" item — pop the session into its own full window. Wiring
+     *   this (or `onCardKill`) is what surfaces the per-card ⋯ menu button; omit both and cards carry
+     *   no menu (the workspace window relies on click-to-expand instead).
+     * @param {(name: string, session: object) => void} [opts.onCardKill] -
+     *   Fired from a card's ⋯ menu "Kill" item after a two-step in-menu confirm — tear the session down.
      * @param {boolean} [opts.showLinks=true] - Draw the connector SVG layer.
      * @param {'window'|'shade'} [opts.mode='window'] - Styling hook only — 'shade' renders
      *   full-width, left-anchored compact family clusters for the short/narrow Session HUD shade
@@ -93,6 +127,11 @@ export class TopologyView {
         this._onSelfMount = opts.onSelfMount || null;
         this._onGhostCleanup = opts.onGhostCleanup || null;
         this._onGhostAdopt = opts.onGhostAdopt || null;
+        this._onCardOpen = opts.onCardOpen || null;
+        this._onCardKill = opts.onCardKill || null;
+        /** @type {object|null} card entry whose ⋯ menu is currently open (one at a time) */
+        this._openMenuEntry = null;
+        this._menuDismiss = null;
         this._showLinks = opts.showLinks !== false;
         this._mode = opts.mode === 'shade' ? 'shade' : 'window';
         this._lastSessions = [];
@@ -176,6 +215,7 @@ export class TopologyView {
         if (this._expandedCard) this._collapseCard(this._expandedCard);
         for (const entry of this._cards.values()) {
             if (entry.selfDispose) entry.selfDispose();
+            this._closeMenu(entry);
             clearTimeout(entry.ghostConfirmTimer);
         }
         this._resizeObserver.disconnect();
@@ -242,6 +282,7 @@ export class TopologyView {
             if (!seenCards.has(name)) {
                 if (entry.expanded) this._collapseCard(name);
                 if (entry.selfDispose) entry.selfDispose();
+                this._closeMenu(entry);
                 clearTimeout(entry.ghostConfirmTimer);
                 entry.card.remove();
                 this._cards.delete(name);
@@ -274,6 +315,7 @@ export class TopologyView {
             entry.ghostBadge.hidden = !isGhost;
             entry.ghostInfoEl.hidden = !isGhost;
             entry.ghostActions.hidden = !isGhost;
+            if (isGhost) { entry.menuBtn.hidden = true; this._closeMenu(entry); }
         }
 
         const tintVar = lineageTintVar(familyRoot, this._lastSessions);
@@ -282,7 +324,12 @@ export class TopologyView {
             entry.tintVar = tintVar;
         }
 
-        if (entry.nameEl.textContent !== name) entry.nameEl.textContent = name;
+        const label = cardDisplayName(session);
+        if (entry.nameEl.textContent !== label) {
+            entry.nameEl.textContent = label;
+            // Tooltip carries the full session name when the card shows only a tail.
+            entry.nameEl.title = label === name ? '' : name;
+        }
 
         if (isGhost) {
             this._renderGhostCard(entry, session);
@@ -333,6 +380,14 @@ export class TopologyView {
                 entry.selfDispose = typeof dispose === 'function' ? dispose : null;
             }
         }
+
+        // ⋯ menu: live, non-self cards only, and only when actions are wired
+        // (the workspace window omits both callbacks → no menu there). The self
+        // card carries a mic instead, and Open/Kill on the session you're already
+        // inside is either redundant or a foot-gun.
+        const wantMenu = !isSelf && !!(this._onCardOpen || this._onCardKill);
+        if (entry.menuBtn.hidden !== !wantMenu) entry.menuBtn.hidden = !wantMenu;
+        if (!wantMenu) this._closeMenu(entry);
     }
 
     _buildCard(name) {
@@ -348,8 +403,9 @@ export class TopologyView {
             if (name === this._selfSession) return;
             if (!this._onCardExpand) return;
             // Clicks inside the expanded slot (the mounted mini-terminal, its
-            // mic button, etc.) must not bubble into a collapse toggle.
-            if (e.target.closest('.topology-card-expand-slot, .topology-card-actions, .topology-ghost-actions')) return;
+            // mic button, etc.), the ⋯ menu, or the ghost actions must not
+            // bubble into a collapse toggle.
+            if (e.target.closest('.topology-card-expand-slot, .topology-card-actions, .topology-ghost-actions, .topology-card-menu, .topology-card-menu-btn')) return;
             this._toggleExpand(name);
         });
 
@@ -361,11 +417,21 @@ export class TopologyView {
         nameEl.className = 'topology-card-name';
         const roleEl = document.createElement('span');
         roleEl.className = 'topology-role-chip';
+        const menuBtn = document.createElement('button');
+        menuBtn.type = 'button';
+        menuBtn.className = 'topology-card-menu-btn';
+        menuBtn.title = 'Actions';
+        menuBtn.textContent = '⋯';
+        menuBtn.hidden = true; // _renderCard shows it for live, non-self cards when actions are wired
+        menuBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._toggleMenu(name, this._cards.get(name));
+        });
         const ghostBadge = document.createElement('span');
         ghostBadge.className = 'topology-ghost-badge';
         ghostBadge.textContent = 'no session';
         ghostBadge.hidden = true;
-        top.append(dot, nameEl, roleEl, ghostBadge);
+        top.append(dot, nameEl, roleEl, menuBtn, ghostBadge);
 
         const sparkEl = document.createElement('div');
         sparkEl.className = 'topology-spark';
@@ -405,11 +471,12 @@ export class TopologyView {
         card.append(top, meta, ghostActions);
 
         const entry = {
-            card, dot, nameEl, roleEl, machineEl, sparkEl, state: null, tintVar: null, session: null,
+            card, dot, nameEl, roleEl, machineEl, sparkEl, menuBtn, state: null, tintVar: null, session: null,
             expanded: false, expandSlot: null, expandDispose: null,
             isSelf: false, selfDispose: null,
             isGhost: false, ghostBadge, ghostInfoEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
             ghostConfirm: null, ghostConfirmTimer: null, ghostBusy: false,
+            menuEl: null, menuOpen: false, resetKill: null,
         };
 
         cleanupBtn.addEventListener('click', (e) => {
@@ -422,6 +489,107 @@ export class TopologyView {
         });
 
         return entry;
+    }
+
+    /** Toggle a card's ⋯ action menu — closing any other open one first
+     * (accordion: one menu at a time across the whole view). */
+    _toggleMenu(name, entry) {
+        if (!entry) return;
+        if (entry.menuOpen) { this._closeMenu(entry); return; }
+        if (this._openMenuEntry && this._openMenuEntry !== entry) this._closeMenu(this._openMenuEntry);
+        if (!entry.menuEl) entry.menuEl = this._buildMenu(name, entry);
+        entry.menuEl.hidden = false;
+        entry.menuOpen = true;
+        entry.menuBtn.classList.add('is-open');
+        this._openMenuEntry = entry;
+        // Position `fixed` from the button rect so the popover escapes the HUD
+        // canvas's overflow clip (right-aligned under the ⋯; clamped into view).
+        const r = entry.menuBtn.getBoundingClientRect();
+        const menu = entry.menuEl;
+        menu.style.top = `${Math.round(r.bottom + 4)}px`;
+        menu.style.left = 'auto';
+        menu.style.right = `${Math.round(Math.max(6, window.innerWidth - r.right))}px`;
+        // Dismiss on outside pointerdown or Escape. Deferred bind so the click
+        // that opened the menu doesn't immediately close it; capture phase so a
+        // click anywhere (including another card) is caught first.
+        this._menuDismiss = (e) => {
+            if (e.type === 'keydown') { if (e.key === 'Escape') this._closeMenu(entry); return; }
+            if (e.target === entry.menuBtn || entry.menuEl.contains(e.target)) return;
+            this._closeMenu(entry);
+        };
+        setTimeout(() => {
+            if (!entry.menuOpen) return;
+            document.addEventListener('pointerdown', this._menuDismiss, true);
+            document.addEventListener('keydown', this._menuDismiss, true);
+        }, 0);
+    }
+
+    _closeMenu(entry) {
+        if (!entry || !entry.menuOpen) return;
+        entry.menuOpen = false;
+        entry.menuBtn?.classList.remove('is-open');
+        if (entry.menuEl) entry.menuEl.hidden = true;
+        entry.resetKill?.(); // disarm a half-confirmed Kill
+        if (this._menuDismiss) {
+            document.removeEventListener('pointerdown', this._menuDismiss, true);
+            document.removeEventListener('keydown', this._menuDismiss, true);
+            this._menuDismiss = null;
+        }
+        if (this._openMenuEntry === entry) this._openMenuEntry = null;
+    }
+
+    /** Build the ⋯ popover: an "Open" item (pop to full window) and a "Kill"
+     * item guarded by an in-menu two-step confirm (mirrors the sidebar close
+     * button's "click, then click again to confirm" pattern). Items appear only
+     * for the callbacks the caller wired. */
+    _buildMenu(name, entry) {
+        const menu = document.createElement('div');
+        menu.className = 'topology-card-menu';
+        menu.hidden = true;
+        menu.addEventListener('click', (e) => e.stopPropagation());
+
+        if (this._onCardOpen) {
+            const openBtn = document.createElement('button');
+            openBtn.type = 'button';
+            openBtn.className = 'topology-card-menu-item';
+            openBtn.innerHTML = '<span class="topology-card-menu-icon">⤢</span>Open window';
+            openBtn.addEventListener('click', () => {
+                this._closeMenu(entry);
+                this._onCardOpen(name, entry.session);
+            });
+            menu.appendChild(openBtn);
+        }
+
+        if (this._onCardKill) {
+            const KILL_HTML = '<span class="topology-card-menu-icon">✕</span>Kill session';
+            const killBtn = document.createElement('button');
+            killBtn.type = 'button';
+            killBtn.className = 'topology-card-menu-item topology-card-menu-item--danger';
+            killBtn.innerHTML = KILL_HTML;
+            let armed = false;
+            let timer = null;
+            entry.resetKill = () => {
+                armed = false;
+                if (timer) { clearTimeout(timer); timer = null; }
+                killBtn.innerHTML = KILL_HTML;
+                killBtn.classList.remove('is-armed');
+            };
+            killBtn.addEventListener('click', () => {
+                if (!armed) {
+                    armed = true;
+                    killBtn.textContent = 'Confirm kill';
+                    killBtn.classList.add('is-armed');
+                    timer = setTimeout(() => entry.resetKill?.(), 3000);
+                    return;
+                }
+                this._closeMenu(entry);
+                this._onCardKill(name, entry.session);
+            });
+            menu.appendChild(killBtn);
+        }
+
+        entry.card.appendChild(menu);
+        return menu;
     }
 
     /** Ghost cards (session.state === 'orphan', #781) skip the live-status


### PR DESCRIPTION
Closes #792

Polish pass on the Session HUD shade cards — keeps the compact aesthetic, spends the extra horizontal room on legibility + quick actions.

## Changes
- **Wider shade cards** — `128→176px` base, self `168→208px` (`desktop.css`).
- **Distinguishing child names** — new `cardDisplayName()` (`topology-render.js`) strips the parent-project prefix so worktree children show their branch/worktree tail instead of the truncated `project…`; full name → hover tooltip. Fallback to worktree-folder basename keeps it cwd-immune.
- **Per-card ⋯ menu** — `Open window` + `Kill session` (two-step confirm), live non-self cards only. `position:fixed` popover escapes the HUD canvas `overflow:auto` clip. New `onCardOpen`/`onCardKill` callbacks wired in `session-hud-controller.js` (Open dynamic-imports desktop.js like card-terminal.js; Kill reuses the sidebar `DELETE /api/sessions` path).

Role chip stays hidden in shade (would still starve the name); meta row unchanged — the width went to the name + menu, not new clutter.

## Validation
- `node --check` (ES-module parse) on both changed JS files ✔
- CSS brace balance ✔
- Live-reviewed in the portal (dev mode) — owner sign-off on the visual result.

Built by [dotdev.dev](https://dotdev.dev)