### PR TITLE
fix(ensure): verify the task-prompt paste and act on the result (#889)

### DIFF
--- a/agentwire/ensure_cli.py
+++ b/agentwire/ensure_cli.py
@@ -106,6 +106,53 @@ def _ensure_remote(args, session: str, machine_id: str, json_mode: bool) -> int:
         return _output_result(False, json_mode, f"SSH to {machine_id} failed: {e}", exit_code=ENSURE_EXIT_SESSION_ERROR)
 
 
+def send_task_prompt(session: str, prompt: str) -> bool:
+    """Paste a task prompt and CONFIRM it was submitted. True iff it landed (#889).
+
+    The scheduler's dispatch was the one unattended send still using the blind
+    path (``pane_manager.send_to_target``): paste, sleep a fixed 1.0s, press
+    Enter, sleep a fixed 0.5s, press Enter again — no confirmation, and a
+    ``None`` return, so ``ensure`` structurally could not tell "delivered" from
+    "sitting unsubmitted in the input box". It then waited for a completion
+    signal that could never arrive.
+
+    Those delays are constants; the thing they are waiting for is not. A task
+    that interpolates a large ``pre`` output pastes tens of KB, and
+    ``session_ready``'s own comments explain why the verified path polls
+    instead: "a large paste renders slowly", so its landing gate allows
+    ``LAND_TIMEOUT`` (8s) where the blind path allows 1.0s. ``send_to_target``'s
+    docstring already records the failure class — "Skipping the second [Enter]
+    leaves the prompt stuck in the input — the failure that hung the scheduler
+    at 8am". The size-adaptive replacement was written and adopted everywhere
+    else (``agentwire send``, ``prompt_router``, ``council``, ``session_cli``,
+    the ``msg`` drain); this path just never moved over.
+
+    A False here is a real, actionable failure, so it must be acted on rather
+    than logged — routing through ``send_verified`` and ignoring the result
+    would reproduce the same silence with more machinery.
+
+    One subtlety kept from ``send_cli``: a False can also mean the paste fully
+    submitted and only the *confirm* read was ambiguous (a laggy host blowing
+    the submit budget, an unparseable box frame). The per-attempt marker rides
+    inside the pasted text, so scrollback can settle that as a fact rather than
+    a text-similarity guess — a marker can only be there if THIS paste
+    submitted. Only when it is absent do we call the send failed.
+    """
+    from .session_ready import (
+        message_on_scrollback,
+        new_delivery_marker,
+        scrollback,
+        send_verified,
+        tag_message,
+    )
+
+    marker = new_delivery_marker()
+    if send_verified(session, tag_message(prompt, marker), marker=marker):
+        return True
+    # False negative check: confirm-read ambiguity vs a paste that never landed.
+    return message_on_scrollback(scrollback(session), marker)
+
+
 def cmd_ensure(args) -> int:
     """Run a named task with reliable session management.
 
@@ -681,8 +728,24 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
         if not json_mode:
             print("Sending task prompt...")
 
-        # Send task prompt using pane_manager for proper multi-line handling
-        pane_manager.send_to_pane(session, 0, prompt, enter=True)
+        # Verified submit (#889). Waiting on a completion signal for a prompt
+        # that never left the input box is how a 30-minute task burns hours in
+        # silence — so a send we can't confirm ends the attempt, loudly, here.
+        if not send_task_prompt(session, prompt):
+            last_status = "failed"
+            last_summary = (
+                f"Task prompt never landed in session '{session}' — paste was "
+                "not confirmed submitted (agent may be wedged on a dialog, or "
+                "the payload outran the input box)"
+            )
+            if not json_mode:
+                print(f"Send failed: {last_summary}")
+            if attempt < max_attempts:
+                if not json_mode:
+                    print(f"Retrying in {task.retry_delay}s...")
+                time.sleep(task.retry_delay)
+                continue
+            break
 
         # Wait for completion signal from hook
         if not json_mode:
@@ -737,12 +800,20 @@ def _run_ensure_task(args, session, task, ctx, shell, project_path, json_mode) -
 
         # on_task_end: send additional prompt after summary is written
         # Note: we don't wait for this to complete - it's fire-and-forget
+        #
+        # Verified like the task prompt (#889), but a failure here only warns:
+        # the task itself already reported its status, so failing the run over
+        # an unsent epilogue would rewrite a completed task as failed. Loud, not
+        # fatal — the asymmetry worth fixing is silence, not the exit code.
         if task.on_task_end:
             try:
                 end_prompt = expand_all(task.on_task_end, ctx)
-                pane_manager.send_to_pane(session, 0, end_prompt, enter=True)
-                if not json_mode:
-                    print("Sent on_task_end prompt (not waiting for completion)")
+                if send_task_prompt(session, end_prompt):
+                    if not json_mode:
+                        print("Sent on_task_end prompt (not waiting for completion)")
+                else:
+                    print(f"Warning: on_task_end prompt was not confirmed submitted "
+                          f"to session '{session}'", file=sys.stderr)
             except TemplateError as e:
                 if not json_mode:
                     print(f"Warning: template error in on_task_end: {e}")

--- a/docs/wiki/scheduling/scheduled-workloads.md
+++ b/docs/wiki/scheduling/scheduled-workloads.md
@@ -486,6 +486,7 @@ declined, rather than silently adding a second dispatcher on every launch.
 so nothing can verify it. `doctor` flags that explicitly (`records no PID —
 predates the PID-based liveness check`) rather than reporting it as stopped.
 Restarting the daemon clears it — which a rebuild already requires anyway.
+
 ---
 
 ## Bounding a Task: `max_duration` (#867)
@@ -528,3 +529,52 @@ Warning: task 'memory-manager' sets keys agentwire ignores: max_durationn
 
 Reported, never fatal: a typo must not break a 04:00 dispatch. `description` is
 allowed as a deliberate no-op annotation.
+
+---
+
+## Prompt Delivery Is Verified, and Its Result Acted On (#889)
+
+A scheduled dispatch's prompt is pasted with `session_ready.send_verified` — the
+same call `agentwire send`, `prompt_router`, `council`, `session_cli` and the
+`msg` drain all make — and **`ensure` fails the attempt when it can't be
+confirmed.**
+
+Until #889 this one path still used the blind paste (`pane_manager.send_to_target`):
+paste, sleep a fixed **1.0s**, press Enter, sleep a fixed **0.5s**, press Enter.
+Two problems, and the second is the one that hurt:
+
+1. **The delays are constants; the paste is not.** A task interpolating a large
+   `pre` output pastes tens of KB. `send_verified` polls for the text to appear
+   with `LAND_TIMEOUT = 8.0s` precisely because — in its own comment — "a large
+   paste renders slowly". The blind path allowed 1.0s. `send_to_target`'s
+   docstring already recorded the failure class: *"Skipping the second [Enter]
+   leaves the prompt stuck in the input — the failure that hung the scheduler at
+   8am."*
+2. **`send_to_pane` returns `None`.** So `ensure` could not distinguish
+   "delivered" from "sitting unsubmitted in the input box". It went straight into
+   `wait_for_completion_signal` and waited for a signal that could never arrive —
+   which is how a task with nobody watching burns hours in silence rather than
+   reporting an error.
+
+Fixing only the first half would have been the trap: routing through
+`send_verified` while ignoring what it returns reproduces the same silence with
+more machinery. **A dispatch that reports "prompt never landed" is strictly
+better than one that waits for a signal that cannot arrive.**
+
+| Send | On unconfirmed delivery |
+|---|---|
+| Task prompt | Attempt **fails** with a named reason; retried if `retries` is set; never falls through to the completion wait |
+| `on_task_end` | **Warns** on stderr only — the task already reported its status, and an unsent epilogue must not rewrite a completed run as failed |
+
+**False negatives are handled, not ignored.** A `False` from `send_verified` can
+also mean the paste fully submitted and only the *confirm* read was ambiguous (a
+laggy host blowing the submit budget). The per-attempt marker (#839) rides inside
+the pasted text, so scrollback settles it as a fact — a marker can only be there
+if *this* paste submitted. Only when it's absent is the send called failed.
+
+> This was filed as a lead on #867, where `memory-manager`'s agent executed zero
+> tool calls for two hours while its ~21 KB prompt (a 1,280-byte template plus a
+> 19,820-byte audit payload) got 1.0s to render. **The asymmetry is worth fixing
+> regardless of whether it turns out to be that hang's cause** — an unattended
+> send path that can silently not-send is a latent version of this for every
+> scheduled task.

--- a/tests/unit/test_ensure_verified_prompt.py
+++ b/tests/unit/test_ensure_verified_prompt.py
@@ -1,0 +1,155 @@
+"""The scheduler's dispatch send is verified, and its result is acted on (#889).
+
+`ensure` sent its task prompt through the blind paste path — fixed 1.0s sleep,
+Enter, fixed 0.5s sleep, Enter — while every other send in the codebase had
+moved to `session_ready.send_verified`, whose docstring says it "Replaces the
+old blind fixed-delay-then-Enter". Two consequences, both covered here:
+
+* those delays are constants and the paste they wait for is not, so a large
+  payload can outrun them; and
+* `send_to_pane` returns `None`, so `ensure` could not tell "delivered" from
+  "sitting unsubmitted in the input box" — it just waited for a completion
+  signal that could never arrive.
+
+The second half is the substantive one: routing through `send_verified` while
+ignoring what it returns would reproduce the same silence with more machinery.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agentwire.ensure_cli import send_task_prompt
+
+
+class TestSendTaskPromptVerifies:
+    def test_uses_the_verified_path_not_the_blind_one(self):
+        """The whole point: this must not call `send_to_pane`/`send_to_target`."""
+        with patch("agentwire.session_ready.send_verified", return_value=True) as sv, \
+             patch("agentwire.pane_manager.send_to_target") as blind:
+            assert send_task_prompt("s", "do the thing") is True
+        sv.assert_called_once()
+        blind.assert_not_called()
+
+    def test_paste_is_marker_tagged_and_the_marker_is_passed_through(self):
+        """Per-attempt marker (#839) makes every downstream check a fact."""
+        with patch("agentwire.session_ready.send_verified", return_value=True) as sv:
+            send_task_prompt("s", "do the thing")
+        args, kwargs = sv.call_args
+        pasted, marker = args[1], kwargs["marker"]
+        assert marker  # a real token was minted
+        assert pasted.startswith("do the thing")
+        assert pasted.endswith(marker)  # rides INSIDE the pasted text
+
+    def test_each_send_mints_a_fresh_marker(self):
+        seen = []
+        with patch("agentwire.session_ready.send_verified", return_value=True) as sv:
+            send_task_prompt("s", "x")
+            send_task_prompt("s", "x")
+        seen = [c.kwargs["marker"] for c in sv.call_args_list]
+        assert seen[0] != seen[1]
+
+    def test_failure_is_reported_as_failure(self):
+        with patch("agentwire.session_ready.send_verified", return_value=False), \
+             patch("agentwire.session_ready.scrollback", return_value=""), \
+             patch("agentwire.session_ready.message_on_scrollback", return_value=False):
+            assert send_task_prompt("s", "do the thing") is False
+
+    def test_ambiguous_confirm_that_actually_landed_is_not_a_failure(self):
+        """A False from send_verified can mean the confirm read was ambiguous.
+
+        The marker can only reach scrollback if THIS paste submitted, so its
+        presence settles it as a fact rather than a text-similarity guess.
+        """
+        with patch("agentwire.session_ready.send_verified", return_value=False), \
+             patch("agentwire.session_ready.scrollback", return_value="...output..."), \
+             patch("agentwire.session_ready.message_on_scrollback", return_value=True):
+            assert send_task_prompt("s", "do the thing") is True
+
+    def test_scrollback_is_checked_against_the_marker_not_the_prompt(self):
+        """Matching bare prompt text would false-positive on a generic prompt."""
+        with patch("agentwire.session_ready.send_verified", return_value=False) as sv, \
+             patch("agentwire.session_ready.scrollback", return_value="hay"), \
+             patch("agentwire.session_ready.message_on_scrollback",
+                   return_value=False) as mos:
+            send_task_prompt("s", "continue")
+        needle = mos.call_args[0][1]
+        assert needle == sv.call_args.kwargs["marker"]
+        assert needle != "continue"
+
+
+def _task(**overrides):
+    """A real TaskConfig — parsed, so no field can silently go missing."""
+    from agentwire.tasks import parse_task_config
+
+    return parse_task_config("t", {"prompt": "do the thing", **overrides})
+
+
+class TestFailedSendEndsTheAttempt:
+    """A prompt that never landed must not fall through into the wait.
+
+    Waiting on a completion signal for a prompt sitting in the input box is
+    exactly the shape of the 2h silence in #867 — so this exercises the real
+    `_run_ensure_task` rather than reading its source.
+    """
+
+    def _run(self, tmp_path, sent, task=None, signal=None):
+        from agentwire import ensure_cli
+        from agentwire.templating import TemplateContext
+
+        task = task or _task()
+        ctx = TemplateContext(session="s", task="t", project_root=str(tmp_path))
+        args = SimpleNamespace(session="s", task="t")
+        (tmp_path / ".agentwire").mkdir(exist_ok=True)
+
+        with patch.object(ensure_cli, "send_task_prompt", side_effect=sent) as send, \
+             patch("agentwire.ensure_cli.tmux_session_exists", return_value=True), \
+             patch("agentwire.session_ready.wait_for_session_ready", return_value=True), \
+             patch("agentwire.completion.wait_for_completion_signal") as wait, \
+             patch("agentwire.completion.write_task_context"), \
+             patch("agentwire.completion.clear_task_context"), \
+             patch("agentwire.ensure_cli.subprocess.run"), \
+             patch("agentwire.ensure_cli.time.sleep"):
+            wait.return_value = signal or {"status": "complete", "summary": "ok"}
+            rc = ensure_cli._run_ensure_task(
+                args, "s", task, ctx, "/bin/sh", tmp_path, json_mode=False)
+        return rc, send, wait
+
+    def test_unconfirmed_send_never_reaches_the_completion_wait(self, tmp_path, capsys):
+        rc, send, wait = self._run(tmp_path, sent=[False])
+        wait.assert_not_called()
+        assert send.call_count == 1
+        assert rc != 0
+        out = capsys.readouterr().out
+        assert "never landed" in out
+
+    def test_a_confirmed_send_proceeds_normally(self, tmp_path):
+        rc, send, wait = self._run(tmp_path, sent=[True])
+        wait.assert_called_once()
+        assert rc == 0
+
+    def test_a_failed_send_is_retried_when_retries_are_configured(self, tmp_path):
+        rc, send, wait = self._run(
+            tmp_path, sent=[False, True], task=_task(retries=1))
+        assert send.call_count == 2
+        wait.assert_called_once()   # the retry landed, so the wait runs once
+        assert rc == 0
+
+    def test_retries_exhausted_reports_the_named_reason(self, tmp_path, capsys):
+        rc, send, wait = self._run(
+            tmp_path, sent=[False, False], task=_task(retries=1))
+        assert send.call_count == 2
+        wait.assert_not_called()
+        assert rc != 0
+        assert "not confirmed submitted" in capsys.readouterr().out
+
+    def test_on_task_end_failure_does_not_rewrite_a_completed_task(
+            self, tmp_path, capsys):
+        """The task already reported its status; an unsent epilogue must warn."""
+        rc, send, wait = self._run(
+            tmp_path,
+            sent=[True, False],                 # task prompt lands, epilogue doesn't
+            task=_task(on_task_end="now push"),
+        )
+        assert send.call_count == 2
+        assert rc == 0                          # still complete
+        assert "not confirmed submitted" in capsys.readouterr().err


### PR DESCRIPTION
Fixes the asymmetry: the scheduler's dispatch was the one unattended send still using the blind paste path, and the one with nobody watching to notice it had failed.

**Fixed because the asymmetry is wrong, not because it might explain #867.** If the instrumented ~20 KB repro comes back negative, this still stands on its own.

## The change

`ensure`'s two prompt sends now route through `session_ready.send_verified` — the same call `agentwire send`, `prompt_router`, `council`, `session_cli` and the `msg` drain already make — via one shared helper, `ensure_cli.send_task_prompt`.

| | Before | After |
|---|---|---|
| Wait for paste to land | `time.sleep(1.0)` | polls the input box, `LAND_TIMEOUT = 8.0s` |
| Enter | 1 press, +1 after `sleep(0.5)` | re-presses until the box clears (`SUBMIT_BUDGET = 20s`, `MIN_ENTER_ATTEMPTS = 4`) |
| Scales with payload | no | yes |
| Return value | `None` | `bool` |

## Acting on the result is the substantive half

You called this out and it's the right call — routing through `send_verified` while ignoring what it returns would reproduce the same silence with more machinery. So:

| Send | On unconfirmed delivery |
|---|---|
| **Task prompt** | Attempt **fails** with a named reason, retried if `retries` is set, and **never falls through to `wait_for_completion_signal`** |
| **`on_task_end`** | **Warns on stderr only** |

```
Send failed: Task prompt never landed in session 'memory-manager' — paste was not
confirmed submitted (agent may be wedged on a dialog, or the payload outran the
input box)
```

The `on_task_end` asymmetry is deliberate: that prompt is already fire-and-forget and the task has *already reported its status*, so failing the run over an unsent epilogue would rewrite a completed task as failed. The problem worth fixing there is silence, not the exit code.

## False negatives are handled, not ignored

A `False` from `send_verified` can also mean the paste fully submitted and only the *confirm* read was ambiguous — a laggy host blowing the submit budget, an unparseable box frame. Treating that as a failed send would abandon a task that is actually running.

So the helper keeps `send_cli`'s discipline: the per-attempt marker (#839) rides **inside** the pasted text, and scrollback is checked for **the marker, not the prompt text**. A marker can only be on scrollback if *this* paste submitted, which makes it a fact rather than a text-similarity guess — matching bare prompt text would false-positive on a generic prompt (`continue`, `yes`) and wrongly report a never-landed send as delivered. Only an absent marker counts as failure.

## Tests

`tests/unit/test_ensure_verified_prompt.py` (new, 11 tests).

`TestFailedSendEndsTheAttempt` drives the **real `_run_ensure_task`** — not a source scrape — with a parsed `TaskConfig`, so no field can silently go missing:

- unconfirmed send → `wait_for_completion_signal` **never called**, non-zero rc, reason printed
- confirmed send → proceeds normally, rc 0
- `retries: 1` with fail-then-succeed → 2 sends, wait called once, rc 0
- retries exhausted → 2 sends, wait never called, named reason
- `on_task_end` fails after a successful task → rc still 0, warning on stderr

`TestSendTaskPromptVerifies` covers the helper: verified path used and the blind one not called, marker minted per attempt and tagged into the paste, fresh marker each send, and the scrollback check keyed on the marker rather than the prompt.

**Mutations verified to fail before restoring:**

| Mutation | Result |
|---|---|
| Route through `send_verified` but **ignore the return value** | 4 failed, 7 passed |
| Revert `send_task_prompt` to the blind `send_to_pane` | 5 failed, 6 passed |

The first is the exact trap you named, so it seemed worth proving the tests catch it.

## Suite

**`6 failed, 3284 passed`.** All 6 failures are the **pre-existing `tests/unit/test_history_resume_name.py` breakage on main** — `AttributeError: 'types.SimpleNamespace' object has no attribute 'conversation_id'` at `core.py:983`, where #871's `record_session_launch` outgrew the test's fake `AgentCommand`. Verified identical on clean `origin/main` with no changes applied. Unrelated to this PR; still happy to fix it separately.

My delta: **+11 tests, 0 new failures.** `ruff check` clean.

## Not verified live

The fleet is running, so no rebuild and no restart. The behavior is covered by tests against the real dispatch function, not by a live 04:00 dispatch. The #867 repro (an instrumented ~20 KB payload) is still outstanding and #867 stays open until it says something either way.

Closes #889
Refs #867

Built by [dotdev.dev](https://dotdev.dev)