### PR TITLE
fix(config): deleted cwd degrades to global config instead of raising (#850)

### DIFF
--- a/agentwire/project_config.py
+++ b/agentwire/project_config.py
@@ -4,6 +4,7 @@ Project-level configuration (.agentwire.yml).
 This file lives in project directories and is the source of truth for session config.
 """
 
+import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -143,6 +144,55 @@ class ProjectConfig:
         )
 
 
+# --- Deleted-cwd guards (#850) ---
+#
+# A worktree torn down while a session is still attached leaves that process
+# with a working directory that no longer exists. Every cwd-dependent pathlib
+# call then raises FileNotFoundError: `Path.cwd()` directly, and `.resolve()`
+# on a RELATIVE path because it needs the cwd to anchor against. (`.exists()`
+# and `.is_dir()` swallow the OSError and answer False, so the directory walk
+# itself is already safe.) Nothing downstream of this module can recover from
+# that, so the guards live here and degrade to "no project config" — an
+# ordinary, already-handled state — instead of propagating a raw traceback.
+
+
+def _safe_cwd() -> Optional[Path]:
+    """The process cwd, or None if it has been deleted out from under us.
+
+    Falls back to ``$PWD`` (the shell's idea of where we are, which survives
+    the directory's deletion) when it still names a real directory.
+    """
+    try:
+        return Path.cwd()
+    except OSError:
+        pass
+    env_pwd = os.environ.get("PWD")
+    if env_pwd:
+        candidate = Path(env_pwd)
+        try:
+            if candidate.is_dir():
+                return candidate
+        except OSError:
+            pass
+    return None
+
+
+def _safe_resolve(path: Path) -> Optional[Path]:
+    """``Path(path).resolve()``, or None when a dead cwd makes it impossible.
+
+    An absolute path never needs the cwd, so it resolves either way; a relative
+    one is anchored against :func:`_safe_cwd` when ``resolve()`` itself fails.
+    """
+    p = Path(path)
+    try:
+        return p.resolve()
+    except OSError:
+        if p.is_absolute():
+            return p
+        base = _safe_cwd()
+        return base / p if base is not None else None
+
+
 def find_project_config(start_path: Optional[Path] = None) -> Optional[Path]:
     """Find project config by walking up from start_path.
 
@@ -156,12 +206,13 @@ def find_project_config(start_path: Optional[Path] = None) -> Optional[Path]:
         start_path: Directory to start searching from. Defaults to cwd.
 
     Returns:
-        Path to the resolved config file if found, None otherwise.
+        Path to the resolved config file if found, None otherwise — including
+        when the cwd has been deleted and there is nowhere to start walking
+        from (#850).
     """
+    start_path = _safe_cwd() if start_path is None else _safe_resolve(start_path)
     if start_path is None:
-        start_path = Path.cwd()
-    else:
-        start_path = Path(start_path).resolve()
+        return None
 
     current = start_path
     while True:
@@ -217,9 +268,13 @@ def save_project_config(config: ProjectConfig, project_dir: Path) -> bool:
         project_dir: Directory to save config in
 
     Returns:
-        True if saved successfully, False otherwise.
+        True if saved successfully, False otherwise (including a relative
+        ``project_dir`` that a deleted cwd leaves unanchorable — #850).
     """
-    project_dir = Path(project_dir).resolve()
+    resolved = _safe_resolve(project_dir)
+    if resolved is None:
+        return False
+    project_dir = resolved
     config_file = project_dir / ".agentwire.yml"
 
     try:
@@ -252,10 +307,14 @@ def ensure_gitignored(
             pass a glob to also cover sibling files, e.g. a staging draft).
 
     Returns:
-        True if .gitignore was modified, False otherwise.
+        True if .gitignore was modified, False otherwise (including a relative
+        ``project_dir`` that a deleted cwd leaves unanchorable — #850).
     """
     pattern = pattern or filename
-    project_dir = Path(project_dir).resolve()
+    resolved = _safe_resolve(project_dir)
+    if resolved is None:
+        return False
+    project_dir = resolved
     try:
         in_repo = subprocess.run(
             ["git", "rev-parse", "--is-inside-work-tree"],

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -1,6 +1,7 @@
 """Tests for agentwire/project_config.py — resolve_posture, ProjectConfig."""
 
 
+import os
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,8 @@ from agentwire.project_config import (
     WorktreeOverrides,
     ensure_gitignored,
     find_project_config,
+    get_parent_from_config,
+    get_voice_from_config,
     load_project_config,
     resolve_posture,
     save_project_config,
@@ -366,6 +369,102 @@ class TestEnsureGitignored:
         gitignore = (tmp_path / ".gitignore").read_text()
         assert ".agentwire.tasks*.yml" in gitignore
         assert ".agentwire.yml" not in gitignore
+
+
+# --- deleted cwd (#850) ---
+#
+# These tests really chdir into a directory and really delete it, because the
+# bug only exists in that state: a guard can look correct and a test can pass
+# green while never once putting the process somewhere that no longer exists.
+
+
+@pytest.fixture
+def dead_cwd(tmp_path, monkeypatch):
+    """Put the process in a directory, then delete it under its own feet.
+
+    Mirrors a worktree being torn down while a session is still attached to it.
+    ``$PWD`` is unset by default so the fallback can't quietly rescue us —
+    tests that want the fallback set it back themselves.
+    """
+    doomed = tmp_path / "worktree-about-to-die"
+    doomed.mkdir()
+    original = os.getcwd()
+    os.chdir(doomed)
+    doomed.rmdir()
+    monkeypatch.delenv("PWD", raising=False)
+
+    # Precondition: the process really is somewhere that no longer exists.
+    with pytest.raises(FileNotFoundError):
+        Path.cwd()
+
+    try:
+        yield doomed
+    finally:
+        os.chdir(original)
+
+
+class TestDeletedCwd:
+    def test_find_project_config_degrades_instead_of_raising(self, dead_cwd):
+        """The reported crash: zero-arg call with a cwd that's gone (#850)."""
+        assert find_project_config() is None
+
+    def test_get_voice_from_config_returns_none(self, dead_cwd):
+        """The observed symptom — `agentwire say` dying on the voice lookup.
+
+        Returning None is what lets the caller's `or` chain reach the global
+        default voice; raising is what stopped it.
+        """
+        assert get_voice_from_config() is None
+
+    def test_get_parent_from_config_returns_none(self, dead_cwd):
+        assert get_parent_from_config() is None
+
+    def test_load_project_config_returns_none(self, dead_cwd):
+        assert load_project_config() is None
+
+    def test_relative_start_path_degrades(self, dead_cwd):
+        """`.resolve()` needs the cwd to anchor a relative path, so it raises too."""
+        assert find_project_config(Path("some/relative/dir")) is None
+
+    def test_absolute_paths_still_work(self, dead_cwd, tmp_path):
+        """Degrading gracefully must not mean degrading always.
+
+        An absolute path never needs the cwd, so a dead cwd is irrelevant to it.
+        """
+        project = tmp_path / "live-project"
+        project.mkdir()
+        (project / ".agentwire.yml").write_text("posture: bare\nvoice: echo\n")
+
+        assert find_project_config(project) == project / ".agentwire.yml"
+        assert get_voice_from_config(project) == "echo"
+
+    def test_falls_back_to_pwd_env(self, dead_cwd, tmp_path, monkeypatch):
+        """$PWD survives the deletion, so a live $PWD still finds the config."""
+        project = tmp_path / "still-here"
+        project.mkdir()
+        (project / ".agentwire.yml").write_text("posture: bare\nvoice: shimmer\n")
+        monkeypatch.setenv("PWD", str(project))
+
+        assert find_project_config() == project / ".agentwire.yml"
+        assert get_voice_from_config() == "shimmer"
+
+    def test_stale_pwd_env_does_not_rescue(self, dead_cwd, monkeypatch):
+        """A $PWD pointing at the same deleted dir degrades, it doesn't raise."""
+        monkeypatch.setenv("PWD", str(dead_cwd))
+        assert find_project_config() is None
+
+    def test_save_project_config_returns_false_for_relative(self, dead_cwd):
+        """Unwritable, but by returning False — its documented failure mode."""
+        assert save_project_config(ProjectConfig(posture="bypass"), Path("rel/dir")) is False
+
+    def test_save_project_config_still_works_for_absolute(self, dead_cwd, tmp_path):
+        target = tmp_path / "writable"
+        target.mkdir()
+        assert save_project_config(ProjectConfig(posture="bare"), target) is True
+        assert (target / ".agentwire.yml").exists()
+
+    def test_ensure_gitignored_returns_false_for_relative(self, dead_cwd):
+        assert ensure_gitignored(Path("rel/dir")) is False
 
     def test_custom_filename_idempotent_via_glob(self, tmp_path):
         _git(tmp_path, "init")


### PR DESCRIPTION
A worktree torn down while a session is still attached leaves that process with a working directory that no longer exists. Every cwd-dependent pathlib call then raises `FileNotFoundError`, which propagated raw to the user — observed as `agentwire say` dying mid-session with an uncaught traceback.

### Why a global voice didn't protect you

Evaluation order in `channels_cli.py:279`:

```python
voice = args.voice or get_voice_from_config() or tts_config.get("default_voice", "default")
```

`get_voice_from_config()` is slot 2 and is evaluated unconditionally before the global default in slot 3 — and it's the thing that crashes, so Python never reached the fallback.

### The fix

Two shared helpers in `project_config.py`, `_safe_cwd()` and `_safe_resolve()`, degrading cwd → `$PWD` (which survives the deletion) → `None`. A missing project config is an ordinary, already-handled state, so returning `None` is strictly better than raising.

**Four unguarded sites** — the one reported, plus three more found auditing the module:

| Site | Pattern |
|---|---|
| `find_project_config()` | `Path.cwd()` when `start_path is None` — **the reported line** |
| `find_project_config()` | `.resolve()` on a **relative** `start_path` — needs the cwd to anchor, raises identically |
| `save_project_config()` | `.resolve()`, sitting **outside** its own `try` block |
| `ensure_gitignored()` | `.resolve()`, likewise outside its `try` |

`.exists()` / `.is_dir()` already swallow the `OSError` and answer `False`, so the upward directory walk itself needed no change. Absolute paths never need the cwd and keep working untouched.

Both reported call sites are fixed **without editing either file** — the single guard covers all three zero-arg callers. `say` now reaches the global default voice; `history` prints its existing "Not in a tracked project directory." message.

### Tests

11 new tests that **really `chdir` into a directory and really delete it** — the bug only exists in that state, and a guard can look correct while a test passes green without ever putting the process somewhere that no longer exists. The fixture asserts `Path.cwd()` raises as a precondition, and unsets `$PWD` so the fallback can't quietly rescue the test.

Verified by reverting the source fix: **9 of the 11 fail** without it. The 2 that stay green are the deliberate anti-regression pair (absolute paths must keep working), plus coverage of the `$PWD` fallback, a *stale* `$PWD` pointing at the same deleted dir, and the reported `say`/`history` symptoms.

Full suite: **2926 passed, 1 failed**. The failure — `test_prompt_router.py::TestRecordSessionCreator::test_self_and_empty_creator_skipped` — is **pre-existing**, confirmed by stashing this branch's changes and reproducing it on a clean tree at `b097119`. It's in `session_cli`/prompt-router code owned by another session this wave, so it's untouched here.

Closes #850

Built by [dotdev.dev](https://dotdev.dev)