### PR TITLE
fix: batch dead-letter escalation emails; block service-session parenting

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -479,8 +479,20 @@ def resolve_default_created_by(caller: str | None, target_path: Path) -> str | N
     `{project}-{name}`, and would misjudge same/cross-project); if the
     caller's real cwd can't be confirmed, treat it as unknown (no inheritance)
     rather than risk a wrong guess.
+
+    A service session (agentwire-portal, -tts, -stt, -kokoro, ...) never
+    qualifies as a parent: it's infrastructure, not an agent that will ever
+    drain its msg inbox, so anything parented to it dead-letters forever. A
+    subprocess the portal shells out to inherits its TMUX_PANE and resolves
+    ``caller`` right back to "agentwire-portal" — this was the root cause of
+    a 147-message dead-letter storm (each mailing the owner individually,
+    2026-07-19).
     """
     if not caller:
+        return None
+    from .services import is_service_session
+
+    if is_service_session(caller):
         return None
     caller_path = _live_session_cwd(caller)
     if caller_path is None:

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -654,9 +654,12 @@ def _escalate_dead_letters(messages: list[Message], reason: str) -> None:
             subject = (
                 f"[agentwire] {len(batch)} undelivered messages → {to} (dead-lettered)"
             )
+        noun = "message" if len(batch) == 1 else "messages"
+        verb = "was" if len(batch) == 1 else "were"
         lines = [
-            f"{len(batch)} load-bearing message(s) on `{host}` were never delivered "
-            f"and have been dead-lettered (last defer reason: {reason}).",
+            f"{len(batch)} load-bearing {noun} on `{host}` {verb} never delivered "
+            f"and {'has' if len(batch) == 1 else 'have'} been dead-lettered "
+            f"(last defer reason: {reason}).",
             "",
         ]
         for msg in batch[:_ESCALATE_DIGEST_DETAIL_CAP]:

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -453,6 +453,7 @@ def gc_sender(sender: str) -> dict:
             # delivered, not lost. Skip GC for this recipient this round.
             continue
         try:
+            newly_dead: list[Message] = []
             for path in paths:
                 if not path.exists():
                     continue  # delivered + unlinked just before we locked
@@ -472,7 +473,7 @@ def gc_sender(sender: str) -> dict:
                             attempts=msg.attempts, reason="sender_exited",
                         )
                         dead += 1
-                        _escalate_dead_letter(msg, "sender_exited")
+                        newly_dead.append(msg)
                     except OSError:
                         pass
                 else:
@@ -481,6 +482,8 @@ def gc_sender(sender: str) -> dict:
                         dropped += 1
                     except OSError:
                         pass
+            # One digest per recipient, not one email per message (#836).
+            _escalate_dead_letters(newly_dead, "sender_exited")
         finally:
             _release_lock(lock)
 
@@ -608,17 +611,32 @@ def _fmt_ts(ms: int) -> str:
     return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ms / 1000))
 
 
-def _escalate_dead_letter(msg: Message, reason: str) -> None:
-    """Email the owner when a load-bearing report-back dead-letters.
+# A single stuck recipient (e.g. a session wrongly parented to a service
+# session that can never drain its inbox) can dead-letter dozens of messages
+# in one drain pass — cap the per-message detail in the digest so the email
+# stays readable instead of dumping an unbounded wall of text.
+_ESCALATE_DIGEST_DETAIL_CAP = 10
+
+
+def _escalate_dead_letters(messages: list[Message], reason: str) -> None:
+    """Email the owner once per batch when load-bearing report-backs dead-letter.
 
     ``done`` / ``request`` / ``escalation`` are load-bearing — a silently-dropped
     one is a real loss, so we surface it out-of-band via the shared Resend wiring
     (the same owner-escalation channel usage-limit parking uses). ``note`` and
-    ``ingest`` are not escalated. Best-effort: a missing key or send failure must
-    never break the drain — the corpse already sits in ``dead/`` for
-    ``agentwire msg dead``.
+    ``ingest`` are not escalated.
+
+    *messages* is everything dead-lettered by one caller's batch (one drain
+    pass for one recipient, or one sender's GC sweep) — a single digest email
+    covers the whole batch instead of one email per message, so a recipient
+    that's been permanently undeliverable for a while (e.g. parented to a
+    service session that never drains) can't spam the owner's inbox one email
+    per stuck message (147 individual emails in ~2s, 2026-07-19). Best-effort:
+    a missing key or send failure must never break the drain — each corpse
+    already sits in ``dead/`` for ``agentwire msg dead``.
     """
