### PR TITLE
fix(sessions): marker-based already-delivered detection (#839) + foreign-draft guard (#845)

### DIFF
--- a/agentwire/send_cli.py
+++ b/agentwire/send_cli.py
@@ -24,41 +24,41 @@ from .core import (
 )
 
 
-def _recover_unverified_send(session: str, prompt: str, sender: str) -> "str | None":
+def _recover_unverified_send(
+    session: str, prompt: str, sender: str, marker: "str | None" = None
+) -> "str | None":
     """Fallback when `send_verified` can't confirm delivery (#834, #835 review).
 
-    First checks whether the bare message is already on scrollback outside
-    the input box. A `send_verified` failure can mean the paste genuinely
-    never landed/submitted, OR that it fully submitted and only the
-    *confirm* read was ambiguous (an unparseable box frame, or a laggy host
-    blowing the submit budget). The msg-inbox drain's own dedup can't catch
-    the latter case on its own: it matches the WRAPPED ``[MSG from ... ]
-    ... <id>`` render (see ``inbox.Message.render``), never the bare text
-    this path pasted directly — enqueuing unconditionally would risk a real
-    duplicate delivery rather than the safe no-op the drain's dedup gives
-    its own messages. Checking here first avoids that duplicate in the
-    common case.
+    First checks whether this attempt is already on scrollback outside the
+    input box. A `send_verified` failure can mean the paste genuinely never
+    landed/submitted, OR that it fully submitted and only the *confirm* read
+    was ambiguous (an unparseable box frame, or a laggy host blowing the
+    submit budget). The msg-inbox drain's own dedup can't catch the latter
+    case on its own: it matches the WRAPPED ``[MSG from ... ] ... <id>``
+    render (see ``inbox.Message.render``), never the bare text this path
+    pasted directly — enqueuing unconditionally would risk a real duplicate
+    delivery rather than the safe no-op the drain's dedup gives its own
+    messages. Checking here first avoids that duplicate in the common case.
+
+    *marker* is the per-attempt delivery marker (``session_ready``'s
+    :func:`new_delivery_marker`) that was appended to the pasted text, and it
+    is what makes this check safe (#839). Matching the BARE prompt instead
+    trades in the opposite direction from every other check in this file: a
+    false match reports "already delivered" and SKIPS the inbox enqueue
+    entirely, so a short or generic message (a bare "yes", "continue",
+    "approved") that happens to sit in the last ``VERIFY_SCROLLBACK_LINES``
+    for an unrelated reason — a legitimate earlier send, coincidental text —
+    silently drops a send that never landed. That is the one outcome this
+    whole fallback exists to prevent. A marker minted per attempt can only
+    appear on scrollback if THIS attempt's paste submitted, so
+    "already_delivered" becomes a fact rather than a text-similarity guess.
+    Callers that pass no marker keep the old bare-text behavior (and the old
+    risk); every caller in this module passes one.
 
     A message that lands only *after* this check runs (queued invisibly
     mid-generation, per ``submit_confirmed``'s own docstring) can still
     duplicate — accepted per this codebase's existing bias that a
     recoverable duplicate beats a silently dropped message.
-
-    Known residual risk (#835 second-pass review): this is the same bare
-    whitespace-normalized substring match ``_deliver_once`` already uses for
-    its own internal idempotent-paste guard — not a new invention — but
-    reused here it trades in the *opposite* direction from most of this
-    file's checks. A false match reports "already delivered" and SKIPS the
-    inbox enqueue entirely: for a short or generic message (a bare "yes",
-    "continue", "approved") that happens to already sit in the last
-    ``VERIFY_SCROLLBACK_LINES`` for an unrelated reason, a send that
-    genuinely never landed could be silently dropped instead of queued —
-    the one outcome this whole fallback exists to prevent. Tracked as a
-    follow-up (a lightweight per-attempt marker, mirroring
-    ``send_verified``'s own ``marker`` param, would close this precisely);
-    not fixed here because it's strictly narrower than the bug this
-    function was written to close (needs a coincidental/repeated-text
-    match, not just any unverified send).
 
     Returns ``"already_delivered"``, ``"inbox"``, ``"inbox_stuck"`` (queued,
     but the original stale draft couldn't be confirmed cleared from the
@@ -67,9 +67,39 @@ def _recover_unverified_send(session: str, prompt: str, sender: str) -> "str | N
     """
     from agentwire.session_ready import message_on_scrollback, recover_failed_seed, scrollback
 
-    if message_on_scrollback(scrollback(session), prompt):
+    if message_on_scrollback(scrollback(session), marker or prompt):
         return "already_delivered"
     return recover_failed_seed(session, prompt, sender=sender)
+
+
+def _foreign_draft_block(
+    session: str, prompt: str, sender: str
+) -> "tuple[bool, str | None]":
+    """Pre-flight (#845): never paste over a draft that was already there.
+
+    ``_deliver_once`` refuses to paste onto a foreign draft, but refusing is
+    only half an answer here: the unverified-send fallback below would then
+    call ``recover_failed_seed``, whose whole job is to Escape/backspace the
+    box clear — erasing the very draft we declined to paste over. That clear
+    is correct for the wreckage of OUR failed paste and wrong for a human's
+    half-typed sentence, and the only way to tell them apart is to look at
+    the box BEFORE trying anything.
+
+    So: look first. If the box already holds unsent content that isn't ours,
+    don't paste and don't clear — queue the durable copy to the msg inbox
+    (``clear=False``) and let the drain deliver it once the box goes idle on
+    its own, exactly as it would for any other polite message.
+
+    Returns ``(False, None)`` when the box is clear to paste into, else
+    ``(True, <recover_failed_seed outcome>)`` — ``"inbox_blocked"`` on a
+    successful enqueue, ``None`` if even that failed.
+    """
+    from agentwire import session_ready
+
+    if not session_ready.box_holds_foreign_draft(session, prompt):
+        return (False, None)
+    return (True, session_ready.recover_failed_seed(
+        session, prompt, sender=sender, clear=False))
 
 
 def _fallback_suffix(fallback: "str | None") -> str:
@@ -81,6 +111,9 @@ def _fallback_suffix(fallback: "str | None") -> str:
         return (" — queued to its msg inbox, but the stale draft could NOT be confirmed cleared "
                 "from the input box; it may still be sitting there and get submitted later by an "
                 "unrelated Enter — check the pane")
+    if fallback == "inbox_blocked":
+        return (" — queued to its msg inbox instead; the existing draft was left untouched and the "
+                "drain delivers once the box goes idle")
     return " and could not be queued — resend manually"
 
 
@@ -121,9 +154,19 @@ def cmd_send(args) -> int:
                 # pane can scroll the echo out of the capture window and produce
                 # a false miss; re-pasting there would deliver the instruction
                 # twice, which is worse than a false "not verified" warning.
-                from agentwire.session_ready import send_verified
+                from agentwire.session_ready import (
+                    new_delivery_marker,
+                    send_verified,
+                    tag_message,
+                )
 
-                ok = send_verified(target_session, prompt, pane_index=pane_index, retries=0)
+                # Tag the paste with a per-attempt marker (#839) so every
+                # internal identity check — landing, idempotent-paste guard,
+                # already-submitted — keys on something unique to THIS send
+                # instead of on how much the text resembles the scrollback.
+                marker = new_delivery_marker()
+                ok = send_verified(target_session, tag_message(prompt, marker),
+                                   marker=marker, pane_index=pane_index, retries=0)
                 if json_mode:
                     _output_json({
                         "success": True, "pane": pane_index, "session": target_session,
@@ -234,19 +277,38 @@ def cmd_send(args) -> int:
     if wait_ready:
         # Wait for the agent to be ready, then send with delivery
         # verification (a paste into a booting Claude vanishes silently).
-        from agentwire.session_ready import send_verified, wait_for_session_ready
+        from agentwire.session_ready import (
+            new_delivery_marker,
+            send_verified,
+            tag_message,
+            wait_for_session_ready,
+        )
 
         timeout = getattr(args, 'timeout', None) or 30.0
         if not wait_for_session_ready(session, timeout=timeout):
             return _output_result(False, json_mode, f"Agent in '{session}' not ready after {timeout:.0f}s")
-        if not send_verified(session, prompt):
+        blocked, fallback = _foreign_draft_block(session, prompt, fallback_sender)
+        if blocked:
+            # #845 — something unsent already owns the box. Readiness probing
+            # normally rules this out for a fresh session, but --wait-ready is
+            # also pointed at sessions that were merely slow to boot.
+            if json_mode:
+                print(json.dumps({"success": False, "session": session_full, "verified": False,
+                                  "fallback": fallback,
+                                  "error": "Input box holds an unrelated unsent draft"}))
+            else:
+                print(f"Not sent to {session}: its input box holds an unrelated unsent draft"
+                      f"{_fallback_suffix(fallback)}", file=sys.stderr)
+            return 1
+        marker = new_delivery_marker()
+        if not send_verified(session, tag_message(prompt, marker), marker=marker):
             # A caller acting on "not verified" text is optional, not
             # guaranteed — under load this is exactly the class of message
             # that must never depend on an LLM noticing and manually
             # resending. Fall back to the durable msg inbox (retried across
             # ticks, dead-lettered + emailed on true exhaustion) instead of
             # returning inert advisory text (#834).
-            fallback = _recover_unverified_send(session, prompt, fallback_sender)
+            fallback = _recover_unverified_send(session, prompt, fallback_sender, marker=marker)
             if json_mode:
                 print(json.dumps({"success": False, "session": session_full, "verified": False,
                                   "fallback": fallback, "error": "Delivery not verified"}))
@@ -270,20 +332,36 @@ def cmd_send(args) -> int:
         # the old double-delivery worry the retries=0 choice guarded against
         # can't happen anymore. Staying patient here is what keeps a laggy host
         # from surfacing a false failure the parent has to clean up by hand.
-        from agentwire.session_ready import send_verified
+        from agentwire.session_ready import (
+            new_delivery_marker,
+            send_verified,
+            tag_message,
+        )
 
-        ok = send_verified(session, prompt, retries=1)
-        fallback = None
-        if not ok:
-            # Same durable fallback as --wait-ready (#834).
-            fallback = _recover_unverified_send(session, prompt, fallback_sender)
+        # #845 — an already-running session is exactly where a stale draft
+        # lives, so look before pasting: a foreign draft means we neither
+        # paste over it nor clear it, just queue the durable copy.
+        blocked, fallback = _foreign_draft_block(session, prompt, fallback_sender)
+        ok = False
+        if not blocked:
+            marker = new_delivery_marker()
+            ok = send_verified(session, tag_message(prompt, marker), marker=marker, retries=1)
+            if not ok:
+                # Same durable fallback as --wait-ready (#834).
+                fallback = _recover_unverified_send(session, prompt, fallback_sender, marker=marker)
+        if blocked:
+            note = "Not sent: the input box holds an unrelated unsent draft"
+        else:
+            note = "Prompt sent" if ok else "Prompt sent but delivery could not be verified"
         if json_mode:
             print(json.dumps({"success": True, "session": session_full, "machine": None,
-                              "verified": ok, "fallback": fallback,
-                              "message": "Prompt sent" if ok else "Prompt sent but delivery could not be verified"}))
+                              "verified": ok, "fallback": fallback, "message": note}))
         else:
             if ok:
                 print(f"Sent to {session} (verified)")
