### PR TITLE
fix(sessions): session_send falls back to durable msg inbox on unverified delivery

### DIFF
--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -162,11 +162,30 @@ def _delivery_result(data: dict, where: str) -> str:
     returns ``verified``: True (landed), False (sent but not seen — likely a
     busy/booting pane that dropped it), or None (remote — unverifiable across
     SSH). Surface that instead of a blind "sent".
+
+    A ``False`` verify from a *session*-level send no longer just hands the
+    problem back to whichever caller reads this string (#834) — the CLI
+    falls back to the durable msg inbox (retried across ticks, dead-lettered
+    + emailed on true exhaustion) when the direct paste can't be confirmed,
+    so report THAT outcome rather than telling the caller to notice and
+    resend by hand. A worker *pane* send has no such fallback (the msg inbox
+    only addresses sessions, not individual panes) — ``data`` won't carry a
+    ``fallback`` key at all in that case, distinguishing "not attempted"
+    from "attempted and failed" so this never claims a fallback that never
+    ran.
     """
     verified = data.get("verified")
     if verified is True:
         return f"Message delivered {where} (verified in pane)."
     if verified is False:
+        if "fallback" in data:
+            if data.get("fallback") == "inbox":
+                return (f"Message sent {where} but delivery could NOT be verified in the pane — "
+                        f"queued to its msg inbox instead, which guarantees delivery (retried "
+                        f"automatically, dead-lettered + emailed to the owner only if it truly "
+                        f"can't land). No action needed.")
+            return (f"Message sent {where} but delivery could NOT be verified, AND the msg-inbox "
+                    f"fallback also failed — this message may be lost. Check the pane or resend.")
         return (f"Message sent {where} but delivery could NOT be verified — it may "
                 f"have been dropped (busy/booting pane). Check the pane or resend.")
     if verified is None and "verified" in data:

--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -179,6 +179,10 @@ def _delivery_result(data: dict, where: str) -> str:
         return f"Message delivered {where} (verified in pane)."
     if verified is False:
         if "fallback" in data:
+            if data.get("fallback") == "already_delivered":
+                return (f"Message sent {where} — the pane confirmation was ambiguous, but the "
+                        f"message is already visible on scrollback, so it was in fact delivered. "
+                        f"No action needed.")
             if data.get("fallback") == "inbox":
                 return (f"Message sent {where} but delivery could NOT be verified in the pane — "
                         f"queued to its msg inbox instead, which guarantees delivery (retried "

--- a/agentwire/mcp_session.py
+++ b/agentwire/mcp_session.py
@@ -227,6 +227,11 @@ def session_send(session: str, message: str) -> str:
             f"{message}"
         )
     args = ["send", "-s", session, "--verify", message]
+    if caller:
+        # Attributes a msg-inbox delivery fallback to the real caller instead
+        # of the generic "agentwire" (#835 review) — the CLI subprocess can't
+        # auto-detect the caller across the MCP boundary itself.
+        args.extend(["--caller-session", caller])
     data = run_agentwire_cmd(args)
     if not data.get("success"):
         return f"Failed to send message: {data.get('error', 'Unknown error')}"

--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -44,6 +44,22 @@ def _recover_unverified_send(session: str, prompt: str, sender: str) -> "str | N
     duplicate — accepted per this codebase's existing bias that a
     recoverable duplicate beats a silently dropped message.
 
+    Known residual risk (#835 second-pass review): this is the same bare
+    whitespace-normalized substring match ``_deliver_once`` already uses for
+    its own internal idempotent-paste guard — not a new invention — but
+    reused here it trades in the *opposite* direction from most of this
+    file's checks. A false match reports "already delivered" and SKIPS the
+    inbox enqueue entirely: for a short or generic message (a bare "yes",
+    "continue", "approved") that happens to already sit in the last
+    ``VERIFY_SCROLLBACK_LINES`` for an unrelated reason, a send that
+    genuinely never landed could be silently dropped instead of queued —
+    the one outcome this whole fallback exists to prevent. Tracked as a
+    follow-up (a lightweight per-attempt marker, mirroring
+    ``send_verified``'s own ``marker`` param, would close this precisely);
+    not fixed here because it's strictly narrower than the bug this
+    function was written to close (needs a coincidental/repeated-text
+    match, not just any unverified send).
+
     Returns ``"already_delivered"``, ``"inbox"``, or ``None`` (the inbox
     fallback itself failed).
     """

--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -167,16 +167,29 @@ def cmd_send(args) -> int:
     if wait_ready:
         # Wait for the agent to be ready, then send with delivery
         # verification (a paste into a booting Claude vanishes silently).
-        from agentwire.session_ready import send_verified, wait_for_session_ready
+        from agentwire.session_ready import (
+            recover_failed_seed,
+            send_verified,
+            wait_for_session_ready,
+        )
 
         timeout = getattr(args, 'timeout', None) or 30.0
         if not wait_for_session_ready(session, timeout=timeout):
             return _output_result(False, json_mode, f"Agent in '{session}' not ready after {timeout:.0f}s")
         if not send_verified(session, prompt):
+            # A caller acting on "not verified" text is optional, not
+            # guaranteed — under load this is exactly the class of message
+            # that must never depend on an LLM noticing and manually
+            # resending. Fall back to the durable msg inbox (retried across
+            # ticks, dead-lettered + emailed on true exhaustion) instead of
+            # returning inert advisory text (#834).
+            fallback = recover_failed_seed(session, prompt, sender="agentwire")
             if json_mode:
-                print(json.dumps({"success": False, "session": session_full, "verified": False, "error": "Delivery not verified"}))
+                print(json.dumps({"success": False, "session": session_full, "verified": False,
+                                  "fallback": fallback, "error": "Delivery not verified"}))
             else:
-                print(f"Sent to {session} but delivery could not be verified", file=sys.stderr)
+                suffix = " — queued to its msg inbox for guaranteed delivery" if fallback == "inbox" else " and could not be queued — resend manually"
+                print(f"Sent to {session} but delivery could not be verified{suffix}", file=sys.stderr)
             return 1
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None, "verified": True, "message": "Prompt sent"}))
@@ -194,15 +207,26 @@ def cmd_send(args) -> int:
         # the old double-delivery worry the retries=0 choice guarded against
         # can't happen anymore. Staying patient here is what keeps a laggy host
         # from surfacing a false failure the parent has to clean up by hand.