-    if msg.kind not in ESCALATE_KINDS:
+    batch = [m for m in messages if m.kind in ESCALATE_KINDS]
+    if not batch:
         return
     try:
         import socket
@@ -626,36 +644,44 @@ def _escalate_dead_letter(msg: Message, reason: str) -> None:
         from .channels.email import send_email
 
         host = socket.gethostname()
-        subject = (
-            f"[agentwire] undelivered {msg.kind}: {msg.sender} → {msg.to} (dead-lettered)"
-        )
-        body = "\n".join([
-            f"A **{msg.kind}** message from **{msg.sender}** to **{msg.to}** on "
-            f"`{host}` was never delivered after {msg.attempts} attempts and has "
-            f"been dead-lettered.",
+        if len(batch) == 1:
+            msg = batch[0]
+            subject = (
+                f"[agentwire] undelivered {msg.kind}: {msg.sender} → {msg.to} (dead-lettered)"
+            )
+        else:
+            to = batch[0].to
+            subject = (
+                f"[agentwire] {len(batch)} undelivered messages → {to} (dead-lettered)"
+            )
+        lines = [
+            f"{len(batch)} load-bearing message(s) on `{host}` were never delivered "
+            f"and have been dead-lettered (last defer reason: {reason}).",
             "",
-            f"- **Kind:** {msg.kind}",
-            f"- **From:** {msg.sender}",
-            f"- **To:** {msg.to}",
-            f"- **Last defer reason:** {reason}",
-            f"- **Sent:** {_fmt_ts(msg.ts)}",
-            f"- **Dead-lettered:** {_fmt_ts(msg.dead_ts)}",
+        ]
+        for msg in batch[:_ESCALATE_DIGEST_DETAIL_CAP]:
+            lines += [
+                f"- **{msg.kind}** {msg.sender} → {msg.to}, sent {_fmt_ts(msg.ts)}, "
+                f"dead-lettered {_fmt_ts(msg.dead_ts)}, {msg.attempts} attempts:",
+                "  ```",
+                f"  {msg.text}",
+                "  ```",
+            ]
+        remaining = len(batch) - _ESCALATE_DIGEST_DETAIL_CAP
+        if remaining > 0:
+            lines.append(f"- ...and {remaining} more.")
+        lines += [
             "",
-            "Message text:",
-            "",
-            "```",
-            msg.text,
-            "```",
-            "",
-            f"Saved in the dead-letter store — review with `agentwire msg dead -s {msg.to}`.",
-        ])
-        result = send_email(subject=subject, body=body)
+            f"Saved in the dead-letter store — review with "
+            f"`agentwire msg dead -s {batch[0].to}`.",
+        ]
+        result = send_email(subject=subject, body="\n".join(lines))
         _log_event(
-            "dead_letter_escalated", id=msg.id, to=msg.to, kind=msg.kind,
+            "dead_letter_escalated", to=batch[0].to, count=len(batch), reason=reason,
             ok=bool(getattr(result, "success", False)),
         )
     except Exception as exc:  # escalation is best-effort; never break the drain
-        _log_event("dead_letter_escalate_failed", id=msg.id, to=msg.to, error=str(exc))
+        _log_event("dead_letter_escalate_failed", to=batch[0].to, count=len(batch), error=str(exc))
 
 
 def _bump_attempts(messages: list[Message], reason: str = "") -> int:
