### PR TITLE
fix(msg): parked recipients defer without penalty; history_cli onto tmux_safe_name

### DIFF
--- a/agentwire/history_cli.py
+++ b/agentwire/history_cli.py
@@ -32,6 +32,7 @@ from .roles import (
     load_roles,
     resolve_roles,
 )
+from .worktree import tmux_safe_name
 
 
 def cmd_history_list(args) -> int:
@@ -190,7 +191,13 @@ def cmd_history_resume(args) -> int:
 
     # Generate session name if not provided
     if not name:
-        base_name = project_path.name.replace(".", "_")
+        # tmux reads `.` as its session.window separator and rewrites it to `_`,
+        # so a project dir carrying one (`~/.claude`) yields the session
+        # `_claude-fork-1`, never `.claude-fork-1`. One implementation of that
+        # mapping, shared with every creation path (#868/#870) — the uniqueness
+        # probe below must run on the sanitized name or it checks for a session
+        # tmux could not have made.
+        base_name = tmux_safe_name(project_path.name)
         # Find unique name with -fork-N suffix
         name = f"{base_name}-fork-1"
         counter = 1
@@ -204,6 +211,11 @@ def cmd_history_resume(args) -> int:
                 break  # Session doesn't exist, use this name
             counter += 1
             name = f"{base_name}-fork-{counter}"
+    else:
+        # Same mapping on an operator-supplied --name: left raw, the
+        # has-session probe and every later `-t <name>` address a *window* that
+        # doesn't exist, while we report a session name tmux never created.
+        name = tmux_safe_name(name)
 
     # Route through resolve_roles with the derived kind so a resumed session
     # carries its kind's intrinsic etiquette. A history-resume has no branch, so

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -69,15 +69,27 @@ MAX_ATTEMPTS = 40
 # (``Message.gone_attempts``) so prior busy penalties don't erode the grace.
 GONE_MAX_ATTEMPTS = 5
 
-# Defer reasons that DON'T penalize: the target is legitimately busy — running a
-# long command (unparseable box → "target_busy") or generating with human-queued
-# input (the "queued messages" placeholder → "queued_placeholder"), or the box
-# holds unrecognized-but-static content ("box_static": identical across
-# consecutive sweeps ≈ an unknown placeholder, not an actively-typed draft).
+# Defer reasons that DON'T penalize: the recipient EXISTS but can't take the
+# message right now — it is not refusing. Either it's legitimately busy (running
+# a long command → unparseable box → "target_busy"; generating with human-queued
+# input → the "queued messages" placeholder → "queued_placeholder"; a box holding
+# unrecognized-but-static content → "box_static", identical across consecutive
+# sweeps ≈ an unknown placeholder, not an actively-typed draft; our own prior
+# paste wedged in the box → "stuck_in_box") — or it's usage-limit PARKED
+# ("target_parked"), where pasting would corrupt the resume.
+#
+# Parked is the *most* clearly temporary of these (#872): a park is bounded and
+# self-clearing — usage-limit recovery parses the reset time and nudges the
+# session afterward — whereas "busy" has no such guarantee. Penalizing it meant a
+# park longer than MAX_ATTEMPTS ticks (~40 min, routinely exceeded by a real
+# reset window) killed every report-back its workers had filed.
+#
 # Such messages stay pending forever instead of burning toward dead-letter;
 # doctor / worktree --watch surface them, and they deliver once the box frees up.
+# The opposite case — a recipient that positively does NOT exist — is NOT in this
+# set: "target_gone" is penalized on its own fast GONE_MAX_ATTEMPTS cap (#694).
 _NO_PENALTY_REASONS = frozenset(
-    {"target_busy", "queued_placeholder", "box_static", "stuck_in_box"}
+    {"target_busy", "queued_placeholder", "box_static", "stuck_in_box", "target_parked"}
 )
 
 # Consecutive sweeps the box must show byte-identical content before the defer
@@ -709,9 +721,10 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
         if msg.path is None:
             continue
         if reason in _NO_PENALTY_REASONS:
-            # Target is busy (long command, or generating with human-queued input),
-            # not refusing — never penalize. Surfaced via `doctor` / `worktree
-            # --watch`; delivers once the prompt is empty/idle.
+            # The recipient exists but can't take it right now — busy (long
+            # command / human-queued input / wedged paste) or usage-limit parked
+            # — not refusing. Never penalize. Surfaced via `doctor` / `worktree
+            # --watch`; delivers once the prompt frees up or the park clears.
             msg.reason = reason
             try:
                 _write_message(msg.path, msg)

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -141,7 +141,7 @@ lands in a durable inbox and is injected only at a safe boundary.
 
 4. **Defer or drop.** If either gate fails, the messages stay put, their
    `attempts` counter bumps, and the defer `reason` (`box_not_empty`,
-   `target_parked`, …) is stamped on each message. After `MAX_ATTEMPTS`
+   `target_not_agent`, …) is stamped on each message. After `MAX_ATTEMPTS`
    (40 ≈ 40 min of a permanently busy session) a message moves to
    `~/.agentwire/inbox/<session>/dead/` carrying that reason + a `dead_ts`, and a
    `dead_letter` event is logged — no infinite retry. `msg dead` surfaces these
@@ -149,14 +149,24 @@ lands in a durable inbox and is injected only at a safe boundary.
 
    Three refinements keep the penalty honest:
 