-        from agentwire.session_ready import send_verified
+        from agentwire.session_ready import recover_failed_seed, send_verified
 
         ok = send_verified(session, prompt, retries=1)
+        fallback = None
+        if not ok:
+            # Same durable fallback as --wait-ready (#834): the drain's
+            # scrollback dedup makes this safe even if the direct send
+            # actually landed and only the confirm read was ambiguous —
+            # it will see the message already delivered and skip re-sending.
+            fallback = recover_failed_seed(session, prompt, sender="agentwire")
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None,
-                              "verified": ok,
+                              "verified": ok, "fallback": fallback,
                               "message": "Prompt sent" if ok else "Prompt sent but delivery could not be verified"}))
         else:
-            print(f"Sent to {session}" + (" (verified)" if ok else " (delivery NOT verified)"))
+            if ok:
+                print(f"Sent to {session} (verified)")
+            else:
+                suffix = " — queued to its msg inbox for guaranteed delivery" if fallback == "inbox" else " and could not be queued — resend manually"
+                print(f"Sent to {session} (delivery NOT verified){suffix}")
         return 0
 
     # Delegate paste + Enter handling to the shared pane_manager helper so

--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -24,6 +24,44 @@ from .core import (
 )
 
 
+def _recover_unverified_send(session: str, prompt: str, sender: str) -> "str | None":
+    """Fallback when `send_verified` can't confirm delivery (#834, #835 review).
+
+    First checks whether the bare message is already on scrollback outside
+    the input box. A `send_verified` failure can mean the paste genuinely
+    never landed/submitted, OR that it fully submitted and only the
+    *confirm* read was ambiguous (an unparseable box frame, or a laggy host
+    blowing the submit budget). The msg-inbox drain's own dedup can't catch
+    the latter case on its own: it matches the WRAPPED ``[MSG from ... ]
+    ... <id>`` render (see ``inbox.Message.render``), never the bare text
+    this path pasted directly — enqueuing unconditionally would risk a real
+    duplicate delivery rather than the safe no-op the drain's dedup gives
+    its own messages. Checking here first avoids that duplicate in the
+    common case.
+
+    A message that lands only *after* this check runs (queued invisibly
+    mid-generation, per ``submit_confirmed``'s own docstring) can still
+    duplicate — accepted per this codebase's existing bias that a
+    recoverable duplicate beats a silently dropped message.
+
+    Returns ``"already_delivered"``, ``"inbox"``, or ``None`` (the inbox
+    fallback itself failed).
+    """
+    from agentwire.session_ready import message_on_scrollback, recover_failed_seed, scrollback
+
+    if message_on_scrollback(scrollback(session), prompt):
+        return "already_delivered"
+    return recover_failed_seed(session, prompt, sender=sender)
+
+
+def _fallback_suffix(fallback: "str | None") -> str:
+    if fallback == "already_delivered":
+        return " — already delivered directly (the confirmation read was just ambiguous); no action needed"
+    if fallback == "inbox":
+        return " — queued to its msg inbox for guaranteed delivery"
+    return " and could not be queued — resend manually"
+
+
 def cmd_send(args) -> int:
     """Send a prompt to a tmux session or pane (adds Enter automatically).
 
@@ -36,6 +74,13 @@ def cmd_send(args) -> int:
     json_mode = getattr(args, 'json', False)
     wait_ready = getattr(args, 'wait_ready', False)
     verify = getattr(args, 'verify', False)
+    # Candidate sender for a msg-inbox fallback's attribution (#835 review):
+    # prefer the real calling session over the generic "agentwire" so
+    # dead-letter emails and the rendered [MSG from ...] header stay
+    # meaningful. MCP forwards --caller-session explicitly (can't reliably
+    # auto-detect the caller across that boundary); a bare CLI invocation
+    # falls back to auto-detecting its own tmux session.
+    fallback_sender = getattr(args, 'caller_session', None) or pane_manager.get_current_session() or "agentwire"
 
     if wait_ready and pane_index is not None:
         return _output_result(False, json_mode, "--wait-ready targets a session's pane 0; it can't be combined with --pane")
@@ -167,11 +212,7 @@ def cmd_send(args) -> int:
     if wait_ready:
         # Wait for the agent to be ready, then send with delivery
         # verification (a paste into a booting Claude vanishes silently).
-        from agentwire.session_ready import (
-            recover_failed_seed,
-            send_verified,
-            wait_for_session_ready,
-        )
+        from agentwire.session_ready import send_verified, wait_for_session_ready
 
         timeout = getattr(args, 'timeout', None) or 30.0
         if not wait_for_session_ready(session, timeout=timeout):
@@ -183,16 +224,16 @@ def cmd_send(args) -> int:
             # resending. Fall back to the durable msg inbox (retried across
             # ticks, dead-lettered + emailed on true exhaustion) instead of
             # returning inert advisory text (#834).
-            fallback = recover_failed_seed(session, prompt, sender="agentwire")
+            fallback = _recover_unverified_send(session, prompt, fallback_sender)
             if json_mode:
                 print(json.dumps({"success": False, "session": session_full, "verified": False,
                                   "fallback": fallback, "error": "Delivery not verified"}))
             else:
-                suffix = " — queued to its msg inbox for guaranteed delivery" if fallback == "inbox" else " and could not be queued — resend manually"
-                print(f"Sent to {session} but delivery could not be verified{suffix}", file=sys.stderr)
+                print(f"Sent to {session} but delivery could not be verified{_fallback_suffix(fallback)}", file=sys.stderr)
             return 1
         if json_mode:
-            print(json.dumps({"success": True, "session": session_full, "machine": None, "verified": True, "message": "Prompt sent"}))
+            print(json.dumps({"success": True, "session": session_full, "machine": None,
+                              "verified": True, "fallback": None, "message": "Prompt sent"}))
         else:
             print(f"Sent to {session} (verified)")
         return 0
@@ -207,16 +248,13 @@ def cmd_send(args) -> int:
         # the old double-delivery worry the retries=0 choice guarded against
         # can't happen anymore. Staying patient here is what keeps a laggy host
         # from surfacing a false failure the parent has to clean up by hand.
-        from agentwire.session_ready import recover_failed_seed, send_verified
+        from agentwire.session_ready import send_verified
 
         ok = send_verified(session, prompt, retries=1)
         fallback = None
         if not ok:
-            # Same durable fallback as --wait-ready (#834): the drain's
-            # scrollback dedup makes this safe even if the direct send
-            # actually landed and only the confirm read was ambiguous —
-            # it will see the message already delivered and skip re-sending.
-            fallback = recover_failed_seed(session, prompt, sender="agentwire")
+            # Same durable fallback as --wait-ready (#834).
+            fallback = _recover_unverified_send(session, prompt, fallback_sender)
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None,
                               "verified": ok, "fallback": fallback,
@@ -225,8 +263,7 @@ def cmd_send(args) -> int:
             if ok:
                 print(f"Sent to {session} (verified)")
             else:
-                suffix = " — queued to its msg inbox for guaranteed delivery" if fallback == "inbox" else " and could not be queued — resend manually"
-                print(f"Sent to {session} (delivery NOT verified){suffix}")
+                print(f"Sent to {session} (delivery NOT verified){_fallback_suffix(fallback)}")
         return 0
 
     # Delegate paste + Enter handling to the shared pane_manager helper so
@@ -337,6 +374,11 @@ def register_send_parser(subparsers) -> None:
                                   "report verified vs unconfirmed instead of blind success")
     send_parser.add_argument("--timeout", type=float, default=30.0,
                              help="Readiness wait timeout in seconds (with --wait-ready, default: 30)")
+    send_parser.add_argument("--caller-session", dest="caller_session",
+                             help="Internal: attribute a msg-inbox delivery fallback to this sender "
+                                  "instead of auto-detecting the calling tmux session. MCP forwards "
+                                  "this explicitly, since the CLI subprocess can't reliably "
+                                  "auto-detect the caller across that boundary.")
     send_parser.add_argument("--json", action="store_true", help="Output as JSON")
     send_parser.set_defaults(func=cmd_send)
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2479,6 +2479,19 @@ class AgentWireServer(
             ["send", "-s", session_name, "--wait-ready", "--timeout", "60", "--", message]
         )
         if not success:
+            if result.get("fallback") in ("inbox", "already_delivered"):
+                # #835: an unverified send now recovers on its own -- either
+                # it was already delivered and the confirm read was just
+                # ambiguous, or it's queued to the durable msg inbox. Either
+                # way the old "paste it manually" toast would be stale,
+                # actively wrong advice.
+                logger.info(f"First message for {session_name} recovered via {result.get('fallback')} fallback")
+                await self._post_toast(
+                    f"First message to {session_name} queued for guaranteed delivery"
+                    if result.get("fallback") == "inbox" else
+                    f"First message to {session_name} delivered (confirmation was just delayed)",
+                    session=session_name, priority="normal", id_prefix="firstmsg")
+                return
             logger.warning(f"First message delivery failed for {session_name}: {result.get('error')}")
             await self._post_toast(
                 f"First message not delivered to {session_name} — paste it manually",

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -590,6 +590,19 @@ def clear_input_box(session: str, pane_index: int = 0) -> bool:
     text]`` chip) and confirms emptiness with the drain's own SGR-aware gate
     (``prompt_router.prompt_is_empty``), so "cleared" here means exactly
     "the drain will deliver". Returns True iff the box ends up empty.
+
+    Refuses to press Escape while the screen shows a live select-menu/dialog
+    (#835 review): this function was written for a brand-new session's
+    failed first-message seed, where nothing else could plausibly be on
+    screen. It is also reused for an already-running, independently-busy
+    session (``agentwire send --verify`` falling back after a failed
+    delivery) — there, "box not empty" can mean a permission dialog or
+    ``AskUserQuestion`` menu belonging to the recipient's own unrelated
+    work, not our stuck paste. Escape is the conventional cancel/decline key
+    for those, so pressing it blind would silently cancel a decision that
+    had nothing to do with us. Returns False without touching the pane in
+    that case; the caller's msg-inbox fallback still gets enqueued and
+    waits for the box to become genuinely idle on its own.
     """
     from agentwire import pane_manager, prompt_router
 
