### PR TITLE
fix(portal): stop hardcoding a stale __version__ in server.py

### DIFF
--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -33,7 +33,7 @@ import jinja2
 import yaml
 from aiohttp import web
 
-from . import prompt_router, security
+from . import __version__, prompt_router, security
 from .cached_status import CachedStatusChecker
 from .config import Config, load_config
 from .routes.artifacts import ArtifactsRoutesMixin, register_artifacts_routes
@@ -65,8 +65,6 @@ from .security import (
 )
 from .ssh import ssh_base_opts
 from .worktree import parse_session_name
-
-__version__ = "1.3.0"
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -68,6 +68,18 @@ class TestHealthEndpoint:
         assert data["status"] == "ok"
         assert "version" in data
 
+    async def test_health_reports_the_real_package_version(self, portal_client):
+        """server.py used to hardcode its own __version__ = "1.3.0",
+        disconnected from agentwire/__init__.py and stale since 2026-02 --
+        /health silently lied about what was actually running. Pin against
+        the real SSOT so a reintroduced hardcode fails this test."""
+        from agentwire import __version__ as real_version
+
+        client, _ = portal_client
+        resp = await client.get("/health")
+        data = await resp.json()
+        assert data["version"] == real_version
+
 
 class TestPwaSurface:
     """PWA manifest + service worker + push API (#483)."""


### PR DESCRIPTION
## Summary
- `server.py` hardcoded its own `__version__ = "1.3.0"`, disconnected from `agentwire/__init__.py`'s real version and stale since 2026-02 -- `/health` (and the desktop UI) silently reported the wrong version for months.
- Now imports the real `__version__` from the package. One SSOT.

## Test plan
- [x] Added a regression test pinning `/health`'s reported version against `agentwire.__version__`
- [x] Full suite green (2830 passed)

Closes #841

Built by dotdev.dev