-   - **No-penalty busy reasons.** `target_busy` (the box can't be parsed — the
-     agent is running a long command) and `queued_placeholder` (the box shows
-     Claude Code's *"Press up to edit queued messages"* — the agent is generating
-     with human-queued input) are *busy*, not refusals. They defer **without**
-     bumping `attempts`, so a legitimately-busy session never burns a report-back
-     toward dead-letter; the message waits and delivers once the box frees up.
-     The placeholder is matched loosely, and only the *penalty* changes — a
-     non-empty box is still never pasted into (see the collision detector below).
+   - **No-penalty "can't take it right now" reasons.** `target_busy` (the box
+     can't be parsed — the agent is running a long command) and
+     `queued_placeholder` (the box shows Claude Code's *"Press up to edit queued
+     messages"* — the agent is generating with human-queued input) are *busy*,
+     not refusals. They defer **without** bumping `attempts`, so a legitimately-busy
+     session never burns a report-back toward dead-letter; the message waits and
+     delivers once the box frees up. The placeholder is matched loosely, and only
+     the *penalty* changes — a non-empty box is still never pasted into (see the
+     collision detector below). `box_static` and `stuck_in_box` join them for the
+     same reason.
+
+     **`target_parked` too (#872).** A usage-limit parked recipient exists and
+     will come back — recovery parses the reset time and nudges the session
+     afterward — it just can't be pasted into without corrupting the resume. It
+     was penalized, which capped tolerance at `MAX_ATTEMPTS` ticks ≈ 40 minutes
+     against a park that routinely runs hours; every `done` a parked parent's
+     workers filed died before the reset landed. It is the most clearly temporary
+     member of the set, and now defers without penalty like the rest.
    - **Gone recipients burn out fast (#694).** Before any box parsing, the
      drain checks the target against the live tmux session list. A recipient
      that *positively doesn't exist* defers as `target_gone` — a penalized

--- a/tests/unit/test_history_resume_name.py
+++ b/tests/unit/test_history_resume_name.py
@@ -1,0 +1,117 @@
+"""``agentwire history resume`` derives a tmux-LEGAL session name (#870).
+
+Sixth copy of the ``.`` → ``_`` mapping #869 consolidated into
+``worktree.tmux_safe_name``. tmux reads ``.`` as its ``session.window``
+separator and rewrites it, so for a project directory carrying one
+(``~/.claude``) the session that exists is ``_claude-fork-1`` — the raw
+``.claude-fork-1`` names a *window* of a session called ``.claude``, which is
+what the uniqueness probe and every later ``-t <name>`` were addressing.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import history_cli
+
+
+@pytest.fixture
+def resume(tmp_path, monkeypatch):
+    """Drive cmd_history_resume with tmux + config stubbed out.
+
+    Returns a callable ``(project_dir_name, name=None, existing=()) -> dict``
+    with the recorded tmux argv lists and the reported session name. *existing*
+    is the set of session names ``tmux has-session`` answers YES for.
+    """
+    from agentwire import history
+
+    monkeypatch.setattr(history, "resolve_session_id", lambda sid, m: None)
+    monkeypatch.setattr(history_cli, "load_project_config", lambda p: None)
+    monkeypatch.setattr(history_cli, "load_config", lambda: {})
+    monkeypatch.setattr(history_cli, "inject_soul", lambda names, cfg: names)
+    monkeypatch.setattr(history_cli, "resolve_roles", lambda kind, project_roles=None: [])
+    monkeypatch.setattr(
+        history_cli, "build_agent_command",
+        lambda posture, roles, resume_session_id=None: SimpleNamespace(command="claude"),
+    )
+    monkeypatch.setattr(history_cli, "_notify_portal_sessions_changed", lambda: None)
+    monkeypatch.setattr(history_cli.time, "sleep", lambda s: None)
+
+    def _run(project_dir_name, name=None, existing=()):
+        project = tmp_path / project_dir_name
+        project.mkdir(parents=True, exist_ok=True)
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            if argv[:2] == ["tmux", "has-session"]:
+                # `-t =<name>` — exact-match form. YES only for *existing*.
+                target = argv[-1].lstrip("=")
+                return SimpleNamespace(returncode=0 if target in existing else 1,
+                                       stdout=b"", stderr=b"")
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(history_cli.subprocess, "run", fake_run)
+        reported = {}
+        monkeypatch.setattr(history_cli, "_output_json", reported.update)
+
+        rc = history_cli.cmd_history_resume(SimpleNamespace(
+            session_id="abc123", name=name, machine="local",
+            project=str(project), json=True,
+        ))
+        created = [c for c in calls if c[:2] == ["tmux", "new-session"]]
+        probed = [c[-1].lstrip("=") for c in calls if c[:2] == ["tmux", "has-session"]]
+        return {
+            "rc": rc,
+            "created": created[0][created[0].index("-s") + 1] if created else None,
+            "probed": probed,
+            "reported": reported.get("session"),
+        }
+
+    return _run
+
+
+class TestDerivedName:
+    @pytest.mark.parametrize("project,expected", [
+        (".claude", "_claude-fork-1"),
+        ("dotdev.dev", "dotdev_dev-fork-1"),
+        ("myapp", "myapp-fork-1"),
+    ])
+    def test_project_dot_is_sanitized(self, resume, project, expected):
+        res = resume(project)
+        assert res["rc"] == 0
+        assert res["created"] == expected
+        assert res["reported"] == expected
+
+    def test_uniqueness_probe_uses_the_sanitized_name(self, resume):
+        """The behavior the line exists to serve.
+
+        A raw ``.claude-fork-1`` probe can never match — tmux has no session by
+        that name — so the collision loop would exit on the first try and hand
+        an occupied name to ``new-session``. Probing the sanitized name is what
+        makes the ``-fork-N`` increment work for a dotted project.
+        """
+        res = resume(".claude", existing={"_claude-fork-1", "_claude-fork-2"})
+        assert res["probed"][:2] == ["_claude-fork-1", "_claude-fork-2"]
+        assert res["created"] == "_claude-fork-3"
+
+
+class TestExplicitName:
+    def test_operator_supplied_name_is_sanitized_too(self, resume):
+        res = resume("myapp", name="my.resume")
+        assert res["created"] == "my_resume"
+        assert res["reported"] == "my_resume"
+        # And the pre-create existence probe checked the same name.
+        assert res["probed"] == ["my_resume"]
+
+    def test_legal_name_is_left_alone(self, resume):
+        res = resume("myapp", name="hand-picked")
+        assert res["created"] == "hand-picked"
+        assert res["reported"] == "hand-picked"
+
+    def test_collision_on_sanitized_name_is_refused(self, resume):
+        """A dotted --name colliding with the session it would really create
+        must fail loudly, not create a duplicate under a different address."""
+        res = resume("myapp", name="my.resume", existing={"my_resume"})
+        assert res["rc"] == 1
+        assert res["created"] is None

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -324,10 +324,13 @@ class TestFlush:
         assert len(msgs) == 1 and msgs[0].attempts == 1
 
     def test_defers_when_safe_deliver_refuses(self, isolate, monkeypatch):
+        # A penalized refusal (the pane runs a shell — pasted text could
+        # EXECUTE, and nothing about that is self-clearing). The other refusal,
+        # target_parked, defers WITHOUT penalty — see TestParkedDefer (#872).
         inbox.enqueue("s", "hi", sender="x")
-        _patch_delivery(monkeypatch, empty=True, deliver=(False, "target_parked"))
+        _patch_delivery(monkeypatch, empty=True, deliver=(False, "target_not_agent"))
         res = inbox.flush_session("s")
-        assert res["deferred"] and res["reason"] == "target_parked"
+        assert res["deferred"] and res["reason"] == "target_not_agent"
         assert inbox.list_messages("s")[0].attempts == 1
 
     def test_batch_coalesces(self, isolate, monkeypatch):
@@ -380,12 +383,14 @@ class TestDead:
         assert dead[0].attempts == inbox.MAX_ATTEMPTS
 
     def test_dead_letter_carries_safe_deliver_reason(self, isolate, monkeypatch):
+        # target_not_agent, not target_parked: parked is penalty-free (#872) and
+        # so can never reach the cap.
         inbox.enqueue("s", "stuck", sender="x")
-        _patch_delivery(monkeypatch, empty=True, deliver=(False, "target_parked"))
+        _patch_delivery(monkeypatch, empty=True, deliver=(False, "target_not_agent"))
         for _ in range(inbox.MAX_ATTEMPTS):
             inbox.flush_session("s")
         dead = inbox.list_dead("s")
-        assert len(dead) == 1 and dead[0].reason == "target_parked"
+        assert len(dead) == 1 and dead[0].reason == "target_not_agent"
 
     def test_list_dead_empty(self, isolate):
         assert inbox.list_dead("nobody") == []
@@ -578,6 +583,98 @@ class TestQueuedPlaceholderDefer:
         )
         inbox.flush_session("s")
         assert sent == []  # box non-empty → never delivered into
+
+
+class TestParkedDefer:
+    """#872: a usage-limit parked recipient defers WITHOUT penalty.
+
+    ``safe_deliver`` refuses a parked target (pasting would corrupt the resume),
+    but ``target_parked`` was penalized, so every ~60s watchdog tick burned an
+    attempt and a worker's ``done`` dead-lettered at MAX_ATTEMPTS ≈ 40 min. A
+    real park lasts until the usage-limit reset — routinely hours — so any park
+    worth the name guaranteed the report-back died. Parked is the *exists but
+    can't take it* case (like ``target_busy``), not the ``target_gone`` case.
+
+    Driven through the REAL ``safe_deliver`` and the REAL ``usage_limit``
+    park-state file rather than a stubbed refusal, so the park→no-penalty chain
+    is exercised end to end and un-parking actually releases the message.
+    """
+
+    @pytest.fixture
+    def park(self, tmp_path, monkeypatch):
+        """Park/un-park a session for real, on a throwaway state dir."""
+        from agentwire import session_ready, usage_limit
+
+        state_dir = tmp_path / "usage-limit"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(usage_limit, "STATE_DIR", state_dir)
+
+        # Everything safe_deliver checks BESIDES the park: session exists, pane
+        # runs an agent, no live menu, empty box, nothing already on scrollback.
+        # The park state is the only variable.
+        monkeypatch.setattr(prompt_router, "_session_exists", lambda s: True)
+        monkeypatch.setattr(prompt_router, "is_agent_pane", lambda s, p=0: True)
+        monkeypatch.setattr(prompt_router, "screen_shows_live_menu", lambda v: False)
+        monkeypatch.setattr(prompt_router, "_capture", lambda t, **kw: "")
+        monkeypatch.setattr(prompt_router, "capture", lambda s, p=0, **kw: "")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda vis: "")
+        monkeypatch.setattr(session_ready, "scrollback", lambda s, p=0, **kw: "")
+
+        sent: list[str] = []
+        monkeypatch.setattr(
+            session_ready, "send_verified",
+            lambda s, text, pane_index=0, **kw: (sent.append(text) or True),
+        )
+
+        assert not usage_limit.is_parked("s")  # fixture really is isolated
+        return SimpleNamespace(
+            sent=sent,
+            on=lambda session: usage_limit.write_park_state({"session": session}),
+            off=lambda session: usage_limit.state_path(session).unlink(),
+        )
+
+    def test_parked_defers_without_penalty(self, isolate, park):
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        park.on("s")
+        res = inbox.flush_session("s")
+        assert res["deferred"] and res["reason"] == "target_parked"
+        assert park.sent == []  # never pasted into a parked session
+        assert inbox.list_messages("s")[0].attempts == 0
+
+    def test_parked_never_dead_letters_then_delivers_on_unpark(self, isolate, park):
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        park.on("s")
+        for _ in range(inbox.MAX_ATTEMPTS + 5):
+            inbox.flush_session("s")
+
+        pending = inbox.list_messages("s")
+        assert len(pending) == 1
+        assert pending[0].attempts == 0
+        assert pending[0].reason == "target_parked"
+        assert inbox.list_dead("s") == []  # survived a park longer than the cap
+
+        # The reset nudge un-parks the session — the held report lands.
+        park.off("s")
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 1 and not res["deferred"]
+        assert len(park.sent) == 1 and "PR done" in park.sent[0]
+        assert inbox.list_messages("s") == []
+
+    def test_gone_still_dies_fast_while_parked_waits(self, isolate, park, monkeypatch):
+        """The distinction the fix preserves: parked defers forever, gone doesn't.
+
+        ``target_gone`` is checked before the park gate and keeps its own fast
+        GONE_MAX_ATTEMPTS cap (#694) — making parked penalty-free must not make
+        a positively-absent recipient immortal too.
+        """
+        inbox.enqueue("s", "PR done", kind="done", sender="worker")
+        park.on("s")
+        monkeypatch.setattr(inbox, "live_sessions", lambda: set())  # s is gone
+        for _ in range(inbox.GONE_MAX_ATTEMPTS):
+            inbox.flush_session("s")
+        assert inbox.list_messages("s") == []
+        dead = inbox.list_dead("s")
+        assert len(dead) == 1 and dead[0].reason == "target_gone"
 
 
 class TestBoxStatic:


### PR DESCRIPTION
Two independent small fixes.

## #872 — `target_parked` burned report-back attempts

**Confirmed.** `agentwire/inbox.py` defined `_NO_PENALTY_REASONS` without `target_parked`, and `_bump_attempts` skips the counter only for members of that set. So a usage-limit parked parent burned one attempt per ~60s watchdog tick and its workers' `done` reports dead-lettered at `MAX_ATTEMPTS = 40` — roughly **40 minutes** of tolerance against a park that lasts until the reset, routinely hours.

That inverts the set's own distinction: `target_gone` (recipient *positively does not exist*) is deliberately given a fast `GONE_MAX_ATTEMPTS = 5` death (#694), while "recipient exists but can't take it right now" defers without penalty. Parked is the second case, and is *more* clearly temporary than `target_busy` — which was already penalty-free — because usage-limit recovery parses the reset time and nudges the session afterward.

**Fix:** add `"target_parked"` to `_NO_PENALTY_REASONS`, and rewrite the set's docstring — it described only "the target is busy", which no longer covers the membership (it also didn't cover `box_static` / `stuck_in_box`). It now states the actual rule ("exists but can't take it right now") and calls out the `target_gone` exclusion explicitly, so the next person adding a reason has the criterion in front of them.

**Live evidence.** `agentwire msg dead` on this machine shows **23** messages killed at exactly `40 attempts (target_parked)`, across the `craps`, `documentscribe`, and `map-libre` clusters. Not all of them are the throwaway "is idle and done working" — several are full review-fixup handoffs (commit SHAs, per-finding responses, PR-ready verdicts) that the parent never received.

## #870 — sixth copy of the tmux dot-sanitizer

**Confirmed.** `agentwire/history_cli.py:193` inlined `project_path.name.replace(".", "_")` — the sixth copy of the `.` → `_` mapping PR #869 consolidated into `worktree.tmux_safe_name()`. Routed onto the SSOT.

**Verified live**, in-worktree, with a throwaway session:

```
$ tmux new-session -d -s ".zzscratch870" -c /tmp
$ tmux ls | grep zzscratch870
_zzscratch870: 1 windows          # tmux rewrote the name
$ tmux has-session -t "=.zzscratch870"
can't find pane: zzscratch870     # rc=1 — parsed as session `.` + pane
$ tmux has-session -t "=_zzscratch870"
                                  # rc=0
```

(Scratch session killed; nothing else touched.)

For the derived-name path this is a **behavior-identical refactor** — `tmux_safe_name` *is* `.replace(".", "_")` — so `TestDerivedName` is a characterization test that passes on both sides of the change. It's there to pin the behavior onto the SSOT, not to catch a regression.

### One extension beyond the issue's literal scope

The `--name` path had the same bug and the issue didn't mention it: an operator-supplied `--name my.resume` was left raw, so the uniqueness probe and every later `tmux -t <name>` addressed a **window** that doesn't exist, while we printed and reported a session name tmux never created (and could create a duplicate under a different address). Sanitizing at that point is the same one-line call. `TestExplicitName` covers it and **does** fail pre-fix. Happy to narrow this out if you'd rather keep the PR strictly to line 193.

### No seventh copy

Grepped the tree (`*.py`, `*.sh`, `*.js`, `*.bash`) for `.replace(".", "_")` in both quote styles, plus `tr`/`sed`/`maketrans`/`translate` variants. The only remaining hit is `worktree.py:192` — the SSOT itself. (`wiki_audit.py:54` is regex escaping, unrelated.) Nothing left behind.

## Tests

Full suite: **3087 passed**, 1 pre-existing warning, 139s — 2923 unit + 151 integration + 13 e2e. `ruff` clean on all changed files.

New coverage:

- `TestParkedDefer` (3 tests) drives the **real** `safe_deliver` against a **real** `usage_limit` park-state file on a throwaway `STATE_DIR`, rather than stubbing the refusal — so the park→no-penalty chain is exercised end to end and un-parking genuinely releases the message. It asserts: deferred with `attempts == 0` and never pasted; survives `MAX_ATTEMPTS + 5` drains still pending with `attempts == 0` and reason `target_parked` and an empty dead/ dir, then delivers on un-park; and that a *gone* recipient still dies at `GONE_MAX_ATTEMPTS` (guard against the fix over-reaching into #694's territory).
- `tests/unit/test_history_resume_name.py` (7 tests) covers derived-name sanitization, the `-fork-N` collision loop probing the sanitized name, and the `--name` path.

**Both fixes fail the pre-fix tree**, verified by stashing each source change and re-running:

- `agentwire/inbox.py` stashed → `test_parked_defers_without_penalty` (attempts == 1) and `test_parked_never_dead_letters_then_delivers_on_unpark` (dead-lettered, 0 pending) FAIL.
- `agentwire/history_cli.py` stashed → `test_operator_supplied_name_is_sanitized_too` and `test_collision_on_sanitized_name_is_refused` FAIL.

## Docs

`docs/wiki/sessions/messaging.md` listed `target_parked` as an example of a reason that gets stamped *and dead-letters*, which is now wrong — swapped for `target_not_agent`, and the no-penalty bullet now covers parked (plus `box_static` / `stuck_in_box`, which it had also omitted). `docs/wiki/sessions/prompt-routing.md` needed no change: it documents `safe_deliver`'s refusal reasons, and the refusal itself is unchanged — only the penalty is.

Two existing tests used `target_parked` as their *penalized* reason and would have silently inverted meaning; both switched to `target_not_agent` with a comment pointing at the new class.

## Verification note

Verified in-worktree only. No `agentwire rebuild`, no portal restart — neither fix can be exercised on the live fleet until this merges and the tool is rebuilt.

Closes #872
Closes #870

Built by [dotdev.dev](https://dotdev.dev)