@@ -602,6 +615,8 @@ def clear_input_box(session: str, pane_index: int = 0) -> bool:
         try:
             if empty():
                 return True
+            if prompt_router.screen_shows_live_menu(_snapshot(session, pane_index)):
+                return False
             pane_manager.run_command(
                 ["tmux", "send-keys", "-t", target, "Escape"], timeout=5
             )

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -227,7 +227,7 @@ class TestCmdSendWaitReady:
         whichever caller reads the response — it queues to the durable msg
         inbox so delivery is retried and eventually dead-lettered LOUDLY
         instead of silently depending on the caller noticing and resending."""
-        from agentwire import session_ready, send_cli
+        from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
@@ -243,7 +243,7 @@ class TestCmdSendWaitReady:
         recover.assert_called_once_with("proj", "my idea", "agentwire")
 
     def test_unverified_and_fallback_fails_is_still_reported(self, capsys, monkeypatch):
-        from agentwire import session_ready, send_cli
+        from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
@@ -261,7 +261,7 @@ class TestCmdSendWaitReady:
         calling session (threaded via --caller-session from the MCP layer),
         not the generic 'agentwire' -- matters for dead-letter email
         attribution and the rendered [MSG from ...] header."""
-        from agentwire import session_ready, send_cli
+        from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -188,12 +188,19 @@ class TestCmdSendWaitReady:
     def _payload(self, capsys):
         return json.loads(capsys.readouterr().out.strip())
 
