### PR TITLE
feat: background artifacts notify instead of stealing focus

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -174,8 +174,8 @@ agentwire listen stop --stdout  # transcribe + print raw transcript to stdout, n
 agentwire tts voices            # list available voices (custom-shim voices or Kokoro presets)
 
 # Artifact windows (agent visual canvas)
-agentwire open <url> --title "T"  # open URL or local file as artifact window
-agentwire open dashboard.html     # open from ~/.agentwire/artifacts/
+agentwire open <url> --title "T"  # announce URL/local file as a click-to-open artifact notification (#817)
+agentwire open dashboard.html     # announce from ~/.agentwire/artifacts/ — human clicks to open
 
 # Channels (outbound notification integrations — email + quo)
 agentwire channels list         # list all registered channels

--- a/.claude/skills/agentwire-desktop-ui/SKILL.md
+++ b/.claude/skills/agentwire-desktop-ui/SKILL.md
@@ -85,10 +85,11 @@ Agents can display HTML content in sandboxed iframe windows on the portal deskto
 
 **Agent workflow (MCP):**
 ```python
-# Write HTML and open in one step
+# Write HTML and announce in one step (click-to-open notification, #817 —
+# artifacts never force-open a window or steal focus)
 desktop_write_artifact(filename="dashboard.html", html_content="<h1>Hello</h1>", title="Dashboard")
 
-# Or open an existing file or external URL
+# Or announce an existing file or external URL
 desktop_open_artifact(url="dashboard.html", title="Dashboard")
 desktop_open_artifact(url="https://example.com", title="External")
 ```

