### PR TITLE
feat(hud): Show all sessions master view — sidebar icon + palette action

### DIFF
--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -45,6 +45,11 @@ const COMMANDS = [
     { id: 'new-session', icon: '▶', label: 'New session', keywords: 'create new session start spawn run project', run: () => setView('new-session') },
     { id: 'worktree', icon: '⎇', label: 'New worktree', keywords: 'worktree branch quicktask task feat fix base', run: () => setView('worktree') },
     { id: 'open-session', icon: '👁', label: 'Open session', keywords: 'open attach connect existing session', run: () => setView('open-session') },
+    { id: 'show-all-sessions', icon: '⧉', label: 'Show all sessions', keywords: 'hud session topology tree map lineage parent child master overview show all every global peek', run: async () => {
+        closeCommandPalette();
+        const { hudController } = await import('./session-hud-controller.js');
+        hudController.showAll();
+    } },
     { id: 'collage', icon: '▦', label: 'Window collage', keywords: 'collage cascade grid windows overview show all tile mission', run: async () => {
         closeCommandPalette();
         const { collage } = await import('./collage.js');

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -61,6 +61,9 @@ class HudController {
         this._resolveWindowSession = null;
         /** @type {string|null} focused session name, or null = global tree */
         this._contextSession = null;
+        /** @type {boolean} "master" mode (showAll) — pin the global tree and
+         * ignore focus re-rooting until the drawer is closed. */
+        this._global = false;
         /** @type {string|null} window id backing _contextSession, for window_unregistered matching */
         this._contextWindowId = null;
         /** @type {Array<object>} pseudo-session records for orphaned worktrees, refreshed via polling */
@@ -98,6 +101,10 @@ class HudController {
         this._fetchGhosts();
         this._ghostTimer = setInterval(() => this._fetchGhosts(), GHOST_POLL_MS);
 
+        // Closing the drawer exits "master" mode, so the next Alt+P open is the
+        // normal context-following view again.
+        sessionHud.onClose(() => { this._global = false; });
+
         desktop.on('active_window_changed', ({ id }) => this._applyFocus(id));
         // Closing the focused session's own window (with nothing else taking
         // focus) falls back to the global tree, rather than leaving the HUD
@@ -112,10 +119,27 @@ class HudController {
     }
 
     _applyFocus(id) {
+        if (this._global) return; // master mode pins the global tree
         const session = this._resolveWindowSession(id);
         if (!session || session === this._contextSession) return;
         this._contextSession = session;
         this._contextWindowId = id;
+        this._render();
+    }
+
+    /**
+     * "Master" view — open the HUD showing the full session tree (every family,
+     * not the focused session's subtree) and pin it there: focus changes no
+     * longer re-root until the drawer closes. Entry points are the Sessions
+     * sidebar-header icon and the "Show all sessions" command-palette action
+     * (no hotkey — the plain Alt+P peek is the context-following view). Idempotent.
+     */
+    showAll() {
+        this._global = true;
+        this._contextSession = null;
+        this._contextWindowId = null;
+        if (sessionHud.segment !== 'sessions') sessionHud.setSegment('sessions');
+        if (!sessionHud.open) sessionHud.toggle(true);
         this._render();
     }
 

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -60,6 +60,14 @@ class SessionHud {
         /** @type {'sessions'|'services'} currently active header segment */
         this.segment = 'sessions';
         this._servicesMounted = false;
+        /** @type {Array<() => void>} fired when the drawer closes — lets the
+         * controller drop its pinned "master/global" view (see showAll). */
+        this._closeListeners = [];
+    }
+
+    /** Subscribe to drawer-close. */
+    onClose(fn) {
+        this._closeListeners.push(fn);
     }
 
     init() {
@@ -295,6 +303,7 @@ class SessionHud {
             this.open = false;
             this.drawer.classList.remove('open');
             this.handle.classList.remove('drawer-open');
+            this._closeListeners.forEach((fn) => fn());
         }
     }
 }

--- a/agentwire/static/js/shortcuts.js
+++ b/agentwire/static/js/shortcuts.js
@@ -82,6 +82,7 @@ export const FEATURE_TOUR = [
     { icon: '🏛', name: 'Council', desc: 'Ask one question, get six lenses (brain, conscience, …) deliberating in parallel. Command palette → Ask council.' },
     { icon: '🎙', name: 'Push-to-talk', desc: 'Hold Ctrl/⌘+Space to talk to a session. Or open /mobile to push-to-talk from your phone.' },
     { icon: '▦', name: 'Window collage', desc: 'F3 fans every window into a grid — click one to dive in. Great for juggling many sessions.' },
+    { icon: '⧉', name: 'Session HUD', desc: 'Alt+P peeks a live map of the session you’re in and its children. "Show all sessions" (command palette, or the Sessions panel ⧉) opens the full tree — every session at once.' },
     { icon: '💡', name: 'New idea', desc: 'Capture a thought and AgentWire spins up a project with an agent already working on it.' },
     { icon: '⎇', name: 'Worktrees', desc: 'Branch a session into an isolated git worktree for parallel work, from the palette or the Sessions panel.' },
     { icon: '📋', name: 'Scratchpad', desc: 'Alt+N opens a quick notes drawer that travels with you across sessions.' },

--- a/agentwire/static/js/sidebar/sessions-section.js
+++ b/agentwire/static/js/sidebar/sessions-section.js
@@ -321,6 +321,7 @@ async function fetchSessions() {
 export const sessionsSection = {
     title: 'Sessions',
     actions: [
+        { id: 'showall', label: '⧉', title: 'Show all sessions in the HUD' },
         { id: 'new', label: '+', title: 'New session' },
         { id: 'worktree', label: '⎇', title: 'New worktree session' },
     ],
@@ -339,6 +340,11 @@ export const sessionsSection = {
     },
 
     onAction(actionId, body) {
+        // Not a form toggle — pop the master Session HUD (all sessions).
+        if (actionId === 'showall') {
+            import('../session-hud-controller.js').then(({ hudController }) => hudController.showAll());
+            return;
+        }
         if (this._formType === actionId) {
             this._formType = null;
         } else {


### PR DESCRIPTION
The Session HUD is context-following — it re-roots to whatever session you're focused on. This adds an explicit way to open its **master view** showing every session at once. No hotkey (per request); two discoverable entry points instead.

## Behavior
`hudController.showAll()` opens the drawer pinned to the **global tree** and holds it there — focus changes stop re-rooting (`_global` flag) until you close the HUD. Closing it (Alt+P / handle / Esc) drops the pin, so the next Alt+P peek is the normal context-following view again. `SessionHud` gains a small `onClose` hook the controller subscribes to.

## Entry points (both call `showAll()`)
- **Sidebar** — a `⧉` icon in the Sessions section header, next to `+` / `⎇`.
- **Command palette** — "Show all sessions".
- Feature-tour entry (F1 help) teaches the HUD + both entry points.

## Validation
`node --check` on all five changed JS files ✔

Built by [dotdev.dev](https://dotdev.dev)