### PR TITLE
fix(sessions): route --first-message seeding through the guarded send path (#840)

### DIFF
--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -113,6 +113,16 @@ def worktree_create(
                 "will deliver it once the box is ready; verify with msg_inbox / "
                 "session_output before assuming the task started."
             )
+        if fallback == "inbox_blocked":
+            return (
+                f"Created worktree session '{session}' at {path}. "
+                "WARNING: seed prompt NOT pasted — the input box already held an "
+                "unrelated unsent draft (someone typing, or an earlier message whose "
+                "Enter was swallowed), which was left untouched rather than clobbered. "
+                "The prompt was queued to the session's msg inbox and the drain "
+                "delivers it once the box goes idle; verify with msg_inbox / "
+                "session_output before assuming the task started."
+            )
         if fallback == "inbox_stuck":
             return (
                 f"Created worktree session '{session}' at {path}. "

--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -584,53 +584,109 @@ def cmd_new(args) -> int:
             )
         save_project_config(project_config, session_path)
 
-    # Deliver the first message once the agent is ready (verified paste).
-    # Delivery failure doesn't fail the command — the session exists — but it
-    # must be LOUD (#695): clear the partial paste out of the box and fall
-    # back to the msg inbox so the prompt still arrives once the box is ready.
+    # Deliver the first message once the agent is ready, through the SAME
+    # guarded send path every other sender uses (#840). Seeding used to paste
+    # bare and, on an unverified confirm, call recover_failed_seed directly —
+    # the one send path that skipped the marker-based already-delivered check
+    # (#839) and the foreign-draft pre-flight (#845), so a seed that actually
+    # landed could be enqueued a second time and a human's half-typed draft
+    # could be erased to make room for it. Delivery failure still doesn't fail
+    # the command — the session exists — but it must be LOUD (#695).
     first_message_delivered = None
     first_message_fallback = None
     if first_message and agent_cmd:
+        from agentwire.send_cli import _foreign_draft_block, _recover_unverified_send
         from agentwire.session_ready import (
+            new_delivery_marker,
             recover_failed_seed,
             send_verified,
+            tag_message,
             wait_for_session_ready,
         )
 
+        # created_by can be None for a legitimate cross-project standalone
+        # spawn (#715) even though a real caller made the call — fall back to
+        # that caller for the recovery message's sender rather than the generic
+        # "agentwire" so the fallback attribution stays accurate.
+        seed_sender = created_by or caller or "agentwire"
         if not json_mode:
             print("Waiting for agent to deliver first message...")
-        first_message_delivered = (
-            wait_for_session_ready(session_name, timeout=60)
-            and send_verified(session_name, first_message)
-        )
-        if not first_message_delivered:
-            # created_by can be None for a legitimate cross-project standalone
-            # spawn (#715) even though a real caller made the call — fall back
-            # to that caller for the recovery message's sender rather than the
-            # generic "agentwire" so the fallback attribution stays accurate.
-            first_message_fallback = recover_failed_seed(
-                session_name, first_message, sender=created_by or caller or "agentwire"
+
+        # marker stays None until we actually paste. That distinction is
+        # load-bearing for the recovery below: "already delivered" is only a
+        # fact when a per-attempt marker could have reached scrollback.
+        marker = None
+        blocked = False
+        verified = False
+        if wait_for_session_ready(session_name, timeout=60):
+            # #845 — a fresh session's box is normally empty, but boot can take
+            # the full 60s above, which is ample room for a human to attach and
+            # start typing. Pasting on top of that garbles both, and the
+            # recovery below would then erase their draft as if it were the
+            # wreckage of our own paste. Look before touching it.
+            blocked, first_message_fallback = _foreign_draft_block(
+                session_name, first_message, seed_sender
             )
-            if not json_mode:
-                if first_message_fallback == "inbox":
-                    print(
-                        f"WARNING: first message NOT delivered to '{session_name}' — "
-                        "queued to its msg inbox for delivery once the input box is ready",
-                        file=sys.stderr,
-                    )
-                elif first_message_fallback == "inbox_stuck":
-                    print(
-                        f"WARNING: first message NOT delivered to '{session_name}' — "
-                        "queued to its msg inbox, but the stuck draft in the input box "
-                        "could not be confirmed cleared; check the pane manually",
-                        file=sys.stderr,
-                    )
-                else:
-                    print(
-                        f"WARNING: first message NOT delivered to '{session_name}' "
-                        "and could not be queued — paste it manually",
-                        file=sys.stderr,
-                    )
+            if not blocked:
+                marker = new_delivery_marker()
+                verified = send_verified(
+                    session_name, tag_message(first_message, marker), marker=marker
+                )
+
+        if verified:
+            first_message_delivered = True
+        elif blocked:
+            first_message_delivered = False
+        else:
+            first_message_fallback = (
+                # We pasted and the confirm was ambiguous — the shared guard
+                # checks scrollback for THIS attempt's marker before enqueuing,
+                # so a seed that really landed is a no-op instead of a duplicate.
+                _recover_unverified_send(
+                    session_name, first_message, seed_sender, marker=marker
+                )
+                if marker
+                # The agent never became ready, so nothing was ever pasted:
+                # there is no marker to match and a bare-text scrollback check
+                # could only produce a false "already delivered" that DROPS the
+                # seed. Go straight to the durable enqueue.
+                else recover_failed_seed(
+                    session_name, first_message, sender=seed_sender
+                )
+            )
+            # A marker on scrollback proves this attempt's paste submitted; the
+            # confirm read was just ambiguous. That is delivered, not failed —
+            # reporting otherwise sends the caller chasing a message that landed.
+            first_message_delivered = first_message_fallback == "already_delivered"
+
+        if not json_mode and not first_message_delivered:
+            if first_message_fallback == "inbox":
+                print(
+                    f"WARNING: first message NOT delivered to '{session_name}' — "
+                    "queued to its msg inbox for delivery once the input box is ready",
+                    file=sys.stderr,
+                )
+            elif first_message_fallback == "inbox_stuck":
+                print(
+                    f"WARNING: first message NOT delivered to '{session_name}' — "
+                    "queued to its msg inbox, but the stuck draft in the input box "
+                    "could not be confirmed cleared; check the pane manually",
+                    file=sys.stderr,
+                )
+            elif first_message_fallback == "inbox_blocked":
+                print(
+                    f"WARNING: first message NOT pasted into '{session_name}' — its "
+                    "input box already held an unrelated unsent draft, which was left "
+                    "untouched; the prompt was queued to its msg inbox and the drain "
+                    "delivers it once the box goes idle",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"WARNING: first message NOT delivered to '{session_name}' "
+                    "and could not be queued — paste it manually",
+                    file=sys.stderr,
+                )
 
     if json_mode:
         result = {
@@ -642,11 +698,15 @@ def cmd_new(args) -> int:
         }
         if first_message:
             result["first_message_delivered"] = bool(first_message_delivered)
-            if not first_message_delivered:
-                # "inbox" (queued, box confirmed cleared), "inbox_stuck"
-                # (queued, but the stale draft in the box couldn't be
-                # confirmed cleared — #843), or None (fallback failed too —
-                # the prompt is gone; caller must redeliver).
+            # Present whenever the straight verified paste didn't carry the
+            # seed on its own: "inbox" (queued, box confirmed cleared),
+            # "inbox_stuck" (queued, but the stale draft in the box couldn't be
+            # confirmed cleared — #843), "inbox_blocked" (queued, a foreign
+            # draft was left untouched — #845), "already_delivered" (the paste
+            # DID land, only the confirm read was ambiguous — #840, and the one
+            # value that pairs with delivered=True), or None (fallback failed
+            # too — the prompt is gone; caller must redeliver).
+            if not first_message_delivered or first_message_fallback:
                 result["first_message_fallback"] = first_message_fallback
         _output_json(result)
     else:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -572,7 +572,8 @@ class TestCmdNewSeedFallback:
     box + msg-inbox fallback) and `first_message_fallback` tells the caller
     (mcp_worktree) which fallback fired, so the failure is never silent."""
 
-    def _run_cmd_new(self, monkeypatch, tmp_path, *, ready, verified, fallback):
+    def _run_cmd_new(self, monkeypatch, tmp_path, *, ready, verified, fallback,
+                     foreign_draft=False, on_scrollback=False):
         from types import SimpleNamespace
 
         from agentwire import session_cli as m
@@ -600,13 +601,26 @@ class TestCmdNewSeedFallback:
         monkeypatch.setattr(
             session_ready, "wait_for_session_ready",
             lambda s, timeout=30.0, pane_index=0: ready)
-        monkeypatch.setattr(
-            session_ready, "send_verified",
-            lambda s, msg, **k: verified)
 
-        def fake_recover(session, message, sender=None, pane_index=0):
+        def fake_send_verified(session, msg, **k):
+            calls["pasted"] = (msg, k.get("marker"))
+            return verified
+
+        monkeypatch.setattr(session_ready, "send_verified", fake_send_verified)
+        # #845 pre-flight and #839 scrollback check both read the live pane —
+        # stub the two primitives so the unit test stays hermetic.
+        monkeypatch.setattr(
+            session_ready, "box_holds_foreign_draft",
+            lambda s, msg, **k: foreign_draft)
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, pane_index=0: "")
+        monkeypatch.setattr(
+            session_ready, "message_on_scrollback",
+            lambda cap, rendered: on_scrollback)
+
+        def fake_recover(session, message, sender=None, pane_index=0, clear=True):
             calls["recover"] = (session, message, sender)
-            return fallback
+            calls["recover_clear"] = clear
+            return "inbox_blocked" if not clear else fallback
 
         monkeypatch.setattr(session_ready, "recover_failed_seed", fake_recover)
 
@@ -658,6 +672,80 @@ class TestCmdNewSeedFallback:
         assert payload["first_message_delivered"] is True
         assert "first_message_fallback" not in payload
         assert "recover" not in calls  # recovery never runs on success
+
+
+class TestCmdNewSeedGuardedPath:
+    """#840 — the seed goes through the SAME guarded send path as every other
+    sender: a per-attempt marker rides inside the paste (#839), an ambiguous
+    confirm consults scrollback before enqueuing a second copy, and a foreign
+    draft in the box is left alone rather than clobbered (#845)."""
+
+    _run_cmd_new = TestCmdNewSeedFallback._run_cmd_new
+
+    def test_seed_paste_carries_a_delivery_marker(self, capsys, monkeypatch, tmp_path):
+        """Without the marker riding inside the paste, the scrollback check
+        below could only guess from bare text."""
+        _rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=True, fallback="inbox")
+        pasted, marker = calls["pasted"]
+        assert marker and marker.startswith("⟨#send-")
+        assert pasted == f"do the thing  {marker}"
+
+    def test_ambiguous_confirm_that_actually_landed_is_not_re_enqueued(
+            self, capsys, monkeypatch, tmp_path):
+        """THE bug: an unverified confirm whose paste really did submit used to
+        enqueue a duplicate copy unconditionally. The marker is on scrollback,
+        so this is a delivery, not a failure."""
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=False, fallback="inbox",
+            on_scrollback=True)
+        assert rc == 0
+        assert "recover" not in calls  # no second copy queued
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is True
+        assert payload["first_message_fallback"] == "already_delivered"
+
+    def test_ambiguous_confirm_that_did_not_land_still_queues(
+            self, capsys, monkeypatch, tmp_path):
+        """The guard must not swallow a genuinely failed seed — no marker on
+        scrollback means the durable enqueue still runs."""
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=False, fallback="inbox",
+            on_scrollback=False)
+        assert rc == 0
+        assert calls["recover"] == ("proj", "do the thing", "orch")
+        assert calls["recover_clear"] is True  # our own wreckage — clear it
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] == "inbox"
+
+    def test_foreign_draft_is_queued_not_clobbered(self, capsys, monkeypatch, tmp_path):
+        """#845 — boot can take the full 60s wait, ample room for a human to
+        attach and start typing. Their draft is neither pasted over nor erased."""
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=True, verified=True, fallback="inbox",
+            foreign_draft=True)
+        assert rc == 0
+        assert "pasted" not in calls  # never pasted on top of the draft
+        assert calls["recover_clear"] is False  # and never erased it either
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] == "inbox_blocked"
+
+    def test_unready_session_never_guesses_from_bare_text(
+            self, capsys, monkeypatch, tmp_path):
+        """Nothing was pasted, so there is no marker to match — a bare-text
+        scrollback hit could only produce a false "already delivered" that
+        DROPS the seed. Enqueue directly instead."""
+        rc, calls = self._run_cmd_new(
+            monkeypatch, tmp_path, ready=False, verified=False, fallback="inbox",
+            on_scrollback=True)
+        assert rc == 0
+        assert "pasted" not in calls
+        assert calls["recover"] == ("proj", "do the thing", "orch")
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["first_message_delivered"] is False
+        assert payload["first_message_fallback"] == "inbox"
 
 
 class TestCmdNewWorktreeMissingDirFailsLoud:


### PR DESCRIPTION
`cmd_new`'s `--first-message` seeding was the one send path that pasted bare and, on an unverified confirm, called `recover_failed_seed` directly — skipping both guards every other sender goes through.

## What was wrong

- **#839's marker-based already-delivered check.** A `send_verified` failure can mean the paste never landed OR that it fully submitted and only the *confirm read* was ambiguous. Seeding assumed the former and unconditionally enqueued a second copy, so a seed that really landed got delivered twice.
- **#845's foreign-draft pre-flight.** Boot can consume the full 60s readiness wait — ample room for a human to attach and start typing — and `recover_failed_seed`'s box-clear would then erase their draft as if it were the wreckage of our own paste.

## The fix

Seeding now mints a per-attempt marker (`new_delivery_marker`), rides it inside the paste (`tag_message`), runs the `_foreign_draft_block` pre-flight, and hands unverified confirms to the shared `send_cli._recover_unverified_send` — no parallel copy of the scrollback logic, per the issue's preferred direction. Nothing in `session_ready.py` or `send_cli.py` was modified; both are called as-is.

A marker on scrollback proves *this* attempt's paste submitted, so that case now reports `first_message_delivered: true` with `first_message_fallback: "already_delivered"` instead of sending the caller chasing a message that landed.

**One deliberate asymmetry:** when the agent never becomes ready, nothing was ever pasted, so there is no marker to match and a bare-text scrollback hit could only produce a false "already delivered" that *drops* the seed. That path goes straight to the durable enqueue, exactly as before.

## Consumer update

`mcp_worktree.py` gains an `inbox_blocked` branch — the new fallback value the foreign-draft pre-flight can emit — so a queued-but-not-pasted seed doesn't report as "could NOT be queued". This is the only file touched outside `session_cli.py`; `scheduler/dispatch.py` and `ensure_cli.py` are untouched.

## Verification

Full suite green — **3001 passed** (unit + integration), `ruff` clean. Five new tests in `TestCmdNewSeedGuardedPath` cover: the marker riding inside the paste, the ambiguous-but-landed confirm not re-enqueuing, a genuinely failed seed still queuing, the foreign draft being neither pasted over nor erased, and the not-ready path never guessing from bare text.

Closes #840

Built by [dotdev.dev](https://dotdev.dev)