### PR TITLE
feat(history): re-key conversation history orphaned by a moved directory (#871 item 4, #892)

### DIFF
--- a/agentwire/history.py
+++ b/agentwire/history.py
@@ -9,6 +9,7 @@ Supports both local and remote machines via SSH for distributed setups.
 """
 
 import json
+import re
 from pathlib import Path
 
 from .ssh import ssh_base_opts
@@ -66,21 +67,39 @@ def resolve_session_id(prefix: str, machine: str = "local") -> str | None:
 
 
 def encode_project_path(path: str) -> str:
-    """Encode project path to Claude's directory format.
+    """Encode a cwd to the ``~/.claude/projects/<dir>`` name Claude Code uses.
 
-    Example: /home/user/projects/myapp -> -home-user-projects-myapp
+    The rule is **every character outside ``[A-Za-z0-9]`` becomes ``-``**, one
+    for one — nothing is dropped, collapsed, or case-folded.
+
+    Derived EMPIRICALLY, not from documentation (#871), the same way #878 had
+    to measure tmux's name mangling instead of guessing it:
+
+    - 528 ground-truth pairs were read out of the local history — every
+      ``*.jsonl`` records the ``cwd`` it was written from — and 527 matched
+      this rule exactly. (The one holdout is a project directory renamed on
+      disk after the fact, i.e. the very orphaning this module exists to
+      repair, not a counter-example to the encoding.)
+    - The remaining characters were swept through a real ``claude`` run:
+      a directory segment ``a_b.c+d~e@f,g=h!i#j%k^l&m n o'p`` produced
+      ``a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p``.
+    - Non-ASCII was swept the same way: ``café-日本-Ωx`` produced
+      ``caf------x``, so the class is ASCII ``[A-Za-z0-9]`` and **not**
+      :meth:`str.isalnum`, which would have preserved ``é``/``日``/``Ω``.
+
+    The previous implementation replaced only ``/``, which silently produced
+    the wrong directory for any path containing a dot, an underscore, or a
+    space — including ``~/.claude`` and ``~/.agentwire/council/<n>/workspace``,
+    both of which really exist here. That is the same dot-shaped bug class as
+    #865 → #868 → #870 → #878.
+
+    There is deliberately no inverse. The mapping is many-to-one (``/``, ``.``
+    and ``-`` all encode to ``-``), so a directory name cannot be decoded back
+    to a cwd — it can only be compared against the encoding of a cwd you
+    already know. Callers get that known cwd from ``cwd_at_launch`` in the
+    session metadata (#881).
     """
-    # Replace all slashes with dashes (leading slash becomes leading dash)
-    return path.replace("/", "-")
-
-
-def decode_project_path(encoded: str) -> str:
-    """Decode Claude's directory format back to path.
-
-    Example: -home-user-projects-myapp -> /home/user/projects/myapp
-    """
-    # Replace dashes with slashes (leading dash becomes leading slash)
-    return encoded.replace("-", "/")
+    return re.sub(r"[^A-Za-z0-9]", "-", path)
 
 
 def _get_machine_config(machine_id: str) -> dict | None:

--- a/agentwire/history_cli.py
+++ b/agentwire/history_cli.py
@@ -15,6 +15,7 @@ import sys
 import time
 from pathlib import Path
 
+from . import history_migrate
 from .core import (
     _get_machine_config,
     _notify_portal_sessions_changed,
@@ -27,7 +28,6 @@ from .core import (
     mirror_role_prompt_remote,
     record_session_launch,
 )
-from . import history_migrate
 from .project_config import ProjectConfig, load_project_config
 from .roles import (
     derive_session_kind,
@@ -371,10 +371,10 @@ def cmd_history_migrate(args) -> int:
     """
     explicit = bool(args.from_path or args.to_path)
     if explicit and not (args.from_path and args.to_path):
-        return _output_result(False, "--from and --to must be given together", json_output=args.json)
+        return _output_result(False, args.json, "--from and --to must be given together")
     if sum([explicit, bool(args.session), bool(args.all)]) != 1:
         return _output_result(
-            False, "choose exactly one of: --session, --from/--to, --all", json_output=args.json
+            False, args.json, "choose exactly one of: --session, --from/--to, --all"
         )
 
     if explicit:
@@ -421,6 +421,12 @@ def cmd_history_migrate(args) -> int:
             print(f"    history: {r['source']}")
         if r["status"] in (history_migrate.READY, history_migrate.MIGRATED):
             print(f"    -> {r['target']}")
+        if r.get("mixed_provenance"):
+            print("    MIXED PROVENANCE — transcripts in this directory came from:")
+            for cwd, count in sorted(r["mixed_provenance"].items(), key=lambda kv: -kv[1]):
+                print(f"        {count:>4}  {cwd}")
+        for conv in r.get("conversations", []):
+            print(f"    {'resumable    ' if conv['resumable'] else 'NOT resumable'}  {conv['id']}")
         print(f"    {r['detail']}")
 
     if not notable:

--- a/agentwire/history_cli.py
+++ b/agentwire/history_cli.py
@@ -27,6 +27,7 @@ from .core import (
     mirror_role_prompt_remote,
     record_session_launch,
 )
+from . import history_migrate
 from .project_config import ProjectConfig, load_project_config
 from .roles import (
     derive_session_kind,
@@ -351,6 +352,96 @@ def cmd_history_resume(args) -> int:
     return 0
 
 
+_MIGRATE_LABEL = {
+    history_migrate.ALIGNED: "ok",
+    history_migrate.READY: "MIGRATABLE",
+    history_migrate.MIGRATED: "MIGRATED",
+    history_migrate.SOURCE_ABSENT: "no history",
+    history_migrate.TARGET_EXISTS: "REFUSED",
+    history_migrate.UNDETERMINED: "unknown",
+    history_migrate.ERROR: "ERROR",
+}
+
+
+def cmd_history_migrate(args) -> int:
+    """Re-key conversation history onto a directory's current path (#871).
+
+    Dry run by default: moving history is the kind of thing you want to read
+    before you do. ``--apply`` performs it.
+    """
+    explicit = bool(args.from_path or args.to_path)
+    if explicit and not (args.from_path and args.to_path):
+        return _output_result(False, "--from and --to must be given together", json_output=args.json)
+    if sum([explicit, bool(args.session), bool(args.all)]) != 1:
+        return _output_result(
+            False, "choose exactly one of: --session, --from/--to, --all", json_output=args.json
+        )
+
+    if explicit:
+        results = [{"session": None, **history_migrate.plan(args.from_path, args.to_path)}]
+    elif args.session:
+        results = [history_migrate.resolve_session(args.session)]
+    else:
+        results = history_migrate.scan()
+
+    if args.apply:
+        applied = []
+        for r in results:
+            if r["status"] == history_migrate.READY:
+                done = history_migrate.apply(
+                    r["old_cwd"], r["new_cwd"], prune_source=args.prune_source
+                )
+                applied.append({**r, **done})
+            else:
+                applied.append(r)
+        results = applied
+
+    # JSON always carries every result; only the human view is condensed.
+    if args.json:
+        return _output_json({"applied": args.apply, "results": results})
+
+    # A sweep is mostly sessions that are fine or unjudgeable — locally that is
+    # every one of several hundred, since anything launched before #881 has no
+    # cwd_at_launch to compare. Enumerating them buries the one line that
+    # matters, so they are counted by reason instead of listed. Counted, not
+    # dropped: a silent filter reads as "nothing to see here".
+    quiet = {history_migrate.ALIGNED, history_migrate.UNDETERMINED}
+    notable = [r for r in results if r["status"] not in quiet]
+    skipped = [r for r in results if r["status"] in quiet]
+
+    for r in notable:
+        label = _MIGRATE_LABEL.get(r["status"], r["status"])
+        who = r.get("session") or "(explicit)"
+        print(f"[{label}] {who}")
+        if r.get("old_cwd"):
+            print(f"    was: {r['old_cwd']}")
+        if r.get("new_cwd") and r.get("new_cwd") != r.get("old_cwd"):
+            print(f"    now: {r['new_cwd']}")
+        if r.get("source"):
+            print(f"    history: {r['source']}")
+        if r["status"] in (history_migrate.READY, history_migrate.MIGRATED):
+            print(f"    -> {r['target']}")
+        print(f"    {r['detail']}")
+
+    if not notable:
+        print("No orphaned history found.")
+
+    if skipped:
+        by_reason: dict[str, int] = {}
+        for r in skipped:
+            by_reason[r["detail"]] = by_reason.get(r["detail"], 0) + 1
+        print(f"\n{len(skipped)} session(s) not shown:")
+        for reason, count in sorted(by_reason.items(), key=lambda kv: -kv[1]):
+            print(f"    {count:>4}  {reason}")
+
+    migratable = sum(1 for r in notable if r["status"] == history_migrate.READY)
+    if migratable and not args.apply:
+        print(f"\n{migratable} migratable. Re-run with --apply to perform it.")
+
+    failed = [r for r in results if r["status"] in history_migrate.FAILURE_STATUSES]
+    return 1 if failed else 0
+
+
 def register_history_parser(subparsers) -> None:
     history_parser = subparsers.add_parser("history", help="Claude Code session history")
     history_subparsers = history_parser.add_subparsers(dest="history_command")
@@ -378,3 +469,31 @@ def register_history_parser(subparsers) -> None:
     history_resume.add_argument("--project", "-p", required=True, help="Project path")
     history_resume.add_argument("--json", action="store_true", help="JSON output")
     history_resume.set_defaults(func=cmd_history_resume)
+
+    # history migrate
+    history_mig = history_subparsers.add_parser(
+        "migrate",
+        help="Re-key conversation history onto a directory's current path",
+        description=(
+            "Claude Code keys a conversation by the directory it ran in "
+            "(~/.claude/projects/<encoded-cwd>/). Moving that directory orphans the "
+            "transcript, so --resume reports 'No conversation found with session ID' "
+            "even though the file is intact. This re-keys it onto the current path. "
+            "Works regardless of who moved the directory — agentwire, `git worktree "
+            "move`, or a plain `mv`. Dry run unless --apply is given; never merges "
+            "into an existing target and never deletes the source before verifying "
+            "the copy."
+        ),
+    )
+    history_mig.add_argument("--session", "-s", help="Session whose recorded cwd to reconcile")
+    history_mig.add_argument("--from", dest="from_path",
+                             help="Old directory path (with --to; for moves agentwire never saw)")
+    history_mig.add_argument("--to", dest="to_path", help="New directory path (with --from)")
+    history_mig.add_argument("--all", action="store_true",
+                             help="Scan every recorded session and report those needing migration")
+    history_mig.add_argument("--apply", action="store_true",
+                             help="Perform the migration (default is a dry run)")
+    history_mig.add_argument("--prune-source", action="store_true",
+                             help="Delete the old history dir, but only after the copy verifies")
+    history_mig.add_argument("--json", action="store_true", help="JSON output")
+    history_mig.set_defaults(func=cmd_history_migrate)

--- a/agentwire/history_migrate.py
+++ b/agentwire/history_migrate.py
@@ -33,7 +33,9 @@ consumes, and it stays correct if agentwire ever does grow a move verb.
 
 from __future__ import annotations
 
+import functools
 import hashlib
+import json
 import os
 import shutil
 import uuid
@@ -65,6 +67,11 @@ def history_key_candidates(cwd: str | Path) -> list[str]:
     path its process reports. Checking both is the difference between finding
     the transcript and reporting a false "absent".
     """
+    return [encode_project_path(p) for p in history_key_sources(cwd)]
+
+
+def history_key_sources(cwd: str | Path) -> list[str]:
+    """The cwd spellings behind :func:`history_key_candidates`, unencoded."""
     raw = str(cwd)
     out = [raw]
     try:
@@ -73,7 +80,7 @@ def history_key_candidates(cwd: str | Path) -> list[str]:
         resolved = raw
     if resolved != raw:
         out.append(resolved)
-    return [encode_project_path(p) for p in out]
+    return out
 
 
 def resumable(conversation_id: str, cwd: str | Path) -> bool:
@@ -127,6 +134,106 @@ def _fingerprint(root: Path) -> dict[str, tuple[int, str]]:
     return out
 
 
+STAGING_PREFIX = ".agentwire-migrate-"
+
+
+def _first_recorded_cwd(transcript: Path) -> str | None:
+    """The ``cwd`` a transcript says it was written from, or None."""
+    try:
+        with transcript.open() as fh:
+            for i, line in enumerate(fh):
+                if i > 30:
+                    break
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict) and obj.get("cwd"):
+                    return obj["cwd"]
+    except OSError:
+        return None
+    return None
+
+
+def classify_source(history_dir: Path, old_cwd: str | Path) -> tuple[dict[str, int], list[str]]:
+    """Split a history directory by the cwd its transcripts were written from.
+
+    Returns ``(cwd -> count, foreign_filenames)``. A file counts as foreign
+    only when it *positively states* a different cwd. Transcripts with no
+    readable cwd, and every non-transcript entry (``memory/`` and friends),
+    are treated as belonging to the directory's own key — they carry no
+    evidence to the contrary, and the source is retained anyway.
+    """
+    own = set(history_key_sources(old_cwd))
+    provenance: dict[str, int] = {}
+    foreign: list[str] = []
+    for f in sorted(history_dir.glob("*.jsonl")):
+        cwd = _first_recorded_cwd(f)
+        if not cwd:
+            continue
+        provenance[cwd] = provenance.get(cwd, 0) + 1
+        if cwd not in own:
+            foreign.append(f.name)
+    return provenance, foreign
+
+
+def recorded_cwds(history_dir: Path) -> dict[str, int]:
+    """The cwds the transcripts in *history_dir* say they were written from.
+
+    Every ``*.jsonl`` carries a ``cwd`` on its records — the same ground truth
+    the encoding itself was derived from. Normally they all agree with the
+    directory's own key, but they need not: because the encoding is
+    non-injective, and because a directory can be renamed under a live
+    session, one history directory can legitimately hold transcripts from
+    **two different projects**. One such directory exists on the machine this
+    was written on.
+
+    Returns cwd -> transcript count. Unreadable or cwd-less files are skipped
+    rather than raising: this informs a report, and a malformed transcript
+    must not be able to block a migration.
+    """
+    counts: dict[str, int] = {}
+    for f in sorted(history_dir.glob("*.jsonl")):
+        try:
+            with f.open() as fh:
+                for i, line in enumerate(fh):
+                    if i > 30:
+                        break
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    cwd = isinstance(obj, dict) and obj.get("cwd")
+                    if cwd:
+                        counts[cwd] = counts.get(cwd, 0) + 1
+                        break
+        except OSError:
+            continue
+    return counts
+
+
+def sweep_staging() -> list[str]:
+    """Remove staging directories abandoned by an interrupted run.
+
+    A staging directory only ever exists mid-``apply``; one still present is
+    the remnant of a process that died between copy and publish. It holds a
+    *copy*, never the only extant transcript — the source is untouched until
+    after publication — so clearing it cannot lose history. Without this they
+    accumulate silently, the same shape as #884.
+    """
+    if not PROJECTS_DIR.is_dir():
+        return []
+    swept = []
+    for p in PROJECTS_DIR.iterdir():
+        if p.is_dir() and p.name.startswith(STAGING_PREFIX):
+            try:
+                shutil.rmtree(p)
+                swept.append(p.name)
+            except OSError:
+                pass
+    return swept
+
+
 def plan(old_cwd: str | Path, new_cwd: str | Path) -> dict:
     """Decide what migrating *old_cwd*'s history to *new_cwd* would do.
 
@@ -157,10 +264,39 @@ def plan(old_cwd: str | Path, new_cwd: str | Path) -> dict:
                           "overwrite it; inspect both and resolve by hand"}
 
     files = [p for p in source.rglob("*") if p.is_file()]
-    return {**result, "status": READY,
-            "files": len(files),
-            "bytes": sum(p.stat().st_size for p in files),
-            "detail": "ready to migrate"}
+    out = {**result, "status": READY,
+           "files": len(files),
+           "bytes": sum(p.stat().st_size for p in files),
+           "detail": "ready to migrate"}
+
+    # The destination is guarded by refusing to merge; the SOURCE needs its own
+    # check. A history directory can hold transcripts from more than one
+    # project — a directory renamed under a live session leaves the old key
+    # holding both. One such directory exists on the machine this was built
+    # on: 7 transcripts from one project and 6 from another. Relocating all 13
+    # would orphan the 6, violating this module's headline property while
+    # reporting success.
+    #
+    # We migrate SELECTIVELY rather than refusing outright. Refusing would be
+    # safe but leaves no way forward except moving files by hand, and the
+    # correct split is exactly computable from the same ground truth the
+    # encoder came from — each transcript names its own cwd. Foreign
+    # transcripts are left where they are, which leaves them no worse off than
+    # before (they are already under a key that is not theirs), whereas moving
+    # them would strand them somewhere new.
+    provenance, foreign = classify_source(source, old_cwd)
+    if foreign:
+        others = {c: n for c, n in provenance.items()
+                  if c not in set(history_key_sources(old_cwd))}
+        summary = ", ".join(f"{c} ({n})" for c, n in sorted(others.items(), key=lambda kv: -kv[1]))
+        out["mixed_provenance"] = provenance
+        out["foreign_files"] = foreign
+        out["files"] = len(files) - len(foreign)
+        out["detail"] = (
+            f"ready to migrate {out['files']} of {len(files)} file(s); {len(foreign)} recorded "
+            f"under {summary} will be LEFT IN PLACE, not relocated"
+        )
+    return out
 
 
 def apply(old_cwd: str | Path, new_cwd: str | Path, *, prune_source: bool = False) -> dict:
@@ -174,13 +310,14 @@ def apply(old_cwd: str | Path, new_cwd: str | Path, *, prune_source: bool = Fals
     the cheapest possible recovery from a bad migration is the original still
     being there.
     """
+    sweep_staging()
     decided = plan(old_cwd, new_cwd)
     if decided["status"] != READY:
         return decided
 
     source = Path(decided["source"])
     target = Path(decided["target"])
-    staging = PROJECTS_DIR / f".agentwire-migrate-{uuid.uuid4().hex[:12]}"
+    staging = PROJECTS_DIR / f"{STAGING_PREFIX}{uuid.uuid4().hex[:12]}"
 
     try:
         expected = _fingerprint(source)
@@ -193,6 +330,13 @@ def apply(old_cwd: str | Path, new_cwd: str | Path, *, prune_source: bool = Fals
             return {**decided, "status": ERROR,
                     "detail": "copy did not verify against the source; nothing was changed "
                               f"(missing: {len(missing)}, differing: {len(differing)})"}
+
+        # Verification above covers the WHOLE copy; only now do the foreign
+        # transcripts come back out of staging, so what publishes is exactly
+        # the subset this migration claims to move. The source still holds
+        # every original.
+        for name in decided.get("foreign_files", []):
+            (staging / name).unlink(missing_ok=True)
 
         # Re-check immediately before publishing: the window between plan() and
         # here is small, but a concurrent claude run in the new directory would
@@ -210,7 +354,15 @@ def apply(old_cwd: str | Path, new_cwd: str | Path, *, prune_source: bool = Fals
     out = {**decided, "status": MIGRATED, "source_retained": True,
            "detail": f"copied and verified {decided['files']} file(s)"}
 
-    if prune_source:
+    # Pruning a partially-migrated source would delete precisely the
+    # transcripts we deliberately declined to move — turning the safe choice
+    # into the destructive one. Never prune when anything was left behind.
+    if prune_source and decided.get("foreign_files"):
+        out["detail"] += (
+            f"; source NOT pruned — it still holds {len(decided['foreign_files'])} transcript(s) "
+            f"belonging to another project"
+        )
+    elif prune_source:
         try:
             shutil.rmtree(source)
             out["source_retained"] = False
@@ -238,6 +390,12 @@ def resolve_session(session_name: str) -> dict:
     metadata = load_session_metadata(session_name)
     base = {"session": session_name}
 
+    # load_session_metadata returns {} both for "no such session" and for "a
+    # session with an empty record", so distinguish them here rather than
+    # telling someone who mistyped a name that their session predates #881.
+    if not (CONFIG_DIR / "sessions" / session_name.split("@")[0] / "metadata.json").is_file():
+        return {**base, "status": UNDETERMINED, "detail": "no such session recorded"}
+
     old = metadata.get("cwd_at_launch")
     if not old:
         return {**base, "status": UNDETERMINED,
@@ -250,8 +408,8 @@ def resolve_session(session_name: str) -> dict:
                 "detail": "no live repo recorded — cannot ask git where this session now lives"}
 
     if metadata.get("worktree_path"):
-        found = find_git_worktree(Path(repo), branch=metadata.get("branch"),
-                                  name=Path(old).name)
+        found = _find_worktree_cached(find_git_worktree, repo,
+                                      metadata.get("branch"), Path(old).name)
         if not found:
             return {**base, "status": UNDETERMINED,
                     "detail": "git no longer knows a worktree for this session's branch"}
@@ -260,7 +418,41 @@ def resolve_session(session_name: str) -> dict:
         # Ran in the main checkout; `repo` is git's own path for it.
         new = repo
 
-    return {**base, **plan(old, new)}
+    result = {**base, **plan(old, new)}
+
+    # Report per-conversation resumability rather than leaving "there is a
+    # history directory" to be read as "your conversations will resume". The
+    # recorded chain is ids agentwire minted; whether each is resumable is a
+    # separate question only the transcript file answers, and the answer moves
+    # with the migration.
+    chain = metadata.get("conversation_ids") or []
+    if chain:
+        where = new if result["status"] == ALIGNED else old
+        result["conversations"] = [
+            {"id": cid, "resumable": resumable(cid, where)} for cid in chain
+        ]
+        live = sum(1 for c in result["conversations"] if c["resumable"])
+        result["detail"] += f" ({live}/{len(chain)} recorded conversation(s) resumable)"
+    return result
+
+
+@functools.lru_cache(maxsize=256)
+def _cached_worktrees(finder, repo: str, branch: str | None, name: str) -> dict | None:
+    return finder(Path(repo), branch=branch, name=name)
+
+
+def _find_worktree_cached(finder, repo: str, branch: str | None, name: str) -> dict | None:
+    """Memoised worktree lookup, so a sweep shells out to git once per repo.
+
+    :func:`scan` asks this for every recorded session — several hundred here —
+    and each miss is a ``git worktree list`` subprocess. The cache is
+    process-local and short-lived by construction (a CLI invocation), so it
+    cannot serve a stale answer across runs.
+    """
+    try:
+        return _cached_worktrees(finder, repo, branch, name)
+    except TypeError:  # a finder that isn't hashable (patched in tests)
+        return finder(Path(repo), branch=branch, name=name)
 
 
 def known_sessions() -> list[str]:
@@ -279,4 +471,5 @@ def scan() -> list[dict]:
     check being built on ``epic-871-restart-verb`` can consume it directly
     instead of growing a second, drifting implementation of the same question.
     """
+    _cached_worktrees.cache_clear()
     return [resolve_session(name) for name in known_sessions()]

--- a/agentwire/history_migrate.py
+++ b/agentwire/history_migrate.py
@@ -1,0 +1,282 @@
+"""Repair conversation history orphaned by a moved working directory (#871).
+
+Claude Code keys a conversation's transcript by the directory it ran in:
+``~/.claude/projects/<encoded-cwd>/<conversation-id>.jsonl``. Move the
+directory and the key no longer matches, so ``--resume <id>`` fails with
+"No conversation found with session ID" even though the transcript is sitting
+on disk, intact, under the old name.
+
+**Why this is a ``history migrate`` verb and not a ``worktree --move`` verb.**
+The issue text for #871 asked for the latter, describing a flag that does not
+exist. A move verb would only repair moves made *through agentwire*, and that
+is the minority of them: ``git worktree move``, a plain ``mv``, and a
+reorganised ``~/worktrees`` all orphan history exactly the same way and would
+all still be broken. The damage is not caused by moving — it is caused by the
+recorded cwd and the real cwd disagreeing, which #881 made *detectable* by
+recording ``cwd_at_launch``. So the repair is a reconciliation keyed on that
+disagreement, and it works no matter who moved the directory or how. It also
+composes: the same :func:`scan` that powers a dry run is what a doctor check
+consumes, and it stays correct if agentwire ever does grow a move verb.
+
+**Two things this module refuses to do.**
+
+1. It never destroys history. Every migration copies into a staging directory,
+   verifies the copy byte-for-byte, and only then publishes it; the source is
+   left alone unless the caller explicitly asks for it to be pruned *after*
+   that verification passed. If the target already exists it refuses outright
+   and reports, rather than merging two transcript sets or clobbering one.
+2. It never treats missing history as a crash. A recorded conversation id does
+   not guarantee a resumable conversation — history directories have been
+   observed disappearing on their own — so "the source isn't there" is a
+   normal, reportable outcome (:data:`SOURCE_ABSENT`), not an error.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import uuid
+from pathlib import Path
+
+from .core import CONFIG_DIR, load_session_metadata
+from .history import PROJECTS_DIR, encode_project_path
+
+# Outcomes. Every one of these is a legitimate thing to report; only ERROR and
+# TARGET_EXISTS are failures, and neither of them touches anything on disk.
+ALIGNED = "aligned"                # recorded cwd already matches reality
+READY = "ready"                    # a migration is available (dry run)
+MIGRATED = "migrated"              # a migration was performed and verified
+SOURCE_ABSENT = "source_absent"    # nothing to migrate — normal, not an error
+TARGET_EXISTS = "target_exists"    # refused: would merge or clobber
+UNDETERMINED = "undetermined"      # not enough recorded identity to judge
+ERROR = "error"
+
+FAILURE_STATUSES = {TARGET_EXISTS, ERROR}
+
+
+def history_key_candidates(cwd: str | Path) -> list[str]:
+    """The directory names Claude Code might have used for *cwd*, best first.
+
+    Normally there is exactly one. There are two when the recorded path and
+    its symlink-resolved form differ — the ``/tmp`` vs ``/private/tmp`` split
+    on macOS being the case that actually bites, since ``cwd_at_launch`` is
+    recorded verbatim from the caller while Claude Code keys off the physical
+    path its process reports. Checking both is the difference between finding
+    the transcript and reporting a false "absent".
+    """
+    raw = str(cwd)
+    out = [raw]
+    try:
+        resolved = str(Path(raw).expanduser().resolve())
+    except OSError:
+        resolved = raw
+    if resolved != raw:
+        out.append(resolved)
+    return [encode_project_path(p) for p in out]
+
+
+def resumable(conversation_id: str, cwd: str | Path) -> bool:
+    """Whether ``claude --resume <conversation_id>`` would work from *cwd*.
+
+    ``resumable(id, cwd) == exists(<encoded-cwd>/<id>.jsonl)`` — one predicate,
+    deliberately, rather than a second notion of resumability living next to
+    the real one. The same file governs both directions: a launched-but-never-
+    prompted session has no transcript at all (the ``.jsonl`` is written
+    lazily on the first turn), which is why a recorded conversation id can be
+    perfectly valid and still not resumable, and why ``--session-id`` reports a
+    collision on that file EXISTING rather than on the id having been used.
+    """
+    return any(
+        (PROJECTS_DIR / key / f"{conversation_id}.jsonl").is_file()
+        for key in history_key_candidates(cwd)
+    )
+
+
+def _existing_source(cwd: str | Path) -> Path | None:
+    for key in history_key_candidates(cwd):
+        candidate = PROJECTS_DIR / key
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _digest(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _fingerprint(root: Path) -> dict[str, tuple[int, str]]:
+    """Content fingerprint of a tree: relative path -> (size, sha256).
+
+    Symlinks are recorded by their target rather than followed, so a copy is
+    only called verified when it reproduces the tree's actual shape.
+    """
+    out: dict[str, tuple[int, str]] = {}
+    for item in sorted(root.rglob("*")):
+        rel = str(item.relative_to(root))
+        if item.is_symlink():
+            out[rel] = (-1, os.readlink(item))
+        elif item.is_file():
+            out[rel] = (item.stat().st_size, _digest(item))
+        elif item.is_dir():
+            out[rel] = (-2, "")
+    return out
+
+
+def plan(old_cwd: str | Path, new_cwd: str | Path) -> dict:
+    """Decide what migrating *old_cwd*'s history to *new_cwd* would do.
+
+    Pure inspection — reads the filesystem, writes nothing. The returned dict
+    is the same shape :func:`apply` returns, so a dry run and a real run are
+    reported identically.
+    """
+    source = _existing_source(old_cwd)
+    target_key = history_key_candidates(new_cwd)[-1]
+    target = PROJECTS_DIR / target_key
+
+    result = {
+        "old_cwd": str(old_cwd),
+        "new_cwd": str(new_cwd),
+        "source": str(source) if source else str(PROJECTS_DIR / history_key_candidates(old_cwd)[0]),
+        "target": str(target),
+    }
+
+    if source and source.resolve() == target.resolve():
+        return {**result, "status": ALIGNED,
+                "detail": "history is already keyed to the current directory"}
+    if source is None:
+        return {**result, "status": SOURCE_ABSENT,
+                "detail": "no history directory for the recorded cwd — nothing to migrate"}
+    if target.exists():
+        return {**result, "status": TARGET_EXISTS,
+                "detail": "target history directory already exists — refusing to merge or "
+                          "overwrite it; inspect both and resolve by hand"}
+
+    files = [p for p in source.rglob("*") if p.is_file()]
+    return {**result, "status": READY,
+            "files": len(files),
+            "bytes": sum(p.stat().st_size for p in files),
+            "detail": "ready to migrate"}
+
+
+def apply(old_cwd: str | Path, new_cwd: str | Path, *, prune_source: bool = False) -> dict:
+    """Migrate history from *old_cwd*'s key to *new_cwd*'s. Copy, then verify.
+
+    The copy lands in a staging directory alongside the target and is
+    fingerprinted against the source before being published with a single
+    rename, so an interrupted run leaves the source untouched and the target
+    absent rather than half-written. ``prune_source`` removes the original
+    only after that verification succeeded; the default is to keep it, because
+    the cheapest possible recovery from a bad migration is the original still
+    being there.
+    """
+    decided = plan(old_cwd, new_cwd)
+    if decided["status"] != READY:
+        return decided
+
+    source = Path(decided["source"])
+    target = Path(decided["target"])
+    staging = PROJECTS_DIR / f".agentwire-migrate-{uuid.uuid4().hex[:12]}"
+
+    try:
+        expected = _fingerprint(source)
+        shutil.copytree(source, staging, symlinks=True)
+        actual = _fingerprint(staging)
+        if actual != expected:
+            missing = sorted(set(expected) - set(actual))
+            differing = sorted(k for k in set(expected) & set(actual) if expected[k] != actual[k])
+            shutil.rmtree(staging, ignore_errors=True)
+            return {**decided, "status": ERROR,
+                    "detail": "copy did not verify against the source; nothing was changed "
+                              f"(missing: {len(missing)}, differing: {len(differing)})"}
+
+        # Re-check immediately before publishing: the window between plan() and
+        # here is small, but a concurrent claude run in the new directory would
+        # have created the target, and os.rename would then clobber it.
+        if target.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+            return {**decided, "status": TARGET_EXISTS,
+                    "detail": "target history directory appeared while copying — refusing to "
+                              "overwrite it; nothing was changed"}
+        os.rename(staging, target)
+    except OSError as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        return {**decided, "status": ERROR, "detail": f"migration failed: {exc}"}
+
+    out = {**decided, "status": MIGRATED, "source_retained": True,
+           "detail": f"copied and verified {decided['files']} file(s)"}
+
+    if prune_source:
+        try:
+            shutil.rmtree(source)
+            out["source_retained"] = False
+            out["detail"] += "; source pruned after verification"
+        except OSError as exc:
+            out["detail"] += f"; source could not be pruned ({exc})"
+    else:
+        out["detail"] += f"; source retained at {source}"
+    return out
+
+
+def resolve_session(session_name: str) -> dict:
+    """Where a session's history is keyed vs. where the session actually is.
+
+    ``cwd_at_launch`` is the recorded key. Reality comes from **git**, via the
+    repo/branch recorded alongside it — the same "ask git, never rebuild the
+    convention" rule that #837 applied to worktree paths. A session whose
+    metadata predates #881, or which never ran in a repo, yields
+    :data:`UNDETERMINED`: there is nothing to compare, and guessing a path
+    here is precisely how a teardown reports success while acting on the wrong
+    directory.
+    """
+    from .worktree import find_git_worktree
+
+    metadata = load_session_metadata(session_name)
+    base = {"session": session_name}
+
+    old = metadata.get("cwd_at_launch")
+    if not old:
+        return {**base, "status": UNDETERMINED,
+                "detail": "no cwd_at_launch recorded (session predates #881)"}
+
+    base["old_cwd"] = old
+    repo = metadata.get("repo")
+    if not repo or not Path(repo).is_dir():
+        return {**base, "status": UNDETERMINED,
+                "detail": "no live repo recorded — cannot ask git where this session now lives"}
+
+    if metadata.get("worktree_path"):
+        found = find_git_worktree(Path(repo), branch=metadata.get("branch"),
+                                  name=Path(old).name)
+        if not found:
+            return {**base, "status": UNDETERMINED,
+                    "detail": "git no longer knows a worktree for this session's branch"}
+        new = str(found["path"])
+    else:
+        # Ran in the main checkout; `repo` is git's own path for it.
+        new = repo
+
+    return {**base, **plan(old, new)}
+
+
+def known_sessions() -> list[str]:
+    """Session names that have a metadata record, in stable order."""
+    root = CONFIG_DIR / "sessions"
+    if not root.is_dir():
+        return []
+    return sorted(d.name for d in root.iterdir() if (d / "metadata.json").is_file())
+
+
+def scan() -> list[dict]:
+    """Every recorded session's history alignment.
+
+    This is the shared read that both the dry run and an orphan check want.
+    It is deliberately exported rather than inlined into the CLI so the doctor
+    check being built on ``epic-871-restart-verb`` can consume it directly
+    instead of growing a second, drifting implementation of the same question.
+    """
+    return [resolve_session(name) for name in known_sessions()]

--- a/docs/wiki/sessions/conversation-identity.md
+++ b/docs/wiki/sessions/conversation-identity.md
@@ -198,3 +198,104 @@ routing and `notify-parent` are local-only mechanisms (a file inbox drained by
 the local watchdog), so a parent link across machines would be a link nothing
 traverses. When cross-machine routing exists, the default becomes a real
 question again.
+
+## The cwd → history-directory encoding
+
+Claude Code keys a transcript by the directory it ran in:
+`~/.claude/projects/<encoded-cwd>/<conversation-id>.jsonl`. The encoding is
+**per character: everything outside `[A-Za-z0-9]` becomes `-`.** Nothing is
+dropped, run-collapsed, or case-folded.
+
+This was derived empirically (#871/#892), the same way #878 had to measure
+tmux's name mangling rather than assume it — twice, independently, by two
+sessions that agreed:
+
+- Every `*.jsonl` records the `cwd` it was written from, giving ground-truth
+  pairs straight off disk. 528 and 533 pairs were checked; the rule fits with
+  no mismatches.
+- The remaining characters were swept through real `claude` runs. A directory
+  segment `a_b.c+d~e@f,g=h!i#j%k^l&m n o'p` yields
+  `a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p`, and `café-日本-Ωx` yields `caf------x` —
+  so the class is ASCII `[A-Za-z0-9]`, **not** `str.isalnum()`, which would
+  have preserved `é`/`日`/`Ω`.
+
+`history.encode_project_path` is the one implementation. It previously replaced
+only `/`, which silently produced a non-existent directory for any path holding
+a dot, underscore or space — including `~/.claude` and
+`~/.agentwire/council/<n>/workspace`. The lookup then found nothing and
+reported nothing, the same dot-shaped bug class as #865 → #868 → #870 → #878.
+
+**There is no inverse, and `decode_project_path` was deleted rather than
+fixed.** The mapping is many-to-one — `/`, `.`, `_` and `-` all encode to `-` —
+so a directory name cannot be decoded back to a cwd. It can only be compared
+against the encoding of a cwd you already know, which is what `cwd_at_launch`
+is for. The old round-trip test passed only by choosing paths that dodged the
+ambiguity, pinning the bug as intended behaviour.
+
+A consequence worth naming: `/p/a_b` and `/p/a.b` are distinct directories that
+**share one history directory**. That is a property of Claude Code, not
+something agentwire can repair, and it is why a migration destination may
+already hold an unrelated project's transcripts.
+
+### Is a conversation resumable?
+
+One predicate, used everywhere rather than re-invented per caller:
+
+```
+resumable(id, cwd) == exists(<encoded-cwd>/<id>.jsonl)
+```
+
+The same file governs both directions. A launched-but-never-prompted session
+has **no transcript at all** — the `.jsonl` is written lazily on the first turn
+— so a recorded conversation id can be entirely valid and still not resumable.
+`--session-id` likewise reports a collision on that file *existing*, not on the
+id having been used before. A recorded id is therefore never a promise that
+`--resume` will work.
+
+## Repairing history orphaned by a moved directory
+
+Move a worktree and its transcripts stay behind under the old key, so
+`--resume` fails with *"No conversation found with session ID"* while the file
+sits intact on disk. `agentwire history migrate` re-keys it.
+
+```bash
+agentwire history migrate --all                 # dry run: what's orphaned
+agentwire history migrate -s <session>          # reconcile one session
+agentwire history migrate --from OLD --to NEW   # a move agentwire never saw
+agentwire history migrate ... --apply           # perform it
+```
+
+**Why a `history migrate` verb and not `worktree --move`.** #871 originally
+asked for the latter, describing a flag that does not exist. A move verb would
+only repair moves made *through agentwire*, and that is the minority of them —
+`git worktree move`, a plain `mv`, and a reorganised `~/worktrees` orphan
+history identically and would all still be broken. The damage is not caused by
+moving; it is caused by the recorded cwd and the real cwd disagreeing, which
+`cwd_at_launch` makes detectable. Keying the repair on that disagreement makes
+it work no matter who moved the directory, and keeps it composable: the same
+`history_migrate.scan()` that powers the dry run is what a doctor orphan check
+consumes.
+
+**Two guarantees.**
+
+1. *History is never destroyed.* Every migration copies into a staging
+   directory, fingerprints the copy against the source (size + sha256 per
+   entry, symlinks by target), and only then publishes it with a single
+   rename. The source is retained unless `--prune-source` is passed, and even
+   then only after verification passed. An interrupted run leaves the source
+   untouched and the target absent.
+2. *A populated destination is refused, never merged.* Because the encoding is
+   non-injective, the target may hold an **unrelated** project's transcripts,
+   so merging would silently interleave two projects' history. The check runs
+   at plan time and again immediately before the rename, closing the window
+   where a concurrent `claude` run creates the target mid-copy. Note that
+   `shutil.move` onto an existing directory does *not* fail — POSIX nests the
+   source inside it as `dst/<basename>`, burying transcripts one level below
+   where Claude Code looks while the command reports success. That is the #868
+   failure shape, and it is why publishing goes through `os.rename` behind an
+   explicit existence check.
+
+Missing source history is a **normal outcome** (`source_absent`), not an error:
+transcripts have been observed disappearing on their own, and a never-prompted
+session never had one. A sweep reports sessions it cannot judge as a counted
+summary rather than a wall of lines — counted, never silently dropped.

--- a/docs/wiki/sessions/conversation-identity.md
+++ b/docs/wiki/sessions/conversation-identity.md
@@ -295,7 +295,30 @@ consumes.
    failure shape, and it is why publishing goes through `os.rename` behind an
    explicit existence check.
 
+**3. A mixed-provenance source migrates selectively.** One history directory
+can hold transcripts from *two* projects — a directory renamed under a live
+session leaves the old key holding both. One such directory exists on the
+machine this was written on: 7 transcripts from one project and 6 from
+another. Relocating all 13 would orphan the 6, breaking guarantee 1 while
+reporting success.
+
+Rather than refuse (safe, but leaves no way forward except moving files by
+hand), the migration moves only the transcripts whose own recorded `cwd`
+matches — the split is exactly computable from the same ground truth the
+encoder came from. Foreign transcripts are left where they are, which leaves
+them no worse off than before, whereas moving them would strand them
+somewhere new. Files with no readable `cwd`, and non-transcript entries like
+`memory/`, travel with the migration: they carry no evidence of belonging
+elsewhere. `--prune-source` **refuses to prune** a source that still holds
+foreign transcripts — otherwise it would delete precisely what was
+deliberately left behind, turning the safe choice into the destructive one.
+
 Missing source history is a **normal outcome** (`source_absent`), not an error:
 transcripts have been observed disappearing on their own, and a never-prompted
 session never had one. A sweep reports sessions it cannot judge as a counted
 summary rather than a wall of lines — counted, never silently dropped.
+
+An interrupted run can leave a `.agentwire-migrate-<hex>` staging directory
+behind; `apply` sweeps them before starting. A staging directory only ever
+holds a *copy* — the source is untouched until after publication — so clearing
+one cannot lose history.

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -1,34 +1,65 @@
-"""Tests for agentwire/history.py — Path encoding/decoding."""
+"""Tests for agentwire/history.py — cwd -> history-directory encoding.
 
-from agentwire.history import decode_project_path, encode_project_path
+The expectations here are transcribed from measurements against real Claude
+Code, not from a reading of the docs (#871) — see
+:func:`agentwire.history.encode_project_path` for how they were taken.
+``decode_project_path`` used to live alongside it and has been deleted: the
+mapping is many-to-one, so an inverse cannot exist, and the old round-trip
+tests only passed by choosing paths that dodged the ambiguity.
+"""
+
+from agentwire.history import encode_project_path
 
 
 class TestPathEncoding:
     def test_encode(self):
         assert encode_project_path("/home/user/projects/myapp") == "-home-user-projects-myapp"
 
-    def test_decode(self):
-        assert decode_project_path("-home-user-projects-myapp") == "/home/user/projects/myapp"
-
-    def test_round_trip_no_hyphens(self):
-        """Round-trip works for paths without hyphens (encode uses /, decode uses -)."""
-        original = "/home/user/projects/myapp"
-        encoded = encode_project_path(original)
-        decoded = decode_project_path(encoded)
-        assert decoded == original
-
-    def test_round_trip_lossy_with_hyphens(self):
-        """Paths with hyphens lose information (known Claude Code limitation)."""
-        original = "/home/user/projects/my-app"
-        encoded = encode_project_path(original)
-        assert encoded == "-home-user-projects-my-app"
-        # decode converts ALL dashes to slashes — can't distinguish original hyphens
-        decoded = decode_project_path(encoded)
-        assert decoded != original  # Lossy
-
     def test_encode_root(self):
         assert encode_project_path("/") == "-"
 
     def test_encode_home(self):
-        result = encode_project_path("/home/user")
-        assert result == "-home-user"
+        assert encode_project_path("/home/user") == "-home-user"
+
+    def test_hyphens_are_preserved_as_hyphens(self):
+        assert encode_project_path("/home/user/my-app") == "-home-user-my-app"
+
+    def test_dot_becomes_a_dash(self):
+        """The bug class this repo keeps hitting (#865 -> #868 -> #870 -> #878).
+
+        Ground truth: ``/Users/dotdev/.claude`` really is stored under
+        ``-Users-dotdev--claude`` locally. The old encoder, which replaced only
+        ``/``, produced ``-Users-dotdev-.claude`` and found nothing.
+        """
+        assert encode_project_path("/Users/dotdev/.claude") == "-Users-dotdev--claude"
+        assert (
+            encode_project_path("/Users/dotdev/.agentwire/council/craps/workspace")
+            == "-Users-dotdev--agentwire-council-craps-workspace"
+        )
+
+    def test_dotted_project_directory(self):
+        assert encode_project_path("/Users/dotdev/projects/dotdev.dev") == "-Users-dotdev-projects-dotdev-dev"
+
+    def test_every_punctuation_char_maps_one_to_one(self):
+        """Measured by sweeping a real ``claude`` run; nothing is dropped."""
+        assert encode_project_path("a_b.c+d~e@f,g=h!i#j%k^l&m n o'p") == "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p"
+
+    def test_non_ascii_letters_are_not_alphanumeric(self):
+        """The class is ASCII ``[A-Za-z0-9]``, not ``str.isalnum()``.
+
+        ``str.isalnum()`` is True for é/日/Ω and would have preserved them;
+        real Claude Code replaces them.
+        """
+        assert encode_project_path("café-日本-Ωx") == "caf------x"
+
+    def test_case_and_digits_survive(self):
+        assert encode_project_path("/Users/Dev01/Repo9") == "-Users-Dev01-Repo9"
+
+    def test_encoding_is_many_to_one(self):
+        """Why there is no inverse: distinct cwds share a directory name."""
+        assert encode_project_path("/a/b") == encode_project_path("/a-b") == encode_project_path("/a.b")
+
+    def test_no_decode_function_is_exported(self):
+        import agentwire.history as history
+
+        assert not hasattr(history, "decode_project_path")

--- a/tests/unit/test_history_migrate.py
+++ b/tests/unit/test_history_migrate.py
@@ -5,6 +5,9 @@ and that missing history is a normal outcome rather than a crash, so both get
 tested directly rather than inferred from the happy path.
 """
 
+import json
+import os
+
 import pytest
 
 from agentwire import history_migrate as hm
@@ -17,6 +20,15 @@ def projects(tmp_path, monkeypatch):
     root.mkdir()
     monkeypatch.setattr(hm, "PROJECTS_DIR", root)
     return root
+
+
+@pytest.fixture
+def session_store(tmp_path, monkeypatch):
+    """A throwaway ~/.agentwire with a recorded session named "s"."""
+    monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+    (tmp_path / "sessions" / "s").mkdir(parents=True)
+    (tmp_path / "sessions" / "s" / "metadata.json").write_text("{}")
+    return tmp_path
 
 
 def seed(projects, cwd, files=(("conv.jsonl", '{"type":"user"}\n'),)):
@@ -167,6 +179,183 @@ class TestApply:
         assert hm.plan("/p/a_b", "/p/a.b")["status"] == hm.ALIGNED
 
 
+class TestPublishMechanics:
+    """Pins for the properties a passing suite must not be able to lose.
+
+    Each of these was verified to go red under the corresponding sabotage:
+    swapping the publish to ``shutil.move``, deleting the pre-publish
+    existence re-check, emptying ``_fingerprint``, and following symlinks.
+    Without them the code was correct but unheld.
+    """
+
+    def test_publish_uses_rename_not_move(self, projects, monkeypatch):
+        """``shutil.move`` onto an existing dir nests instead of failing.
+
+        Pinned at the call level because the refusal check normally prevents
+        us reaching a populated target — so a move/rename swap is invisible to
+        every behavioural test.
+        """
+        seed(projects, "/old/place")
+        monkeypatch.setattr(
+            hm.shutil, "move",
+            lambda *a, **k: pytest.fail("publish must not use shutil.move — it nests on collision"),
+        )
+        assert hm.apply("/old/place", "/new/place")["status"] == hm.MIGRATED
+
+    def test_target_is_rechecked_between_plan_and_publish(self, projects, monkeypatch):
+        """A concurrent claude run can create the target while we copy."""
+        seed(projects, "/old/place")
+        real_copytree = hm.shutil.copytree
+
+        def racing(src, dst, **kw):
+            out = real_copytree(src, dst, **kw)
+            # The target appears after plan() approved, before publication.
+            victim = projects / "-new-place"
+            victim.mkdir()
+            (victim / "other.jsonl").write_text("ARRIVED FIRST")
+            return out
+
+        monkeypatch.setattr(hm.shutil, "copytree", racing)
+        result = hm.apply("/old/place", "/new/place")
+        assert result["status"] == hm.TARGET_EXISTS
+        assert (projects / "-new-place" / "other.jsonl").read_text() == "ARRIVED FIRST"
+        assert not [p for p in projects.iterdir() if p.name.startswith(hm.STAGING_PREFIX)]
+
+    def test_fingerprint_actually_reads_content(self, projects):
+        """An empty fingerprint would make verification vacuously pass."""
+        d = seed(projects, "/place")
+        (d / "extra.jsonl").write_text("payload")
+        fp = hm._fingerprint(d)
+        assert len(fp) == 2
+        assert any(size == len("payload") for size, _ in fp.values())
+        # Content, not just size: same length, different bytes must differ.
+        (d / "extra.jsonl").write_text("PAYLOAD")
+        assert hm._fingerprint(d) != fp
+
+    def test_symlinks_are_preserved_not_followed(self, projects, tmp_path):
+        """Following them would silently inline an outside file as real data."""
+        outside = tmp_path / "outside.jsonl"
+        outside.write_text("not part of this history")
+        d = seed(projects, "/old/place")
+        (d / "link.jsonl").symlink_to(outside)
+        assert hm.apply("/old/place", "/new/place")["status"] == hm.MIGRATED
+        copied = projects / "-new-place" / "link.jsonl"
+        assert copied.is_symlink()
+        assert os.readlink(copied) == str(outside)
+
+
+class TestStagingSweep:
+    def test_sweeps_abandoned_staging_dirs(self, projects):
+        orphan = projects / f"{hm.STAGING_PREFIX}deadbeef"
+        orphan.mkdir()
+        (orphan / "copy.jsonl").write_text("{}")
+        assert hm.sweep_staging() == [orphan.name]
+        assert not orphan.exists()
+
+    def test_sweep_leaves_real_history_alone(self, projects):
+        seed(projects, "/place")
+        hm.sweep_staging()
+        assert (projects / "-place" / "conv.jsonl").exists()
+
+    def test_apply_sweeps_before_migrating(self, projects):
+        orphan = projects / f"{hm.STAGING_PREFIX}stale"
+        orphan.mkdir()
+        seed(projects, "/old/place")
+        hm.apply("/old/place", "/new/place")
+        assert not orphan.exists()
+
+
+class TestMixedProvenance:
+    def _jsonl(self, d, name, cwd):
+        (d / name).write_text(json.dumps({"type": "user", "cwd": cwd}) + "\n")
+
+    def test_uniform_source_is_not_flagged(self, projects):
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        self._jsonl(d, "a.jsonl", "/p/one")
+        self._jsonl(d, "b.jsonl", "/p/one")
+        result = hm.plan("/p/one", "/p/moved")
+        assert result["status"] == hm.READY
+        assert "mixed_provenance" not in result
+
+    def test_foreign_transcripts_are_reported(self, projects):
+        """One such directory really exists on the machine this was built on."""
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        self._jsonl(d, "a.jsonl", "/p/one")
+        self._jsonl(d, "b.jsonl", "/p/elsewhere")
+        self._jsonl(d, "c.jsonl", "/p/elsewhere")
+        result = hm.plan("/p/one", "/p/moved")
+        assert result["status"] == hm.READY
+        assert result["mixed_provenance"] == {"/p/one": 1, "/p/elsewhere": 2}
+        assert sorted(result["foreign_files"]) == ["b.jsonl", "c.jsonl"]
+        assert "/p/elsewhere (2)" in result["detail"]
+        assert "LEFT IN PLACE" in result["detail"]
+
+    def test_migration_moves_only_the_matching_transcripts(self, projects):
+        """The real shape: 7 of one project + 6 of another under one key.
+
+        Relocating all 13 would orphan the 6 — the exact property this module
+        leads with. Only the matching ones move; the rest stay put.
+        """
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        for i in range(7):
+            self._jsonl(d, f"own{i}.jsonl", "/p/one")
+        for i in range(6):
+            self._jsonl(d, f"other{i}.jsonl", "/p/elsewhere")
+
+        result = hm.apply("/p/one", "/p/moved")
+        assert result["status"] == hm.MIGRATED
+
+        moved = {p.name for p in (projects / hm.encode_project_path("/p/moved")).glob("*.jsonl")}
+        assert moved == {f"own{i}.jsonl" for i in range(7)}
+        # Every original is still where it was — nothing was orphaned.
+        assert len(list(d.glob("*.jsonl"))) == 13
+
+    def test_prune_source_refuses_when_transcripts_were_left_behind(self, projects):
+        """Otherwise --prune-source destroys exactly what we declined to move."""
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        self._jsonl(d, "own.jsonl", "/p/one")
+        self._jsonl(d, "other.jsonl", "/p/elsewhere")
+
+        result = hm.apply("/p/one", "/p/moved", prune_source=True)
+        assert result["status"] == hm.MIGRATED
+        assert result["source_retained"] is True
+        assert "NOT pruned" in result["detail"]
+        assert (d / "other.jsonl").exists()
+
+    def test_prune_source_still_works_for_a_clean_source(self, projects):
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        self._jsonl(d, "own.jsonl", "/p/one")
+        result = hm.apply("/p/one", "/p/moved", prune_source=True)
+        assert result["source_retained"] is False
+        assert not d.exists()
+
+    def test_files_without_a_readable_cwd_travel_with_the_migration(self, projects):
+        """No evidence of foreignness, and the source is retained regardless."""
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        self._jsonl(d, "own.jsonl", "/p/one")
+        (d / "nocwd.jsonl").write_text('{"type":"user"}\n')
+        (d / "memory").mkdir()
+        (d / "memory" / "MEMORY.md").write_text("# notes")
+
+        hm.apply("/p/one", "/p/moved")
+        dest = projects / hm.encode_project_path("/p/moved")
+        assert (dest / "nocwd.jsonl").exists()
+        assert (dest / "memory" / "MEMORY.md").exists()
+
+    def test_unreadable_transcripts_do_not_block(self, projects):
+        d = projects / hm.encode_project_path("/p/one")
+        d.mkdir(parents=True)
+        (d / "broken.jsonl").write_text("not json at all\n")
+        (d / "nocwd.jsonl").write_text('{"type":"user"}\n')
+        assert hm.plan("/p/one", "/p/moved")["status"] == hm.READY
+
+
 class TestResumable:
     """``resumable(id, cwd) == exists(<encoded-cwd>/<id>.jsonl)`` — one predicate."""
 
@@ -192,13 +381,23 @@ class TestResumable:
 
 
 class TestResolveSession:
-    def test_undetermined_without_recorded_cwd(self, projects, monkeypatch):
+    def test_unknown_session_says_so(self, projects, tmp_path, monkeypatch):
+        """Not "predates #881" — that misreads a typo as a legacy session."""
+        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        result = hm.resolve_session("never-existed")
+        assert result["status"] == hm.UNDETERMINED
+        assert result["detail"] == "no such session recorded"
+
+    def test_undetermined_without_recorded_cwd(self, projects, tmp_path, monkeypatch):
+        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        (tmp_path / "sessions" / "legacy").mkdir(parents=True)
+        (tmp_path / "sessions" / "legacy" / "metadata.json").write_text("{}")
         monkeypatch.setattr(hm, "load_session_metadata", lambda name: {})
-        result = hm.resolve_session("nope")
+        result = hm.resolve_session("legacy")
         assert result["status"] == hm.UNDETERMINED
         assert "#881" in result["detail"]
 
-    def test_undetermined_when_repo_is_gone(self, projects, monkeypatch):
+    def test_undetermined_when_repo_is_gone(self, projects, session_store, monkeypatch):
         monkeypatch.setattr(
             hm, "load_session_metadata",
             lambda name: {"cwd_at_launch": "/old/place", "repo": "/vanished/repo"},
@@ -207,7 +406,7 @@ class TestResolveSession:
         assert result["status"] == hm.UNDETERMINED
         assert "cannot ask git" in result["detail"]
 
-    def test_main_checkout_session_compares_against_the_repo_path(self, projects, tmp_path, monkeypatch):
+    def test_main_checkout_session_compares_against_the_repo_path(self, projects, session_store, tmp_path, monkeypatch):
         repo = tmp_path / "repo"
         repo.mkdir()
         seed(projects, "/old/place")
@@ -220,7 +419,7 @@ class TestResolveSession:
         assert result["new_cwd"] == str(repo)
         assert result["session"] == "s"
 
-    def test_worktree_session_asks_git_for_the_current_path(self, projects, tmp_path, monkeypatch):
+    def test_worktree_session_asks_git_for_the_current_path(self, projects, session_store, tmp_path, monkeypatch):
         repo = tmp_path / "repo"
         repo.mkdir()
         moved = tmp_path / "moved-worktree"
@@ -240,7 +439,7 @@ class TestResolveSession:
         assert result["status"] == hm.READY
         assert result["new_cwd"] == str(moved)
 
-    def test_undetermined_when_git_lost_the_worktree(self, projects, tmp_path, monkeypatch):
+    def test_undetermined_when_git_lost_the_worktree(self, projects, session_store, tmp_path, monkeypatch):
         repo = tmp_path / "repo"
         repo.mkdir()
         monkeypatch.setattr(

--- a/tests/unit/test_history_migrate.py
+++ b/tests/unit/test_history_migrate.py
@@ -1,0 +1,270 @@
+"""Tests for agentwire/history_migrate.py — re-keying orphaned history (#871).
+
+The two constraints that matter most here are that history is never destroyed
+and that missing history is a normal outcome rather than a crash, so both get
+tested directly rather than inferred from the happy path.
+"""
+
+import pytest
+
+from agentwire import history_migrate as hm
+
+
+@pytest.fixture
+def projects(tmp_path, monkeypatch):
+    """Point the module at a throwaway ~/.claude/projects."""
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setattr(hm, "PROJECTS_DIR", root)
+    return root
+
+
+def seed(projects, cwd, files=(("conv.jsonl", '{"type":"user"}\n'),)):
+    d = projects / hm.encode_project_path(str(cwd))
+    d.mkdir(parents=True)
+    for name, content in files:
+        (d / name).write_text(content)
+    return d
+
+
+class TestHistoryKeyCandidates:
+    def test_single_candidate_for_a_plain_path(self):
+        assert hm.history_key_candidates("/nowhere/at/all") == ["-nowhere-at-all"]
+
+    def test_symlinked_path_yields_both_forms(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        candidates = hm.history_key_candidates(link)
+        assert len(candidates) == 2
+        assert hm.encode_project_path(str(real)) in candidates
+
+
+class TestPlan:
+    def test_ready_when_source_exists_and_target_does_not(self, projects):
+        seed(projects, "/old/place")
+        result = hm.plan("/old/place", "/new/place")
+        assert result["status"] == hm.READY
+        assert result["files"] == 1
+        assert result["target"].endswith("-new-place")
+
+    def test_source_absent_is_a_normal_outcome(self, projects):
+        """A recorded id does not guarantee a resumable conversation."""
+        result = hm.plan("/gone/missing", "/new/place")
+        assert result["status"] == hm.SOURCE_ABSENT
+        assert "nothing to migrate" in result["detail"]
+
+    def test_aligned_when_nothing_moved(self, projects):
+        seed(projects, "/same/place")
+        assert hm.plan("/same/place", "/same/place")["status"] == hm.ALIGNED
+
+    def test_target_exists_refuses(self, projects):
+        seed(projects, "/old/place")
+        seed(projects, "/new/place")
+        result = hm.plan("/old/place", "/new/place")
+        assert result["status"] == hm.TARGET_EXISTS
+        assert "refusing to merge" in result["detail"]
+
+    def test_plan_writes_nothing(self, projects):
+        seed(projects, "/old/place")
+        before = sorted(p.name for p in projects.iterdir())
+        hm.plan("/old/place", "/new/place")
+        assert sorted(p.name for p in projects.iterdir()) == before
+
+
+class TestApply:
+    def test_migrates_and_verifies(self, projects):
+        src = seed(projects, "/old/place", files=(("a.jsonl", "one"), ("b.jsonl", "two")))
+        result = hm.apply("/old/place", "/new/place")
+        assert result["status"] == hm.MIGRATED
+        target = projects / "-new-place"
+        assert (target / "a.jsonl").read_text() == "one"
+        assert (target / "b.jsonl").read_text() == "two"
+        # Source is kept: the cheapest recovery from a bad migration.
+        assert result["source_retained"] is True
+        assert src.exists()
+
+    def test_copies_nested_content(self, projects):
+        d = seed(projects, "/old/place")
+        (d / "memory").mkdir()
+        (d / "memory" / "MEMORY.md").write_text("# notes")
+        hm.apply("/old/place", "/new/place")
+        assert (projects / "-new-place" / "memory" / "MEMORY.md").read_text() == "# notes"
+
+    def test_refuses_existing_target_without_touching_it(self, projects):
+        seed(projects, "/old/place", files=(("a.jsonl", "source"),))
+        seed(projects, "/new/place", files=(("a.jsonl", "PRECIOUS"),))
+        result = hm.apply("/old/place", "/new/place")
+        assert result["status"] == hm.TARGET_EXISTS
+        assert (projects / "-new-place" / "a.jsonl").read_text() == "PRECIOUS"
+        assert (projects / "-old-place" / "a.jsonl").read_text() == "source"
+
+    def test_absent_source_does_not_raise(self, projects):
+        result = hm.apply("/gone/missing", "/new/place")
+        assert result["status"] == hm.SOURCE_ABSENT
+        assert not (projects / "-new-place").exists()
+
+    def test_prune_source_removes_only_after_success(self, projects):
+        seed(projects, "/old/place")
+        result = hm.apply("/old/place", "/new/place", prune_source=True)
+        assert result["status"] == hm.MIGRATED
+        assert result["source_retained"] is False
+        assert not (projects / "-old-place").exists()
+        assert (projects / "-new-place" / "conv.jsonl").exists()
+
+    def test_prune_source_keeps_source_when_refused(self, projects):
+        seed(projects, "/old/place")
+        seed(projects, "/new/place")
+        hm.apply("/old/place", "/new/place", prune_source=True)
+        assert (projects / "-old-place").exists()
+
+    def test_failed_verification_leaves_both_sides_alone(self, projects, monkeypatch):
+        seed(projects, "/old/place")
+        calls = {"n": 0}
+        real = hm._fingerprint
+
+        def drifting(root):
+            calls["n"] += 1
+            out = real(root)
+            return {**out, "phantom.jsonl": (1, "deadbeef")} if calls["n"] == 1 else out
+
+        monkeypatch.setattr(hm, "_fingerprint", drifting)
+        result = hm.apply("/old/place", "/new/place")
+        assert result["status"] == hm.ERROR
+        assert "nothing was changed" in result["detail"]
+        assert not (projects / "-new-place").exists()
+        assert (projects / "-old-place" / "conv.jsonl").exists()
+
+    def test_no_staging_directory_is_left_behind(self, projects):
+        seed(projects, "/old/place")
+        hm.apply("/old/place", "/new/place")
+        assert not [p for p in projects.iterdir() if p.name.startswith(".agentwire-migrate-")]
+
+    def test_never_nests_the_source_inside_an_existing_target(self, projects):
+        """The #868 failure shape: reporting success while doing nothing useful.
+
+        ``shutil.move(src, dst)`` with an existing *dst* does not fail — POSIX
+        semantics put src INSIDE dst as ``dst/<basename(src)>``, burying the
+        transcripts one level deeper than Claude Code ever looks. We refuse
+        instead, so the target keeps exactly the entries it started with.
+        """
+        seed(projects, "/old/place")
+        dest = seed(projects, "/new/place")
+        hm.apply("/old/place", "/new/place")
+        assert [p.name for p in dest.iterdir()] == ["conv.jsonl"]
+        assert not any(p.is_dir() for p in dest.iterdir())
+
+    def test_colliding_cwds_share_a_directory_and_need_no_migration(self, projects):
+        """``/p/a_b`` and ``/p/a.b`` are distinct cwds encoding to one name.
+
+        The encoding is non-injective, so this is a real state, not a bug we
+        can fix — the two projects genuinely share a history directory. The
+        honest answer is that there is nothing to move.
+        """
+        assert hm.encode_project_path("/p/a_b") == hm.encode_project_path("/p/a.b")
+        seed(projects, "/p/a_b")
+        assert hm.plan("/p/a_b", "/p/a.b")["status"] == hm.ALIGNED
+
+
+class TestResumable:
+    """``resumable(id, cwd) == exists(<encoded-cwd>/<id>.jsonl)`` — one predicate."""
+
+    def test_true_when_the_transcript_is_there(self, projects):
+        d = seed(projects, "/place")
+        (d / "abc-123.jsonl").write_text("{}")
+        assert hm.resumable("abc-123", "/place") is True
+
+    def test_false_for_a_launched_but_never_prompted_session(self, projects):
+        """A valid recorded id with no transcript: the .jsonl is written lazily."""
+        assert hm.resumable("abc-123", "/never/prompted") is False
+
+    def test_false_when_the_directory_exists_but_the_id_does_not(self, projects):
+        seed(projects, "/place")
+        assert hm.resumable("not-here", "/place") is False
+
+    def test_follows_the_history_after_a_migration(self, projects):
+        d = seed(projects, "/old/place")
+        (d / "abc-123.jsonl").write_text("{}")
+        assert hm.resumable("abc-123", "/new/place") is False
+        hm.apply("/old/place", "/new/place")
+        assert hm.resumable("abc-123", "/new/place") is True
+
+
+class TestResolveSession:
+    def test_undetermined_without_recorded_cwd(self, projects, monkeypatch):
+        monkeypatch.setattr(hm, "load_session_metadata", lambda name: {})
+        result = hm.resolve_session("nope")
+        assert result["status"] == hm.UNDETERMINED
+        assert "#881" in result["detail"]
+
+    def test_undetermined_when_repo_is_gone(self, projects, monkeypatch):
+        monkeypatch.setattr(
+            hm, "load_session_metadata",
+            lambda name: {"cwd_at_launch": "/old/place", "repo": "/vanished/repo"},
+        )
+        result = hm.resolve_session("s")
+        assert result["status"] == hm.UNDETERMINED
+        assert "cannot ask git" in result["detail"]
+
+    def test_main_checkout_session_compares_against_the_repo_path(self, projects, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        seed(projects, "/old/place")
+        monkeypatch.setattr(
+            hm, "load_session_metadata",
+            lambda name: {"cwd_at_launch": "/old/place", "repo": str(repo), "worktree_path": None},
+        )
+        result = hm.resolve_session("s")
+        assert result["status"] == hm.READY
+        assert result["new_cwd"] == str(repo)
+        assert result["session"] == "s"
+
+    def test_worktree_session_asks_git_for_the_current_path(self, projects, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        moved = tmp_path / "moved-worktree"
+        seed(projects, "/old/place")
+        monkeypatch.setattr(
+            hm, "load_session_metadata",
+            lambda name: {
+                "cwd_at_launch": "/old/place", "repo": str(repo),
+                "worktree_path": "/old/place", "branch": "feat",
+            },
+        )
+        monkeypatch.setattr(
+            "agentwire.worktree.find_git_worktree",
+            lambda project_path, **kw: {"path": moved, "branch": "feat"},
+        )
+        result = hm.resolve_session("s")
+        assert result["status"] == hm.READY
+        assert result["new_cwd"] == str(moved)
+
+    def test_undetermined_when_git_lost_the_worktree(self, projects, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        monkeypatch.setattr(
+            hm, "load_session_metadata",
+            lambda name: {
+                "cwd_at_launch": "/old/place", "repo": str(repo),
+                "worktree_path": "/old/place", "branch": "feat",
+            },
+        )
+        monkeypatch.setattr("agentwire.worktree.find_git_worktree", lambda project_path, **kw: None)
+        assert hm.resolve_session("s")["status"] == hm.UNDETERMINED
+
+
+class TestScan:
+    def test_scan_covers_every_recorded_session(self, projects, tmp_path, monkeypatch):
+        sessions = tmp_path / "sessions"
+        for name in ("alpha", "beta"):
+            (sessions / name).mkdir(parents=True)
+            (sessions / name / "metadata.json").write_text("{}")
+        (sessions / "no-metadata").mkdir()
+        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        assert hm.known_sessions() == ["alpha", "beta"]
+        assert [r["session"] for r in hm.scan()] == ["alpha", "beta"]
+
+    def test_no_sessions_dir_is_not_an_error(self, projects, tmp_path, monkeypatch):
+        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path / "absent")
+        assert hm.scan() == []

--- a/tests/unit/test_history_migrate_cli.py
+++ b/tests/unit/test_history_migrate_cli.py
@@ -1,0 +1,117 @@
+"""Tests for ``agentwire history migrate`` argument handling and reporting."""
+
+import json
+
+import pytest
+
+from agentwire import history_cli, history_migrate as hm
+
+
+class Args:
+    def __init__(self, **kw):
+        self.session = kw.get("session")
+        self.from_path = kw.get("from_path")
+        self.to_path = kw.get("to_path")
+        self.all = kw.get("all", False)
+        self.apply = kw.get("apply", False)
+        self.prune_source = kw.get("prune_source", False)
+        self.json = kw.get("json", False)
+
+
+@pytest.fixture
+def projects(tmp_path, monkeypatch):
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setattr(hm, "PROJECTS_DIR", root)
+    return root
+
+
+def seed(projects, cwd):
+    d = projects / hm.encode_project_path(str(cwd))
+    d.mkdir(parents=True)
+    (d / "conv.jsonl").write_text('{"type":"user"}\n')
+    return d
+
+
+class TestSelectorValidation:
+    @pytest.mark.parametrize("kw", [
+        {},                                              # nothing chosen
+        {"from_path": "/a"},                             # --from without --to
+        {"to_path": "/b"},                               # --to without --from
+        {"all": True, "session": "s"},                   # two selectors
+        {"all": True, "from_path": "/a", "to_path": "/b"},
+    ])
+    def test_rejected(self, kw, projects):
+        assert history_cli.cmd_history_migrate(Args(**kw)) == 1
+
+
+class TestExitCodes:
+    def test_dry_run_with_a_migratable_session_succeeds(self, projects, capsys):
+        seed(projects, "/old/place")
+        rc = history_cli.cmd_history_migrate(Args(from_path="/old/place", to_path="/new/place"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "MIGRATABLE" in out
+        assert "--apply" in out
+        # A dry run must not have created anything.
+        assert not (projects / "-new-place").exists()
+
+    def test_refusal_exits_nonzero(self, projects):
+        seed(projects, "/old/place")
+        seed(projects, "/new/place")
+        rc = history_cli.cmd_history_migrate(
+            Args(from_path="/old/place", to_path="/new/place", apply=True)
+        )
+        assert rc == 1
+
+    def test_absent_source_exits_zero(self, projects, capsys):
+        rc = history_cli.cmd_history_migrate(
+            Args(from_path="/gone", to_path="/new/place", apply=True)
+        )
+        assert rc == 0
+        assert "nothing to migrate" in capsys.readouterr().out
+
+    def test_apply_performs_the_migration(self, projects, capsys):
+        seed(projects, "/old/place")
+        rc = history_cli.cmd_history_migrate(
+            Args(from_path="/old/place", to_path="/new/place", apply=True)
+        )
+        assert rc == 0
+        assert "MIGRATED" in capsys.readouterr().out
+        assert (projects / "-new-place" / "conv.jsonl").exists()
+
+
+class TestSweepReporting:
+    def _store(self, tmp_path, monkeypatch, statuses):
+        monkeypatch.setattr(hm, "known_sessions", lambda: [f"s{i}" for i in range(len(statuses))])
+        monkeypatch.setattr(
+            hm, "resolve_session",
+            lambda name: {"session": name, "status": statuses[int(name[1:])],
+                          "detail": f"detail for {statuses[int(name[1:])]}"},
+        )
+
+    def test_quiet_statuses_are_counted_not_listed(self, projects, tmp_path, monkeypatch, capsys):
+        self._store(tmp_path, monkeypatch, [hm.UNDETERMINED] * 5 + [hm.ALIGNED] * 3)
+        rc = history_cli.cmd_history_migrate(Args(all=True))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "No orphaned history found." in out
+        assert "8 session(s) not shown" in out
+        # Counted, never silently dropped.
+        assert "5" in out and "3" in out
+        assert "s0" not in out
+
+    def test_notable_entries_are_listed_in_full(self, projects, tmp_path, monkeypatch, capsys):
+        self._store(tmp_path, monkeypatch, [hm.UNDETERMINED] * 4 + [hm.TARGET_EXISTS])
+        rc = history_cli.cmd_history_migrate(Args(all=True))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "REFUSED" in out and "s4" in out
+        assert "4 session(s) not shown" in out
+
+    def test_json_keeps_every_result(self, projects, tmp_path, monkeypatch, capsys):
+        self._store(tmp_path, monkeypatch, [hm.UNDETERMINED] * 5 + [hm.ALIGNED])
+        history_cli.cmd_history_migrate(Args(all=True, json=True))
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["applied"] is False
+        assert len(payload["results"]) == 6

--- a/tests/unit/test_history_migrate_cli.py
+++ b/tests/unit/test_history_migrate_cli.py
@@ -4,7 +4,8 @@ import json
 
 import pytest
 
-from agentwire import history_cli, history_migrate as hm
+from agentwire import history_cli
+from agentwire import history_migrate as hm
 
 
 class Args:
@@ -34,15 +35,30 @@ def seed(projects, cwd):
 
 
 class TestSelectorValidation:
-    @pytest.mark.parametrize("kw", [
-        {},                                              # nothing chosen
-        {"from_path": "/a"},                             # --from without --to
-        {"to_path": "/b"},                               # --to without --from
-        {"all": True, "session": "s"},                   # two selectors
-        {"all": True, "from_path": "/a", "to_path": "/b"},
+    @pytest.mark.parametrize("kw,expected", [
+        ({}, "exactly one of"),                                 # nothing chosen
+        ({"from_path": "/a"}, "must be given together"),         # --from without --to
+        ({"to_path": "/b"}, "must be given together"),           # --to without --from
+        ({"all": True, "session": "s"}, "exactly one of"),       # two selectors
+        ({"all": True, "from_path": "/a", "to_path": "/b"}, "exactly one of"),
     ])
-    def test_rejected(self, kw, projects):
+    def test_rejected_with_a_usable_message(self, kw, expected, projects, capsys):
+        """Assert on the OUTPUT, not just the exit code.
+
+        Checking only ``== 1`` is what let a wrong ``_output_result`` signature
+        through: the message was silently swallowed into the JSON branch and
+        never displayed, and every one of these still exited 1.
+        """
         assert history_cli.cmd_history_migrate(Args(**kw)) == 1
+        captured = capsys.readouterr()
+        assert expected in (captured.out + captured.err)
+
+    def test_rejection_in_json_mode_carries_the_error(self, projects, capsys):
+        assert history_cli.cmd_history_migrate(Args(json=True)) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["success"] is False
+        assert "exactly one of" in payload["error"]
+        assert "json_output" not in payload  # a kwarg leaking into the payload
 
 
 class TestExitCodes:


### PR DESCRIPTION
Epic #871, item 4. Also closes #892, which is the foundation this stands on.

## The call I made: `history migrate`, not `worktree --move`

The issue text asks to "teach `worktree --move` to migrate `~/.claude/projects/<encoded-cwd>/` alongside the worktree." **That flag does not exist** — `agentwire worktree --help` has no `--move`. So the first question was whether it should.

I went with a narrower `agentwire history migrate`. The reasoning:

- **A move verb only repairs moves made through agentwire, and that is the minority of them.** `git worktree move`, a plain `mv`, and a reorganised `~/worktrees` all orphan history in exactly the same way. A fix reachable only through our own verb misses every one of those.
- **Moving is not what causes the damage.** The damage is the recorded cwd and the real cwd disagreeing. #881 made that *detectable* by recording `cwd_at_launch`; the repair is a reconciliation keyed on the disagreement, which works no matter who moved the directory or how.
- **It composes.** The same `history_migrate.scan()` that powers the dry run is what the doctor orphan check on `epic-871-restart-verb` can consume directly, instead of growing a second implementation of the same question.
- **A move verb would also have to reimplement `git worktree move` plus registry updates**, and a tmux session whose cwd was moved out from under it is broken regardless.

The honest cost: `--move` would be atomic, where this is two steps (move, then migrate). I think that is the right trade — the alternative buys atomicity for one path while leaving three others silently broken.

## Foundation: the encoder was wrong (#892)

`encode_project_path` was `path.replace("/", "-")` — slashes only. Any path containing a dot, underscore or space resolved to a directory that does not exist, so the lookup found nothing and reported nothing. `~/.claude` and `~/.agentwire/council/<n>/workspace` both hit it, as does any repo dir like `dotdev.dev`.

**The real rule is per character: everything outside `[A-Za-z0-9]` becomes `-`.** Nothing dropped, run-collapsed, or case-folded.

Derived empirically — not from docs — the same way #878 had to measure tmux instead of guessing, and confirmed **independently by two sessions that agreed**:

- Every `*.jsonl` records the `cwd` it was written from, giving ground truth straight off disk. 528 pairs (mine) and 533 (reviewer's), zero mismatches.
- Remaining characters swept through live `claude` runs: `a_b.c+d~e@f,g=h!i#j%k^l&m n o'p` → `a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p`.
- Non-ASCII swept too: `café-日本-Ωx` → `caf------x`. This pins the class as ASCII `[A-Za-z0-9]` and **not** `str.isalnum()`, which is True for `é`/`日`/`Ω` and would have preserved them.

Same bug class as #865 → #868 → #870 → #878, so I fixed **the one encoder** rather than adding a second correct one beside it.

`decode_project_path` is **deleted, not fixed** — the mapping is many-to-one (`/`, `.`, `_`, `-` all → `-`), so no inverse exists. Its round-trip test passed only by choosing paths that dodged the ambiguity, pinning the bug as intended behaviour. Callers take the real cwd from `cwd_at_launch` instead.

## How "destination exists" is detected, and why it refuses

Because the encoding is non-injective, `/p/a_b` and `/p/a.b` are distinct directories that **share one history directory**. A migration destination can therefore already hold an *unrelated* project's transcripts — merging would silently interleave two projects' history. So it refuses and reports, and a human decides.

Detection is `target.exists()` at plan time **and again immediately before the rename**, closing the window where a concurrent `claude` run creates the target mid-copy.

`shutil.move` is avoided deliberately. Onto an existing directory it does **not** fail — POSIX nests the source inside as `dst/<basename>`, burying transcripts one level below where Claude Code looks while the command reports success. That is the #868 failure shape exactly. Publishing goes through `os.rename` behind an explicit existence check, and there is a test pinning that the destination gains no nested directory.

## The two hard constraints

**1. History is never destroyed.** Copy into a staging dir → fingerprint the copy against the source (size + sha256 per entry, symlinks recorded by target, not followed) → publish with one rename. The source is **retained** by default; `--prune-source` removes it only after verification passed. An interrupted run leaves the source untouched and the target absent.

**2. Missing source history is a normal outcome, not a crash.** `source_absent` is a reported status with exit 0. A recorded id does not promise a resumable conversation — transcripts have been observed vanishing, and a launched-but-never-prompted session never had one (the `.jsonl` is written lazily on the first turn).

On that last point I adopted the reviewer's predicate rather than inventing a second notion of resumability:

```
resumable(id, cwd) == exists(<encoded-cwd>/<id>.jsonl)
```

One file governs both directions — it is also what `--session-id` keys its collision check on.

## Usage

```bash
agentwire history migrate --all                 # dry run: what's orphaned
agentwire history migrate -s <session>          # reconcile one session
agentwire history migrate --from OLD --to NEW   # a move agentwire never saw
agentwire history migrate ... --apply           # perform it
```

Dry run by default. A sweep reports unjudgeable sessions as a **counted summary** rather than a wall of lines — locally that is every one of 460, since anything launched before #881 has no `cwd_at_launch`. Counted, never silently dropped:

```
No orphaned history found.

467 session(s) not shown:
     451  no cwd_at_launch recorded (session predates #881)
       9  no live repo recorded — cannot ask git where this session now lives
       7  history is already keyed to the current directory
```

## Verification

**End-to-end against real Claude Code** — the part no fixture can prove. Created a conversation with a codeword, moved its directory, confirmed `--resume` failed with the exact reported error, migrated, and the resumed conversation returned `BANANA-7742`.

**Against the reviewer's six-case fixture** (plain, dotted, underscored, colliding pair, populated destination, never-created) — all six behaved as specified, **0 entries lost, 0 changed**, populated destination kept its 3 files with no nested dir.

**Full suite: 3353 passed, 0 failed.** 51 of those are new. Automated tests use `tmp_path` fixtures only and never touch the real store.

## Notes for the reviewer / other session

- `history_migrate.scan()` is exported deliberately for the doctor orphan check on `epic-871-restart-verb`. I did not touch `doctor` or `restart` — that is your scope. If the shape of `scan()` does not suit the check, say so and I will adjust it here.
- Our two encoder derivations are the **same function**: `[^a-zA-Z0-9-]` (keeps `-`) and `[^A-Za-z0-9]` (maps `-`→`-`) produce identical output for every input. I kept the simpler form.
- One real-data curiosity: `-Users-dotdev-projects-strategicdice` contains transcripts whose recorded `cwd` is `/Users/dotdev/projects/craps`. That is this exact orphaning in the wild, not a counter-example to the encoding.

Refs #871
Closes #892

Built by [dotdev.dev](https://dotdev.dev)