### PR TITLE
test(rooting): update created_by='' expectations to match #848

### DIFF
--- a/tests/unit/test_prompt_router.py
+++ b/tests/unit/test_prompt_router.py
@@ -781,14 +781,27 @@ class TestRecordSessionCreator:
         assert meta["created_via"] == "new"
         assert meta["existing"] == "kept"
 
-    def test_self_and_empty_creator_skipped(self, tmp_path, monkeypatch):
+    def test_self_and_none_creator_skipped(self, tmp_path, monkeypatch):
         import agentwire.__main__ as cli
 
         monkeypatch.setattr("agentwire.core.CONFIG_DIR", tmp_path)
         cli._record_session_creator("child", "child", via="new")
-        cli._record_session_creator("child", "", via="new")
         cli._record_session_creator("child", None, via="new")
         assert cli.load_session_metadata("child") == {}
+
+    def test_empty_creator_recorded_as_explicitly_rootless(self, tmp_path, monkeypatch):
+        """`--created-by ''` means "no parent" and must be written (#848).
+
+        Skipping it left a stale parent from a prior creation in place, so
+        `resolve_parent` kept routing to a creator the caller had explicitly
+        disowned. Only `None` — no signal at all — is a skip.
+        """
+        import agentwire.__main__ as cli
+
+        monkeypatch.setattr("agentwire.core.CONFIG_DIR", tmp_path)
+        cli.store_session_metadata("child", {"created_by": "stale-orch"})
+        cli._record_session_creator("child", "", via="new")
+        assert cli.load_session_metadata("child")["created_by"] == ""
 
 
 class TestNotifyPermissionRequest:


### PR DESCRIPTION
## Why

`#848` (merged today) changed `_record_session_creator` to skip only on `None`, not on any falsy value — `created_by=''` means *explicitly rootless* and must be written, or force-recreating an already-parented session leaves a stale parent in `metadata.json` and `resolve_parent` keeps routing to a creator the caller disowned.

`tests/unit/test_prompt_router.py::TestRecordSessionCreator::test_self_and_empty_creator_skipped` pinned the **old** behavior and asserted `''` was skipped. The fork that shipped #848 didn't update it, so main went red the moment it merged. Caught by the full-suite gate before fanning out the next wave, not by CI — this repo's ruleset has zero required status checks.

## What changed

Split one test into two so the reversed case is asserted **positively** rather than vanishing into a deleted line:

| Test | Asserts |
|---|---|
| `test_self_and_none_creator_skipped` | self-creator and `None` still skip |
| `test_empty_creator_recorded_as_explicitly_rootless` | `''` **overwrites** a pre-existing stale parent |

The second seeds `created_by: "stale-orch"` first, so it fails if the skip behavior ever returns — the regression #848 exists to prevent.

## Verification

`tests/unit/test_prompt_router.py` — 78 passed. Full suite was 1 failed / 2947 passed before this; this was the only failure.

Built by [dotdev.dev](https://dotdev.dev)