+            elif blocked:
+                print(f"Not sent to {session}: its input box holds an unrelated unsent draft"
+                      f"{_fallback_suffix(fallback)}")
             else:
                 print(f"Sent to {session} (delivery NOT verified){_fallback_suffix(fallback)}")
         return 0

--- a/agentwire/server.py
+++ b/agentwire/server.py
@@ -2506,6 +2506,20 @@ class AgentWireServer(
                     "box could not be confirmed cleared — check the pane",
                     session=session_name, priority="high", id_prefix="firstmsg")
                 return
+            if fallback == "inbox_blocked":
+                # #845: the box already held an unrelated unsent draft, so
+                # nothing was pasted (and nothing erased). The durable copy is
+                # queued and the drain delivers once the box goes idle — same
+                # calm outcome as "inbox", just with a different cause, and
+                # emphatically NOT the "paste it manually" advice below.
+                logger.info(
+                    f"First message for {session_name} queued to inbox — its input box "
+                    "held an unrelated unsent draft, which was left untouched")
+                await self._post_toast(
+                    f"First message to {session_name} queued — its input box held an "
+                    "unrelated draft, so nothing was pasted over it",
+                    session=session_name, priority="normal", id_prefix="firstmsg")
+                return
             logger.warning(f"First message delivery failed for {session_name}: {result.get('error')}")
             await self._post_toast(
                 f"First message not delivered to {session_name} — paste it manually",

--- a/agentwire/session_ready.py
+++ b/agentwire/session_ready.py
@@ -10,6 +10,7 @@ through here.
 """
 
 import time
+import uuid
 
 # How far back into scrollback to look when verifying delivery. A fast bypass
 # agent consumes the paste, submits it, and emits tool output within the settle
@@ -444,6 +445,90 @@ def message_on_scrollback(capture: str, rendered: str) -> bool:
     return needle in "".join(outside.split())
 
 
+def new_delivery_marker() -> str:
+    """A ``⟨#send-xxxxxx⟩`` token unique to ONE delivery attempt (#839).
+
+    ``send_verified``'s ``marker`` parameter answers "did this attempt reach
+    the recipient's scrollback?" — but only as precisely as the marker is
+    unique, and until now nothing minted a unique one. Council passes a
+    CONSTANT marker (``[COUNCIL PROMPT #1]``), so a hit may be the previous
+    message; a caller passing no marker falls back to matching the bare
+    message text, which for a short or generic prompt ("yes", "continue",
+    "approved") collides with any coincidental earlier occurrence inside the
+    same ``VERIFY_SCROLLBACK_LINES`` window. Both make "already delivered" an
+    inference. A token minted per attempt and APPENDED to the pasted text
+    (:func:`tag_message`) makes it a fact: the token is on scrollback iff
+    *this* attempt's paste submitted.
+
+    Deliberately mirrors ``inbox.Message.render``'s trailing ``⟨#id⟩``, which
+    exists for exactly this reason (#621) and is already familiar on screen —
+    the recipient sees one short tag, the same shape msg deliveries carry.
+    """
+    return f"⟨#send-{uuid.uuid4().hex[:6]}⟩"
+
+
+def tag_message(message: str, marker: str) -> str:
+    """*message* with *marker* appended, ready to paste (#839).
+
+    Pass the same *marker* as :func:`send_verified`'s ``marker`` argument and
+    to :func:`message_on_scrollback` afterwards. Because the token rides
+    INSIDE the pasted text, every downstream check keys on it for free: the
+    landing gate, the pre-paste identity guard, and the caller's
+    already-delivered fallback all become per-attempt precise rather than
+    text-similarity guesses. Two spaces before the token mirror
+    ``inbox.Message.render`` so the rendered line reads the same way.
+    """
+    return f"{message}  {marker}"
+
+
+def box_holds_foreign_draft(
+    session: str,
+    message: str,
+    pane_index: int = 0,
+    capture: "str | None" = None,
+) -> bool:
+    """Is the input box occupied by unsent content that is NOT *message*? (#845)
+
+    The state the idempotent-paste guard had no name for: a stale draft — a
+    previous sender's message whose Enter was swallowed, a human mid-typing, a
+    half-composed large paste — sitting unsubmitted in the box. Pasting on top
+    of it concatenates the two into one garbled string that the next Enter
+    submits as a single turn, a broader corruption than the "a later bare
+    Enter submits the old draft alone" hole #843/#844 addressed.
+
+    Two-stage on purpose, cheapest and most conservative first:
+
+    1. The plain box parse must show non-empty content that fails
+       :func:`box_shows_message` — including its #851 window test, so a draft
+       too tall to render whole still reads as OURS, not foreign. Chips are
+       excluded (``allow_chip=False``): pre-paste a ``[Pasted text …]``
+       placeholder is either somebody else's draft or an earlier attempt's,
+       and both want the same answer (don't paste on top of it).
+    2. Only then, the SGR-aware gate ``prompt_router.prompt_is_empty`` gets a
+       veto. Claude Code renders ghost/autosuggest text inside the box DIM
+       (#669), and the plain parse can't tell it from a draft — without this
+       second opinion an idle session showing an autosuggestion would refuse
+       every send. It is the same gate the msg drain delivers behind, so
+       "foreign draft" here means exactly "the drain would defer".
+
+    Every ambiguity resolves to False (an unparseable box, a capture that
+    raised): refusing to deliver is not free, so it must be positively
+    justified.
+    """
+    from agentwire import prompt_router
+
+    try:
+        cap = _snapshot(session, pane_index) if capture is None else capture
+        box = input_box(cap)
+        if box is None or not box.strip():
+            return False
+        if box_shows_message(box, message, allow_chip=False):
+            return False
+        return not prompt_router.prompt_is_empty(session, pane_index)
+    except Exception:
+        return False
+
+
 def scrollback(session: str, pane_index: int = 0) -> str:
     """Public capture of a pane's verify-window scrollback (#621 dedup)."""
     return _snapshot(session, pane_index)
@@ -499,6 +584,21 @@ def _deliver_once(
             from agentwire import prompt_router
 
             if prompt_router.screen_shows_live_menu(cap):
+                return False
+            # A stale, DIFFERENT draft owns the box (#845). The guard above
+            # proves only that the box does not hold OUR message; it said
+            # nothing about what it does hold, so the fall-through pasted on
+            # top of foreign content and let one Enter submit the concatenation
+            # as a single garbled turn. Refuse instead of pasting, and refuse
+            # instead of clearing: this is the delivery primitive, and it
+            # cannot tell a human's half-typed sentence from a wedged paste.
+            # Box surgery belongs to the recovery layer, which knows whether
+            # the draft predates our attempt (see ``send_cli``'s pre-flight
+            # and :func:`recover_failed_seed`). Every caller already handles
+            # False — the msg drain retries next tick behind safe_deliver's
+            # own empty-box gate, `send --verify` falls back to the durable
+            # inbox — so refusing defers delivery without dropping it.
+            if box_holds_foreign_draft(session, message, pane_index, capture=cap):
                 return False
     except Exception:
         pass
@@ -726,7 +826,11 @@ def clear_input_box(session: str, pane_index: int = 0) -> bool:
 
 
 def recover_failed_seed(
-    session: str, message: str, sender: "str | None" = None, pane_index: int = 0
+    session: str,
+    message: str,
+    sender: "str | None" = None,
+    pane_index: int = 0,
+    clear: bool = True,
 ) -> "str | None":
     """Recover a first-message seed that failed to deliver (#695).
 
@@ -746,20 +850,36 @@ def recover_failed_seed(
     queued either way — still better than nothing — but the return value
     is honest about which happened instead of reporting blanket success.
 
+    Step 1 is also SKIPPABLE (``clear=False``, #845). Clearing is right when
+    the draft in the box is the wreckage of our own failed paste — the case
+    this function was written for. It is wrong when the draft was already
+    there before we tried: erasing a human's half-typed sentence (or another
+    sender's landed-but-unsubmitted message) to make room for ours is the
+    clobber the whole polite-messaging design exists to prevent. Only the
+    caller knows which it is, because only the caller saw the box BEFORE the
+    attempt; ``send_cli``'s pre-flight passes ``clear=False`` for a draft it
+    positively knows predates us, and the queued copy simply waits for the
+    box to go idle on its own.
+
     Returns ``"inbox"`` when the box was confirmed cleared AND the prompt
     was queued, ``"inbox_stuck"`` when the prompt was queued but the box
     could NOT be confirmed cleared (a stale draft may still be sitting
-    there — needs manual intervention), or None when even the durable
-    enqueue failed. Never raises.
+    there — needs manual intervention), ``"inbox_blocked"`` when the prompt
+    was queued and the box was deliberately left alone (``clear=False``), or
+    None when even the durable enqueue failed. Never raises.
     """
-    try:
-        cleared = clear_input_box(session, pane_index=pane_index)
-    except Exception:
-        cleared = False
+    cleared = False
+    if clear:
+        try:
+            cleared = clear_input_box(session, pane_index=pane_index)
+        except Exception:
+            cleared = False
     try:
         from agentwire import inbox
 
         inbox.enqueue(session, message, kind="request", sender=sender or "agentwire")
+        if not clear:
+            return "inbox_blocked"
         return "inbox" if cleared else "inbox_stuck"
     except Exception:
         return None

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -72,7 +72,42 @@ lands in a durable inbox and is injected only at a safe boundary.
    *pile* of other sessions' notifications sitting in the box); and **(b) no
    blind re-paste** — before pasting, each attempt checks whether the message
    already sits landed-but-unsubmitted in the box, and if so retries only the
-   *submit*, so a whole-send retry can never double the draft.
+   *submit*, so a whole-send retry can never double the draft. "Already in the
+   box" is **window-aware** (#851): the input box has a bounded visible height
+   and scrolls, so a draft taller than it renders only a contiguous window of
+   itself — accepted as ours when it is at least `MIN_BOX_FRAGMENT` (80
+   normalized chars) long and shorter than the message, which is what keeps a
+   short foreign draft ("ok") from reading as our paste landing. When Escape
+   can't clear such a draft, `clear_input_box` escalates to a bounded backspace
+   sweep.
+
+   **Nothing pastes onto a foreign draft (#845).** The identity guard above
+   proves only that the box does *not* hold our message; it said nothing about
+   what it *does* hold, so a stale, different draft — a previous sender's
+   swallowed message, a human mid-typing, a half-composed large paste — got our
+   text pasted on top of it, and one Enter submitted the concatenation as a
+   single garbled turn. `session_ready.box_holds_foreign_draft` names that
+   state (plain box parse says non-empty and not-ours, then the SGR-aware
+   `prompt_is_empty` vetoes, so dim ghost/autosuggest text never counts), and
+   `_deliver_once` **refuses** rather than pasting — it is the delivery
+   primitive and cannot tell a human's sentence from wedged wreckage. Box
+   surgery stays in the recovery layer: `agentwire send --verify/--wait-ready`
+   look at the box *before* attempting anything, and a draft that predates the
+   attempt is queued to the msg inbox with `recover_failed_seed(clear=False)`
+   → outcome **`inbox_blocked`** (queued, box left untouched) rather than the
+   `inbox`/`inbox_stuck` clear-then-queue path (#843/#844).
+
+   **Per-attempt delivery markers (#839).** A direct verified send tags its
+   paste with `session_ready.new_delivery_marker()` — a unique
+   `⟨#send-xxxxxx⟩` token appended via `tag_message`, mirroring the drain's own
+   `⟨#id6⟩` tail. The token rides inside the pasted text, so the landing gate,
+   the idempotent-paste guard and the unverified-send fallback all key on
+   something unique to *this* attempt. Without it, `_recover_unverified_send`
+   matched the bare prompt against scrollback, and a short or generic message
+   ("yes", "continue", "approved") that happened to sit in the last 200 lines
+   for an unrelated reason reported `already_delivered` and **skipped the inbox
+   enqueue entirely** — silently dropping a send that never landed, the one
+   outcome the fallback exists to prevent.
 
    **Pasted ≠ submitted (#689, hardened by #698).** Closures for the
    paste-lands-but-Enter-is-swallowed failure: **(a)** `message_on_scrollback`

--- a/tests/integration/test_send_verified_tmux.py
+++ b/tests/integration/test_send_verified_tmux.py
@@ -105,7 +105,15 @@ while True:
         # If the remaining bytes could be the start of the marker, wait for more.
         if marker.startswith(data):
             break
-        ch = data[:1].decode("utf-8", "replace"); data = data[1:]
+        # Consume a WHOLE utf-8 sequence, not one byte: delivery markers are
+        # non-ASCII by design (⟨#send-xxxxxx⟩, mirroring inbox's ⟨#id⟩), and a
+        # byte-at-a-time decode turns each into three replacement chars, so
+        # the box would never render what was actually pasted.
+        lead = data[0]
+        n = 4 if lead >= 0xF0 else 3 if lead >= 0xE0 else 2 if lead >= 0xC0 else 1
+        if len(data) < n:
+            break                    # rest of the sequence hasn't arrived yet
+        ch = data[:n].decode("utf-8", "replace"); data = data[n:]
         progressed = True
         if in_paste:
             buf += ch                # pasted bytes are literal (incl. \n / \r)
@@ -381,6 +389,59 @@ def test_tall_draft_retry_does_not_double_paste(emulator_factory, monkeypatch):
     # (A visible-window check can't catch this — the tail of a doubled draft is
     # still a suffix of the message. The paste count is the real invariant.)
     assert len(pastes) == 1, f"re-pasted a landed draft {len(pastes)}x"
+
+
+def test_foreign_draft_is_never_pasted_over(emulator_factory, monkeypatch):
+    # #845 against a real pane: a stale draft (a previous sender's message
+    # whose Enter was swallowed) sits unsubmitted in the box. The pre-fix
+    # guard only knew "does the box hold OUR message" and fell through to
+    # paste_no_enter, concatenating the two drafts into one string that the
+    # next Enter submits as a single garbled turn. This asserts the real
+    # emulator's buffer is left holding EXACTLY the stale draft.
+    session, socket, _ = emulator_factory()
+    _patch_pane_manager(monkeypatch, socket)
+    _patch_prompt_router(monkeypatch, socket)
+
+    stale = "[MSG from other-worker - done] PR 41 drafted, needs review"
+    session_ready.paste_no_enter(session, stale)
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+        if session_ready.text_landed(cap, stale):
+            break
+        time.sleep(0.1)
+    assert session_ready.text_landed(cap, stale), "stale-draft setup failed"
+
+    ours = "run the full suite and report back"
+    assert session_ready.box_holds_foreign_draft(session, ours)
+    assert not session_ready.send_verified(session, ours, retries=1)
+
+    box = session_ready.input_box(
+        _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    )
+    assert box == stale, f"box was mutated: {box!r}"
+    assert ours not in box  # no concatenation — the whole point of #845
+
+
+def test_tagged_paste_delivers_and_the_marker_lands_on_scrollback(
+        emulator_factory, monkeypatch):
+    # #839 against a real pane: the per-attempt marker rides inside the paste,
+    # so after a genuine submit it is findable OUTSIDE the input box — which
+    # is what makes _recover_unverified_send's "already_delivered" a fact
+    # rather than a text-similarity guess. The emulator scrolls submitted
+    # turns away, so we keep the turn on screen by checking the box first.
+    session, socket, _ = emulator_factory()
+    _patch_pane_manager(monkeypatch, socket)
+
+    marker = session_ready.new_delivery_marker()
+    tagged = session_ready.tag_message("continue", marker)
+    assert session_ready.send_verified(session, tagged, marker=marker)
+
+    cap = _tmux("-S", socket, "capture-pane", "-t", f"{session}.0", "-p").stdout
+    assert session_ready.input_box(cap) == "", "tagged draft sat unsent"
+    # A DIFFERENT attempt's marker must never match this one's echo.
+    assert not session_ready.message_on_scrollback(
+        cap, session_ready.new_delivery_marker())
 
 
 def test_clear_input_box_empties_a_tall_draft(emulator_factory, monkeypatch):

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import yaml
 
@@ -189,12 +189,17 @@ class TestCmdSendWaitReady:
         return json.loads(capsys.readouterr().out.strip())
 
     def _mock_has_session(self, monkeypatch):
+        from agentwire import session_ready
+
         has_session = MagicMock(returncode=0)
         monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
         # get_current_session shells out to real tmux and depends on the test
         # runner's own environment ($TMUX_PANE) -- pin it so fallback_sender
         # resolution is deterministic regardless of where tests run.
         monkeypatch.setattr("agentwire.send_cli.pane_manager.get_current_session", lambda: None)
+        # #845 pre-flight: box is clear unless a test says otherwise (the real
+        # one captures a live pane).
+        monkeypatch.setattr(session_ready, "box_holds_foreign_draft", lambda *a, **k: False)
 
     def test_happy_path_verified(self, capsys, monkeypatch):
         from agentwire import session_ready
@@ -202,13 +207,68 @@ class TestCmdSendWaitReady:
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: True)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None: True)
 
         assert cmd_send(self._args()) == 0
         payload = self._payload(capsys)
         assert payload["success"] is True
         assert payload["verified"] is True
         assert payload["fallback"] is None
+
+    def test_paste_carries_a_per_attempt_delivery_marker(self, capsys, monkeypatch):
+        """#839: the text pasted must carry a marker unique to this attempt,
+        and the SAME marker must reach send_verified + the fallback -- that is
+        what turns 'already delivered' from a text-similarity guess into a
+        fact about this specific send."""
+        from agentwire import send_cli, session_ready
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
+        seen = {}
+
+        def fake_send(s, m, marker=None):
+            seen["pasted"] = m
+            seen["marker"] = marker
+            return False
+
+        monkeypatch.setattr(session_ready, "send_verified", fake_send)
+        recover = MagicMock(return_value="inbox")
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
+
+        cmd_send(self._args())
+
+        assert seen["marker"].startswith("⟨#send-")
+        assert seen["pasted"] == f"my idea  {seen['marker']}"
+        # The inbox copy is the BARE prompt (the drain adds its own ⟨#id⟩),
+        # while the marker rides along for the scrollback check.
+        recover.assert_called_once_with(
+            "proj", "my idea", "agentwire", marker=seen["marker"])
+
+    def test_foreign_draft_blocks_the_send_without_clearing(self, capsys, monkeypatch):
+        """#845: a draft that was already in the box before we tried anything
+        is not ours to paste over OR to erase -- queue and leave it alone."""
+        from agentwire import session_ready
+        from agentwire.send_cli import cmd_send
+
+        self._mock_has_session(monkeypatch)
+        monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
+        monkeypatch.setattr(session_ready, "box_holds_foreign_draft", lambda *a, **k: True)
+        sent = MagicMock()
+        monkeypatch.setattr(session_ready, "send_verified", sent)
+        cleared = MagicMock()
+        monkeypatch.setattr(session_ready, "clear_input_box", cleared)
+        seed = MagicMock(return_value="inbox_blocked")
+        monkeypatch.setattr(session_ready, "recover_failed_seed", seed)
+
+        assert cmd_send(self._args()) == 1
+        payload = self._payload(capsys)
+        assert payload["verified"] is False
+        assert payload["fallback"] == "inbox_blocked"
+        sent.assert_not_called()      # never pasted on top of the draft
+        cleared.assert_not_called()   # and never erased it
+        seed.assert_called_once_with(
+            "proj", "my idea", sender="agentwire", clear=False)
 
     def test_not_ready_fails(self, capsys, monkeypatch):
         from agentwire import session_ready
@@ -232,7 +292,7 @@ class TestCmdSendWaitReady:
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None: False)
         recover = MagicMock(return_value="inbox")
         monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
@@ -240,7 +300,7 @@ class TestCmdSendWaitReady:
         payload = self._payload(capsys)
         assert payload["verified"] is False
         assert payload["fallback"] == "inbox"
-        recover.assert_called_once_with("proj", "my idea", "agentwire")
+        recover.assert_called_once_with("proj", "my idea", "agentwire", marker=ANY)
 
     def test_unverified_and_fallback_fails_is_still_reported(self, capsys, monkeypatch):
         from agentwire import send_cli, session_ready
@@ -248,8 +308,8 @@ class TestCmdSendWaitReady:
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
-        monkeypatch.setattr(send_cli, "_recover_unverified_send", lambda s, m, sender: None)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None: False)
+        monkeypatch.setattr(send_cli, "_recover_unverified_send", lambda s, m, sender, marker=None: None)
 
         assert cmd_send(self._args()) == 1
         payload = self._payload(capsys)
@@ -266,12 +326,12 @@ class TestCmdSendWaitReady:
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None: False)
         recover = MagicMock(return_value="inbox")
         monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
         cmd_send(self._args(caller_session="council-brain"))
-        recover.assert_called_once_with("proj", "my idea", "council-brain")
+        recover.assert_called_once_with("proj", "my idea", "council-brain", marker=ANY)
 
     def test_unverified_falls_back_to_stuck_inbox(self, capsys, monkeypatch):
         """#843: an "inbox_stuck" fallback (queued, but the stale draft in
@@ -282,7 +342,7 @@ class TestCmdSendWaitReady:
 
         self._mock_has_session(monkeypatch)
         monkeypatch.setattr(session_ready, "wait_for_session_ready", lambda s, timeout: True)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m: False)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None: False)
         recover = MagicMock(return_value="inbox_stuck")
         monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
@@ -321,16 +381,19 @@ class TestCmdSendVerify:
         return json.loads(capsys.readouterr().out.strip())
 
     def _mock_has_session(self, monkeypatch):
+        from agentwire import session_ready
+
         has_session = MagicMock(returncode=0)
         monkeypatch.setattr("agentwire.send_cli.subprocess.run", lambda *a, **k: has_session)
         monkeypatch.setattr("agentwire.send_cli.pane_manager.get_current_session", lambda: None)
+        monkeypatch.setattr(session_ready, "box_holds_foreign_draft", lambda *a, **k: False)
 
     def test_happy_path_verified_skips_fallback(self, capsys, monkeypatch):
         from agentwire import send_cli, session_ready
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: True)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None, retries=1: True)
         recover = MagicMock()
         monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
@@ -346,7 +409,7 @@ class TestCmdSendVerify:
         from agentwire.send_cli import cmd_send
 
         self._mock_has_session(monkeypatch)
-        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, retries=1: False)
+        monkeypatch.setattr(session_ready, "send_verified", lambda s, m, marker=None, retries=1: False)
         recover = MagicMock(return_value="inbox")
         monkeypatch.setattr(send_cli, "_recover_unverified_send", recover)
 
@@ -354,7 +417,7 @@ class TestCmdSendVerify:
         payload = self._payload(capsys)
         assert payload["verified"] is False
         assert payload["fallback"] == "inbox"
-        recover.assert_called_once_with("proj", "my idea", "agentwire")
+        recover.assert_called_once_with("proj", "my idea", "agentwire", marker=ANY)
 
     def test_remote_with_verify_never_touches_the_fallback(self, capsys, monkeypatch):
         """Remote (session@machine) sends return from an earlier branch
@@ -403,6 +466,15 @@ class TestFallbackSuffix:
 
         assert "resend manually" in _fallback_suffix(None)
 
+    def test_inbox_blocked_suffix_says_the_draft_was_left_alone(self):
+        """#845: distinct from inbox_stuck -- nothing was pasted and nothing
+        was erased, so the operator should NOT go hunting for our wreckage."""
+        from agentwire.send_cli import _fallback_suffix
+
+        suffix = _fallback_suffix("inbox_blocked")
+        assert "left untouched" in suffix
+        assert "could NOT be confirmed cleared" not in suffix
+
 
 class TestRecoverUnverifiedSend:
     """#835 review finding 2: the msg-inbox drain's dedup matches the
@@ -435,6 +507,48 @@ class TestRecoverUnverifiedSend:
 
         assert _recover_unverified_send("proj", "genuinely stuck", "council-brain") == "inbox"
         recover.assert_called_once_with("proj", "genuinely stuck", sender="council-brain")
+
+    def test_marker_is_what_gets_matched_when_supplied(self, monkeypatch):
+        """#839: with a per-attempt marker, 'already delivered' keys on THIS
+        attempt's token, not on how much the prompt resembles the scrollback."""
+        from agentwire import session_ready
+        from agentwire.send_cli import _recover_unverified_send
+
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, pane_index=0: "cap")
+        needles = []
+        monkeypatch.setattr(
+            session_ready, "message_on_scrollback",
+            lambda cap, msg: needles.append(msg) or False)
+        monkeypatch.setattr(
+            session_ready, "recover_failed_seed",
+            lambda *a, **k: "inbox")
+
+        _recover_unverified_send("proj", "continue", "agentwire", marker="⟨#send-abc123⟩")
+        assert needles == ["⟨#send-abc123⟩"]
+
+    def test_generic_prompt_on_scrollback_no_longer_swallows_a_failed_send(
+            self, monkeypatch):
+        """#839's false positive, end to end: a bare 'continue' from an
+        UNRELATED earlier send sits in the scrollback window. Matching the bare
+        text reports already_delivered and skips the inbox enqueue entirely --
+        silently dropping a send that never landed. The marker makes the
+        difference."""
+        from agentwire import session_ready
+        from agentwire.send_cli import _recover_unverified_send
+
+        old_marker = session_ready.new_delivery_marker()
+        this_marker = session_ready.new_delivery_marker()
+        rule = "─" * 20
+        cap = f"> continue  {old_marker}\n{rule}\n❯\n{rule}"
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, pane_index=0: cap)
+        monkeypatch.setattr(
+            session_ready, "recover_failed_seed", lambda *a, **k: "inbox")
+
+        # Bare text (the pre-#839 behavior): the unrelated echo swallows it.
+        assert _recover_unverified_send("proj", "continue", "agentwire") == "already_delivered"
+        # Per-attempt marker: this send is correctly recognized as NOT delivered.
+        assert _recover_unverified_send(
+            "proj", "continue", "agentwire", marker=this_marker) == "inbox"
 
 
 # --- cmd_new --first-message ---

--- a/tests/unit/test_session_ready.py
+++ b/tests/unit/test_session_ready.py
@@ -1,8 +1,10 @@
 """Tests for agentwire.session_ready — readiness detection + verified delivery."""
 
+import pytest
+
 from agentwire import session_ready
 
-BANNER = "❯ \nBypassing Permissions"
+BANNER ="❯ \nBypassing Permissions"
 TRUST = "Do you trust this folder?\nPress Enter to confirm"
 
 RULE = "─" * 20
@@ -324,6 +326,17 @@ def _env(monkeypatch, frame):
     monkeypatch.setattr(session_ready, "paste_no_enter", paste)
     monkeypatch.setattr(session_ready, "press_enter", enter)
     monkeypatch.setattr(session_ready, "capture_session", capture)
+
+    # The #845 foreign-draft guard asks prompt_router's SGR-aware gate for a
+    # second opinion before refusing (dim ghost text is not a draft). These
+    # frames carry no SGR, so mirror the plain parse -- and, crucially, keep
+    # the guard from shelling out to the developer's LIVE tmux server.
+    from agentwire import prompt_router
+
+    def is_empty(session, pane_index=0):
+        return session_ready.input_box(frame(actions)) == ""
+
+    monkeypatch.setattr(prompt_router, "prompt_is_empty", is_empty)
     return actions
 
 
@@ -443,10 +456,13 @@ class TestSendVerifiedAdaptive:
 
     def test_large_paste_placeholder_lands(self, monkeypatch):
         # Large paste renders as the [Pasted text] placeholder in the box; that
-        # counts as landed, then submits.
+        # counts as landed, then submits. (The box is empty until we paste --
+        # a chip sitting there BEFORE the paste is a foreign draft, #845.)
         _fake_clock(monkeypatch)
 
         def frame(a):
+            if a["pastes"] == 0:
+                return render_box()
             if a["enters"] == 0:
                 return render_box("[Pasted text #1 +40 lines]")
             return render_working()
@@ -511,12 +527,15 @@ class TestNoDoublePaste:
         )
         ours = "[NOTIFY from agentwire-dev-issue-661-bar] is idle and done working"
         # Box shows only OTHER sessions' same-prefix notifications, ours never
-        # renders: Phase 1 must fail (no false landing) and Enter must never be
-        # pressed into the pile (the old 32-char fragment matched instantly and
-        # then hammered Enter for 20s against a pile that could never clear).
+        # renders: no false landing, and Enter must never be pressed into the
+        # pile (the old 32-char fragment matched instantly and then hammered
+        # Enter for 20s against a pile that could never clear). Post-#845 the
+        # pile is also recognized as a foreign draft, so we never paste our
+        # message on top of it either.
         actions = _env(monkeypatch, lambda a: render_box(pile))
         assert not session_ready.send_verified("s", ours)
         assert actions["enters"] == 0
+        assert actions["pastes"] == 0
 
 
 class TestPrePasteGuardIdentity:
@@ -560,28 +579,18 @@ class TestPrePasteGuardIdentity:
     def test_foreign_pasted_placeholder_is_not_our_landing(self, monkeypatch):
         # A human's half-composed large paste sits in the target box as
         # [Pasted text ...]. Pre-paste that placeholder can only be someone
-        # ELSE's draft: we must not skip our paste, and we must never press
-        # Enter before pasting (which would force-submit the foreign draft).
+        # ELSE's draft (or an earlier attempt's), so it never counts as our
+        # landing: no Enter may be pressed before we paste, which would
+        # force-submit the foreign draft.
+        #
+        # #845 goes further than #621 did: pasting our text ON TOP of that
+        # draft concatenates the two into one garbled turn, so the send is
+        # refused outright and the caller's durable fallback takes over.
         _fake_clock(monkeypatch)
-
-        def frame(a):
-            if a["pastes"] == 0:
-                return render_box("[Pasted text #1 +57 lines]")
-            if a["enters"] == 0:
-                return render_box("our own report")
-            return render_working()
-
-        actions = _env(monkeypatch, frame)
-
-        real_enter = session_ready.press_enter
-
-        def guarded_enter(s, pane_index=0):
-            assert actions["pastes"] > 0, "Enter pressed into a foreign draft before pasting"
-            real_enter(s, pane_index=pane_index)
-
-        monkeypatch.setattr(session_ready, "press_enter", guarded_enter)
-        assert session_ready.send_verified("s", "our own report")
-        assert actions["pastes"] == 1
+        actions = _env(monkeypatch, lambda a: render_box("[Pasted text #1 +57 lines]"))
+        assert not session_ready.send_verified("s", "our own report")
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 0
 
     def test_full_message_on_scrollback_short_circuits_as_submitted(self, monkeypatch):
         # Positive identity: our FULL rendered message already on scrollback
@@ -990,6 +999,252 @@ class TestRecoverFailedSeed:
 
         monkeypatch.setattr(inbox, "enqueue", boom)
         assert session_ready.recover_failed_seed("sess", "x") is None
+
+
+class TestDeliveryMarker:
+    """#839 — a per-attempt marker appended to the paste turns 'is this attempt
+    already on scrollback?' from a text-similarity guess into a fact."""
+
+    def test_marker_is_unique_per_attempt(self):
+        markers = {session_ready.new_delivery_marker() for _ in range(200)}
+        assert len(markers) == 200
+
+    def test_marker_shape_mirrors_inbox_render(self):
+        marker = session_ready.new_delivery_marker()
+        assert marker.startswith("⟨#send-")
+        assert marker.endswith("⟩")
+
+    def test_tag_appends_the_marker(self):
+        marker = session_ready.new_delivery_marker()
+        assert session_ready.tag_message("continue", marker) == f"continue  {marker}"
+
+    def test_tagged_paste_is_what_lands_and_submits(self, monkeypatch):
+        _fake_clock(monkeypatch)
+        marker = session_ready.new_delivery_marker()
+        tagged = session_ready.tag_message("yes", marker)
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return render_box()
+            if a["enters"] == 0:
+                return render_box(tagged)
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", tagged, marker=marker)
+        assert actions["enters"] == 1
+
+    def test_marker_on_scrollback_is_per_attempt(self):
+        # The false positive #839 is about: a bare generic message coincidentally
+        # already on scrollback from an UNRELATED earlier send.
+        old = session_ready.new_delivery_marker()
+        new = session_ready.new_delivery_marker()
+        cap = f"> continue  {old}\n" + render_box()
+        assert session_ready.message_on_scrollback(cap, "continue")   # bare: collides
+        assert session_ready.message_on_scrollback(cap, old)
+        assert not session_ready.message_on_scrollback(cap, new)      # marker: precise
+
+    def test_marker_in_the_box_is_not_on_scrollback(self):
+        # Composes with #689: a tagged paste sitting UNSENT in the box must
+        # never read as delivered just because its marker is on screen.
+        marker = session_ready.new_delivery_marker()
+        tagged = session_ready.tag_message("continue", marker)
+        cap = "some history\n" + render_box(tagged)
+        assert not session_ready.message_on_scrollback(cap, marker)
+
+
+class TestForeignDraftGuard:
+    """#845 — a stale, DIFFERENT draft in the box was invisible to the
+    idempotent-paste guard, which only knew 'holds our message' vs 'live menu'.
+    Pasting on top concatenates the two into one garbled submitted turn."""
+
+    def _wire(self, monkeypatch, box_content):
+        _fake_clock(monkeypatch)
+        return _env(monkeypatch, lambda a: render_box(box_content))
+
+    def test_refuses_to_paste_over_a_stale_draft(self, monkeypatch):
+        actions = self._wire(monkeypatch, "half-typed thought from a human")
+        assert not session_ready.send_verified("s", "our new instruction")
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 0
+
+    def test_refuses_a_wedged_message_from_another_sender(self, monkeypatch):
+        stale = "[MSG from other-worker · done] PR 41 drafted  ⟨#aaa111⟩"
+        actions = self._wire(monkeypatch, stale)
+        assert not session_ready.send_verified("s", "unrelated instruction")
+        assert actions["pastes"] == 0
+
+    def test_never_clears_the_draft_itself(self, monkeypatch):
+        """The delivery primitive refuses; it does not do box surgery. It
+        cannot tell a human's half-typed sentence from a wedged paste, and the
+        recovery layer (which saw the box BEFORE the attempt) can."""
+        self._wire(monkeypatch, "someone else's words")
+        cleared = []
+        monkeypatch.setattr(
+            session_ready, "clear_input_box",
+            lambda s, pane_index=0: cleared.append(s) or True)
+        assert not session_ready.send_verified("s", "ours")
+        assert cleared == []
+
+    def test_empty_box_still_pastes(self, monkeypatch):
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return render_box()
+            if a["enters"] == 0:
+                return render_box("ours")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "ours")
+        assert actions["pastes"] == 1
+
+    def test_our_own_landed_copy_is_not_foreign(self, monkeypatch):
+        # #667 must keep holding: our own landed-but-unsubmitted paste means
+        # retry the SUBMIT, not refuse.
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box("leftover from a prior attempt")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "leftover from a prior attempt")
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 1
+
+    def test_our_own_tall_draft_window_is_not_foreign(self, monkeypatch):
+        # #851 must keep holding: a draft too tall to render whole shows only a
+        # window of itself, and that window is still OURS.
+        msg = TestTallDraftWindow.MSG
+        _fake_clock(monkeypatch)
+
+        def frame(a):
+            if a["enters"] == 0:
+                return render_box(msg[-454:])
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", msg)
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 1
+
+    def test_already_submitted_wins_over_a_foreign_draft(self, monkeypatch):
+        # Our message echoed OUTSIDE the box means a prior attempt submitted
+        # it -- report success rather than refusing over whatever the recipient
+        # has since started typing.
+        _fake_clock(monkeypatch)
+        msg = "[MSG from w · done] finished  ⟨#abc123⟩"
+        actions = _env(
+            monkeypatch, lambda a: f"{msg}\n" + render_box("a new thought"))
+        assert session_ready.send_verified("s", msg)
+        assert actions["pastes"] == 0
+        assert actions["enters"] == 0
+
+    def test_dim_ghost_text_is_not_a_foreign_draft(self, monkeypatch):
+        """#669 composition: Claude renders autosuggest/ghost text inside the
+        box DIM, and the plain parse can't tell it from a draft. Without the
+        SGR-aware second opinion, an idle session showing a suggestion would
+        refuse every send."""
+        _fake_clock(monkeypatch)
+        ghost = "try asking about the build failure"
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return render_box(ghost)   # plain parse: looks like a draft
+            if a["enters"] == 0:
+                return render_box("ours")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        # prompt_is_empty is the authority and it sees dim text as empty.
+        from agentwire import prompt_router
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: True)
+        assert session_ready.send_verified("s", "ours")
+        assert actions["pastes"] == 1
+
+    def test_unparseable_box_still_pastes(self, monkeypatch):
+        # No box parse → nothing is provable, and refusing must be positively
+        # justified. Unchanged from before #845.
+        _fake_clock(monkeypatch)
+        busy = "⏺ Bash(build)\n✶ Working… (esc to interrupt)\nno box parses here"
+
+        def frame(a):
+            if a["pastes"] == 0:
+                return busy
+            if a["enters"] == 0:
+                return render_box("ours")
+            return render_working()
+
+        actions = _env(monkeypatch, frame)
+        assert session_ready.send_verified("s", "ours")
+        assert actions["pastes"] == 1
+
+    def test_predicate_is_conservative_on_a_dead_pane(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("no such pane")
+
+        monkeypatch.setattr(session_ready, "capture_session", boom)
+        assert session_ready.box_holds_foreign_draft("s", "ours") is False
+
+    def test_predicate_accepts_a_supplied_capture(self, monkeypatch):
+        from agentwire import prompt_router
+
+        monkeypatch.setattr(prompt_router, "prompt_is_empty", lambda s, p=0: False)
+        monkeypatch.setattr(
+            session_ready, "capture_session",
+            lambda *a, **k: pytest.fail("re-captured instead of using the frame"))
+        assert session_ready.box_holds_foreign_draft(
+            "s", "ours", capture=render_box("theirs"))
+        assert not session_ready.box_holds_foreign_draft(
+            "s", "ours", capture=render_box("ours"))
+        assert not session_ready.box_holds_foreign_draft(
+            "s", "ours", capture=render_box(""))
+
+
+class TestRecoverFailedSeedNoClear:
+    """#845 — the recovery layer must be able to queue WITHOUT clearing, so a
+    draft that predates our attempt (a human mid-typing) isn't erased to make
+    room for a message we already declined to paste."""
+
+    def _no_clear(self, monkeypatch):
+        from agentwire import inbox
+        seen = {"cleared": False, "enqueued": None}
+
+        def clear(s, pane_index=0):
+            seen["cleared"] = True
+            return True
+
+        monkeypatch.setattr(session_ready, "clear_input_box", clear)
+        monkeypatch.setattr(
+            inbox, "enqueue",
+            lambda to, text, kind="note", sender=None, ref="":
+                seen.update(enqueued=(to, text, kind, sender)) or [])
+        return seen
+
+    def test_clear_false_queues_and_leaves_the_box_alone(self, monkeypatch):
+        seen = self._no_clear(monkeypatch)
+        result = session_ready.recover_failed_seed(
+            "sess", "our prompt", sender="orch", clear=False)
+        assert result == "inbox_blocked"
+        assert seen["cleared"] is False
+        assert seen["enqueued"] == ("sess", "our prompt", "request", "orch")
+
+    def test_clear_true_is_unchanged(self, monkeypatch):
+        seen = self._no_clear(monkeypatch)
+        assert session_ready.recover_failed_seed("sess", "x", clear=True) == "inbox"
+        assert seen["cleared"] is True
+
+    def test_enqueue_failure_still_returns_none(self, monkeypatch):
+        from agentwire import inbox
+
+        def boom(*a, **k):
+            raise OSError("inbox unwritable")
+
+        monkeypatch.setattr(inbox, "enqueue", boom)
+        assert session_ready.recover_failed_seed("s", "x", clear=False) is None
 
 
 class TestLiveMenuAbort:


### PR DESCRIPTION
Two holes in the same seam — the verified-delivery path could not tell **which** send it was looking at, and could not tell **what** was already in the box.

## #839 — per-attempt delivery markers

`_recover_unverified_send` matched the **bare prompt** against the recipient's scrollback to decide `already_delivered`. For a short or generic message (`yes`, `continue`, `approved`) that collides with any coincidental earlier occurrence in the same 200-line window — reporting delivered and **skipping the inbox enqueue** for a send that never landed. That is the silent loss #834/#835 exist to prevent, reached by a narrower path.

- `session_ready.new_delivery_marker()` mints a unique `⟨#send-xxxxxx⟩` token (mirroring `inbox.Message.render`'s `⟨#id6⟩`, proven in production).
- `session_ready.tag_message(msg, marker)` appends it to the paste, so the token rides *inside* the text — the landing gate, the idempotent-paste guard and the fallback all key on something unique to **this** attempt.
- All three `agentwire send` verified paths (`--verify`, `--wait-ready`, `--pane --verify`) tag their paste and thread the marker into both `send_verified` and `_recover_unverified_send`.
- The inbox copy stays the **bare** prompt (the drain adds its own `⟨#id⟩`).

## #845 — nothing pastes onto a foreign draft

The idempotent-paste guard proved only that the box does *not* hold our message; it said nothing about what it *does* hold. A stale different draft — a previous sender's swallowed message, a human mid-typing, a half-composed large paste — got our text pasted on top, and one Enter submitted the concatenation as a single garbled turn.

- `session_ready.box_holds_foreign_draft()` names that state: plain box parse says non-empty and not-ours, then the SGR-aware `prompt_is_empty` gets a veto (dim ghost/autosuggest text is not a draft, #669) so an idle session showing a suggestion doesn't refuse every send. Every ambiguity resolves to `False`.
- `_deliver_once` **refuses** rather than pasting — and rather than clearing. It is the delivery primitive and cannot tell a human's half-typed sentence from wedged wreckage. Every caller already handles `False`: the msg drain retries next tick, `send --verify` falls back to the durable inbox.
- Box surgery stays in the recovery layer, which can tell the difference *because it looked first*: `send --verify/--wait-ready` check the box **before** attempting anything, and a draft that predates the attempt is queued via `recover_failed_seed(clear=False)` → new **`inbox_blocked`** outcome (queued, box left untouched) instead of erasing someone else's words to make room for ours.

## Composition with #851 (do-not-regress)

`box_holds_foreign_draft` delegates to `box_shows_message`, so the window-aware landing gate is what decides "ours": a draft too tall to render whole still reads as **ours**, not foreign. Regression tests cover the tall-draft delivery and the no-double-paste retry explicitly. `clear_input_box`'s backspace escalation is untouched.

## Behavior changes worth naming

- A pre-existing `[Pasted text …]` chip in the box now **refuses** the send instead of pasting over it (`TestPrePasteGuardIdentity::test_foreign_pasted_placeholder_is_not_our_landing` inverted, with the reasoning recorded).
- Verified sends deliver one extra visible token per prompt (`… ⟨#send-a1b2c3⟩`), the same shape msg deliveries already carry.
- A session in the `queued messages` busy placeholder state now routes through the inbox rather than pasting — consistent with what the drain already does there.

## Verification

- Full suite: **2929 passed**, plus the 3 new/updated unit classes and 2 new real-tmux integration tests.
- Real paste path exercised end-to-end against a live tmux pane (private socket, never the developer's server): a stale draft is left **byte-identical** after a refused send (`assert box == stale`), and a tagged paste submits with its marker findable outside the box.
- Fixed the integration emulator's byte-at-a-time stdin decode, which turned every multi-byte char into three replacement chars — markers are non-ASCII by design, so the harness had to become UTF-8 correct to test them for real. (This is why the pre-existing stuck-paste test used ASCII `(#deadbe)` instead of `⟨#deadbe⟩`.)

## Left out / flagged

- **Pre-existing failure on the branch base**, not touched: `tests/unit/test_prompt_router.py::TestRecordSessionCreator::test_self_and_empty_creator_skipped` fails on `main` too — stale assertion after #848 made `--created-by ''` record an empty string rather than skip. Its subject file (`session_cli.py`) is owned by another wave, so I left it alone.
- Did not touch `session_cli.py`'s `cmd_new --first-message` seeding (#840, later wave). `new_delivery_marker` / `tag_message` are public, documented, and importable for it to adopt.
- `agentwire/server.py` got one small branch so an `inbox_blocked` first-message no longer falls through to the "paste it manually" toast, which would be actively wrong advice.

Closes #839
Closes #845

Built by [dotdev.dev](https://dotdev.dev)