### PR TITLE
fix(statusline): model first, drop cost and duration (#849)

### DIFF
--- a/agentwire/templates/statusline.sh
+++ b/agentwire/templates/statusline.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# AgentWire Recommended Claude Code Status Line
+#
+# Line 1: model   folder   branch
+# Line 2: full-width context battery
+#
+# Install: cp to ~/.claude/statusline.sh, chmod +x, and point
+# ~/.claude/settings.json at it:
+#   "statusLine": { "type": "command", "command": "~/.claude/statusline.sh" }
+
+set -e
+
+JSON=$(cat)
+
+# One jq pass for every field — the statusline re-renders constantly, so
+# separate jq spawns per render is the whole cost of this script.
+eval "$(printf '%s' "$JSON" | jq -r '
+  @sh "CURRENT_DIR=\(.workspace.current_dir // "")",
+  @sh "MODEL_ID=\((.model|objects|.id) // (.model|objects|.display_name) // (.model|strings) // "")",
+  @sh "USED_PCT=\(if .context_window.used_percentage then (.context_window.used_percentage|floor|tostring) else "" end)"
+' 2>/dev/null)"
+
+# ─── Directory ────────────────────────────────────────────────
+if [ -n "$CURRENT_DIR" ]; then
+  DIR_SHORT=$(echo "$CURRENT_DIR" | sed "s|$HOME|~|")
+  if [ ${#DIR_SHORT} -gt 30 ]; then
+    DIR_SHORT="…/$(echo "$DIR_SHORT" | rev | cut -d'/' -f1-2 | rev)"
+  fi
+else
+  DIR_SHORT="?"
+fi
+
+# ─── Git branch ──────────────────────────────────────────────
+GIT_BRANCH=""
+if [ -n "$CURRENT_DIR" ]; then
+  GIT_BRANCH=$(git -C "$CURRENT_DIR" branch --show-current 2>/dev/null || echo "")
+fi
+
+# ─── Model ───────────────────────────────────────────────────
+MODEL_SHORT=""
+if [ -n "$MODEL_ID" ]; then
+  case "$MODEL_ID" in
+    *opus*) MODEL_SHORT="opus" ;;
+    *sonnet*) MODEL_SHORT="sonnet" ;;
+    *haiku*) MODEL_SHORT="haiku" ;;
+    *fable*) MODEL_SHORT="fable" ;;
+    *) MODEL_SHORT="$MODEL_ID" ;;
+  esac
+fi
+
+# ─── Context battery (pre-calculated percentage) ─────────────
+REMAINING=""
+BAT_COLOR=""
+if [ -n "$USED_PCT" ] && [ "$USED_PCT" != "0" ]; then
+  REMAINING=$((100 - USED_PCT))
+  [ "$REMAINING" -lt 0 ] && REMAINING=0
+
+  if [ "$REMAINING" -gt 50 ]; then
+    BAT_COLOR='\033[0;32m'
+  elif [ "$REMAINING" -gt 25 ]; then
+    BAT_COLOR='\033[0;33m'
+  else
+    BAT_COLOR='\033[0;31m'
+  fi
+fi
+
+# ─── Colors ──────────────────────────────────────────────────
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+MAGENTA='\033[0;35m'
+RESET='\033[0m'
+
+# ─── Terminal width ──────────────────────────────────────────
+# Detect live width per render. Sources, most reliable first:
+#   1. tmux pane width  — correct inside tmux/agentwire panes, where
+#      $COLUMNS is unset and `tput cols` can't measure a piped stdout.
+#   2. $COLUMNS          — exported by Claude Code in a plain terminal.
+#   3. tput cols         — last resort (often the static 80 default here).
+WIDTH=""
+if [ -n "$TMUX_PANE" ] && command -v tmux >/dev/null 2>&1; then
+  WIDTH=$(tmux display -p -t "$TMUX_PANE" '#{pane_width}' 2>/dev/null)
+fi
+[ -z "$WIDTH" ] && WIDTH=$COLUMNS
+[ -z "$WIDTH" ] && WIDTH=$(tput cols 2>/dev/null)
+case "$WIDTH" in ''|*[!0-9]*) WIDTH=80 ;; esac
+[ "$WIDTH" -lt 20 ] && WIDTH=80
+# Inset margin: the statusline is padded a column or two each side,
+# so leave room or the bar wraps to a phantom extra line.
+WIDTH=$((WIDTH - 4))
+
+# ─── Line 1: model  folder  branch ───────────────────────────
+SEP="  "
+LINE1=""
+add_field() { # $1 = colored
+  if [ -n "$LINE1" ]; then LINE1="${LINE1}${SEP}$1"; else LINE1="$1"; fi
+}
+[ -n "$MODEL_SHORT" ] && add_field "${MAGENTA}${MODEL_SHORT}${RESET}"
+add_field "${CYAN}${DIR_SHORT}${RESET}"
+[ -n "$GIT_BRANCH" ] && add_field "${YELLOW}${GIT_BRANCH}${RESET}"
+
+# ─── Line 2: full-width context battery ──────────────────────
+# [███████████████████████████████░░░░░░░░] 80%
+LINE2=""
+if [ -n "$REMAINING" ]; then
+  LABEL=" ${REMAINING}%"
+  # Reserve room for the brackets and the percentage label.
+  BAR_WIDTH=$((WIDTH - ${#LABEL} - 2))
+  [ "$BAR_WIDTH" -lt 1 ] && BAR_WIDTH=1
+  FILLED=$((REMAINING * BAR_WIDTH / 100))
+  [ "$FILLED" -gt "$BAR_WIDTH" ] && FILLED=$BAR_WIDTH
+  [ "$FILLED" -lt 0 ] && FILLED=0
+  EMPTY=$((BAR_WIDTH - FILLED))
+  BAR=$(printf '█%.0s' $(seq 1 $FILLED 2>/dev/null) || true)
+  BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY 2>/dev/null) || true)"
+  LINE2="${BAT_COLOR}[${BAR}]${LABEL}${RESET}"
+fi
+
+printf '%b\n' "$LINE1"
+if [ -n "$LINE2" ]; then
+  printf '%b\n' "$LINE2"
+fi

--- a/agentwire/templates/tmux.conf
+++ b/agentwire/templates/tmux.conf
@@ -100,7 +100,7 @@ bind r source-file ~/.tmux.conf \; display "Config reloaded"
 # ─────────────────────────────────────────────────────────────
 # Status Bar
 # ─────────────────────────────────────────────────────────────
-# Layout: [session] window_num    branch | ~/path | CPU:N% RAM:N% HH:MM
+# Layout: [session] window_num    ~/path | branch | CPU:N% RAM:N% HH:MM
 # Status bar at top keeps the command prompt at the bottom where you expect it.
 
 set -g status-position top
@@ -113,12 +113,14 @@ set -g status-left-length 30
 setw -g window-status-format "#I"
 setw -g window-status-current-format "#[fg=cyan,bold]#I#[fg=white,nobold]"
 
-# Right: git branch | working dir | CPU/RAM | time
+# Right: working dir | git branch | CPU/RAM | time
+# Field order matches the recommended statusline.sh (templates/statusline.sh):
+# model (tmux can't see it) then directory then branch — no cost, no duration.
 # Uses platform detection (macOS vs Linux) for system metrics
 set -g status-right-length 100
 set -g status-right "\
-#[fg=yellow]#(cd '#{pane_current_path}' && git branch --show-current 2>/dev/null || echo '-')#[fg=white] | \
 #[fg=cyan]#(echo '#{pane_current_path}' | sed \"s|$HOME|~|\")#[fg=white] | \
+#[fg=yellow]#(cd '#{pane_current_path}' && git branch --show-current 2>/dev/null || echo '-')#[fg=white] | \
 CPU:#(if [ $(uname) = Darwin ]; then top -l 1 -n 0 2>/dev/null | awk '/CPU usage/{print int($3)}'; else top -bn1 2>/dev/null | awk '/Cpu/{print int($2+$4)}'; fi)%% \
 RAM:#(if [ $(uname) = Darwin ]; then memory_pressure 2>/dev/null | awk '/System-wide/{print int(100-$5)}'; else free 2>/dev/null | awk '/Mem:/{print int($3/$2*100)}'; fi)%% \
 %H:%M"

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -70,6 +70,23 @@ set -g window-size largest
 
 `agentwire doctor` warns if the running tmux server has `focus-events` or `mouse` off.
 
+### Recommended Claude Code status line
+
+The bundled `agentwire/templates/statusline.sh` renders a two-line status line inside every agent pane: **model, directory, branch** on line 1, a full-width context battery on line 2. Same field order as the tmux status bar above, so a session and its workers read the same left-to-right.
+
+Copy it out of the installed package (or your checkout) and make it executable:
+
+```bash
+cp "$(python3 -c 'import agentwire, pathlib; print(pathlib.Path(agentwire.__file__).parent)')/templates/statusline.sh" ~/.claude/statusline.sh
+chmod +x ~/.claude/statusline.sh
+```
+
+Then point Claude Code at it in `~/.claude/settings.json`:
+
+```json
+"statusLine": { "type": "command", "command": "~/.claude/statusline.sh", "padding": 0 }
+```
+
 ---
 
 ## Have the repo cloned? `agentwire dev`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ include = [
     "agentwire/templates/**/*.css.j2",
     "agentwire/templates/**/*.txt",
     "agentwire/templates/**/*.conf",
+    "agentwire/templates/**/*.sh",
     "agentwire/static/**/*",
     # Role/prompt content bundled with the CLI
     "agentwire/roles/*.md",


### PR DESCRIPTION
Reorders the recommended Claude Code status line to **model → directory → branch** and drops **cost** and **duration** entirely. Same field order applied to the tmux status bar, so a session and its workers read the same left-to-right. No config toggle — the surrounding code has no per-field toggle pattern, and the ask was a changed default.

## Before / after

**statusline.sh** — same payload (`opus`, `$1.23`, `14m` present in the JSON; cost/duration now simply ignored):

```
BEFORE   …/agentwire-dev/fix-849-statusline  fix-849-statusline      opus  $1.23  14m
         [████████████████████████████░░░░░░░░░░░░░░] 63%

AFTER    opus  …/agentwire-dev/fix-849-statusline  fix-849-statusline
         [████████████████████████████░░░░░░░░░░░░░░] 63%
```

Line 2 (context battery) is unchanged. With the right-hand group empty, the left/right split-and-pad math goes away too.

**tmux status-right** (`agentwire/templates/tmux.conf`) — tmux can't see the model, so "where applicable" is directory then branch:

```
BEFORE   [session] 0                    fix-849-statusline | ~/worktrees/…  | CPU:12% RAM:48% 09:12
AFTER    [session] 0                    ~/worktrees/…  | fix-849-statusline | CPU:12% RAM:48% 09:12
```

There was never cost or duration in the tmux line — only the ordering changed there.

## Parents vs children

One script and one tmux config serve both, so parents and children are consistent by construction — model first, no cost, no duration. Nothing role-specific was added.

## Why the script is a new file

The "recommended statusline.sh" only existed as a local `~/.claude/statusline.sh` (its header reads "AgentWire Recommended Claude Code Status Line") — nothing in `agentwire/` shipped or referenced it. It now lives at `agentwire/templates/statusline.sh` next to the tmux template, ships in the wheel (`*.sh` added to the hatch include list — verified in a built wheel), and is documented in `docs/wiki/quickstart.md` with the copy + `settings.json` snippet. **The owner's live `~/.claude/statusline.sh` is untouched** — copy it over per the quickstart to pick this up.

## Verification

- `bash -n` clean; rendered against realistic payloads (full, no-branch/no-model, empty `{}`) — no unbound-variable or width regressions.
- `tmux -L <private-socket> -f agentwire/templates/tmux.conf` loads clean; `show -g status-right` confirms the new order. No live tmux server touched.
- `uv run --extra dev pytest`: **2915 passed, 1 failed**. The failure is `tests/unit/test_prompt_router.py::TestRecordSessionCreator::test_self_and_empty_creator_skipped`, which **fails identically on a clean tree at this base** (pre-existing, from the `--created-by ''` change in b097119) — unrelated to this PR.

Closes #849

Built by [dotdev.dev](https://dotdev.dev)