### PR TITLE
refactor(worktree): one implementation of the worktree-name sanitizer

### DIFF
--- a/agentwire/session_cli.py
+++ b/agentwire/session_cli.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import datetime
 import json
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -70,6 +69,7 @@ from .worktree import (
     parse_session_name,
     register_worktree,
     remove_worktree,
+    safe_worktree_name,
     worktree_status,
 )
 
@@ -1043,7 +1043,7 @@ def cmd_worktree(args) -> int:
     # branch may be templated separately via worktree.naming. The worktree
     # nests per project — ~/worktrees/<project>/<name>/ — mirroring
     # ~/projects/<project>/; the tmux session name stays flat {project}-{name}.
-    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+    safe_name = safe_worktree_name(name)
     session_name = f"{project_name}-{safe_name}"
     worktree_path = worktree_dir / project_name / safe_name
 
@@ -1473,7 +1473,7 @@ def _resolve_worktree_entry(name: str, project_path: Path, worktree_dir: Path) -
 
     # No registry entry — ask git directly. Covers hand-created worktrees,
     # pre-registry ones, and any layout that isn't the documented default.
-    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+    safe_name = safe_worktree_name(name)
     if safe_name.startswith(f"{project_name}-"):
         safe_name = safe_name[len(project_name) + 1:]
 

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -160,6 +160,17 @@ def is_git_repo(path: Path) -> bool:
     return (path / ".git").exists()
 
 
+def safe_worktree_name(name: str) -> str:
+    """Sanitize ``name`` into the token used for session names and directories.
+
+    Separators that would be read as path or session structure collapse to
+    ``-``; an empty result falls back to ``wt``. Callers need this on its own
+    (not just via :func:`worktree_session_name`) because the same token also
+    names the worktree directory.
+    """
+    return re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
+
+
 def worktree_session_name(project_path: Path, name: str) -> str:
     """tmux session name for a child session on ``project_path``.
 
@@ -167,13 +178,8 @@ def worktree_session_name(project_path: Path, name: str) -> str:
     shares — deliberately NOT ``project/name``, which
     :func:`parse_session_name` would read as a branch (and which ``cmd_new``
     would then try to build a worktree for).
-
-    One convention, one implementation: ``agentwire helper`` (#838) calls
-    this, and ``session_cli.cmd_worktree`` inlines a byte-identical copy that
-    can collapse to this call whenever that file is free to edit.
     """
-    safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
-    return f"{Path(project_path).name}-{safe_name}"
+    return f"{Path(project_path).name}-{safe_worktree_name(name)}"
 
 
 def ensure_worktree(


### PR DESCRIPTION
## Why

#864 (merged minutes ago) added `worktree.worktree_session_name()` and flagged that `session_cli.cmd_worktree` inlined a byte-identical copy of the sanitizer, deferring the collapse because `session_cli.py` was owned by #840 at the time. That file is free now.

## The suggested collapse didn't work as described

#864 proposed replacing these two lines with a `worktree_session_name()` call:

```python
safe_name = re.sub(r"[\s/:.]+", "-", name).strip("-") or "wt"
session_name = f"{project_name}-{safe_name}"
```

But `safe_name` is used **again on the next line** — the same token names the worktree *directory*, not just the session:

```python
worktree_path = worktree_dir / project_name / safe_name
```

Collapsing only the session name would have left the regex inlined anyway. And there was a **second** inlined copy the note didn't mention, at the resolve-by-asking-git path, where it strips a project prefix.

So the single source of truth is the **sanitizer**, not the session name.

## What changed

| | |
|---|---|
| `worktree.safe_worktree_name()` | **new** — the sanitizer, extracted |
| `worktree.worktree_session_name()` | now calls it instead of re-implementing |
| `session_cli.py` × 2 | both inlined copies route through it |
| `session_cli.py` | `import re` dropped — those were its last uses |

Three occurrences → one. Behavior is unchanged: `safe_worktree_name` is the same expression the three sites already ran.

## Verification

`ruff check agentwire/` clean. 182 passed across `test_helper_session`, `test_worktree_layout`, `test_worktree_git_truth`, `test_cli_commands`, `test_worktree_cmd` — the suites covering all three call sites and the helper.

Built by [dotdev.dev](https://dotdev.dev)