--- a/.claude/skills/agentwire-mcp-tools/SKILL.md
+++ b/.claude/skills/agentwire-mcp-tools/SKILL.md
@@ -162,8 +162,8 @@ up|down`) — the MCP surface is read-only introspection.
 | Preview windows in a collage overlay | `desktop_collage()` |
 | Open session window | `desktop_open_session(session="...", mode="monitor")` |
 | Open panel | `desktop_open_panel(panel_type="sessions")` |
-| Open artifact window (URL/file) | `desktop_open_artifact(url="...", title="...")` |
-| Write HTML + open as artifact | `desktop_write_artifact(filename="...", html_content="...", title="...")` |
+| Announce artifact, click-to-open (URL/file) | `desktop_open_artifact(url="...", title="...")` — notification, never steals focus (#817) |
+| Write HTML + announce as artifact | `desktop_write_artifact(filename="...", html_content="...", title="...")` |
 | Post toast to the human | `notify_user(text="...", session="...", priority="normal")` (safe markdown: bold, [links](url), line breaks) |
 | Close window | `desktop_close_window(window_id="...")` |
 | Focus window | `desktop_focus_window(window_id="...")` |

--- a/agentwire/council/cli.py
+++ b/agentwire/council/cli.py
@@ -164,11 +164,14 @@ def current_session() -> str | None:
     return pane_manager.get_current_session()
 
 
-def open_artifact_window(url: str, title: str) -> bool:
-    """Best-effort: open a rendered artifact as a portal window.
+def notify_artifact(url: str, title: str) -> bool:
+    """Best-effort: announce a rendered artifact via a portal notification.
 
-    Returns True only when the portal accepted the open; a down or erroring
-    portal returns False — the artifact file exists on disk either way.
+    Posts a click-to-open notice (toast + HUD entry, #817) rather than
+    force-opening a window — a background render must never steal focus from
+    whatever the human is working in. Returns True only when the portal
+    accepted the notification; a down or erroring portal returns False — the
+    artifact file exists on disk either way.
     """
     import os
 
@@ -184,8 +187,8 @@ def open_artifact_window(url: str, title: str) -> bool:
     try:
         resp = core.portal_request(
             "POST",
-            f"{portal}/api/desktop/window/open",
-            json={"type": "artifact", "url": url, "title": title},
+            f"{portal}/api/desktop/notification",
+            json={"artifact": {"url": url, "title": title}},
             timeout=5,
         )
         return resp.status_code == 200 and bool(resp.json().get("success"))
@@ -372,20 +375,20 @@ def _synthesis_text(value: str | None) -> str:
 def _render_minutes(
     name: str, prompt_ids: list[int] | None = None, synthesis: str = ""
 ) -> tuple[str | None, bool | None]:
-    """Write the minutes artifact and best-effort open it in the portal.
+    """Write the minutes artifact and best-effort announce it in the portal.
 
-    Returns ``(path, opened)`` — both None when the sitting has no matching
-    prompt history (nothing rendered, nothing opened).
+    Returns ``(path, notified)`` — both None when the sitting has no matching
+    prompt history (nothing rendered, nothing announced).
     """
     from agentwire.council import minutes
 
     path = minutes.write_minutes(name, prompt_ids, synthesis=synthesis)
     if path is None:
         return None, None
-    opened = open_artifact_window(
+    notified = notify_artifact(
         minutes.artifact_url(name), f"Council minutes — {name}"
     )
-    return str(path), opened
+    return str(path), notified
 
 
 def cmd_council_stop(args) -> int:
@@ -399,9 +402,9 @@ def cmd_council_stop(args) -> int:
     # Minutes before teardown (#708): tri-state --minutes/--no-minutes,
     # default (None) renders exactly when any prompt history exists.
     minutes_path: str | None = None
-    minutes_opened: bool | None = None
+    minutes_notified: bool | None = None
     if getattr(args, "minutes", None) is not False:
-        minutes_path, minutes_opened = _render_minutes(
+        minutes_path, minutes_notified = _render_minutes(
             name, synthesis=_synthesis_text(getattr(args, "synthesis", None))
         )
 
@@ -420,7 +423,7 @@ def cmd_council_stop(args) -> int:
         "killed": killed,
         "not_running": not_running,
         "minutes": minutes_path,
-        "minutes_opened": minutes_opened,
+        "minutes_notified": minutes_notified,
     }
     human = (
         f"Council '{name}' stopped ({len(killed)} sessions killed). "
@@ -456,14 +459,14 @@ def cmd_council_minutes(args) -> int:
                 f"(available: {', '.join(map(str, available))})",
             )
 
-    path, opened = _render_minutes(
+    path, notified = _render_minutes(
         name, prompt_ids, synthesis=_synthesis_text(getattr(args, "synthesis", None))
     )
 
-    payload = {"success": True, "path": path, "opened": opened}
+    payload = {"success": True, "path": path, "notified": notified}
     human = f"Minutes: {path}"
-    if opened:
-        human += "\nOpened as a portal artifact window."
+    if notified:
+        human += "\nAnnounced in the portal — click the notification to open."
     return _emit(args, payload, human, council=name)
 
 

--- a/agentwire/mcp_council.py
+++ b/agentwire/mcp_council.py
@@ -212,9 +212,10 @@ def council_minutes(name: str = "", prompt: str = "", synthesis: str = "") -> st
     Deterministically renders the sitting's persisted prompt history
     (question + attributed take/ack/pass replies) plus your optional
     synthesis into a self-contained HTML artifact at
-    ``~/.agentwire/artifacts/council-<name>-minutes/index.html``, and opens
-    it as a portal artifact window when the portal is up. Works for live and
-    dismissed sittings alike — prompt history survives ``council_stop``.
+    ``~/.agentwire/artifacts/council-<name>-minutes/index.html``, and
+    announces it as a click-to-open portal notification when the portal is
+    up (#817 — never steals focus). Works for live and dismissed sittings
+    alike — prompt history survives ``council_stop``.
 
     Args:
         prompt: Prompt id to render, or 'all' (empty = all)
@@ -222,7 +223,7 @@ def council_minutes(name: str = "", prompt: str = "", synthesis: str = "") -> st
         name: Sitting name (empty = cwd-repo-slug / sole live sitting)
 
     Returns:
-        The rendered artifact's path, and whether a portal window opened.
+        The rendered artifact's path, and whether the portal was notified.
     """
     args = ["council", "minutes"]
     if name:
@@ -235,6 +236,6 @@ def council_minutes(name: str = "", prompt: str = "", synthesis: str = "") -> st
     if not data.get("success"):
         return f"Failed to render minutes: {data.get('error') or data}"
     out = f"{_council_tag(data)}Minutes: {data.get('path')}"
-    if data.get("opened"):
-        out += "\nOpened as a portal artifact window."
+    if data.get("notified"):
+        out += "\nAnnounced in the portal — the human clicks the notification to open."
     return out

--- a/agentwire/mcp_desktop.py
+++ b/agentwire/mcp_desktop.py
@@ -106,9 +106,23 @@ def desktop_open_panel(panel_type: str) -> str:
     return f"Failed to open panel: {data.get('error', 'Unknown error')}"
 
 
+def _announce_artifact(url: str, title: str, artifact_id: str | None) -> dict:
+    """POST the click-to-open artifact notification (#817) — the single
+    portal-side path for surfacing an artifact; there is no force-open."""
+    artifact = {"url": url, "title": title}
+    if artifact_id:
+        artifact["artifact_id"] = artifact_id
+    return _portal_request("POST", "/api/desktop/notification", {"artifact": artifact})
+
+
 @mcp.tool()
 def desktop_open_artifact(url: str, title: str = "Artifact", artifact_id: str | None = None) -> str:
-    """Open a URL or local artifact file in an iframe window on the portal desktop.
+    """Announce a URL or local artifact file on the portal desktop (click-to-open).
+
+    Posts a notification (toast + Session HUD entry) carrying the artifact
+    target instead of force-opening a window (#817) — a background-produced
+    artifact must never steal focus. The human clicks the notice to open the
+    artifact window, focused.
 
     For local files, use a filename from ~/.agentwire/artifacts/ (e.g., "dashboard.html").
     For external sites, use a full URL (e.g., "https://example.com").
@@ -119,21 +133,12 @@ def desktop_open_artifact(url: str, title: str = "Artifact", artifact_id: str | 
         artifact_id: Optional unique window ID. If omitted, derived from URL.
 
     Returns:
-        Window ID of the opened window or error.
+        Notification ID or error description.
     """
-    body = {
-        "type": "artifact",
-        "url": url,
-        "title": title,
-    }
-    if artifact_id:
-        body["artifact_id"] = artifact_id
-
-    data = _portal_request("POST", "/api/desktop/window/open", body)
+    data = _announce_artifact(url, title, artifact_id)
     if data.get("success"):
-        wid = data.get("window_id", "unknown")
-        return f"Opened artifact window '{title}' (id: {wid})."
-    return f"Failed to open artifact window: {data.get('error', 'Unknown error')}"
+        return f"Artifact '{title}' announced (notification id: {data.get('id', 'unknown')}) — the human clicks to open."
+    return f"Failed to announce artifact: {data.get('error', 'Unknown error')}"
 
 
 @mcp.tool()
@@ -143,11 +148,12 @@ def desktop_write_artifact(
     title: str = "Artifact",
     artifact_id: str | None = None,
 ) -> str:
-    """Write HTML content to a file and open it as an artifact window.
+    """Write HTML content to a file and announce it as a click-to-open artifact.
 
-    Atomically writes content to ~/.agentwire/artifacts/<filename>, then opens
-    it in an iframe window on the portal desktop. Use this to display
-    dashboards, diagrams, reports, or any HTML content.
+    Atomically writes content to ~/.agentwire/artifacts/<filename>, then posts
+    a click-to-open notification (toast + Session HUD entry, #817) — the human
+    clicks to open the artifact window; it never steals focus. Use this to
+    deliver dashboards, diagrams, reports, or any HTML content.
 
     Args:
         filename: Output filename (must end in .html, e.g., "dashboard.html")
@@ -156,9 +162,8 @@ def desktop_write_artifact(
         artifact_id: Optional unique window ID. If omitted, derived from filename.
 
     Returns:
-        Window ID of the opened window or error.
+        Notification ID or error description.
     """
-    # Step 1: Upload the file
     upload_data = _portal_request("POST", "/api/artifacts/upload", {
         "filename": filename,
         "content": html_content,
@@ -166,20 +171,10 @@ def desktop_write_artifact(
     if not upload_data.get("success"):
         return f"Failed to write artifact: {upload_data.get('error', 'Unknown error')}"
 
-    # Step 2: Open it as a window
-    body = {
-        "type": "artifact",
-        "url": filename,
-        "title": title,
-    }
-    if artifact_id:
-        body["artifact_id"] = artifact_id
-
-    open_data = _portal_request("POST", "/api/desktop/window/open", body)
+    open_data = _announce_artifact(filename, title, artifact_id)
     if open_data.get("success"):
-        wid = open_data.get("window_id", "unknown")
-        return f"Artifact '{filename}' written and opened (id: {wid})."
-    return f"File written but failed to open window: {open_data.get('error', 'Unknown error')}"
+        return f"Artifact '{filename}' written and announced (notification id: {open_data.get('id', 'unknown')})."
+    return f"File written but failed to announce it: {open_data.get('error', 'Unknown error')}"
 
 
 @mcp.tool()

--- a/agentwire/mcp_notify.py
+++ b/agentwire/mcp_notify.py
@@ -65,7 +65,8 @@ def notify_event(event: str, session: str | None = None) -> str:
 
 
 @mcp.tool()
-def notify_user(text: str, session: str | None = None, priority: str = "normal") -> str:
+def notify_user(text: str, session: str | None = None, priority: str = "normal",
+                artifact_url: str | None = None, artifact_title: str | None = None) -> str:
     """Show the HUMAN a desktop toast on the portal (persistent, visual).
 
     The human-screen channel — the asymmetric text partner to `say` (audio).
@@ -74,11 +75,18 @@ def notify_user(text: str, session: str | None = None, priority: str = "normal")
     (portal lifecycle). Clicking the toast opens the session that generated the
     notification (the `session` below); a toast with no session is non-clickable.
 
+    With `artifact_url` set, the toast instead becomes a click-to-open artifact
+    notice (#817): it sticks until dismissed, also appears in the Session HUD,
+    and clicking it opens that artifact window — use this to hand the human a
+    rendered deliverable without stealing focus.
+
     Args:
         text: Notification text. Bold (**x**), line breaks, and [links](https://…)
             render; everything else is escaped.
         session: Session this relates to (shown as a badge).
         priority: 'normal' or 'high' (high gets an accent border).
+        artifact_url: URL or ~/.agentwire/artifacts/ filename to open on click.
+        artifact_title: Window title for the artifact (default: "Artifact").
 
     Returns:
         Notification ID or error description.
@@ -86,6 +94,8 @@ def notify_user(text: str, session: str | None = None, priority: str = "normal")
     body = {"text": text, "priority": priority}
     if session:
         body["session"] = session
+    if artifact_url:
+        body["artifact"] = {"url": artifact_url, "title": artifact_title or "Artifact"}
     data = _portal_request("POST", "/api/desktop/notification", body)
     if not data.get("success"):
         return f"Failed to post notification: {data.get('error', 'Unknown error')}"

--- a/agentwire/mcp_scheduler.py
+++ b/agentwire/mcp_scheduler.py
@@ -258,7 +258,7 @@ def scheduler_report(since: str = "8h", artifact: bool = False) -> str:
 
     Args:
         since: Time window to cover (e.g. '8h', '12h', '1d') default: '8h'
-        artifact: If True, open the report as a portal artifact window
+        artifact: If True, announce the report as a click-to-open portal notification
 
     Returns:
         Path to generated HTML report and summary statistics.

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -149,7 +149,11 @@ def cmd_notify_parent(args) -> int:
 
 
 def cmd_open(args) -> int:
-    """Open a URL or local file as an artifact window in the portal.
+    """Announce a URL or local file as a click-to-open artifact notification.
+
+    Posts a portal notification (toast + Session HUD entry) carrying the
+    artifact target instead of force-opening a window (#817) — the window
+    opens, focused, only when the human clicks the notice.
 
     Examples:
         agentwire open dashboard.html --title "Dashboard"
@@ -167,26 +171,23 @@ def cmd_open(args) -> int:
 
     portal_url = _get_portal_url()
 
-    body = {
-        "type": "artifact",
-        "url": url,
-        "title": title,
-    }
+    artifact = {"url": url, "title": title}
     if artifact_id:
-        body["artifact_id"] = artifact_id
+        artifact["artifact_id"] = artifact_id
 
     try:
         resp = portal_request(
             "POST",
-            f"{portal_url}/api/desktop/window/open",
-            json=body,
+            f"{portal_url}/api/desktop/notification",
+            json={"artifact": artifact},
         )
         data = resp.json()
 
         if json_output:
             print(json.dumps(data))
         elif data.get("success"):
-            print(f"Opened artifact window: {title} (id: {data.get('window_id', 'unknown')})")
+            print(f"Artifact announced: {title} (notification id: {data.get('id', 'unknown')}) "
+                  "— click the toast or HUD entry to open")
         else:
             print(f"Failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
             return 1
@@ -311,11 +312,11 @@ def register_notify_parser(subparsers) -> None:
     notify_cmd_parser.add_argument("--json", action="store_true", help="Output as JSON")
     notify_cmd_parser.set_defaults(func=cmd_notify_parent)
 
-    # === open command (artifact windows) ===
-    open_parser = subparsers.add_parser("open", help="Open a URL or local file as an artifact window in the portal")
-    open_parser.add_argument("url", help="URL or filename to open (filenames served from ~/.agentwire/artifacts/)")
+    # === open command (artifact notifications) ===
+    open_parser = subparsers.add_parser("open", help="Announce a URL or local file as a click-to-open artifact notification in the portal")
+    open_parser.add_argument("url", help="URL or filename to announce (filenames served from ~/.agentwire/artifacts/)")
     open_parser.add_argument("--title", "-t", type=str, default="Artifact", help="Window title")
-    open_parser.add_argument("--artifact-id", type=str, help="Unique window ID (auto-generated if omitted)")
+    open_parser.add_argument("--artifact-id", type=str, help="Unique window ID for the opened artifact (auto-generated if omitted)")
     open_parser.add_argument("--json", action="store_true", help="Output JSON")
     open_parser.set_defaults(func=cmd_open)
 

--- a/agentwire/routes/desktop.py
+++ b/agentwire/routes/desktop.py
@@ -44,7 +44,12 @@ class DesktopRoutesMixin:
         return web.json_response({"success": True, "windows": windows})
 
     async def api_desktop_open(self, request):
-        """POST /api/desktop/window/open — open a window in the portal."""
+        """POST /api/desktop/window/open — open a window in the portal.
+
+        Session and panel windows only. Artifacts deliberately have no
+        force-open path (#817): producers POST /api/desktop/notification with
+        an ``artifact`` target and the window opens when the human clicks.
+        """
         data = await request.json()
         window_type = data.get("type", "session")
         window_id = None
@@ -68,18 +73,6 @@ class DesktopRoutesMixin:
             await self.broadcast_dashboard("desktop_open_window", {
                 "window_type": "panel",
                 "panel": panel,
-            })
-        elif window_type == "artifact":
-            url = data.get("url")
-            title = data.get("title", "Artifact")
-            if not url:
-                return web.json_response({"success": False, "error": "url required"}, status=400)
-            window_id = data.get("artifact_id") or f"artifact-{url.replace('/', '-').replace('.', '-')}"
-            await self.broadcast_dashboard("desktop_open_window", {
-                "window_type": "artifact",
-                "url": url,
-                "title": title,
-                "artifact_id": window_id,
             })
         else:
             return web.json_response({"success": False, "error": f"unknown type: {window_type}"}, status=400)
@@ -160,9 +153,31 @@ class DesktopRoutesMixin:
         One toast per session: if a toast with the same `session` is already
         active, it is dismissed before the new one is posted. Keeps the nagger
         from stacking N toasts for the same idle session across nag cycles.
+
+        Optional ``artifact`` ``{url, title, artifact_id}`` (#817) makes the
+        notification a click-to-open artifact notice — the sole portal-side
+        path for announcing a background-produced artifact. ``text`` may be
+        omitted then (a default is synthesized from the title); ``artifact_id``
+        defaults to the same url-derived window id the frontend uses.
         """
         data = await request.json()
         text = data.get("text", "")
+
+        artifact = data.get("artifact")
+        if artifact is not None:
+            url = (artifact or {}).get("url")
+            if not url:
+                return web.json_response({"success": False, "error": "artifact.url required"}, status=400)
+            title = artifact.get("title") or "Artifact"
+            artifact = {
+                "url": url,
+                "title": title,
+                "artifact_id": artifact.get("artifact_id")
+                or f"artifact-{url.replace('/', '-').replace('.', '-')}",
+            }
+            if not text:
+                text = f"**{title}** is ready — click to open"
+
         if not text:
             return web.json_response({"success": False, "error": "text required"}, status=400)
 
@@ -180,6 +195,7 @@ class DesktopRoutesMixin:
             priority=data.get("priority", "normal"),
             notification_id=data.get("id"),
             timeout=timeout,
+            artifact=artifact,
         )
 
         # Report how many dashboards saw it live. 0 isn't a failure — the toast

--- a/agentwire/scheduler_cli.py
+++ b/agentwire/scheduler_cli.py
@@ -714,7 +714,7 @@ def cmd_scheduler_live(args) -> int:
 
 
 def cmd_scheduler_dashboard(args) -> int:
-    """Generate and open a live HTML dashboard as a portal artifact."""
+    """Generate a live HTML dashboard and announce it as a portal artifact."""
     no_open = getattr(args, 'no_open', False)
 
     html = _generate_dashboard_html()
@@ -990,12 +990,12 @@ def register_scheduler_parser(subparsers) -> None:
 
     # scheduler dashboard
     sched_dashboard = scheduler_subparsers.add_parser("dashboard", help="Open scheduler dashboard")
-    sched_dashboard.add_argument("--no-open", action="store_true", help="Generate HTML without opening")
+    sched_dashboard.add_argument("--no-open", action="store_true", help="Generate HTML without announcing it in the portal")
     sched_dashboard.set_defaults(func=cmd_scheduler_dashboard)
 
     # scheduler report
     sched_report = scheduler_subparsers.add_parser("report", help="Generate morning report of recent task runs")
     sched_report.add_argument("--since", default="8h", metavar="DURATION", help="Time window (e.g. 8h, 12h, 1d) default: 8h")
-    sched_report.add_argument("--artifact", action="store_true", help="Open report as portal artifact")
+    sched_report.add_argument("--artifact", action="store_true", help="Announce report as a click-to-open portal notification")
     sched_report.add_argument("--json", action="store_true", help="Output JSON")
     sched_report.set_defaults(func=cmd_scheduler_report)

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -1784,7 +1784,8 @@ class AgentWireServer(
     async def _post_toast(self, text: str, session: str | None = None,
                           priority: str = "normal", id_prefix: str = "toast",
                           notification_id: str | None = None,
-                          timeout: float | None = None) -> str:
+                          timeout: float | None = None,
+                          artifact: dict | None = None) -> str:
         """Post a dashboard toast notification, replacing any stale toast
         for the same session key. Single emit path — the HTTP endpoint
         delegates here too.
@@ -1793,14 +1794,30 @@ class AgentWireServer(
         auto-fade after a default timeout, ``high`` toasts stick until
         dismissed. An explicit ``timeout`` (seconds) overrides the default;
         0 means sticky. Returns the notification id.
+
+        ``artifact`` (#817) is a ``{url, title, artifact_id}`` click-to-open
+        target: the frontend renders these as actionable notices (toast + HUD
+        entry) and only opens the artifact window when the human clicks. They
+        default to sticky — an unclicked deliverable must not silently fade —
+        dedup against their own ``artifact_id`` (a re-render replaces the old
+        notice), and are exempt from the same-session sweep in both
+        directions: seeing the session ≠ seeing the artifact.
         """
         notification_id = notification_id or f"{id_prefix}-{str(uuid.uuid4())[:8]}"
         if session:
             stale = [nid for nid, n in self.active_notifications.items()
-                     if n.get("session") == session]
+                     if n.get("session") == session and not n.get("artifact")]
             for nid in stale:
                 self.active_notifications.pop(nid, None)
                 await self.broadcast_dashboard("notification_dismiss", {"id": nid})
+        if artifact:
+            stale = [nid for nid, n in self.active_notifications.items()
+                     if (n.get("artifact") or {}).get("artifact_id") == artifact.get("artifact_id")]
+            for nid in stale:
+                self.active_notifications.pop(nid, None)
+                await self.broadcast_dashboard("notification_dismiss", {"id": nid})
+            if timeout is None:
+                timeout = 0
         notification = {
             "id": notification_id,
             "text": text,
@@ -1810,6 +1827,8 @@ class AgentWireServer(
         }
         if timeout is not None:
             notification["timeout"] = timeout
+        if artifact:
+            notification["artifact"] = artifact
         self.active_notifications[notification_id] = notification
         await self.broadcast_dashboard("notification", notification)
         await self._fanout_push(text, session=session, priority=priority)

--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5684,6 +5684,16 @@ body.sidebar-pinned .sidebar-tab {
     border-color: var(--error);
 }
 
+/* Artifact notices (#817): blue accent marks "click opens a deliverable",
+   distinct from the red actionable-high border. */
+.notification-toast.artifact {
+    border-color: var(--neon-blue-subtle);
+}
+
+.notification-toast.artifact .notification-toast-body:hover {
+    color: var(--neon-blue);
+}
+
 /* Transient info toasts: a thin bar drains over the auto-fade countdown so
    it's visually obvious the toast is ephemeral. Paused on hover / hidden tab
    (the .fading class is toggled in sync with the JS timer). */
@@ -7352,4 +7362,76 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
 
 .session-hud-drawer[data-segment="sessions"] .session-hud-services {
     display: none;
+}
+
+/* ============================================
+   Session HUD — pending artifact notices (#817)
+   Click-to-open deliverables (council minutes, reports) announced by
+   background producers. Strip sits between the header and the segment
+   canvases, visible in both segments. Neon-blue accent = artifact, keeping
+   green for session/live state (brand palette: green primary, blue secondary).
+   ============================================ */
+
+.session-hud-notices {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 4px 12px 8px;
+}
+
+.hud-notice-card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    background: var(--neon-blue-hover);
+    border: 1px solid var(--neon-blue-subtle);
+    border-radius: 8px;
+    color: var(--text);
+    cursor: pointer;
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+.hud-notice-card:hover,
+.hud-notice-card:focus-visible {
+    background: color-mix(in srgb, var(--neon-blue) 18%, transparent);
+    border-color: var(--neon-blue);
+    outline: none;
+}
+
+.hud-notice-icon {
+    flex: 0 0 auto;
+    color: var(--neon-blue);
+    font-size: 14px;
+}
+
+.hud-notice-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+}
+
+.hud-notice-time {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.hud-notice-dismiss {
+    flex: 0 0 auto;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 15px;
+    line-height: 1;
+    padding: 0 2px;
+    cursor: pointer;
+}
+
+.hud-notice-dismiss:hover {
+    color: var(--text);
 }

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -36,6 +36,7 @@ import { notificationsPanel } from './notifications-panel.js';
 import { scratchpad } from './scratchpad.js';
 import { sessionHud } from './session-hud.js';
 import { hudController } from './session-hud-controller.js';
+import { hudNotices } from './session-hud-notices.js';
 import { openCommandPalette, isCommandPaletteOpen } from './command-palette.js';
 import { setupHelp, openHelp, isHelpOpen } from './help-modal.js';
 import { PttController } from './ptt.js';
@@ -217,14 +218,14 @@ async function init() {
         }
     });
 
-    // Desktop UI control (from MCP agents via portal API)
+    // Desktop UI control (from MCP agents via portal API). No artifact case:
+    // artifact producers can't broadcast a window open anymore (#817) — they
+    // arrive as notifications, and the open happens only on click (below).
     desktop.on('desktop_open_window', (msg) => {
         if (msg.window_type === 'session') {
             openSessionTerminal(msg.session, msg.mode || 'monitor');
         } else if (msg.window_type === 'panel') {
             sidebar.expandSection(msg.panel);
-        } else if (msg.window_type === 'artifact') {
-            openArtifactWindow(msg.url, msg.title || 'Artifact', msg.artifact_id);
         }
     });
 
@@ -272,6 +273,7 @@ async function init() {
     // re-rooted onto the focused session) and mounts TopologyView itself.
     sessionHud.init();
     hudController.init(sessionHud.canvas, getWindowSession);
+    hudNotices.init(sessionHud.noticesEl);
 
     // Click on a toast -> open the subject session it's about as interactive terminal.
     // No subject (e.g. a system-level toast) -> no-op, never fall back to the bridge.
@@ -280,6 +282,18 @@ async function init() {
         if (session) {
             openSessionTerminal(session, 'terminal');
         }
+    });
+
+    // Click on an artifact notice (toast body or HUD notice card) — the
+    // deliberate open (#817), and the ONLY path that opens an artifact
+    // window from a notification: dismiss the notice everywhere, drop the
+    // HUD peek if it's up, then run the standard focused open.
+    document.addEventListener('open-notification-artifact', (e) => {
+        const { url, title, artifactId, noticeId } = e.detail || {};
+        if (!url) return;
+        if (noticeId) notificationsPanel.dismiss(noticeId);
+        if (sessionHud.open) sessionHud.toggle(false);
+        openArtifactWindow(url, title || 'Artifact', artifactId || null);
     });
 
     // Set initial voice indicator state

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -14,6 +14,7 @@
 
 import { apiFetch } from './api.js';
 import { desktop } from './desktop-manager.js';
+import { escapeHtml, renderRichText } from './utils/rich-text.js';
 
 const MAX_TOASTS = 8;
 // Lifecycle contract: `normal` toasts are transient info — they auto-fade
@@ -108,13 +109,17 @@ class NotificationsPanel {
 
         const timeStr = this._formatTime(timestamp);
 
+        // Artifact notices render with links OFF (#821 review): the text
+        // embeds the caller-supplied artifact title, and the whole body is
+        // already a click-to-open button — link syntax in a title must show
+        // as literal text, never a spoofable anchor.
         toast.innerHTML = `
             <div class="notification-toast-header">
