### PR TITLE
fix(scheduler): dispatch no longer dies when a session shares the project dir (#854)

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -173,6 +173,10 @@ tasks:
     work_branch: agent/task    # Branch for agent's work (default: agent/<task>-<date>)
     pr_target: main            # PR target branch (default: starting_ref)
     pr_draft: true             # Create as draft PR (default: true)
+    allow_shared_dir: true     # Let the dispatch attach even when another live
+                               # session's cwd is the project dir. Default is
+                               # derived: off for tasks with `starting_ref`
+                               # (they mutate the tree), on for branchless ones.
 
     # Context inheritance
     starting_session: ctx-loaded  # Fork Claude context from this session before running

--- a/agentwire/ensure_cli.py
+++ b/agentwire/ensure_cli.py
@@ -430,6 +430,31 @@ def _create_task_pr(project_path, task, work_branch, last_summary, json_mode) ->
     return pr_url
 
 
+def _dispatch_shares_dir(task) -> bool:
+    """Whether this dispatch may attach its session to a working dir another
+    session already occupies (#854).
+
+    The shared-working-dir guard in ``session_cli.cmd_new`` exists to stop two
+    agents mutating one git working tree — one's dirty state visible to the
+    other, branches mixing. That is an *accident* an interactive `agentwire new`
+    can stumble into; a scheduled dispatch is declared intent, so the guard
+    should only bind it when the dispatch actually manipulates the tree.
+
+    ``starting_ref`` is exactly that dividing line: it is the field that makes
+    ``ensure`` run ``git checkout`` / create a work branch / reset the tree
+    around the task (``_setup_task_branch`` and ``_commit_and_pr``). With it
+    set, the guard stays armed and refuses with its usual "use a worktree"
+    hint. Without it, the dispatch touches no branch state and can co-reside.
+
+    ``allow_shared_dir`` in the task config overrides the derivation in either
+    direction — re-arm it for a branchless task whose *prompt* does git work,
+    or open it for a ``starting_ref`` task whose tree is known to be private.
+    """
+    if task.allow_shared_dir is not None:
+        return task.allow_shared_dir
+    return not task.starting_ref
+
+
 def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -> int:
     """Run the task (called within lock context).
 
@@ -492,6 +517,15 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
                         self.roles = task_role if task_role else None
                         self.model = None
                         self.json = json_mode
+                        # #854: the shared-working-dir guard defends against an
+                        # ACCIDENTAL second agent in one tree. A dispatch is the
+                        # opposite — the task config names this project, on a
+                        # schedule, on purpose (same reasoning as services.py's
+                        # `--allow-shared-dir`). Left armed, any live session
+                        # whose pane cwd is the project dir silently kills every
+                        # nightly. Opted out only when the dispatch does no
+                        # branch work of its own — see _dispatch_shares_dir.
+                        self.allow_shared_dir = _dispatch_shares_dir(task)
                         # Force the pre-#715 unconditional-inherit behavior:
                         # ensure is the scheduler's dispatch primitive — the
                         # scheduler daemon fans out across many projects from

--- a/agentwire/tasks.py
+++ b/agentwire/tasks.py
@@ -115,6 +115,11 @@ class TaskConfig:
     starting_session: str | None = None  # Fork Claude context from this session before running
     role: str | None = None              # Role override for this task
 
+    # #854: override the shared-working-dir guard for this task's dispatch.
+    # None = derive from starting_ref (branchless tasks co-reside, git tasks
+    # keep the guard) — see ensure_cli._dispatch_shares_dir.
+    allow_shared_dir: bool | None = None
+
     # Unattended (no-human) safety: damage-control rule ids this scheduled task
     # is permitted to run when the dispatch is unattended, EXTENDING the global
     # default allowlist (safety.unattended_allow / DEFAULT_UNATTENDED_ALLOW).
@@ -218,6 +223,10 @@ def parse_task_config(name: str, config: dict, default_shell: str | None = None)
         pr_draft=config.get("pr_draft", True),
         starting_session=config.get("starting_session"),
         role=config.get("role"),
+        allow_shared_dir=(
+            None if config.get("allow_shared_dir") is None
+            else bool(config["allow_shared_dir"])
+        ),
         unattended_allow=(
             list(config.get("unattended_allow", []))
             if isinstance(config.get("unattended_allow"), list)

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -52,6 +52,8 @@ tasks:
     work_branch: agent/task  # Branch for agent's work (default: agent/<task>-<date>)
     pr_target: main          # PR target branch (default: starting_ref)
     pr_draft: true           # Create as draft PR (default: true)
+    allow_shared_dir: true   # Attach even if another session sits in the project
+                             # dir (default: derived — see below)
 
     # Context inheritance
     starting_session: ctx-loaded  # Fork Claude context from this session before running
@@ -115,6 +117,29 @@ When `starting_ref` is set, the task lifecycle handles all git plumbing automati
 |----------|-------------|
 | `{{ work_branch }}` | Branch name used for agent's work |
 | `{{ pr_url }}` | URL of the created PR (empty if no PR was created) |
+
+### Sharing a working dir with a live session (#854)
+
+`agentwire new` refuses to attach a session to a directory that is already some
+other live session's working dir — two agents in one tree means dirty state
+bleeding across and branches mixing. That guard is written for the *accidental*
+case; a scheduled dispatch is declared intent (the task config names the
+project, on a schedule, on purpose), so `ensure` opts out of it — but only when
+the dispatch does no branch work of its own.
+
+The derivation keys off `starting_ref`, since that is the field that makes
+`ensure` check out, branch, and reset the tree:
+
+| Task | Guard | Why |
+|------|-------|-----|
+| no `starting_ref` | **off** — dispatch proceeds | branchless: fans out, writes files, opens no branches |
+| `starting_ref` set | **on** — dispatch refuses | mutates the shared checkout; use a worktree task instead |
+
+Set `allow_shared_dir` explicitly to override in either direction — `false`
+re-arms the guard for a branchless task whose *prompt* does git work, `true`
+opens it for a `starting_ref` task whose tree is known to be private. The
+dispatch never uses `--force` for this: force would kill-replace a live
+same-name session.
 
 ---
 

--- a/tests/unit/test_ensure_shared_dir.py
+++ b/tests/unit/test_ensure_shared_dir.py
@@ -1,0 +1,97 @@
+"""Scheduler dispatch vs the shared-working-dir guard (#854).
+
+The dispatch path built its `NewArgs` with no `allow_shared_dir` attribute at
+all, so `session_cli.cmd_new`'s `getattr(args, "allow_shared_dir", False)` was
+always False and any live session sitting in the task's project dir killed every
+dispatch into it.
+"""
+
+import pytest
+
+from agentwire import ensure_cli
+from agentwire.ensure_cli import ENSURE_EXIT_SESSION_ERROR, _dispatch_shares_dir
+from agentwire.tasks import parse_task_config
+
+
+def _task(**overrides):
+    return parse_task_config("t", {"prompt": "do the thing", **overrides})
+
+
+# --- derivation ------------------------------------------------------------
+
+
+def test_branchless_task_shares_dir():
+    # No starting_ref => the dispatch does no branch work in the tree.
+    assert _dispatch_shares_dir(_task()) is True
+
+
+def test_starting_ref_task_keeps_guard():
+    # starting_ref => checkout/work-branch/reset — exactly what the guard is for.
+    assert _dispatch_shares_dir(_task(starting_ref="main")) is False
+
+
+# --- explicit override wins in both directions -----------------------------
+
+
+def test_explicit_false_rearms_guard_on_branchless_task():
+    assert _dispatch_shares_dir(_task(allow_shared_dir=False)) is False
+
+
+def test_explicit_true_opens_guard_on_git_task():
+    assert _dispatch_shares_dir(
+        _task(starting_ref="main", allow_shared_dir=True)
+    ) is True
+
+
+def test_unset_is_none_not_false():
+    # None must mean "derive", so a missing key can't be confused with `false`.
+    assert _task().allow_shared_dir is None
+    assert _task(allow_shared_dir=False).allow_shared_dir is False
+
+
+# --- wiring: the attribute actually reaches cmd_new ------------------------
+
+
+class _Ctx:
+    attempt = 0
+    summary_file = None
+
+    def set_pre_output(self, *_):  # pragma: no cover - unused in these paths
+        pass
+
+
+@pytest.fixture
+def captured_new_args(monkeypatch, tmp_path):
+    """Drive `_run_ensure_task` far enough to capture the NewArgs it builds."""
+    from agentwire import session_cli
+
+    seen = {}
+    monkeypatch.setattr(ensure_cli, "tmux_session_exists", lambda _s: False)
+
+    def fake_cmd_new(args):
+        seen["args"] = args
+        return 1  # bail out right after construction
+
+    monkeypatch.setattr(session_cli, "cmd_new", fake_cmd_new)
+
+    def run(task):
+        rc = ensure_cli._run_ensure_task(
+            args=None, session="memory-manager", task=task, ctx=_Ctx(),
+            shell=None, project_path=tmp_path, json_mode=True,
+        )
+        assert rc == ENSURE_EXIT_SESSION_ERROR
+        return seen["args"]
+
+    return run
+
+
+def test_dispatch_passes_allow_shared_dir_for_branchless_task(captured_new_args):
+    args = captured_new_args(_task())
+    assert args.allow_shared_dir is True
+    # Never via --force: that would kill-replace an existing same-name session.
+    assert args.force is False
+
+
+def test_dispatch_keeps_guard_for_git_task(captured_new_args):
+    args = captured_new_args(_task(starting_ref="main"))
+    assert args.allow_shared_dir is False


### PR DESCRIPTION
## The bug

`ensure_cli.py`'s dispatch built its `NewArgs` with `self.force = False` and **no `allow_shared_dir` attribute at all**, so the guard's `getattr(args, "allow_shared_dir", False)` in `session_cli.cmd_new` was always `False`. The moment any live session's pane cwd was the task's `project:` dir, every dispatch into that project was refused:

> Refusing to attach session 'memory-manager' to /Users/dotdev/projects/agentwire-dev: already the working directory of active session(s): agentwire.

Confirmed at `agentwire/ensure_cli.py:486-507` before fixing. The nightly `memory-manager` has been failing in 0s with `Failed to create session 'memory-manager'` on every night the owner had a session sitting in `~/projects/agentwire-dev` — which is most of them (six sessions share that dir right now).

## Why this fix, and not the alternatives

**Considered (a) blanket opt-out in the dispatch path.** Defensible — a scheduled dispatch is *declared intent*, not the accident the guard was written for; `services.py` already passes `--allow-shared-dir` on exactly that reasoning ("registering a service is explicit intent"). But it disarms the guard for tasks that genuinely rewrite the shared checkout, which is the footgun the guard exists for.

**Considered (b) narrowing the guard in `session_cli.py`.** Rejected. The guard's shape — *any* live session sharing the cwd — is correct for its actual caller, interactive `agentwire new`, where the second session really is an accident. Narrowing it there would weaken the interactive path to fix a dispatch-path problem. **No `session_cli.py` change was needed.**

**Shipped (c): the dispatch opts out, but only when it isn't touching the tree.**

`starting_ref` is exactly the dividing line — it is the one field that makes `ensure` run `git checkout` / create a work branch / reset the tree around the task (`_setup_task_branch`, `_commit_and_pr`). So:

| Task | Guard | Rationale |
|------|-------|-----------|
| no `starting_ref` | **off** | branchless: fans out and writes files, opens no branches — safe to co-reside |
| `starting_ref` set | **on** | mutates the shared checkout; refuses with the existing "use a worktree" hint |

Plus an explicit `allow_shared_dir: true\|false` task field that overrides the derivation in **either** direction: re-arm the guard for a branchless task whose *prompt* does git work, or open it for a `starting_ref` task whose tree is known private. The derived default is what unblocks the nightly on merge, with no edit to the untracked `.agentwire.tasks.yml` required; the field is the lever for the cases the derivation can't see.

Deliberately **not** `--force` — that would additionally kill-replace a live same-name session.

Per the constraint in the issue, `worktree: true` is not proposed: `.agentwire.tasks.yml` is untracked, so a worktree checkout of `origin/main` has no task definition to dispatch from.

## Changes

- `agentwire/ensure_cli.py` — new `_dispatch_shares_dir(task)`; `NewArgs` now sets `allow_shared_dir` from it.
- `agentwire/tasks.py` — `TaskConfig.allow_shared_dir: bool | None = None` (`None` = derive) + parse.
- `tests/unit/test_ensure_shared_dir.py` — 7 tests: derivation, both override directions, `None`-is-not-`False`, and a wiring test that drives `_run_ensure_task` with a captured `cmd_new` to assert the attribute actually reaches the guard (the literal bug).
- Docs: `docs/wiki/scheduling/scheduled-workloads.md` + `agentwire-project-config` skill.

## Verification

Full suite: **2922 passed, 1 failed** — the single failure is `tests/unit/test_prompt_router.py::TestRecordSessionCreator::test_self_and_empty_creator_skipped`, **pre-existing on a clean `main`** (verified by stashing this branch's changes and re-running). It looks like a stale assertion left behind by #848, which deliberately made `--created-by ''` record an empty creator instead of skipping. Untouched here — different file, different owner.

Not verifiable in-worktree: the live nightly dispatch itself. Worth a `agentwire scheduler run memory-manager` after merge + rebuild, with the `agentwire` session open, to confirm end-to-end.

Closes #854

Built by [dotdev.dev](https://dotdev.dev)