### PR TITLE
fix(portal): guard setView against palette closed mid-load

### DIFF
--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -170,6 +170,7 @@ async function loadBindBrowse(path) {
 async function navigateBindFolder(path) {
     try {
         await loadBindBrowse(path);
+        if (!paletteEl) return;  // palette closed while loading
         renderView();
         focusActiveInput();
     } catch (err) {

--- a/agentwire/static/js/command-palette.js
+++ b/agentwire/static/js/command-palette.js
@@ -1025,12 +1025,14 @@ async function setView(view) {
         } catch (err) {
             const { toastError } = await import('./toast.js');
             toastError(err?.message || 'Failed to browse folders');
+            if (!paletteEl) return;  // palette closed while loading
             currentView = 'root';
             renderView();
             focusActiveInput();
             return;
         }
     }
+    if (!paletteEl) return;  // palette closed while loading
     renderView();
     focusActiveInput();
 }


### PR DESCRIPTION
`setView(view)` awaits a network call depending on the view, then unconditionally calls `renderView()` + `focusActiveInput()`. If the palette is closed (Escape, click-outside) while that await is pending, `closeCommandPalette()` nulls `paletteEl` and removes it from the DOM, so the resumed `setView()` throws:

```
TypeError: Cannot read properties of null (reading 'querySelector')
    at renderView (command-palette.js)
    at setView (command-palette.js)
```

Fix: bail out with `if (!paletteEl) return;` after the awaits, before touching the DOM — the same guard `closeCommandPalette()` uses at its own entry. Two guards cover all four await points: one on the main path (after `loadSessions`/`loadProjects`/`loadCustomCommands`/successful `loadBindBrowse` — only one branch runs per call), and one on the `bind-folder` catch path, which awaits a toast import and returns early. The error toast still fires either way.

Verified with `node --check --input-type=module`.

Closes #819

Built by [dotdev.dev](https://dotdev.dev)