### PR TITLE
fix(scheduler): verify daemon liveness by PID, refuse a second dispatcher (#873)

### DIFF
--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -529,18 +529,17 @@ def _scheduler_daemon_started_at() -> float | None:
     Reads the daemon's own self-reported ``started_at`` from the live-state
     file it already writes every loop tick (``scheduler/loop.py`` ->
     ``_write_live_state`` -> ``read_live_state()``) rather than reimplementing
-    process-start-time discovery via ``ps``/``pgrep`` PID matching, which is
-    both platform-fragile (``ps`` elapsed-time output format varies) and
-    ambiguous if a stray/duplicate daemon process happens to be running.
-    ``tmux_session_exists`` confirms the daemon is actually alive, so a
-    leftover live-state file from a since-stopped daemon doesn't produce a
-    false "stale" reading.
+    process-start-time discovery via ``ps`` elapsed-time parsing, which is
+    platform-fragile. ``live_daemon_state`` verifies the recorded PID is a live
+    scheduler process, so a leftover file from a since-stopped daemon doesn't
+    produce a false "stale" reading — and unlike the ``tmux_session_exists``
+    gate it replaced (#873), it also sees a daemon supervised outside tmux,
+    where skipping this check silently disabled the most useful diagnostic
+    exactly when it was needed.
     """
-    from .scheduler import SCHEDULER_SESSION, read_live_state
+    from .scheduler import live_daemon_state
 
-    if not tmux_session_exists(SCHEDULER_SESSION):
-        return None
-    state = read_live_state()
+    state = live_daemon_state()
     if not state:
         return None
     started_at = state.get("started_at")
@@ -551,6 +550,23 @@ def _scheduler_daemon_started_at() -> float | None:
         return datetime.fromisoformat(started_at).timestamp()
     except (ValueError, TypeError):
         return None
+
+
+def _scheduler_daemon_predates_pid_stamp() -> bool:
+    """True when a tmux-hosted daemon is up but its live state records no PID.
+
+    The one transitional state #873 leaves behind: a daemon started before the
+    PID stamp existed is alive but unverifiable. tmux is evidence enough to say
+    "something is running" here — it just isn't evidence anyone should keep
+    inferring liveness from, which is why it lives in this diagnostic rather
+    than back in ``live_daemon_state``.
+    """
+    from .scheduler import SCHEDULER_SESSION, read_live_state
+
+    state = read_live_state()
+    if not state or isinstance(state.get("pid"), int):
+        return False
+    return tmux_session_exists(SCHEDULER_SESSION)
 
 
 def _newest_installed_source_mtime(pkg_dir: Path | None = None) -> float:
@@ -573,9 +589,20 @@ def _render_scheduler_staleness_section() -> int:
     up since before the last rebuild is silently executing stale dispatch
     logic: any bug fixed since then stays live in production until the
     daemon is restarted.
+
+    Also flags the one state where liveness genuinely cannot be determined: a
+    daemon started before #873 writes no ``pid``, so nothing can verify it.
+    That is itself a stale daemon, and saying so beats reporting it as stopped.
     """
     started_at = _scheduler_daemon_started_at()
     if started_at is None:
+        if _scheduler_daemon_predates_pid_stamp():
+            print("  [!!] Scheduler daemon records no PID — it predates the "
+                  "PID-based liveness check (#873)")
+            print("       Liveness and the staleness check below can't be verified "
+                  "until it restarts.")
+            print("       Fix: agentwire scheduler stop && agentwire scheduler start")
+            return 1
         print("  [..] Scheduler daemon not running — skipping staleness check")
         return 0
 

--- a/agentwire/routes/scheduler.py
+++ b/agentwire/routes/scheduler.py
@@ -19,18 +19,12 @@ class SchedulerRoutesMixin:
     async def api_scheduler_live(self, request: web.Request) -> web.Response:
         """GET /api/scheduler/live - Live scheduler state.
 
-        Checks if the scheduler tmux session is actually running.
-        Returns 404 with running=false if the daemon isn't active,
-        even if a stale state file exists.
+        Verifies the daemon is actually alive (recorded PID, not a tmux session
+        name) so a stale state file never reads as running, and a daemon
+        supervised outside tmux is never reported as stopped (#873).
         """
         try:
-            # Check if scheduler tmux session is alive
-            is_running = await self._is_scheduler_running()
-            if not is_running:
-                return web.json_response({"running": False}, status=404)
-
-            from ..scheduler import read_live_state
-            state = read_live_state()
+            state = await self._live_scheduler_state()
             if state is None:
                 return web.json_response({"running": False}, status=404)
             state["running"] = True
@@ -38,15 +32,24 @@ class SchedulerRoutesMixin:
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
+    async def _live_scheduler_state(self) -> dict | None:
+        """Live state of a verified-alive daemon, or ``None``.
+
+        Off-thread: the liveness check shells out to ``ps``, which must not sit
+        on the event loop.
+        """
+        from ..scheduler import live_daemon_state
+        return await asyncio.to_thread(live_daemon_state)
+
     async def _is_scheduler_running(self) -> bool:
-        """Check if the agentwire-scheduler tmux session exists."""
-        proc = await asyncio.create_subprocess_exec(
-            "tmux", "has-session", "-t", "=agentwire-scheduler",
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
-        return proc.returncode == 0
+        """Is a scheduler daemon dispatching against this board?
+
+        Was ``tmux has-session``, which only ever saw daemons tmux itself
+        hosts — so the portal's autostart happily launched a second dispatcher
+        alongside a launchd-supervised one, and the board double-dispatched
+        (#873).
+        """
+        return await self._live_scheduler_state() is not None
 
     async def api_scheduler_events(self, request: web.Request) -> web.Response:
         """GET /api/scheduler/events - Recent scheduler events."""
@@ -106,9 +109,20 @@ class SchedulerRoutesMixin:
     async def _start_scheduler_daemon(self) -> bool:
         """Launch the scheduler daemon in a detached tmux session.
 
-        No-op if it's already running. Returns True if it was started.
+        No-op if a daemon is already dispatching — including one this portal
+        did not start and tmux cannot see (#873). Skipping is logged rather
+        than silent, so "the portal didn't start it" is visible in the log
+        instead of being inferred from a board that dispatches twice.
+
+        Returns True if it was started.
         """
-        if await self._is_scheduler_running():
+        live = await self._live_scheduler_state()
+        if live is not None:
+            logger.info(
+                "Scheduler daemon already running (pid %s, up since %s) — "
+                "skipping autostart to avoid a second dispatcher",
+                live.get("pid"), live.get("started_at"),
+            )
             return False
         # Create tmux session and launch scheduler serve (same as CLI but detached)
         proc = await asyncio.create_subprocess_exec(

--- a/agentwire/scheduler/__init__.py
+++ b/agentwire/scheduler/__init__.py
@@ -87,6 +87,7 @@ from .report import (
     format_overdue,
     format_schedule,
     get_board_display,
+    live_daemon_state,
     read_events,
     read_live_state,
 )

--- a/agentwire/scheduler/report.py
+++ b/agentwire/scheduler/report.py
@@ -1,6 +1,8 @@
 """Event logging, live state, portal notifications, and board display."""
 
 import json
+import os
+import subprocess
 import tempfile
 import time
 from datetime import datetime, timezone
@@ -30,9 +32,19 @@ def _log_event(event: str, **fields) -> None:
 
 
 def _write_live_state(**fields) -> None:
-    """Atomically write the live state JSON file."""
+    """Atomically write the live state JSON file.
+
+    The writer's own PID is stamped on every write (#873). Liveness used to be
+    inferred from ``tmux_session_exists(SCHEDULER_SESSION)``, which is false for
+    a daemon supervised outside tmux (launchd), so a running daemon read as
+    ``stopped`` and doctor skipped its staleness check exactly when it mattered.
+    The PID is what the tmux gate was standing in for: something that says "the
+    process that wrote this file is still alive", so a leftover file from a
+    since-stopped daemon can't read as live. See :func:`live_daemon_state`.
+    """
     from agentwire import scheduler as _sched
 
+    fields["pid"] = os.getpid()
     try:
         live_path = _sched._sched_config().live_state_file
         live_path.parent.mkdir(parents=True, exist_ok=True)
@@ -259,3 +271,62 @@ def read_live_state() -> dict | None:
         return json.loads(live_path.read_text())
     except (json.JSONDecodeError, OSError):
         return None
+
+
+def _pid_is_scheduler(pid: int) -> bool:
+    """Is *pid* a live process, and does it look like a scheduler daemon?
+
+    Two checks, in order of cost:
+
+    1. ``os.kill(pid, 0)`` — a pure syscall. ``ProcessLookupError`` means dead;
+       ``PermissionError`` means alive but owned by someone else.
+    2. The process's command line, via ``ps``, must mention ``scheduler``. PIDs
+       are recycled, and treating an unrelated process that inherited a dead
+       daemon's PID as "the scheduler is running" would suppress the autostart
+       guard and leave the board with no dispatcher at all. If ``ps`` is
+       unavailable or unreadable we keep the step-1 answer rather than
+       reporting a live daemon as dead.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if out.returncode != 0 or not out.stdout.strip():
+        return True
+    return "scheduler" in out.stdout
+
+
+def live_daemon_state() -> dict | None:
+    """Live state of a VERIFIED-ALIVE scheduler daemon, else ``None`` (#873).
+
+    The single source of truth for "is the scheduler daemon running". Every
+    status surface (``scheduler status``, ``doctor``, the portal's autostart
+    guard) routes through here instead of asking tmux, because tmux only knows
+    about daemons it hosts — a launchd-supervised ``agentwire scheduler serve``
+    is invisible to it, which both misreported liveness and let the portal
+    autostart a SECOND dispatcher onto the same board.
+
+    A state file with no ``pid`` was written by a daemon predating this change
+    and cannot be verified, so it reads as not-running; restarting the daemon
+    (which a rebuild already requires) heals it.
+    """
+    state = read_live_state()
+    if not state:
+        return None
+    pid = state.get("pid")
+    if not isinstance(pid, int):
+        return None
+    return state if _pid_is_scheduler(pid) else None

--- a/agentwire/scheduler/report.py
+++ b/agentwire/scheduler/report.py
@@ -280,12 +280,20 @@ def _pid_is_scheduler(pid: int) -> bool:
 
     1. ``os.kill(pid, 0)`` — a pure syscall. ``ProcessLookupError`` means dead;
        ``PermissionError`` means alive but owned by someone else.
-    2. The process's command line, via ``ps``, must mention ``scheduler``. PIDs
-       are recycled, and treating an unrelated process that inherited a dead
-       daemon's PID as "the scheduler is running" would suppress the autostart
-       guard and leave the board with no dispatcher at all. If ``ps`` is
-       unavailable or unreadable we keep the step-1 answer rather than
-       reporting a live daemon as dead.
+    2. The process's ``ps`` command line, TOKENISED, must contain both
+       ``scheduler`` and ``serve`` as whole argv words.
+
+    Step 2 exists because PIDs are recycled: an unrelated process inheriting a
+    dead daemon's PID and reading as "the scheduler is running" would suppress
+    the autostart guard and leave the board with NO dispatcher — worse than the
+    bug this check fixes. A substring test is not enough for that, because the
+    recycled process can easily be another agentwire command: ``agentwire
+    scheduler live --watch`` contains ``scheduler`` but dispatches nothing, and
+    would make ``status`` misreport AND ``serve`` / ``start`` / autostart all
+    refuse. Only ``scheduler serve`` is a dispatcher, so require both words.
+
+    ``ps`` unavailable or unreadable keeps the step-1 answer rather than
+    reporting a live daemon dead.
     """
     if pid <= 0:
         return False
@@ -306,7 +314,10 @@ def _pid_is_scheduler(pid: int) -> bool:
         return True
     if out.returncode != 0 or not out.stdout.strip():
         return True
-    return "scheduler" in out.stdout
+    # Whole-word match on argv: a path component or a flag value that merely
+    # contains "serve" must not qualify.
+    argv = out.stdout.split()
+    return "scheduler" in argv and "serve" in argv
 
 
 def live_daemon_state() -> dict | None:

--- a/agentwire/scheduler_cli.py
+++ b/agentwire/scheduler_cli.py
@@ -22,18 +22,34 @@ from .core import (
     _output_result,
     tmux_session_exists,
 )
+from .scheduler.models import SCHEDULER_SESSION
 
 # =============================================================================
 # Scheduler Commands
 # =============================================================================
 
 
-SCHEDULER_SESSION = "agentwire-scheduler"
+def _describe_live_daemon(state: dict) -> str:
+    """One-line identification of an already-running daemon, for refusals."""
+    pid = state.get("pid")
+    started = state.get("started_at") or "unknown start time"
+    return f"pid {pid}, up since {started}"
 
 
 def cmd_scheduler_start(args) -> int:
     """Start the scheduler daemon in a tmux session."""
+    from .scheduler import live_daemon_state
+
     if not _check_tmux_installed():
+        return 1
+
+    # A daemon supervised outside tmux (launchd) has no session to find, so the
+    # tmux check below would happily start a SECOND dispatcher onto the same
+    # board (#873). Ask the live-state file first — it knows either way.
+    live = live_daemon_state()
+    if live and not tmux_session_exists(SCHEDULER_SESSION):
+        print(f"Scheduler already running outside tmux ({_describe_live_daemon(live)}).")
+        print("Refusing to start a second dispatcher on the same board.")
         return 1
 
     if tmux_session_exists(SCHEDULER_SESSION):
@@ -57,8 +73,23 @@ def cmd_scheduler_start(args) -> int:
 
 
 def cmd_scheduler_serve(args) -> int:
-    """Run the scheduler loop in the foreground (for tmux)."""
-    from .scheduler import run_scheduler_loop
+    """Run the scheduler loop in the foreground (for tmux or an external supervisor).
+
+    Refuses to become a second dispatcher (#873). Two daemons on one board
+    double-dispatch tasks, and the only thing that used to stop it was the tmux
+    session-name collision in ``scheduler start`` — an accident of naming that
+    doesn't fire at all when the other daemon is supervised elsewhere.
+    """
+    from .scheduler import live_daemon_state, run_scheduler_loop
+
+    live = live_daemon_state()
+    if live and not getattr(args, "force", False):
+        print(f"A scheduler daemon is already running ({_describe_live_daemon(live)}).",
+              file=sys.stderr)
+        print("Refusing to start a second dispatcher on the same board — "
+              "stop the running one first, or pass --force if it is a stale record.",
+              file=sys.stderr)
+        return 1
 
     run_scheduler_loop()
     return 0
@@ -66,7 +97,16 @@ def cmd_scheduler_serve(args) -> int:
 
 def cmd_scheduler_stop(args) -> int:
     """Stop the scheduler daemon."""
+    from .scheduler import live_daemon_state
+
     if not tmux_session_exists(SCHEDULER_SESSION):
+        live = live_daemon_state()
+        if live:
+            # Running, just not in tmux — say so rather than the flatly false
+            # "not running" the tmux-only check used to print (#873).
+            print(f"Scheduler is running outside tmux ({_describe_live_daemon(live)}) "
+                  "— stop it through its supervisor (e.g. launchctl).")
+            return 1
         print("Scheduler is not running.")
         return 1
 
@@ -80,13 +120,18 @@ def cmd_scheduler_status(args) -> int:
     from .config import get_config
     from .scheduler import (
         format_interval,
+        live_daemon_state,
         load_board,
         pick_next_task,
         read_events,
     )
 
     json_mode = getattr(args, 'json', False)
-    running = tmux_session_exists(SCHEDULER_SESSION)
+    # Liveness comes from the daemon's own live-state record, not from tmux
+    # (#873): a launchd-supervised daemon has no tmux session and used to print
+    # "stopped" while it was dispatching.
+    live = live_daemon_state()
+    running = live is not None
     board_path = get_config().scheduler.board_file
 
     if not board_path.exists():
@@ -108,6 +153,8 @@ def cmd_scheduler_status(args) -> int:
 
     result = {
         "running": running,
+        "pid": live.get("pid") if live else None,
+        "in_tmux": tmux_session_exists(SCHEDULER_SESSION),
         "board_path": str(board_path),
         "task_count": task_count,
         "enabled_count": enabled_count,
@@ -120,7 +167,11 @@ def cmd_scheduler_status(args) -> int:
         _output_json({"success": True, **result})
         return 0
 
-    status_str = "running" if running else "stopped"
+    if running:
+        where = "tmux" if result["in_tmux"] else "external supervisor"
+        status_str = f"running (pid {live.get('pid')}, {where})"
+    else:
+        status_str = "stopped"
     print(f"Scheduler: {status_str}")
     print(f"Board: {board_path}")
     print(f"Tasks: {enabled_count}/{task_count} enabled")
@@ -938,6 +989,10 @@ def register_scheduler_parser(subparsers) -> None:
 
     # scheduler serve (foreground, for tmux)
     sched_serve = scheduler_subparsers.add_parser("serve", help="Run scheduler in foreground")
+    sched_serve.add_argument(
+        "--force", action="store_true",
+        help="Start even when another daemon is recorded as live (#873)",
+    )
     sched_serve.set_defaults(func=cmd_scheduler_serve)
 
     # scheduler stop

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -434,3 +434,47 @@ tasks:
 ```
 
 Each night: tests task and lint task each fork their own branch, do their work, and open a draft PR. Morning report runs after both, generates an HTML dashboard showing statuses and PR links.
+
+---
+
+## Daemon Liveness and the Single-Dispatcher Rule (#873)
+
+**One board, one dispatcher.** Two `agentwire scheduler serve` processes against
+the same `scheduler.yaml` double-dispatch tasks: the same task fires twice, the
+first attempt usually times out, a later one completes, and the board shows both.
+
+Liveness is determined from the daemon's own live-state file
+(`~/.agentwire/scheduler-live.json`), which records the writing process's `pid`
+on every loop tick. `live_daemon_state()` (`agentwire/scheduler/report.py`) is
+the single source of truth: it returns the state only when that PID is alive
+*and* its command line still looks like a scheduler, so a leftover file from a
+stopped daemon reads as not-running, and a recycled PID can't masquerade as one.
+
+This replaced `tmux_session_exists("agentwire-scheduler")`, which only ever knew
+about daemons tmux itself hosts. A daemon under an external supervisor (launchd
+`RunAtLoad` + `KeepAlive`) has no tmux session, so it:
+
+- reported as `stopped` while it was actively dispatching, and
+- caused `agentwire doctor` to **skip** the daemon-staleness check — the
+  diagnostic that catches a wedged daemon — exactly where it was most needed.
+
+Everything that asks "is the scheduler running" now routes through the same
+check:
+
+| Surface | Behavior |
+|---|---|
+| `agentwire scheduler status` | Reports `running (pid N, tmux \| external supervisor)` |
+| `agentwire scheduler serve` | **Refuses to start** if a daemon is already live (`--force` overrides) |
+| `agentwire scheduler start` | Refuses when a daemon is live outside tmux |
+| `agentwire scheduler stop` | Says "running outside tmux — stop it through its supervisor" instead of the false "not running" |
+| `agentwire doctor` | Runs the staleness check for tmux and non-tmux daemons alike |
+| Portal autostart (`scheduler.autostart`) | Skips with a logged notice when any daemon is live, not just a tmux one |
+
+`scheduler.autostart` still defaults to `true`. With the guard in place that is
+safe alongside an external supervisor: the portal checks first and logs why it
+declined, rather than silently adding a second dispatcher on every launch.
+
+**One transitional state:** a daemon started before this change writes no `pid`,
+so nothing can verify it. `doctor` flags that explicitly (`records no PID —
+predates the PID-based liveness check`) rather than reporting it as stopped.
+Restarting the daemon clears it — which a rebuild already requires anyway.

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -447,8 +447,16 @@ Liveness is determined from the daemon's own live-state file
 (`~/.agentwire/scheduler-live.json`), which records the writing process's `pid`
 on every loop tick. `live_daemon_state()` (`agentwire/scheduler/report.py`) is
 the single source of truth: it returns the state only when that PID is alive
-*and* its command line still looks like a scheduler, so a leftover file from a
-stopped daemon reads as not-running, and a recycled PID can't masquerade as one.
+*and* its `ps` argv contains both `scheduler` and `serve` as whole words. A
+leftover file from a stopped daemon therefore reads as not-running, and a
+recycled PID can't masquerade as one.
+
+The whole-word test on **both** words is load-bearing, not fussiness. A
+recycled PID is quite likely to be another agentwire command: `agentwire
+scheduler live --watch` is not a dispatcher, but a substring test for
+`scheduler` accepts it — which would misreport liveness *and* make `serve`,
+`start`, and portal autostart all refuse, leaving the board with **no**
+dispatcher. Only `scheduler serve` dispatches.
 
 This replaced `tmux_session_exists("agentwire-scheduler")`, which only ever knew
 about daemons tmux itself hosts. A daemon under an external supervisor (launchd

--- a/tests/unit/test_doctor_scheduler_staleness.py
+++ b/tests/unit/test_doctor_scheduler_staleness.py
@@ -19,34 +19,40 @@ from agentwire.doctor_cli import (
 
 class TestSchedulerDaemonStartedAt:
     def test_not_running_returns_none(self):
-        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=False):
-            assert _scheduler_daemon_started_at() is None
-
-    def test_running_but_no_live_state_returns_none(self):
-        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
-             patch("agentwire.scheduler.read_live_state", return_value=None):
+        with patch("agentwire.scheduler.live_daemon_state", return_value=None):
             assert _scheduler_daemon_started_at() is None
 
     def test_running_but_no_started_at_field_returns_none(self):
-        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
-             patch("agentwire.scheduler.read_live_state", return_value={"status": "running"}):
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"status": "running", "pid": 1}):
             assert _scheduler_daemon_started_at() is None
 
     def test_running_reads_started_at_from_live_state(self):
         from datetime import datetime, timedelta, timezone
         started = datetime.now(timezone.utc) - timedelta(hours=1)
-        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
-             patch("agentwire.scheduler.read_live_state",
-                   return_value={"started_at": started.isoformat()}):
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"started_at": started.isoformat(), "pid": 1}):
             result = _scheduler_daemon_started_at()
         assert result is not None
         assert abs(result - started.timestamp()) < 1
 
     def test_unparseable_started_at_returns_none(self):
-        with patch("agentwire.doctor_cli.tmux_session_exists", return_value=True), \
-             patch("agentwire.scheduler.read_live_state",
-                   return_value={"started_at": "not-a-date"}):
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"started_at": "not-a-date", "pid": 1}):
             assert _scheduler_daemon_started_at() is None
+
+    def test_daemon_outside_tmux_is_still_checked(self):
+        """The staleness check must not be skipped for a launchd daemon (#873).
+
+        The tmux gate this replaced early-returned before ever reading the live
+        state, silently disabling the check exactly where it mattered most.
+        """
+        from datetime import datetime, timedelta, timezone
+        started = datetime.now(timezone.utc) - timedelta(days=11)
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"started_at": started.isoformat(), "pid": 4242}), \
+             patch("agentwire.doctor_cli.tmux_session_exists", return_value=False):
+            assert _scheduler_daemon_started_at() is not None
 
 
 class TestNewestInstalledSourceMtime:
@@ -73,12 +79,49 @@ class TestNewestInstalledSourceMtime:
         assert _newest_installed_source_mtime(tmp_path / "nope") == 0.0
 
 
+class TestSchedulerDaemonPredatesPidStamp:
+    def test_no_state_file(self):
+        from agentwire.doctor_cli import _scheduler_daemon_predates_pid_stamp
+        with patch("agentwire.scheduler.read_live_state", return_value=None):
+            assert _scheduler_daemon_predates_pid_stamp() is False
+
+    def test_state_with_pid_is_not_transitional(self):
+        from agentwire.doctor_cli import _scheduler_daemon_predates_pid_stamp
+        with patch("agentwire.scheduler.read_live_state", return_value={"pid": 42}):
+            assert _scheduler_daemon_predates_pid_stamp() is False
+
+    def test_pidless_state_without_tmux_is_just_leftover(self):
+        from agentwire.doctor_cli import _scheduler_daemon_predates_pid_stamp
+        with patch("agentwire.scheduler.read_live_state", return_value={"status": "running"}), \
+             patch("agentwire.doctor_cli.tmux_session_exists", return_value=False):
+            assert _scheduler_daemon_predates_pid_stamp() is False
+
+    def test_pidless_state_with_live_tmux_session(self):
+        from agentwire.doctor_cli import _scheduler_daemon_predates_pid_stamp
+        with patch("agentwire.scheduler.read_live_state", return_value={"status": "running"}), \
+             patch("agentwire.doctor_cli.tmux_session_exists", return_value=True):
+            assert _scheduler_daemon_predates_pid_stamp() is True
+
+
 class TestRenderSchedulerStalenessSection:
     def test_daemon_not_running(self, capsys):
-        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=None):
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=None), \
+             patch("agentwire.doctor_cli._scheduler_daemon_predates_pid_stamp",
+                   return_value=False):
             count = _render_scheduler_staleness_section()
         assert count == 0
         assert "not running" in capsys.readouterr().out
+
+    def test_pidless_running_daemon_is_flagged_not_reported_stopped(self, capsys):
+        with patch("agentwire.doctor_cli._scheduler_daemon_started_at", return_value=None), \
+             patch("agentwire.doctor_cli._scheduler_daemon_predates_pid_stamp",
+                   return_value=True):
+            count = _render_scheduler_staleness_section()
+        out = capsys.readouterr().out
+        assert count == 1
+        assert "[!!]" in out
+        assert "records no PID" in out
+        assert "not running" not in out
 
     def test_daemon_current(self, capsys):
         now = time.time()

--- a/tests/unit/test_scheduler_liveness.py
+++ b/tests/unit/test_scheduler_liveness.py
@@ -1,0 +1,242 @@
+"""Scheduler daemon liveness + single-dispatcher guard (#873).
+
+Liveness used to be "does the tmux session `agentwire-scheduler` exist?", which
+is false for a daemon supervised outside tmux (launchd). Two consequences, both
+covered here:
+
+1. A running daemon reported as `stopped`, and `doctor` skipped its staleness
+   check — the diagnostic that would catch a wedged daemon, disabled exactly
+   when it was needed.
+2. Nothing refused a second dispatcher: the portal autostarted its own daemon
+   next to the launchd one, and the board double-dispatched.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentwire.scheduler.report import (
+    _pid_is_scheduler,
+    _write_live_state,
+    live_daemon_state,
+    read_live_state,
+)
+
+
+@pytest.fixture
+def live_state_file(tmp_path, monkeypatch):
+    """Point the scheduler's live-state path at a temp file."""
+    path = tmp_path / "scheduler-live.json"
+    cfg = MagicMock()
+    cfg.live_state_file = path
+    monkeypatch.setattr("agentwire.scheduler._sched_config", lambda: cfg)
+    return path
+
+
+class TestWriteLiveStateStampsPid:
+    def test_pid_recorded_on_every_write(self, live_state_file):
+        _write_live_state(status="running", started_at="2026-08-04T13:03:47Z")
+        data = json.loads(live_state_file.read_text())
+        assert data["pid"] == os.getpid()
+        assert data["status"] == "running"
+
+    def test_pid_is_refreshed_not_carried(self, live_state_file):
+        _write_live_state(status="running")
+        _write_live_state(status="running", pid=999999)
+        # The writer's real PID always wins — a caller can't spoof it.
+        assert json.loads(live_state_file.read_text())["pid"] == os.getpid()
+
+
+class TestPidIsScheduler:
+    def test_own_pid_running_a_scheduler_cmdline(self):
+        with patch("agentwire.scheduler.report.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=0, stdout="/usr/bin/python agentwire scheduler serve")
+            assert _pid_is_scheduler(os.getpid()) is True
+
+    def test_dead_pid_is_false(self):
+        # PID 0 / negative are never valid targets for a liveness probe.
+        assert _pid_is_scheduler(0) is False
+        assert _pid_is_scheduler(-1) is False
+
+    def test_lookup_error_means_dead(self):
+        with patch("agentwire.scheduler.report.os.kill", side_effect=ProcessLookupError):
+            assert _pid_is_scheduler(12345) is False
+
+    def test_permission_error_means_alive(self):
+        with patch("agentwire.scheduler.report.os.kill", side_effect=PermissionError):
+            assert _pid_is_scheduler(12345) is True
+
+    def test_recycled_pid_running_something_else_is_false(self):
+        """PID reuse must not read as "the scheduler is running"."""
+        with patch("agentwire.scheduler.report.os.kill", return_value=None), \
+             patch("agentwire.scheduler.report.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="/usr/sbin/cupsd -l")
+            assert _pid_is_scheduler(12345) is False
+
+    def test_ps_unavailable_keeps_the_kill_answer(self):
+        with patch("agentwire.scheduler.report.os.kill", return_value=None), \
+             patch("agentwire.scheduler.report.subprocess.run", side_effect=OSError):
+            assert _pid_is_scheduler(12345) is True
+
+
+class TestLiveDaemonState:
+    def test_no_state_file(self, live_state_file):
+        assert read_live_state() is None
+        assert live_daemon_state() is None
+
+    def test_leftover_file_from_stopped_daemon_is_not_live(self, live_state_file):
+        """The requirement the tmux gate existed to satisfy, kept."""
+        live_state_file.write_text(json.dumps({"status": "running", "pid": 999999}))
+        with patch("agentwire.scheduler.report._pid_is_scheduler", return_value=False):
+            assert live_daemon_state() is None
+
+    def test_state_without_pid_cannot_be_verified(self, live_state_file):
+        live_state_file.write_text(json.dumps({"status": "running"}))
+        assert live_daemon_state() is None
+
+    def test_live_pid_returns_the_state(self, live_state_file):
+        live_state_file.write_text(
+            json.dumps({"status": "running", "pid": 4242, "started_at": "x"}))
+        with patch("agentwire.scheduler.report._pid_is_scheduler", return_value=True):
+            state = live_daemon_state()
+        assert state is not None
+        assert state["pid"] == 4242
+
+    def test_daemon_outside_tmux_reads_as_running(self, live_state_file):
+        """The launchd case: no tmux session anywhere, daemon very much alive."""
+        live_state_file.write_text(json.dumps({"status": "running", "pid": 4242}))
+        with patch("agentwire.scheduler.report._pid_is_scheduler", return_value=True), \
+             patch("agentwire.core.tmux_session_exists", return_value=False):
+            assert live_daemon_state() is not None
+
+
+class TestServeRefusesASecondDispatcher:
+    def _args(self, force=False):
+        ns = MagicMock()
+        ns.force = force
+        return ns
+
+    def test_refuses_when_a_daemon_is_already_live(self, capsys):
+        from agentwire.scheduler_cli import cmd_scheduler_serve
+
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"pid": 4242, "started_at": "2026-08-04T13:03:47Z"}), \
+             patch("agentwire.scheduler.run_scheduler_loop") as loop:
+            rc = cmd_scheduler_serve(self._args())
+        assert rc == 1
+        loop.assert_not_called()
+        err = capsys.readouterr().err
+        assert "4242" in err
+        assert "second dispatcher" in err
+
+    def test_force_overrides(self):
+        from agentwire.scheduler_cli import cmd_scheduler_serve
+
+        with patch("agentwire.scheduler.live_daemon_state", return_value={"pid": 4242}), \
+             patch("agentwire.scheduler.run_scheduler_loop") as loop:
+            rc = cmd_scheduler_serve(self._args(force=True))
+        assert rc == 0
+        loop.assert_called_once()
+
+    def test_starts_when_nothing_is_running(self):
+        from agentwire.scheduler_cli import cmd_scheduler_serve
+
+        with patch("agentwire.scheduler.live_daemon_state", return_value=None), \
+             patch("agentwire.scheduler.run_scheduler_loop") as loop:
+            rc = cmd_scheduler_serve(self._args())
+        assert rc == 0
+        loop.assert_called_once()
+
+
+class TestStartAndStopSeeNonTmuxDaemons:
+    def test_start_refuses_when_daemon_runs_outside_tmux(self, capsys):
+        from agentwire.scheduler_cli import cmd_scheduler_start
+
+        with patch("agentwire.scheduler_cli._check_tmux_installed", return_value=True), \
+             patch("agentwire.scheduler.live_daemon_state", return_value={"pid": 4242}), \
+             patch("agentwire.scheduler_cli.tmux_session_exists", return_value=False), \
+             patch("agentwire.scheduler_cli.subprocess.run") as run:
+            rc = cmd_scheduler_start(MagicMock())
+        assert rc == 1
+        run.assert_not_called()
+        assert "Refusing to start a second dispatcher" in capsys.readouterr().out
+
+    def test_stop_reports_an_external_daemon_honestly(self, capsys):
+        from agentwire.scheduler_cli import cmd_scheduler_stop
+
+        with patch("agentwire.scheduler.live_daemon_state", return_value={"pid": 4242}), \
+             patch("agentwire.scheduler_cli.tmux_session_exists", return_value=False), \
+             patch("agentwire.scheduler_cli.subprocess.run") as run:
+            rc = cmd_scheduler_stop(MagicMock())
+        assert rc == 1
+        run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "outside tmux" in out
+        assert "not running" not in out
+
+    def test_stop_still_reports_a_genuinely_stopped_daemon(self, capsys):
+        from agentwire.scheduler_cli import cmd_scheduler_stop
+
+        with patch("agentwire.scheduler.live_daemon_state", return_value=None), \
+             patch("agentwire.scheduler_cli.tmux_session_exists", return_value=False):
+            rc = cmd_scheduler_stop(MagicMock())
+        assert rc == 1
+        assert "not running" in capsys.readouterr().out
+
+
+class TestPortalAutostartGuard:
+    """The portal must not add a dispatcher next to an externally-supervised one."""
+
+    def _server(self):
+        from agentwire.routes.scheduler import SchedulerRoutesMixin
+
+        class _S(SchedulerRoutesMixin):
+            pass
+
+        return _S()
+
+    @pytest.mark.asyncio
+    async def test_skips_autostart_when_a_daemon_runs_outside_tmux(self, caplog):
+        import logging
+
+        server = self._server()
+        with patch("agentwire.scheduler.live_daemon_state",
+                   return_value={"pid": 4242, "started_at": "2026-07-27T00:00:00Z"}), \
+             patch("asyncio.create_subprocess_exec") as spawn, \
+             caplog.at_level(logging.INFO, logger="agentwire.routes.scheduler"):
+            started = await server._start_scheduler_daemon()
+        assert started is False
+        spawn.assert_not_called()
+        # Skipping is logged, not silent — otherwise the only evidence the
+        # portal declined is a board that doesn't double-dispatch.
+        assert "4242" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_starts_when_no_daemon_is_live(self):
+        server = self._server()
+        proc = MagicMock()
+
+        async def _wait():
+            return 0
+
+        proc.wait = _wait
+
+        async def _spawn(*a, **kw):
+            return proc
+
+        with patch("agentwire.scheduler.live_daemon_state", return_value=None), \
+             patch("asyncio.create_subprocess_exec", side_effect=_spawn) as spawn:
+            started = await server._start_scheduler_daemon()
+        assert started is True
+        assert spawn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_is_running_no_longer_asks_tmux(self):
+        server = self._server()
+        with patch("agentwire.scheduler.live_daemon_state", return_value={"pid": 1}), \
+             patch("asyncio.create_subprocess_exec") as spawn:
+            assert await server._is_scheduler_running() is True
+        spawn.assert_not_called()

--- a/tests/unit/test_scheduler_liveness.py
+++ b/tests/unit/test_scheduler_liveness.py
@@ -56,6 +56,40 @@ class TestPidIsScheduler:
                 returncode=0, stdout="/usr/bin/python agentwire scheduler serve")
             assert _pid_is_scheduler(os.getpid()) is True
 
+    def test_serve_with_flags_still_qualifies(self):
+        with patch("agentwire.scheduler.report.os.kill", return_value=None), \
+             patch("agentwire.scheduler.report.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=0,
+                stdout="/opt/venv/bin/python3 /usr/local/bin/agentwire scheduler serve --force\n")
+            assert _pid_is_scheduler(12345) is True
+
+    def test_module_invocation_qualifies(self):
+        with patch("agentwire.scheduler.report.os.kill", return_value=None), \
+             patch("agentwire.scheduler.report.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=0, stdout="python -m agentwire scheduler serve")
+            assert _pid_is_scheduler(12345) is True
+
+    @pytest.mark.parametrize("cmdline", [
+        # The reproduction from review: a recycled PID running a READ-ONLY
+        # scheduler command. Substring-matching "scheduler" accepted this,
+        # which re-created the false-stale reading AND made serve/start/
+        # autostart all refuse — a board with no dispatcher.
+        "/usr/local/bin/agentwire scheduler live --watch",
+        "/usr/local/bin/agentwire scheduler status",
+        "/usr/local/bin/agentwire scheduler board",
+        "/usr/local/bin/agentwire scheduler run memory-manager",
+        # A path that merely contains the words.
+        "/Users/x/scheduler/serve-helper.sh",
+        "vim /etc/scheduler-serve.conf",
+    ])
+    def test_non_dispatcher_processes_are_rejected(self, cmdline):
+        with patch("agentwire.scheduler.report.os.kill", return_value=None), \
+             patch("agentwire.scheduler.report.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=cmdline)
+            assert _pid_is_scheduler(12345) is False
+
     def test_dead_pid_is_false(self):
         # PID 0 / negative are never valid targets for a liveness probe.
         assert _pid_is_scheduler(0) is False
@@ -111,6 +145,81 @@ class TestLiveDaemonState:
         with patch("agentwire.scheduler.report._pid_is_scheduler", return_value=True), \
              patch("agentwire.core.tmux_session_exists", return_value=False):
             assert live_daemon_state() is not None
+
+
+class TestStatusReportsLivenessNotTmux:
+    """The headline symptom of #873, pinned.
+
+    `scheduler status` printed `Scheduler: stopped` while the daemon was
+    actively dispatching, because it asked tmux. These tests fail if
+    `cmd_scheduler_status` goes back to `tmux_session_exists` in either
+    direction — a launchd daemon must read running, and a leftover state file
+    must not.
+    """
+
+    def _run_status(self, tmp_path, live, in_tmux, json_mode=False):
+        from agentwire.scheduler_cli import cmd_scheduler_status
+
+        board_path = tmp_path / "scheduler.yaml"
+        board_path.write_text("tasks: {}\n")
+        cfg = MagicMock()
+        cfg.scheduler.board_file = board_path
+        board = MagicMock()
+        board.tasks = {}
+
+        args = MagicMock()
+        args.json = json_mode
+
+        with patch("agentwire.config.get_config", return_value=cfg), \
+             patch("agentwire.scheduler.live_daemon_state", return_value=live), \
+             patch("agentwire.scheduler.load_board", return_value=board), \
+             patch("agentwire.scheduler.pick_next_task", return_value=(None, 60.0)), \
+             patch("agentwire.scheduler.read_events", return_value=[]), \
+             patch("agentwire.scheduler_cli.tmux_session_exists", return_value=in_tmux):
+            rc = cmd_scheduler_status(args)
+        return rc
+
+    def test_launchd_daemon_reports_running_with_no_tmux_session(self, tmp_path, capsys):
+        self._run_status(
+            tmp_path,
+            live={"pid": 4242, "started_at": "2026-08-04T13:03:47Z"},
+            in_tmux=False,
+        )
+        out = capsys.readouterr().out
+        assert "Scheduler: running" in out
+        assert "stopped" not in out
+        assert "4242" in out
+        assert "external supervisor" in out
+
+    def test_launchd_daemon_reports_running_in_json(self, tmp_path, capsys):
+        self._run_status(
+            tmp_path, live={"pid": 4242}, in_tmux=False, json_mode=True)
+        data = json.loads(capsys.readouterr().out)
+        assert data["running"] is True
+        assert data["pid"] == 4242
+        assert data["in_tmux"] is False
+
+    def test_tmux_hosted_daemon_is_labelled_as_such(self, tmp_path, capsys):
+        self._run_status(tmp_path, live={"pid": 77}, in_tmux=True)
+        out = capsys.readouterr().out
+        assert "Scheduler: running" in out
+        assert "tmux" in out
+        assert "external supervisor" not in out
+
+    def test_leftover_state_with_a_live_tmux_session_still_reads_stopped(
+            self, tmp_path, capsys):
+        """The other direction: deleting the gate outright must not pass either.
+
+        tmux says the session exists; the PID behind the state file does not
+        resolve to a dispatcher, so the daemon is not running.
+        """
+        self._run_status(tmp_path, live=None, in_tmux=True)
+        out = capsys.readouterr().out
+        assert "Scheduler: stopped" in out
+
+    def test_nothing_running_reports_stopped(self, tmp_path, capsys):
+        self._run_status(tmp_path, live=None, in_tmux=False)
+        assert "Scheduler: stopped" in capsys.readouterr().out
 
 
 class TestServeRefusesASecondDispatcher:


### PR DESCRIPTION
## What

Scheduler liveness now reflects whether the daemon process is actually running, and starting a second dispatcher is refused.

## Verified before changing anything

| Claim | Verdict |
|---|---|
| `scheduler_cli.py` infers liveness from `tmux_session_exists(SCHEDULER_SESSION)` | Confirmed (was line 88) |
| `doctor_cli._scheduler_daemon_started_at` early-returns on the same check before `read_live_state()` | Confirmed |
| `~/.agentwire/scheduler-live.json` has no `pid` field | Confirmed — the fix had to add the stamp first |
| `scheduler.autostart` defaults `True` (`config.py:439`) and the portal starts a daemon on launch (`server.py:3026`) | Confirmed |
| The portal's `_is_scheduler_running` was `tmux has-session -t =agentwire-scheduler` | Confirmed (`routes/scheduler.py:41`) |
| `SCHEDULER_SESSION` was defined twice — `scheduler/models.py:16` and `scheduler_cli.py:31` | Confirmed; deduped |

## The mechanism

`_write_live_state` stamps `os.getpid()` on every tick — one place, so no call site changed. `live_daemon_state()` (`agentwire/scheduler/report.py`) is the single source of truth: it returns the state only when the recorded PID is alive **and** its `ps` command line still mentions `scheduler`.

That preserves what the tmux gate existed for (its comment: a leftover live-state file from a since-stopped daemon must not read as "stale") — a dead PID reads as not-running. The cmdline check matters in the other direction: a recycled PID reading as "the scheduler is running" would suppress the autostart guard and leave the board with **no** dispatcher, which is worse than the bug being fixed. `ps` unavailable falls back to the `os.kill(pid, 0)` answer rather than reporting a live daemon dead.

The portal's version runs it via `asyncio.to_thread` so the `ps` call never sits on the event loop.

## Surfaces routed through it

| Surface | Before | After |
|---|---|---|
| `scheduler status` | `Scheduler: stopped` while dispatching | `running (pid N, tmux \| external supervisor)`; JSON gains `pid` + `in_tmux` |
| `scheduler serve` | started unconditionally | refuses when a daemon is live; `--force` overrides |
| `scheduler start` | tmux-name collision only | also refuses a live non-tmux daemon |
| `scheduler stop` | `Scheduler is not running.` (false) | `running outside tmux — stop it through its supervisor` |
| `doctor` | `daemon not running — skipping staleness check` | runs the check for tmux and non-tmux daemons alike |
| Portal autostart | started a second dispatcher | skips with a logged notice naming the live pid |

`scheduler.autostart` still defaults `true` — with the guard in place that is safe next to an external supervisor, and the log line makes "the portal declined" visible instead of something you infer from a board that stopped double-dispatching.

## One transitional state, made loud rather than silent

A daemon started before this change writes no `pid`, so nothing can verify it — it reads as not-running. Rather than a compat shim in the liveness helper (which would reintroduce tmux as an authority), `doctor` names it:

```
  [!!] Scheduler daemon records no PID — it predates the PID-based liveness check (#873)
       Liveness and the staleness check below can't be verified until it restarts.
       Fix: agentwire scheduler stop && agentwire scheduler start
```

Verified against the live daemon on this machine, which is in exactly that state. Restarting it clears the flag — which `rebuild` already requires anyway. **This PR does not restart the live daemon; the fleet is running.**

## Tests

`tests/unit/test_scheduler_liveness.py` (new, 22 tests) covers the PID stamp, `_pid_is_scheduler` (dead / permission-denied / recycled-PID / no-`ps`), `live_daemon_state` (missing file, leftover file, pidless state, non-tmux daemon), the `serve` / `start` / `stop` refusals, and the portal autostart guard. `test_doctor_scheduler_staleness.py` gains the transitional-state cases and one asserting the staleness check is no longer skipped for a non-tmux daemon.

**Full suite: 3104 passed, 1 warning (pre-existing aiohttp `NotAppKeyWarning`), 133s.** `ruff check` clean.

Docs: a "Daemon Liveness and the Single-Dispatcher Rule" section in `docs/wiki/scheduling/scheduled-workloads.md`.

## Not verifiable in-worktree

The launchd path itself (a daemon supervised outside tmux reporting `running`) can only be confirmed once the installed package is rebuilt and the daemon restarted. The code path is covered by tests, not by a live launchd run.

Closes #873

Built by [dotdev.dev](https://dotdev.dev)