### PR TITLE
fix: address #822 follow-ups from #821 adversarial review

### DIFF
--- a/agentwire/routes/desktop.py
+++ b/agentwire/routes/desktop.py
@@ -10,6 +10,22 @@ through the composed server's MRO.
 from aiohttp import web
 
 
+def _artifact_url_hash(url: str) -> str:
+    """FNV-1a 32-bit hash of ``url``, as 8 lowercase hex chars.
+
+    Must match ``artifactUrlHash`` in static/js/desktop.js byte-for-byte —
+    the server and frontend both derive the same fallback artifact id from
+    the same URL, and a naive char-substitution slug (the prior approach)
+    let distinct URLs like "reports/jan.html" and "reports-jan.html" collide
+    onto the same id. A hash isn't lossy the way substitution is.
+    """
+    h = 0x811C9DC5
+    for b in url.encode("utf-8"):
+        h ^= b
+        h = (h * 0x01000193) & 0xFFFFFFFF
+    return f"{h:08x}"
+
+
 class DesktopRoutesMixin:
     async def api_desktop_windows(self, request):
         """GET /api/desktop/windows — query browser clients for open windows."""
@@ -173,7 +189,7 @@ class DesktopRoutesMixin:
                 "url": url,
                 "title": title,
                 "artifact_id": artifact.get("artifact_id")
-                or f"artifact-{url.replace('/', '-').replace('.', '-')}",
+                or f"artifact-{_artifact_url_hash(url)}",
             }
             if not text:
                 text = f"**{title}** is ready — click to open"