+    def _mock_has_session(self, monkeypatch):
+        has_session = MagicMock(returncode=0)
+        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        # get_current_session shells out to real tmux and depends on the test
+        # runner's own environment ($TMUX_PANE) -- pin it so fallback_sender
+        # resolution is deterministic regardless of where tests run.
+        monkeypatch.setattr("agentwire.send_cli.pane_manager.get_current_session", lambda: None)
+
     def test_happy_path_verified(self, capsys, monkeypatch):
         from agentwire import session_ready
         from agentwire.send_cli import cmd_send
 
-        has_session = MagicMock(returncode=0)
-        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m: True)
 
@@ -201,13 +208,13 @@ class TestCmdSendWaitReady:
         payload = self._payload(capsys)
         assert payload["success"] is True
         assert payload["verified"] is True
+        assert payload["fallback"] is None
 
     def test_not_ready_fails(self, capsys, monkeypatch):
         from agentwire import session_ready
         from agentwire.send_cli import cmd_send
 
-        has_session = MagicMock(returncode=0)
-        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: False)
 
         assert cmd_send(self._args()) == 1
@@ -220,34 +227,51 @@ class TestCmdSendWaitReady:
         whichever caller reads the response — it queues to the durable msg
         inbox so delivery is retried and eventually dead-lettered LOUDLY
         instead of silently depending on the caller noticing and resending."""
-        from agentwire import session_ready
+        from agentwire import session_ready, send_cli
         from agentwire.send_cli import cmd_send
 
-        has_session = MagicMock(returncode=0)
-        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
-        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: "inbox")
+        recover = MagicMock(return_value="inbox")
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
         assert cmd_send(self._args()) == 1
         payload = self._payload(capsys)
         assert payload["verified"] is False
         assert payload["fallback"] == "inbox"
+        recover.assert_called_once_with("proj", "my idea", "agentwire")
 
     def test_unverified_and_fallback_fails_is_still_reported(self, capsys, monkeypatch):
-        from agentwire import session_ready
+        from agentwire import session_ready, send_cli
         from agentwire.send_cli import cmd_send
 
-        has_session = MagicMock(returncode=0)
-        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
-        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: None)
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", lambda s, m, sender: None)
 
         assert cmd_send(self._args()) == 1
         payload = self._payload(capsys)
         assert payload["verified"] is False
         assert payload["fallback"] is None
+
+    def test_caller_session_arg_wins_over_autodetect(self, capsys, monkeypatch):
+        """#835 review: attribute a fallback's msg-inbox entry to the real
+        calling session (threaded via --caller-session from the MCP layer),
+        not the generic 'agentwire' -- matters for dead-letter email
+        attribution and the rendered [MSG from ...] header."""
+        from agentwire import session_ready, send_cli
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        recover = MagicMock(return_value="inbox")
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
+
+        cmd_send(self._args(caller_session="council-brain"))
+        recover.assert_called_once_with("proj", "my idea", "council-brain")
 
     def test_remote_rejected(self, capsys):
         from agentwire.send_cli import cmd_send
@@ -281,15 +305,16 @@ class TestCmdSendVerify:
     def _mock_has_session(self, monkeypatch):
         has_session = MagicMock(returncode=0)
         monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        monkeypatch.setattr("agentwire.send_cli.pane_manager.get_current_session", lambda: None)
 
     def test_happy_path_verified_skips_fallback(self, capsys, monkeypatch):
-        from agentwire import session_ready
+        from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: True)
         recover = MagicMock()
-        monkeypatch.setattr(session_ready, "recover_failed_seed", recover)
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
         assert cmd_send(self._args()) == 0
         payload = self._payload(capsys)
@@ -299,17 +324,76 @@ class TestCmdSendVerify:
 
     def test_unverified_falls_back_to_inbox(self, capsys, monkeypatch):
         """#834: same durable-fallback guarantee as --wait-ready."""
