### PR TITLE
fix(tmux,msg): mirror tmux's ':' rewrite; surface long-pending report-backs

### DIFF
--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -523,6 +523,43 @@ def _render_orphaned_worktrees_section() -> int:
     return len(orphans)
 
 
+def _render_pending_messages_section() -> int:
+    """Doctor section: load-bearing messages queued too long (#879).
+
+    The dead-letter section only sees messages that BURNED OUT. A penalty-free
+    defer (``target_parked``, ``target_busy``, …) never dead-letters, so it
+    reaches neither that section nor the owner email it triggers. #872 made that
+    gap load-bearing by admitting ``target_parked`` — the one defer reason that
+    legitimately lasts hours — so a worker's ``done`` can now sit in a parked
+    parent's queue indefinitely with nothing announcing it. This is that surface.
+
+    Returns 1 if anything is stale (one issue, not one per message — a parked
+    parent strands its whole cohort at once, and that's a single situation).
+    """
+    from . import inbox
+
+    stale = inbox.stale_pending()
+    if not stale:
+        print("  [ok] No report-backs pending past the staleness threshold")
+        return 0
+
+    hours = inbox.STALE_PENDING_MS / 3_600_000
+    now_ms = time.time() * 1000
+    print(f"  [!!] {len(stale)} load-bearing message(s) pending over {hours:g}h:")
+    for session, m in stale:
+        waited = (now_ms - m.ts) / 3_600_000
+        print(f"       - To: {session}, Kind: {m.kind}, Sender: {m.sender}, "
+              f"Waiting: {waited:.1f}h, Reason: {m.reason or 'not yet attempted'}")
+    parked = sorted({s for s, m in stale if m.reason == "target_parked"})
+    if parked:
+        print(f"       Parked recipient(s): {', '.join(parked)} — these deliver on "
+              "their own once the usage limit resets (`agentwire limits status`), "
+              "so this is FYI, not a failure.")
+    print("       Inspect: `agentwire msg inbox -s <session>`   "
+          "Force: `agentwire msg flush -s <session> --force`")
+    return 1
+
+
 def _scheduler_daemon_started_at() -> float | None:
     """Epoch seconds the scheduler daemon process started, or ``None`` if not running.
 
@@ -1126,6 +1163,10 @@ def cmd_doctor(args) -> int:
                 print("  [ok] No dead-lettered done/escalation messages found (any dead-letters are informational)")
     except Exception as e:
         print(f"  [..] Could not check dead-lettered messages: {e}")
+
+    # 10b. Long-pending report-backs (#879) — see _render_pending_messages_section.
+    print("\nChecking for long-pending report-backs...")
+    issues_found += _render_pending_messages_section()
 
     # 11. Check for dangling worktree sessions (live, open PR, no live parent
     # to review/merge it — #716's concrete failure mode: a rootless-but-

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -84,10 +84,17 @@ GONE_MAX_ATTEMPTS = 5
 # park longer than MAX_ATTEMPTS ticks (~40 min, routinely exceeded by a real
 # reset window) killed every report-back its workers had filed.
 #
-# Such messages stay pending forever instead of burning toward dead-letter;
-# doctor / worktree --watch surface them, and they deliver once the box frees up.
-# The opposite case — a recipient that positively does NOT exist — is NOT in this
-# set: "target_gone" is penalized on its own fast GONE_MAX_ATTEMPTS cap (#694).
+# Such messages stay pending indefinitely instead of burning toward dead-letter,
+# and deliver once the box frees up or the park clears. The opposite case — a
+# recipient that positively does NOT exist — is NOT in this set: "target_gone"
+# is penalized on its own fast GONE_MAX_ATTEMPTS cap (#694).
+#
+# Never dead-lettering also means never triggering the dead-letter owner email,
+# so a load-bearing report can now wait hours with nothing announcing it (#879 —
+# a gap that #872 widened by admitting the one reason that legitimately lasts
+# hours). `agentwire msg inbox` shows a queue on request; `agentwire doctor`
+# reports load-bearing messages pending past STALE_PENDING_MS (see
+# stale_pending), which is the unprompted surface.
 _NO_PENALTY_REASONS = frozenset(
     {"target_busy", "queued_placeholder", "box_static", "stuck_in_box", "target_parked"}
 )
@@ -102,6 +109,15 @@ _BOX_STATIC_THRESHOLD = 3
 # is escalated out-of-band (owner email). note is fire-and-forget and ingest
 # never auto-delivers, so neither is worth an owner email.
 ESCALATE_KINDS = ("done", "request", "escalation")
+
+# How long a load-bearing message may sit pending before `doctor` reports it
+# (#879). Comfortably longer than any box-state defer — those clear in minutes —
+# so the section stays quiet in normal operation and only speaks up for the case
+# it exists to catch: a recipient parked or wedged long enough that its workers'
+# reports are effectively stranded. Deliberately NOT an owner email: a multi-hour
+# park is the EXPECTED shape now, and emailing on it would be the noise that
+# gets the whole channel muted (option 3 in #879, declined).
+STALE_PENDING_MS = 2 * 60 * 60 * 1000  # 2 hours
 
 _RESERVED_DIRS = {"dead", "sent", ".lock", "ingest"}
 
@@ -339,6 +355,44 @@ def list_dead(session: str) -> list[Message]:
     if not ddir.is_dir():
         return []
     return [m for m in (_read_message(f) for f in sorted(ddir.glob("*.json"))) if m]
+
+
+def stale_pending(older_than_ms: int = STALE_PENDING_MS) -> list[tuple[str, Message]]:
+    """Load-bearing messages queued longer than *older_than_ms*, oldest first.
+
+    The unprompted surface for the penalty-free defer path (#879). A message
+    deferring for a no-penalty reason never dead-letters, so it never triggers
+    the dead-letter owner email either — before #872 that was self-limiting
+    (every such reason was a short-lived box state), but ``target_parked`` can
+    legitimately wait hours. Without this, the only way to notice a `done`
+    sitting in a parked parent's queue was to run ``msg inbox`` against that
+    exact recipient, already suspecting it.
+
+    Scoped to ESCALATE_KINDS for the same reason the dead-letter email is: a
+    lost ``note`` is fire-and-forget and ``ingest`` is pull-only by design, so
+    reporting either would be noise that trains people to ignore the section.
+
+    Returns ``(recipient_session, message)`` pairs. Never raises — an
+    unreadable inbox yields nothing rather than failing ``doctor``.
+    """
+    now = _now_ms()
+    stale: list[tuple[str, Message]] = []
+    try:
+        sessions = _iter_pending_sessions()
+    except OSError:
+        return []
+    for session in sessions:
+        try:
+            messages = list_messages(session)
+        except OSError:
+            continue
+        for msg in messages:
+            if msg.kind not in ESCALATE_KINDS:
+                continue
+            if msg.ts and now - msg.ts >= older_than_ms:
+                stale.append((session, msg))
+    stale.sort(key=lambda pair: pair[1].ts)
+    return stale
 
 
 def dead_sessions() -> list[str]:
@@ -723,8 +777,10 @@ def _bump_attempts(messages: list[Message], reason: str = "") -> int:
         if reason in _NO_PENALTY_REASONS:
             # The recipient exists but can't take it right now — busy (long
             # command / human-queued input / wedged paste) or usage-limit parked
-            # — not refusing. Never penalize. Surfaced via `doctor` / `worktree
-            # --watch`; delivers once the prompt frees up or the park clears.
+            # — not refusing. Never penalize; delivers once the prompt frees up
+            # or the park clears. Surfaced by `agentwire msg inbox` on request,
+            # and by `agentwire doctor` once it's been waiting past
+            # STALE_PENDING_MS (#879).
             msg.reason = reason
             try:
                 _write_message(msg.path, msg)

--- a/agentwire/worktree.py
+++ b/agentwire/worktree.py
@@ -174,22 +174,38 @@ def safe_worktree_name(name: str) -> str:
 def tmux_safe_name(name: str) -> str:
     """Make ``name`` legal as a tmux session name.
 
-    ``.`` is tmux's ``session.window`` address separator, so **tmux itself**
-    rewrites it to ``_``: ``tmux new-session -d -s .foo`` succeeds and gives
-    you a session named ``_foo``. This mirrors tmux's own mapping rather than
-    inventing one — which is what makes it safe to apply at *resolution*
-    time, since the name derived here is the name tmux will have chosen.
+    ``.`` and ``:`` are tmux's address separators — ``session.window`` and
+    ``session:window`` — so **tmux itself** rewrites both to ``_``:
+    ``tmux new-session -d -s .foo`` succeeds and gives you a session named
+    ``_foo``, and ``-s a:b`` gives you ``a_b``. This mirrors tmux's own
+    mapping rather than inventing one — which is what makes it safe to apply
+    at *resolution* time, since the name derived here is the name tmux will
+    have chosen.
 
     Creation applied it inline (five copies in ``session_cli``); resolution
     didn't. So for a project directory containing a dot (``~/.claude``),
     teardown looked for ``.claude-fix`` while the session was
     ``_claude-fix`` — matched nothing, killed nothing, reported success, and
     left the session running in the directory it had just deleted (#868).
+    ``:`` was the same hole, reachable through an operator-supplied name
+    rather than a derived one (#878).
 
     Slashes are preserved — ``project/branch`` is a legal tmux name and is
     the convention ``cmd_new`` builds for worktree sessions.
+
+    **The substitution set is exactly these two** — established by sweeping
+    every printable ASCII character through ``tmux new-session`` on an
+    isolated socket (tmux 3.5a), not by reading tmux's source and hoping.
+    UTF-8 passes through untouched. tmux does *also* transform ``\\``, tab,
+    newline and other control characters, but by **vis-escaping** them (``\\t``,
+    ``\\001``) — an expansion to a longer string, not a 1:1 substitution — so it
+    can't be mirrored by a ``replace`` and isn't attempted here. Such a name
+    would break this function's fixed-point invariant, but it is not reachable
+    from what actually feeds these names: project directory names and
+    operator/agent-supplied session names. See ``TestTmuxRewriteSet``, which
+    pins both the mirrored set and that boundary.
     """
-    return name.replace(".", "_")
+    return name.replace(".", "_").replace(":", "_")
 
 
 def worktree_session_name(project_path: Path, name: str) -> str:

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -167,6 +167,19 @@ lands in a durable inbox and is injected only at a safe boundary.
      against a park that routinely runs hours; every `done` a parked parent's
      workers filed died before the reset landed. It is the most clearly temporary
      member of the set, and now defers without penalty like the rest.
+
+     **Penalty-free means invisible unless something looks (#879).** Never
+     dead-lettering also means never firing the dead-letter owner email, which is
+     the only *unprompted* signal in the whole path. That was harmless while every
+     no-penalty reason was a short-lived box state; admitting `target_parked`
+     changed it, since a park can legitimately last hours. So `agentwire doctor`
+     reports load-bearing (`done` / `request` / `escalation`) messages still
+     pending past `inbox.STALE_PENDING_MS` (2h), naming the recipient, the wait,
+     and the defer reason — and flagging parked recipients as self-resolving so
+     the section reads as FYI rather than failure. `agentwire msg inbox -s
+     <session>` remains the on-request view. Deliberately *not* an owner email: a
+     multi-hour park is the expected shape now, so emailing on it is the noise
+     that gets the channel muted.
    - **Gone recipients burn out fast (#694).** Before any box parsing, the
      drain checks the target against the live tmux session list. A recipient
      that *positively doesn't exist* defers as `target_gone` — a penalized

--- a/tests/integration/test_tmux_name_rewrite.py
+++ b/tests/integration/test_tmux_name_rewrite.py
@@ -1,0 +1,166 @@
+"""``tmux_safe_name`` is verified against REAL tmux, not against our belief (#878).
+
+``worktree.tmux_safe_name`` is safe to apply at *resolution* time only because
+it MIRRORS tmux's own name mapping — the name it derives is the name tmux will
+have chosen. That invariant is about an external binary's behavior, so a unit
+test asserting our own constants can't establish it. This drives actual
+``tmux new-session`` on a private socket and reads back the name tmux really
+created.
+
+Why it earns its keep: #865 → #868 → #870 → #878 is four rounds of this class,
+three of them because the rewrite set was assumed rather than measured. If a
+future tmux starts rewriting another character, THIS is the test that fails —
+instead of a teardown silently killing nothing while reporting success.
+
+Never touches the user's live tmux server: every command runs against a
+dedicated ``-S <socket>`` in a short-lived temp dir (macOS caps Unix-domain
+socket paths at ~104 bytes, so pytest's tmp_path is too long to use directly —
+same constraint as test_send_verified_tmux.py).
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentwire.worktree import tmux_safe_name
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None, reason="tmux not available"
+)
+
+# Printable ASCII — the realistic input space for a session name. Control
+# characters are excluded: tmux vis-escapes rather than substitutes them, which
+# tmux_safe_name deliberately doesn't mirror (see its docstring and
+# TestTmuxRewriteSet.test_vis_escaped_chars_are_a_documented_non_goal).
+PRINTABLE = [chr(i) for i in range(32, 127)]
+
+# The one PRINTABLE character tmux transforms by vis-escaping rather than
+# substituting, so it is excluded from the mapping sweep and gets its own test
+# below. Not an oversight — see test_backslash_has_no_fixed_point.
+UNMIRRORABLE = "\\"
+
+
+@pytest.fixture(scope="module")
+def tmux_sock():
+    """A private tmux server, torn down with the module."""
+    sock_dir = Path(tempfile.mkdtemp(prefix="awn-"))
+    socket = str(sock_dir / "s")
+
+    def run(*args):
+        return subprocess.run(
+            ["tmux", "-S", socket, *args], capture_output=True, text=True
+        )
+
+    yield run
+    run("kill-server")
+
+
+def _real_name(run, requested: str) -> str | None:
+    """Create a session named *requested*; return the name tmux actually used."""
+    created = run("new-session", "-d", "-s", requested)
+    if created.returncode != 0:
+        return None
+    listed = run("list-sessions", "-F", "#{session_name}")
+    names = [n for n in listed.stdout.splitlines() if n]
+    for n in names:
+        run("kill-session", "-t", "=" + n)
+    return names[0] if names else None
+
+
+class TestMirrorsRealTmux:
+    @pytest.mark.parametrize("requested", [
+        ".claude-fix",
+        "dotdev.dev-fix-bug",
+        "proj:x-fork-1",
+        "a.b:c.d",
+        "myapp/feat",           # slash is legal — must NOT be rewritten
+        "myapp-fix-bug",
+        "café-fix",
+    ])
+    def test_derived_name_is_the_name_tmux_creates(self, tmux_sock, requested):
+        """THE invariant. Ask tmux for the raw name; it must land on ours."""
+        actual = _real_name(tmux_sock, requested)
+        assert actual is not None, f"tmux refused to create {requested!r}"
+        assert actual == tmux_safe_name(requested)
+
+    @pytest.mark.parametrize("requested", [
+        "_claude-fix", "proj_x-fork-1", "myapp/feat", "myapp-fix-bug",
+    ])
+    def test_sanitized_names_are_fixed_points_of_real_tmux(self, tmux_sock, requested):
+        """A name we hand to new-session must survive it unchanged.
+
+        Creation passes tmux_safe_name output straight to ``-s``; if tmux
+        rewrites it again, the recorded name is not the live one all over again.
+        """
+        assert tmux_safe_name(requested) == requested  # precondition
+        assert _real_name(tmux_sock, requested) == requested
+
+
+class TestRewriteSetIsComplete:
+    def test_sweep_of_printable_ascii_matches_our_mapping(self, tmux_sock):
+        """Every printable ASCII char, through real tmux, versus our function.
+
+        Catches BOTH directions in one pass: a character tmux rewrites that we
+        don't (the #868/#878 bug — a lookup that can never match), and a
+        character we rewrite that tmux doesn't (over-sanitizing, which renames
+        sessions that were already fine).
+        """
+        mismatches = []
+        for ch in PRINTABLE:
+            if ch == UNMIRRORABLE:
+                continue
+            requested = f"a{ch}b"
+            actual = _real_name(tmux_sock, requested)
+            if actual is None:
+                continue  # tmux refused it outright — not a mapping question
+            if actual != tmux_safe_name(requested):
+                mismatches.append((ch, actual, tmux_safe_name(requested)))
+        assert not mismatches, (
+            "tmux_safe_name diverges from real tmux for: "
+            + ", ".join(f"{c!r}: tmux={a!r} ours={o!r}" for c, a, o in mismatches)
+        )
+
+    def test_measured_substitution_set_is_exactly_dot_and_colon(self, tmux_sock):
+        """Pin the set itself, so a tmux upgrade that adds one is visible.
+
+        The sweep above would also fail, but it reports a diff against our
+        function; this reports the ground truth independently of it.
+        """
+        substituted = {
+            ch for ch in PRINTABLE
+            if (actual := _real_name(tmux_sock, f"a{ch}b")) is not None
+            and actual == "a_b" and ch != "_"
+        }
+        assert substituted == {".", ":"}
+
+    def test_backslash_has_no_fixed_point(self, tmux_sock):
+        """Why `\\` is excluded above: it is *unmirrorable*, not merely rare.
+
+        tmux vis-escapes it, and the escaping is NOT idempotent — it re-escapes
+        on every pass:
+
+            a\\b  (3 chars) -> a\\\\b  (4)
+            a\\\\b (4 chars) -> a\\\\\\\\b (6)
+
+        So no name containing a backslash has a fixed point under
+        ``new-session``: there is no string you can hand to ``-s`` that comes
+        back unchanged. ``tmux_safe_name``'s entire contract is "the name I
+        derive is the name tmux will have chosen", and resolution applies it to
+        already-recorded names (``session_cli`` re-sanitizes on read), so a
+        mapping that grows on each application would break resolution rather
+        than fix it. Leaving it untouched is the only coherent option.
+
+        Unreachable in practice as well: git rejects `\\` in a branch name, and
+        the other input is a project directory name.
+        """
+        once = _real_name(tmux_sock, "a\\b")
+        twice = _real_name(tmux_sock, once)
+        assert once != "a\\b"          # tmux mangles it
+        assert twice != once           # ...and keeps mangling — no fixed point
+        assert len(twice) > len(once)  # strictly growing, so no convergence
+
+        # And we leave it alone rather than pretending to mirror it.
+        assert tmux_safe_name("a\\b") == "a\\b"

--- a/tests/unit/test_pending_message_visibility.py
+++ b/tests/unit/test_pending_message_visibility.py
@@ -1,0 +1,149 @@
+"""Long-pending report-backs are surfaced by doctor (#879).
+
+A penalty-free defer never dead-letters, so it never reaches doctor's
+dead-letter section OR the owner email that section's existence justifies.
+#872 made that gap load-bearing: ``target_parked`` legitimately defers for
+hours, so a worker's ``done`` can now sit in a parked parent's queue with
+nothing announcing it in either direction.
+
+Covers ``inbox.stale_pending`` (which messages qualify) and
+``doctor_cli._render_pending_messages_section`` (how they're reported).
+"""
+
+import pytest
+
+from agentwire import doctor_cli, inbox, prompt_router
+
+HOUR_MS = 3_600_000
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    root = tmp_path / "inbox"
+    monkeypatch.setattr(inbox, "INBOX_ROOT", root)
+    monkeypatch.setattr(inbox, "EVENTS_FILE", tmp_path / "inbox-events.jsonl")
+    return root
+
+
+def _age(session: str, hours: float, reason: str = "target_parked", **kw):
+    """Enqueue a message and backdate it *hours* into the past."""
+    msg = inbox.enqueue(session, kw.pop("text", "PR done"),
+                        kind=kw.pop("kind", "done"), sender=kw.pop("sender", "worker"))[0]
+    msg.ts = inbox._now_ms() - int(hours * HOUR_MS)
+    msg.reason = reason
+    inbox._write_message(msg.path, msg)
+    return msg
+
+
+class TestStalePending:
+    def test_empty_inbox_is_quiet(self, isolate):
+        assert inbox.stale_pending() == []
+
+    def test_fresh_message_is_not_stale(self, isolate):
+        _age("s", hours=0.1)
+        assert inbox.stale_pending() == []
+
+    def test_message_older_than_threshold_is_reported(self, isolate):
+        _age("s", hours=5)
+        stale = inbox.stale_pending()
+        assert len(stale) == 1
+        session, msg = stale[0]
+        assert session == "s"
+        assert msg.kind == "done" and msg.reason == "target_parked"
+
+    def test_only_load_bearing_kinds_qualify(self, isolate):
+        """Same rule as the dead-letter email: a lost `note` is fire-and-forget
+        and `ingest` is pull-only BY DESIGN, so reporting either is pure noise."""
+        _age("s", hours=5, kind="note")
+        _age("s", hours=5, kind="ingest")
+        assert inbox.stale_pending() == []
+        for kind in inbox.ESCALATE_KINDS:
+            _age(f"s-{kind}", hours=5, kind=kind)
+        assert {k for _, m in inbox.stale_pending() for k in [m.kind]} == set(
+            inbox.ESCALATE_KINDS
+        )
+
+    def test_threshold_is_the_boundary(self, isolate):
+        _age("under", hours=inbox.STALE_PENDING_MS / HOUR_MS - 0.5)
+        _age("over", hours=inbox.STALE_PENDING_MS / HOUR_MS + 0.5)
+        assert [s for s, _ in inbox.stale_pending()] == ["over"]
+
+    def test_custom_threshold_is_honored(self, isolate):
+        _age("s", hours=1)
+        assert inbox.stale_pending() == []                      # default 2h
+        assert len(inbox.stale_pending(older_than_ms=30 * 60_000)) == 1
+
+    def test_worktree_recipients_resolve_their_nested_name(self, isolate):
+        """Worktree session names contain `/` and nest a directory level — the
+        recipient must come back whole, or the `msg inbox -s` hint is useless."""
+        _age("proj/feature-x", hours=5)
+        assert [s for s, _ in inbox.stale_pending()] == ["proj/feature-x"]
+
+    def test_oldest_first(self, isolate):
+        _age("newer", hours=3)
+        _age("older", hours=9)
+        assert [s for s, _ in inbox.stale_pending()] == ["older", "newer"]
+
+    def test_dead_lettered_messages_are_not_counted(self, isolate, monkeypatch):
+        """Those belong to the dead-letter section; double-reporting one
+        situation in two places is how a doctor run stops being read."""
+        msgs = inbox.enqueue("s", "burned out", kind="done", sender="worker")
+        msgs[0].ts = inbox._now_ms() - 9 * HOUR_MS
+        inbox._write_message(msgs[0].path, msgs[0])
+        monkeypatch.setattr(inbox, "live_sessions", lambda: None)
+        monkeypatch.setattr(prompt_router, "capture", lambda s, p=0, **kw: "x")
+        monkeypatch.setattr(prompt_router, "input_box_content_sgr", lambda v: None)
+        # Drive it to dead-letter with a PENALIZED reason.
+        monkeypatch.setattr(inbox, "_NO_PENALTY_REASONS", frozenset())
+        for _ in range(inbox.MAX_ATTEMPTS):
+            inbox.flush_session("s")
+        assert inbox.list_dead("s")          # it really did dead-letter
+        assert inbox.stale_pending() == []   # and is not re-reported here
+
+    def test_unreadable_inbox_yields_nothing_rather_than_raising(self, isolate, monkeypatch):
+        """doctor must never fail because one section's data is broken."""
+        monkeypatch.setattr(
+            inbox, "_iter_pending_sessions",
+            lambda: (_ for _ in ()).throw(OSError("permission denied")),
+        )
+        assert inbox.stale_pending() == []
+
+
+class TestDoctorSection:
+    def test_quiet_when_nothing_pending(self, isolate, capsys):
+        assert doctor_cli._render_pending_messages_section() == 0
+        assert "[ok]" in capsys.readouterr().out
+
+    def test_reports_a_stale_report_back(self, isolate, capsys):
+        _age("orchestrator", hours=6, sender="worker-a")
+        rc = doctor_cli._render_pending_messages_section()
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "[!!]" in out
+        assert "orchestrator" in out and "worker-a" in out
+        assert "6.0h" in out                       # how long it has waited
+        assert "target_parked" in out              # why it hasn't landed
+        assert "msg inbox -s" in out               # what to do about it
+
+    def test_parked_recipients_get_the_it_resolves_itself_hint(self, isolate, capsys):
+        _age("parked-parent", hours=6, reason="target_parked")
+        doctor_cli._render_pending_messages_section()
+        out = capsys.readouterr().out
+        assert "limits status" in out
+        assert "FYI, not a failure" in out
+
+    def test_non_parked_stall_omits_the_parked_hint(self, isolate, capsys):
+        _age("busy-parent", hours=6, reason="target_busy")
+        doctor_cli._render_pending_messages_section()
+        out = capsys.readouterr().out
+        assert "target_busy" in out
+        assert "limits status" not in out
+
+    def test_counts_one_issue_for_a_whole_stranded_cohort(self, isolate, capsys):
+        """A parked parent strands every child at once — that's ONE situation,
+        and inflating issues_found by the cohort size misrepresents severity."""
+        for i in range(4):
+            _age("parent", hours=6, sender=f"worker-{i}")
+        rc = doctor_cli._render_pending_messages_section()
+        assert rc == 1
+        assert capsys.readouterr().out.count("worker-") == 4  # all still listed

--- a/tests/unit/test_worktree_dot_project.py
+++ b/tests/unit/test_worktree_dot_project.py
@@ -1,10 +1,12 @@
-"""Unit tests for tmux-legal session-name derivation (#868).
+"""Unit tests for tmux-legal session-name derivation (#868, #878).
 
-tmux forbids ``.`` in session names, so every creation path maps it to ``_``.
-Resolution used the project directory's name RAW, so for any project whose
-directory contains a dot (``~/.claude``, ``~/projects/dotdev.dev``) teardown
-derived a name no session could ever have — matched nothing, and said it had
-removed one anyway. Same class as #855 on the session-name axis.
+tmux rewrites its address separators in session names, so every creation path
+maps them to ``_``. Resolution used the project directory's name RAW, so for
+any project whose directory contains a dot (``~/.claude``,
+``~/projects/dotdev.dev``) teardown derived a name no session could ever have —
+matched nothing, and said it had removed one anyway. Same class as #855 on the
+session-name axis. ``:`` is the second separator and had the identical hole
+(#878); ``TestTmuxRewriteSet`` pins the complete set so this stops recurring.
 """
 
 import pytest
@@ -21,17 +23,77 @@ class TestTmuxSafeName:
     def test_dots_become_underscores(self):
         assert tmux_safe_name(".claude-fix") == "_claude-fix"
 
+    def test_colons_become_underscores(self):
+        # `:` is tmux's session:window separator and gets the SAME treatment as
+        # `.` — `-s proj:x` yields the session `proj_x` (#878).
+        assert tmux_safe_name("proj:x-fork-1") == "proj_x-fork-1"
+
+    def test_both_separators_in_one_name(self):
+        assert tmux_safe_name("a.b:c.d") == "a_b_c_d"
+
     def test_slashes_are_preserved(self):
         # `project/branch` is a legal tmux name and IS the convention cmd_new
         # builds for worktree sessions — collapsing it would rename every one.
         assert tmux_safe_name("myapp/feat") == "myapp/feat"
 
     def test_idempotent(self):
-        once = tmux_safe_name("dotdev.dev/v2.0")
+        once = tmux_safe_name("dotdev.dev/v2.0:rc1")
         assert tmux_safe_name(once) == once
 
     def test_leaves_an_already_legal_name_alone(self):
         assert tmux_safe_name("myapp-fix-bug") == "myapp-fix-bug"
+
+
+class TestTmuxRewriteSet:
+    """Pin the COMPLETE set of characters tmux rewrites 1:1 in a session name.
+
+    #865 → #868 → #870 → #878 is four rounds of the same class, three of them
+    because nobody established the set. It was established by sweeping every
+    printable ASCII character through ``tmux new-session`` on an isolated
+    socket (tmux 3.5a); ``tests/integration/test_tmux_name_rewrite.py`` re-runs
+    that sweep against the real binary. These are the cheap always-run pins.
+    """
+
+    #: Characters tmux substitutes 1:1 with ``_`` — its two address separators.
+    SUBSTITUTED = {".", ":"}
+
+    #: Characters tmux transforms by VIS-ESCAPING (expanding to a longer
+    #: string: ``\\`` → ``\\\\``, tab → ``\\t``, ``\x01`` → ``\\001``). A
+    #: different kind of transformation — not expressible as a ``replace`` —
+    #: and deliberately NOT mirrored: see tmux_safe_name's docstring.
+    VIS_ESCAPED = {"\\", "\t", "\n", "\r", "\x01", "\x7f"}
+
+    @pytest.mark.parametrize("ch", sorted(SUBSTITUTED))
+    def test_every_substituted_char_is_mapped(self, ch):
+        assert tmux_safe_name(f"a{ch}b") == "a_b"
+
+    @pytest.mark.parametrize("ch", sorted(
+        set(map(chr, range(32, 127))) - SUBSTITUTED - VIS_ESCAPED
+    ))
+    def test_no_other_printable_ascii_is_touched(self, ch):
+        """The other direction: over-sanitizing renames sessions that were fine.
+
+        `/` is the load-bearing one — `project/branch` is the convention every
+        worktree session uses — but the guarantee is general.
+        """
+        name = f"a{ch}b"
+        assert tmux_safe_name(name) == name
+
+    def test_utf8_passes_through(self):
+        assert tmux_safe_name("café-→-fix") == "café-→-fix"
+
+    @pytest.mark.parametrize("ch", sorted(VIS_ESCAPED))
+    def test_vis_escaped_chars_are_a_documented_non_goal(self, ch):
+        """tmux mangles these, and tmux_safe_name deliberately does NOT mirror it.
+
+        Mirroring would mean reimplementing tmux's ``vis`` escaping, and these
+        are unreachable from what actually feeds session names (project dir
+        names, operator/agent-supplied names). Pinned so the gap is a recorded
+        decision rather than an oversight — if one ever becomes reachable, this
+        test is where the argument lives.
+        """
+        name = f"a{ch}b"
+        assert tmux_safe_name(name) == name  # untouched — NOT a fixed point of tmux
 
 
 class TestWorktreeSessionName:

--- a/uv.lock
+++ b/uv.lock
@@ -74,7 +74,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "kokoro-onnx", marker = "python_full_version < '3.14'", specifier = ">=0.4.9" },
     { name = "markdown", specifier = ">=3.5" },
-    { name = "mcp", specifier = ">=1.2.0" },
+    { name = "mcp", specifier = ">=1.2.0,<2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic", marker = "extra == 'tts'", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },


### PR DESCRIPTION
Both follow-ups from the #876 review.

## #878 — `tmux_safe_name` missed `:`

Confirmed and fixed in the SSOT, so all 16 call sites inherit it.

The issue asked me to check whether any *other* character tmux rewrites is reachable — "better to establish the full set once than to file this issue a third time." So I measured it rather than reading tmux's source and hoping: every printable ASCII character swept through real `tmux new-session` on an isolated socket (tmux 3.5a), reading back the name tmux actually created.

**The 1:1 substitution set is exactly `{'.', ':'}`.** UTF-8 (`é`, `→`) passes through untouched. Nothing else in printable ASCII is substituted.

### The one interesting finding: `\` is unmirrorable, not merely rare

tmux *does* transform `\`, tab, newline and control characters — but by **vis-escaping** them (`\` → `\\`, tab → `\t`, `\x01` → `\001`). That's an expansion, not a substitution. My first version of the sweep test caught this immediately, which is exactly what I wanted it to do.

The decisive part is that the escaping is **not idempotent**:

```
requested 'a\b'    (3 chars) -> tmux made 'a\\b'     (4 chars)
requested 'a\\b'   (4 chars) -> tmux made 'a\\\\b'   (6 chars)
```

So **no name containing a backslash has a fixed point under `new-session`** — there is no string you can pass to `-s` that comes back unchanged. `tmux_safe_name`'s entire contract is "the name I derive is the name tmux will have chosen", and resolution re-applies it to already-recorded names (`session_cli.py:1443`). A mapping that grows on each application would break resolution rather than fix it. Leaving it alone is the only coherent option, so that's a recorded decision with the argument attached (`test_backslash_has_no_fixed_point`), not an oversight.

It's unreachable anyway — `git check-ref-format` rejects `\` in a branch name (it also rejects `:`, which is why #878 is reachable only via an operator-supplied `-s`/`--name`, matching the issue's own analysis).

### Call-site audit

Checked all 16 before adding `:`: every one passes a session **name** (`project/branch`, `project-name`), never a `session:window.pane` **target**. Nothing constructs a tmux target through this function, so widening it can't mangle an address.

### Tests

- `TestTmuxRewriteSet` (unit, always runs) pins the substitution set, asserts no *other* printable ASCII is touched — over-sanitizing renames sessions that were fine, and `/` is load-bearing — and pins the vis-escape boundary.
- `tests/integration/test_tmux_name_rewrite.py` (skips without tmux, private `-S` socket) re-runs the sweep against the **real binary**. This is the point: the invariant is about an external program's behavior, so a test asserting our own constants can't establish it. If a future tmux rewrites another character, this fails — instead of a teardown silently killing nothing while reporting success.

## #879 — nothing surfaced pending messages

You're right, and I'll own the specific part: the claim was pre-existing, but I **rewrote that comment in #876 and carried the false claim forward** instead of checking it. `worktree --watch` reports worktree git state (`--watch  Watch registered worktree sessions in a loop and report status`) — it has never known anything about inboxes.

Options 1 + 2 as directed.

**1 — Comment corrected**, in both places (the `_NO_PENALTY_REASONS` docstring and the `_bump_attempts` branch), plus the same claim in `docs/wiki/sessions/messaging.md`.

**2 — `doctor` section**, mirroring the dead-letter one. `inbox.stale_pending()` holds the logic (SSOT; doctor stays thin), `doctor_cli._render_pending_messages_section()` renders it.

Design calls worth reviewing:

- **Threshold 2h** (`inbox.STALE_PENDING_MS`) — comfortably past any box-state defer, which clear in minutes, so the section stays quiet in normal operation.
- **Scoped to `ESCALATE_KINDS`** — same rule the dead-letter email uses. A lost `note` is fire-and-forget and `ingest` is pull-only *by design*; reporting either is the noise that trains people to skim past the section.
- **One issue, not one per message** — a parked parent strands its whole cohort simultaneously. That's one situation; inflating `issues_found` by cohort size misrepresents severity. All messages are still listed.
- **Parked recipients flagged self-resolving** ("FYI, not a failure", with `agentwire limits status`), since they genuinely deliver on their own after the reset.
- **Option 3 (owner email) declined** — a multi-hour park is now the *expected* shape, so mailing on it is precisely the noise that gets the channel muted. Noted in the code comment so the reasoning survives.

Rendered output, eyeballed against a synthetic inbox (not just asserted on):

```
Checking for long-pending report-backs...
  [!!] 3 load-bearing message(s) pending over 2h:
       - To: documentscribe/661-chat, Kind: done, Sender: worker-b, Waiting: 7.0h, Reason: target_busy
       - To: agentwire, Kind: done, Sender: agentwire-dev-review-p1, Waiting: 5.0h, Reason: target_parked
       - To: agentwire, Kind: done, Sender: agentwire-dev-fix-p1, Waiting: 3.0h, Reason: target_parked
       Parked recipient(s): agentwire — these deliver on their own once the usage limit resets (`agentwire limits status`), so this is FYI, not a failure.
       Inspect: `agentwire msg inbox -s <session>`   Force: `agentwire msg flush -s <session> --force`
```

Both suggested commands verified against the actual parsers in `msg_cli.py`. Also run against the **real** inbox on this machine — currently `[ok]`, correctly quiet.

Notable test cases: dead-lettered messages are **not** double-reported here (one situation in two doctor sections is how a doctor run stops being read); worktree recipients keep their nested `proj/feature-x` name, or the `msg inbox -s` hint would be unusable; and an unreadable inbox yields nothing rather than failing the whole doctor run.

## Tests

Full suite: **3219 passed**, 1 pre-existing warning, 132s — 3041 unit + 165 integration + 13 e2e. `ruff check agentwire/ tests/` clean.

Red before the fix, verified by stashing each source file:

- `agentwire/worktree.py` stashed → **6 fail**, including the live-tmux sweep reporting the exact divergence: `tmux_safe_name diverges from real tmux for: ':': tmux='a_b' ours='a:b'`.
- `agentwire/inbox.py` + `agentwire/doctor_cli.py` stashed → **all 15 fail**.

No stray tmux sessions on the live server after the run (integration tests use a private `-S` socket in a short temp dir — macOS caps socket paths at ~104 bytes, so `tmp_path` is too long; same constraint `test_send_verified_tmux.py` documents).

## Incidental

`uv.lock` is relocked. Main's lockfile was out of sync with its own `pyproject.toml` — #875 added the `mcp>=1.2.0,<2` bound but didn't relock, so `uv sync` regenerated it. Flagging so it doesn't read as unrelated drift.

## Verification note

In-worktree only — no `agentwire rebuild`, no portal restart. The new `doctor` section won't appear in the installed CLI until this merges and the tool is rebuilt.

Closes #878
Closes #879

Built by [dotdev.dev](https://dotdev.dev)