--- a/agentwire/static/js/desktop.js
+++ b/agentwire/static/js/desktop.js
@@ -825,6 +825,24 @@ function _mountSessionWindow(session, mode, machine, id) {
 }
 
 /**
+ * FNV-1a 32-bit hash of `url`, as 8 lowercase hex chars. Must match
+ * `_artifact_url_hash` in routes/desktop.py byte-for-byte — server and
+ * frontend both derive the same fallback artifact id from the same URL. A
+ * hash isn't lossy the way the prior char-substitution slug was (distinct
+ * URLs like "reports/jan.html" and "reports-jan.html" collided onto the
+ * same id).
+ */
+function artifactUrlHash(url) {
+    let h = 0x811c9dc5;
+    const bytes = new TextEncoder().encode(url);
+    for (const b of bytes) {
+        h ^= b;
+        h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    return h.toString(16).padStart(8, '0');
+}
+
+/**
  * Open an artifact window (agent-generated HTML or external URL).
  *
  * @param {string} url - URL or filename to load
@@ -832,7 +850,7 @@ function _mountSessionWindow(session, mode, machine, id) {
  * @param {string|null} artifactId - Optional explicit window ID
  */
 export function openArtifactWindow(url, title = 'Artifact', artifactId = null) {
-    const id = artifactId || `artifact-${url.replace(/[\/\.]/g, '-')}`;
+    const id = artifactId || `artifact-${artifactUrlHash(url)}`;
 
     // Check if already open — restore if minimized, otherwise focus
     if (artifactWindows.has(id)) {

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -86,10 +86,11 @@ class NotificationsPanel {
             this._removeToast(id, false);
         }
 
-        // Evict the oldest NON-sticky toast if at capacity. Sticky artifact
-        // toasts are exempt: an unclicked deliverable must not silently fade
-        // (#817) — the cap only trims ephemeral/auto-fading toasts. If every
-        // current toast happens to be a sticky artifact notice, the panel
+        // Evict the oldest toast NOT carrying an artifact notice, if at
+        // capacity. Artifact toasts are exempt regardless of priority: an
+        // unclicked deliverable must not silently fade (#817) — the cap
+        // only trims ordinary toasts (sticky `high`-priority ones included).
+        // If every current toast is an artifact notice, the panel
         // temporarily exceeds MAX_TOASTS rather than dropping one.
         if (this.toasts.size >= MAX_TOASTS) {
             for (const id of this.toasts.keys()) {

--- a/agentwire/static/js/notifications-panel.js
+++ b/agentwire/static/js/notifications-panel.js
@@ -86,10 +86,18 @@ class NotificationsPanel {
             this._removeToast(id, false);
         }
 
-        // Evict oldest if at capacity
+        // Evict the oldest NON-sticky toast if at capacity. Sticky artifact
+        // toasts are exempt: an unclicked deliverable must not silently fade
+        // (#817) — the cap only trims ephemeral/auto-fading toasts. If every
+        // current toast happens to be a sticky artifact notice, the panel
+        // temporarily exceeds MAX_TOASTS rather than dropping one.
         if (this.toasts.size >= MAX_TOASTS) {
-            const oldest = this.toasts.keys().next().value;
-            this._removeToast(oldest, false);
+            for (const id of this.toasts.keys()) {
+                if (!this.artifactNotices.has(id)) {
+                    this._removeToast(id, false);
+                    break;
+                }
+            }
         }
 
         // Resolve auto-fade: explicit timeout wins (0 = sticky); otherwise

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -212,6 +212,35 @@ class TestVoiceTools:
         assert "parked" in result
 
 
+class TestNotifyUserArtifactParams:
+    """#822: notify_user's artifact_url/artifact_title params (#821) had zero
+    test coverage — cover the body it builds for /api/desktop/notification."""
+
+    @patch("agentwire.mcp_notify._portal_request")
+    def test_artifact_url_sets_artifact_body_with_default_title(self, mock_req):
+        from agentwire.mcp_notify import notify_user
+        mock_req.return_value = _success(id="n1", clients=1)
+        notify_user(text="ready", artifact_url="report.html")
+        body = mock_req.call_args[0][2]
+        assert body["artifact"] == {"url": "report.html", "title": "Artifact"}
+
+    @patch("agentwire.mcp_notify._portal_request")
+    def test_artifact_title_overrides_default(self, mock_req):
+        from agentwire.mcp_notify import notify_user
+        mock_req.return_value = _success(id="n1", clients=1)
+        notify_user(text="ready", artifact_url="report.html", artifact_title="Q3 Report")
+        body = mock_req.call_args[0][2]
+        assert body["artifact"] == {"url": "report.html", "title": "Q3 Report"}
+
+    @patch("agentwire.mcp_notify._portal_request")
+    def test_no_artifact_url_omits_artifact_body(self, mock_req):
+        from agentwire.mcp_notify import notify_user
+        mock_req.return_value = _success(id="n1", clients=1)
+        notify_user(text="plain toast", artifact_title="ignored without a url")
+        body = mock_req.call_args[0][2]
+        assert "artifact" not in body
+
+
 # ---------------------------------------------------------------------------
 # Desktop tools
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -630,8 +630,10 @@ class TestApiDesktopNotification:
 
     async def test_artifact_notice_defaults(self, portal_client):
         """#817: an artifact notice needs no text (synthesized from the title),
-        derives the frontend's url-slug window id, and defaults to sticky —
-        an unclicked deliverable must never silently fade."""
+        derives the frontend's hash-based window id (#822 — a lossy
+        char-substitution slug let distinct URLs collide onto the same id),
+        and defaults to sticky — an unclicked deliverable must never
+        silently fade."""
         client, server = portal_client
         server.broadcast_dashboard = AsyncMock()
         resp = await client.post("/api/desktop/notification", json={
@@ -645,8 +647,26 @@ class TestApiDesktopNotification:
         assert notice["artifact"] == {
             "url": "council-proj-minutes/index.html",
             "title": "Council minutes — proj",
-            "artifact_id": "artifact-council-proj-minutes-index-html",
+            "artifact_id": "artifact-d569834e",
         }
+
+    async def test_artifact_id_does_not_collide_across_similar_urls(self, portal_client):
+        """#822: the fallback id used to be a lossy char-substitution slug —
+        "reports/jan.html" and "reports-jan.html" both became
+        "artifact-reports-jan-html", so a new artifact could dedup-clobber a
+        different still-pending one. A hash of the full url doesn't collide
+        on this pair, so both notices coexist."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        await client.post("/api/desktop/notification", json={
+            "artifact": {"url": "reports/jan.html", "title": "Jan (nested)"},
+        })
+        await client.post("/api/desktop/notification", json={
+            "artifact": {"url": "reports-jan.html", "title": "Jan (flat)"},
+        })
+        assert len(server.active_notifications) == 2
+        ids = {n["artifact"]["artifact_id"] for n in server.active_notifications.values()}
+        assert len(ids) == 2
 
     async def test_artifact_requires_url(self, portal_client):
         client, server = portal_client
@@ -666,6 +686,23 @@ class TestApiDesktopNotification:
                 "artifact": {"url": "report.html", "title": "Report"},
             })
         assert len(server.active_notifications) == 1
