### PR TITLE
feat(hud): full-width pulse-strip activity viz (#800)

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -6659,20 +6659,60 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     gap: 6px;
 }
 
-.topology-spark {
-    display: flex;
-    align-items: flex-end;
-    gap: 2px;
-    height: 12px;
+/* Full-width activity pulse strip (#800), replacing the old bar sparkline.
+   The rules below are the `idle` resting state — dim, slow, low-amplitude,
+   still visibly "alive". flow/awaiting/stuck override speed/amplitude/colour
+   further down, keyed off the card's state class. */
+.topology-pulse {
+    position: relative;
+    width: 100%;
+    height: 20px;
+    border-radius: 4px;
 }
 
-.topology-spark i {
+.topology-pulse-svg {
     display: block;
-    width: 2px;
-    height: 3px;
-    border-radius: 1px;
-    background: var(--text-muted);
-    opacity: 0.5;
+    width: 100%;
+    height: 100%;
+}
+
+.topology-pulse-base {
+    stroke: var(--text-muted);
+    stroke-width: 1px;
+    opacity: 0.18;
+}
+
+.topology-pulse-scroll {
+    animation: topology-pulse-scroll 3.2s linear infinite;
+}
+
+.topology-pulse-trace {
+    fill: none;
+    stroke: var(--text-muted);
+    stroke-width: 1.6px;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    opacity: 0.4;
+    vector-effect: non-scaling-stroke;
+    transform-box: fill-box;
+    transform-origin: center;
+    transform: scaleY(0.32);
+}
+
+.topology-pulse-marker {
+    position: absolute;
+    top: 50%;
+    right: 3px;
+    width: 5px;
+    height: 5px;
+    margin-top: -2.5px;
+    border-radius: 50%;
+    opacity: 0;
+    pointer-events: none;
+}
+
+@keyframes topology-pulse-scroll {
+    to { transform: translateX(-240px); }
 }
 
 .topology-card-machine {
@@ -6789,10 +6829,18 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     opacity: 0.5;
     animation: topology-dot-ring 1.8s ease-out infinite;
 }
-.topology-card--flow .topology-spark i {
-    background: var(--card-tint, var(--lineage-tint-1));
-    opacity: 0.9;
-    animation: topology-spark-eq 1s ease-in-out infinite;
+.topology-card--flow .topology-pulse-base {
+    stroke: var(--card-tint, var(--lineage-tint-1));
+    opacity: 0.22;
+}
+.topology-card--flow .topology-pulse-scroll {
+    animation-duration: 1.15s;
+}
+.topology-card--flow .topology-pulse-trace {
+    stroke: var(--card-tint, var(--lineage-tint-1));
+    opacity: 0.95;
+    transform: scaleY(1);
+    filter: drop-shadow(0 0 3px color-mix(in srgb, var(--card-tint, var(--lineage-tint-1)) 55%, transparent));
 }
 
 /* Failure-state parity (#749): awaiting/stuck override the lineage tint
@@ -6807,9 +6855,19 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     opacity: 0.6;
     animation: topology-dot-ring 1.3s ease-out infinite;
 }
-.topology-card--awaiting .topology-spark i {
+.topology-card--awaiting .topology-pulse-trace {
+    stroke: var(--topology-awaiting);
+    opacity: 0.9;
+    transform: scaleY(0.7);
+}
+.topology-card--awaiting .topology-pulse-scroll {
+    animation-duration: 2s;
+}
+.topology-card--awaiting .topology-pulse-marker {
     background: var(--topology-awaiting);
-    opacity: 0.7;
+    box-shadow: 0 0 5px var(--topology-awaiting-glow);
+    opacity: 1;
+    animation: topology-pulse-blink 1.1s ease-in-out infinite;
 }
 .topology-card--stuck .topology-status-dot {
     background: var(--topology-stuck);
@@ -6820,9 +6878,23 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     opacity: 0.7;
     animation: topology-dot-ring 0.9s ease-out infinite;
 }
-.topology-card--stuck .topology-spark i {
+.topology-card--stuck .topology-pulse-base {
+    stroke: var(--topology-stuck);
+    opacity: 0.3;
+}
+.topology-card--stuck .topology-pulse-trace {
+    stroke: var(--topology-stuck);
+    opacity: 0.9;
+    transform: scaleY(0.16);
+}
+.topology-card--stuck .topology-pulse-scroll {
+    animation-duration: 0.9s;
+}
+.topology-card--stuck .topology-pulse-marker {
     background: var(--topology-stuck);
-    opacity: 0.7;
+    box-shadow: 0 0 6px var(--topology-stuck-glow);
+    opacity: 1;
+    animation: topology-pulse-blink 0.7s steps(2, jump-none) infinite;
 }
 
 /* "You-are-here" self/root card (#778) — the Session HUD's re-rooted view
@@ -6849,9 +6921,9 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     0% { transform: scale(0.6); opacity: 0.7; }
     100% { transform: scale(1.9); opacity: 0; }
 }
-@keyframes topology-spark-eq {
-    0%, 100% { height: 3px; }
-    50% { height: 11px; }
+@keyframes topology-pulse-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.15; }
 }
 
 .topology-link {
@@ -6890,7 +6962,8 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
 
 @media (prefers-reduced-motion: reduce) {
     .topology-status-dot::after,
-    .topology-card--flow .topology-spark i,
+    .topology-pulse-scroll,
+    .topology-pulse-marker,
     .topology-link--flow,
     .topology-link--awaiting,
     .topology-link--stuck {
@@ -7046,7 +7119,8 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
 /* Expanded card hosts a live terminal — the activity sparkline is redundant
    and just steals a row, so hide it, and tighten the card's gap. Reclaims
    vertical space for terminal rows (the card was mostly chrome above it). */
-.topology-card--expanded .topology-card-meta { display: none; }
+.topology-card--expanded .topology-card-meta,
+.topology-card--expanded .topology-pulse { display: none; }
 .topology-card--expanded { gap: 4px; }
 
 /* --- born-from-parent placement (#745, absorbed into the HUD by #780) ---

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -31,6 +31,53 @@ import { activityStates } from './sidebar/sessions-section.js';
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
+ * Full-width activity "pulse strip" (#800) — replaces the old 4-5 bar
+ * sparkline. A dim baseline plus a heartbeat trace that scrolls left; all of
+ * its state (speed, amplitude, colour, the trailing needs-input marker) is
+ * driven purely by the card's `topology-card--{idle,flow,awaiting,stuck}`
+ * class in CSS, so it stays inside the idempotent render — no per-card
+ * animation loop to start or tear down on spawn/kill.
+ *
+ * The <svg> stretches to card width (`preserveAspectRatio="none"`); the trace
+ * spans two identical periods (0..480, viewBox shows one) so the CSS
+ * translateX(-240) scroll loops seamlessly. `vector-effect: non-scaling-stroke`
+ * keeps the line crisp despite the non-uniform horizontal stretch. The
+ * needs-input marker is a DOM span (not an SVG circle) so the stretch can't
+ * squash it into an ellipse.
+ */
+const PULSE_VIEW_W = 240;
+const PULSE_BEAT_D =
+    'M0 12 H92 L100 9 L106 3 L112 21 L118 9 L126 12 H332 L340 9 L346 3 L352 21 L358 9 L366 12 H480';
+
+function buildPulseStrip() {
+    const wrap = document.createElement('div');
+    wrap.className = 'topology-pulse';
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('class', 'topology-pulse-svg');
+    svg.setAttribute('viewBox', `0 0 ${PULSE_VIEW_W} 24`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+    svg.setAttribute('aria-hidden', 'true');
+    const base = document.createElementNS(SVG_NS, 'line');
+    base.setAttribute('class', 'topology-pulse-base');
+    base.setAttribute('x1', '0');
+    base.setAttribute('y1', '12');
+    base.setAttribute('x2', String(PULSE_VIEW_W));
+    base.setAttribute('y2', '12');
+    const scroll = document.createElementNS(SVG_NS, 'g');
+    scroll.setAttribute('class', 'topology-pulse-scroll');
+    const trace = document.createElementNS(SVG_NS, 'path');
+    trace.setAttribute('class', 'topology-pulse-trace');
+    trace.setAttribute('d', PULSE_BEAT_D);
+    scroll.appendChild(trace);
+    svg.append(base, scroll);
+    const marker = document.createElement('span');
+    marker.className = 'topology-pulse-marker';
+    marker.setAttribute('aria-hidden', 'true');
+    wrap.append(svg, marker);
+    return wrap;
+}
+
+/**
  * 'idle' | 'flow' (processing/generating/playing) | 'awaiting' | 'stuck'.
  * `state`/`state_kind` (needs_input/off) only land on the session record
  * right after an /api/sessions/local fetch — not on every periodic
@@ -347,7 +394,7 @@ export class TopologyView {
             entry.isGhost = isGhost;
             entry.card.classList.toggle('topology-card--ghost', isGhost);
             entry.roleEl.hidden = isGhost;
-            entry.sparkEl.hidden = isGhost;
+            entry.pulseEl.hidden = isGhost;
             entry.ghostBadge.hidden = !isGhost;
             entry.ghostInfoEl.hidden = !isGhost;
             entry.ghostGitEl.hidden = !isGhost;
@@ -399,6 +446,10 @@ export class TopologyView {
             entry.machineEl.textContent = machine;
             entry.machineEl.hidden = !machine;
         }
+        // The meta row now holds only the (usually-absent) machine tag + ghost
+        // info, so collapse it when both are hidden — otherwise the empty flex
+        // item still draws the card's column-gap as a dead band under the pulse.
+        entry.metaEl.hidden = entry.machineEl.hidden && entry.ghostInfoEl.hidden;
 
         const isSelf = name === this._selfSession;
         if (entry.isSelf !== isSelf) {
@@ -470,13 +521,8 @@ export class TopologyView {
         ghostBadge.hidden = true;
         top.append(dot, nameEl, roleEl, menuBtn, ghostBadge);
 
-        const sparkEl = document.createElement('div');
-        sparkEl.className = 'topology-spark';
-        for (let i = 0; i < 5; i++) {
-            const bar = document.createElement('i');
-            bar.style.animationDelay = `${i * 90}ms`;
-            sparkEl.appendChild(bar);
-        }
+        const pulseEl = buildPulseStrip();
+
         const machineEl = document.createElement('span');
         machineEl.className = 'topology-card-machine';
         machineEl.hidden = true;
@@ -487,7 +533,7 @@ export class TopologyView {
 
         const meta = document.createElement('div');
         meta.className = 'topology-card-meta';
-        meta.append(sparkEl, machineEl, ghostInfoEl);
+        meta.append(machineEl, ghostInfoEl);
 
         const ghostGitEl = document.createElement('div');
         ghostGitEl.className = 'topology-ghost-git';
@@ -509,10 +555,10 @@ export class TopologyView {
         noteEl.hidden = true;
         ghostActions.append(cleanupBtn, adoptBtn, noteEl);
 
-        card.append(top, meta, ghostGitEl, ghostActions);
+        card.append(top, pulseEl, meta, ghostGitEl, ghostActions);
 
         const entry = {
-            card, dot, nameEl, roleEl, machineEl, sparkEl, menuBtn, state: null, tintVar: null, session: null,
+            card, dot, nameEl, roleEl, machineEl, metaEl: meta, pulseEl, menuBtn, state: null, tintVar: null, session: null,
             expanded: false, expandSlot: null, expandDispose: null,
             isSelf: false, selfDispose: null,
             isGhost: false, ghostBadge, ghostInfoEl, ghostGitEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
@@ -651,7 +697,9 @@ export class TopologyView {
             session.worktreePath || null,
         ].filter(Boolean).join('  ·  ');
         if (entry.ghostInfoEl.textContent !== info) entry.ghostInfoEl.textContent = info;
+        entry.ghostInfoEl.hidden = !info;
         entry.machineEl.hidden = true;
+        entry.metaEl.hidden = entry.machineEl.hidden && entry.ghostInfoEl.hidden;
 
         const gitHtml = gitBadgesHtml(session.git);
         if (entry.ghostGitEl.innerHTML !== gitHtml) entry.ghostGitEl.innerHTML = gitHtml;


### PR DESCRIPTION
Replaces the 4-5 bar `.topology-spark` in the Session HUD topology cards with a **full-width SVG pulse strip** — a heartbeat trace that scrolls left, its speed/amplitude/colour and needs-input marker driven purely by the card's `topology-card--{idle,flow,awaiting,stuck}` class (stays inside the idempotent render — no per-card animation loop).

| state | treatment |
|-------|-----------|
| flow | bright family-hue, full-amplitude spike + glow, fast scroll |
| idle | dim, slow, low-amplitude (still visibly alive) |
| awaiting | amber trace + blinking trailing marker (round DOM span — the `preserveAspectRatio=none` stretch can't squash it) |
| stuck | red near-flatline + alarm-blink marker |

Ghost/expanded cards hide the strip; reduced-motion freezes scroll+blink. Trace spans two identical 240u periods (0..480); CSS `translateX(-240px)` loops seamlessly (verified: transform stays in [0,-240] user units).

**Adversarial review** (coverage-first) + fixes applied:
- empty `.topology-card-meta` dead-band on local cards → hidden in JS when machine+ghostInfo both absent (`:empty` wouldn't fire — the row always has hidden children)
- marker glow was clipped by a redundant wrapper `overflow:hidden` (the SVG viewport already clips the scroll) → removed
- trimmed strip 22→20px to protect the shade's vertical budget

**Orchestrator Chrome e2e** (one tab, cleaned up): verified all four states side-by-side, seamless scroll, round markers, tight card (no dead band), zero console errors.

Closes #800

Built by [dotdev.dev](https://dotdev.dev)