-                ${session ? `<span class="notification-session-badge">${this._escapeHtml(session)}</span>` : ''}
+                ${session ? `<span class="notification-session-badge">${escapeHtml(session)}</span>` : ''}
                 <span class="notification-time">${timeStr}</span>
                 <button class="notification-dismiss" title="Dismiss">&times;</button>
             </div>
-            <div class="notification-toast-body">${this._renderRichText(text)}</div>
+            <div class="notification-toast-body">${renderRichText(text, { links: !artifact })}</div>
         `;
 
         // Click body -> artifact notices open their artifact (the deliberate
@@ -267,29 +272,6 @@ class NotificationsPanel {
         if (!timestamp) return '';
         const d = new Date(timestamp * 1000);
         return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    }
-
-    _escapeHtml(str) {
-        const div = document.createElement('div');
-        div.textContent = str;
-        return div.innerHTML;
-    }
-
-    // Render a SAFE markdown subset: bold, links, line breaks. Escape everything
-    // FIRST so no source HTML survives, then introduce only our own known tags.
-    // Links are restricted to http(s)/mailto (no javascript:/data:), and because
-    // quotes are already escaped, the agent text can't break out of the href.
-    _renderRichText(str) {
-        let s = this._escapeHtml(str);
-        // Links before bold so [**label**](url) composes. URL came through escape,
-        // so any " is already &quot; — it can't close the attribute.
-        s = s.replace(
-            /\[([^\]]+)\]\((https?:\/\/[^\s)]+|mailto:[^\s)]+)\)/g,
-            (_m, label, url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`
-        );
-        s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-        s = s.replace(/\n/g, '<br>');
-        return s;
     }
 }
 

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -3,6 +3,13 @@
  *
  * Listens for 'notification' events from desktop-manager, renders toasts,
  * supports dismiss and click-to-open-session.