+
+    async def test_two_distinct_artifact_notices_coexist(self, portal_client):
+        """Two different concurrent unclicked artifact deliverables must both
+        stay pending — dedup keys on artifact_id, so distinct artifacts must
+        never clobber each other the way a same-id re-render intentionally
+        does above."""
+        client, server = portal_client
+        server.broadcast_dashboard = AsyncMock()
+        await client.post("/api/desktop/notification", json={
+            "artifact": {"url": "report-a.html", "title": "Report A"},
+        })
+        await client.post("/api/desktop/notification", json={
+            "artifact": {"url": "report-b.html", "title": "Report B"},
+        })
+        assert len(server.active_notifications) == 2
+        titles = sorted(n["artifact"]["title"] for n in server.active_notifications.values())
+        assert titles == ["Report A", "Report B"]
 
     async def test_session_sweep_spares_artifact_notices(self, portal_client):
         """The one-toast-per-session replacement must not eat a pending

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -614,6 +614,35 @@ class TestApiNotify:
         assert data["clients"] == 2
 
 
+class TestArtifactUrlHash:
+    """#822: pins `_artifact_url_hash` (routes/desktop.py) against known
+    vectors, independently cross-checked in Node against its JS twin
+    (`artifactUrlHash` in static/js/desktop.js) — the two have no shared
+    source and no JS test harness exists in this repo, so this is the only
+    automated guard against the two silently drifting apart. If you change
+    the hash algorithm on either side, recompute vectors on the OTHER side
+    (e.g. `node -e "..."` mirroring this function) before touching this
+    test — a passing Python-only test proves nothing about JS parity."""
+
+    @pytest.mark.parametrize("url,expected", [
+        ("", "811c9dc5"),
+        ("a", "e40c292c"),
+        ("reports/jan.html", "7084fac5"),
+        ("reports-jan.html", "b5f6349b"),
+        ("https://example.com", "6fbc04d3"),
+        ("council-proj-minutes/index.html", "d569834e"),
+        ("日本語", "805f5ce7"),  # multi-byte UTF-8
+        ("🦉", "11131011"),  # astral/surrogate-pair UTF-8
+    ])
+    def test_pinned_vectors(self, url, expected):
+        from agentwire.routes.desktop import _artifact_url_hash
+        assert _artifact_url_hash(url) == expected
+
+    def test_distinct_urls_that_collided_under_the_old_slug_now_differ(self):
+        from agentwire.routes.desktop import _artifact_url_hash
+        assert _artifact_url_hash("reports/jan.html") != _artifact_url_hash("reports-jan.html")
+
+
 class TestApiDesktopNotification:
     async def test_toast_reports_client_count(self, portal_client):
         """#444: posting a toast reports how many dashboards saw it live (the


### PR DESCRIPTION
## Summary
Three low-severity findings deferred out of #821's adversarial review (background artifacts notify instead of stealing focus):

1. **MAX_TOASTS eviction bypassed the sticky guarantee** — `notifications-panel.js` evicted the oldest toast at capacity via `_removeToast(oldest, false)`, not `_dropNotice`, so an unclicked sticky artifact toast could silently vanish from the panel while surviving in the HUD notice strip. Fixed by exempting sticky artifact toasts from the cap entirely (skip to the oldest non-sticky toast; if all 8 are sticky artifacts, the panel temporarily exceeds the cap rather than dropping one).
2. **artifact_id slug collisions** — the fallback (`f"artifact-{url.replace('/', '-').replace('.', '-')}"`) mapped distinct URLs like `reports/jan.html` and `reports-jan.html` onto the same id, letting an unrelated new artifact dedup-clobber a different still-pending one. Turned out to live in exactly two places (not five, per the original issue text — `mcp_desktop.py`/`council/cli.py`/`notify_cli.py` all just forward to the one portal endpoint and never compute this themselves): `routes/desktop.py` (server) and `static/js/desktop.js` (frontend window id) — the two **must** produce identical output for dedup to work, so both now use the same FNV-1a 32-bit hash, verified byte-for-byte identical in Python and JS with the same test vectors.
3. **Thin test coverage** — added: two distinct concurrent artifact notices coexisting, a direct regression test for the slug-collision fix, and `notify_user`'s `artifact_url`/`artifact_title` params (added in #821, previously untested).

Closes #822

## Test plan
- [x] `uv run pytest tests/unit tests/integration` — 2802 passed
- [x] Verified the FNV-1a hash produces identical output in Python (`hashlib`-free, pure arithmetic) and Node.js for the same test-vector URLs before wiring it in
- [x] `node --check --input-type=module` on both changed JS files (no JS lint in this repo's CI)
- [x] New tests: `test_artifact_id_does_not_collide_across_similar_urls`, `test_two_distinct_artifact_notices_coexist`, `TestNotifyUserArtifactParams` (3 cases)

Built by dotdev.dev