### PR TITLE
feat(hud): git-status badges + current-repo scoping for phantom cards

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -7125,6 +7125,21 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     text-overflow: ellipsis;
 }
 
+/* Read-only git-status badges (#801) — reuses the sidebar's `.sidebar-git-badge`
+   + `.git-*` classes (sidebar/sessions-section.js's `renderGitBadges`) so a
+   worktree reads identically whether it's a live session or a ghost; only the
+   row layout is ghost-specific. Same [hidden]-override gotcha as
+   `.topology-ghost-actions` below — the JS toggles `hidden` every render. */
+.topology-ghost-git[hidden] {
+    display: none;
+}
+.topology-ghost-git {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
 /* [hidden] must win over the flex display below (equal specificity, later
    author rule otherwise beats the UA [hidden]{display:none} stylesheet) —
    the JS toggles this element's `hidden` attribute per card every render. */

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -35,12 +35,17 @@
  * sessions, so they don't belong in sidebar/sessions-section.js's shared
  * `getAllSessions()` — and merged into the array passed to `render()` as
  * pseudo-session records (`state: 'orphan'`, plus `branch`/`worktreePath`/
- * `projectPath`). Each ghost's `parent` is whatever `--list` resolved as its
- * dead session's recorded creator (may be undefined): `groupFamilies`/
- * `lineageOf` (lineage.js) already treat an unresolvable parent name as "this
- * is its own root", so a ghost with no known lineage naturally lands as its
- * own single-card family — the "unattached / needs cleanup" case — with zero
- * extra grouping logic here.
+ * `projectPath`/`git` — the same read-only git-status shape the sidebar
+ * badges worktree sessions with, #801). Each ghost's `parent` is whatever
+ * `--list` resolved as its dead session's recorded creator (may be
+ * undefined): `groupFamilies`/`lineageOf` (lineage.js) already treat an
+ * unresolvable parent name as "this is its own root", so in the global tree
+ * a ghost with no known lineage naturally lands as its own single-card
+ * family with zero extra grouping logic here. Once a session is focused,
+ * `_scopedGhosts` additionally scopes the fetched list to "the repo you're
+ * looking at" (#801) — see its own doc comment for the two cases it
+ * distinguishes (lineage-linked ghosts vs. unattached ones grafted onto the
+ * focused session when their repo matches).
  */
 
 import { desktop } from './desktop-manager.js';
@@ -52,8 +57,36 @@ import { sessionHud } from './session-hud.js';
 import { apiFetch } from './api.js';
 import { normalizeMachine } from './session-id.js';
 import { toastSuccess, toastError } from './toast.js';
+import { projectFromCwd } from './safety-shared.js';
 
 const GHOST_POLL_MS = 20000;