-        from agentwire import session_ready
+        from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: False)
-        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: "inbox")
+        recover = MagicMock(return_value="inbox")
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
         assert cmd_send(self._args()) == 0  # verify-without-wait-ready reports success=True; verified carries the real state
         payload = self._payload(capsys)
         assert payload["verified"] is False
         assert payload["fallback"] == "inbox"
+        recover.assert_called_once_with("proj", "my idea", "agentwire")
+
+    def test_remote_with_verify_never_touches_the_fallback(self, capsys, monkeypatch):
+        """Remote (session@machine) sends return from an earlier branch
+        entirely -- verify=True there only marks the result unverifiable
+        across SSH, and must never reach the new fallback machinery."""
+        from agentwire import send_cli
+        from agentwire.send_cli import cmd_send
+
+        recover = MagicMock()
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
+        monkeypatch.setattr(
+            "agentwire.send_cli._run_remote",
+            lambda machine_id, cmd: MagicMock(returncode=0),
+        )
+        monkeypatch.setattr(
+            "agentwire.send_cli._get_machine_config",
+            lambda machine_id: {"host": "example.com"},
+        )
+
+        assert cmd_send(self._args(session="proj@gpu")) == 0
+        payload = self._payload(capsys)
+        assert payload["verified"] is None
+        assert "fallback" not in payload
+        recover.assert_not_called()
+
+
+class TestRecoverUnverifiedSend:
+    """#835 review finding 2: the msg-inbox drain's dedup matches the
+    WRAPPED `[MSG from ... ] ... <id>` render, never the bare text a direct
+    paste puts on screen -- so blindly enqueuing risks a real duplicate
+    delivery when the original send actually landed and only the confirm
+    read was ambiguous. _recover_unverified_send closes the common case by
+    checking scrollback for the bare message first."""
+
+    def test_already_on_scrollback_skips_the_inbox_enqueue(self, monkeypatch):
+        from agentwire import session_ready
+        from agentwire.send_cli import _recover_unverified_send
+
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, pane_index=0: "...fake capture...")
+        monkeypatch.setattr(session_ready, "message_on_scrollback", lambda cap, msg: True)
+        recover = MagicMock()
+        monkeypatch.setattr(session_ready, "recover_failed_seed", recover)
+
+        assert _recover_unverified_send("proj", "already sent", "agentwire") == "already_delivered"
+        recover.assert_not_called()
+
+    def test_not_on_scrollback_falls_back_to_the_inbox(self, monkeypatch):
+        from agentwire import session_ready
+        from agentwire.send_cli import _recover_unverified_send
+
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, pane_index=0: "...fake capture...")
+        monkeypatch.setattr(session_ready, "message_on_scrollback", lambda cap, msg: False)
+        recover = MagicMock(return_value="inbox")
+        monkeypatch.setattr(session_ready, "recover_failed_seed", recover)
+
+        assert _recover_unverified_send("proj", "genuinely stuck", "council-brain") == "inbox"
+        recover.assert_called_once_with("proj", "genuinely stuck", sender="council-brain")
 
 
 # --- cmd_new --first-message ---

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -215,7 +215,11 @@ class TestCmdSendWaitReady:
         assert payload["success"] is False
         assert "not ready" in payload["error"]
 
