### PR TITLE
fix(scheduler): unattended email allow + gate-skip visibility + worktree seed drift

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -185,9 +185,10 @@ tasks:
 **`unattended_allow`** (per-task): when the scheduler dispatches a task headless
 (`AGENTWIRE_UNATTENDED=1`), the damage-control hook resolves `ask`-tier commands
 by **failing closed** — block + email the owner — unless the matched rule id is
-on the allowlist. The default allowlist lets a task work and open a PR
-(`git.add`/`git.commit`/`git.push`/`gh.pr-create`); list extra rule ids here to
-permit a normally-gated action (deploy, DB write, outbound email) for **this task
+on the allowlist. The default allowlist lets a task work, open a PR, and email
+the owner (`git.add`/`git.commit`/`git.push`/`gh.pr-create`/`outbound.agentwire-email`
+— the last is a blanket allow, any recipient, #804); list extra rule ids here to
+permit a normally-gated action (deploy, DB write, outbound SMS) for **this task
 only**. Blocked actions name the exact rule id (in the email and `agentwire safety
 logs`) so widening is copy-paste. Hard blocks (`rm -rf`, `git push --force`) and
 interactive sessions are unaffected. See `docs/wiki/internals/damage-control.md`.

--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -13,6 +13,14 @@ from typing import Optional
 
 import yaml
 
+# Gitignored files a fresh git worktree needs seeded — a worktree can't load
+# its session/task config without them. Single source of truth: referenced
+# by WorktreesConfig's default below, the config-loading fallback further
+# down, AND worktree.py's mandatory (never-omittable) seed set (#803) — a
+# stale `copy_files:` in a user's config.yaml that predates one of these
+# being added here must not silently drop it from every fresh worktree.
+DEFAULT_WORKTREE_COPY_FILES = [".env", ".agentwire.yml", ".agentwire.tasks.yml"]
+
 
 def _get_default_agent_command() -> str:
     """Get the default agent command.
@@ -105,7 +113,7 @@ class WorktreesConfig:
     # tasks can't load their session/task config without them when the project
     # gitignores them (the latter is the protected, host-authored task-exec file —
     # #720).
-    copy_files: list = field(default_factory=lambda: [".env", ".agentwire.yml", ".agentwire.tasks.yml"])
+    copy_files: list = field(default_factory=lambda: list(DEFAULT_WORKTREE_COPY_FILES))
 
 
 @dataclass
@@ -623,7 +631,7 @@ def _dict_to_config(data: dict) -> Config:
         enabled=worktrees_data.get("enabled", True),
         suffix=worktrees_data.get("suffix", "-worktrees"),
         auto_create_branch=worktrees_data.get("auto_create_branch", True),
-        copy_files=worktrees_data.get("copy_files", [".env", ".agentwire.yml", ".agentwire.tasks.yml"]),
+        copy_files=worktrees_data.get("copy_files", list(DEFAULT_WORKTREE_COPY_FILES)),
     )
     projects = ProjectsConfig(
         dir=projects_data.get("dir", "~/projects"),

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -19,6 +19,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from .core import (
@@ -475,6 +476,75 @@ def _render_shim_liveness_section() -> int:
     return len(dead)
 
 
+def _scheduler_daemon_started_at() -> float | None:
+    """Epoch seconds the scheduler daemon process started, or ``None`` if not running.
+
+    Reads the daemon's own self-reported ``started_at`` from the live-state
+    file it already writes every loop tick (``scheduler/loop.py`` ->
+    ``_write_live_state`` -> ``read_live_state()``) rather than reimplementing
+    process-start-time discovery via ``ps``/``pgrep`` PID matching, which is
+    both platform-fragile (``ps`` elapsed-time output format varies) and
+    ambiguous if a stray/duplicate daemon process happens to be running.
+    ``tmux_session_exists`` confirms the daemon is actually alive, so a
+    leftover live-state file from a since-stopped daemon doesn't produce a
+    false "stale" reading.
+    """
+    from .scheduler import SCHEDULER_SESSION, read_live_state
+
+    if not tmux_session_exists(SCHEDULER_SESSION):
+        return None
+    state = read_live_state()
+    if not state:
+        return None
+    started_at = state.get("started_at")
+    if not started_at:
+        return None
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(started_at).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _newest_installed_source_mtime(pkg_dir: Path | None = None) -> float:
+    """Newest mtime among the installed ``agentwire`` package's ``.py`` files."""
+    if pkg_dir is None:
+        pkg_dir = Path(__file__).resolve().parent
+    try:
+        return max((f.stat().st_mtime for f in pkg_dir.rglob("*.py")), default=0.0)
+    except Exception:
+        return 0.0
+
+
+def _render_scheduler_staleness_section() -> int:
+    """Doctor section: flag a scheduler daemon older than the installed code (#803).
+
+    ``agentwire scheduler serve`` is a long-running Python process — like the
+    MCP server, it imports its modules once at start and never re-reads them.
+    ``agentwire rebuild`` updates the on-disk package but can't touch an
+    already-running interpreter's loaded bytecode, so a daemon that has been
+    up since before the last rebuild is silently executing stale dispatch
+    logic: any bug fixed since then stays live in production until the
+    daemon is restarted.
+    """
+    started_at = _scheduler_daemon_started_at()
+    if started_at is None:
+        print("  [..] Scheduler daemon not running — skipping staleness check")
+        return 0
+
+    newest_src = _newest_installed_source_mtime()
+    if not newest_src or newest_src <= started_at:
+        print("  [ok] Scheduler daemon is current with the installed package")
+        return 0
+
+    age_days = (time.time() - started_at) / 86400
+    print(f"  [!!] Scheduler daemon has been running {age_days:.1f}d — "
+          "predates the most recent `agentwire rebuild`")
+    print("       Any dispatch bug fixed since then is still live in the running daemon.")
+    print("       Fix: agentwire scheduler stop && agentwire scheduler start")
+    return 1
+
+
 def cmd_doctor(args) -> int:
     """Auto-diagnose and fix common issues."""
     from .hooks_cli import _managed_file_state, _managed_hook_files, get_hooks_source
@@ -652,6 +722,14 @@ def cmd_doctor(args) -> int:
             issues_found += 1
         else:
             print("  [ok] Local main up to date with origin/main")
+
+    # 4d. Scheduler daemon staleness — the daemon is a long-running process
+    # that never re-imports its code, so it can silently run a dispatch bug
+    # that's since been fixed on disk (#803). Distinct from the git-drift
+    # check above: that flags an out-of-date CHECKOUT, this flags a
+    # currently-running PROCESS that predates the last install.
+    print("\nChecking scheduler daemon freshness...")
+    issues_found += _render_scheduler_staleness_section()
 
     # Check custom services (registry-driven: built-in notifications bridge
     # + user-defined services from services.custom)

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -613,8 +613,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -629,6 +629,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -609,8 +609,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -625,6 +625,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -621,8 +621,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -637,6 +637,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -615,8 +615,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -631,6 +631,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -608,8 +608,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -624,6 +624,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -577,8 +577,8 @@ def load_config(
 # dispatch by the scheduler), the hook resolves ``ask`` by FAILING CLOSED:
 # block + notify the owner, UNLESS the matched rule's stable ID is on the
 # allowlist. The allowlist is the union of:
-#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (tight — work + open a PR, nothing
-#      irreversible or outward-facing),
+#   1. ``DEFAULT_UNATTENDED_ALLOW`` below (work + open a PR + notify the owner
+#      by email — nothing else irreversible or outward-facing),
 #   2. ``safety.unattended_allow`` from global / project config,
 #   3. ``AGENTWIRE_UNATTENDED_ALLOW`` (comma-separated) — the per-task
 #      extension the scheduler stamps from a task's ``unattended_allow``.
@@ -593,6 +593,7 @@ DEFAULT_UNATTENDED_ALLOW = {
     "git.commit",    # commit
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
+    "outbound.agentwire-email",  # blanket allow, any recipient (#804)
 }
 
 

--- a/agentwire/scheduler/gates.py
+++ b/agentwire/scheduler/gates.py
@@ -46,7 +46,25 @@ def _check_gate(board, task_name: str) -> bool:
     project = task.project
 
     def _gate_skip(gate_type: str, reason: str, **extra):
-        """Record a gate skip, only logging on first occurrence."""
+        """Record a gate skip. Logs only on first occurrence (spam control),
+        but persists ``last_gate_skip`` on every REASON CHANGE.
+
+        Distinct from ``_gate_error`` below: this is the CLEAN "not ready
+        yet" path (e.g. a ``command`` gate legitimately returning nonzero),
+        not an exception. Recorded so the board can show "waiting on gate"
+        instead of reading as silently-falling-behind overdue (#803).
+        Persisting on reason-change (not just first-occurrence, which
+        ``_gated_tasks`` alone gates) matters for multi-condition gates: if
+        task's blocker shifts from ``git_commit`` to ``command`` without the
+        gate ever fully passing in between, ``task_name`` never leaves
+        ``_gated_tasks``, so a first-occurrence-only write would leave the
+        board showing the ORIGINAL, now-stale reason.
+        """
+        skip_text = f"{gate_type}: {reason}"
+        if state.last_gate_skip != skip_text:
+            state.last_gate_skip = skip_text
+            board.state[task_name] = state
+            _sched.save_board(board)
         if task_name not in _gated_tasks:
             _sched._log_event("task_gated", task=task_name, gate_type=gate_type,
                               reason=reason, **extra)
@@ -69,6 +87,7 @@ def _check_gate(board, task_name: str) -> bool:
             print(f"[{_ts()}] Gate error on {task_name}: {gate_type} "
                   f"({reason}) — failing open")
             state.last_gate_error = f"{gate_type}: {reason}"
+            state.last_gate_skip = ""  # failing open — no longer "waiting on gate"
             board.state[task_name] = state
             _sched.save_board(board)
         _gated_tasks.discard(task_name)
@@ -131,16 +150,20 @@ def _check_gate(board, task_name: str) -> bool:
 
 
 def _clear_gate_error(board, task_name: str) -> None:
-    """Clear a previously-recorded gate error once the gate evaluates cleanly.
+    """Clear a previously-recorded gate error/skip once the gate evaluates cleanly.
 
-    No-op (and no board write) unless this task actually had an error, so
-    the common clean path stays cheap.
+    No-op (and no board write) unless this task actually had something
+    recorded, so the common clean path stays cheap. Clears BOTH
+    ``last_gate_error`` (exception path) and ``last_gate_skip`` (clean
+    "not ready yet" path, #803) — both are stale the moment the gate passes.
     """
     from agentwire import scheduler as _sched
 
     state = board.state.get(task_name)
     had_tracked = _gate_errored.pop(task_name, None) is not None
-    if had_tracked or (state is not None and state.last_gate_error):
-        if state is not None and state.last_gate_error:
+    had_state = state is not None and (state.last_gate_error or state.last_gate_skip)
+    if had_tracked or had_state:
+        if state is not None and (state.last_gate_error or state.last_gate_skip):
             state.last_gate_error = ""
+            state.last_gate_skip = ""
             _sched.save_board(board)

--- a/agentwire/scheduler/models.py
+++ b/agentwire/scheduler/models.py
@@ -89,6 +89,7 @@ class TaskState:
     run_count: int = 0
     last_summary: str = ""
     last_gate_error: str = ""     # last gate-eval exception reason (failed open)
+    last_gate_skip: str = ""      # currently-blocking gate reason (clean skip, not an error)
     last_gate_commit: str = ""    # HEAD at last dispatch (for gate checks)
     last_dispatch: datetime | None = None  # set BEFORE running (restart safety)
     # Active worktree-PR tracking (set on finalize, cleared by the reaper on

--- a/agentwire/scheduler/report.py
+++ b/agentwire/scheduler/report.py
@@ -199,6 +199,8 @@ def get_board_display(board: Board) -> list[dict]:
             row["last_summary"] = state.last_summary
         if state.last_gate_error:
             row["last_gate_error"] = state.last_gate_error
+        if state.last_gate_skip:
+            row["last_gate_skip"] = state.last_gate_skip
         rows.append(row)
 
     # Sort: enabled first, then by overdue (most overdue first)

--- a/agentwire/scheduler/state.py
+++ b/agentwire/scheduler/state.py
@@ -112,6 +112,7 @@ def load_board() -> Board:
                 run_count=int(s.get("run_count", 0)),
                 last_summary=str(s.get("last_summary", "")),
                 last_gate_error=str(s.get("last_gate_error", "")),
+                last_gate_skip=str(s.get("last_gate_skip", "")),
                 last_gate_commit=str(s.get("last_gate_commit", "")),
                 last_dispatch=_parse_datetime_field(s.get("last_dispatch")),
                 worktree_branch=str(s.get("worktree_branch", "")),
@@ -163,6 +164,8 @@ def _state_to_dict(board: Board) -> dict:
             entry["last_summary"] = s.last_summary
         if s.last_gate_error:
             entry["last_gate_error"] = s.last_gate_error
+        if s.last_gate_skip:
+            entry["last_gate_skip"] = s.last_gate_skip
         if s.last_gate_commit:
             entry["last_gate_commit"] = s.last_gate_commit
         if s.last_dispatch:

--- a/agentwire/scheduler_cli.py
+++ b/agentwire/scheduler_cli.py
@@ -148,7 +148,7 @@ def _recent_activity(events: list[dict], limit: int = 5) -> list[dict]:
     glance at `scheduler status` shows recent results — including the
     fail-open gate errors that used to vanish entirely.
     """
-    keep = {"task_completed", "task_failed", "gate_error"}
+    keep = {"task_completed", "task_failed", "gate_error", "task_gated"}
     out: list[dict] = []
     for evt in reversed(events):
         etype = evt.get("event")
@@ -165,6 +165,8 @@ def _recent_activity(events: list[dict], limit: int = 5) -> list[dict]:
             detail = f"{status}" + (f" — {summary}" if summary else "")
         elif etype == "task_failed":
             detail = "failed — " + (evt.get("summary") or evt.get("reason") or "?")
+        elif etype == "task_gated":
+            detail = f"[gated] {evt.get('gate_type', '?')}: {evt.get('reason', '?')}"
         else:  # gate_error
             detail = f"[gate-error] {evt.get('gate_type', '?')}: {evt.get('reason', '?')}"
         if len(detail) > 80:
@@ -254,10 +256,14 @@ def cmd_scheduler_board(args) -> int:
             )
 
             # Surface WHY: a gate-eval error (fail-open, would otherwise be
-            # invisible) takes precedence; else the summary behind a bad status.
+            # invisible) takes precedence; then a currently-blocking gate
+            # (so "+4h11m" reads as "waiting on gate", not silently falling
+            # behind, #803); else the summary behind a bad status.
             detail = ""
             if r.get("last_gate_error"):
                 detail = f"[gate-error] {r['last_gate_error']}"
+            elif r.get("last_gate_skip"):
+                detail = f"[gated] {r['last_gate_skip']}"
             elif status_str in _BAD_STATUSES and r.get("last_summary"):
                 detail = r["last_summary"]
             if detail:

--- a/agentwire/static/js/sidebar/scheduler-section.js
+++ b/agentwire/static/js/sidebar/scheduler-section.js
@@ -99,8 +99,13 @@ export const schedulerSection = {
 
         // Overdue meta: real "+13h12m" string once it's run before; a plain
         // "due" badge for never-run tasks (their overdue_str is epoch garbage).
+        // A task with a currently-blocking gate (e.g. "run only when the CC
+        // version changes") reads as "gated", not "overdue" — it's waiting on
+        // a precondition by design, not silently falling behind (#803).
         let meta = '';
-        if (enabled && !isCurrent && obj.overdue_by > 0) {
+        if (enabled && !isCurrent && obj.last_gate_skip) {
+            meta = `<span class="sidebar-list-item-meta" title="${_escape(obj.last_gate_skip)}">gated</span>`;
+        } else if (enabled && !isCurrent && obj.overdue_by > 0) {
             meta = obj.last_run_iso
                 ? `<span class="sidebar-list-item-meta overdue">${_escape(obj.overdue_str || 'overdue')}</span>`
                 : `<span class="sidebar-list-item-meta">due</span>`;

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -240,11 +240,20 @@ def _seed_worktree_files(
     `git worktree add` only checks out tracked files — untracked/ignored
     files like .env, .env.local, or local config never come along, so an
     agent working in the worktree can't authenticate. Copy a configured
-    seed list (relative paths) from the main repo. Best-effort: missing
-    sources are skipped and copy errors are swallowed. Files that are
-    gitignored in the repo stay ignored in the worktree, so they're never
-    committed.
+    seed list (relative paths) from the main repo, always including
+    :data:`config.DEFAULT_WORKTREE_COPY_FILES` regardless of what the
+    resolved `copy_files` says — a `config.yaml` written before
+    `.agentwire.tasks.yml` split out of `.agentwire.yml` (#720) can carry a
+    stale, narrower override (e.g. just `[.env, .agentwire.yml]`) that
+    silently drops the newer file, and every worktree-dispatched scheduled
+    task then fails with "No .agentwire.tasks.yml found" (#803).
+    `copy_files` can only extend this mandatory set, never shrink it.
+    Best-effort: missing sources are skipped and copy errors are swallowed.
+    Files that are gitignored in the repo stay ignored in the worktree, so
+    they're never committed.
     """
+    from .config import DEFAULT_WORKTREE_COPY_FILES
+
     if copy_files is None:
         try:
             from .config import load_config
@@ -252,9 +261,11 @@ def _seed_worktree_files(
         except Exception:
             copy_files = []
 
+    seed_files = list(dict.fromkeys([*DEFAULT_WORKTREE_COPY_FILES, *(copy_files or [])]))
+
     import shutil
 
-    for rel in copy_files or []:
+    for rel in seed_files:
         src = project_path / rel
         dst = worktree_path / rel
         if not src.exists() or dst.exists():

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -359,7 +359,7 @@ unattended gate is inert too (enable safety for scheduled projects to engage it)
 
 | Source | Where | Scope |
 |--------|-------|-------|
-| `DEFAULT_UNATTENDED_ALLOW` | `safety/_core.py` | Built-in: `git.add`, `git.add-u`, `git.commit`, `git.push`, `gh.pr-create` — work + open a PR, nothing irreversible or outward-facing |
+| `DEFAULT_UNATTENDED_ALLOW` | `safety/_core.py` | Built-in: `git.add`, `git.add-u`, `git.commit`, `git.push`, `gh.pr-create`, `outbound.agentwire-email` — work + open a PR + notify the owner by email |
 | `unattended_allow` | `~/.agentwire/damagecontrol.yml` / project `.damagecontrol.yml` | Global / per-project extension (list of rule ids) |
 | `unattended_allow` | per-task in `.agentwire.tasks.yml` | Per-task extension — the pressure-relief valve: widen for one task instead of loosening the global default |
 
@@ -372,6 +372,18 @@ description edits.
 When a command is blocked, the owner email and `agentwire safety logs` name the
 exact rule id, so widening is copy-paste: add that id to the task's
 `unattended_allow`.
+
+**`agentwire email` is a blanket unattended-allow, by design (#804).** Emailing
+the owner is the *primary* way an unattended agent reports back — fail-closed
+blocking it defeats the use case (a scheduled review silently never reaches the
+owner). `outbound.agentwire-email` is on `DEFAULT_UNATTENDED_ALLOW`
+unconditionally: **any** `--to`, not just the owner's own address. A narrower
+owner-address-only exemption was considered and rejected — the owner explicitly
+accepted the exfil tradeoff in favor of the simpler blanket allow. `agentwire
+quo` (SMS) is unaffected and still fails closed unattended; widen it per-task
+via `unattended_allow` (`outbound.agentwire-quo`) same as any other verb. This
+applies identically to the Bash shell-out and the `email_send` MCP tool (both
+resolve through the same `resolve_unattended_allow`).
 
 ```yaml
 # project .agentwire.tasks.yml — let ONE scheduled task run terraform apply unattended
@@ -414,7 +426,8 @@ catastrophic, never-reversible verbs are `block` (fire in every mode).
 | **Deploy — containers** | `kubectl apply` | ask | kubectl tooldef |
 | | `docker push`, `docker compose push` | ask | `containers.yaml` (`container.docker-push`) |
 | **Deploy — CI/release** | `gh release create`, `gh workflow run`, `gh pr merge` | ask | gh tooldef |
-| **Outbound comms** | `agentwire email`, `agentwire quo`, `twilio … messages create`, `aws ses send-email`, `aws sns publish`, `sendmail`, `mail -s` | ask | `outbound.yaml` (`outbound.*`) |
+| **Outbound comms** | `agentwire email` | ask (unattended-allowed by default, #804) | `outbound.yaml` (`outbound.agentwire-email`) |
+| | `agentwire quo`, `twilio … messages create`, `aws ses send-email`, `aws sns publish`, `sendmail`, `mail -s` | ask | `outbound.yaml` (`outbound.*`) |
 | **DB migrations** | `prisma migrate deploy`/`dev`, `prisma db push`, `supabase db push`, `supabase migration up`, `alembic upgrade`/`downgrade`, `manage.py migrate`, `rails`/`rake db:migrate`, `knex migrate:*`, `sequelize db:migrate`, `flyway migrate`, `liquibase update` | ask | `databases.yaml` (`db.*`) |
 | **DB raw writes** | `psql`/`mysql` executing INSERT/UPDATE/ALTER/CREATE/GRANT, `mongosh` insert/update/delete | ask | `databases.yaml` (`db.psql-write`, `db.mysql-write`, `db.mongosh-write`) |
 | **DB schema-drop** | `prisma migrate reset`, `flyway clean` | **block** | `databases.yaml` (`db.prisma-reset`, `db.flyway-clean`) |
@@ -424,8 +437,9 @@ catastrophic, never-reversible verbs are `block` (fire in every mode).
 
 **Allowlisting a covered verb for one task** — the block message and owner email
 name the exact rule id, so widening is copy-paste into the task's
-`unattended_allow` (e.g. `deploy.vercel`, `outbound.agentwire-email`,
-`db.prisma-migrate`).
+`unattended_allow` (e.g. `deploy.vercel`, `outbound.agentwire-quo`,
+`db.prisma-migrate`). `outbound.agentwire-email` doesn't need this — it's
+already on `DEFAULT_UNATTENDED_ALLOW`.
 
 **Residual gaps (intentional / known):**
 
@@ -469,9 +483,10 @@ hook gates them:
   `scripts/regen_damage_control_hooks.py` like the other three — never hand-edit
   between the GENERATED markers.
 
-Effect: an unattended scheduler dispatch can no longer send irreversible
-email/SMS silently, and an attended session now gets a real `ask` prompt instead
-of zero friction.
+Effect: an unattended scheduler dispatch can no longer send SMS silently (email
+is a deliberate exception — see the blanket-unattended-allow discussion above,
+#804), and an attended session now gets a real `ask` prompt instead of zero
+friction.
 
 ### MCP surface audit — what is gated vs left open
 

--- a/tests/integration/test_scheduler_board.py
+++ b/tests/integration/test_scheduler_board.py
@@ -124,6 +124,28 @@ class TestSchedulerBoardRoundTrip:
         assert board2.tasks["code-quality"].schedule.every == "1h"
         assert board2.tasks["doc-drift"].filler is True
 
+    def test_last_gate_skip_round_trips_and_surfaces_on_board(self, board_env):
+        # A currently-blocking gate (#803) must persist across save/load and
+        # surface on the board display so it reads as "waiting on gate", not
+        # silently-falling-behind overdue.
+        board = load_board()
+        board.state["code-quality"] = TaskState(
+            last_status="never",
+            last_gate_skip="command: exit 1",
+        )
+        save_board(board)
+
+        board2 = load_board()
+        assert board2.state["code-quality"].last_gate_skip == "command: exit 1"
+
+        row = next(r for r in get_board_display(board2) if r["name"] == "code-quality")
+        assert row["last_gate_skip"] == "command: exit 1"
+
+    def test_last_gate_skip_absent_when_not_gated(self, board_env):
+        board = load_board()
+        row = next(r for r in get_board_display(board) if r["name"] == "code-quality")
+        assert "last_gate_skip" not in row
+
 
 # Pure parser tests for _parse_duration / _parse_time / _day_matches live in
 # tests/unit/test_scheduler_parsing.py — they have no scheduler-board state

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -358,6 +358,15 @@ class TestUnattendedAllowlist:
         allow = bash_hook.resolve_unattended_allow({"safety": {}})
         assert {"task.rule-a", "task.rule-b"} <= allow
 
+    def test_default_allowlist_covers_agentwire_email(self, bash_hook, monkeypatch):
+        # `agentwire email` is a blanket unattended-allow (#804) — the primary
+        # way an unattended agent reports back, so fail-closed blocking it
+        # defeats the use case. `agentwire quo` (SMS) is deliberately NOT here.
+        monkeypatch.delenv("AGENTWIRE_UNATTENDED_ALLOW", raising=False)
+        allow = bash_hook.resolve_unattended_allow({"safety": {}})
+        assert "outbound.agentwire-email" in allow
+        assert "outbound.agentwire-quo" not in allow
+
 
 class TestUnattendedSubprocess:
     """End-to-end exit codes for the unattended ask resolution (#401)."""
@@ -414,6 +423,19 @@ class TestUnattendedSubprocess:
             allow_env="tooldef.github-cli-merge-a-pull-request",
         )
         assert proc.returncode == 0
+
+    def test_email_any_recipient_allowed_when_unattended(self):
+        # outbound.agentwire-email is a blanket unattended-allow (#804) — ANY
+        # recipient, not just the owner's own address (owner-accepted tradeoff).
+        proc = self._run("agentwire email --to anyone@example.com", unattended=True)
+        assert proc.returncode == 0
+
+    def test_quo_still_blocks_when_unattended(self):
+        # agentwire quo (SMS) is a separate outbound channel and unaffected —
+        # still fails closed unless explicitly allowlisted.
+        proc = self._run("agentwire quo --to +15551234567", unattended=True)
+        assert proc.returncode == 2
+        assert "outbound.agentwire-quo" in proc.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -738,15 +760,16 @@ class TestMcpHookSubprocess:
         proc = self._run("mcp__agentwire__say", {"text": "hi"})
         assert proc.returncode == 0
 
-    def test_email_unattended_not_allowlisted_blocks(self):
+    def test_email_unattended_allowed_by_default(self):
+        # outbound.agentwire-email is a blanket unattended-allow (#804) — no
+        # unattended_allow entry needed, and ANY recipient (owner-accepted
+        # tradeoff), not just the owner's own address.
         proc = self._run(
             "mcp__agentwire__email_send",
-            {"body": "x", "to": "a@b.com", "subject": "s"},
+            {"body": "x", "to": "someone-else@example.com", "subject": "s"},
             unattended=True,
         )
-        assert proc.returncode == 2
-        assert "unattended" in proc.stderr.lower()
-        assert "outbound.agentwire-email" in proc.stderr
+        assert proc.returncode == 0
 
     def test_quo_unattended_not_allowlisted_blocks(self):
         proc = self._run(
@@ -755,13 +778,7 @@ class TestMcpHookSubprocess:
         )
         assert proc.returncode == 2
         assert "unattended" in proc.stderr.lower()
-
-    def test_email_unattended_allowlisted_proceeds(self):
-        proc = self._run(
-            "mcp__agentwire__email_send", {"body": "x", "to": "a@b.com"},
-            unattended=True, allow_env="outbound.agentwire-email",
-        )
-        assert proc.returncode == 0
+        assert "outbound.agentwire-quo" in proc.stderr
 
     def test_quo_unattended_allowlisted_proceeds(self):
         proc = self._run(

--- a/tests/unit/test_doctor_scheduler_staleness.py
+++ b/tests/unit/test_doctor_scheduler_staleness.py
@@ -1,0 +1,109 @@
+"""Tests for the doctor scheduler-daemon-staleness check (#803).
+
+`agentwire scheduler serve` is a long-running Python process that imports
+its modules once at start — `agentwire rebuild` updates the on-disk package
+but can't touch an already-running interpreter's loaded bytecode. A daemon
+that predates the last rebuild silently runs stale dispatch logic. Doctor
+must surface exactly that state.
+"""
+
+import time
+from unittest.mock import patch
+
+from agentwire.doctor_cli import (
+    _newest_installed_source_mtime,
+    _render_scheduler_staleness_section,
+    _scheduler_daemon_started_at,
+)
+
+
+class TestSchedulerDaemonStartedAt:
+    def test_not_running_returns_none(self):
+        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=False):
+            assert _scheduler_daemon_started_at() is None
+
+    def test_running_but_no_live_state_returns_none(self):
+        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
+             patch("agentwire.scheduler.read_live_state", return_value=None):
+            assert _scheduler_daemon_started_at() is None
+
+    def test_running_but_no_started_at_field_returns_none(self):
+        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
+             patch("agentwire.scheduler.read_live_state", return_value={"status": "running"}):
+            assert _scheduler_daemon_started_at() is None
+
+    def test_running_reads_started_at_from_live_state(self):
+        from datetime import datetime, timedelta, timezone
+        started = datetime.now(timezone.utc) - timedelta(hours=1)
+        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
+             patch("agentwire.scheduler.read_live_state",
+                   return_value={"started_at": started.isoformat()}):
+            result = _scheduler_daemon_started_at()
+        assert result is not None
+        assert abs(result - started.timestamp()) < 1
+
+    def test_unparseable_started_at_returns_none(self):
+        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
+             patch("agentwire.scheduler.read_live_state",
+                   return_value={"started_at": "not-a-date"}):
+            assert _scheduler_daemon_started_at() is None
+
+
+class TestNewestInstalledSourceMtime:
+    def test_finds_newest_py_file(self, tmp_path):
+        old = tmp_path / "a.py"
+        old.write_text("x = 1\n")
+        new = tmp_path / "sub" / "b.py"
+        new.parent.mkdir()
+        new.write_text("y = 2\n")
+
+        import os
+        old_time = time.time() - 100
+        new_time = time.time()
+        os.utime(old, (old_time, old_time))
+        os.utime(new, (new_time, new_time))
+
+        result = _newest_installed_source_mtime(tmp_path)
+        assert abs(result - new_time) < 1
+
+    def test_empty_dir_returns_zero(self, tmp_path):
+        assert _newest_installed_source_mtime(tmp_path) == 0.0
+
+    def test_missing_dir_returns_zero(self, tmp_path):
+        assert _newest_installed_source_mtime(tmp_path / "nope") == 0.0
+
+
+class TestRenderSchedulerStalenessSection:
+    def test_daemon_not_running(self, capsys):
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=None):
+            count = _render_scheduler_staleness_section()
+        assert count == 0
+        assert "not running" in capsys.readouterr().out
+
+    def test_daemon_current(self, capsys):
+        now = time.time()
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=now), \
+             patch("agentwire.doctor_cli._newest_installed_source_mtime", return_value=now - 100):
+            count = _render_scheduler_staleness_section()
+        assert count == 0
+        assert "[ok]" in capsys.readouterr().out
+
+    def test_daemon_stale_flags_and_suggests_restart(self, capsys):
+        started_at = time.time() - (11 * 86400)  # 11 days ago
+        newest_src = time.time() - 3600           # rebuilt an hour ago
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=started_at), \
+             patch("agentwire.doctor_cli._newest_installed_source_mtime", return_value=newest_src):
+            count = _render_scheduler_staleness_section()
+        out = capsys.readouterr().out
+        assert count == 1
+        assert "[!!]" in out
+        assert "11.0d" in out
+        assert "agentwire scheduler stop && agentwire scheduler start" in out
+
+    def test_no_installed_source_found_treated_as_ok(self, capsys):
+        # newest_src == 0.0 (couldn't determine) — don't false-positive.
+        now = time.time()
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=now), \
+             patch("agentwire.doctor_cli._newest_installed_source_mtime", return_value=0.0):
+            count = _render_scheduler_staleness_section()
+        assert count == 0

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -61,6 +61,22 @@ class TestCheckGate:
     True so the task can run.
     """
 
+    @pytest.fixture(autouse=True)
+    def _no_real_board_write(self):
+        # A gate skip now persists `last_gate_skip` (#803) — patch save_board
+        # so these pure decision-logic tests never touch the real
+        # ~/.agentwire/scheduler-state.yaml (same hazard TestGateError already
+        # guards against for the gate-error path). Also reset the module-level
+        # `_gated_tasks` dedup set: it's keyed by task name ("t", shared by
+        # every test in this class) and only the FIRST transition into a
+        # gated state writes `last_gate_skip` — a leftover entry from an
+        # earlier test would silently skip that write here too.
+        import agentwire.scheduler as sched
+        sched._gated_tasks.clear()
+        with patch("agentwire.scheduler.save_board"):
+            yield
+        sched._gated_tasks.clear()
+
     @pytest.fixture
     def git_project(self, tmp_path):
         """Initialize a git repo with one commit; return the path."""
@@ -170,6 +186,56 @@ class TestCheckGate:
         board.tasks["t"].gate = {"git_commit": True, "command": "false"}
         assert _check_gate(board, "t") is False
 
+    def test_command_gate_skip_records_last_gate_skip(self, board, git_project):
+        # A clean "not ready yet" skip (distinct from a gate-eval exception)
+        # is recorded on state so the board can show it instead of reading
+        # as silently-falling-behind overdue (#803).
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "false"}
+        assert _check_gate(board, "t") is False
+        assert "command" in board.state["t"].last_gate_skip
+        assert "exit 1" in board.state["t"].last_gate_skip
+
+    def test_gate_pass_clears_last_gate_skip(self, board, git_project):
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "false"}
+        _check_gate(board, "t")
+        assert board.state["t"].last_gate_skip
+
+        board.tasks["t"].gate = {"command": "true"}
+        assert _check_gate(board, "t") is True
+        assert board.state["t"].last_gate_skip == ""
+
+    def test_no_gate_clears_stale_last_gate_skip(self, board, git_project):
+        # Removing the gate entirely (not just satisfying it) must also
+        # clear a stale skip note — same "gate no longer blocking" outcome.
+        from agentwire.scheduler import _check_gate
+        board.tasks["t"].gate = {"command": "false"}
+        _check_gate(board, "t")
+        assert board.state["t"].last_gate_skip
+
+        board.tasks["t"].gate = None
+        assert _check_gate(board, "t") is True
+        assert board.state["t"].last_gate_skip == ""
+
+    def test_gate_skip_reason_updates_when_blocker_changes(self, board, git_project):
+        # Multi-condition gate: the blocker shifts from git_commit to
+        # command WITHOUT the gate ever fully passing in between, so
+        # `_gated_tasks` (the log-spam dedup) never clears. The board must
+        # still track the CURRENT blocker, not the original one.
+        from agentwire.scheduler import _check_gate
+        old = self._head(git_project)
+        board.state["t"].last_gate_commit = old
+        board.tasks["t"].gate = {"git_commit": True, "command": "false"}
+
+        assert _check_gate(board, "t") is False
+        assert "git_commit" in board.state["t"].last_gate_skip
+
+        self._new_commit(git_project)  # git_commit now passes; command still fails
+        assert _check_gate(board, "t") is False
+        assert "command" in board.state["t"].last_gate_skip
+        assert "git_commit" not in board.state["t"].last_gate_skip
+
 
 # --- _check_gate: gate-eval errors surface instead of vanishing ---
 
@@ -244,6 +310,23 @@ class TestGateError:
         with patch("agentwire.scheduler.save_board"):
             assert _check_gate(board, "t") is True
         assert board.state["t"].last_gate_error == ""
+
+    def test_error_clears_stale_last_gate_skip(self, board):
+        # A gate that was previously a clean skip (#803) and now errors
+        # fails open (task runs) — a leftover "waiting on gate" note would
+        # be actively misleading once the task is about to dispatch.
+        import subprocess
+        from unittest.mock import patch
+
+        from agentwire.scheduler import _check_gate
+
+        board.state["t"].last_gate_skip = "command: exit 1"
+        boom = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        with patch("agentwire.scheduler.subprocess.run", side_effect=boom), \
+             patch("agentwire.scheduler.save_board"), \
+             patch("agentwire.scheduler._log_event"):
+            assert _check_gate(board, "t") is True
+        assert board.state["t"].last_gate_skip == ""
 
 
 # --- _EXIT_TO_STATUS mapping ---

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -245,6 +245,33 @@ class TestWorktreeSeeding:
         assert ensure_worktree(repo, "f3", wt, copy_files=["secret.env"])
         assert not (wt / "secret.env").exists()
 
+    def test_mandatory_files_seeded_even_when_copy_files_omits_them(self, tmp_path):
+        # #803: a config.yaml written before the #720 task-file split can
+        # carry a stale `copy_files: [.env, .agentwire.yml]` that predates
+        # `.agentwire.tasks.yml` — every worktree-dispatched scheduled task
+        # then fails with "No .agentwire.tasks.yml found". These three are
+        # mandatory regardless of what the configured list says.
+        repo, git = self._repo(tmp_path)
+        (repo / ".env").write_text("API_KEY=abc\n")
+        (repo / ".agentwire.yml").write_text("posture: bypass\n")
+        (repo / ".agentwire.tasks.yml").write_text("tasks:\n  x:\n    prompt: hi\n")
+
+        wt = tmp_path / "repo-worktrees" / "f4"
+        # Stale/narrow copy_files — omits .agentwire.tasks.yml entirely.
+        assert ensure_worktree(repo, "f4", wt, copy_files=[".env", ".agentwire.yml"])
+
+        assert (wt / ".env").read_text() == "API_KEY=abc\n"
+        assert (wt / ".agentwire.yml").read_text() == "posture: bypass\n"
+        assert (wt / ".agentwire.tasks.yml").exists()
+
+    def test_mandatory_files_seeded_with_empty_copy_files(self, tmp_path):
+        repo, git = self._repo(tmp_path)
+        (repo / ".agentwire.tasks.yml").write_text("tasks: {}\n")
+
+        wt = tmp_path / "repo-worktrees" / "f5"
+        assert ensure_worktree(repo, "f5", wt, copy_files=[])
+        assert (wt / ".agentwire.tasks.yml").exists()
+
 
 # --- remove_worktree (#717: force by default, reports (removed, error)) ---
 


### PR DESCRIPTION
## Summary

Two related scheduler/unattended issues, both root-caused and fixed in this worktree.

### #804 — unattended agents were fail-closed blocked from `agentwire email`

An unattended (scheduled) agent's owner-notification email was blocked by `outbound.agentwire-email` (ask-tier → fail-closed for unattended), defeating the primary way a headless agent reports back.

**Owner decision (see issue comment): blanket allow, not owner-address-scoped.** `outbound.agentwire-email` is added to `DEFAULT_UNATTENDED_ALLOW` in `agentwire/safety/_core.py` — any `--to`, owner-accepted exfil tradeoff. Ships in the packaged default (no local `~/.agentwire/damagecontrol.yml` edit needed). `agentwire quo` (SMS) is unaffected and still fails closed unattended.

*(An earlier iteration implemented a narrower `--to == owner address only` exemption; the owner explicitly rejected that in favor of the simpler blanket allow — see commit history / issue comments.)*

### #803 — scheduler tasks wedged/failing, root-caused

- **`cc-dialog-drift` "+4h11m overdue"**: the gate (`command` — only run when Claude Code's version changes) is working *exactly as designed* — no version drift since the last successful test run, confirmed by manually running the gate command (`v == s` → exit 1). The real bug was the **board display**, which had no way to distinguish "gate currently blocking, by design" from "genuinely falling behind." Fixed: new `TaskState.last_gate_skip` field, set/cleared alongside gate evaluation, surfaced on `agentwire scheduler board`/`status` and the portal sidebar (shows a "gated" badge instead of a scary overdue duration).

- **`ai-morning-briefing` — missing task-execution config file in the worktree**: NOT a cwd/project-resolution bug. `~/.agentwire/config.yaml`'s `projects.worktrees.copy_files` list is stale, predating the #720 split that moved scheduled-task definitions out of `.agentwire.yml` into a dedicated file. Every fresh worktree — including this PR's own worktree — was missing the file as a result. Fixed: the three infra files (`.env`, `.agentwire.yml`, and the task-execution config file) are now always seeded regardless of the configured `copy_files` list (which becomes purely additive). Consolidated the file list into one shared constant in `config.py` (was already duplicated 2x there; a 3rd independent copy in `worktree.py` would have made the exact class of drift bug easier to reintroduce).

- **`daily-book-report` — "Failed to create session 'book-report'"**: reproduced `agentwire new` manually against the exact project/session name — succeeds every time with current code. Traced to the **scheduler daemon process running continuously since 2026-07-04** (11+ days, confirmed via the daemon's own live-state `started_at`) while `agentwire rebuild` has updated the installed package many times since (most recently the day before this investigation) — the daemon never re-imports its Python modules, so it's silently executing 11-day-old dispatch logic. Same class of staleness CLAUDE.md already documents for the MCP server, previously unguarded for the scheduler daemon. Fixed: new `agentwire doctor` check flags a daemon older than the installed code and suggests `agentwire scheduler stop && agentwire scheduler start`. (Did **not** restart the live daemon myself — worker protocol forbids restarting shared services; the owner needs to do this.)

- **`roblox-digest` — "incomplete"**: investigated, no code fix applicable. Damage-control audit logs for 4 sampled "incomplete" days show **zero** `agentwire email` invocation attempts at all (not a block — the agent never even tries), while the one "complete" day shows a successful, allowed `agentwire email` call. This is agent/prompt behavior (consistently stopping after composing + saving the report locally, before the prompt's final "send via Bash" step), not an agentwire scheduler bug. Recommend tightening the task prompt's step 3 into an unmissable imperative.

## Review

Adversarial `/code-review high` pass on both diffs (via parallel finder+verify agents). All findings fixed:
- Stale doc claims in the project-config skill doc and the damage-control wiki page (#804)
- Overlong decorative comment in `_core.py` vs the file's one-line-per-entry convention (#804)
- `last_gate_skip` could go stale on multi-condition gates (blocker shifts from one condition to another without the gate ever fully passing) — fixed to update on every reason change, not just first occurrence (#803)
- Doctor's daemon-staleness check reimplemented process-start-time discovery via fragile `ps -o etime=` parsing + ambiguous multi-PID `pgrep` matching — rewritten to read the daemon's own authoritative `started_at` from the live-state file it already writes every loop tick (#803)
- New mandatory-seed-files constant triplicated a list already duplicated 2x in `config.py` — consolidated into one shared constant (#803)

## Test plan

- [x] Full unit+integration suite: **2748 passed**, 0 failures
- [x] `scripts/regen_damage_control_hooks.py --check` — hooks stay in sync with `_core.py`
- [x] `node --check` on the touched sidebar JS file
- [x] **#804 e2e** (real hook subprocess invocations, no mocks):
  - `agentwire email --to <owner>` under `AGENTWIRE_UNATTENDED=1` → **exit 0** (allowed)
  - `agentwire email --to <anyone-else>` under `AGENTWIRE_UNATTENDED=1` → **exit 0** (allowed — blanket)
  - `agentwire quo --to <anyone>` under `AGENTWIRE_UNATTENDED=1` → **exit 2** (still blocked — proves the fix is scoped to email)
  - Attended non-bypass session → still gets a real `ask` prompt, not a silent allow
  - MCP `email_send` path (unattended) → exit 0
  - Hard block (`git push --force`) still fires unattended regardless
- [x] **#803 e2e** (real CLI against a sandboxed board + a real throwaway git repo, no mocks):
  - `agentwire scheduler status`/`board`/`board --json` against a sandboxed board with a real always-failing `gate: {command: "false"}` task → `recent_activity` shows `"[gated] command: exit 1"`, board printout shows `↳ [gated] command: exit 1` beneath the overdue duration, JSON includes the gate reason field
  - `ensure_worktree()` run for real (real `git worktree add`, real file copies) against a throwaway repo + a config.yaml reproducing the **exact live stale copy_files list** — confirmed the task-execution config file gets seeded anyway, and stays gitignored (clean `git status` in the new worktree)
  - Daemon-staleness check run **unmocked against the real live scheduler daemon** — correctly reports it started `2026-07-04 07:35:19`, matching independent `ps`-based investigation exactly, and the doctor section correctly flags it stale with the restart command. (Read-only — did not restart it.)

Closes #804
Closes #803

Built by dotdev.dev