+
+/** Fallback-tier repo name from a filesystem path, for when a session has no
+ * entry in `_sessionProject` (the authoritative, server-resolved lookup
+ * `_scopedGhosts` prefers — see there). No explicit "project" field is
+ * plumbed onto live session records (docs/design/session-card-fields.md tags
+ * it "derive→plumb"), so this is a best-effort guess from the path's shape:
+ * reuses `projectFromCwd` (safety-shared.js, already handles a plain
+ * `~/projects/<project>/` checkout and the legacy scheduler-dispatch
+ * `~/projects/<project>-worktrees/<branch>/` layout), layering in the
+ * `agentwire worktree` default layout (`~/worktrees/<project>/<branch>/`,
+ * CLAUDE.md) it doesn't cover. Both this and `projectFromCwd`'s "projects"
+ * lookup are name-based and go stale under a non-default `worktree.dir`
+ * override — a gap `_sessionProject` (an exact, config-independent lookup)
+ * doesn't have, which is why that's the primary path and this is only the
+ * fallback for sessions never registered via `agentwire worktree`.
+ * @param {string|null|undefined} path
+ * @returns {string|null}
+ */
+function repoNameFromPath(path) {
+    if (!path) return null;
+    const parts = String(path).replace(/\/+$/, '').split('/').filter(Boolean);
+    if (!parts.length) return null;
+    const wtIdx = parts.lastIndexOf('worktrees');
+    if (wtIdx !== -1 && wtIdx + 1 < parts.length) return parts[wtIdx + 1];
+    const viaProjects = projectFromCwd(path);
+    return viaProjects && viaProjects !== '—' ? viaProjects : parts[parts.length - 1];
+}
 
 class HudController {
     constructor() {
@@ -68,6 +101,11 @@ class HudController {
         this._contextWindowId = null;
         /** @type {Array<object>} pseudo-session records for orphaned worktrees, refreshed via polling */
         this._ghosts = [];
+        /** @type {Map<string, string>} session name → repo root path, from EVERY
+         * worktree-registry entry (alive and dead) the last `/api/worktrees`
+         * poll returned — exact and server-resolved (git_root()), so repo
+         * scoping (#801) prefers this over guessing from a live pane cwd. */
+        this._sessionProject = new Map();
         this._ghostTimer = null;
     }
 
@@ -146,6 +184,7 @@ class HudController {
     _render() {
         if (!this._view) return;
         const sessions = getAllSessions();
+        let contextRecord = this._contextSession ? sessions.find((s) => s.name === this._contextSession) : null;
         // The context session may have closed/renamed since it was last
         // focused — fall back to the global tree rather than rendering an
         // empty subtree for a name nothing matches anymore. Gated on
@@ -153,13 +192,73 @@ class HudController {
         // sessions fetch hasn't resolved yet, e.g. mid-restoreTaskbarState())
         // means "no data yet", not "this session is gone" — resetting on
         // that would wipe a just-restored focus before it ever got to render.
-        if (this._contextSession && sessions.length > 0 && !sessions.some((s) => s.name === this._contextSession)) {
+        if (this._contextSession && sessions.length > 0 && !contextRecord) {
             this._contextSession = null;
             this._contextWindowId = null;
+            contextRecord = null;
         }
-        const merged = this._ghosts.length ? [...sessions, ...this._ghosts] : sessions;
+        const ghosts = this._scopedGhosts(sessions, contextRecord);
+        const merged = ghosts.length ? [...sessions, ...ghosts] : sessions;
         this._view.setSelfSession(this._contextSession);
         this._view.render(this._contextSession ? subtreeOf(this._contextSession, merged) : merged);
+    }
+
+    /**
+     * Phantom cards scoped to "the repo you're looking at" (#801). Two cases,
+     * kept deliberately separate:
+     *   - A ghost with a resolvable `.parent` is already reachable through
+     *     normal family lineage (`groupFamilies`/`subtreeOf`, lineage.js) and
+     *     always shows under that family, whatever repo it's actually in —
+     *     cross-project parenting via `--created-by` is a supported pattern
+     *     (CLAUDE.md's rooting section), so repo-scoping must never hide it.
+     *   - A ghost with NO resolvable parent (its creator session is also
+     *     gone, or was never recorded) is the "unattached, needs cleanup"
+     *     case — today it surfaces only as its own standalone-root family in
+     *     the global tree and is invisible from any focused view at all
+     *     (`subtreeOf` only walks `.parent` reachability, so nothing without
+     *     a parent link can ever appear as a descendant). Once a session is
+     *     focused, if such a ghost's repo matches the focused session's repo,
+     *     graft it onto that session (synthetic `parent`) so it actually
+     *     surfaces grouped with the family you're looking at instead of
+     *     staying invisible; a different repo's unattached ghost is left out
+     *     of this particular view (it still shows in the global tree).
+     * With no session focused (global tree) there's no single "current repo"
+     * to scope to, so every fetched ghost shows, same as before.
+     */
+    _scopedGhosts(sessions, contextRecord) {
+        if (!this._ghosts.length || !this._contextSession) return this._ghosts;
+        const repo = this._currentRepoName(contextRecord);
+        if (!repo) return this._ghosts;
+        const knownNames = new Set(sessions.map((s) => s.name));
+        for (const g of this._ghosts) knownNames.add(g.name);
+        const out = [];
+        for (const g of this._ghosts) {
+            if (g.parent && knownNames.has(g.parent)) { out.push(g); continue; }
+            if (!g.projectPath || repoNameFromPath(g.projectPath) === repo) {
+                // `parent` here is display-only (grafts the card under the
+                // focused family's wire) — `syntheticParent` tells
+                // `_adoptGhost` not to record it as the real creator, since
+                // this ghost never actually had one.
+                out.push({ ...g, parent: this._contextSession, syntheticParent: true });
+            }
+        }
+        return out;
+    }
+
+    /** The focused session's repo, or null when it can't be determined
+     * confidently (fail open — `_scopedGhosts` shows everything unfiltered
+     * rather than risk hiding a real phantom card on a bad guess). Prefers
+     * the exact, server-resolved `_sessionProject` lookup (immune to pane-cwd
+     * drift and `worktree.dir` overrides) over the `repoNameFromPath`
+     * heuristic, which only runs for a session never registered via
+     * `agentwire worktree` (main/pane topology). Remote sessions (`machine`
+     * set) have no local-registry signal to scope against — `/api/worktrees`
+     * is local-machine only — so they're left unscoped too. */
+    _currentRepoName(contextRecord) {
+        if (!contextRecord || contextRecord.machine) return null;
+        const project = this._sessionProject.get(this._contextSession);
+        if (project) return repoNameFromPath(project);
+        return repoNameFromPath(contextRecord.path);
     }
 
     _expandCard(name, session, slotEl) {
@@ -208,11 +307,20 @@ class HudController {
         try {
             const res = await apiFetch('/api/worktrees');
             const data = await res.json();
-            this._ghosts = (data.entries || [])
+            const entries = data.entries || [];
+            this._ghosts = entries
                 .filter((e) => e.exists && !e.alive)
                 .map((e) => this._toGhostRecord(e));
+            // Every registered worktree session (alive or dead), not just the
+            // phantom ones above — the repo-scoping lookup (#801, `_currentRepoName`)
+            // needs the CURRENTLY FOCUSED session's repo too, which is usually
+            // alive and therefore filtered out of `this._ghosts`.
+            this._sessionProject = new Map(
+                entries.filter((e) => e.session && e.project).map((e) => [e.session, e.project])
+            );
         } catch (e) {
             this._ghosts = [];
+            this._sessionProject = new Map();
         }
         this._render();
     }
@@ -226,6 +334,7 @@ class HudController {
             branch,
             worktreePath: e.worktree_path,
             projectPath: e.project,
+            git: e.git || null,
         };
     }
 
@@ -262,7 +371,10 @@ class HudController {
                 body: JSON.stringify({
                     name: session.branch,
                     project: session.projectPath,
-                    createdBy: session.parent || undefined,
+                    // A synthetic `parent` (#801 repo-scoping graft, `_scopedGhosts`)
+                    // is display-only — this ghost never actually had a
+                    // creator, so adopting it must not record one.
+                    createdBy: session.syntheticParent ? undefined : (session.parent || undefined),
                 }),
             });
             const result = await res.json().catch(() => ({}));

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -79,6 +79,40 @@ export function cardDisplayName(session) {
     return raw;
 }
 
+/** Compact git-status badges for a ghost card — same shape and CSS classes
+ * (`sidebar-git-badge` + `git-dirty`/`git-clean`/`git-ahead`/`git-behind`/
+ * `git-unpushed`/`git-pushed`) as the sidebar's `renderGitBadges`
+ * (sidebar/sessions-section.js) so a worktree reads identically whether it's
+ * shown as a live session or a ghost. Reimplemented, not imported: the
+ * sidebar version isn't just unexported, it's also keyed by session name and
+ * closes over that module's private `worktreeGit` map rather than taking a
+ * git-status object directly, so reusing it here would mean changing its
+ * signature — an edit to sidebar/sessions-section.js, which is out of this
+ * feature's edit scope (#801, parallel-worktree file split).
+ * @param {{exists?: boolean, dirty?: boolean, staged?: number, unstaged?: number,
+ *   untracked?: number, upstream?: string|null, ahead?: number, behind?: number,
+ *   pushed?: boolean}|null|undefined} git - `worktree_status()` shape (worktree.py).
+ * @returns {string} badge spans HTML, or '' when there's no git status to show.
+ */
+function gitBadgesHtml(git) {
+    if (!git || !git.exists) return '';
+    const badges = [];
+    if (git.dirty) {
+        const n = (git.staged || 0) + (git.unstaged || 0) + (git.untracked || 0);
+        badges.push(`<span class="sidebar-git-badge git-dirty" title="${git.staged || 0} staged, ${git.unstaged || 0} unstaged, ${git.untracked || 0} untracked">● dirty${n ? ` ${n}` : ''}</span>`);
+    } else {
+        badges.push('<span class="sidebar-git-badge git-clean" title="Working tree clean">clean</span>');
+    }
+    if (!git.upstream) {
+        badges.push('<span class="sidebar-git-badge git-unpushed" title="No upstream — branch not pushed">unpushed</span>');
+    } else {
+        if (git.ahead) badges.push(`<span class="sidebar-git-badge git-ahead" title="${git.ahead} commit(s) ahead of upstream">↑${git.ahead}</span>`);
+        if (git.behind) badges.push(`<span class="sidebar-git-badge git-behind" title="${git.behind} commit(s) behind upstream">↓${git.behind}</span>`);
+        if (git.pushed && !git.ahead) badges.push('<span class="sidebar-git-badge git-pushed" title="Pushed — upstream up to date">pushed</span>');
+    }
+    return badges.join('');
+}
+
 /** Vertical S-curve from a parent card's bottom edge to a child card's top
  * edge — reads sensibly whether the pair ends up side by side or stacked
  * across a row wrap. */
@@ -316,6 +350,7 @@ export class TopologyView {
             entry.sparkEl.hidden = isGhost;
             entry.ghostBadge.hidden = !isGhost;
             entry.ghostInfoEl.hidden = !isGhost;
+            entry.ghostGitEl.hidden = !isGhost;
             entry.ghostActions.hidden = !isGhost;
             if (isGhost) { entry.menuBtn.hidden = true; this._closeMenu(entry); }
         }
@@ -454,6 +489,10 @@ export class TopologyView {
         meta.className = 'topology-card-meta';
         meta.append(sparkEl, machineEl, ghostInfoEl);
 
+        const ghostGitEl = document.createElement('div');
+        ghostGitEl.className = 'topology-ghost-git';
+        ghostGitEl.hidden = true;
+
         const ghostActions = document.createElement('div');
         ghostActions.className = 'topology-ghost-actions';
         ghostActions.hidden = true;
@@ -470,13 +509,13 @@ export class TopologyView {
         noteEl.hidden = true;
         ghostActions.append(cleanupBtn, adoptBtn, noteEl);
 
-        card.append(top, meta, ghostActions);
+        card.append(top, meta, ghostGitEl, ghostActions);
 
         const entry = {
             card, dot, nameEl, roleEl, machineEl, sparkEl, menuBtn, state: null, tintVar: null, session: null,
             expanded: false, expandSlot: null, expandDispose: null,
             isSelf: false, selfDispose: null,
-            isGhost: false, ghostBadge, ghostInfoEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
+            isGhost: false, ghostBadge, ghostInfoEl, ghostGitEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
             ghostConfirm: null, ghostConfirmTimer: null, ghostBusy: false,
             menuEl: null, menuOpen: false, resetKill: null,
         };
@@ -604,7 +643,8 @@ export class TopologyView {
 
     /** Ghost cards (session.state === 'orphan', #781) skip the live-status
      * dot/spark/role logic and just show what's on disk: branch + worktree
-     * path, and the two action buttons built in `_buildCard`. */
+     * path, read-only git-status badges (#801), and the two action buttons
+     * built in `_buildCard`. */
     _renderGhostCard(entry, session) {
         const info = [
             session.branch ? `⎇ ${session.branch}` : null,
@@ -612,6 +652,10 @@ export class TopologyView {
         ].filter(Boolean).join('  ·  ');
         if (entry.ghostInfoEl.textContent !== info) entry.ghostInfoEl.textContent = info;
         entry.machineEl.hidden = true;
+
+        const gitHtml = gitBadgesHtml(session.git);
+        if (entry.ghostGitEl.innerHTML !== gitHtml) entry.ghostGitEl.innerHTML = gitHtml;
+        entry.ghostGitEl.hidden = !gitHtml;
     }
 
     /** Two-step confirm (matches the sidebar's close-button "sure?" pattern) —


### PR DESCRIPTION
## Summary

Enhances the existing ghost/phantom HUD cards (session-less worktrees, #781):

- **Git-status badges** — `_toGhostRecord` now threads the `git` field already present on each `/api/worktrees` entry onto the ghost pseudo-session record, and `topology-render.js` renders it as dirty/clean/ahead/behind/pushed badges. Reuses the sidebar's exact CSS classes (`.sidebar-git-badge` + `.git-dirty`/`.git-clean`/`.git-ahead`/`.git-behind`/`.git-unpushed`/`.git-pushed`) so a worktree reads identically whether it's a live sidebar row or a ghost card. The rendering logic itself (`gitBadgesHtml`) is a small, deliberate reimplementation of the sidebar's `renderGitBadges` — that function is unexported *and* closure-coupled to a private module map, so reusing it would mean editing `sidebar/sessions-section.js`, which is outside this task's file scope (a sibling worktree owns it in parallel).
- **Current-repo scoping** — phantom cards now reflect "the repo you're looking at": once a session window is focused, an *unattached* ghost (no resolvable creator — the common case, since the creator is usually also dead) only surfaces if its repo matches the focused session's, grafted onto that family so it's visible instead of the previous behavior (invisible unless it had a resolvable `.parent`, or shown unfiltered across every project in the global tree). A ghost that already has a real `.parent` link is **never** touched by scoping — this preserves the documented cross-project `--created-by` parenting pattern, which an earlier version of this scoping logic broke (caught in review).

## Design notes on repo resolution

Repo scoping prefers an **exact, server-resolved lookup**: `_fetchGhosts` now also builds a `session → project` map from the *entire* `/api/worktrees` payload (not just the phantom subset), since `project` there is the backend's `git_root()`-resolved repo path for every worktree-topology session, alive or dead. This is immune to pane-cwd drift (an agent `cd`-ing around) and to a customized `worktree.dir` config.

A path-string heuristic (`repoNameFromPath`, layered on the existing `projectFromCwd` in `safety-shared.js`) is only a **fallback**, used for a focused session that was never registered via `agentwire worktree` (main/pane topology) — no registry entry exists for it. This has one documented residual limitation: a main-topology session whose checkout isn't under `~/projects/` *and* whose agent has `cd`'d into a subdirectory can still yield a wrong guess. Full resolution needs a backend-plumbed `project` field on live session records (`docs/design/session-card-fields.md` already tags this "derive→plumb") — out of scope for this frontend-only task; noted in the code comment as a candidate follow-up.

## Review

Ran an 8-angle adversarial `/code-review high` pass on the diff. Four independent angles converged on the same core bug in my first pass (path-heuristic broke on cwd drift / custom `worktree_dir`, and — most severely — the scoping filter ran *before* `subtreeOf`, so it silently dropped legitimately cross-project-parented ghosts). Redesigned per above; also caught and fixed a self-introduced bug during that redesign (a synthetic display-only `parent` was leaking into `_adoptGhost`'s `createdBy` POST body — added a `syntheticParent` marker so adopting an unattached ghost never fabricates a creator). Minor findings (a small CSS property overlap with the sidebar's row layout, the `[hidden]`-override idiom repeated per ghost element, recompute-without-memoization on each render) were dismissed with reasoning — all match existing patterns already established elsewhere in these files, and none affect correctness.

`node --check --input-type=module` clean on both changed JS files, CSS brace-balanced, existing worktree-registry unit/integration tests green (unaffected — no Python changed).

Files touched (per scope): `agentwire/static/js/topology-render.js`, `agentwire/static/js/session-hud-controller.js`, `agentwire/static/css/desktop.css` (ghost/phantom-card rules only).

Closes #801

## Test plan (for the orchestrator's one-tab e2e pass)

Needs at least one **orphaned worktree** on disk with no live session (create one, e.g. `agentwire worktree e2e-ghost-test`, then `agentwire kill -s <project>-e2e-ghost-test` leaving the worktree dir behind) — ideally with some uncommitted changes so the dirty badge has something to show.

1. **Global tree (no session focused)** — Alt+P with nothing focused, or the "Show all sessions" sidebar icon/palette action. Confirm the orphaned worktree's ghost card appears (dashed border, "no session" badge) with a **git-status badge row** underneath the branch/path line: `clean`/`● dirty N`, plus `unpushed` or `↑N`/`↓N`/`pushed` depending on the branch's actual state. Hover a badge to confirm the tooltip text (staged/unstaged/untracked counts, or ahead/behind commit counts).
2. **Focus a session in the SAME repo as the ghost** — open/focus any live session in that project, Alt+P. Confirm the ghost card still shows, now nested/grouped under that session's family (wire connects it), git badges unchanged.
3. **Focus a session in a DIFFERENT repo** — focus a live session belonging to some other project. Confirm the same ghost card is now **absent** from the drawer (repo-scoped out) — then switch back to "Show all sessions" and confirm it reappears (global tree is never scoped).
4. **Cross-project parenting (if easy to set up)** — a worktree created with `--created-by <session-in-another-project>` that's since died should still show under its creator's family when that creator is focused, even though it's a different repo (this is the case the review caught as broken in an earlier draft — confirms the fix held).
5. **Adopt / Clean up still work** — from the global tree, click Adopt on the test ghost (confirm it becomes a live session with no bogus `created_by`), or Clean up (confirm the worktree/branch actually gets removed and the card disappears from the next poll).
6. **Sanity**: compare a badge's look for a *live* worktree session in the sidebar vs. its ghost-card badges to confirm visual consistency (same pill shape/colors).

Built by [dotdev.dev](https://dotdev.dev)
