### PR TITLE
fix(hud): portal ⋯ card menu to <body> so it isn't clipped inside the fold

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6716,8 +6716,10 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
 }
 
 /* Popover positioned `fixed` (top/left set inline in JS from the ⋯ button's
-   rect) so it escapes the HUD canvas's `overflow:auto` clip — a bottom-row
-   card's menu must never get cut off. z above the drawer (9001) + sidebar tab. */
+   rect) and portaled to <body> (topology-render.js) so it escapes both the
+   HUD canvas's `overflow:auto` clip AND the drawer's backdrop-filter/transform
+   containing block — a collapsed bottom-row card's menu must never render
+   "inside the fold". z above the drawer (9001) + sidebar tab. */
 .topology-card-menu {
     position: fixed;
     z-index: 9050;

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -216,6 +216,7 @@ export class TopologyView {
         for (const entry of this._cards.values()) {
             if (entry.selfDispose) entry.selfDispose();
             this._closeMenu(entry);
+            entry.menuEl?.remove(); // portaled to <body>
             clearTimeout(entry.ghostConfirmTimer);
         }
         this._resizeObserver.disconnect();
@@ -283,6 +284,7 @@ export class TopologyView {
                 if (entry.expanded) this._collapseCard(name);
                 if (entry.selfDispose) entry.selfDispose();
                 this._closeMenu(entry);
+                entry.menuEl?.remove(); // portaled to <body>, so card.remove() won't take it
                 clearTimeout(entry.ghostConfirmTimer);
                 entry.card.remove();
                 this._cards.delete(name);
@@ -502,8 +504,10 @@ export class TopologyView {
         entry.menuOpen = true;
         entry.menuBtn.classList.add('is-open');
         this._openMenuEntry = entry;
-        // Position `fixed` from the button rect so the popover escapes the HUD
-        // canvas's overflow clip (right-aligned under the ⋯; clamped into view).
+        // Position `fixed` from the button's viewport rect (right-aligned under
+        // the ⋯, clamped into view). Correct because the menu is portaled to
+        // <body> in _buildMenu — see there for why nesting it under the drawer
+        // breaks fixed positioning.
         const r = entry.menuBtn.getBoundingClientRect();
         const menu = entry.menuEl;
         menu.style.top = `${Math.round(r.bottom + 4)}px`;
@@ -588,7 +592,13 @@ export class TopologyView {
             menu.appendChild(killBtn);
         }
 
-        entry.card.appendChild(menu);
+        // Portal to <body>, NOT the card: the HUD drawer's backdrop-filter +
+        // transform each make it the containing block for position:fixed
+        // descendants, so a menu nested under it would be positioned/clipped
+        // relative to the drawer (rendering "inside the fold") instead of the
+        // viewport. On body there's no such ancestor, so the fixed coords set
+        // from the button's viewport rect land correctly and nothing clips.
+        document.body.appendChild(menu);
         return menu;
     }
 


### PR DESCRIPTION
Follow-up to #792 (owner-reported).

**Symptom:** pressing a collapsed child card's ⋯ menu showed the menu content "inside the fold", glitching; it worked only after expanding the card first.

**Cause:** the menu is `position:fixed`, but it was appended under the card, which lives inside `.session-hud-drawer` — and that drawer has both `backdrop-filter: blur()` and a `transform` (open/detent animation). Either property makes an element the *containing block* for `fixed`-position descendants, so the menu was positioned + clipped relative to the drawer, not the viewport. The inline coords (from the button's viewport rect) therefore landed wrong. Expanding the card grew the drawer to 50vh, incidentally bringing the mispositioned menu into view.

**Fix:** portal the menu to `document.body` (no transformed/filtered ancestor) so `fixed` is genuinely viewport-relative and the button-rect coords are correct. Explicitly `remove()` the portaled node on prune/dispose since `card.remove()` no longer carries it.

## Validation
- `node --check` ✔, CSS brace balance ✔

Built by [dotdev.dev](https://dotdev.dev)