### PR TITLE
fix(tests): repair main — #871's metadata write outgrew a test's AgentCommand fake

### DIFF
--- a/tests/unit/test_history_resume_name.py
+++ b/tests/unit/test_history_resume_name.py
@@ -32,7 +32,16 @@ def resume(tmp_path, monkeypatch):
     monkeypatch.setattr(history_cli, "resolve_roles", lambda kind, project_roles=None: [])
     monkeypatch.setattr(
         history_cli, "build_agent_command",
-        lambda posture, roles, resume_session_id=None: SimpleNamespace(command="claude"),
+        # The fake must carry every attribute record_session_launch reads off an
+        # AgentCommand (#871), not just the ones cmd_history_resume itself uses —
+        # a launch now also WRITES the session's metadata record.
+        lambda posture, roles, resume_session_id=None: SimpleNamespace(
+            command="claude",
+            conversation_id=None,
+            posture=posture,
+            roles=roles or [],
+            role_prompt_path=None,
+        ),
     )
     monkeypatch.setattr(history_cli, "_notify_portal_sessions_changed", lambda: None)
     monkeypatch.setattr(history_cli.time, "sleep", lambda s: None)


### PR DESCRIPTION
## Main is red

`tests/unit/test_history_resume_name.py` — 6 failures on a clean `origin/main` with no local changes:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'conversation_id'
  agentwire/core.py:983
```

## Why it slipped through

Neither PR was wrong, and neither touched the other's files:

- **#876** added the test with a fake `AgentCommand` — `SimpleNamespace(command="claude")`, which was every attribute `cmd_history_resume` read at the time.
- **#881** made every launch path also *write* the session metadata record. `record_session_launch` reads four more attributes off the `AgentCommand`: `conversation_id`, `posture`, `roles`, `role_prompt_path`.

Both branches were green. The merge of the two is red. A semantic conflict with zero textual overlap — the kind a per-branch green run structurally cannot catch, and a merge queue running the full suite post-merge would.

## Fix

Give the fake the full attribute surface the writer reads, with a comment saying *why* it needs more than the caller uses — so the next person extending `record_session_launch` sees the coupling.

## Verification

- `tests/unit/test_history_resume_name.py`: 6 failed → **7 passed**
- Full unit suite: **3096 passed**, 1 pre-existing warning

Found by the #867/#889 worker while rebasing, which independently confirmed it reproduces on clean `origin/main` with zero changes applied.

Built by [dotdev.dev](https://dotdev.dev)