### PR TITLE
fix(sessions): recover_failed_seed reports honest outcome when box clear is unconfirmed

### DIFF
--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -188,6 +188,11 @@ def _delivery_result(data: dict, where: str) -> str:
                         f"queued to its msg inbox instead, which guarantees delivery (retried "
                         f"automatically, dead-lettered + emailed to the owner only if it truly "
                         f"can't land). No action needed.")
+            if data.get("fallback") == "inbox_stuck":
+                return (f"Message sent {where} but delivery could NOT be verified in the pane — "
+                        f"queued to its msg inbox as a durable backup, but the ORIGINAL stale draft "
+                        f"could NOT be confirmed cleared from the input box. It may still be sitting "
+                        f"there and get submitted later by an unrelated Enter. Check the pane manually.")
             return (f"Message sent {where} but delivery could NOT be verified, AND the msg-inbox "
                     f"fallback also failed — this message may be lost. Check the pane or resend.")
         return (f"Message sent {where} but delivery could NOT be verified — it may "

--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -104,13 +104,23 @@ def worktree_create(
     # invisible to an orchestrator skimming results, and the session then sits
     # idle with the task never delivered.
     if prompt and not data.get("first_message_delivered"):
-        if data.get("first_message_fallback") == "inbox":
+        fallback = data.get("first_message_fallback")
+        if fallback == "inbox":
             return (
                 f"Created worktree session '{session}' at {path}. "
                 "WARNING: seed prompt NOT delivered — the input box was not ready. "
                 "The prompt was queued to the session's msg inbox and the watchdog "
                 "will deliver it once the box is ready; verify with msg_inbox / "
                 "session_output before assuming the task started."
+            )
+        if fallback == "inbox_stuck":
+            return (
+                f"Created worktree session '{session}' at {path}. "
+                "WARNING: seed prompt NOT delivered — the input box was not ready, AND the "
+                "stale draft could NOT be confirmed cleared from it. The prompt was queued to "
+                "the session's msg inbox as a durable backup, but a leftover draft may still be "
+                "sitting in the pane and could get submitted later by an unrelated Enter — check "
+                f"session_output for '{session}' before assuming the box is clean."
             )
         return (
             f"Created worktree session '{session}' at {path}. "

--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -60,7 +60,9 @@ def _recover_unverified_send(session: str, prompt: str, sender: str) -> "str | N
     function was written to close (needs a coincidental/repeated-text
     match, not just any unverified send).
 
-    Returns ``"already_delivered"``, ``"inbox"``, or ``None`` (the inbox
+    Returns ``"already_delivered"``, ``"inbox"``, ``"inbox_stuck"`` (queued,
+    but the original stale draft couldn't be confirmed cleared from the
+    input box — see ``recover_failed_seed``, #843), or ``None`` (the inbox
     fallback itself failed).
     """
     from agentwire.session_ready import message_on_scrollback, recover_failed_seed, scrollback
@@ -75,6 +77,10 @@ def _fallback_suffix(fallback: "str | None") -> str:
         return " — already delivered directly (the confirmation read was just ambiguous); no action needed"
     if fallback == "inbox":
         return " — queued to its msg inbox for guaranteed delivery"
+    if fallback == "inbox_stuck":
+        return (" — queued to its msg inbox, but the stale draft could NOT be confirmed cleared "
+                "from the input box; it may still be sitting there and get submitted later by an "
+                "unrelated Enter — check the pane")
     return " and could not be queued — resend manually"
 
 

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2477,18 +2477,34 @@ class AgentWireServer(
             ["send", "-s", session_name, "--wait-ready", "--timeout", "60", "--", message]
         )
         if not success:
-            if result.get("fallback") in ("inbox", "already_delivered"):
+            fallback = result.get("fallback")
+            if fallback in ("inbox", "already_delivered"):
                 # #835: an unverified send now recovers on its own -- either
                 # it was already delivered and the confirm read was just
                 # ambiguous, or it's queued to the durable msg inbox. Either
                 # way the old "paste it manually" toast would be stale,
                 # actively wrong advice.
-                logger.info(f"First message for {session_name} recovered via {result.get('fallback')} fallback")
+                logger.info(f"First message for {session_name} recovered via {fallback} fallback")
                 await self._post_toast(
                     f"First message to {session_name} queued for guaranteed delivery"
-                    if result.get("fallback") == "inbox" else
+                    if fallback == "inbox" else
                     f"First message to {session_name} delivered (confirmation was just delayed)",
                     session=session_name, priority="normal", id_prefix="firstmsg")
+                return
+            if fallback == "inbox_stuck":
+                # #843: queued to the msg inbox, but the ORIGINAL stale draft
+                # could not be confirmed cleared from the input box -- unlike
+                # the plain "inbox" case above, this is NOT fully resolved:
+                # a leftover draft may still be sitting there for a later
+                # unrelated Enter to submit. Surface that distinctly instead
+                # of the calm "queued for guaranteed delivery" toast.
+                logger.warning(
+                    f"First message for {session_name} queued to inbox, but its input box "
+                    "could not be confirmed cleared -- a stale draft may still be stuck there")
+                await self._post_toast(
+                    f"First message to {session_name} queued, but a stuck draft in its input "
+                    "box could not be confirmed cleared — check the pane",
+                    session=session_name, priority="high", id_prefix="firstmsg")
                 return
             logger.warning(f"First message delivery failed for {session_name}: {result.get('error')}")
             await self._post_toast(

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -578,6 +578,13 @@ def cmd_new(args) -> int:
                         "queued to its msg inbox for delivery once the input box is ready",
                         file=sys.stderr,
                     )
+                elif first_message_fallback == "inbox_stuck":
+                    print(
+                        f"WARNING: first message NOT delivered to '{session_name}' — "
+                        "queued to its msg inbox, but the stuck draft in the input box "
+                        "could not be confirmed cleared; check the pane manually",
+                        file=sys.stderr,
+                    )
                 else:
                     print(
                         f"WARNING: first message NOT delivered to '{session_name}' "
@@ -596,8 +603,10 @@ def cmd_new(args) -> int:
         if first_message:
             result["first_message_delivered"] = bool(first_message_delivered)
             if not first_message_delivered:
-                # "inbox" (queued for watchdog delivery) or None (fallback
-                # failed too — the prompt is gone; caller must redeliver).
+                # "inbox" (queued, box confirmed cleared), "inbox_stuck"
+                # (queued, but the stale draft in the box couldn't be
+                # confirmed cleared — #843), or None (fallback failed too —
+                # the prompt is gone; caller must redeliver).
                 result["first_message_fallback"] = first_message_fallback
         _output_json(result)
     else:

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -639,18 +639,29 @@ def recover_failed_seed(
        that can never deliver dead-letters LOUDLY (owner email) instead of
        vanishing.
 
-    Returns ``"inbox"`` when the prompt was queued, None when even the
-    fallback failed (the caller must tell the user to deliver manually).
-    Never raises.
+    Step 1's outcome is NOT assumed (#843): if ``clear_input_box`` can't
+    confirm the box ended up empty (Escape did nothing, or the call raised),
+    the ORIGINAL stale, unsubmitted draft may still be sitting in the box —
+    live for whatever unrelated Enter reaches the pane next (a later
+    message's own retry, a human keypress) to submit it, looking exactly
+    like a fresh, legitimate instruction. The durable copy still gets
+    queued either way — still better than nothing — but the return value
+    is honest about which happened instead of reporting blanket success.
+
+    Returns ``"inbox"`` when the box was confirmed cleared AND the prompt
+    was queued, ``"inbox_stuck"`` when the prompt was queued but the box
+    could NOT be confirmed cleared (a stale draft may still be sitting
+    there — needs manual intervention), or None when even the durable
+    enqueue failed. Never raises.
     """
     try:
-        clear_input_box(session, pane_index=pane_index)
+        cleared = clear_input_box(session, pane_index=pane_index)
     except Exception:
-        pass
+        cleared = False
     try:
         from agentwire import inbox
 
         inbox.enqueue(session, message, kind="request", sender=sender or "agentwire")
-        return "inbox"
+        return "inbox" if cleared else "inbox_stuck"
     except Exception:
         return None

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -273,6 +273,24 @@ class TestCmdSendWaitReady:
         cmd_send(self._args(caller_session="council-brain"))
         recover.assert_called_once_with("proj", "my idea", "council-brain")
 
+    def test_unverified_falls_back_to_stuck_inbox(self, capsys, monkeypatch):
+        """#843: an "inbox_stuck" fallback (queued, but the stale draft in
+        the input box could not be confirmed cleared) must propagate through
+        untouched -- never collapsed into the plain "inbox" success case."""
+        from agentwire import send_cli, session_ready
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        recover = MagicMock(return_value="inbox_stuck")
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
+
+        assert cmd_send(self._args()) == 1
+        payload = self._payload(capsys)
+        assert payload["verified"] is False
+        assert payload["fallback"] == "inbox_stuck"
+
     def test_remote_rejected(self, capsys):
         from agentwire.send_cli import cmd_send
 
@@ -361,6 +379,29 @@ class TestCmdSendVerify:
         assert payload["verified"] is None
         assert "fallback" not in payload
         recover.assert_not_called()
+
+
+class TestFallbackSuffix:
+    """#843: the human-readable suffix must distinguish a fully-recovered
+    "inbox" fallback from "inbox_stuck", where the original draft could not
+    be confirmed cleared from the input box."""
+
+    def test_inbox_suffix_says_guaranteed_delivery(self):
+        from agentwire.send_cli import _fallback_suffix
+
+        assert "guaranteed delivery" in _fallback_suffix("inbox")
+
+    def test_inbox_stuck_suffix_warns_of_leftover_draft(self):
+        from agentwire.send_cli import _fallback_suffix
+
+        suffix = _fallback_suffix("inbox_stuck")
+        assert "could NOT be confirmed cleared" in suffix
+        assert "guaranteed delivery" not in suffix
+
+    def test_none_suffix_says_resend_manually(self):
+        from agentwire.send_cli import _fallback_suffix
+
+        assert "resend manually" in _fallback_suffix(None)
 
 
 class TestRecoverUnverifiedSend:
@@ -472,6 +513,19 @@ class TestCmdNewSeedFallback:
         assert payload["first_message_delivered"] is False
         assert payload["first_message_fallback"] == "inbox"
         # Recovery got the prompt and the creator as sender.
+        assert calls["recover"] == ("proj", "do the thing", "orch")
+
+    def test_seed_failure_reports_stuck_draft_distinctly(self, capsys, monkeypatch, tmp_path):
+        """#843: cmd_new's JSON contract must carry "inbox_stuck" through
+        untouched -- collapsing it into "inbox" would tell the caller the
+        box was cleared when it wasn't."""
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=False, verified=False, fallback="inbox_stuck")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["success"] is True
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] == "inbox_stuck"
         assert calls["recover"] == ("proj", "do the thing", "orch")
 
     def test_seed_failure_fallback_also_failed(self, capsys, monkeypatch, tmp_path):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -175,6 +175,17 @@ class TestDeliveryResultBehavior:
         assert "already visible on scrollback" in result
         assert "No action needed" in result
 
+    def test_unverified_with_inbox_stuck_fallback_warns_to_check_pane(self):
+        """#843: "inbox_stuck" (queued, but the original stale draft could
+        not be confirmed cleared from the input box) must read as an honest
+        warning, distinct from the calm "No action needed" wording used for
+        a fully-recovered "inbox" fallback."""
+        from agentwire.mcp_core import _delivery_result
+        result = _delivery_result({"verified": False, "fallback": "inbox_stuck"}, "to session 'proj'")
+        assert "could NOT be confirmed cleared" in result
+        assert "Check the pane manually" in result
+        assert "No action needed" not in result
+
     def test_unverified_with_no_fallback_still_warns(self):
         from agentwire.mcp_core import _delivery_result
         result = _delivery_result({"verified": False, "fallback": None}, "to session 'proj'")

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -550,6 +550,21 @@ class TestWorktreeCreateSeedResult:
 
     @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
     @patch("agentwire.mcp_worktree.run_agentwire_cmd")
+    def test_seed_failure_with_inbox_stuck_fallback_warns_of_leftover_draft(self, mock_cmd, _caller):
+        """#843: "inbox_stuck" (queued, but the stale draft could not be
+        confirmed cleared from the input box) must read distinctly from the
+        plain "inbox" success-ish case above — the caller needs to know a
+        leftover draft may still be sitting in the pane."""
+        result = self._create(mock_cmd, _success(
+            session="proj-x", path="/w/proj-x",
+            first_message_delivered=False, first_message_fallback="inbox_stuck"))
+        assert "WARNING" in result
+        assert "NOT delivered" in result
+        assert "could NOT be confirmed cleared" in result
+        assert "(seeded)" not in result
+
+    @patch("agentwire.mcp_worktree.get_caller_session", return_value=None)
+    @patch("agentwire.mcp_worktree.run_agentwire_cmd")
     def test_seed_failure_without_fallback_is_loud(self, mock_cmd, _caller):
         result = self._create(mock_cmd, _success(
             session="proj-x", path="/w/proj-x",

--- a/tests/unit/test_portal_api.py
+++ b/tests/unit/test_portal_api.py
@@ -344,6 +344,34 @@ class TestApiCreateSession:
             assert "paste it manually" not in toasts[0]["text"]
             assert "delivered" in toasts[0]["text"]
 
+    async def test_create_first_message_stuck_draft_warns_not_calm_queued_toast(self, portal_client):
+        """#843: an "inbox_stuck" fallback (queued, but the stale draft in
+        the input box could not be confirmed cleared) must NOT reuse the
+        calm "queued for guaranteed delivery" toast the plain "inbox" case
+        gets -- the original draft may still be sitting there."""
+        import asyncio
+
+        client, server = portal_client
+
+        async def cmd_router(args, json_output=True):
+            if args[0] == "send":
+                return (False, {"error": "Delivery not verified", "fallback": "inbox_stuck"})
+            return (True, {"session": "ideaproj", "path": "/p"})
+
+        with patch.object(server, "run_agentwire_cmd", side_effect=cmd_router):
+            server.broadcast_dashboard = AsyncMock()
+            resp = await client.post("/api/create", json={
+                "name": "ideaproj", "first_message": "an idea",
+            })
+            assert (await resp.json()).get("success") is True
+            await asyncio.gather(*server._background_tasks)
+            toasts = [n for n in server.active_notifications.values()
+                      if n["session"] == "ideaproj"]
+            assert len(toasts) == 1
+            assert "paste it manually" not in toasts[0]["text"]
+            assert "queued for guaranteed delivery" not in toasts[0]["text"]
+            assert "could not be confirmed cleared" in toasts[0]["text"]
+
     async def test_create_without_first_message_no_background_task(self, portal_client):
         client, server = portal_client
         with patch.object(server, "run_agentwire_cmd", new_callable=AsyncMock) as mock_cmd:

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -801,15 +801,41 @@ class TestRecoverFailedSeed:
         assert seen["sender"] == "agentwire"
 
     def test_clear_failure_still_queues(self, monkeypatch):
+        """#843: clear_input_box raising must not be reported as full
+        recovery -- the box's actual state was never confirmed, so the
+        original stale draft may still be sitting there."""
         from agentwire import inbox
 
         def boom(*a, **k):
             raise RuntimeError("no pane")
 
         monkeypatch.setattr(session_ready, "clear_input_box", boom)
+        enqueued = {}
         monkeypatch.setattr(
-            inbox, "enqueue", lambda to, text, kind="note", sender=None, ref="": [])
-        assert session_ready.recover_failed_seed("sess", "x") == "inbox"
+            inbox, "enqueue",
+            lambda to, text, kind="note", sender=None, ref="": enqueued.setdefault("called", True) or [])
+        assert session_ready.recover_failed_seed("sess", "x") == "inbox_stuck"
+        assert enqueued["called"]  # durable copy still queued -- better than nothing
+
+    def test_clear_returns_false_reports_stuck_not_inbox(self, monkeypatch):
+        """#843: recover_failed_seed must never report "inbox" (implying full
+        recovery) when clear_input_box returns False -- the caller needs an
+        honest signal that the box wasn't confirmed cleared, since the
+        original draft could otherwise get flushed later by an unrelated
+        Enter looking like a fresh, legitimate instruction."""
+        from agentwire import inbox
+
+        monkeypatch.setattr(session_ready, "clear_input_box", lambda s, pane_index=0: False)
+        enqueued = {}
+        monkeypatch.setattr(
+            inbox, "enqueue",
+            lambda to, text, kind="note", sender=None, ref="": enqueued.setdefault("called", True) or [])
+
+        result = session_ready.recover_failed_seed("sess", "x")
+
+        assert result == "inbox_stuck"
+        assert result != "inbox"
+        assert enqueued["called"]  # durable copy still queued -- better than nothing
 
     def test_enqueue_failure_returns_none_never_raises(self, monkeypatch):
         from agentwire import inbox


### PR DESCRIPTION
## Summary

`recover_failed_seed()` (`agentwire/session_ready.py`) called `clear_input_box()` to Escape-clear a stuck, unsubmitted draft before enqueueing a durable msg-inbox fallback — but never checked whether the clear actually succeeded. If Escape failed to confirm the box empty, the code still returned `"inbox"` (implying full recovery), while the original stale draft stayed sitting in the recipient's input box. The next *unrelated* Enter that reaches that pane (a later retry, a human keypress) then submits the leftover draft — looking exactly like a fresh, legitimate instruction.

## Fix

`recover_failed_seed` now captures `clear_input_box`'s return value (treating an exception as "not confirmed cleared," matching its prior fail-open handling) and returns a distinct outcome:

- `"inbox"` — box confirmed cleared **and** the durable copy was queued (unchanged, full recovery).
- `"inbox_stuck"` — the durable copy was still queued (still better than nothing, per the issue's guidance), but the box could **not** be confirmed cleared — a stale draft may still be sitting there.
- `None` — unchanged: even the durable enqueue failed.

Every caller-facing surface now handles `"inbox_stuck"` distinctly instead of collapsing it into the calm "queued for guaranteed delivery" wording:

- `send_cli._fallback_suffix` (`agentwire send --verify`/`--wait-ready` CLI output)
- `session_cli.cmd_new`'s non-JSON stderr warning (JSON already passes the raw value through)
- `mcp_core._delivery_result` (MCP `session_send`/`notify_*` tool text)
- `server.py`'s `_deliver_first_message` portal toast (was lumping `"inbox"` and `"already_delivered"` together; `"inbox_stuck"` now gets its own high-priority toast)
- `mcp_worktree.worktree_create`'s result text

## Investigation findings (per the issue's questions)

1. **Can `clear_input_box` genuinely fail against a plain single-line draft, or only against a live-menu?** There's a real third screen state neither branch handles: `input_box_content_sgr` returns `None` (not `""`) whenever the box's bordering rule-lines can't be parsed — a mid-redraw frame, or tmux `capture-pane` lagging behind actual terminal state under host load (documented elsewhere in this file as a real, expected condition). `prompt_is_empty` correctly treats `None` as "not empty" (conservative), but `screen_shows_live_menu` doesn't recognize an unparseable/transitional frame as a menu either (it matches specific dialog patterns) — so `clear_input_box` just keeps blindly re-pressing Escape into an unrecognized state for `CLEAR_BOX_ATTEMPTS` (3) rounds and gives up. This can happen to a plain single-line draft under host lag, not just a live-menu case.

2. **Why would a manual Enter succeed later when `_submit_phase`'s automated retries didn't?** `press_enter` and `send-keys`'s raw Enter use the identical `tmux send-keys ... Enter` primitive — there's no mechanism difference. The more likely explanation is budget vs. real lag: `SUBMIT_BUDGET` (20s) plus `clear_input_box`'s own bound (`CLEAR_BOX_ATTEMPTS × CLEAR_BOX_TIMEOUT` ≈ 9s) total well under the ~25s+ the live incident actually took to resolve — the automated path gave up before the host's lag cleared. It's also possible the confirm poll's own `capture-pane` reads were themselves lagging, so an Enter had already landed while the poll still saw stale non-empty content. Not fixed here — tracked as a tuning follow-up per the issue (interoperates with #839/#840).

## Testing

- New regression tests in `test_session_ready.py`: `clear_input_box` returning `False` (and raising) → `recover_failed_seed` returns `"inbox_stuck"`, not `"inbox"`, while still queuing the durable copy.
- Propagation tests added across `test_cli_commands.py` (`_fallback_suffix`, `cmd_send`, `cmd_new`), `test_mcp_server.py` (`_delivery_result`), `test_mcp_tools_args.py` (`worktree_create`), and `test_portal_api.py` (first-message toast).
- Full suite: `uv run pytest -q` → 2852 passed.

Closes #843