+ *
+ * Also the SSOT for pending ARTIFACT notices (#817): notifications carrying
+ * an `artifact` {url, title, artifact_id} target are tracked in a separate
+ * store the Session HUD's notice strip renders from, so toast and HUD entry
+ * share one lifecycle — dismissing or clicking either surface clears both.
+ * Clicking an artifact toast dispatches `open-notification-artifact`
+ * (handled centrally in desktop.js) instead of `open-notification-session`.
  */
 
 import { apiFetch } from './api.js';
@@ -21,6 +28,10 @@ class NotificationsPanel {
         /** @type {Map<string, number>} id -> auto-fade setTimeout handle */
         this.fadeTimers = new Map();
         this.container = null;
+        /** @type {Map<string, object>} id -> notification carrying an artifact target (#817) */
+        this.artifactNotices = new Map();
+        /** @type {Array<() => void>} subscribers to artifact-notice set changes */
+        this._noticeListeners = [];
     }
 
     init() {
@@ -30,7 +41,10 @@ class NotificationsPanel {
 
         // Listen for notification events
         desktop.on('notification', (data) => this._addToast(data));
-        desktop.on('notification_dismiss', ({ id }) => this._removeToast(id));
+        desktop.on('notification_dismiss', ({ id }) => {
+            this._removeToast(id);
+            this._dropNotice(id);
+        });
 
         // Auto-fade only counts down while the tab is actually visible —
         // a toast posted to a background tab shouldn't vanish unseen.
@@ -61,8 +75,10 @@ class NotificationsPanel {
     }
 
     _addToast(notification) {
-        const { id, text, session, priority, timestamp, timeout } = notification;
+        const { id, text, session, priority, timestamp, timeout, artifact } = notification;
         if (!id || !text) return;
+
+        if (artifact) this._setNotice(notification);
 
         // Update existing toast if same id
         if (this.toasts.has(id)) {
@@ -85,7 +101,7 @@ class NotificationsPanel {
         }
 
         const toast = document.createElement('div');
-        toast.className = `notification-toast${priority === 'high' ? ' high' : ''}${fadeSeconds ? ' auto-fade' : ''}`;
+        toast.className = `notification-toast${priority === 'high' ? ' high' : ''}${fadeSeconds ? ' auto-fade' : ''}${artifact ? ' artifact' : ''}`;
         toast.dataset.id = id;
         toast.dataset.session = session || '';
         toast.dataset.fadeSeconds = String(fadeSeconds);
@@ -101,8 +117,20 @@ class NotificationsPanel {
             <div class="notification-toast-body">${this._renderRichText(text)}</div>
         `;
 
-        // Click body -> open the subject session this notification is about
+        // Click body -> artifact notices open their artifact (the deliberate
+        // open, #817); everything else opens the subject session it's about.
         toast.querySelector('.notification-toast-body').addEventListener('click', () => {
+            if (artifact) {
+                document.dispatchEvent(new CustomEvent('open-notification-artifact', {
+                    detail: {
+                        url: artifact.url,
+                        title: artifact.title,
+                        artifactId: artifact.artifact_id,
+                        noticeId: id,
+                    },
+                }));
+                return;
+            }
             const event = new CustomEvent('open-notification-session', {
                 detail: { session: toast.dataset.session || '' },
             });
@@ -183,13 +211,46 @@ class NotificationsPanel {
     dismissForSession(session) {
         if (!session) return;
         for (const [id, toast] of this.toasts) {
-            if (toast.dataset.session === session) {
+            // Artifact notices survive: tabbing into the producing session
+            // means the user saw the SESSION, not the artifact it delivered.
+            if (toast.dataset.session === session && !this.artifactNotices.has(id)) {
                 this._dismissToast(id);
             }
         }
     }
 
+    // ─── Artifact-notice store (#817) ───────────────────────────
+    // Notifications carrying an `artifact` target, kept until dismissed —
+    // the Session HUD's notice strip renders from here.
+
+    /** @returns {Array<object>} active artifact-target notifications, oldest first */
+    getArtifactNotices() {
+        return [...this.artifactNotices.values()];
+    }
+
+    /** Subscribe to artifact-notice set changes. */
+    onNoticesChanged(fn) {
+        this._noticeListeners.push(fn);
+    }
+
+    /** Dismiss a notification everywhere — toast, HUD notice, server. */
+    dismiss(id) {
+        this._dismissToast(id);
+    }
+
+    _setNotice(notification) {
+        this.artifactNotices.set(notification.id, notification);
+        this._noticeListeners.forEach((fn) => fn());
+    }
+
+    _dropNotice(id) {
+        if (this.artifactNotices.delete(id)) {
+            this._noticeListeners.forEach((fn) => fn());
+        }
+    }
+
     async _dismissToast(id) {
+        this._dropNotice(id);
         this._removeToast(id, true);
         try {
             await apiFetch('/api/desktop/notification/dismiss', {

--- a/agentwire/static/js/session-hud-notices.js
+++ b/agentwire/static/js/session-hud-notices.js
@@ -1,0 +1,107 @@
+/**
+ * session-hud-notices.js — pending artifact notices in the Session HUD (#817).
+ *
+ * Background-produced artifacts (council minutes, handoff renders, reports)
+ * announce themselves as notifications instead of force-opening a window.
+ * This module renders those pending notices as clickable cards in the
+ * `.session-hud-notices` strip pinned above the HUD's segment canvases —
+ * an ad-hoc entry type not tied to any live session/worktree card.
+ *
+ * Data source is notifications-panel.js's artifact-notice store (the SSOT
+ * shared with the toasts), so the two surfaces always agree: dismissing or
+ * clicking either one clears both.
+ *
+ * A card click dispatches the same `open-notification-artifact` event a
+ * toast-body click does; desktop.js owns the single handler that dismisses
+ * the notice, closes the HUD peek, and opens the artifact window. Event
+ * rather than import because desktop.js is the module that boots this one —
+ * a static import back would be circular (same reason as card-terminal.js).
+ */
+
+import { notificationsPanel } from './notifications-panel.js';
+
+class HudNotices {
+    constructor() {
+        /** @type {HTMLElement|null} sessionHud's `.session-hud-notices` strip */
+        this._container = null;
+    }
+
+    /** @param {HTMLElement} container - sessionHud.noticesEl */
+    init(container) {
+        this._container = container;
+        notificationsPanel.onNoticesChanged(() => this._render());
+        this._render();
+    }
+
+    // Full rebuild, not a diff: notices are few (bounded by active
+    // notifications) and change rarely, unlike the topology's live tree.
+    _render() {
+        const notices = notificationsPanel.getArtifactNotices();
+        this._container.replaceChildren(...notices.map((n) => this._buildCard(n)));
+        this._container.hidden = notices.length === 0;
+    }
+
+    _buildCard(notice) {
+        const artifact = notice.artifact || {};
+
+        // A <div role="button">, not a <button>: the dismiss control nests
+        // inside, and button-in-button is invalid HTML.
+        const card = document.createElement('div');
+        card.className = 'hud-notice-card';
+        card.setAttribute('role', 'button');
+        card.tabIndex = 0;
+        card.title = 'Open artifact';
+
+        const icon = document.createElement('span');
+        icon.className = 'hud-notice-icon';
+        icon.textContent = '⧉';
+        icon.setAttribute('aria-hidden', 'true');
+
+        const title = document.createElement('span');
+        title.className = 'hud-notice-title';
+        title.textContent = artifact.title || 'Artifact';
+
+        const time = document.createElement('span');
+        time.className = 'hud-notice-time';
+        time.textContent = notice.timestamp
+            ? new Date(notice.timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+            : '';
+
+        const dismiss = document.createElement('button');
+        dismiss.type = 'button';
+        dismiss.className = 'hud-notice-dismiss';
+        dismiss.title = 'Dismiss';
+        dismiss.innerHTML = '&times;';
+        dismiss.addEventListener('click', (e) => {
+            e.stopPropagation();
+            notificationsPanel.dismiss(notice.id);
+        });
+
+        card.append(icon, title, time, dismiss);
+
+        const open = () => {
+            document.dispatchEvent(new CustomEvent('open-notification-artifact', {
+                detail: {
+                    url: artifact.url,
+                    title: artifact.title,
+                    artifactId: artifact.artifact_id,
+                    noticeId: notice.id,
+                },
+            }));
+        };
+        card.addEventListener('click', (e) => {
+            if (e.target.closest('.hud-notice-dismiss')) return;
+            open();
+        });
+        card.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                open();
+            }
+        });
+
+        return card;
+    }
+}
+
+export const hudNotices = new HudNotices();

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -32,6 +32,12 @@
  * segments only toggles CSS visibility (`data-segment` on the drawer); the
  * topology is never unmounted, so its live state and focus-rerooting
  * survive a round trip. Last-selected segment persists in localStorage.
+ *
+ * Notices strip (#817): `.session-hud-notices` sits between the header and
+ * the segment canvases, visible in BOTH segments — session-hud-notices.js
+ * renders pending artifact notifications (click-to-open deliverables not
+ * tied to any live session card) into it. Its height joins the header's in
+ * the peek auto-size sum below.
  */
 
 import { sidebar } from './sidebar.js';
@@ -64,6 +70,8 @@ class SessionHud {
         this._grownFromDetent = null;
         /** @type {HTMLElement|null} header strip hosting the Sessions|Services segmented control (#779) */
         this.header = null;
+        /** @type {HTMLElement|null} pending artifact-notice strip, filled by session-hud-notices.js (#817) */
+        this.noticesEl = null;
         /** @type {HTMLElement|null} sibling mount point for the Services segment's content */
         this.servicesCanvas = null;
         /** @type {'sessions'|'services'} currently active header segment */
@@ -123,12 +131,14 @@ class SessionHud {
                     <button type="button" class="session-hud-segment-btn" data-segment="services" role="tab">Services</button>
                 </div>
             </div>
+            <div class="session-hud-notices" hidden></div>
             <div class="session-hud-canvas"></div>
             <div class="session-hud-services"></div>
         `;
         document.body.appendChild(drawer);
         this.drawer = drawer;
         this.header = drawer.querySelector('.session-hud-header');
+        this.noticesEl = drawer.querySelector('.session-hud-notices');
         this.canvas = drawer.querySelector('.session-hud-canvas');
         this.servicesCanvas = drawer.querySelector('.session-hud-services');
 
@@ -164,6 +174,10 @@ class SessionHud {
         this._contentObserver.disconnect();
         const el = this.segment === 'services' ? this.servicesCanvas : this.canvas;
         this._contentObserver.observe(el, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden', 'class'] });
+        // The notices strip (#817) is segment-independent and part of the
+        // auto-size sum, so it's watched alongside whichever segment is up —
+        // a notice arriving/clearing must resize the open drawer too.
+        this._contentObserver.observe(this.noticesEl, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden', 'class'] });
     }
 
     _wireHandleDrag() {
@@ -298,7 +312,9 @@ class SessionHud {
     _applyAutoHeight() {
         if (!this.open || this.detent !== 'peek' || this._grownFromDetent !== null || this._dragging) return;
         const headerPx = this.header ? this.header.getBoundingClientRect().height : 0;
-        const rawPx = headerPx + this._contentHeightPx();
+        const noticesPx = this.noticesEl && !this.noticesEl.hidden
+            ? this.noticesEl.getBoundingClientRect().height : 0;
+        const rawPx = headerPx + noticesPx + this._contentHeightPx();
         const heightPx = clamp(rawPx, window.innerHeight * DRAG_MIN_VH, window.innerHeight * HALF_VH);
         this.drawer.style.height = `${heightPx}px`;
         this.handle.style.top = `${heightPx}px`;

--- a/agentwire/static/js/utils/rich-text.js
+++ b/agentwire/static/js/utils/rich-text.js
@@ -1,0 +1,40 @@
+/**
+ * rich-text.js — the one safe markdown-subset renderer for toast text.
+ *
+ * Escape everything FIRST so no source HTML survives, then introduce only
+ * our own known tags: [links](url) (http/https/mailto only), **bold**, and
+ * line breaks. Pure string-in/string-out — no DOM — so the rendering is
+ * regression-testable under plain node (tests/unit/test_rich_text_js.py).
+ *
+ * `links: false` renders link syntax as LITERAL text instead of an anchor.
+ * Artifact-notice toasts use it (#821 review): their text embeds a
+ * caller-supplied artifact title, and the whole toast body is already a
+ * click-to-open button — an embedded anchor would both fight that click
+ * handler and let a title like "[Click Here](https://evil.example)" spoof
+ * a trusted-looking link inside a system toast.
+ */
+
+export function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+export function renderRichText(str, { links = true } = {}) {
+    let s = escapeHtml(str);
+    if (links) {
+        // Links before bold so [**label**](url) composes. The url came
+        // through escapeHtml, so any quote in it is already &quot; and
+        // can't close the href attribute.
+        s = s.replace(
+            /\[([^\]]+)\]\((https?:\/\/[^\s)]+|mailto:[^\s)]+)\)/g,
+            (_m, label, url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`
+        );
+    }
+    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    s = s.replace(/\n/g, '<br>');
+    return s;
+}

--- a/docs/wiki/council.md
+++ b/docs/wiki/council.md
@@ -135,8 +135,9 @@ section per prompt — following the handoff pattern
   artifact CSP blocks external fetches; verbatim text is HTML-escaped),
   theme-aware light/dark, at
   `~/.agentwire/artifacts/council-<name>-minutes/index.html`. The command
-  prints the path and best-effort opens it as a portal artifact window when
-  the portal is up (`opened` in the `--json` payload).
+  prints the path and best-effort announces it as a click-to-open portal
+  notification — toast + Session HUD entry, never a focus-stealing window
+  open (#817) — when the portal is up (`notified` in the `--json` payload).
 - **`council stop` renders minutes automatically** when any prompt exists
   (`--no-minutes` to skip, `--synthesis` to include your synthesis), so
   closing a sitting leaves the record behind. Prompt history survives stop,

--- a/tests/unit/test_council_minutes.py
+++ b/tests/unit/test_council_minutes.py
@@ -2,8 +2,8 @@
 
 Covers the pure renderer (``agentwire/council/minutes.py``), the
 ``council minutes`` CLI handler, and the ``council stop`` auto-minutes
-integration. Artifacts land in a tmp dir and the portal open is mocked, so
-nothing touches ``~/.agentwire`` or the network.
+integration. Artifacts land in a tmp dir and the portal notification is mocked,
+so nothing touches ``~/.agentwire`` or the network.
 """
 
 import argparse
@@ -32,15 +32,15 @@ def artifacts_root(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def portal_opens(monkeypatch):
-    """Mock the best-effort portal window open; record calls."""
+def portal_notices(monkeypatch):
+    """Mock the best-effort portal artifact notification; record calls."""
     calls = []
 
-    def fake_open(url, title):
+    def fake_notify(url, title):
         calls.append((url, title))
         return True
 
-    monkeypatch.setattr(cli, "open_artifact_window", fake_open)
+    monkeypatch.setattr(cli, "notify_artifact", fake_notify)
     return calls
 
 
@@ -201,24 +201,24 @@ class TestMinutesCmd:
         kw.setdefault("synthesis", None)
         return cli.cmd_council_minutes(_args(**kw))
 
-    def test_renders_prints_path_and_opens_window(self, capsys, portal_opens):
+    def test_renders_prints_path_and_notifies(self, capsys, portal_notices):
         seat()
         make_round()
         assert self._run() == 0
         payload = _payload(capsys)
-        assert payload["success"] and payload["opened"]
+        assert payload["success"] and payload["notified"]
         assert payload["path"].endswith(f"council-{NAME}-minutes/index.html")
-        assert portal_opens == [
+        assert portal_notices == [
             (f"council-{NAME}-minutes/index.html", f"Council minutes — {NAME}")
         ]
 
     def test_portal_down_is_best_effort(self, capsys, monkeypatch):
         seat()
         make_round()
-        monkeypatch.setattr(cli, "open_artifact_window", lambda url, title: False)
+        monkeypatch.setattr(cli, "notify_artifact", lambda url, title: False)
         assert self._run() == 0
         payload = _payload(capsys)
-        assert payload["success"] and payload["opened"] is False
+        assert payload["success"] and payload["notified"] is False
 
     def test_zero_prompts_errors(self, capsys):
         seat()

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -240,11 +240,27 @@ class TestDesktopTools:
         from agentwire.mcp_desktop import desktop_write_artifact
         mock_req.side_effect = [
             {"success": True, "path": "/tmp/x.html", "url": "/artifacts/x.html"},
-            {"success": True, "window_id": "art-1"},
+            {"success": True, "id": "toast-1234", "clients": 1},
         ]
         result = desktop_write_artifact(filename="x.html", html_content="<h1>Hi</h1>")
-        assert "art-1" in result
+        assert "toast-1234" in result
+        assert "announced" in result
         assert mock_req.call_count == 2
+        # Step 2 is the click-to-open notification (#817), never a window open.
+        assert mock_req.call_args_list[1].args == (
+            "POST", "/api/desktop/notification",
+            {"artifact": {"url": "x.html", "title": "Artifact"}},
+        )
+
+    @patch("agentwire.mcp_desktop._portal_request")
+    def test_open_artifact_announces_not_opens(self, mock_req):
+        from agentwire.mcp_desktop import desktop_open_artifact
+        mock_req.return_value = {"success": True, "id": "toast-5678", "clients": 0}
+        result = desktop_open_artifact(url="report.html", title="Report", artifact_id="rep-1")
+        mock_req.assert_called_once_with("POST", "/api/desktop/notification", {
+            "artifact": {"url": "report.html", "title": "Report", "artifact_id": "rep-1"},
+        })
+        assert "toast-5678" in result
 
     @patch("agentwire.mcp_desktop._portal_request")
     def test_write_artifact_upload_failure(self, mock_req):

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -628,6 +628,71 @@ class TestApiDesktopNotification:
         assert data["clients"] == 1
         assert "id" in data
 
+    async def test_artifact_notice_defaults(self, portal_client):
+        """#817: an artifact notice needs no text (synthesized from the title),
+        derives the frontend's url-slug window id, and defaults to sticky —
+        an unclicked deliverable must never silently fade."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        resp = await client.post("/api/desktop/notification", json={
+            "artifact": {"url": "council-proj-minutes/index.html",
+                         "title": "Council minutes — proj"},
+        })
+        assert resp.status == 200
+        [notice] = server.active_notifications.values()
+        assert notice["text"] == "**Council minutes — proj** is ready — click to open"
+        assert notice["timeout"] == 0
+        assert notice["artifact"] == {
+            "url": "council-proj-minutes/index.html",
+            "title": "Council minutes — proj",
+            "artifact_id": "artifact-council-proj-minutes-index-html",
+        }
+
+    async def test_artifact_requires_url(self, portal_client):
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        resp = await client.post("/api/desktop/notification", json={
+            "artifact": {"title": "No url"},
+        })
+        assert resp.status == 400
+
+    async def test_artifact_dedup_by_artifact_id(self, portal_client):
+        """A re-render of the same artifact replaces its pending notice
+        instead of stacking a second one."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        for _ in range(2):
+            await client.post("/api/desktop/notification", json={
+                "artifact": {"url": "report.html", "title": "Report"},
+            })
+        assert len(server.active_notifications) == 1
+
+    async def test_session_sweep_spares_artifact_notices(self, portal_client):
+        """The one-toast-per-session replacement must not eat a pending
+        artifact notice tagged with the same session — seeing the session
+        is not seeing the artifact (#817)."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        await client.post("/api/desktop/notification", json={
+            "session": "proj",
+            "artifact": {"url": "report.html", "title": "Report"},
+        })
+        await client.post("/api/desktop/notification", json={
+            "session": "proj", "text": "idle nag",
+        })
+        texts = sorted(n["text"] for n in server.active_notifications.values())
+        assert texts == ["**Report** is ready — click to open", "idle nag"]
+
+    async def test_window_open_rejects_artifact_type(self, portal_client):
+        """#817: the force-open path for artifacts is gone — producers go
+        through /api/desktop/notification instead."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        resp = await client.post("/api/desktop/window/open", json={
+            "type": "artifact", "url": "x.html", "title": "X",
+        })
+        assert resp.status == 400
+
 
 # ---------------------------------------------------------------------------
 # Security middleware: Origin validation (CSRF guard)

--- a/tests/unit/test_rich_text_js.py
+++ b/tests/unit/test_rich_text_js.py
@@ -1,0 +1,61 @@
+"""Artifact-toast titles must never render as markdown links (#821 review).
+
+The synthesized artifact-notice text embeds a caller-supplied title
+(``**{title}** is ready — click to open``), and the toast frontend renders
+text through a markdown subset whose link rule would turn a title like
+``[Click Here](http://evil.example)`` into a real clickable anchor inside a
+trusted-looking system toast. Artifact toasts therefore render with links
+disabled (notifications-panel.js passes ``links: !artifact``).
+
+These tests drive the REAL frontend renderer — static/js/utils/rich-text.js
+is pure string-in/string-out precisely so this is testable under plain node,
+no browser harness needed.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+RICH_TEXT_JS = (
+    Path(__file__).resolve().parents[2] / "agentwire" / "static" / "js" / "utils" / "rich-text.js"
+)
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+
+
+def _render(text: str, links: bool) -> str:
+    script = (
+        f"import({json.dumps(RICH_TEXT_JS.as_uri())}).then(m => "
+        f"process.stdout.write(JSON.stringify(m.renderRichText("
+        f"{json.dumps(text)}, {{links: {json.dumps(links)}}}))))"
+    )
+    out = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+class TestArtifactToastTitleNotLinkified:
+    TITLE = "[Click Here](http://evil.example)"
+    SYNTHESIZED = f"**{TITLE}** is ready — click to open"
+
+    def test_links_off_renders_link_syntax_as_literal_text(self):
+        html = _render(self.SYNTHESIZED, links=False)
+        assert "<a " not in html
+        assert self.TITLE in html  # literal, visible verbatim
+        assert html.startswith("<strong>")  # bold still applies
+
+    def test_normal_toasts_keep_links(self):
+        html = _render("see [docs](https://example.com/docs)", links=True)
+        assert '<a href="https://example.com/docs"' in html
+        assert 'rel="noopener noreferrer"' in html
+
+    def test_source_html_never_survives_either_mode(self):
+        for links in (True, False):
+            html = _render('<script>alert(1)</script>"onmouseover="x', links=links)
+            assert "<script>" not in html
+            assert '"onmouseover' not in html  # quotes escaped too


### PR DESCRIPTION
## What

Background-produced artifacts (council minutes, handoff renders, wiki lint reports, scheduler reports) no longer auto-open a window on top of whatever the user is working in. They fire a click-to-open notification instead: a toast (bottom-right) plus a pending-notice card in the Session HUD peek/drawer. The window opens, focused, only when the user clicks either surface.

## How

**Backend — the force-open path for artifacts is gone entirely:**
- `POST /api/desktop/window/open` rejects `type: "artifact"` (session/panel opens unchanged). Enforcing this server-side means no current or future producer can steal focus, rather than patching call sites one by one.
- `POST /api/desktop/notification` gains an `artifact: {url, title, artifact_id}` target. Text is synthesized from the title when omitted; `artifact_id` defaults to the same url-derived slug the frontend uses for window ids.
- `_post_toast`: artifact notices default **sticky** (an unclicked deliverable must not fade away unseen), dedup against their own `artifact_id` (a re-render replaces the pending notice — verified e2e), and are exempt from the one-toast-per-session sweep in both directions (seeing the session ≠ seeing the artifact).
- Producers rerouted: council `_render_minutes` (now `notify_artifact`; JSON keys `minutes_opened`/`opened` → `minutes_notified`/`notified`), `agentwire open` CLI, MCP `desktop_open_artifact` / `desktop_write_artifact`. `notify_user` gains optional `artifact_url`/`artifact_title` so agents can hand the human a deliverable with custom toast text.

**Frontend:**
- `notifications-panel.js` is the SSOT for pending artifact notices — toast and HUD entry share one lifecycle (dismissing or clicking either clears both, persisted server-side). Artifact toasts get a neon-blue accent border; `dismissForSession` (auto-dismiss when tabbing into a session) spares artifact notices.
- New `session-hud-notices.js` renders the notices strip pinned above the HUD topology canvas, visible in both header segments; the peek auto-height includes it.
- Both surfaces dispatch one `open-notification-artifact` event; the single handler in `desktop.js` dismisses the notice, closes the HUD peek, and opens the artifact. All CSS via existing theme variables (neon-blue secondary = artifact accent; green stays session/live state).

**Click-path judgment call (issue asked for reasoning):** the click reuses the standard `openArtifactWindow` (minimize-others + maximize) rather than a focus-only raise. The desktop is architecturally single-window-mode (`registerWindow` in desktop-manager.js re-applies minimize-all + maximize on every registration, and the owner runs the portal in a narrow window where stacked windows aren't visible anyway), so a focus-only open would fight the window manager for no visible benefit. The bug was never the minimize — it was that it happened *unprompted*. A click is a prompt, and now behaves exactly like every other deliberate open (sidebar session click, etc.). Notification arrival also does **not** auto-open the HUD peek — the toast is the transient cue; the HUD entry is the persistent one for whenever the user opens it.

## Verification

- Full suite: **2777 passed** (`uv run pytest tests/`), including new endpoint tests (artifact defaults/dedup/session-sweep exemption, window/open artifact rejection) and updated council/MCP tests. `ruff` clean; JS validated via `node --check --input-type=module`.
- Chrome e2e against an isolated dev portal (`agentwire portal serve --port 8199` from the worktree, no-SSL config; real portal untouched):
  - Opened a session monitor window, then posted an artifact notification while it had focus → **no window opened, no focus change**; sticky blue-accent toast appeared.
  - Alt+P peek showed the pending notice card above the topology; drawer auto-sized to include it.
  - Clicking the HUD card → peek closed, toast + notice dismissed (server-side list empty afterward), artifact window opened focused with the right content.
  - Clicking a toast body directly → same open + dismissal.
  - Posting twice for the same artifact → one pending notice (artifact_id dedup, observed via `/api/desktop/notifications`).
  - Regression: a session-tagged toast still opens/focuses that session's window on click (`open-notification-session` unchanged). No console errors.

Closes #817

Built by [dotdev.dev](https://dotdev.dev)