### PR TITLE
fix: --created-by '' silently no-ops instead of clearing a stale parent

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -740,8 +740,13 @@ def _record_session_creator(session_name: str, created_by: str | None, via: str)
 
     The creator becomes the session's parent for prompt routing
     (prompt_router.resolve_parent), winning over .agentwire.yml `parent:`.
+
+    ``created_by`` of ``''`` means "explicitly rootless" and must still be
+    written — otherwise a re-`new`/`recreate` that forces standalone (e.g.
+    `--created-by ''`) leaves a stale parent from a prior creation in place,
+    since `not created_by` is also true for `''`.
     """
-    if not created_by or created_by == session_name.split("@")[0]:
+    if created_by is None or created_by == session_name.split("@")[0]:
         return
     metadata = load_session_metadata(session_name)
     metadata.update({


### PR DESCRIPTION
## Summary

`_record_session_creator` skips writing whenever `created_by` is falsy — which also matches the empty string used to force a rootless session (`--created-by ''`, or the auto-root default `--kind orchestrator` gets per #715). So force-recreating an already-parented session with `--created-by ''` left the stale parent in `metadata.json`, and `prompt_router.resolve_parent` kept routing prompts/notify-parent back to the old creator even though the caller explicitly asked for standalone.

Found while recreating a long-lived local session (previously parented from before #715 shipped) as a root orchestrator — the tmux env var cleared correctly, but the persisted metadata (the actual source `resolve_parent` reads) didn't budge.

Fix: only skip when `created_by is None` (no signal to record), not when it's `''` (explicit "no parent").

## Test plan

- [ ] Existing session metadata/rooting tests still pass
- [ ] `agentwire new -s <name> -p <path> -f --created-by ''` on a session with a previously-recorded parent now clears it (`metadata.json`'s `created_by` becomes `""`)
- [ ] `prompt_router.resolve_parent` returns `None` for that session afterward