@@ -675,6 +701,7 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
     burns out on schedule.
     """
     dead = 0
+    newly_dead: list[Message] = []
     for msg in messages:
         if msg.path is None:
             continue
@@ -705,7 +732,7 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
                     attempts=msg.attempts, reason=reason,
                 )
                 dead += 1
-                _escalate_dead_letter(msg, reason)
+                newly_dead.append(msg)
             except OSError:
                 pass
         else:
@@ -713,6 +740,9 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
                 _write_message(msg.path, msg)
             except OSError:
                 pass
+    # One digest email for the whole batch (all share the same recipient —
+    # `messages` is always one session's inbox), not one per message (#836).
+    _escalate_dead_letters(newly_dead, reason)
     return dead
 
 

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -143,8 +143,14 @@ lands in a durable inbox and is injected only at a safe boundary.
      / `escalation`) does dead-letter, the owner is emailed via the shared Resend
      wiring (the same channel usage-limit parking uses) so the loss is surfaced
      even if nobody runs `msg dead`. `note` is fire-and-forget and `ingest` never
-     auto-delivers, so neither is escalated. Escalation is best-effort — a send
-     failure is logged (`dead_letter_escalate_failed`) and never breaks the drain.
+     auto-delivers, so neither is escalated. Escalation is **batched per drain
+     pass, not per message** (#829/#830): every message dead-lettered in the
+     same batch for one recipient gets a single digest email (detail capped at
+     the first 10, "...and N more" beyond that) instead of one email each — a
+     recipient stuck permanently undeliverable (e.g. wrongly parented to a
+     service session that never drains) can't spam the owner one email per
+     stuck message. Escalation is best-effort — a send failure is logged
+     (`dead_letter_escalate_failed`) and never breaks the drain.
 
 ### `prompt_is_empty` — the collision detector
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def _no_real_outbound_email(request, monkeypatch):
     """No test may send real email — ever.
 
