### PR TITLE
fix(tasks): bound a task attempt with max_duration, report ignored keys (#867)

### DIFF
--- a/.claude/skills/agentwire-project-config/SKILL.md
+++ b/.claude/skills/agentwire-project-config/SKILL.md
@@ -142,10 +142,10 @@ shell: /bin/sh  # Project-level default shell
 tasks:
   morning-briefing:
     shell: /bin/bash           # Task-level override
-    priority: 10               # Pipeline ordering (lower = higher priority, default: 99)
     retries: 2                 # Retry on failure (default: 0)
     retry_delay: 30            # Seconds between retries (default: 30)
     idle_timeout: 30           # Seconds of idle before completion (default: 30)
+    max_duration: 1800         # Hard wall-clock ceiling per attempt (default: 0 = unbounded)
     exit_on_complete: true     # Exit session after completion (default: true)
     role: task-runner          # Role override for this task (optional)
     pre:                       # Data gathering (NO {{ }} - these PRODUCE variables)

--- a/agentwire/completion.py
+++ b/agentwire/completion.py
@@ -187,25 +187,38 @@ def wait_for_completion_signal(
     session: str,
     poll_interval: float = 10.0,
     summary_path: Path | None = None,
+    max_duration: int = 0,
 ) -> dict:
     """Wait for task completion by polling the summary file directly.
 
     Exits when:
     1. Summary file appears (task completed normally)
     2. Session dies (agent crashed, tmux killed)
+    3. ``max_duration`` elapses, when the task sets one
 
-    There is no wall-clock timeout. Tasks run until one of these conditions.
+    Completion is otherwise agent-driven: the idle hook fires, the agent writes
+    a summary, and this returns. An agent that never goes idle never produces
+    either exit — wedged on an unrecognized dialog, or blocked inside a tool
+    call — and before ``max_duration`` existed the wait was unbounded, so that
+    read as a silent multi-hour hang whose only visible end was the scheduler's
+    4h process-group watchdog (#867).
+
+    ``max_duration`` is a per-attempt wall clock, not an idle timer: it can't
+    tell a wedged agent from a slow one, so a task that legitimately runs long
+    should set it high or leave it at 0 rather than get killed mid-work.
 
     Args:
         session: tmux session name
         poll_interval: Seconds between checks
         summary_path: Path to the summary .md file the agent will write
+        max_duration: Seconds before giving up (0 = unbounded)
 
     Returns:
         Dict with 'status', 'summary', 'summary_file' keys
 
     Raises:
-        CompletionTimeout: If session dies before task completed
+        CompletionTimeout: If the session dies, or max_duration elapses, before
+            the task completed. The message names which.
     """
     # Build glob pattern for fuzzy summary detection (agents sometimes
     # invent their own timestamp instead of using the provided filename).
@@ -216,6 +229,8 @@ def wait_for_completion_signal(
         # Strip the timestamp suffix (last 19 chars: YYYY-MM-DDTHH-MM-SS)
         prefix = stem[:-19] if len(stem) > 19 else stem
         summary_glob = f"{prefix}*.md"
+
+    started = time.time()
 
     while True:
         # Primary: check if the agent has written the summary file AND
@@ -273,6 +288,14 @@ def wait_for_completion_signal(
             raise CompletionTimeout(
                 f"Session '{session}' died or agent exited before task completed"
             )
+
+        if max_duration > 0:
+            elapsed = time.time() - started
+            if elapsed >= max_duration:
+                raise CompletionTimeout(
+                    f"Task exceeded max_duration ({max_duration}s) after "
+                    f"{int(elapsed)}s — the agent never signalled completion"
+                )
 
         time.sleep(poll_interval)
 

--- a/agentwire/ensure_cli.py
+++ b/agentwire/ensure_cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import datetime
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -178,6 +179,12 @@ def cmd_ensure(args) -> int:
     if issues:
         return _output_result(False, json_mode, f"Task validation failed: {', '.join(issues)}", exit_code=ENSURE_EXIT_SESSION_ERROR)
 
+    # Warn, never fail: an ignored key means the task isn't behaving the way
+    # its author configured it, but a typo must not break a 04:00 dispatch.
+    if task.unknown_keys:
+        print(f"Warning: task '{task.name}' sets keys agentwire ignores: "
+              f"{', '.join(task.unknown_keys)}", file=sys.stderr)
+
     # Determine shell
     shell = task.shell or "/bin/sh"
 
@@ -195,6 +202,8 @@ def cmd_ensure(args) -> int:
         print(f"Task: {task_name}")
         print(f"Shell: {shell}")
         print(f"Idle timeout: {task.idle_timeout}s")
+        print("Max duration: "
+              + (f"{task.max_duration}s" if task.max_duration else "unbounded"))
         print(f"Retries: {task.retries}")
         print()
 
@@ -500,12 +509,14 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
     """
     from .completion import (
         CompletionTimeout,
+        _session_has_agent,
         clear_task_context,
         generate_summary_filename,
         status_to_exit_code,
         wait_for_completion_signal,
         write_task_context,
     )
+    from .core import _graceful_kill
     from .tasks import PreCommandError, run_post_command, run_pre_command
     from .templating import TemplateError, expand_all
 
@@ -679,18 +690,29 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
 
         try:
             signal = wait_for_completion_signal(
-                session, summary_path=summary_path
+                session, summary_path=summary_path,
+                max_duration=task.max_duration,
             )
             last_status = signal.get("status", "incomplete")
             last_summary = signal.get("summary", "")
             ctx.status = last_status
             ctx.summary = last_summary
-        except CompletionTimeout:
+        except CompletionTimeout as e:
             # Don't clear task context here — the hook may still need it.
             # Hook cleans up after itself (exit_on_complete kills session).
             # Task context files are cleared at the START of next run.
             last_status = "incomplete"
-            last_summary = "Timeout waiting for task completion"
+            # Carry the real reason (max_duration vs session died) into the
+            # summary — the board used to show one indistinguishable line for
+            # both, which is what made #867 take a log archaeology dig.
+            last_summary = str(e) or "Timeout waiting for task completion"
+            if not json_mode:
+                print(f"Timeout: {last_summary}")
+            # A max_duration expiry leaves the agent still running. Nothing
+            # else reaps it before the scheduler's 4h process-group watchdog,
+            # so tear it down here rather than leak a wedged session for hours.
+            if task.max_duration > 0 and _session_has_agent(session):
+                _graceful_kill(session)
             if attempt < max_attempts:
                 if not json_mode:
                     print(f"Timeout, retrying in {task.retry_delay}s...")
@@ -872,6 +894,7 @@ def cmd_task_show(args) -> int:
             "retries": task.retries,
             "retry_delay": task.retry_delay,
             "idle_timeout": task.idle_timeout,
+            "max_duration": task.max_duration,
             "mode": task.mode,
             "max_iterations": task.max_iterations,
             "loop_review": task.loop_review,
@@ -881,6 +904,7 @@ def cmd_task_show(args) -> int:
             "post": task.post,
             "output": {"capture": task.output.capture, "save": task.output.save},
             "validation_issues": issues,
+            "unknown_keys": task.unknown_keys,
         })
         return 0
 
@@ -894,6 +918,10 @@ def cmd_task_show(args) -> int:
             print(f"Loop delay: {task.loop_delay}s")
     print(f"Retries: {task.retries} (delay: {task.retry_delay}s)")
     print(f"Idle timeout: {task.idle_timeout}s")
+    print(f"Max duration: {task.max_duration}s" if task.max_duration
+          else "Max duration: unbounded")
+    if task.unknown_keys:
+        print(f"Ignored keys: {', '.join(task.unknown_keys)}")
     print()
 
     if task.pre:
@@ -954,15 +982,24 @@ def cmd_task_validate(args) -> int:
         return _output_result(False, json_mode, str(e))
 
     issues = validate_task(task)
+    # Ignored keys are reported, not counted as invalid — the task still runs,
+    # it just doesn't do what its author configured (#867).
+    warnings = (
+        [f"ignored key(s) {', '.join(task.unknown_keys)} — agentwire does not read these"]
+        if task.unknown_keys else []
+    )
 
     if json_mode:
         _output_json({
             "valid": len(issues) == 0,
             "issues": issues,
+            "warnings": warnings,
             "task": task_name,
         })
         return 0 if not issues else 1
 
+    for warning in warnings:
+        print(f"Warning: {warning}")
     if issues:
         print(f"Task '{task_name}' has issues:")
         for issue in issues:

--- a/agentwire/mcp_task.py
+++ b/agentwire/mcp_task.py
@@ -60,6 +60,11 @@ def task_show(session: str, task: str) -> str:
     lines.append(f"  Shell: {data.get('shell') or '/bin/sh'}")
     lines.append(f"  Retries: {data.get('retries', 0)}")
     lines.append(f"  Idle timeout: {data.get('idle_timeout', 30)}s")
+    max_duration = data.get("max_duration", 0)
+    lines.append(f"  Max duration: {max_duration}s" if max_duration
+                 else "  Max duration: unbounded")
+    if unknown := data.get("unknown_keys"):
+        lines.append(f"  Ignored keys: {', '.join(unknown)}")
 
     if pre := data.get("pre"):
         lines.append(f"  Pre-commands: {len(pre)}")

--- a/agentwire/tasks.py
+++ b/agentwire/tasks.py
@@ -89,6 +89,13 @@ class TaskConfig:
     idle_timeout: int = 30  # Seconds of idle before completion
     exit_on_complete: bool = True  # Exit session after task completion
 
+    # Hard wall-clock ceiling for a single attempt, in seconds (0 = unbounded).
+    # Completion is otherwise driven entirely by the agent going idle, so an
+    # agent that never goes idle — wedged on a dialog, or blocked in a tool
+    # call — is waited on forever (#867). This is the bound that turns that
+    # into a reported failure instead of a silent multi-hour hang.
+    max_duration: int = 0
+
     # Loop configuration
     mode: str = "standard"  # "standard" or "loop"
     max_iterations: int = 3  # Safety limit for loop mode (1-20)
@@ -125,6 +132,30 @@ class TaskConfig:
     # default allowlist (safety.unattended_allow / DEFAULT_UNATTENDED_ALLOW).
     # Anything ask-tier and off the merged list is blocked + owner-notified.
     unattended_allow: list[str] = field(default_factory=list)
+
+    # Keys present in the YAML that this dataclass doesn't know about. A task
+    # author who sets a field agentwire silently ignores gets the behavior they
+    # configured against, not the behavior they asked for — `max_duration` was
+    # exactly that for the whole life of `.agentwire.tasks.yml` (#867). Surfaced
+    # as a warning, never a hard failure: a typo must not break a 04:00 dispatch.
+    unknown_keys: list[str] = field(default_factory=list)
+
+
+# Every key `parse_task` reads out of a task's YAML block. Derived from the
+# reads below rather than from `TaskConfig`'s fields, because the two differ:
+# `name` comes from the mapping key, `unknown_keys` is computed. Anything in a
+# task block and not in here is silently ignored — which is the whole point of
+# reporting it (#867).
+KNOWN_TASK_KEYS = frozenset({
+    "prompt", "shell", "retries", "retry_delay", "idle_timeout", "max_duration",
+    "exit_on_complete", "mode", "max_iterations", "loop_review", "loop_delay",
+    "pre", "on_task_end", "post", "output", "starting_ref", "work_branch",
+    "pr_target", "pr_draft", "starting_session", "role", "allow_shared_dir",
+    "unattended_allow",
+    # Author's note to the next reader. Deliberately consumed by nothing —
+    # listed so an annotation doesn't read as a field agentwire dropped.
+    "description",
+})
 
 
 def parse_pre_command(name: str, config: str | dict) -> PreCommand:
@@ -208,6 +239,7 @@ def parse_task_config(name: str, config: dict, default_shell: str | None = None)
         retries=config.get("retries", 0),
         retry_delay=config.get("retry_delay", 30),
         idle_timeout=config.get("idle_timeout", 30),
+        max_duration=config.get("max_duration", 0),
         exit_on_complete=config.get("exit_on_complete", True),
         mode=config.get("mode", "standard"),
         max_iterations=config.get("max_iterations", 3),
@@ -232,6 +264,7 @@ def parse_task_config(name: str, config: dict, default_shell: str | None = None)
             if isinstance(config.get("unattended_allow"), list)
             else []
         ),
+        unknown_keys=sorted(set(config) - KNOWN_TASK_KEYS),
     )
 
 
@@ -341,6 +374,9 @@ def validate_task(task: TaskConfig) -> list[str]:
 
     if task.idle_timeout <= 0:
         issues.append("Invalid idle_timeout (must be > 0)")
+
+    if task.max_duration < 0:
+        issues.append("Negative max_duration (use 0 for no limit)")
 
     if task.mode not in ("standard", "loop"):
         issues.append(f"Invalid mode '{task.mode}' (must be 'standard' or 'loop')")

--- a/agentwire/tasks_cli.py
+++ b/agentwire/tasks_cli.py
@@ -110,6 +110,13 @@ def _validate_draft(data: dict) -> list[str]:
         try:
             task = parse_task_config(name, cfg, default_shell=default_shell)
             issues.extend(f"{name}: {i}" for i in validate_task(task))
+            if task.unknown_keys:
+                # Not a hard failure — but a key agentwire ignores is a task
+                # that won't behave the way it reads, so the reviewer sees it
+                # before promoting (#867).
+                issues.append(
+                    f"{name}: ignored key(s) {', '.join(task.unknown_keys)} "
+                    "— agentwire does not read these")
         except Exception as e:  # noqa: BLE001 — surfaced to the reviewer, not raised
             issues.append(f"{name}: {e}")
     return issues

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -40,10 +40,10 @@ tasks:
   write-tests:
     # Execution control
     shell: /bin/bash         # Override shell for this task
-    priority: 10             # Pipeline ordering (lower = higher priority, default: 99)
     retries: 2               # Retry on failure (default: 0)
     retry_delay: 30          # Seconds between retries (default: 30)
     idle_timeout: 60         # Seconds of idle before completion (default: 30)
+    max_duration: 1800       # Hard wall-clock ceiling per attempt (default: 0 = unbounded)
     exit_on_complete: true   # Exit session after completion (default: true)
     role: piinpoint-test-writer  # Role override for this task (optional)
 
@@ -486,3 +486,45 @@ declined, rather than silently adding a second dispatcher on every launch.
 so nothing can verify it. `doctor` flags that explicitly (`records no PID —
 predates the PID-based liveness check`) rather than reporting it as stopped.
 Restarting the daemon clears it — which a rebuild already requires anyway.
+---
+
+## Bounding a Task: `max_duration` (#867)
+
+Completion is **agent-driven**. `ensure` sends the prompt and then waits for the
+agent to go idle, the idle hook to prompt for a summary, and the summary file to
+appear. Nothing in that chain has a clock. An agent that never goes idle — wedged
+on an unrecognized dialog, or blocked inside a long tool call — produces no
+completion signal and no error, so the wait simply never ends.
+
+`max_duration` is the wall clock that bounds a single attempt:
+
+```yaml
+tasks:
+  memory-manager:
+    max_duration: 1800   # give up after 30 min (default: 0 = unbounded)
+```
+
+On expiry the attempt reports `incomplete`, the summary names the reason
+(`Task exceeded max_duration (1800s) after 1802s — the agent never signalled
+completion`), and the session is torn down — otherwise the wedged agent keeps
+running until the scheduler's 4h `dispatch_max_runtime` process-group kill.
+
+**It is a wall clock, not an idle timer.** It cannot distinguish a wedged agent
+from a slow one, so a task that legitimately runs long should set it generously
+or leave it at `0`. `idle_timeout` is *not* an equivalent bound: agentwire does
+not control the harness's idle threshold, so that field configures the summary
+handoff, not a ceiling on the run.
+
+### Keys agentwire doesn't read are now reported
+
+`max_duration` existed in `.agentwire.tasks.yml` files across the fleet long
+before anything read it — a task that looked bounded at 30 minutes was in fact
+unbounded. Unknown keys in a task block are now surfaced by `agentwire task
+show` / `task validate` / `tasks review`, and warned about at dispatch:
+
+```
+Warning: task 'memory-manager' sets keys agentwire ignores: max_durationn
+```
+
+Reported, never fatal: a typo must not break a 04:00 dispatch. `description` is
+allowed as a deliberate no-op annotation.

--- a/tests/unit/test_task_max_duration.py
+++ b/tests/unit/test_task_max_duration.py
@@ -1,0 +1,171 @@
+"""Wall-clock bound on a task attempt, and loud phantom task keys (#867).
+
+`memory-manager` ran 2h unattended and reported `incomplete — Timeout waiting
+for task completion`, having set `max_duration: 1800` in its
+`.agentwire.tasks.yml`. That field was read by nothing: completion is agent-
+driven (idle hook → summary file), and the wait had no wall clock at all, so an
+agent that never goes idle was waited on until something else killed it.
+
+Two things are covered here:
+
+* `max_duration` is enforced, and its expiry is distinguishable on the board
+  from "the session died" — the two used to share one summary line.
+* A key in a task block that agentwire doesn't read is reported rather than
+  silently dropped, which is what let `max_duration` look configured for the
+  whole life of the file.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentwire.completion import CompletionTimeout, wait_for_completion_signal
+from agentwire.tasks import KNOWN_TASK_KEYS, parse_task_config, validate_task
+
+
+class TestMaxDurationParsing:
+    def test_defaults_to_unbounded(self):
+        task = parse_task_config("t", {"prompt": "go"})
+        assert task.max_duration == 0
+
+    def test_parsed_from_config(self):
+        task = parse_task_config("t", {"prompt": "go", "max_duration": 1800})
+        assert task.max_duration == 1800
+
+    def test_negative_is_a_validation_issue(self):
+        task = parse_task_config("t", {"prompt": "go", "max_duration": -1})
+        assert any("max_duration" in i for i in validate_task(task))
+
+    def test_zero_is_valid(self):
+        task = parse_task_config("t", {"prompt": "go", "max_duration": 0})
+        assert validate_task(task) == []
+
+    def test_max_duration_is_a_known_key(self):
+        """The regression this whole PR exists for."""
+        assert "max_duration" in KNOWN_TASK_KEYS
+
+
+class TestUnknownTaskKeys:
+    def test_known_keys_produce_no_warning(self):
+        task = parse_task_config("t", {
+            "prompt": "go", "idle_timeout": 300, "max_duration": 1800,
+            "exit_on_complete": True, "pre": {"x": "echo hi"},
+        })
+        assert task.unknown_keys == []
+
+    def test_unknown_key_is_recorded(self):
+        task = parse_task_config("t", {"prompt": "go", "max_durationn": 1800})
+        assert task.unknown_keys == ["max_durationn"]
+
+    def test_unknown_keys_are_sorted_and_deduped(self):
+        task = parse_task_config("t", {"prompt": "go", "zeta": 1, "alpha": 2})
+        assert task.unknown_keys == ["alpha", "zeta"]
+
+    def test_unknown_keys_never_fail_validation(self):
+        """A typo must not break a 04:00 dispatch — ensure hard-fails on issues."""
+        task = parse_task_config("t", {"prompt": "go", "nonsense": True})
+        assert validate_task(task) == []
+
+
+class _Clock:
+    """Monotonic fake clock — one tick per call, so the wait can't run real time."""
+
+    def __init__(self, step: float = 10.0):
+        self.now = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        self.now += self.step
+        return self.now
+
+
+class TestWaitHonorsMaxDuration:
+    def _patches(self, has_agent=True):
+        return (
+            patch("agentwire.completion._session_has_agent", return_value=has_agent),
+            patch("agentwire.usage_limit.check_and_park", return_value=False),
+        )
+
+    def test_expiry_raises_with_a_named_reason(self):
+        agent, park = self._patches()
+        with agent, park, \
+             patch("agentwire.completion.time.sleep"), \
+             patch("agentwire.completion.time.time", _Clock(step=10.0)):
+            with pytest.raises(CompletionTimeout) as exc:
+                wait_for_completion_signal("s", poll_interval=0, max_duration=10)
+        assert "max_duration (10s)" in str(exc.value)
+        assert "never signalled completion" in str(exc.value)
+
+    def test_wait_continues_while_inside_the_budget(self):
+        """The clock must not end the wait early — only at or past the ceiling."""
+        agent, park = self._patches()
+        clock = _Clock(step=1.0)
+        with agent, park, \
+             patch("agentwire.completion.time.sleep") as sleep, \
+             patch("agentwire.completion.time.time", clock):
+            with pytest.raises(CompletionTimeout):
+                wait_for_completion_signal("s", poll_interval=0, max_duration=5)
+        # started=1; expiry at t=6 → polls at 2,3,4,5 slept through first.
+        assert sleep.call_count == 4
+
+    def test_zero_max_duration_does_not_bound_the_wait(self):
+        """Unbounded stays unbounded — the wait only ends when the session dies."""
+        agent, park = self._patches(has_agent=False)
+        with agent, park:
+            with pytest.raises(CompletionTimeout) as exc:
+                wait_for_completion_signal("s", poll_interval=0, max_duration=0)
+        # The session-died path, not a duration expiry.
+        assert "died or agent exited" in str(exc.value)
+        assert "max_duration" not in str(exc.value)
+
+    def test_a_dead_session_still_wins_over_the_clock(self):
+        agent, park = self._patches(has_agent=False)
+        with agent, park, patch("agentwire.completion.time.sleep"):
+            with pytest.raises(CompletionTimeout) as exc:
+                wait_for_completion_signal("s", poll_interval=0, max_duration=1)
+        assert "died or agent exited" in str(exc.value)
+
+    def test_summary_before_expiry_returns_normally(self, tmp_path):
+        summary = tmp_path / "task-summary-s-t-2026-08-04T04-00-00.md"
+        summary.write_text("---\nstatus: complete\nsummary: done\n---\n")
+        agent, park = self._patches()
+        with agent, park, \
+             patch("agentwire.completion.TASKS_DIR", tmp_path / "nope"):
+            result = wait_for_completion_signal(
+                "s", poll_interval=0, summary_path=summary, max_duration=1800)
+        assert result["status"] == "complete"
+
+
+class TestVacuousWaitDoesNotHang:
+    """Hypothesis 3 from #867: a fan-out that produced zero children must not
+    leave the parent blocked on a join that never resolves."""
+
+    def test_wait_with_no_ledger_returns_immediately_resolved(self, tmp_path, monkeypatch):
+        from agentwire import cohort
+
+        monkeypatch.setattr(cohort, "COHORT_ROOT", tmp_path / "cohorts")
+        result = cohort.wait("memory-manager", timeout=999)
+        assert result["resolved"] is True
+        assert result["cohort"] is False
+        assert result["pending"] == []
+
+    def test_wait_does_not_sleep_when_there_is_no_cohort(self, tmp_path, monkeypatch):
+        from agentwire import cohort
+
+        monkeypatch.setattr(cohort, "COHORT_ROOT", tmp_path / "cohorts")
+        with patch("agentwire.cohort.time.sleep") as sleep:
+            cohort.wait("memory-manager", timeout=999)
+        sleep.assert_not_called()
+
+    def test_cli_reports_nothing_to_wait_on_and_exits_zero(self, tmp_path, monkeypatch, capsys):
+        from agentwire import cohort
+        from agentwire.wait_cli import cmd_wait
+
+        monkeypatch.setattr(cohort, "COHORT_ROOT", tmp_path / "cohorts")
+        args = MagicMock()
+        args.session = "memory-manager"
+        args.json = False
+        args.timeout = 999
+        rc = cmd_wait(args)
+        assert rc == 0
+        assert "nothing to wait on" in capsys.readouterr().out


### PR DESCRIPTION
**`Refs #867` — deliberately not `Closes`.** This makes the failure bounded and legible and fixes the silent-config-key defect underneath it. It does **not** explain the hang. Full corrected root cause is posted on the issue.

## Correction: the unattended-guardrail hypothesis is refuted

I ran the real hook against the exact fan-out command with `AGENTWIRE_UNATTENDED=1` → **rc 0, allowed**. `rules/agentwire.yaml` has no pattern for `agentwire new` at all, and the unattended fail-closed path only fires on a rule that already matched with `ask: true`. There was never anything to fail closed on.

**No `unattended_allow` entry is proposed, and `~/.agentwire/damagecontrol.yml` is untouched.** Such an entry would have been both scoped and completely inert.

## The sharpened fact: the agent ran nothing

The 08-04 damage-control JSONL has zero entries from any session between 00:00–08:00 local. I checked the instrument is valid first — scheduler-dispatched sessions do log:

| Session (same day) | Dispatched | Entries |
|---|---|---|
| `artifactsmmo` | 12:01 local | 82 |
| `book-report` | 13:30 local | 39 |
| **`memory-manager`** | **04:00 local** | **0** |

The fan-out was **never attempted**. Children weren't blocked, they were never requested — so nothing about `unattended_allow`, `wait --children`, or cohort behavior is upstream of it.

## And the 2h was not a timeout

`grep -rE '7200|hours=2'` over `agentwire/` returns exactly one hit — `_IN_FLIGHT_GRACE` (`scheduler/models.py:40`), board-display / eligibility logic that never ends a run. The real ceiling is `dispatch_max_runtime = 14400` (4h), which emits a distinct `dispatch_timeout` event and status `timeout`; `ai-morning-briefing` did exactly that the same day at exactly 14400s. `memory-manager` emitted no such event.

There is exactly **one** `raise CompletionTimeout` in the codebase (`completion.py:273`) — the `not _session_has_agent()` path. So the run ended at 7217s because **the session died**, not because anything timed out. A second dispatcher (#873) is also ruled out: one `scheduler_started` since 08-03, one `task_started`, no duplicate.

## What this PR changes

### 1. Unknown task-config keys are loud — the actual defect

`parse_task_config` builds `TaskConfig` from explicit `config.get()` calls, so any key it doesn't name is dropped with no warning and no validation error. `max_duration` is just its first victim; the next typo'd key would fail exactly as invisibly.

Unknown keys are now recorded on the `TaskConfig` and surfaced by `agentwire task validate` (the natural surface), `task show`, `tasks review`, and a stderr warning at dispatch:

```
Warning: task 'memory-manager' sets keys agentwire ignores: max_durationn
```

**Warn, never reject.** `ensure` hard-fails on any `validate_task` issue, so promoting unknown keys to a validation error would turn a typo into a broken 04:00 dispatch — strictly worse than the bug. `description` is allowlisted as a deliberate no-op annotation.

### 2. `max_duration` — decision: implement it

`max_duration` appears **zero times** in `agentwire/`. It is not a `TaskConfig` field at all. **12 declarations across the fleet** set it — 5 in `agentwire-dev/.agentwire.tasks.yml` (ai-morning-briefing 900, dev-health 1200, weekly-stars 600, tooling-research 900, memory-manager 1800), plus artifactsmmo, cc-dialog-drift, daily-book-report, documentscribe ×2, personal-briefings ×2.

I implemented it rather than deleting the declarations, for three reasons:

1. **Twelve authors independently wrote the same field.** The config is stating an intent the code should honor, not a typo to scrub.
2. **Deleting is not cheaper — it's more expensive and less safe.** `.agentwire.tasks.yml` is protected control-plane; a policed agent can't edit it, so deletion means the owner hand-edits 6 files. And the end state is *every* long-running task genuinely unbounded, which is how a 30-minute task ran for 2 hours in silence.
3. **The concept already exists one layer up.** `dispatch_max_runtime` is a wall-clock ceiling at the dispatch layer. A per-task one is consistent, not novel.

Enforced as a per-attempt wall clock in `wait_for_completion_signal` (default `0` = unbounded, so existing behavior is unchanged for anything that doesn't set it). On expiry the session is torn down — a bound that reports but doesn't reap just leaves a wedged agent running until the 4h process-group kill.

### 3. The board now says *which* timeout

`CompletionTimeout`'s message reaches the summary, so `Task exceeded max_duration (1800s) after 1802s` is distinguishable from `Session 'memory-manager' died or agent exited before task completed`. Those shared one indistinguishable line — which is most of why this took log archaeology, and why two of us landed on the guardrail theory.

**On this run it would have printed the session-died message and pointed straight at the session lifecycle.**

### 4. Hypothesis 3, regression-tested

`cohort.wait()` (`cohort.py:422`) returns `{"cohort": False, "resolved": True, "pending": []}` immediately on an absent ledger and never sleeps. Two tests pin it.

### 5. Docs

`priority` was documented as a project-task field in `docs/wiki/` and the `agentwire-project-config` skill. It's a scheduler-board field and is ignored in a task block — removed from both rather than allowlisted, since the new warning is correct about it.

## Explicitly NOT claimed

**Why the agent ran nothing is unresolved**, and a `max_duration` that had fired would have masked it, not fixed it. The scrollback is gone. The leading remaining lead is prompt submission, not the guardrail:

- The prompt interpolates the entire `memory-audit --fix --json` payload — re-running it read-only today gives **19,820 bytes / 524 lines**, and the 08-04 run had 70 findings across 4 stores.
- `pane_manager.send_to_target` pastes via `load-buffer` + `paste-buffer -p`, then presses Enter after a **fixed** 1.0s and again after 0.5s — constant regardless of payload size.
- Its own docstring records this exact failure class: *"Skipping the second [Enter] leaves the prompt stuck in the input — the failure that hung the scheduler at 8am."*
- A prompt that never submits produces exactly what was observed: zero tool calls, no summary, no idle notification.

Unproven. Happy to open a separate issue for a size-proportional settle + submission verification (the `send_verified` machinery already exists for `msg`) — say the word and I'll file it.

What this PR buys for the next occurrence: `memory-manager`'s existing `max_duration: 1800` now actually fires, so it ends at 30 minutes with a named reason and a reaped session instead of 2h of silence.

## Verified

```
$ agentwire ensure -s memory-manager --task memory-manager --project ~/projects/agentwire-dev --dry-run
Idle timeout: 300s
Max duration: 1800s      <-- previously absent; the field reached nothing
```

`tests/unit/test_task_max_duration.py` (new, 17 tests): parsing + validation, the enforcement clock (expiry message, in-budget polling, unbounded stays unbounded, dead-session-wins-over-clock, summary-before-expiry), unknown-key recording, and the vacuous-wait cases.

**Full suite: 3094 passed**, 1 warning (pre-existing aiohttp `NotAppKeyWarning`), 134s. `ruff check` clean.

Not verifiable in-worktree: the fleet is running, so no rebuild, no portal restart, no scheduler stop/start.

Refs #867

Built by [dotdev.dev](https://dotdev.dev)