### PR TITLE
fix(ci): mark the tmux name sweep requires_tmux — main has been red since #883

### DIFF
--- a/tests/integration/test_tmux_name_rewrite.py
+++ b/tests/integration/test_tmux_name_rewrite.py
@@ -27,9 +27,17 @@ import pytest
 
 from agentwire.worktree import tmux_safe_name
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("tmux") is None, reason="tmux not available"
-)
+# Two guards, and both are needed. ``skipif`` covers a machine with no tmux at
+# all; ``requires_tmux`` is what the hermetic CI job deselects on
+# (``-m "not requires_tmux"``). The binary being on PATH is NOT sufficient —
+# these tests measure what a real tmux SERVER does to a session name, and a CI
+# runner's tmux answers differently enough that the sweep reads back its own
+# probe string unchanged and every assertion fails. Marker only, so local runs
+# with a working tmux still exercise the real thing.
+pytestmark = [
+    pytest.mark.requires_tmux,
+    pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not available"),
+]
 
 # Printable ASCII — the realistic input space for a session name. Control
 # characters are excluded: tmux vis-escapes rather than substitutes them, which


### PR DESCRIPTION
## Main is red in CI

`pytest (hermetic)` has been failing on `main` since #883 merged. `ruff` and `security` are green, so it was easy to miss.

```
FAILED tests/integration/test_tmux_name_rewrite.py::TestRewriteSetIsComplete::test_sweep_of_printable_ascii_matches_our_mapping
FAILED tests/integration/test_tmux_name_rewrite.py::TestRewriteSetIsComplete::test_measured_substitution_set_is_exactly_dot_and_colon
FAILED tests/integration/test_tmux_name_rewrite.py::TestRewriteSetIsComplete::test_backslash_has_no_fixed_point

E  AssertionError: assert set() == {'.', ':'}
E  AssertionError: tmux_safe_name diverges from real tmux for: '$': tmux='a\\$b' ours='a$b'
```

## Why

That sweep measures what a real tmux **server** does to a session name — it's the test that made #878's "the substitution set is exactly `{'.', ':'}`" a measured claim instead of a guess, which was the whole point of it.

It guarded on `shutil.which("tmux") is None`. A CI runner *has* the binary, so the guard passes and the tests run — but the runner's tmux answers differently enough that the probe reads back unchanged (`a\\$b` for every input). The measured substitution set comes out empty, and every assertion fails.

Binary-on-PATH was never the right predicate. The hermetic job already deselects `-m "not requires_tmux"`; this file simply never carried the marker.

## Fix

Add `pytest.mark.requires_tmux` alongside the existing `skipif`. Both are needed and they cover different things — `skipif` for a machine with no tmux at all, the marker for the hermetic CI job. Local runs with a working tmux still exercise the real thing, which is the only place this test is meaningful.

## Verification

- `-m "not requires_tmux"` (what CI runs): **14 deselected**
- unmarked, locally against real tmux: **14 passed**

Found while reviewing PR #894 — its reviewer noticed the branch's red CI and correctly attributed it to `main` rather than blaming the PR.

Built by [dotdev.dev](https://dotdev.dev)