### PR TITLE
fix(portal): reject unrecognized project names in New Session modal

### DIFF
--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -496,10 +496,11 @@ function bindNewSessionForm(form) {
         const name = form.querySelector('input[name="project"]').value.trim();
         if (!name) { showError('Pick a project.'); return; }
         const proj = findProject(name);
+        if (!proj) { showError(`Unknown project "${name}" — pick one from the list.`); return; }
         showProgress(`Starting session for ${name}…`);
         try {
             await spawnAndOpen({
-                name, path: proj?.path, machine: proj?.machine,
+                name, path: proj.path, machine: proj.machine,
                 roles, posture: postureSel.value || undefined,
             });
         } catch (err) {


### PR DESCRIPTION
## Summary
- The New Session modal's free-text project input let an unmatched/typo'd name submit anyway, resolving `path: undefined` downstream with no error surfaced.
- `bindNewSessionForm`'s submit handler now checks `findProject(name)` and blocks submission with an inline error (`Unknown project "X" — pick one from the list.`) when it doesn't resolve.

## Test plan
- [x] Verified in a source-run portal instance (non-default port): typing an unrecognized project name and submitting shows the inline error and does not proceed.
- [x] Verified a recognized project name still resolves its real path and submits normally (confirmed via the downstream "already the working directory of an active session" error, which only fires once the path resolved correctly).

Closes #815

Built by dotdev.dev