### PR TITLE
fix(tmux): ship base-index 0, and warn against hardcoding either way

### DIFF
--- a/agentwire/templates/tmux.conf
+++ b/agentwire/templates/tmux.conf
@@ -16,9 +16,18 @@ set -g focus-events on
 # Large scrollback buffer — agent sessions produce a lot of output
 set -g history-limit 50000
 
-# Windows start at 1 (keyboard convenience), panes stay at 0
-# Pane 0 = orchestrator convention is used by agentwire hooks
-set -g base-index 1
+# Windows and panes both start at 0.
+# Pane 0 = orchestrator convention is used by agentwire hooks, and keeping the
+# window axis on the same base means a session's agent is at `<session>:0.0`
+# under this config — one less place for an off-by-one to hide.
+#
+# NOTE for agentwire code: this is a DEFAULT, never a guarantee. A user may set
+# their own base-index, and windows created before a change keep their old
+# index regardless. Resolve a session's real pane (e.g. the first row of
+# `tmux list-panes -t <session> -F '#{window_index}.#{pane_index}'`) instead of
+# hardcoding an index — see #901, where a hardcoded `:0.0` failed against a
+# base-index-1 machine.
+set -g base-index 0
 setw -g pane-base-index 0
 
 # Renumber windows when one is closed (no gaps)


### PR DESCRIPTION
## What

`agentwire/templates/tmux.conf` shipped `set -g base-index 1` while panes stayed at 0, so a session's agent lived at `<session>:1.0` — two axes on different bases. Owner wants both on 0.

Also updated the live `~/.tmux.conf` on this machine (backup at `~/.tmux.conf.pre-base-index-0`) and reloaded.

## Why the comment matters more than the value

This came out of the #901 incident. While diagnosing, I prescribed "target pane 0" as the fix for #898's `tmux_session_cwd` bug — which was wrong, because this machine was on `base-index 1` and `capture-pane -t '<session>:0.0'` fails with `can't find window: 0`.

Then the review session measured something worse, which I reproduced on an isolated socket:

**`tmux display-message` does not error on an unresolvable target — it silently returns the ACTIVE pane.**

```
layout: win0=/private/tmp, win1=/usr, win1 active

display-message -t '=s'      →  rc=0, ''            (the #898 bug)
display-message -t '=s:0.0'  →  rc=0, /private/tmp  (correct here)
display-message -t '=s:9.9'  →  rc=0, /usr          ← BOGUS TARGET, silent wrong answer
```

A completely invalid target yields a plausible path with `rc=0`. Note this is **per-subcommand**: `capture-pane` *does* fail loudly on the same bad target. Don't generalise from either.

## The correct resolution, with one trap

```bash
tmux list-panes -s -t "=<session>" -F '#{window_index}.#{pane_index}' | head -1
```

**`-s` is load-bearing.** Without it, `list-panes` scopes to the session's *active window*, so the first line is the wrong pane whenever the agent isn't in it:

```
list-panes    -t '=s'  →  1.0 /usr                       ← active window only
list-panes -s -t '=s'  →  0.0 /private/tmp | 1.0 /usr    ← whole session, index order
```

With `-s` it emits in index order (line 1 is correct under any base-index), needs no knowledge of either option, and **fails loudly** (`rc=1`, `can't find window: nosuch`) on a bad target.

## Note for reviewers

This changes nothing for **existing** windows — they keep their index. Any machine that had the old template now has both conventions live simultaneously. That is exactly why the code must stay index-agnostic rather than switching its hardcoded assumption from 1 to 0, and the template now says so in a comment.

Built by [dotdev.dev](https://dotdev.dev)