-    def test_unverified_fails(self, capsys, monkeypatch):
+    def test_unverified_falls_back_to_inbox(self, capsys, monkeypatch):
+        """#834: an unverified send must never just hand the problem back to
+        whichever caller reads the response — it queues to the durable msg
+        inbox so delivery is retried and eventually dead-lettered LOUDLY
+        instead of silently depending on the caller noticing and resending."""
         from agentwire import session_ready
         from agentwire.send_cli import cmd_send
 
@@ -223,10 +227,27 @@ class TestCmdSendWaitReady:
         monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
         monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: "inbox")
 
         assert cmd_send(self._args()) == 1
         payload = self._payload(capsys)
         assert payload["verified"] is False
+        assert payload["fallback"] == "inbox"
+
+    def test_unverified_and_fallback_fails_is_still_reported(self, capsys, monkeypatch):
+        from agentwire import session_ready
+        from agentwire.send_cli import cmd_send
+
+        has_session = MagicMock(returncode=0)
+        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+        monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: None)
+
+        assert cmd_send(self._args()) == 1
+        payload = self._payload(capsys)
+        assert payload["verified"] is False
+        assert payload["fallback"] is None
 
     def test_remote_rejected(self, capsys):
         from agentwire.send_cli import cmd_send
@@ -241,6 +262,54 @@ class TestCmdSendWaitReady:
         assert cmd_send(self._args(pane=1)) == 1
         payload = self._payload(capsys)
         assert "--pane" in payload["error"]
+
+
+# --- cmd_send --verify (no --wait-ready) ---
+
+class TestCmdSendVerify:
+    def _args(self, **overrides):
+        defaults = dict(
+            session="proj", pane=None, prompt=["my", "idea"],
+            json=True, wait_ready=False, verify=True, timeout=None,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def _payload(self, capsys):
+        return json.loads(capsys.readouterr().out.strip())
+
+    def _mock_has_session(self, monkeypatch):
+        has_session = MagicMock(returncode=0)
+        monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
+
+    def test_happy_path_verified_skips_fallback(self, capsys, monkeypatch):
+        from agentwire import session_ready
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: True)
+        recover = MagicMock()
+        monkeypatch.setattr(session_ready, "recover_failed_seed", recover)
+
+        assert cmd_send(self._args()) == 0
+        payload = self._payload(capsys)
+        assert payload["verified"] is True
+        assert payload["fallback"] is None
+        recover.assert_not_called()
+
+    def test_unverified_falls_back_to_inbox(self, capsys, monkeypatch):
+        """#834: same durable-fallback guarantee as --wait-ready."""
+        from agentwire import session_ready
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: False)
+        monkeypatch.setattr(session_ready, "recover_failed_seed", lambda s, m, sender=None: "inbox")
+
+        assert cmd_send(self._args()) == 0  # verify-without-wait-ready reports success=True; verified carries the real state
+        payload = self._payload(capsys)
+        assert payload["verified"] is False
+        assert payload["fallback"] == "inbox"
 
 
 # --- cmd_new --first-message ---

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -151,6 +151,48 @@ class TestFormatProjectsBehavior:
         assert ".agentwire.yml" not in result
 
 
