### PR TITLE
feat(sessions): agentwire helper — worker session with no isolation (#838)

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -92,6 +92,21 @@ agentwire tabs list [--session name]  # list tracked tabs (debug leaked verifica
 agentwire fork -s name          # fork session into new worktree
 agentwire fork -s name -t project/branch --commit abc123  # fork from specific commit
 
+# Helper session — a worker session with NO isolation (#838): shares the
+# caller's checkout, so zero git work at creation (no worktree, no branch,
+# nothing in the worktree registry). Reproduces a worker pane's one real
+# advantage while keeping msg inbox / voice / prompt routing / portal
+# visibility. `wait --children` collects its report then reaps it (topology
+# "main"), unlike a worktree child which is left alive.
+agentwire helper name           # worker session sharing this checkout
+agentwire helper name -p ~/projects/repo --prompt "run the suite, report failures"
+agentwire helper name --roles wiki  # extra roles STACK on worker + shared-checkout
+                                #   The `shared-checkout` role is auto-injected:
+                                #   read/edit freely, NEVER commit/branch/checkout/
+                                #   stash/reset/pull — the checkout's owner commits.
+                                #   Needs a commit or a PR? Use `worktree` instead.
+                                #   Teardown is just `agentwire kill -s name`.
+
 # Pane commands (worker PANES inside the current session — NOT worktree
 # sessions; for parallel autonomous work use `agentwire worktree` above)
 agentwire spawn --roles worker  # spawn worker pane

--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -190,7 +190,7 @@ Command Categories:
     from . import doctor_cli, history_cli, machine_cli, safety_cli
     from . import handoff_cli, hooks_cli, mcp_cli, roles_cli, tunnels_cli
     from . import notify_cli, palette_cli, push_cli, repo_cli, system_cli, wiki_cli
-    from . import tabs_cli, wait_cli
+    from . import tabs_cli, wait_cli, worktree_cli
     from .council import cli as council_cli
 
     _REGISTRARS = [  # noqa: N806  # registry constant; Phase 1 of #495 appends here
@@ -226,6 +226,7 @@ Command Categories:
         palette_cli.register_palette_parser,
         tabs_cli.register_tabs_parser,
         wait_cli.register_wait_parser,
+        worktree_cli.register_helper_parser,
     ]
     for _reg in _REGISTRARS:
         _reg(subparsers)

--- a/agentwire/roles/shared-checkout.md
+++ b/agentwire/roles/shared-checkout.md
@@ -1,0 +1,60 @@
+---
+name: shared-checkout
+description: Amends worker etiquette for a session sharing another agent's working tree — edit freely, never mutate git state
+---
+
+# Shared checkout
+
+You are running in a working tree **another agent is using right now**. There is
+no worktree and no branch of your own — your cwd is their checkout. This role
+amends the worker etiquette above it; where the two disagree, this wins.
+
+## The line
+
+**Files: yours. Git state: theirs.**
+
+Read anything, edit anything, run anything. Editing the shared tree is the whole
+point of this session — that is why you exist instead of a worktree session.
+
+But **never mutate git state**:
+
+- No `git commit`, `git add`, `git stash`
+- No `git checkout` / `switch` / `restore`, no `git branch`, no new branch
+- No `git reset`, `git rebase`, `git merge`, `git pull`, `git revert`
+- No `git push`, no PR
+
+## Why — this is not a formality
+
+The other agent has in-flight, uncommitted work in these same files:
+
+- `git commit -a` / `git add .` sweeps **their** unrelated edits into your
+  commit. You will not see it happen and neither will they.
+- `git checkout` / `stash` / `reset` / `pull` / `rebase` rewrites the tree
+  **under them, mid-edit** — the file they are halfway through changes shape
+  between their read and their write.
+- You are both on one branch ref. Two agents committing interleaves unrelated
+  histories onto it.
+
+Read-only git is fine and often the point: `git status`, `git diff`, `git log`,
+`git show`, `git blame`, `git grep`.
+
+## Shared, non-git state — check before you clobber
+
+The build tree is shared too. Before anything destructive, assume someone is
+using it: don't `rm -rf` a `.venv` / `node_modules` / build cache, and don't
+start a dev server on a default port (theirs is probably already there — pick
+an unused one).
+
+## Finishing
+
+Report what you changed; **do not commit it**. The checkout's owner decides what
+lands and when. Your report should name the files you touched so they can review
+and commit them alongside their own work:
+
+```
+agentwire msg send --to <parent> --kind done "<session>: <what you did> — touched: <files>"
+```
+
+If the task genuinely requires committing, branching, or opening a PR, you are
+in the wrong session shape. Say so and stop — the right tool is
+`agentwire worktree <name>`, which gets its own branch and checkout.

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -160,6 +160,22 @@ def is_git_repo(path: Path) -> bool:
     return (path / ".git").exists()
 
 
+def worktree_session_name(project_path: Path, name: str) -> str:
+    """tmux session name for a child session on ``project_path``.
+
+    The flat ``{project}-{safe_name}`` convention every child-session verb
+    shares — deliberately NOT ``project/name``, which
+    :func:`parse_session_name` would read as a branch (and which ``cmd_new``
+    would then try to build a worktree for).
+
+    One convention, one implementation: ``agentwire helper`` (#838) calls
+    this, and ``session_cli.cmd_worktree`` inlines a byte-identical copy that
+    can collapse to this call whenever that file is free to edit.
+    """
+    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+    return f"{Path(project_path).name}-{safe_name}"
+
+
 def ensure_worktree(
     project_path: Path,
     branch: str,

--- a/agentwire/worktree_cli.py
+++ b/agentwire/worktree_cli.py
@@ -1,0 +1,152 @@
+"""``agentwire helper`` — a worker session with NO isolation (#838).
+
+A worker pane's one genuine advantage over a worktree session is that it
+shares the orchestrator's checkout: no ``git worktree add``, no branch, no
+directory, instant. Everything else about a pane is a regression — no msg
+inbox (#834), no voice, a headless exit-summary instead of report-back.
+
+This verb reproduces that one advantage on a real *session*. The cwd IS the
+caller's own working tree; creation performs zero git operations. Everything
+else — msg inbox, voice, prompt routing, cohort enrollment, portal
+visibility — comes free from being an ordinary session.
+
+**Not a creation path.** :func:`cmd_helper` creates nothing. It resolves a
+directory, derives a session name, and delegates to ``session_cli.cmd_new``
+— the one session-creation path — exactly as ``cmd_orchestrator`` delegates
+to ``cmd_worktree``.
+
+Two things make sharing a checkout safe:
+
+1. **The guard is declared past, not disarmed.** ``session_cli.cmd_new``'s
+   shared-working-dir guard refuses to put a second agent in a tree that
+   already has one, because two agents in one working tree is a real footgun
+   (see the ``shared-checkout`` role for the concrete list). ``helper`` is
+   *literally* the sentence "put a second agent in this tree", so it passes
+   ``allow_shared_dir=True`` — the same posture as ``services.py``
+   ("registering a service is explicit intent") and #857's dispatch
+   derivation. Deliberately NOT ``--force``, which would additionally
+   kill-replace a live same-name session. The guard stays fully armed for
+   interactive ``agentwire new``.
+2. **The ``shared-checkout`` role states the constraint.** Read and edit
+   freely — editing the shared tree is the entire point — but never mutate
+   git state (checkout/commit/stash/reset/branch/pull/rebase), because that
+   rewrites the tree under the co-resident agent or sweeps its in-flight
+   edits into your commit.
+
+Nothing is written to the worktree registry: this session creates no
+directory and no branch, so there is no git resource for
+``--list``/``--prune``/``--remove``/``--dangling`` to track. ``agentwire
+kill`` reclaims all of it.
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from .core import _output_result
+from .worktree import git_root, worktree_session_name
+
+#: Stacked after the non-overridable ``worker`` rail (recency weight), so its
+#: "never mutate git state" corrects ``worker.md``'s "commit your work" —
+#: which is right for a pane or a worktree and wrong in a shared checkout.
+SHARED_CHECKOUT_ROLE = "shared-checkout"
+
+
+def _resolve_checkout(project_arg: str | None) -> Path:
+    """The working tree the helper will share.
+
+    ``--project`` (an explicit path, or a bare project name resolved against
+    the configured projects dir) else cwd — then normalized to that
+    directory's git top-level. Run from inside a *linked* worktree,
+    :func:`worktree.git_root` returns that worktree's own root, which is
+    right: a worktree worker spawning a helper wants it sharing ITS files,
+    not the main checkout's. A non-git directory is fine and is left as-is —
+    a pane never required a repo either.
+    """
+    from .config import load_config as load_config_typed
+    from .session_cli import _resolve_project_arg
+
+    if project_arg:
+        base = _resolve_project_arg(project_arg, load_config_typed().projects.dir)
+    else:
+        base = Path(os.getcwd())
+    return git_root(base) or base
+
+
+def cmd_helper(args) -> int:
+    """Create a worker session that shares the caller's checkout.
+
+    Role is fixed to ``worker`` — there is no ``--kind``. A helper is
+    definitionally a subordinate, and an orchestrator persona co-resident in
+    someone else's working tree is the exact footgun the shared-dir guard
+    exists for.
+    """
+    json_mode = getattr(args, "json", False)
+
+    name = getattr(args, "name", None)
+    if not name:
+        return _output_result(False, json_mode, "Usage: agentwire helper <name> [-p <project>]")
+
+    checkout = _resolve_checkout(getattr(args, "project", None))
+    if not checkout.is_dir():
+        return _output_result(False, json_mode, f"Not a directory: {checkout}")
+
+    # User roles STACK on the safety rail; shared-checkout rides directly
+    # behind the intrinsic `worker` etiquette it amends.
+    user_roles = [r.strip() for r in (getattr(args, "roles", None) or "").split(",") if r.strip()]
+    roles = ",".join([SHARED_CHECKOUT_ROLE, *(r for r in user_roles if r != SHARED_CHECKOUT_ROLE)])
+
+    from .session_cli import cmd_new
+
+    return cmd_new(argparse.Namespace(
+        session=worktree_session_name(checkout, name),
+        path=str(checkout),
+        json=json_mode,
+        # `worker` + worktree_topology=False resolves to the `worker`
+        # etiquette (already written for "a standalone session on the same
+        # checkout"), and enrolls in the caller's cohort as topology "main"
+        # so `wait --children` collects the report and THEN kills it — the
+        # pane lifecycle, on a real session.
+        kind="worker",
+        worktree_topology=False,
+        # Declared intent, not an accident — see the module docstring.
+        allow_shared_dir=True,
+        force=False,
+        roles=roles,
+        posture=getattr(args, "posture", None),
+        model=getattr(args, "model", None),
+        first_message=getattr(args, "prompt", None),
+        env=getattr(args, "env", None),
+        created_by=getattr(args, "created_by", None),
+        caller_session=getattr(args, "caller_session", None),
+        no_cohort=getattr(args, "no_cohort", False),
+        no_soul=getattr(args, "no_soul", False),
+        # Branchless by construction: cmd_new errors loudly if these are set.
+        base=None,
+        pull_first=None,
+        bare=False,
+        prompted=False,
+        instructions=None,
+        persist=False,
+    ))
+
+
+def register_helper_parser(subparsers) -> None:
+    """Register ``agentwire helper``."""
+    p = subparsers.add_parser(
+        "helper",
+        help="Worker session sharing the current checkout — no worktree, no branch (#838)",
+    )
+    p.add_argument("name", nargs="?", help="Helper name (session becomes {project}-{name})")
+    p.add_argument("--project", "-p", help="Repo/dir to share (default: git root of cwd)")
+    p.add_argument("--prompt", help="First message to deliver once the session is ready")
+    p.add_argument("--roles", help="Extra roles (comma-separated) — STACK on the worker rail")
+    p.add_argument("--posture", help="Permission posture (default: bypass)")
+    p.add_argument("--model", help="Model override")
+    p.add_argument("--env", action="append", help="Env var KEY=VALUE (repeatable)")
+    p.add_argument("--created-by", help="Force the parent session ('' for a standalone root)")
+    p.add_argument("--caller-session", help="Override the detected calling session")
+    p.add_argument("--no-cohort", action="store_true", help="Skip fan-out cohort enrollment")
+    p.add_argument("--no-soul", action="store_true", help="Skip the soul personality role")
+    p.add_argument("--json", action="store_true", help="Output JSON")
+    p.set_defaults(func=cmd_helper)

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -21,6 +21,7 @@ New to AgentWire? Start here:
 How AgentWire runs AI agents — postures, REPLs, and permission models.
 
 - **[Worktree sessions](sessions/worktree-sessions.md)** — `agentwire worktree <name>`: isolated branch + worktree + standalone session for one unit of work; repo-derived base branch, naming templates, monorepo support, local branch↔session registry (`--list`/`--remove`/`--prune`/`--dangling`); `--kind orchestrator` / `agentwire orchestrator` for a durable project window on the same topology (role⟂topology, #716)
+- **[Helper sessions](sessions/helper-sessions.md)** — `agentwire helper <name>`: a worker session with NO isolation, sharing the caller's checkout (no worktree, no branch, no registry entry, zero git work at creation). Reproduces a worker pane's one real advantage on a real session — msg inbox, voice, prompt routing, portal visibility all included; the `shared-checkout` role holds the line at "files yours, git state theirs" (#838)
 - **[claude-code-auto-mode](sessions/claude-code-auto-mode.md)** — Auto mode posture with classifier safety net
 - **[Window sizing](sessions/window-sizing.md)** — how tmux `window-size` policies interact with the portal (v1.33+ behavior change, healing stuck windows, policy picker)
 - **[Custom services](services.md)** — registered long-running sessions: autostart on portal launch, watchdog health checks + restart with backoff, `agentwire services` CLI

--- a/docs/wiki/sessions/helper-sessions.md
+++ b/docs/wiki/sessions/helper-sessions.md
@@ -1,0 +1,103 @@
+# Helper sessions (no isolation)
+
+`agentwire helper <name>` creates a worker **session** that shares the caller's
+checkout — no `git worktree add`, no branch, no directory, no registry entry.
+
+This is the one thing a worker pane could do that a worktree session couldn't
+(#838). Everything else a pane offered was a regression: no `agentwire msg`
+inbox (#834), no voice, a headless exit-summary instead of report-back, no
+portal visibility. A helper is a real session, so it gets all of those for free.
+
+```bash
+agentwire helper digest --prompt "Run the full suite and tell me what fails"
+agentwire helper scout -p ~/projects/other-repo --prompt "Map the auth flow"
+```
+
+## What it is
+
+| | `agentwire worktree` | `agentwire helper` |
+|---|---|---|
+| Directory | new, `~/worktrees/<project>/<name>/` | **the caller's own checkout** |
+| Branch | new (or `--existing` / `--ref`) | **none** |
+| Git work at creation | `fetch` + `worktree add` + `checkout -b` + seed | **none** |
+| Worktree registry | registered | **not registered** — no git resource exists |
+| Teardown | `worktree --remove` (after merge verification, #756) | `agentwire kill` |
+| Cohort topology | `worktree` → `wait` leaves it alive | `main` → `wait` collects the report, then reaps it |
+| Role | `worker-worktree` | `worker` + `shared-checkout` |
+| msg inbox / voice / portal | yes | yes |
+
+Rooting, prompt routing, and `notify-parent` behave identically — a helper is
+by definition in the caller's own project, so it's parented like any
+same-project spawn (#715).
+
+## The safety model
+
+Two agents in one working tree is a real footgun, which is why
+`session_cli.cmd_new` has a shared-working-dir guard (#854/#857). `helper` does
+**not** weaken that guard — it *declares* past it with `allow_shared_dir=True`,
+the same posture `services.py` takes ("registering a service is explicit
+intent"). Interactive `agentwire new` is unaffected: it still refuses.
+
+What makes the sharing safe is the constraint the `shared-checkout` role puts on
+the agent:
+
+> **Files: yours. Git state: theirs.**
+
+Read and edit freely — editing the shared tree is the entire point. Never
+`commit`, `add`, `stash`, `checkout`, `branch`, `reset`, `rebase`, `pull`, or
+`push`. Concretely, on a tree someone else has in-flight work in:
+
+- `git commit -a` / `git add .` sweeps **their** unrelated edits into your commit.
+- `checkout` / `stash` / `reset` / `pull` / `rebase` rewrites the tree under
+  them, mid-edit.
+- You share one branch ref, so two committers interleave unrelated histories.
+- `.venv`, `node_modules`, build caches and fixed-port dev servers are shared
+  and raceable.
+
+`shared-checkout` stacks *after* the non-overridable `worker` rail
+(`["worker", "shared-checkout", …your --roles]`), so its "never mutate git
+state" corrects `worker.md`'s "commit your work" by recency weight. Your
+`--roles` stack on top of both; they never replace either.
+
+**If the task needs a commit, a branch, or a PR, it's the wrong session shape** —
+use `agentwire worktree <name>`.
+
+## Why nothing is written to the worktree registry
+
+The registry exists to catch one failure: a directory and a branch left on disk
+that nothing tracks (#837). A helper creates neither, and `agentwire kill`
+reclaims 100% of it.
+
+An entry pointing at the repo's own checkout would be a resource that doesn't
+exist, and the destructive verbs would eventually act on it: `--remove` resolves
+through `find_git_worktree`, which deliberately never returns the main checkout
+(#855/#862), so it could never resolve; `--prune` drops entries whose path is
+gone, and the main checkout never is, so the entry would accumulate forever.
+
+Helpers are visible where sessions are visible — `agentwire sessions`, the
+portal sidebar, `session_created` events. That's the session list; the worktree
+registry is not the session list.
+
+## Cost
+
+Measured on `agentwire-dev` (555 tracked files), warm:
+
+| | `agentwire worktree` | `agentwire helper` |
+|---|---|---|
+| `git fetch origin <base>` | ~750–900 ms (network) | — |
+| `git worktree add` | ~500–550 ms | — |
+| `git checkout -b` | ~170–260 ms | — |
+| seed gitignored files | ~50 ms | — |
+| **git total** | **~1.5–1.7 s** | **0 ms, 0 commands** |
+| files written to disk | 555 | 0 |
+
+Both then pay the same `tmux new-session`. The gap is structural, not tuning:
+the fetch is an unbounded network round-trip and `worktree add` is a full
+checkout. Use `worktree` when you need isolation — that cost buys a branch you
+can PR. Use `helper` when you don't.
+
+## See also
+
+- [Worktree sessions](worktree-sessions.md) — the isolated sibling
+- [Fan-out cohorts](fan-out-cohorts.md) — `wait --children` reaps helpers, leaves worktrees alive
+- [Polite messaging](messaging.md) — how a helper reports back

--- a/tests/unit/test_helper_session.py
+++ b/tests/unit/test_helper_session.py
@@ -1,0 +1,219 @@
+"""Unit tests for ``agentwire helper`` — the no-isolation worker session (#838).
+
+The feature is composition, so these tests pin the composition: what
+``cmd_helper`` hands ``cmd_new``, and the invariants that make sharing a
+checkout safe (guard declared, git untouched, registry untouched, the
+git-state constraint actually reaching the agent as a role).
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentwire import worktree_cli, worktree_registry
+from agentwire.roles import discover_role, resolve_roles
+from agentwire.worktree import worktree_session_name
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real git repo with one commit (so ``git worktree list`` works)."""
+    root = tmp_path / "myapp"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "a.py").write_text("x = 1\n")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=root, check=True)
+    return root
+
+
+@pytest.fixture
+def captured_new(monkeypatch):
+    """Replace ``session_cli.cmd_new`` and capture the args it's handed."""
+    from agentwire import session_cli
+
+    seen = {}
+
+    def fake_cmd_new(args):
+        seen["args"] = args
+        return 0
+
+    monkeypatch.setattr(session_cli, "cmd_new", fake_cmd_new)
+    return seen
+
+
+def _run(repo, captured_new, **kwargs):
+    import argparse
+    defaults = dict(name="digest", project=str(repo), json=True, prompt=None,
+                    roles=None, posture=None, model=None, env=None,
+                    created_by=None, caller_session=None, no_cohort=False,
+                    no_soul=False)
+    defaults.update(kwargs)
+    assert worktree_cli.cmd_helper(argparse.Namespace(**defaults)) == 0
+    return captured_new["args"]
+
+
+# --- worktree_session_name: SSOT for the flat {project}-{safe} convention ---
+
+class TestSessionName:
+    def test_flat_convention(self, tmp_path):
+        assert worktree_session_name(tmp_path / "myapp", "fix-bug") == "myapp-fix-bug"
+
+    def test_unsafe_chars_sanitized(self, tmp_path):
+        assert worktree_session_name(tmp_path / "myapp", "feat/ui: v2.0") == "myapp-feat-ui-v2-0"
+
+    def test_empty_after_sanitizing_falls_back(self, tmp_path):
+        assert worktree_session_name(tmp_path / "myapp", "///") == "myapp-wt"
+
+    def test_no_slash_so_cmd_new_cannot_read_it_as_a_branch(self, tmp_path):
+        # A "project/branch" name would send cmd_new down the worktree path —
+        # the exact thing this verb must never trigger.
+        from agentwire.worktree import parse_session_name
+        name = worktree_session_name(tmp_path / "myapp", "some/thing")
+        assert parse_session_name(name)[1] is None
+
+    @pytest.mark.parametrize("name", ["fix-bug", "feat/ui: v2.0", "///", "a b"])
+    def test_matches_cmd_worktree_inlined_copy(self, tmp_path, name):
+        """Byte-identical to session_cli.cmd_worktree's inlined derivation.
+
+        Pins the equivalence so collapsing those two lines to a call to this
+        function stays a safe no-op (see the #838 PR body).
+        """
+        project = tmp_path / "myapp"
+        inlined_safe = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+        assert worktree_session_name(project, name) == f"{project.name}-{inlined_safe}"
+
+
+# --- What cmd_helper hands cmd_new -----------------------------------------
+
+class TestComposition:
+    def test_shares_the_checkout_verbatim(self, repo, captured_new):
+        assert Path(_run(repo, captured_new).path) == repo
+
+    def test_session_named_by_the_shared_convention(self, repo, captured_new):
+        assert _run(repo, captured_new).session == "myapp-digest"
+
+    def test_role_is_worker_on_main_topology(self, repo, captured_new):
+        args = _run(repo, captured_new)
+        # kind=worker + worktree_topology=False selects `worker.md` (written
+        # for "a standalone session on the same checkout") and enrolls in the
+        # cohort as topology "main" — so `wait --children` reaps it.
+        assert args.kind == "worker"
+        assert args.worktree_topology is False
+
+    def test_declares_the_shared_dir_without_force(self, repo, captured_new):
+        args = _run(repo, captured_new)
+        assert args.allow_shared_dir is True
+        # --force would additionally kill-replace a live same-name session.
+        assert args.force is False
+
+    def test_branchless_flags_stay_none(self, repo, captured_new):
+        # cmd_new errors loudly if --base/--pull-first are set without a branch.
+        args = _run(repo, captured_new)
+        assert args.base is None and args.pull_first is None
+
+    def test_prompt_becomes_first_message(self, repo, captured_new):
+        assert _run(repo, captured_new, prompt="go").first_message == "go"
+
+    def test_rooting_and_cohort_left_to_cmd_new(self, repo, captured_new):
+        # A helper is in the caller's own project, so cmd_new's default
+        # created_by resolution parents it — no override here.
+        args = _run(repo, captured_new)
+        assert args.created_by is None
+        assert args.no_cohort is False
+
+
+class TestRoles:
+    def test_shared_checkout_role_is_injected(self, repo, captured_new):
+        assert _run(repo, captured_new).roles == "shared-checkout"
+
+    def test_user_roles_stack_behind_it(self, repo, captured_new):
+        assert _run(repo, captured_new, roles="react, wiki").roles == "shared-checkout,react,wiki"
+
+    def test_user_cannot_duplicate_it(self, repo, captured_new):
+        assert _run(repo, captured_new, roles="shared-checkout").roles == "shared-checkout"
+
+    def test_resolves_after_the_non_overridable_worker_rail(self):
+        # Recency weight: shared-checkout's "never mutate git state" lands
+        # after worker.md's "commit your work", which is wrong here.
+        assert resolve_roles(
+            "worker", worktree_topology=False, cli_roles=["shared-checkout"],
+        ) == ["worker", "shared-checkout"]
+
+    def test_role_file_is_discoverable(self):
+        assert discover_role("shared-checkout") is not None
+
+
+class TestCheckoutResolution:
+    def test_subdir_normalizes_to_the_git_root(self, repo, captured_new):
+        assert Path(_run(repo, captured_new, project=str(repo / "src")).path) == repo
+
+    def test_linked_worktree_shares_itself_not_the_main_checkout(self, repo, captured_new, tmp_path):
+        """A worktree worker spawning a helper wants it in ITS files."""
+        linked = tmp_path / "wt-feature"
+        subprocess.run(["git", "-C", str(repo), "worktree", "add", "-q",
+                        "-b", "feature", str(linked)], check=True)
+        assert Path(_run(repo, captured_new, project=str(linked)).path) == linked
+
+    def test_non_git_directory_is_allowed(self, tmp_path, captured_new):
+        plain = tmp_path / "notes"
+        plain.mkdir()
+        assert Path(_run(plain, captured_new, project=str(plain)).path) == plain
+
+    def test_missing_directory_fails(self, tmp_path, captured_new):
+        import argparse
+        rc = worktree_cli.cmd_helper(argparse.Namespace(
+            name="x", project=str(tmp_path / "nope"), json=True))
+        assert rc != 0
+        assert "args" not in captured_new
+
+    def test_name_is_required(self, repo, captured_new):
+        import argparse
+        assert worktree_cli.cmd_helper(argparse.Namespace(
+            name=None, project=str(repo), json=True)) != 0
+        assert "args" not in captured_new
+
+
+class TestNoGitFootprint:
+    """The whole premise: zero git operations, nothing to clean up."""
+
+    def test_creates_no_worktree_and_no_branch(self, repo, captured_new):
+        before_wt = subprocess.run(["git", "-C", str(repo), "worktree", "list"],
+                                   capture_output=True, text=True).stdout
+        before_br = subprocess.run(["git", "-C", str(repo), "branch", "--list"],
+                                   capture_output=True, text=True).stdout
+        _run(repo, captured_new)
+        after_wt = subprocess.run(["git", "-C", str(repo), "worktree", "list"],
+                                  capture_output=True, text=True).stdout
+        after_br = subprocess.run(["git", "-C", str(repo), "branch", "--list"],
+                                  capture_output=True, text=True).stdout
+        assert before_wt == after_wt
+        assert before_br == after_br
+
+    def test_writes_nothing_to_the_worktree_registry(self, repo, captured_new,
+                                                     tmp_path, monkeypatch):
+        # A registry entry pointing at the repo's OWN checkout is a resource
+        # that doesn't exist: --remove can't resolve it (find_git_worktree
+        # never returns the main checkout) and --prune can never drop it
+        # (the dir is always there). So nothing is written.
+        monkeypatch.setattr(worktree_registry, "REGISTRY_DIR", tmp_path / "registry")
+        _run(repo, captured_new)
+        assert worktree_registry.entries(repo) == []
+        assert worktree_registry.all_entries() == []
+
+    def test_leaves_the_shared_tree_untouched(self, repo, captured_new):
+        _run(repo, captured_new)
+        status = subprocess.run(["git", "-C", str(repo), "status", "--porcelain"],
+                                capture_output=True, text=True).stdout
+        assert status == ""
+
+
+def test_registered_on_the_cli():
+    from agentwire.__main__ import build_parser
+    args = build_parser().parse_args(["helper", "digest", "-p", "/tmp/x"])
+    assert args.func is worktree_cli.cmd_helper
+    assert args.name == "digest"


### PR DESCRIPTION
Ships `agentwire helper <name>` — a worker **session** that shares the caller's
checkout instead of getting its own. That is the one thing a worker pane can do
that a worktree session couldn't, so panes now have no remaining differentiator
(#836's option (a) becomes a clean follow-up).

Closes #838

---

# The design

## Variant chosen: share the caller's checkout directly. Zero git operations.

The session's cwd **is** the repo's own working tree (`git_root(cwd)`, or `-p`).
No `git worktree add`, no `git fetch`, no branch, no directory. Creation is one
`tmux new-session` — the same cost as a pane, because it does the same nothing.

### Rejected: a linked worktree on the *same branch*

Git refuses it outright (`fatal: 'main' is already checked out at ...`), so this
requires `--force`, which buys two checkouts of one ref: two indexes, two HEADs,
both able to commit onto the same branch. One commits and the other's tree has
moved under it.

More importantly it doesn't deliver the thing panes deliver. The pane property
is **"my edits are the orchestrator's files."** A same-branch linked worktree
puts your edits in a *different directory* the orchestrator can't see. And it
still costs a full checkout of disk, so it isn't even the fast option. Worse on
every axis — correctness, semantics, and speed.

### Rejected: a linked worktree detached at HEAD, no branch

That is still isolation — a separate directory. It's a normal worktree session
with the branch step skipped. It saves a `checkout -b` and solves none of what
panes solve.

## Rejected: registering it in the worktree registry

The issue asks for "registry visibility". I think that's the wrong instinct and
did not build it.

The registry exists to prevent exactly one failure: **a directory and a branch
left on disk that nothing tracks** (#837). A no-isolation session creates
neither. `agentwire kill <session>` reclaims 100% of it. An entry whose
`worktree_path` is the repo's own checkout is a lie the destructive verbs would
eventually act on:

- `--remove` resolves through `find_git_worktree`, which post-#862 *deliberately*
  never returns the main checkout — so it would fail-unresolved, permanently.
- `--prune` drops entries whose path is gone. The main checkout is never gone, so
  the entry would accumulate forever with no way to clear it.
- `--dangling` looks for an open PR on the entry's branch. There is no branch.

Registering would have bought three new special-cases in `session_cli.py`'s
teardown verbs to describe a resource that doesn't exist. The issue's actual
verification bullet — *"shows up in normal session listing/dashboard like any
worktree session"* — is satisfied by it **being** an ordinary tmux session:
`agentwire sessions`, the portal sidebar, `session_created` events, session
metadata. That's the session list. The worktree registry is not the session list.

## What breaks when two sessions share one checkout

This is why the shared-working-dir guard exists, and #857 was right not to
weaken it. Concretely:

| Hazard | Effect on the co-resident session |
|---|---|
| `git checkout` / `switch` / `stash` / `reset` / `rebase` / `pull` | the tree is rewritten under it, mid-edit |
| `git commit -a`, `git add .` | sweeps the *other* agent's unrelated in-flight edits into this commit |
| both on one branch ref | two agents interleave unrelated commits onto one history |
| `.venv`, `node_modules`, build caches, a dev server on a fixed port | shared and raceable |

Note what is **not** on that list: editing files. Editing the same tree is the
whole point — it's the pane property. The hazard is **git state mutation**, not
file mutation. That distinction is the design.

So the variant carries two things:

**1. It declares the shared dir rather than disarming the guard.**
`cmd_helper` passes `allow_shared_dir=True` — the same posture as `services.py`
("registering a service is explicit intent") and #857's dispatch derivation.
`agentwire helper` *is* the sentence "put a second agent in this tree"; it is
declared, never the accident the guard was written for. Deliberately **not**
`--force`, which would additionally kill-replace a live same-name session. The
guard stays fully armed for interactive `agentwire new`, untouched.

**2. A new `shared-checkout` role states the constraint.**
Read freely, edit freely, run anything — never mutate git state; the checkout's
owner commits. This is the rule a branchless pane has always operated under
without anyone having written it down.

It's needed for a real reason, not polish: the existing `worker.md` says
"**Commit your work** — if the task involves code changes", which is actively
wrong in a shared tree. `shared-checkout` stacks *after* `worker` on the
non-overridable safety rail (`resolve_roles` → `["worker", "shared-checkout",
…user]`), so recency weight corrects it. **No change to `roles/__init__.py`** —
this uses the existing stacking contract exactly as designed, rather than adding
a third value to the topology axis.

## Role: `worker`, not `worker-worktree` — already written

`worker.md` already opens with *"a pane sharing its dashboard, **or a standalone
session on the same checkout (no separate worktree)**"*, and its exit-summary
section already branches on precisely that case. So `resolve_roles("worker",
worktree_topology=False)` → `["worker"]` is correct as-is. Nothing to add.

`worktree_topology=False` also lands the rest of the lifecycle correctly for
free, because the existing machinery keys on it:

- **Cohort** enrolls it as `topology="main"`, so `agentwire wait --children`
  collects its report **and kills it** — instead of `left_alive`, which is
  reserved for children holding a branch/open PR. That is the pane lifecycle,
  restored on a real session.
- **Rooting**: a helper is by definition in the caller's own project, so
  `resolve_default_created_by` parents it. Prompt routing and `notify-parent`
  work with no special case.
- **msg inbox**, voice, and the portal dashboard come free from being a session
  — the three things #834/#836 identified as straight regressions in panes.

## Surface: a sugar verb, not `worktree --no-isolation`

The issue floated `worktree --no-isolation`. Rejected: that verb's entire job is
git worktrees, and **every** one of its management flags — `--list`, `--prune`,
`--remove`, `--dangling`, `--status`, `--base`, `--existing`, `--ref` — is
meaningless for a session with no worktree. A flag that invalidates eight
sibling flags wants to be a verb.

`agentwire helper` reads alongside `agentwire worktree` / `agentwire
orchestrator` as the third answer to "spawn me a child session of shape X".

**Naming is the one thing I'd happily change in review** — the issue said TBD.
`helper` / `sidekick` / `hand` are all fine; the mechanism doesn't care.

**It is not a sixth creation path.** `cmd_helper` creates nothing. It resolves a
directory, derives a session name, and delegates to `cmd_new` — the one session
creation path — exactly as `cmd_orchestrator` delegates to `cmd_worktree`. The
entire diff is composition.

---

# Timing (the issue asked for a comparison)

Measured on this repo (555 tracked files), warm, 3 runs. Both variants then pay
the same `tmux new-session`, so it's excluded from both sides — what's left is
exactly the git work `helper` skips:

| step | `agentwire worktree` | `agentwire helper` |
|---|---|---|
| `git fetch origin <base>` | 903 / 744 / 759 ms | — |
| `git worktree add` | 498 / 551 / 513 ms | — |
| `git checkout -b` | 260 / 173 / 217 ms | — |
| seed gitignored files | 58 / 51 / 47 ms | — |
| **git total** | **1719 / 1519 / 1536 ms** | **0 ms — 0 commands** |
| files written to disk | 555 | 0 |

The gap is structural, not tuning: the fetch is an unbounded network round-trip
and `worktree add` is a full checkout of every tracked file. `helper` runs no
git at all.

# Verified live

Run end-to-end in this worktree, which my own session already occupies — so it
also exercises the guard bypass for real:

```
$ python -m agentwire new -s probe-guard -p . --json      # ← guard must refuse
{"success": false, "error": "Refusing to attach session 'probe-guard' to
 /Users/.../fix-838-no-isolation: already the working directory of active
 session(s): agentwire-dev-fix-838-no-isolation. ..."}

$ python -m agentwire helper probe --no-cohort --json     # ← declares past it
{"success": true, "session": "fix-838-no-isolation-probe",
 "path": "/Users/.../fix-838-no-isolation", "branch": null}
```

Confirmed on the live session before teardown:

- pane cwd **is** the shared checkout
- `git worktree list` and `git branch` **unchanged**; `git status` shows only
  this PR's own edits — zero footprint
- **no** worktree-registry entry written
- `AGENTWIRE_CREATED_BY=agentwire-dev-fix-838-no-isolation` — parented, so
  prompt routing and `notify-parent` work
- the `shared-checkout` role text (*"Files: yours. Git state: theirs."*,
  *"no worktree and no branch of your own"*) is present in the running agent's
  system prompt
- `agentwire kill -s fix-838-no-isolation-probe` reclaimed everything — which is
  the whole "no registry entry needed" argument, demonstrated

Full suite green: **3026 passed** (29 of them new).

---

# Files

| File | Change |
|---|---|
| `agentwire/worktree_cli.py` | **new** — `cmd_helper` + registrar (~90 lines, all composition) |
| `agentwire/roles/shared-checkout.md` | **new** — the never-mutate-git-state contract |
| `agentwire/worktree.py` | `+worktree_session_name()` — SSOT for the flat `{project}-{safe}` convention |
| `agentwire/__main__.py` | import + one `_REGISTRARS` line |
| `docs/wiki/sessions/helper-sessions.md` | **new** — reference (+ 1 line in `INDEX.md`) |
| `.claude/skills/agentwire-cli/SKILL.md` | the verb, so agents can find it |
| `tests/unit/test_helper_session.py` | **new** — 29 tests |

`agentwire/worktree_registry.py` is **unchanged** — that's the "rejected:
registering it" decision above, not an oversight.

# One-line hook another session needs (NOT made here)

`session_cli.py` is owned by #840 this pass, so I didn't touch it. There is one
optional SSOT cleanup available whenever it's free:

`cmd_worktree` inlines the session-name convention at `session_cli.py:986-987`:

```python
safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
session_name = f"{project_name}-{safe_name}"
```

That is now `worktree.worktree_session_name(project_path, name)`, which
`worktree_cli.py` uses. Collapsing those two lines to the call would give the
convention one implementation. `worktree_session_name` is byte-identical to the
inlined version and is tested against it, so this is safe to do or skip — the
feature does not depend on it.

# Deliberately NOT built

- **Removing worker panes.** #836's option (a), explicitly out of scope in #838.
  This clears the blocker; it isn't the follow-up.
- **Registry integration** — argued against above.
- **`agentwire spawn` → `helper` aliasing.** Panes still work exactly as before.
  Re-pointing `spawn` is a migration decision that belongs with the removal
  issue, not with shipping the replacement.
- **A `topology="shared"` third value** on the registry/cohort axis. `main`
  already means "no worktree", which is the truth here, and every consumer
  (`cohort._teardown`, `resolve_roles`) already does the right thing with it.
  A third value would have been three special-cases buying nothing.
- **Remote (`@machine`) helpers.** `--project` is local-only; the shared-checkout
  reasoning is about one filesystem.
- **`--kind` on `helper`.** A helper is definitionally a worker. An orchestrator
  persona co-resident in a shared checkout is the exact footgun the guard exists
  for, so the kind is fixed rather than exposed.

Built by dotdev.dev
