### PR TITLE
fix(deps): bound mcp<2 and teach doctor to notice a dead MCP entrypoint (#874)

### DIFF
--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -592,6 +592,37 @@ def _render_scheduler_staleness_section() -> int:
     return 1
 
 
+def _render_mcp_import_section() -> int:
+    """Doctor section: does the MCP server entrypoint actually import? (#874)
+
+    ``agentwire mcp`` is launched by Claude Code, not by agentwire, so an
+    import-time failure never surfaces as an agentwire error — the client
+    reports a connection close and the agent in the session just finds its
+    ``mcp__agentwire__*`` tools missing. #874 was exactly this: an unbounded
+    ``mcp>=1.2.0`` let a rebuild resolve SDK 2.x, which dropped the
+    ``mcp.server.fastmcp`` module ``mcp_core`` imports, and ``rebuild`` still
+    printed success. Import the real entrypoint chain in a subprocess so a
+    broken server is reported by the tool that is supposed to notice.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", "import agentwire.mcp_server"],
+        capture_output=True, text=True, timeout=120,
+    )
+    if proc.returncode == 0:
+        print("  [ok] MCP server entrypoint imports cleanly")
+        return 0
+
+    err = (proc.stderr or "").strip().splitlines()
+    print("  [!!] MCP server entrypoint fails to import — every mcp__agentwire__* "
+          "tool is missing from every session")
+    if err:
+        print(f"       {err[-1]}")
+    print("       Verify with: claude mcp list   (expect 'agentwire: ✘ Failed to connect')")
+    print("       Usually a dependency resolution: check the bounds in pyproject.toml, "
+          "then `agentwire rebuild`.")
+    return 1
+
+
 def cmd_doctor(args) -> int:
     """Auto-diagnose and fix common issues."""
     from .hooks_cli import _managed_file_state, _managed_hook_files, get_hooks_source
@@ -777,6 +808,11 @@ def cmd_doctor(args) -> int:
     # currently-running PROCESS that predates the last install.
     print("\nChecking scheduler daemon freshness...")
     issues_found += _render_scheduler_staleness_section()
+
+    # 4e. MCP server entrypoint — a dependency resolution can break it on a
+    # rebuild and the failure only ever shows up client-side (#874).
+    print("\nChecking MCP server entrypoint (#874)...")
+    issues_found += _render_mcp_import_section()
 
     # Check custom services (registry-driven: built-in notifications bridge
     # + user-defined services from services.custom)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ dependencies = [
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",  # >=1.2.2 clears CVE-2026-28684
     "requests>=2.33.0",  # >=2.33.0 clears CVE-2026-25645
-    "mcp>=1.2.0",
+    # <2 is load-bearing: MCP SDK 2.x removed `mcp.server.fastmcp`, which
+    # agentwire/mcp_core.py imports. Unbounded, any `agentwire rebuild` after
+    # the 2.x release resolves it and every mcp__agentwire__* tool silently
+    # disappears from every session (#874). Lift only with a 2.x port.
+    "mcp>=1.2.0,<2",
     "resend>=2.0.0",
     "markdown>=3.5",
     # In-process WebM/Opus decoding for /transcribe (avoids ffmpeg subprocess startup).


### PR DESCRIPTION
## What

Two changes, both from #874:

1. **`pyproject.toml`** — `mcp>=1.2.0` → `mcp>=1.2.0,<2`, with a comment saying why the bound is load-bearing.
2. **`agentwire/doctor_cli.py`** — new `_render_mcp_import_section()`, wired into `cmd_doctor` as step 4e.

## Why

MCP SDK 2.x removed `mcp.server.fastmcp`, which `agentwire/mcp_core.py:15` imports. Unbounded, any `agentwire rebuild` after the 2.x release resolved it and the MCP entrypoint died at import — every `mcp__agentwire__*` tool disappeared from every session, while `rebuild` printed `Rebuild complete. New version is active.`

This was observed live rebuilding onto 1.66.0: the tool venv had resolved `mcp 2.0.0` and `claude mcp list` reported `agentwire: ✘ Failed to connect`.

The reason it hides: `agentwire mcp` is launched by Claude Code, not by agentwire, so an import-time failure never surfaces as an agentwire error. Hence the doctor check — it imports the real entrypoint chain (`import agentwire.mcp_server`) in a subprocess under `sys.executable`, which on a uv-tool install is the tool venv's own interpreter.

Pinning rather than porting to 2.x, per the issue: smaller change, unblocks rebuilds immediately. The comment marks the bound as intentional so a future dependency sweep doesn't lift it blind.

## Verification

- `agentwire rebuild` now resolves **mcp 1.29.0**
- `claude mcp list` → `agentwire: ✔ Connected`
- `agentwire doctor` → `[ok] MCP server entrypoint imports cleanly`
- Failure branch exercised with a simulated `ModuleNotFoundError`: renders the diagnostic and returns `1` so it counts toward `issues_found`

Closes #874

Built by [dotdev.dev](https://dotdev.dev)