+class TestDeliveryResultBehavior:
+    """#834: an unverified send must report its inbox fallback, not just
+    hand an inert 'check the pane or resend' string back to the caller."""
+
+    def test_verified_true(self):
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": True}, "to session 'proj'")
+        assert "verified in pane" in result
+
+    def test_unverified_with_inbox_fallback_reports_no_action_needed(self):
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": False, "fallback": "inbox"}, "to session 'proj'")
+        assert "queued to its msg inbox" in result
+        assert "No action needed" in result
+
+    def test_unverified_with_no_fallback_still_warns(self):
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": False, "fallback": None}, "to session 'proj'")
+        assert "may be lost" in result
+
+    def test_pane_send_has_no_fallback_key_and_must_not_claim_one_failed(self):
+        """pane_send's `agentwire send --pane` branch never attempts the
+        inbox fallback (the msg inbox only addresses sessions, not panes) —
+        it omits the `fallback` key entirely. This must read as the original
+        'may have been dropped' warning, not falsely claim a fallback ran
+        and failed."""
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": False}, "to pane 1")
+        assert "may have been dropped" in result
+        assert "msg-inbox fallback" not in result
+
+    def test_remote_unverifiable(self):
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": None}, "to session 'proj'")
+        assert "can't be verified across SSH" in result
+
+    def test_no_verified_key_plain_sent(self):
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({}, "to session 'proj'")
+        assert result == "Message sent to session 'proj'."
+
+
 class TestFormatRolesBehavior:
     def test_full_role_format(self):
         from agentwire.mcp_core import format_roles

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -166,6 +166,15 @@ class TestDeliveryResultBehavior:
         assert "queued to its msg inbox" in result
         assert "No action needed" in result
 
+    def test_unverified_but_already_delivered_reports_no_action_needed(self):
+        """#835 second-pass review: the 'already_delivered' branch (the
+        confirm read was ambiguous but the message was actually on
+        scrollback already) had no direct test pinning its wording."""
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": False, "fallback": "already_delivered"}, "to session 'proj'")
+        assert "already visible on scrollback" in result
+        assert "No action needed" in result
+
     def test_unverified_with_no_fallback_still_warns(self):
         from agentwire.mcp_core import _delivery_result
         result = _delivery_result({"verified": False, "fallback": None}, "to session 'proj'")

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -129,6 +129,10 @@ class TestSessionTools:
         sent_msg = args[4]  # message follows --verify
         assert '[MESSAGE FROM SESSION "orchestrator"' in sent_msg
         assert 'session_send(session="orchestrator"' in sent_msg
+        # #835 review: a msg-inbox fallback attributes to the real caller
+        # (dead-letter emails, the rendered header) instead of the generic
+        # "agentwire" -- the CLI subprocess can't auto-detect it itself.
+        assert args[5:] == ["--caller-session", "orchestrator"]
 
     @patch("agentwire.mcp_session.run_agentwire_cmd")
     @patch("agentwire.mcp_session.get_caller_session", return_value=None)

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -280,6 +280,33 @@ class TestApiCreateSession:
                             if c[0][0] == "notification"]
             assert len(notify_calls) == 1
 
+    async def test_create_first_message_unverified_but_queued_does_not_say_paste_manually(self, portal_client):
+        """#835: an unverified first-message send that recovered via the
+        msg-inbox fallback (or was found already delivered) must not show
+        the stale 'paste it manually' toast -- the system already handled
+        it, and telling the human to intervene would be actively wrong."""
+        import asyncio
+
+        client, server = portal_client
+
+        async def cmd_router(args, json_output=True):
+            if args[0] == "send":
+                return (False, {"error": "Delivery not verified", "fallback": "inbox"})
+            return (True, {"session": "ideaproj", "path": "/p"})
+
+        with patch.object(server, "run_agentwire_cmd", side_effect=cmd_router):
+            server.broadcast_dashboard = AsyncMock()
+            resp = await client.post("/api/create", json={
+                "name": "ideaproj", "first_message": "an idea",
+            })
+            assert (await resp.json()).get("success") is True
+            await asyncio.gather(*server._background_tasks)
+            toasts = [n for n in server.active_notifications.values()
+                      if n["session"] == "ideaproj"]
+            assert len(toasts) == 1
+            assert "paste it manually" not in toasts[0]["text"]
+            assert "queued" in toasts[0]["text"]
+
     async def test_create_without_first_message_no_background_task(self, portal_client):
         client, server = portal_client
         with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -307,6 +307,31 @@ class TestApiCreateSession:
             assert "paste it manually" not in toasts[0]["text"]
             assert "queued" in toasts[0]["text"]
 
