### PR TITLE
fix(roles): worker/reviewer worktree etiquette clears dangling /loop wakeups before finishing

### DIFF
--- a/agentwire/roles/reviewer-worktree.md
+++ b/agentwire/roles/reviewer-worktree.md
@@ -27,6 +27,8 @@ If you open a claude-in-chrome tab to test the branch, track it immediately with
 
 ## Reporting
 
+If you ever used `/loop` (self-paced iteration via `ScheduleWakeup`) at any point in this session, call `ScheduleWakeup(stop: true)` before reporting. A scheduled wakeup outlives task completion — it fires later regardless of whether the review is done, re-injecting its prompt as fresh input, which reads as a stray, unprompted instruction and re-engages you on a review that's already concluded.
+
 When your review reaches a conclusion, `notify_parent` with a structured verdict — never leave it implicit and never just exit:
 
 - **approve** — no blocking findings; safe to merge as-is (note any non-blocking nits separately)

--- a/agentwire/roles/worker-worktree.md
+++ b/agentwire/roles/worker-worktree.md
@@ -23,11 +23,12 @@ If you open a claude-in-chrome tab to verify your work (dev server, screenshots)
 
 When the task is done:
 
-1. Close any claude-in-chrome tabs you opened (`tabs_close_mcp`) and drop their tracking (`chrome_tab_untrack`). A verification tab must never survive your teardown.
-2. Commit with a clear message, following any commit-footer conventions from your global instructions.
-3. Push your branch (`git push -u origin <branch>`).
-4. Open a DRAFT pull request against the base branch.
-5. Report back to your creator with a **polite, non-interrupting** message so you never clobber a draft they're half-way through typing:
+1. If you ever used `/loop` (self-paced iteration via `ScheduleWakeup`) at any point in this session, call `ScheduleWakeup(stop: true)` now, before anything else below. A scheduled wakeup outlives task completion — it fires later regardless of whether the work is done, re-injecting its prompt as fresh input, which reads as a stray, unprompted instruction to whoever's watching the pane and re-engages you on a task that's already finished.
+2. Close any claude-in-chrome tabs you opened (`tabs_close_mcp`) and drop their tracking (`chrome_tab_untrack`). A verification tab must never survive your teardown.
+3. Commit with a clear message, following any commit-footer conventions from your global instructions.
+4. Push your branch (`git push -u origin <branch>`).
+5. Open a DRAFT pull request against the base branch.
+6. Report back to your creator with a **polite, non-interrupting** message so you never clobber a draft they're half-way through typing:
 
    ```
    agentwire msg send --to <creator> --kind done "<session>: <one-liner + PR URL>"


### PR DESCRIPTION
## Summary

A worktree worker/reviewer that used `/loop` (ScheduleWakeup dynamic mode) at any point retains its scheduled wakeup even after the task is done and reported — the wakeup fires later regardless, re-injecting its stored prompt as fresh input. The model has no memory that the task already finished, so it free-associates a plausible "what's next" continuation — which reads as a stray, unprompted instruction to anyone watching the pane.

Root-caused from a live incident reported by a peer project's orchestrator (see #846 for full evidence, including a first-hand confirmation of the same failure mode earlier today in this session).

## Fix

`agentwire/roles/worker-worktree.md`'s "Finish" section and `agentwire/roles/reviewer-worktree.md`'s "Reporting" section now instruct: if `/loop` was ever used during the session, call `ScheduleWakeup(stop: true)` before finishing/reporting.

This is a prompt-instruction mitigation, not a structural guarantee (relies on the model remembering) — a deeper, structural fix is tracked as an open follow-up in #846 if one turns out to be possible.

## Testing

`uv run pytest tests/unit/test_roles.py -q` — 83 passed (no content-string test asserts on the added lines; existing structural/etiquette-needle assertions untouched).

Closes #846