-    ``_escalate_dead_letter`` (and friends) call the live Resend wiring, so a
+    ``_escalate_dead_letters`` (and friends) call the live Resend wiring, so a
     test that dead-letters a done/request/escalation message without mocking
     ``send_email`` silently emails the owner on every suite run (found the hard
     way: ``test_purge_leaves_ingest_and_dead`` flooded the inbox with

--- a/tests/unit/test_core_created_by_rooting.py
+++ b/tests/unit/test_core_created_by_rooting.py
@@ -115,3 +115,14 @@ class TestResolveDefaultCreatedBy:
         monkeypatch.setattr(core, "tmux_session_exists", lambda s: False)
         repo = _make_repo(tmp_path)
         assert core.resolve_default_created_by("myproject-fix-bug", repo) is None
+
+    def test_service_session_caller_returns_none(self, monkeypatch, tmp_path):
+        # Regression (2026-07-19): a session created via the portal web UI
+        # inherits the portal server subprocess's TMUX_PANE, so `caller`
+        # resolves to the "agentwire-portal" service session. Parenting to it
+        # is a bug even when same_project would otherwise match — a service
+        # session never drains its msg inbox, so anything parented to it
+        # dead-letters forever (147-message escalation-email storm).
+        repo = _make_repo(tmp_path)
+        monkeypatch.setattr(core, "_live_session_cwd", lambda s: repo)
+        assert core.resolve_default_created_by("agentwire-portal", repo) is None

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -760,6 +760,8 @@ class TestDeadLetterEscalation:
         assert len(inbox.list_dead("s")) == 1  # still archived for audit
 
     def test_request_and_escalation_also_email(self, isolate, monkeypatch):
+        # Both dead-letter in the same drain pass (same recipient) — one
+        # digest email covers the batch, not one email per kind (#836).
         inbox.enqueue("s", "need creds", kind="request", sender="w")
         inbox.enqueue("s", "stuck!", kind="escalation", sender="w")
         self._occupied_agent(monkeypatch)
@@ -767,8 +769,9 @@ class TestDeadLetterEscalation:
         self._capture_email(monkeypatch, sent)
         for _ in range(inbox.MAX_ATTEMPTS):
             inbox.flush_session("s")
-        kinds = sorted(k["subject"].split("undelivered ")[1].split(":")[0] for k in sent)
-        assert kinds == ["escalation", "request"]
+        assert len(sent) == 1
+        assert "2 undelivered messages" in sent[0]["subject"]
+        assert "request" in sent[0]["body"] and "escalation" in sent[0]["body"]
 
     def test_note_dead_letter_does_not_email(self, isolate, monkeypatch):
         inbox.enqueue("s", "fyi", kind="note", sender="worker")
@@ -791,6 +794,23 @@ class TestDeadLetterEscalation:
         for _ in range(inbox.MAX_ATTEMPTS):
             inbox.flush_session("s")
         assert len(inbox.list_dead("s")) == 1  # drain survived; corpse archived
+
+    def test_large_batch_sends_one_digest_not_one_per_message(self, isolate, monkeypatch):
+        # Regression (2026-07-19): a recipient stuck permanently undeliverable
+        # (e.g. wrongly parented to a service session) can accumulate a large
+        # backlog that all crosses MAX_ATTEMPTS in the same drain pass. That
+        # must fire ONE digest email, not one per message (147 individual
+        # emails in ~2s was the real incident).
+        for i in range(20):
+            inbox.enqueue("s", f"report {i}", kind="done", sender="w")
+        self._occupied_agent(monkeypatch)
+        sent = []
+        self._capture_email(monkeypatch, sent)
+        for _ in range(inbox.MAX_ATTEMPTS):
+            inbox.flush_session("s")
+        assert len(inbox.list_dead("s")) == 20
+        assert len(sent) == 1
+        assert "20 undelivered messages" in sent[0]["subject"]
 
 
 class TestIdempotentDelivery:
@@ -959,8 +979,8 @@ class TestForceFlush:
 class TestGcSender:
     def test_gc_dead_letters_load_bearing(self, isolate, monkeypatch):
         emailed = []
-        monkeypatch.setattr(inbox, "_escalate_dead_letter",
-                            lambda m, r: emailed.append((m.kind, r)))
+        monkeypatch.setattr(inbox, "_escalate_dead_letters",
+                            lambda batch, r: emailed.extend((m.kind, r) for m in batch))
         inbox.enqueue("orch", "PR drafted", kind="done", sender="worker")
         inbox.enqueue("orch", "need review", kind="request", sender="worker")
         res = inbox.gc_sender("worker")
@@ -970,7 +990,7 @@ class TestGcSender:
         assert emailed and all(r == "sender_exited" for _, r in emailed)
 
     def test_gc_drops_non_load_bearing(self, isolate, monkeypatch):
-        monkeypatch.setattr(inbox, "_escalate_dead_letter", lambda m, r: None)
+        monkeypatch.setattr(inbox, "_escalate_dead_letters", lambda batch, r: None)
         inbox.enqueue("orch", "fyi", kind="note", sender="worker")
         res = inbox.gc_sender("worker")
         assert res["dropped"] == 1 and res["dead"] == 0
@@ -981,8 +1001,8 @@ class TestGcSender:
         # A flush draining this inbox holds the per-session lock; gc must NOT
         # dead-letter (and email) a message that flush is mid-delivery on.
         emailed = []
-        monkeypatch.setattr(inbox, "_escalate_dead_letter",
-                            lambda m, r: emailed.append(m.id))
+        monkeypatch.setattr(inbox, "_escalate_dead_letters",
+                            lambda batch, r: emailed.extend(m.id for m in batch))
         inbox.enqueue("orch", "in flight", kind="done", sender="worker")
         held = inbox._acquire_lock("orch")  # simulate an in-flight flush
         try:

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -812,6 +812,32 @@ class TestDeadLetterEscalation:
         assert len(sent) == 1
         assert "20 undelivered messages" in sent[0]["subject"]
 
+    def _msg(self, i):
+        return inbox.Message(
+            id=f"id{i}", sender="w", to="s", kind="done", text=f"report {i}",
+            ts=1000 + i, dead_ts=2000 + i,
+        )
+
+    def test_digest_detail_cap_boundary(self, isolate, monkeypatch):
+        # Exactly at the cap: every message gets detail, no truncation line.
+        sent = []
+        self._capture_email(monkeypatch, sent)
+        batch = [self._msg(i) for i in range(inbox._ESCALATE_DIGEST_DETAIL_CAP)]
+        inbox._escalate_dead_letters(batch, "target_gone")
+        assert len(sent) == 1
+        assert "...and" not in sent[0]["body"]
+        assert all(f"report {i}" in sent[0]["body"] for i in range(len(batch)))
+
+    def test_digest_detail_cap_truncates_beyond_boundary(self, isolate, monkeypatch):
+        # One over the cap: detail for the first CAP, a single "...and 1 more."
+        sent = []
+        self._capture_email(monkeypatch, sent)
+        batch = [self._msg(i) for i in range(inbox._ESCALATE_DIGEST_DETAIL_CAP + 1)]
+        inbox._escalate_dead_letters(batch, "target_gone")
+        assert len(sent) == 1
+        assert "...and 1 more." in sent[0]["body"]
+        assert f"report {inbox._ESCALATE_DIGEST_DETAIL_CAP}" not in sent[0]["body"]
+
 
 class TestIdempotentDelivery:
     """#621: a delivery_unverified false-negative must NOT re-inject a landed
@@ -1020,6 +1046,24 @@ class TestGcSender:
         assert res == {"dead": 0, "dropped": 0}
         assert len(inbox.list_messages("orch")) == 1  # other sender's done kept
         assert inbox.list_ingest("orch")  # ingest untouched
+
+    def test_gc_batches_one_email_per_recipient(self, isolate, monkeypatch):
+        # Regression (#829/#830): gc_sender must send ONE digest email per
+        # recipient, not one per dead-lettered message — exercised against the
+        # real send_email seam (not a stubbed _escalate_dead_letters), so a
+        # regression back to per-message escalation inside the gc loop would
+        # actually be caught here.
+        sent = []
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **kw: sent.append(kw) or SimpleNamespace(success=True),
+        )
+        inbox.enqueue("orch", "PR drafted", kind="done", sender="worker")
+        inbox.enqueue("orch", "need review", kind="request", sender="worker")
+        res = inbox.gc_sender("worker")
+        assert res["dead"] == 2
+        assert len(sent) == 1
+        assert "2 undelivered messages" in sent[0]["subject"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Dead-letter escalation now sends one digest email per drain batch instead of one per message — the 147-email storm from this morning's portal restart can't recur regardless of what causes the backlog.
- `resolve_default_created_by` now rejects a service session (agentwire-portal/-tts/-stt/-kokoro/custom) as a parent — closes the actual hole that let 3 sessions get permanently stuck.
- Data cleanup (already applied live, not part of this diff): reparented documentscribe/agentwire-website/fragmentz to root, purged the 190 pending + 147 dead-lettered messages stuck in agentwire-portal's inbox.

Closes #829

## Test plan
- [x] `uv run pytest tests/unit/test_inbox.py tests/unit/test_core_created_by_rooting.py` — new regression tests for both fixes
- [x] Full suite: `uv run pytest -q` — 2802 passed
- [ ] No UI surface touched — backend messaging/session-parenting fix only, chrome e2e gate n/a

Built by [dotdev.dev](https://dotdev.dev)