+    async def test_create_first_message_already_delivered_does_not_say_paste_manually(self, portal_client):
+        """#835 second-pass review: the 'already_delivered' arm of the same
+        ternary had no direct test -- only 'inbox' was exercised."""
+        import asyncio
+
+        client, server = portal_client
+
+        async def cmd_router(args, json_output=True):
+            if args[0] == "send":
+                return (False, {"error": "Delivery not verified", "fallback": "already_delivered"})
+            return (True, {"session": "ideaproj", "path": "/p"})
+
+        with patch.object(server, "run_agentwire_cmd", side_effect=cmd_router):
+            server.broadcast_dashboard = AsyncMock()
+            resp = await client.post("/api/create", json={
+                "name": "ideaproj", "first_message": "an idea",
+            })
+            assert (await resp.json()).get("success") is True
+            await asyncio.gather(*server._background_tasks)
+            toasts = [n for n in server.active_notifications.values()
+                      if n["session"] == "ideaproj"]
+            assert len(toasts) == 1
+            assert "paste it manually" not in toasts[0]["text"]
+            assert "delivered" in toasts[0]["text"]
+
     async def test_create_without_first_message_no_background_task(self, portal_client):
         client, server = portal_client
         with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -702,13 +702,17 @@ class TestClearInputBox:
     the drain's own SGR-aware emptiness gate (so 'cleared' means exactly 'the
     inbox fallback can deliver')."""
 
-    def _wire(self, monkeypatch, empty_after: int):
+    def _wire(self, monkeypatch, empty_after: int, live_menu: bool = False):
         """prompt_is_empty flips True after N Escapes; returns the key log."""
         from agentwire import pane_manager, prompt_router
         state = {"escapes": 0}
         monkeypatch.setattr(
             prompt_router, "prompt_is_empty",
             lambda s, p=0: state["escapes"] >= empty_after)
+        # No live menu on screen by default -- the snapshot content itself
+        # doesn't matter here, only screen_shows_live_menu's verdict on it.
+        monkeypatch.setattr(session_ready, "capture_session", lambda *a, **k: "")
+        monkeypatch.setattr(prompt_router, "screen_shows_live_menu", lambda cap: live_menu)
 
         def run(cmd, timeout=5):
             if cmd[-1] == "Escape":
@@ -745,6 +749,23 @@ class TestClearInputBox:
         monkeypatch.setattr(prompt_router, "prompt_is_empty", boom)
         monkeypatch.setattr(pane_manager, "run_command", lambda *a, **k: None)
         assert session_ready.clear_input_box("s") is False
+
+    def test_live_menu_refuses_to_press_escape(self, monkeypatch):
+        """#835 review: reused against an already-running, independently-busy
+        session (agentwire send --verify's fallback), 'box not empty' can
+        mean a permission dialog or AskUserQuestion menu belonging to the
+        recipient's own unrelated work. Escape is the conventional
+        cancel/decline key for those -- must never press it blind."""
+        _fake_clock(monkeypatch)
+        state = self._wire(monkeypatch, empty_after=1, live_menu=True)
+        assert session_ready.clear_input_box("s") is False
+        assert state["escapes"] == 0
+
+    def test_no_live_menu_still_clears_normally(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        state = self._wire(monkeypatch, empty_after=1, live_menu=False)
+        assert session_ready.clear_input_box("s") is True
+        assert state["escapes"] == 1
 
 
 class TestRecoverFailedSeed:


### PR DESCRIPTION
## Summary
- `agentwire send --verify`/`--wait-ready` (what `session_send` MCP tool uses) only retried Enter submission once, then returned inert advisory text on failure -- fully dependent on the calling agent noticing and manually resending.
- Now falls back to `recover_failed_seed()` (clear the stray paste, enqueue into the recipient's durable msg inbox) so delivery is retried across ticks and dead-lettered + emailed to the owner if it truly can't land -- never silent.
- Safe against double-delivery: the inbox drain already dedups against pane scrollback by full message text.
- `pane_send` unaffected by design; fixed `_delivery_result` to distinguish "no fallback attempted" (pane sends) from "fallback attempted and failed" (session sends) so it doesn't misreport pane failures.

## Test plan
- [x] Unit tests for both `cmd_send` fallback branches (`--wait-ready`, `--verify`)
- [x] Unit tests for `_delivery_result` wording, incl. pane_send no-fallback-key regression
- [x] Full suite green (2819 passed)

Closes #834

Built by dotdev.dev