### PR TITLE
feat(hud): drawer auto-sizes to content, floored/capped by half detent

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5958,8 +5958,12 @@ body.sidebar-pinned .sidebar-tab {
 
 /* ============================================
    Session HUD — top-edge frosted drawer (#776, foundation shell)
-   Two detents (peek 33vh / half 50vh), top-center pull handle. Content is
-   mounted into .session-hud-canvas by a later issue (#777, TopologyView).
+   Two detents, top-center pull handle: "peek" auto-sizes to content, floored
+   and capped at the fixed "half" (50vh) ceiling (#802, session-hud.js's
+   _applyAutoHeight); the 33vh height below is only the pre-JS-measurement
+   fallback for the instant the drawer is created, before content exists.
+   Content is mounted into .session-hud-canvas by a later issue (#777,
+   TopologyView).
    ============================================ */
 
 /* Left offset shared by the drawer and its handle so the two never drift.

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -2,9 +2,18 @@
  * Session HUD — top-edge frosted drawer (foundation shell, #776).
  *
  * Slides down from the top edge of the desktop area (right of the sidebar).
- * Two detents — peek (~33vh) and half (~50vh) — set by dragging the
- * top-center pull handle, which snaps to the nearest of closed/peek/half on
- * release. Clicking the handle (no drag) toggles open/closed.
+ * Two detents — peek and half (~50vh) — set by dragging the top-center pull
+ * handle, which snaps to the nearest of closed/peek/half on release.
+ * Clicking the handle (no drag) toggles open/closed.
+ *
+ * "Peek" auto-sizes to content (#802) rather than a fixed 33vh: it tracks
+ * `.session-hud-canvas`/`.session-hud-services`' `scrollHeight` (whichever
+ * segment is active) via a MutationObserver, floored at DRAG_MIN_VH so a
+ * single card never shrinks the drawer to nothing and capped at HALF_VH so
+ * it never grows past the "half" detent on its own — half stays a fixed,
+ * content-independent ceiling, reachable by dragging past the midpoint or
+ * via growToHalf(). PEEK_VH itself no longer renders anything; it only
+ * anchors the drag-release snap thresholds below.
  *
  * `.session-hud-canvas` is the mount point session-hud-controller.js (#778)
  * fills with TopologyView. Mirrors scratchpad.js's create-once drawer
@@ -63,6 +72,11 @@ class SessionHud {
         /** @type {Array<() => void>} fired when the drawer closes — lets the
          * controller drop its pinned "master/global" view (see showAll). */
         this._closeListeners = [];
+        /** @type {boolean} true while the handle is mid-drag — auto-height
+         * recomputes stand down so they don't fight the user's own gesture. */
+        this._dragging = false;
+        /** @type {number|null} pending rAF handle for a debounced auto-height pass */
+        this._autoRaf = null;
     }
 
     /** Subscribe to drawer-close. */
@@ -90,6 +104,11 @@ class SessionHud {
                 this.toggle();
             }
         }, true);
+
+        // The vh-based floor/cap move with the viewport (e.g. a resized
+        // browser window) — re-run auto-height so a stale px value doesn't
+        // linger outside the current clamp range.
+        window.addEventListener('resize', () => this._scheduleAutoHeight());
     }
 
     // ─── DOM ────────────────────────────────────────────────────
