### PR TITLE
fix: hard-delete genuinely orphaned worktree directories on teardown

### DIFF
--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -1586,8 +1586,10 @@ def _teardown_entry(
     _, remove_error = remove_worktree(project_path, worktree_path, force=True)
     subprocess.run(["git", "-C", str(project_path), "worktree", "prune"], capture_output=True)
 
+    hard_deleted_orphan = False
     if worktree_path.exists() and not was_registered:
         shutil.rmtree(worktree_path, ignore_errors=True)
+        hard_deleted_orphan = not worktree_path.exists()
 
     if worktree_path.exists():
         reason = remove_error or "worktree directory still present after `git worktree remove --force`"
@@ -1621,7 +1623,7 @@ def _teardown_entry(
     return {"success": True, "session": session_name, "path": str(worktree_path),
             "killed": killed, "worktree_removed": True,
             "branch": branch, "branch_deleted": branch_deleted, "branch_note": branch_note,
-            "orphaned_tabs": orphaned_tabs}
+            "orphaned_tabs": orphaned_tabs, "hard_deleted_orphan": hard_deleted_orphan}
 
 
 def _worktree_remove(args, project_path: Path, worktree_dir: Path, json_mode: bool) -> int:
@@ -1657,7 +1659,9 @@ def _worktree_remove(args, project_path: Path, worktree_dir: Path, json_mode: bo
     else:
         msg = (f"Removed worktree session '{result['session']}'"
                + (" (killed live session)" if result["killed"] else "")
-               + f"; worktree {result['path']} removed")
+               + f"; worktree {result['path']} removed"
+               + (" (git had no registration for it — hard-deleted the leftover directory)"
+                  if result.get("hard_deleted_orphan") else ""))
         if result["branch"]:
             msg += f"; branch '{result['branch']}' " + ("deleted" if result["branch_deleted"] else f"kept ({result['branch_note']})")
         if result["orphaned_tabs"]:

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -62,6 +62,7 @@ from .worktree import (
     default_base_branch,
     ensure_worktree,
     git_root,
+    is_registered_worktree,
     is_valid_branch_name,
     parse_session_name,
     remove_worktree,
@@ -1561,7 +1562,17 @@ def _teardown_entry(
     Never reports worktree_removed=True while the dir is still on disk: if
     `git worktree remove --force` can't clear it, this fails LOUDLY
     (success: False) and leaves the registry entry in place, instead of
-    silently "unregistering" an orphan.
+    silently "unregistering" an orphan — UNLESS git *already had no record of
+    the path before we touched it* (see `is_registered_worktree`), in which
+    case there's no registered worktree left to protect and the leftover
+    directory (a stale build-tool cache, typically) is hard-deleted instead.
+
+    That pre-check matters: `git worktree prune` below runs unconditionally
+    and clears any entry git marks "prunable" (e.g. one whose linked `.git`
+    file was deleted) as a side effect of THIS call — checking registration
+    after prune would misread a worktree that was real and registered right
+    up until this attempt as a pre-existing orphan, and hard-delete content
+    the fail-loud path exists to protect.
 
     The worktree removal is attempted BEFORE the session is killed, and the
     session is only killed once removal is confirmed — never the reverse.
@@ -1569,9 +1580,14 @@ def _teardown_entry(
     disk with no session left to notice, on any removal failure (bad
     project_path, a stuck worktree, ...) (#740).
     """
+    was_registered = is_registered_worktree(project_path, worktree_path)
+
     # Force-remove the git worktree, then prune admin files either way.
     _, remove_error = remove_worktree(project_path, worktree_path, force=True)
     subprocess.run(["git", "-C", str(project_path), "worktree", "prune"], capture_output=True)
+
+    if worktree_path.exists() and not was_registered:
+        shutil.rmtree(worktree_path, ignore_errors=True)
 
     if worktree_path.exists():
         reason = remove_error or "worktree directory still present after `git worktree remove --force`"

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -309,6 +309,32 @@ def remove_worktree(project_path: Path, worktree_path: Path, *, force: bool = Tr
     return False, (result.stderr or result.stdout).strip()
 
 
+def is_registered_worktree(project_path: Path, worktree_path: Path) -> bool:
+    """Does git's own worktree registry (still) know about ``worktree_path``?
+
+    A directory can outlive its registration — e.g. `git worktree remove`
+    succeeded on a prior teardown attempt but the `rm -rf` half crashed
+    before clearing a build-tool cache dir left inside, or the admin file
+    under `.git/worktrees/` was pruned independently. In that state git
+    reports "fatal: ... is not a working tree" for every future removal
+    attempt, forever — this lets a caller distinguish that (provably safe
+    to hard-delete, git has nothing to lose) from a real registered
+    worktree that `remove --force` merely failed to clear.
+    """
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=project_path, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return False
+    target = str(worktree_path.resolve())
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            if str(Path(line[len("worktree "):]).resolve()) == target:
+                return True
+    return False
+
+
 def worktree_status(worktree_path: Path) -> dict:
     """Read-only git status for a worktree. Local git only — no network, no gh.
 

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -317,16 +317,23 @@ def is_registered_worktree(project_path: Path, worktree_path: Path) -> bool:
     before clearing a build-tool cache dir left inside, or the admin file
     under `.git/worktrees/` was pruned independently. In that state git
     reports "fatal: ... is not a working tree" for every future removal
-    attempt, forever — this lets a caller distinguish that (provably safe
-    to hard-delete, git has nothing to lose) from a real registered
-    worktree that `remove --force` merely failed to clear.
+    attempt, forever — this lets a caller distinguish that from a real
+    registered worktree that `remove --force` merely failed to clear. It
+    says nothing about whether the directory holds valuable content — that
+    judgment (e.g. "orphaned + unregistered is safe to hard-delete") belongs
+    to the caller, not this function.
+
+    Fails closed on an inconclusive read: if `git worktree list` itself
+    errors (corrupt repo, I/O, lock contention), that's reported as
+    registered rather than not — a caller gating a destructive action on
+    this should default to "assume real" when unsure, not "assume orphan".
     """
     result = subprocess.run(
         ["git", "worktree", "list", "--porcelain"],
         cwd=project_path, capture_output=True, text=True,
     )
     if result.returncode != 0:
-        return False
+        return True
     target = str(worktree_path.resolve())
     for line in result.stdout.splitlines():
         if line.startswith("worktree "):

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -643,6 +643,37 @@ def test_remove_fails_loudly_when_dir_survives(tmp_path, monkeypatch, wt_env, ca
     assert payload["error"]
 
 
+def test_remove_hard_deletes_unregistered_orphan_directory(tmp_path, monkeypatch, wt_env, capsys):
+    """A directory git no longer registers as a worktree at all (its
+    `.git/worktrees/<name>` admin entry is gone, e.g. from a prior teardown
+    that crashed mid-way) must not get stuck failing `git worktree remove`
+    forever — since git has nothing left to lose, the leftover directory is
+    hard-deleted and teardown proceeds and succeeds."""
+    import shutil
+
+    _, clone = _origin_and_clone(tmp_path, default_branch="develop")
+    wt_dir = tmp_path / "worktrees"
+    cfg = _config(wt_dir)
+    assert _run(monkeypatch, cfg, name="orphan", project=str(clone)) == 0
+    wt_path = wt_dir / "clone-repo" / "orphan"
+    assert wt_path.exists()
+
+    # Simulate the crashed-partial-teardown state: git's own registration is
+    # gone, but the directory (with leftover content) survives on disk.
+    shutil.rmtree(clone / ".git" / "worktrees" / "orphan")
+    (wt_path / "stale-cache-file").write_text("leftover\n")
+
+    capsys.readouterr()
+    rc = _run(monkeypatch, cfg, name="orphan", project=str(clone), remove=True)
+    assert rc == 0
+    assert not wt_path.exists()
+    assert reg.entries(clone.resolve()) == []
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["worktree_removed"] is True
+
+
 def test_remove_kills_alive_session(tmp_path, monkeypatch, wt_env, capsys):
     _, clone = _origin_and_clone(tmp_path, default_branch="develop")
     wt_dir = tmp_path / "worktrees"

--- a/tests/integration/test_worktree_cmd.py
+++ b/tests/integration/test_worktree_cmd.py
@@ -672,6 +672,7 @@ def test_remove_hard_deletes_unregistered_orphan_directory(tmp_path, monkeypatch
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is True
     assert payload["worktree_removed"] is True
+    assert payload["hard_deleted_orphan"] is True
 
 
 def test_remove_kills_alive_session(tmp_path, monkeypatch, wt_env, capsys):

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -12,6 +12,7 @@ from agentwire.worktree import (
     git_common_dir,
     git_root,
     is_git_repo,
+    is_registered_worktree,
     is_valid_branch_name,
     parse_session_name,
     remove_worktree,
@@ -303,3 +304,36 @@ class TestRemoveWorktree:
         removed, error = remove_worktree(not_repo, tmp_path / "wherever")
         assert removed is False
         assert error
+
+
+# --- is_registered_worktree ---
+
+class TestIsRegisteredWorktree:
+    def test_true_for_a_live_worktree(self, tmp_path):
+        repo, _ = _make_repo(tmp_path)
+        wt = tmp_path / "repo-worktrees" / "feature"
+        assert ensure_worktree(repo, "feature", wt)
+        assert is_registered_worktree(repo, wt) is True
+
+    def test_false_once_gits_own_admin_dir_is_gone(self, tmp_path):
+        """A directory can outlive its registration (e.g. a prior teardown's
+        `rm` half crashed, or the admin dir was pruned independently) — once
+        git's `.git/worktrees/<name>` entry is gone, git itself no longer
+        considers this path a worktree, even though it still exists on disk.
+        """
+        import shutil
+
+        repo, _ = _make_repo(tmp_path)
+        wt = tmp_path / "repo-worktrees" / "feature"
+        assert ensure_worktree(repo, "feature", wt)
+
+        shutil.rmtree(repo / ".git" / "worktrees" / "feature")
+
+        assert wt.exists()  # leftover directory content untouched
+        assert is_registered_worktree(repo, wt) is False
+
+    def test_false_for_a_path_never_registered(self, tmp_path):
+        repo, _ = _make_repo(tmp_path)
+        bogus = tmp_path / "never-a-worktree"
+        bogus.mkdir()
+        assert is_registered_worktree(repo, bogus) is False

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -337,3 +337,12 @@ class TestIsRegisteredWorktree:
         bogus = tmp_path / "never-a-worktree"
         bogus.mkdir()
         assert is_registered_worktree(repo, bogus) is False
+
+    def test_fails_closed_toward_registered_when_git_errors(self, tmp_path):
+        """An inconclusive `git worktree list` (corrupt repo, I/O error, ...)
+        must not be read as "definitely orphaned" — a caller gating a
+        destructive hard-delete on this should default to treating it as a
+        real worktree when unsure, not as safe to discard."""
+        not_a_repo = tmp_path / "not-a-repo"
+        not_a_repo.mkdir()
+        assert is_registered_worktree(not_a_repo, tmp_path / "wherever") is True


### PR DESCRIPTION
## Summary
- `_teardown_entry` failed forever on a worktree directory git no longer had any registration for (a prior teardown left it behind) — the `#717` fail-loud safety net had no path forward for it, since retrying `git worktree remove` on an unregistered path always fails identically.
- Adds `is_registered_worktree` (worktree.py) and snapshots that state **before** attempting removal — `git worktree prune` runs unconditionally afterward and clears "prunable" entries as a side effect, which would corrupt the signal if checked after the fact and risk hard-deleting a worktree that was live and registered right up until this attempt.
- Confirmed live against the actual stuck directory (`~/worktrees/craps/craps-issue-36-bankroll-race`) before/after the fix — `agentwire worktree --remove` now succeeds and clears the directory, branch (local+remote), and registry entry.

Closes #831

## Test plan
- [x] `tests/unit/test_worktree.py::TestIsRegisteredWorktree` — true for a live worktree, false once git's admin dir is gone, false for a path never registered
- [x] `tests/integration/test_worktree_cmd.py::test_remove_hard_deletes_unregistered_orphan_directory` — new orphan-cleanup case
- [x] Existing fail-loud tests (`test_remove_fails_loudly_when_dir_survives`, `test_remove_does_not_kill_session_when_worktree_removal_fails`, `test_remove_failure_keeps_tracked_tabs_untouched`) still pass unchanged — confirms a worktree registered going in still fails loudly even if `git worktree prune` clears it as a side effect
- [x] Full suite: `uv run pytest tests/unit/test_worktree.py tests/integration/test_worktree_cmd.py` — 95 passed

Built by dotdev.dev