### PR TITLE
fix(sessions): carry the pane launch command in the env, not keystrokes (#856)

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -968,6 +968,28 @@ def _guarded_launch_command(path_str: str, agent_cmd: str | None) -> str:
     return f"{guard} && {agent_cmd}" if agent_cmd else guard
 
 
+# The pane's launch command travels as an ENV VAR, not as keystrokes (#856).
+#
+# `send-keys` fires 0.1s after `tmux new-session`, before the shell has put
+# its tty into raw mode, so the keystrokes land in the tty's CANONICAL-mode
+# input buffer — which is capped at 1024 bytes per line on macOS
+# (MAX_CANON/`N_TTY_BUF_SIZE`; Linux is 4096). Everything past the cap is
+# discarded SILENTLY, and since the launch line ends in
+# `--append-system-prompt "$(</tmp/…)"`, a truncated one is syntactically
+# incomplete: zsh sits at a continuation prompt forever, `claude` never runs,
+# and the session is a bare shell that `wait_for_session_ready` can only
+# report as "Agent not running". #742/#743 grew `_guarded_launch_command` by
+# ~700 chars, which pushed long-named worktree sessions (the scheduler's
+# `scheduler-<task>-<timestamp>`, whose path is interpolated FOUR times) over
+# the cap — deterministically, since the length is a pure function of the
+# session name.
+#
+# tmux `-e` is not keyboard input, so it has no such cap. Sending a fixed
+# ~70-char `eval` line instead makes the launch length-independent.
+LAUNCH_CMD_ENV = "AGENTWIRE_LAUNCH_CMD"
+_LAUNCH_EVAL = f'eval "${{{LAUNCH_CMD_ENV}:?agentwire: launch command not injected}}"'
+
+
 def _launch_tmux_session(
     session_name: str,
     session_path,
@@ -980,9 +1002,14 @@ def _launch_tmux_session(
     The one launch sequence shared by ``new`` / ``recreate`` / ``fork`` (#630):
     `tmux new-session -e K=V` injects *env* into the session environment
     BEFORE the initial shell starts (post-hoc `set-environment` never reaches
-    it), then `send-keys` cd's into place (guarded — see
-    ``_guarded_launch_command``) and, if *agent_cmd* is non-empty, starts the
-    agent after a short settle.
+    it), then `send-keys` runs the guarded launch line (see
+    ``_guarded_launch_command``) which cd's into place and, if *agent_cmd* is
+    non-empty, starts the agent after a short settle.
+
+    That launch line rides in as ``AGENTWIRE_LAUNCH_CMD`` and is `eval`'d by
+    the pane, rather than being typed out in full — see
+    :data:`LAUNCH_CMD_ENV` for why typing it is length-limited and fails
+    silently.
 
     Local (machine_id None): runs subprocess calls with check=True (raises on
     tmux failure) and returns None. Remote: runs one composite shell command
@@ -992,23 +1019,25 @@ def _launch_tmux_session(
 
     path_str = str(session_path)
     launch_cmd = _guarded_launch_command(path_str, agent_cmd)
+    # Copy, never mutate: callers reuse `agent.env` after the launch.
+    launch_env = {**env, LAUNCH_CMD_ENV: launch_cmd}
     if machine_id:
-        env_flags = _build_tmux_env_flags_shell(env)
+        env_flags = _build_tmux_env_flags_shell(launch_env)
         create_cmd = (
             f"tmux new-session -d -s {shlex.quote(session_name)} -c {shlex.quote(path_str)} {env_flags}&& "
             f"sleep 0.1 && "
-            f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(launch_cmd)} Enter"
+            f"tmux send-keys -t {shlex.quote(session_name)} {shlex.quote(_LAUNCH_EVAL)} Enter"
         )
         return _run_remote(machine_id, create_cmd)
 
     subprocess.run(
         ["tmux", "new-session", "-d", "-s", session_name, "-c", path_str,
-         *_build_tmux_env_flags(env)],
+         *_build_tmux_env_flags(launch_env)],
         check=True,
     )
     time.sleep(0.1)
     subprocess.run(
-        ["tmux", "send-keys", "-t", session_name, launch_cmd, "Enter"],
+        ["tmux", "send-keys", "-t", session_name, _LAUNCH_EVAL, "Enter"],
         check=True,
     )
     return None

--- a/agentwire/ensure_cli.py
+++ b/agentwire/ensure_cli.py
@@ -430,6 +430,39 @@ def _create_task_pr(project_path, task, work_branch, last_summary, json_mode) ->
     return pr_url
 
 
+def _pane_diagnosis(session: str, pane_index: int = 0) -> str:
+    """A one-line "what is that pane actually doing" for a readiness failure.
+
+    ``Agent not running in session '<name>'`` on its own is unactionable, and
+    the session it names is usually GONE by the time a human reads it — the
+    zombie reaper kills a bare-shell scheduler session 60s later (#739), so
+    the scrollback that would explain the failure is destroyed before anyone
+    looks. #856 sat unexplained for 17 nightly runs behind exactly that.
+
+    Returns ``pane=<current command>, last: <last non-empty rendered line>``,
+    or ``""`` if tmux can't answer (the caller then reports the bare message).
+    """
+    parts: list[str] = []
+    try:
+        r = subprocess.run(
+            ["tmux", "list-panes", "-t", f"={session}", "-F", "#{pane_current_command}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        cmds = [c for c in r.stdout.strip().splitlines() if c] if r.returncode == 0 else []
+        if cmds:
+            parts.append(f"pane={','.join(cmds)}")
+    except Exception:
+        pass
+    try:
+        capture = pane_manager.capture_pane(session, pane_index, lines=40)
+        tail = [ln.rstrip() for ln in capture.splitlines() if ln.strip()]
+        if tail:
+            parts.append(f"last: {tail[-1].strip()[:200]}")
+    except Exception:
+        pass
+    return ", ".join(parts)
+
+
 def _dispatch_shares_dir(task) -> bool:
     """Whether this dispatch may attach its session to a working dir another
     session already occupies (#854).
@@ -549,10 +582,16 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
             print("Waiting for agent to be ready...")
         from agentwire.session_ready import wait_for_session_ready
         if not wait_for_session_ready(session, timeout=30):
-            # Agent never started — session is dead, bail out
+            # Agent never started — session is dead, bail out. Say WHY while
+            # the pane still exists to be asked (#856): the reaper deletes
+            # the evidence a minute later.
+            diagnosis = _pane_diagnosis(session)
+            message = f"Agent not running in session '{session}'"
+            if diagnosis:
+                message = f"{message} ({diagnosis})"
             if not json_mode:
                 print(f"Agent not ready in session '{session}' after 30s")
-            return _output_result(False, json_mode, f"Agent not running in session '{session}'", exit_code=ENSURE_EXIT_SESSION_ERROR)
+            return _output_result(False, json_mode, message, exit_code=ENSURE_EXIT_SESSION_ERROR)
 
         # Set up work branch if starting_ref is configured
         work_branch = None

--- a/agentwire/scheduler/zombie.py
+++ b/agentwire/scheduler/zombie.py
@@ -80,7 +80,29 @@ def scan() -> list[dict]:
     return zombies
 
 
-def _notify(session: str, branch: str, command: str) -> None:
+def _pane_tail(session: str, lines: int = 3) -> str:
+    """The last few rendered lines of a zombie's pane, joined with ' / '.
+
+    Captured BEFORE the kill, because the kill is what destroys the only
+    record of why the launch never reached its agent (#856: a launch line
+    truncated at the tty's canonical-input cap left an unterminated
+    `--append-system-prompt "$(<…` sitting at a continuation prompt — visible
+    here, invisible everywhere else). Best-effort: "" when tmux can't answer.
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", f"={session}", "-p", "-S", "-40"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return ""
+        rendered = [ln.rstrip() for ln in result.stdout.splitlines() if ln.strip()]
+        return " / ".join(ln.strip()[:200] for ln in rendered[-lines:])
+    except Exception:
+        return ""
+
+
+def _notify(session: str, branch: str, command: str, pane_tail: str = "") -> None:
     """Alert on a reaped zombie session (#739 + #743).
 
     Always posts a portal toast, so the reap is visible in-band rather than
@@ -100,6 +122,8 @@ def _notify(session: str, branch: str, command: str) -> None:
         f"`{branch}`) — launch crashed at a bare shell (`{command}`) before "
         "the agent started."
     )
+    if pane_tail:
+        text += f" Pane tail: {pane_tail}"
 
     try:
         from ..core import _post_desktop_notification
@@ -135,7 +159,8 @@ def _notify(session: str, branch: str, command: str) -> None:
                 "failure mode where the worktree launch crashes before "
                 "`claude` starts (e.g. a missing worktree directory). The "
                 "watchdog killed the session so it can't linger.\n\n"
-                "Check the scheduler events log for the originating "
+                + (f"Pane tail before the kill:\n\n    {pane_tail}\n\n" if pane_tail else "")
+                + "Check the scheduler events log for the originating "
                 "dispatch failure."
             ),
         )
@@ -149,11 +174,14 @@ def reap() -> dict:
 
     killed = []
     for z in scan():
+        # Read the pane BEFORE killing it — the kill is what erases the only
+        # evidence of why the launch never reached its agent (#856).
+        pane_tail = _pane_tail(z["session"])
         _sched._kill_session(z["session"])
         _sched._log_event("zombie_session_reaped", session=z["session"],
                           branch=z["branch"], command=z["command"],
-                          age_seconds=z["age_seconds"])
-        _notify(z["session"], z["branch"], z["command"])
+                          age_seconds=z["age_seconds"], pane_tail=pane_tail)
+        _notify(z["session"], z["branch"], z["command"], pane_tail)
         killed.append(z["session"])
     return {"killed": killed}
 

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -93,7 +93,7 @@ Implementation reference for contributors and advanced users.
 - **[Session topology](internals/session-topology.md)** — parent→child visualization: born-from-parent ghost placement, the shared `TopologyView` renderer + its Session Workspace window and phantom-overlay mounts, lineage-tinted/hierarchy-grouped collage, live `session_created` appearance, and the shared design tokens behind all of it
 - **[Large parallel refactors](internals/parallel-refactor.md)** — splitting a huge file across parallel worktrees: positional-interleaving conflicts, regenerate-against-fresh-base + sequential merges, foundation-first, verification discipline
 - **[Window collage](internals/window-collage.md)** — Mission Control overlay: preview-tile architecture + why mutating real WinBox windows can never work
-- **[Shell escaping](internals/shell-escaping.md)** — how complex strings cross tmux boundaries
+- **[Shell escaping](internals/shell-escaping.md)** — how complex strings cross tmux boundaries (incl. the 1024-byte cap on anything typed into a fresh pane)
 - **[Damage control](internals/damage-control.md)** — safety hooks: rules, patterns, audit log
 - **[Troubleshooting](internals/troubleshooting.md)** — common issues and fixes
 

--- a/docs/wiki/internals/shell-escaping.md
+++ b/docs/wiki/internals/shell-escaping.md
@@ -107,6 +107,66 @@ The temp file path is returned on `AgentCommand.temp_file` so the caller can cle
 
 ---
 
+## The Second Trap: the launch line has a 1024-byte ceiling (#856)
+
+The temp-file trick keeps the launch line *short-ish*, not short. It still has
+to be **typed** into the pane, and the pane's tty imposes a hard per-line cap
+that has nothing to do with quoting.
+
+`_launch_tmux_session` fires `send-keys` 0.1s after `tmux new-session` —
+before the shell has switched its tty out of **canonical (cooked) mode**. In
+canonical mode the line discipline buffers input until a newline, and that
+buffer is capped: **1024 bytes on macOS** (`MAX_CANON` / `N_TTY_BUF_SIZE`;
+Linux is 4096). Everything past the cap is discarded **silently** — no error,
+no partial-write signal.
+
+Because the launch line ends in `--append-system-prompt "$(<…)"`, a truncated
+one is syntactically incomplete. zsh parks at a continuation prompt, `claude`
+never runs, and the session is a **bare shell** — the exact zombie shape
+`agentwire/scheduler/zombie.py` reaps, and all `ensure` can say is
+`Agent not running in session '<name>'`.
+
+Measured (2026-08-03, `tmux send-keys` 0.1s after `new-session`, macOS):
+
+| Typed line length | Arrives intact? |
+|---|---|
+| 500 / 1000 / 1024 | yes |
+| 1045 / 1200 / 1500 | **no — tail silently dropped** |
+
+After the shell settles (~1s+, ZLE has the tty in raw mode) the cap is gone
+and a 1500-char line lands fine. That's why the bug reads as flaky and why it
+tracks *session name length*: #742/#743 grew `_guarded_launch_command` by
+~700 chars (it interpolates the worktree path **four** times), so a scheduler
+worktree with a long name — `scheduler-ai-morning-briefing-<timestamp>` —
+crossed 1024 while `scheduler-weekly-stars-<timestamp>` stayed under it. Same
+code, one task broken every night, the rest fine.
+
+### The fix: carry the command in the env, don't type it
+
+`tmux new-session -e K=V` is protocol data, not keyboard input, so it has no
+tty cap. The launch line rides in as `AGENTWIRE_LAUNCH_CMD` and the pane is
+sent a fixed ~70-char line instead:
+
+```python
+LAUNCH_CMD_ENV = "AGENTWIRE_LAUNCH_CMD"
+_LAUNCH_EVAL = f'eval "${{{LAUNCH_CMD_ENV}:?agentwire: launch command not injected}}"'
+```
+
+The typed line's length is now **independent of** the path, the posture flags,
+the model override, and the role temp-file path. `:?` makes a missing var
+loud instead of another silent bare shell.
+
+**Why not `paste-buffer`?** A buffer paste goes through the same pane input
+path and hits the same cap. It's the right tool for prompts sent to a
+*running* Claude (raw mode — see `pane_manager.send_to_target`), not for the
+pre-agent shell.
+
+**Rule for new code:** never type anything of unbounded length into a
+freshly-created pane. Inject it (`-e`) and `eval`, or write it to a file and
+`source` it.
+
+---
+
 ## Testing Shell Escaping
 
 When debugging escaping issues:
@@ -157,8 +217,10 @@ tmux send-keys -t test $'echo "hello\nworld"' Enter
 ### Debug checklist
 
 - [ ] Does `pgrep` show the process running?
-- [ ] Does `tmux capture-pane` show `quote>` prompts?
-- [ ] Is the command under ~8KB total length?
+- [ ] Does `tmux capture-pane` show `quote>` prompts, or a line that just
+      *stops* mid-token? (Truncation, not quoting — see the 1024-byte cap.)
+- [ ] Is the line **typed into a fresh pane** under 1024 bytes? Anything
+      longer must be injected via `-e` + `eval`, not typed.
 - [ ] Are there any unescaped special characters?
 
 ---

--- a/tests/unit/test_ensure_shared_dir.py
+++ b/tests/unit/test_ensure_shared_dir.py
@@ -6,6 +6,8 @@ always False and any live session sitting in the task's project dir killed every
 dispatch into it.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from agentwire import ensure_cli
@@ -95,3 +97,39 @@ def test_dispatch_passes_allow_shared_dir_for_branchless_task(captured_new_args)
 def test_dispatch_keeps_guard_for_git_task(captured_new_args):
     args = captured_new_args(_task(starting_ref="main"))
     assert args.allow_shared_dir is False
+
+
+class TestPaneDiagnosis:
+    """#856: `Agent not running in session '<name>'` names a session that the
+    zombie reaper deletes 60s later — the message must carry the evidence."""
+
+    def test_reports_pane_command_and_last_line(self, monkeypatch):
+        monkeypatch.setattr(
+            ensure_cli.subprocess, "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="zsh\n"),
+        )
+        monkeypatch.setattr(
+            ensure_cli.pane_manager, "capture_pane",
+            lambda *a, **k: 'cd /tmp/wt && claude \\\n\n  --append-system-prompt "$(</var/f\n',
+        )
+        out = ensure_cli._pane_diagnosis("proj/scheduler-a-1")
+        assert "pane=zsh" in out
+        assert "--append-system-prompt" in out
+
+    def test_degrades_to_empty_when_tmux_cannot_answer(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("no tmux")
+
+        monkeypatch.setattr(ensure_cli.subprocess, "run", boom)
+        monkeypatch.setattr(ensure_cli.pane_manager, "capture_pane", boom)
+        assert ensure_cli._pane_diagnosis("proj/scheduler-a-1") == ""
+
+    def test_long_lines_are_truncated(self, monkeypatch):
+        monkeypatch.setattr(
+            ensure_cli.subprocess, "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout=""),
+        )
+        monkeypatch.setattr(
+            ensure_cli.pane_manager, "capture_pane", lambda *a, **k: "x" * 5000,
+        )
+        assert len(ensure_cli._pane_diagnosis("s")) < 300

--- a/tests/unit/test_launch_via_env.py
+++ b/tests/unit/test_launch_via_env.py
@@ -1,0 +1,106 @@
+"""`_launch_tmux_session` must not TYPE the launch line into the pane (#856).
+
+`send-keys` fires 0.1s after `tmux new-session`, before the shell has put its
+tty into raw mode, so the keystrokes land in the tty's canonical-mode input
+buffer — capped at 1024 bytes per line on macOS. Past the cap the tail is
+discarded silently, and a launch line ending in
+`--append-system-prompt "$(</tmp/…)"` truncates into something syntactically
+incomplete: zsh waits at a continuation prompt forever and `claude` never
+runs. The fix carries the line in as an env var (`tmux -e`, not keyboard
+input) and types a fixed-length `eval` instead.
+"""
+
+from unittest.mock import patch
+
+from agentwire.core import (
+    LAUNCH_CMD_ENV,
+    _guarded_launch_command,
+    _launch_tmux_session,
+)
+
+# macOS `MAX_CANON` / `N_TTY_BUF_SIZE`: the per-line cap on canonical-mode tty
+# input. The whole point of the fix is that the typed line stays far under it
+# no matter how long the real launch command gets.
+TTY_CANON_LIMIT = 1024
+
+
+def _local_calls(session="proj/branch", path="/tmp/wt", env=None, agent="claude --flag"):
+    """Run a local launch with tmux mocked; return the two subprocess argvs."""
+    with patch("agentwire.core.subprocess.run") as run, \
+            patch("time.sleep"):
+        _launch_tmux_session(session, path, dict(env or {}), agent)
+    return [call.args[0] for call in run.call_args_list]
+
+
+class TestLaunchCommandTravelsAsEnv:
+    def test_send_keys_payload_is_short_and_fixed_length(self):
+        """The typed line's length must not depend on the launch command."""
+        short = _local_calls(path="/tmp/a", agent="claude")[1]
+        long_path = "/Users/dotdev/projects/agentwire-dev-worktrees/" + "x" * 300
+        long_cmd = 'claude --dangerously-skip-permissions --append-system-prompt "$(</var/folders/xx/yy/T/tmp1234.txt)"'
+        long = _local_calls(path=long_path, agent=long_cmd)[1]
+
+        typed_short = short[short.index("send-keys") + 4]
+        typed_long = long[long.index("send-keys") + 4]
+        assert typed_short == typed_long
+        assert len(typed_long) < 200
+
+    def test_real_world_length_would_have_blown_the_tty_cap(self):
+        """Regression anchor: the exact #856 shape exceeds 1024 typed chars."""
+        path = ("/Users/dotdev/projects/agentwire-dev-worktrees/"
+                "scheduler-ai-morning-briefing-20260803-100520")
+        agent = ('claude --dangerously-skip-permissions --append-system-prompt '
+                 '"$(</var/folders/1d/g63f4vld5x79q6m_swhxjpb0000gn/T/tmpabcd1234.txt)"')
+        assert len(_guarded_launch_command(path, agent)) > TTY_CANON_LIMIT
+
+        calls = _local_calls(path=path, agent=agent)
+        typed = calls[1][calls[1].index("send-keys") + 4]
+        assert len(typed) < TTY_CANON_LIMIT
+
+    def test_launch_command_is_injected_as_env_flag(self):
+        path = "/tmp/wt"
+        agent = "claude --flag"
+        create = _local_calls(path=path, agent=agent)[0]
+        expected = _guarded_launch_command(path, agent)
+        assert f"{LAUNCH_CMD_ENV}={expected}" in create
+
+    def test_typed_line_evaluates_the_injected_var(self):
+        typed = _local_calls()[1][-2]
+        assert LAUNCH_CMD_ENV in typed
+        assert typed.startswith("eval ")
+        # A missing var must be loud, not a silent bare shell.
+        assert ":?" in typed
+
+    def test_caller_env_is_not_mutated(self):
+        env = {"AGENTWIRE_SESSION_NAME": "proj/branch"}
+        _local_calls(env=env)
+        assert LAUNCH_CMD_ENV not in env
+
+    def test_other_env_vars_still_injected(self):
+        create = _local_calls(env={"FOO": "bar"})[0]
+        assert "FOO=bar" in create
+
+    def test_bare_posture_still_routed_through_env(self):
+        """No agent command still means a guarded cd — carried the same way."""
+        with patch("agentwire.core.subprocess.run") as run, \
+                patch("time.sleep"):
+            _launch_tmux_session("s", "/tmp/wt", {}, None)
+        create = run.call_args_list[0].args[0]
+        assert f"{LAUNCH_CMD_ENV}={_guarded_launch_command('/tmp/wt', None)}" in create
+
+
+class TestRemoteLaunch:
+    def test_remote_send_keys_is_short_and_env_carries_the_command(self):
+        path = ("/Users/dotdev/projects/agentwire-dev-worktrees/"
+                "scheduler-ai-morning-briefing-20260803-100520")
+        agent = ('claude --dangerously-skip-permissions --append-system-prompt '
+                 '"$(</var/folders/1d/g63f4vld5x79q6m_swhxjpb0000gn/T/tmpabcd1234.txt)"')
+        with patch("agentwire.core._run_remote") as remote:
+            _launch_tmux_session("s", path, {}, agent, machine_id="box")
+        composite = remote.call_args.args[1]
+
+        assert LAUNCH_CMD_ENV in composite
+        # The send-keys half of the composite must stay under the tty cap even
+        # though the whole SSH command (which carries the -e flag) is longer.
+        send_half = composite.split("tmux send-keys", 1)[1]
+        assert len(send_half) < TTY_CANON_LIMIT

--- a/tests/unit/test_scheduler_zombie.py
+++ b/tests/unit/test_scheduler_zombie.py
@@ -141,8 +141,9 @@ class TestReap:
         monkeypatch.setattr(sched_pkg, "_kill_session", lambda s: killed.append(s))
         monkeypatch.setattr(sched_pkg, "_log_event",
                             lambda event, **f: logged.append((event, f)))
+        monkeypatch.setattr(zombie, "_pane_tail", lambda session, lines=3: "")
         monkeypatch.setattr(zombie, "_notify",
-                            lambda session, branch, command: notified.append(session))
+                            lambda session, branch, command, tail="": notified.append(session))
 
         result = zombie.reap()
 
@@ -267,3 +268,74 @@ class TestNotifyRouting:
         monkeypatch.setattr(core_mod, "load_session_metadata", lambda s: {})
         monkeypatch.setattr("agentwire.channels.email.send_email", lambda **k: None)
         zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh")  # must not raise
+
+
+class TestPaneTail:
+    """#856: the kill destroys the only record of why the launch failed, so
+    the pane must be read BEFORE it, and the tail carried into the alert."""
+
+    def test_returns_last_non_empty_lines(self, monkeypatch):
+        capture = "cd /tmp/wt && claude \\\n\n  --append-system-prompt \"$(</var/f\n\n"
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            lambda *a, **k: MagicMock(returncode=0, stdout=capture),
+        )
+        tail = zombie._pane_tail("proj/scheduler-a-1", lines=2)
+        assert "--append-system-prompt" in tail
+        assert " / " in tail  # two lines joined
+        assert "\n" not in tail
+
+    def test_empty_on_tmux_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            zombie.subprocess, "run",
+            lambda *a, **k: MagicMock(returncode=1, stdout=""),
+        )
+        assert zombie._pane_tail("proj/scheduler-a-1") == ""
+
+    def test_never_raises(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("tmux gone")
+
+        monkeypatch.setattr(zombie.subprocess, "run", boom)
+        assert zombie._pane_tail("proj/scheduler-a-1") == ""
+
+    def test_reap_reads_the_pane_before_killing_it(self, monkeypatch):
+        order = []
+        monkeypatch.setattr(zombie, "scan", lambda: [
+            {"session": "proj/scheduler-a-1", "branch": "scheduler-a-1",
+             "command": "zsh", "age_seconds": 90},
+        ])
+        monkeypatch.setattr(zombie, "_pane_tail",
+                            lambda s, lines=3: order.append("read") or "stuck line")
+
+        import agentwire.scheduler as sched_pkg
+        monkeypatch.setattr(sched_pkg, "_kill_session",
+                            lambda s: order.append("kill"))
+        logged = []
+        monkeypatch.setattr(sched_pkg, "_log_event",
+                            lambda event, **f: logged.append(f))
+        notified = []
+        monkeypatch.setattr(zombie, "_notify",
+                            lambda s, b, c, tail="": notified.append(tail))
+
+        zombie.reap()
+
+        assert order == ["read", "kill"]
+        assert notified == ["stuck line"]
+        assert logged[0]["pane_tail"] == "stuck line"
+
+    def test_tail_reaches_the_parent_escalation(self, monkeypatch):
+        import agentwire.core as core_mod
+        import agentwire.inbox as inbox_mod
+
+        monkeypatch.setattr(core_mod, "_post_desktop_notification", lambda *a, **k: None)
+        monkeypatch.setattr(core_mod, "load_session_metadata",
+                            lambda s: {"created_by": "orchestrator"})
+        sent = {}
+        monkeypatch.setattr(inbox_mod, "enqueue",
+                            lambda target, text, **k: sent.update(text=text))
+
+        zombie._notify("proj/scheduler-a-1", "scheduler-a-1", "zsh",
+                       'claude --append-system-prompt "$(</var/f')
+
+        assert "--append-system-prompt" in sent["text"]


### PR DESCRIPTION
## Which root cause it was

Candidate **#1** — "the agent command launches but exits immediately" — with a twist: it never launched *at all*. Ruled out in order:

| # | Candidate | Verdict |
|---|---|---|
| 1 | Agent command launches but dies | **THIS**, refined: `claude` was never executed. The pane sat at `zsh`, in the *correct* worktree dir, with a **truncated** launch line at a zsh continuation prompt. |
| 2 | Worktree-checkout / agent-launch race | No. The `cd` succeeded (`pane_current_path` was the worktree, and the guard's `exit 1` would have torn the session down otherwise). |
| 3 | Readiness polls the wrong pane / name mismatch | No. `wait_for_session_ready` on the exact slash-form name returns `True` in 1.9s against a healthy session; `tmux_session_exists` matched (otherwise the error would be `Failed to create session`). |
| 4 | Untracked `.agentwire.tasks.yml` doesn't survive the `origin/main` checkout | No — already fixed by #803's mandatory `_seed_worktree_files` set. (It *was* the failure from 07-07 to 07-15: `No .agentwire.tasks.yml found`. Fixing it is what unmasked this bug on 07-16.) |

## The bug

`_launch_tmux_session` **types** the launch line into the pane with `send-keys`, 0.1s after `tmux new-session` — before the shell has put its tty into raw mode. The keystrokes land in the tty's **canonical-mode** input buffer, which is capped at **1024 bytes per line on macOS** (`MAX_CANON` / `N_TTY_BUF_SIZE`). Everything past the cap is discarded **silently**.

The line ends in `--append-system-prompt "$(</var/folders/…)"`, so a truncated one is syntactically incomplete. zsh parks at a continuation prompt, `claude` never runs, and the session is a bare shell — which is all `ensure` can report as `Agent not running`, and which the zombie reaper kills 60s later, destroying the evidence.

Measured on this machine (`send-keys` 0.1s after `new-session`):

| Typed line length | Arrives intact? |
|---|---|
| 500 / 1000 / 1024 | yes |
| 1045 / 1200 / 1500 | **no — tail silently dropped** |

After the shell settles the cap is gone and a 1500-char line lands fine — which is why this reads as flaky, and why it tracks **session-name length**. #742/#743 grew `_guarded_launch_command` by ~700 chars (it interpolates the worktree path **four** times), so:

- `scheduler-ai-morning-briefing-<ts>` → **1045 chars** → over the cap, fails every night
- `scheduler-weekly-stars-<ts>` → under the cap → fine

Same code, one task broken. Truncation point in the captured pane (`…"$(</var/folders/1d/g63f4vld5x79q6m_swhxjpb0`) matches byte 1024 of the reconstructed command.

Timeline confirms it: complete through 07-06 → `No .agentwire.tasks.yml found` 07-07…07-15 (#803) → `Agent not running` from 07-16 onward, once dispatch got far enough to reach the launch. The guard grew on 07-08, hidden behind the earlier failure.

## The fix

`tmux new-session -e K=V` is protocol data, not keyboard input, so it has no tty cap. The launch line now rides in as `AGENTWIRE_LAUNCH_CMD` and the pane is sent a fixed ~70-char line:

```python
LAUNCH_CMD_ENV = "AGENTWIRE_LAUNCH_CMD"
_LAUNCH_EVAL = f'eval "${{{LAUNCH_CMD_ENV}:?agentwire: launch command not injected}}"'
```

The typed line's length is now independent of the path, posture flags, model override, and role temp-file path. `:?` makes a missing var loud instead of another silent bare shell. Both the local and the remote (SSH) launch paths are fixed — they share the builder.

Not `paste-buffer`: a buffer paste goes through the same pane input path and hits the same cap. It's correct for prompts sent to a *running* Claude (raw mode — `pane_manager.send_to_target`), not for the pre-agent shell.

### So the next one isn't a 17-run whodunnit

- `ensure_cli._pane_diagnosis` — the readiness failure now reads `Agent not running in session 'x' (pane=zsh, last: …"$(</var/f)` instead of a shrug, captured **while the pane still exists**.
- `zombie._pane_tail` — the reaper reads the pane **before** killing it and carries the tail into the event, the portal toast, the parent escalation, and the owner email. The kill is what erases the only record.

## Scope note

The root-cause fix is one function in `agentwire/core.py` (`_launch_tmux_session`), not in the three files scoped to this task — the dispatch and readiness code were correct; they were faithfully reporting a launch that never happened. `session_cli.py`, `session_ready.py`, `send_cli.py`, `worktree.py`, `worktree_registry.py` are untouched.

## Verification

**Real supervised run** (`agentwire scheduler run ai-morning-briefing`, source-on-PATH shim so the dispatch's `agentwire new` / `ensure` subprocesses use this branch — no `rebuild` from a worktree):

- before: `status=failed, duration=30`, pane `cmd=zsh`, agent never started
- after: **`status=complete, duration=317`**, pane `cmd=2.1.220` (claude), 7 WebSearch queries, briefing email sent (Resend id `3e0ec024-5fcf-4e28-bd05-326f27642e1a`), worktree cleaned up, no leftover session or branch

**Full suite: 3012 passed** (`main` @ 8126a22 is green; the failure PR #857 saw was fixed by #861).

New tests: `tests/unit/test_launch_via_env.py` (8) — the typed line is fixed-length and under 1024 for the exact #856 shape, the command reaches the `-e` flag, the caller's env dict isn't mutated, bare posture and the remote path both route through it. Plus `_pane_tail` / `_pane_diagnosis` coverage incl. read-before-kill ordering.

Docs: `docs/wiki/internals/shell-escaping.md` gains "The Second Trap: the launch line has a 1024-byte ceiling", and its debug checklist's wrong "~8KB" limit is corrected.

Closes #856

Built by [dotdev.dev](https://dotdev.dev)