### PR TITLE
fix(hud): reserve bottom margin in peek auto-size; fix Services and scrollbar undercounts

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -7380,6 +7380,14 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     padding: 4px 12px 8px;
 }
 
+/* Same [hidden]-override gotcha as .topology-ghost-actions: the author
+   display:flex above beats the UA [hidden]{display:none}, so without this
+   the empty strip still renders its 12px of padding — phantom height the
+   peek auto-size sum counts as 0 (#823). */
+.session-hud-notices[hidden] {
+    display: none;
+}
+
 .hud-notice-card {
     display: flex;
     align-items: center;

--- a/agentwire/static/js/session-hud.js
+++ b/agentwire/static/js/session-hud.js
@@ -51,6 +51,14 @@ const MID_THRESHOLD = (PEEK_VH + HALF_VH) / 2;
 const DRAG_MIN_VH = 0.12;
 const DRAG_MAX_VH = 0.66;
 const CLICK_TOLERANCE_PX = 3;
+/** Reserved gap between the last card and the drawer's border-bottom in the
+ * peek auto-size sum (#823). Deliberate and segment-independent: the mounted
+ * content's own bottom padding (8px on .topology-view--shade, 12px on
+ * .session-hud-services) is incidental and not guaranteed, and measurement
+ * timing slop (rAF firing before an in-progress card animation settles) can
+ * leave the real render slightly taller than what was measured — this margin
+ * absorbs both so content never sits flush against the border. */
+const PEEK_BOTTOM_MARGIN_PX = 10;
 
 /** localStorage key for the last-selected header segment (#779). */
 const SEGMENT_KEY = 'aw-hud-segment';
@@ -274,22 +282,39 @@ class SessionHud {
     }
 
     /** Natural content height of whichever header segment is currently
-     * visible. Measure the canvas's *content child*, not the canvas itself:
+     * visible. Measure the canvas's *content children*, not the canvas itself:
      * the canvas is `flex:1 1 0` and stretches to fill the drawer, so its own
      * `scrollHeight` is floored by its `clientHeight` and can never report
      * *less* than the current drawer height — which let auto-size grow (content
      * overflows) but never shrink below the peek detent for a single-card view
-     * (#802). The inner content root (`.topology-view` / the services list) is
-     * content-sized in both directions, so its rendered height + the canvas's
-     * own vertical padding is the height the canvas would take at rest. */
+     * (#802). The children are content-sized in both directions, so their
+     * rendered heights + the canvas's own vertical padding is the height the
+     * canvas would take at rest. Summed over ALL children (+ their vertical
+     * margins), not just the first: the topology mounts a single
+     * `.topology-view` root, but the services section renders a flat list of
+     * sibling cards — measuring only the first child sized the drawer to one
+     * card and left the rest scrolled out of view (#823). */
     _contentHeightPx() {
         const el = this.segment === 'services' ? this.servicesCanvas : this.canvas;
         if (!el) return 0;
-        const content = el.firstElementChild;
-        if (!content) return el.scrollHeight;
+        // A classic (non-overlay) horizontal scrollbar consumes canvas inner
+        // height without appearing in the children's own measured heights —
+        // omit it and the drawer clips exactly that many px off the last
+        // row of cards (#823). offsetHeight−clientHeight is its current
+        // rendered thickness (0 for overlay scrollbars or no horizontal
+        // overflow), and it's stable across the height change this measure
+        // feeds: presence depends on content width vs canvas width, not on
+        // the drawer's height.
+        const scrollbarPx = el.offsetHeight - el.clientHeight;
+        if (!el.firstElementChild) return el.scrollHeight + scrollbarPx;
         const cs = getComputedStyle(el);
-        const padV = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
-        return content.getBoundingClientRect().height + padV;
+        let heightPx = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom) + scrollbarPx;
+        for (const child of el.children) {
+            const ccs = getComputedStyle(child);
+            heightPx += child.getBoundingClientRect().height
+                + parseFloat(ccs.marginTop) + parseFloat(ccs.marginBottom);
+        }
+        return heightPx;
     }
 
     /** Debounced entry point for content-driven mutations (MutationObserver,
@@ -314,7 +339,7 @@ class SessionHud {
         const headerPx = this.header ? this.header.getBoundingClientRect().height : 0;
         const noticesPx = this.noticesEl && !this.noticesEl.hidden
             ? this.noticesEl.getBoundingClientRect().height : 0;
-        const rawPx = headerPx + noticesPx + this._contentHeightPx();
+        const rawPx = headerPx + noticesPx + this._contentHeightPx() + PEEK_BOTTOM_MARGIN_PX;
         const heightPx = clamp(rawPx, window.innerHeight * DRAG_MIN_VH, window.innerHeight * HALF_VH);
         this.drawer.style.height = `${heightPx}px`;
         this.handle.style.top = `${heightPx}px`;


### PR DESCRIPTION
Fixes the HUD peek drawer's last card sitting flush against (or crossing) the border-bottom. Browser verification found the reserved-margin gap was only one of THREE contributors — all fixed:

1. **No reserved margin** — `_applyAutoHeight()` summed header + notices + content exactly. Added `PEEK_BOTTOM_MARGIN_PX = 10` to the sum, independent of whatever incidental bottom padding the mounted segment has (8px on `.topology-view--shade`, 12px on `.session-hud-services` — 10px on top of either reads as a consistent, deliberate gap without doubling up).
2. **Horizontal scrollbar undercount** — with classic (non-overlay) scrollbars, the canvas's horizontal scrollbar consumes 15px of inner height that the content-child measure never counted, clipping exactly that many px off the last row of cards. `_contentHeightPx()` now adds `offsetHeight − clientHeight` (0 for overlay scrollbars / no horizontal overflow).
3. **Services measured only one card** — `_contentHeightPx()` read `firstElementChild` only; the Services segment renders a *flat list* of sibling cards, so the drawer sized to a single card (measured 138px vs 324px of actual content) and scrolled the rest out of view. It now sums all children plus their vertical margins.

Plus a related phantom-height bug: `.session-hud-notices` sets `display: flex`, which overrides the UA's `[hidden] { display: none }` — the "hidden" empty strip still rendered 12px of padding that the auto-size sum counted as 0. Added the `[hidden]` override (same documented gotcha as `.topology-ghost-actions`).

## Fresh recompute on open (part 2 of the issue)

Confirmed already true, no changes needed: every closed→open transition goes through `toggle()`'s open branch, which schedules a recompute for peek or clears the inline height for half; the close branch clears the inline height unconditionally. `peekForSpawn()`, `restoreDetent()`, drag-release `_settle()`, `_applySegment()`, and the window-resize listener all funnel into the same scheduled recompute. Verified empirically (below) that closing leaves no inline height and each reopen re-measures from live content.

## Browser verification (isolated dev portal on :8823, ~16 live session cards + 4-5 services)

- **Sessions segment**: drawer height lands at exactly header + content + scrollbar + 10 (e.g. 39 + 248 + 15 + 10 = 312px), `scrollHeight − clientHeight = 0` (nothing clipped), last card bottom 33px above the border (8 shade padding + 15 scrollbar + 10 margin). Visually: clean space under the last row, then the scrollbar, then the border — nothing flush or crossing.
- **Services segment**: previously sized to one card with 226px of content scrolled out of view; now all cards visible, 26px gap (12 padding + 4 card margin + 10 margin), zero clipped. At 5 cards the computed 450px sat just under the 453px half-cap; content beyond the cap correctly clamps and scrolls (by design, #802).
- **Toggle cycles ×3**: inline height empty string after every close, recomputed to the identical correct value on every reopen, gap unchanged each cycle.
- **Segment switches both directions**: each switch re-measured and resized correctly.
- **Resize**: viewport width change reflowed the topology and the recomputed gap held (verified visually at two window sizes).
- **Live churn**: sessions/services appearing and disappearing mid-test consistently converged to correct height on the next recompute pass — including content-shrink (drawer shrinks back down) and content-grow.

One test-environment caveat: the verification Chrome window was OS-occluded part of the time, which freezes rAF — the auto-height debounce had to be flushed manually in those moments (same code path the rAF invokes). On a visible tab the MutationObserver → rAF pipeline fires normally, as it did in the initial visible-tab measurements.

Full `uv run --extra dev pytest`: 2780 passed.

Closes #823

Built by [dotdev.dev](https://dotdev.dev)