### PR TITLE
fix(portal): restyle HUD peek scrollbars onto the shared thin treatment

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -5310,23 +5310,43 @@ body.sidebar-pinned .sidebar-tab {
     flex: 1;
     overflow-y: auto;
     padding: var(--spacing-base);
+}
 
-    /* Thin, muted scrollbar that blends into the sidebar chrome.
-       Firefox uses the `scrollbar-*` properties; WebKit/Blink uses
-       the `::-webkit-scrollbar*` pseudo-elements below. */
+/* Thin, muted scrollbar that blends into the frosted-glass chrome — shared
+   by the sidebar and the Session HUD's scroll containers. Firefox uses the
+   `scrollbar-*` properties; WebKit/Blink uses the `::-webkit-scrollbar*`
+   pseudo-elements below. */
+.sidebar-sections,
+.session-hud-canvas,
+.session-hud-services {
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
 }
 
-.sidebar-sections::-webkit-scrollbar {
+.sidebar-sections::-webkit-scrollbar,
+.session-hud-canvas::-webkit-scrollbar,
+.session-hud-services::-webkit-scrollbar {
     width: 6px;
+    /* height covers the horizontal scrollbar — .session-hud-canvas scrolls
+       both ways (shade-mode topology flows left-to-right). */
+    height: 6px;
 }
 
-.sidebar-sections::-webkit-scrollbar-track {
+.sidebar-sections::-webkit-scrollbar-track,
+.session-hud-canvas::-webkit-scrollbar-track,
+.session-hud-services::-webkit-scrollbar-track {
     background: transparent;
 }
 
-.sidebar-sections::-webkit-scrollbar-thumb {
+/* Corner square where the two scrollbars meet on the both-axis canvas —
+   defaults to an opaque box that punches a hole in the frosted glass. */
+.session-hud-canvas::-webkit-scrollbar-corner {
+    background: transparent;
+}
+
+.sidebar-sections::-webkit-scrollbar-thumb,
+.session-hud-canvas::-webkit-scrollbar-thumb,
+.session-hud-services::-webkit-scrollbar-thumb {
     background: rgba(255, 255, 255, 0.12);
     border-radius: 3px;
     /* Inset the thumb so it sits at the edge rather than filling the gutter,
@@ -5335,7 +5355,9 @@ body.sidebar-pinned .sidebar-tab {
     background-clip: padding-box;
 }
 
-.sidebar-sections::-webkit-scrollbar-thumb:hover {
+.sidebar-sections::-webkit-scrollbar-thumb:hover,
+.session-hud-canvas::-webkit-scrollbar-thumb:hover,
+.session-hud-services::-webkit-scrollbar-thumb:hover {
     background: rgba(255, 255, 255, 0.28);
     background-clip: padding-box;
 }


### PR DESCRIPTION
The Session HUD peek/drawer showed default browser scrollbars when its topology overflowed (shade-mode flows left-to-right, so horizontal overflow is the common case), clashing with the dark frosted-glass chrome.

Per the SSOT convention, this groups `.session-hud-canvas` and `.session-hud-services` into the existing `.sidebar-sections` thin/muted floating-scrollbar rules rather than adding a third scrollbar variant. Two additions beyond the grouping:

- The shared `::-webkit-scrollbar` rule now sets `height: 6px` alongside `width` — the canvas scrolls both axes (harmless for the vertical-only containers, where height never applies).
- `.session-hud-canvas::-webkit-scrollbar-corner { background: transparent }` — with both scrollbars visible the corner square otherwise defaults to an opaque box punching a hole in the frosted glass.

`.session-hud-services` (vertical-only, `overflow-y: auto`) gets the same treatment since a long services list can overflow too.

## Verification

Ran an isolated dev portal from this worktree (`uv run agentwire portal serve --port 8899`, worktree source served — confirmed the modified CSS via curl before testing). Opened the HUD peek with Alt+P in Chrome; the live session families (agentwire + documentscribe workers) overflowed the canvas on **both** axes without needing dummy sessions:

- Horizontal and vertical scrollbars both render as the thin (6px), rounded, muted `rgba(255,255,255,0.12)` floating thumb on a transparent track — matching the sidebar exactly — instead of the thick gray OS defaults. They persist while idle (custom styling active, not macOS overlay auto-hide).
- Programmatic check: canvas computed `scrollbar-width: thin`, `scrollbar-color: rgba(255,255,255,0.12) transparent`, `scrollWidth > clientWidth` and `scrollHeight > clientHeight` both true; `.session-hud-services` picks up the same computed values (no overflow with the current 4 services, styled when it grows).
- No ugly corner box where the two scrollbars meet.
- Regression check: `.sidebar-sections` computed values unchanged after the refactor.
- Light theme: N/A — the portal is dark-only (no `prefers-color-scheme`/`data-theme` anywhere in desktop.css).

No throwaway sessions were spawned, portal instance stopped and Chrome tab closed after testing.

Closes #824

Built by [dotdev.dev](https://dotdev.dev)