@@ -113,6 +132,8 @@ class SessionHud {
         this.canvas = drawer.querySelector('.session-hud-canvas');
         this.servicesCanvas = drawer.querySelector('.session-hud-services');
 
+        this._contentObserver = new MutationObserver(() => this._scheduleAutoHeight());
+
         this.header.querySelectorAll('.session-hud-segment-btn').forEach((btn) => {
             btn.addEventListener('click', () => this.setSegment(btn.dataset.segment));
         });
@@ -128,15 +149,31 @@ class SessionHud {
         this._wireHandleDrag();
     }
 
+    /** (Re)targets the content MutationObserver at whichever segment is
+     * currently visible — `_contentHeightPx()` only ever reads that one, so
+     * watching the hidden segment too would just schedule wasted recomputes
+     * of an unchanged, already-correct height (the segment switch itself
+     * re-measures fresh via `_applySegment()`). Rows/cards are added and
+     * removed as childList mutations (family/row/card elements — see
+     * topology-render.js), which covers "grow as rows are added"; `hidden`/
+     * `class` are also watched because a ghost↔live card swap (#781) or a
+     * card's live-state dot only flip those attributes — no element is
+     * added or removed, so childList alone would miss a card that got
+     * visibly taller or shorter without changing the DOM's shape. */
+    _observeContent() {
+        this._contentObserver.disconnect();
+        const el = this.segment === 'services' ? this.servicesCanvas : this.canvas;
+        this._contentObserver.observe(el, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden', 'class'] });
+    }
+
     _wireHandleDrag() {
         const handle = this.handle;
-        let dragging = false;
         let moved = false;
         let startY = 0;
         let startHeight = 0;
 
         const onMove = (e) => {
-            if (!dragging) return;
+            if (!this._dragging) return;
             const dy = e.clientY - startY;
             if (!moved && Math.abs(dy) <= CLICK_TOLERANCE_PX) return;
             moved = true;
@@ -148,14 +185,26 @@ class SessionHud {
             this._applyDragHeight(heightPx);
         };
 
-        const onUp = (e) => {
-            if (!dragging) return;
-            dragging = false;
+        // Shared teardown for both a normal release and an interrupted
+        // gesture (OS/browser-cancelled pointer capture, e.g. a touch
+        // scroll takeover or focus loss mid-drag). `_dragging` is no longer
+        // just a cosmetic flag — `_applyAutoHeight()` bails out while it's
+        // true — so a `pointerup` that never arrives must not leave it
+        // stuck forever, or auto-sizing silently stops for the rest of the
+        // page's life.
+        const endDrag = (e) => {
+            this._dragging = false;
             handle.classList.remove('dragging');
             this.drawer.classList.remove('dragging');
             handle.releasePointerCapture?.(e.pointerId);
             window.removeEventListener('pointermove', onMove);
             window.removeEventListener('pointerup', onUp);
+            window.removeEventListener('pointercancel', onCancel);
+        };
+
+        const onUp = (e) => {
+            if (!this._dragging) return;
+            endDrag(e);
 
             if (!moved) {
                 this.toggle();
@@ -171,10 +220,18 @@ class SessionHud {
             }
         };
 
+        // No reliable final position on a cancel — just drop the gesture in
+        // place (leave the drawer at its current height) rather than
+        // guessing a detent to snap to.
+        const onCancel = (e) => {
+            if (!this._dragging) return;
+            endDrag(e);
+        };
+
         handle.addEventListener('pointerdown', (e) => {
             if (e.button !== undefined && e.button !== 0) return;
             e.preventDefault();
-            dragging = true;
+            this._dragging = true;
             moved = false;
             startY = e.clientY;
             startHeight = this.open ? this.drawer.getBoundingClientRect().height : 0;
@@ -183,6 +240,7 @@ class SessionHud {
             handle.setPointerCapture?.(e.pointerId);
             window.addEventListener('pointermove', onMove);
             window.addEventListener('pointerup', onUp);
+            window.addEventListener('pointercancel', onCancel);
         });
     }
 
@@ -199,6 +257,41 @@ class SessionHud {
     _settle(detent) {
         this.detent = detent;
         this.toggle(true);
+    }
+
+    /** Natural (unclipped) content height of whichever header segment is
+     * currently visible — `scrollHeight` reports the full content size
+     * regardless of the container's own clipped/`overflow:auto` box, so this
+     * is accurate even while the drawer itself is shorter than its content. */
+    _contentHeightPx() {
+        const el = this.segment === 'services' ? this.servicesCanvas : this.canvas;
+        return el ? el.scrollHeight : 0;
+    }
+
+    /** Debounced entry point for content-driven mutations (MutationObserver,
+     * window resize) — coalesces a burst of DOM changes from one render pass
+     * into a single measure-and-apply. */
+    _scheduleAutoHeight() {
+        if (this._autoRaf !== null) return;
+        this._autoRaf = requestAnimationFrame(() => {
+            this._autoRaf = null;
+            this._applyAutoHeight();
+        });
+    }
+
+    /** Resize the open drawer to fit its current content, floored at
+     * DRAG_MIN_VH and capped at HALF_VH — the "auto-size as the floor, half
+     * stays the max" behavior (#802). No-op while closed, while grown to
+     * half for a mini-terminal (growToHalf owns the height then), while
+     * settled on the fixed half detent, or mid-drag (the user's gesture
+     * wins). */
+    _applyAutoHeight() {
+        if (!this.open || this.detent !== 'peek' || this._grownFromDetent !== null || this._dragging) return;
+        const headerPx = this.header ? this.header.getBoundingClientRect().height : 0;
+        const rawPx = headerPx + this._contentHeightPx();
+        const heightPx = clamp(rawPx, window.innerHeight * DRAG_MIN_VH, window.innerHeight * HALF_VH);
+        this.drawer.style.height = `${heightPx}px`;
+        this.handle.style.top = `${heightPx}px`;
     }
 
     /**
@@ -226,9 +319,10 @@ class SessionHud {
     }
 
     /**
-     * Auto-peek for a spawn (#780) — opens to the peek detent (~33vh) if
-     * currently closed. A no-op if already open: an open HUD means the user
-     * is already looking at it (or grew it to half for a mini-terminal), and
+     * Auto-peek for a spawn (#780) — opens to the peek detent (auto-sized to
+     * content, #802) if currently closed. A no-op if already open: an open
+     * HUD means the user is already looking at it (or grew it to half for a
+     * mini-terminal), and
      * a spawn shouldn't yank it to a different detent out from under them.
      * Returns whether it actually opened, so a caller knows whether it now
      * owns retracting the HUD again later.
@@ -271,26 +365,27 @@ class SessionHud {
             btn.classList.toggle('active', active);
             btn.setAttribute('aria-selected', String(active));
         });
-        if (segment !== 'services') return;
         // Reuse the sidebar's servicesSection singleton (SSOT for the
         // fetch/render/start-stop logic) — mount once into our own
         // container, then just re-render on every subsequent visit since
         // its onSessionsChanged subscription already keeps content live
         // while hidden.
-        if (!this._servicesMounted) {
-            this._servicesMounted = true;
-            servicesSection.mount(this.servicesCanvas);
-        } else {
-            servicesSection.refresh(this.servicesCanvas);
+        if (segment === 'services') {
+            if (!this._servicesMounted) {
+                this._servicesMounted = true;
+                servicesSection.mount(this.servicesCanvas);
+            } else {
+                servicesSection.refresh(this.servicesCanvas);
+            }
         }
+        this._observeContent();
+        this._scheduleAutoHeight();
     }
 
     // ─── State ──────────────────────────────────────────────────
 
     toggle(force = null) {
         const next = force ?? !this.open;
-        this.drawer.style.height = '';
-        this.handle.style.top = '';
         if (next) {
             this.drawer.classList.toggle('detent-half', this.detent === 'half');
             this.handle.classList.toggle('detent-half', this.detent === 'half');
@@ -299,10 +394,34 @@ class SessionHud {
             this.handle.classList.add('drawer-open');
             sidebar.close();
             if (scratchpad.open) scratchpad.toggle(false);
+            // 'half' is a fixed CSS-driven height (see .detent-half) — only
+            // 'peek' (auto-size) needs a JS-measured inline height applied.
+            // Scheduled rather than applied inline: some callers (e.g.
+            // session-hud-controller.js's showAll()) open the drawer BEFORE
+            // re-rendering the canvas for the new context, so measuring
+            // synchronously here would size the drawer to the stale,
+            // about-to-be-replaced content — deferring a frame lets that
+            // synchronous re-render land first.
+            if (this.detent === 'peek') {
+                this._scheduleAutoHeight();
+            } else {
+                this.drawer.style.height = '';
+                this.handle.style.top = '';
+            }
         } else {
+            this.drawer.style.height = '';
+            this.handle.style.top = '';
             this.open = false;
             this.drawer.classList.remove('open');
             this.handle.classList.remove('drawer-open');
+            // A card left expanded (growToHalf'd) when the drawer itself
+            // closes — e.g. Alt+P, or the sidebar/scratchpad's own
+            // mutually-exclusive close — never gets its matching
+            // restoreDetent() (that only fires when the CARD collapses).
+            // Left stale, _applyAutoHeight()'s grown-guard would silently
+            // no-op forever on every future peek-open. Closing the drawer
+            // is a clean boundary to drop that leftover bookkeeping.
+            this._grownFromDetent = null;
             this._closeListeners.forEach((fn) => fn());
         }
     }


### PR DESCRIPTION
## Summary
- The Session HUD drawer's "peek" detent now auto-sizes to its content instead of a fixed 33vh: measures the visible segment's (Sessions or Services) natural content height via a `MutationObserver`, floored at 12vh (`DRAG_MIN_VH`) and capped at 50vh (`HALF_VH`, the existing "half" ceiling).
- One card (just the orchestrator/main session) shrinks the drawer down; a deeper family tree (more depth rows) grows it, up to the cap — matches #802's spec.
- "half" stays a fixed, content-independent ceiling — reachable by dragging the handle past the midpoint, or programmatically via `growToHalf()`/`restoreDetent()` (mini-terminal open/close), both unchanged in contract.
- Scope: `agentwire/static/js/session-hud.js` (drawer height/detent logic) + `agentwire/static/css/desktop.css` (comments only, drawer/`.session-hud-*` section) — did not touch `topology-render.js` or ghost-card CSS (owned by a parallel worktree).

## Adversarial review (8-angle `/code-review high`, coverage-first)
Ran all 8 finder angles (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) in parallel, verified every candidate against the actual code, then fixed every confirmed correctness issue:

- **Ghost↔live card transitions missed** — the observer was `childList`-only, but a ghost card adopting back to live (#781) only flips `.hidden` on existing elements (no element added/removed) → added `attributes:true, attributeFilter:['hidden','class']`.
- **Observer watched both segments unconditionally** — wasted reflows when the hidden segment's content changed (e.g. Services list rebuilding on an unrelated TTS/audio event while Sessions is showing) → retargeted to only the currently-active segment, re-targeted on every segment switch.
- **Stale measurement on mini-terminal collapse** — `topology-render.js`'s `_collapseCard()` calls the dispose/`restoreDetent()` chain *before* removing the expand slot's DOM, so a synchronous measurement saw the still-mounted terminal and produced a visible double-hitch (shrink-then-shrink-more) — fixed by routing every peek-height application through the existing rAF-deferred `_scheduleAutoHeight()`, so measurement always happens after the same-tick DOM mutation completes.
- **Same root cause, different caller** — `session-hud-controller.js`'s `showAll()` opens the drawer *before* its own re-render populates the master tree; the defer-via-scheduler fix above resolves this too (no separate change needed).
- **Double computation on segment switch** — fixed by calling the scheduler once; its own pending-guard coalesces the explicit call with any MutationObserver-triggered one into a single measurement.
- **Stuck drag flag** — `_dragging` was promoted from a closure-local variable to instance state that gates auto-sizing, but no `pointercancel` handler existed; an interrupted drag (OS/browser-cancelled pointer capture) would leave it `true` forever, permanently disabling auto-size. Added `pointercancel` handling with shared teardown.
- **Stale grow-restore bookkeeping** — closing the HUD while a card's mini-terminal was still expanded (closing doesn't collapse the card) left `_grownFromDetent` non-null forever; reopening later via `peekForSpawn()` (forces `detent='peek'`) then silently no-op'd auto-sizing, wedging the drawer at the static 33vh CSS fallback until an unrelated future expand/collapse happened to clear it. Fixed by clearing it on drawer close.

**Dismissed, with rationale** (all lower-severity cleanup/design suggestions, not correctness bugs):
- Duplicated rAF-debounce shape vs. `topology-render.js`'s own `_scheduleRedraw` — real, but extracting a shared utility means touching `topology-render.js`, out of scope (owned by a parallel worktree this cycle).
- Repeated 2-line "set drawer height + handle top together" write across 3 call sites — true, minor; skipped to keep the diff focused on confirmed bugs.
- `PEEK_VH`'s name is now slightly stale (only anchors drag-release thresholds, doesn't render at that height) — addressed via a doc comment rather than a rename.
- Header height re-measured via `getBoundingClientRect()` on every auto-height pass instead of cached once — real micro-optimization, skipped as low-value against the added cache-invalidation complexity.
- `scrollHeight`-depends-on-current-CSS fragility (`overflow`/`min-height:0` on `.session-hud-canvas`) and the broader "DOM-mutation-watching is a fragile proxy for a real content-height hook" critique — legitimate forward-looking design notes; a proper fix would mean `topology-render.js`/`session-hud-controller.js` explicitly reporting height, which is a larger change than #802 needs and touches the parallel worktree's file. Worth a follow-up issue if it ever bites.
- Overlapping guard conditions in `_applyAutoHeight()` — harmless redundancy, not a bug; a full detent-mode-enum refactor is disproportionate here.

## Mechanical checks
- `node --check --input-type=module` on `session-hud.js` — passes
- CSS brace-balance check on `desktop.css` — balanced (1220/1220)
- No JS unit-test harness exists in this repo for frontend logic (no `package.json`/test runner); confirmed no Python test references `session-hud.js`.

## Test plan (for the orchestrator's one-tab e2e — do NOT run claude-in-chrome from this worktree)
1. Open the portal, focus a window with only the orchestrator/main session visible in its family tree, hit **Alt+P** — the drawer should open noticeably shorter than the old fixed 33vh (just enough for the header + one card row).
2. Spawn 2-3 child sessions (or open a session with several worker panes/worktrees) so the family tree grows deeper (more rows) — watch the drawer grow to fit, animating smoothly.
3. Keep spawning/growing a deep tree until content would exceed 50vh — confirm the drawer stops growing at the half-detent cap and the canvas scrolls internally for the rest.
4. Grab the pull handle and drag it past the midpoint — confirm it still snaps to the fixed "half" (50vh) detent as before, and dragging back up snaps to auto-size again (not a stale fixed height).
5. Click a card to open its mini-terminal — confirm the drawer grows to half (`growToHalf()`), then click again to collapse it — confirm it shrinks back smoothly to the auto-sized "peek" height with no visible double-hitch/stutter.
6. Switch the Sessions|Services header segment back and forth — confirm the drawer resizes appropriately for each segment's content (Services list is typically shorter).
7. Edge case: expand a card's mini-terminal, then press Alt+P to close the HUD *without* first collapsing the card, then reopen (Alt+P again, or trigger a new spawn) — confirm the drawer doesn't get stuck at a stale fixed height.

Closes #802

Built by [dotdev.dev](https://dotdev.dev)