### PR TITLE
fix(tests): stop the suite writing into the real ~/.agentwire; make session_metadata_path a real SSOT (#893, #899)

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1024,8 +1024,25 @@ def session_metadata_path(session_name: str) -> Path:
 
     The ``@machine`` suffix is stripped HERE and nowhere else — the store is
     keyed by bare session name, so ``web@remote`` and ``web`` are one record.
+
+    The result is CONTAINED to the store. A session name is operator-supplied
+    and reaches this from the CLI, and the path it returns is unlinked by
+    ``agentwire kill`` — so ``../../../evil`` would have addressed, and
+    deleted, a file outside the store entirely. That was equally true of the
+    inlined copy this replaced, but consolidating is the moment the check
+    becomes possible to write once instead of four times.
     """
-    return sessions_dir() / session_name.split("@")[0] / "metadata.json"
+    clean = session_name.split("@")[0]
+    root = sessions_dir()
+    candidate = root / clean / "metadata.json"
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved.relative_to(root.resolve(strict=False))
+    except (ValueError, OSError):
+        raise ValueError(
+            f"session name escapes the session store: {session_name!r}"
+        ) from None
+    return candidate
 
 
 def load_session_metadata(session_name: str) -> dict:

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1000,6 +1000,34 @@ def _output_result(success: bool, json_mode: bool, message: str = "", exit_code:
     return 0 if success else 1
 
 
+def sessions_dir() -> Path:
+    """The session-record store. The ROOT half of the path SSOT (#899).
+
+    Consolidating only the leaf left this built by hand wherever something
+    *enumerates* records rather than addressing one — which is how a "single
+    source of truth" ends up with two spellings of where it lives.
+    """
+    return CONFIG_DIR / "sessions"
+
+
+def session_metadata_path(session_name: str) -> Path:
+    """Where a session's record lives. One implementation, every direction.
+
+    Read, written, enumerated and unlinked through here — reads by
+    :func:`load_session_metadata`, writes by :func:`store_session_metadata`,
+    and the unlink by ``agentwire kill``. The docstring used to claim "both
+    directions" while the reader and the unlink each rebuilt the path inline
+    (#899), which is the same shape as ``tmux_safe_name`` (#865 → #868 → #870
+    → #878) and ``encode_project_path`` (#892): the helper existed, and callers
+    simply did not route through it. In every prior round the divergence stayed
+    invisible until production behaved wrongly.
+
+    The ``@machine`` suffix is stripped HERE and nowhere else — the store is
+    keyed by bare session name, so ``web@remote`` and ``web`` are one record.
+    """
+    return sessions_dir() / session_name.split("@")[0] / "metadata.json"
+
+
 def load_session_metadata(session_name: str) -> dict:
     """Load session metadata from storage.
 
@@ -1009,10 +1037,7 @@ def load_session_metadata(session_name: str) -> dict:
     Returns:
         Dictionary of metadata (empty dict if not found)
     """
-    # Parse session name to extract just the name part (remove @machine)
-    clean_name = session_name.split("@")[0]
-
-    metadata_file = CONFIG_DIR / "sessions" / clean_name / "metadata.json"
+    metadata_file = session_metadata_path(session_name)
 
     if not metadata_file.exists():
         return {}
@@ -1022,11 +1047,6 @@ def load_session_metadata(session_name: str) -> dict:
             return json.load(f) or {}
     except (json.JSONDecodeError, IOError):
         return {}
-
-
-def session_metadata_path(session_name: str) -> Path:
-    """Where a session's record lives. One implementation, both directions."""
-    return CONFIG_DIR / "sessions" / session_name.split("@")[0] / "metadata.json"
 
 
 def recorded_sessions() -> list[str]:
@@ -1045,11 +1065,11 @@ def recorded_sessions() -> list[str]:
     records on this machine — a sweep built on it would silently skip 58% of
     the fleet while reporting itself clean.
     """
-    sessions_dir = CONFIG_DIR / "sessions"
+    root = sessions_dir()
     try:
         return sorted(
-            str(f.parent.relative_to(sessions_dir))
-            for f in sessions_dir.glob("**/metadata.json")
+            str(f.parent.relative_to(root))
+            for f in root.glob("**/metadata.json")
         )
     except OSError:
         return []

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -818,7 +818,7 @@ def _render_role_prompt_store_section(
     from . import core, role_prompts
 
     store = core.role_prompts_dir()
-    sessions_dir = core.CONFIG_DIR / "sessions"
+    sessions_dir = core.sessions_dir()
     s = role_prompts.status(store, sessions_dir)
 
     if not s["exists"]:

--- a/agentwire/history_migrate.py
+++ b/agentwire/history_migrate.py
@@ -41,7 +41,7 @@ import shutil
 import uuid
 from pathlib import Path
 
-from .core import CONFIG_DIR, load_session_metadata
+from .core import load_session_metadata, recorded_sessions, session_metadata_path
 from .history import (
     PROJECTS_DIR,
     history_key_candidates,
@@ -374,7 +374,7 @@ def resolve_session(session_name: str) -> dict:
     # load_session_metadata returns {} both for "no such session" and for "a
     # session with an empty record", so distinguish them here rather than
     # telling someone who mistyped a name that their session predates #881.
-    if not (CONFIG_DIR / "sessions" / session_name.split("@")[0] / "metadata.json").is_file():
+    if not session_metadata_path(session_name).is_file():
         return {**base, "status": UNDETERMINED, "detail": "no such session recorded"}
 
     old = metadata.get("cwd_at_launch")
@@ -437,11 +437,18 @@ def _find_worktree_cached(finder, repo: str, branch: str | None, name: str) -> d
 
 
 def known_sessions() -> list[str]:
-    """Session names that have a metadata record, in stable order."""
-    root = CONFIG_DIR / "sessions"
-    if not root.is_dir():
-        return []
-    return sorted(d.name for d in root.iterdir() if (d / "metadata.json").is_file())
+    """Session names that have a metadata record, in stable order.
+
+    Delegates to :func:`core.recorded_sessions` rather than scanning here.
+    This used to do a FLAT scan of the store, which is wrong for the reason
+    #898 measured: session names contain slashes by design (``project/branch``
+    is what every ``agentwire worktree`` and every scheduler dispatch is
+    called), so those records nest one level deeper. A flat scan found 469 of
+    1106 records on that machine — this sweep would have silently skipped 58%
+    of the fleet while reporting itself clean, which is the exact failure mode
+    :func:`scan` exists to catch in someone else's data.
+    """
+    return recorded_sessions()
 
 
 def scan() -> list[dict]:

--- a/agentwire/pane_cli.py
+++ b/agentwire/pane_cli.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 from . import pane_manager
 from .core import (
-    CONFIG_DIR,
     _add_posture_flag,
     _check_tmux_installed,
     _display_parent,
@@ -39,6 +38,7 @@ from .core import (
     load_config,
     load_session_metadata,
     parse_env_args,
+    session_metadata_path,
     tmux_session_exists,
 )
 from .project_config import load_project_config
@@ -579,6 +579,28 @@ def _wants_graceful_exit(posture: str | None, pane_command: str | None) -> bool:
     return True
 
 
+def _drop_session_metadata(session: str) -> None:
+    """Remove a killed session's record, addressed through the path SSOT (#899).
+
+    Dropping it is deliberate: the record carries ``created_by``, so leaving it
+    behind would let an unrelated future session that reuses the name inherit a
+    stale parent. Consistent with the store's lifetime — when the session is
+    gone, so is the tmux environment holding its launch line, and nothing can
+    re-read it.
+
+    Routed through :func:`session_metadata_path` rather than reassembling the
+    store layout inline, so an unlink can never address a different file than
+    the write did.
+    """
+    path = session_metadata_path(session)
+    if not path.exists():
+        return
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
 def cmd_kill(args) -> int:
     """Kill a tmux session or pane (graceful /exit first, then kill).
 
@@ -757,14 +779,7 @@ def kill_local_session(session: str, force: bool = False, timeout: int = 10,
     if verbose:
         print(f"Killed session '{session}'")
 
-    # Drop session metadata (creator record) so a future unrelated session
-    # reusing this name doesn't inherit a stale parent.
-    metadata_file = CONFIG_DIR / "sessions" / session.split("@")[0] / "metadata.json"
-    if metadata_file.exists():
-        try:
-            metadata_file.unlink()
-        except OSError:
-            pass
+    _drop_session_metadata(session)
 
     # GC this sender's still-pending outbound across every recipient inbox (#621)
     # so report-backs it left undelivered don't accumulate. Load-bearing kinds

--- a/agentwire/role_prompts.py
+++ b/agentwire/role_prompts.py
@@ -274,7 +274,7 @@ def tick() -> dict:
     from . import core
 
     store = core.role_prompts_dir()
-    sessions_dir = core.CONFIG_DIR / "sessions"
+    sessions_dir = core.sessions_dir()
     stamp = core.CONFIG_DIR / "role-prompt-sweep.json"
     now = time.time()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,10 @@ markers = [
     # Deselected in the hermetic CI gate via `-m 'not requires_tmux'` (#323);
     # still runs locally where tmux is on PATH.
     "requires_tmux: spawns a real tmux process; deselected in hermetic CI (#323)",
+    # Opts a test out of the ~/.agentwire redirect so it can assert on the REAL
+    # deployment paths (#893). READ-ONLY by intent — the session-scoped backstop
+    # still fails the run if an opted-out test writes anything.
+    "real_agentwire_home: sees the real ~/.agentwire paths instead of the tmp redirect (#893)",
 ]
 asyncio_mode = "auto"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,15 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests import home_guard
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 #: The owner's real config directory. Nothing in the suite may write here.
-REAL_AGENTWIRE_HOME = Path.home() / ".agentwire"
+#: Re-exported from the single owner so both halves agree on what "real" is.
+REAL_AGENTWIRE_HOME = home_guard.REAL_AGENTWIRE_HOME
+
+home_guard.install()
 
 
 def _agentwire_modules():
@@ -47,11 +52,18 @@ def _import_every_agentwire_module():
 
     import agentwire
 
-    for info in pkgutil.walk_packages(agentwire.__path__, prefix="agentwire."):
-        try:
-            importlib.import_module(info.name)
-        except Exception:
-            continue
+    # Importing the package touches the real config dir: `agentwire_dir()`
+    # both resolves AND mkdirs, and some modules call it at import. That is the
+    # package's own import-time behaviour, not a test polluting the store, and
+    # attributing it to whichever test happened to be first would be a lie. It
+    # is sanctioned rather than silenced, so it still shows up in
+    # SANCTIONED_WRITES if anyone wants to look.
+    with home_guard.sanctioned_real_home_write():
+        for info in pkgutil.walk_packages(agentwire.__path__, prefix="agentwire."):
+            try:
+                importlib.import_module(info.name)
+            except Exception:
+                continue
 
 
 _import_every_agentwire_module()
@@ -127,94 +139,18 @@ def _isolate_agentwire_home(request, tmp_path_factory, monkeypatch):
     return fake_config
 
 
-#: Populated by the audit hook below: (test id, path) for every write that
-#: escaped the redirect. Module-level so the hook, which cannot be removed
-#: once installed, stays a pure recorder.
-_REAL_HOME_WRITES: list = []
-_CURRENT_TEST: list = [None]
-
-#: Audit events that create, modify or delete a path. ``open`` is checked for
-#: a writing mode; the rest are unconditional.
-_WRITE_EVENTS = {
-    "os.mkdir", "os.rename", "os.remove", "os.rmdir", "os.link",
-    "os.symlink", "os.truncate", "os.chmod", "shutil.copyfile", "shutil.move",
-}
-
-
-def _install_real_home_audit_hook():
-    """Record any in-process write under the real ~/.agentwire.
-
-    Deliberately an audit hook rather than a before/after filesystem
-    snapshot. A snapshot cannot tell *this process* from the rest of the
-    machine, and on the owner's box ~/.agentwire is written continuously by
-    the live system — the watchdog, the message inbox, damage-control logs. A
-    snapshot-based guard flagged `logs/damage-control/<today>.jsonl` on its
-    first run, which was an agent's shell command in another process, not the
-    suite. A guard that cries wolf gets switched off, and then it is not a
-    guard.
-
-    An audit hook sees only this interpreter, so concurrent activity is
-    invisible to it, and it fires on the syscall — which means it names the
-    test that did it instead of reporting that *something*, *somewhere* in the
-    session escaped.
-    """
-    import sys
-
-    real = str(REAL_AGENTWIRE_HOME)
-
-    def hook(event, args):
-        if event == "open":
-            if len(args) < 2 or not args[1] or not any(c in str(args[1]) for c in "wax+"):
-                return
-            target = args[0]
-        elif event in _WRITE_EVENTS:
-            target = args[0] if args else None
-        else:
-            return
-        try:
-            path = str(target)
-        except Exception:
-            return
-        if path.startswith(real):
-            _REAL_HOME_WRITES.append((_CURRENT_TEST[0], event, path))
-
-    sys.addaudithook(hook)
-
-
-_install_real_home_audit_hook()
-
-
-@pytest.fixture(autouse=True)
-def _track_current_test(request):
-    """Name the test currently running, so a violation can be attributed."""
-    _CURRENT_TEST[0] = request.node.nodeid
-    yield
-    _CURRENT_TEST[0] = None
-
-
 @pytest.fixture(scope="session", autouse=True)
 def _real_agentwire_home_untouched():
     """Backstop: fail the run loudly if anything escaped the redirect (#893).
 
-    The redirect above is prevention; this is detection, and it exists because
-    the failure it guards against went unnoticed long enough to accumulate 80
-    fabricated conversation ids.
+    The redirect above is prevention; this is detection. Implementation lives
+    in :mod:`tests.home_guard` so there is exactly one recorder — see the note
+    there about pytest loading this file under two module names.
     """
     yield
-    if not _REAL_HOME_WRITES:
-        return
-    seen, lines = set(), []
-    for test_id, event, path in _REAL_HOME_WRITES:
-        key = (test_id, path)
-        if key in seen:
-            continue
-        seen.add(key)
-        lines.append(f"  {test_id or '<session>'}\n      {event}  {path}")
-    pytest.fail(
-        f"the test suite wrote into the REAL ~/.agentwire ({len(seen)} write(s), #893)\n"
-        + "\n".join(lines[:25]),
-        pytrace=False,
-    )
+    failure = home_guard.report()
+    if failure:
+        pytest.fail(failure, pytrace=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,220 @@
 """Shared test fixtures for the AgentWire test suite."""
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+#: The owner's real config directory. Nothing in the suite may write here.
+REAL_AGENTWIRE_HOME = Path.home() / ".agentwire"
+
+
+def _agentwire_modules():
+    """Loaded agentwire modules, snapshotted (import can mutate sys.modules)."""
+    return [m for name, m in list(sys.modules.items())
+            if name == "agentwire" or name.startswith("agentwire.")
+            if m is not None]
+
+
+def _import_every_agentwire_module():
+    """Import the whole package once, BEFORE any test redirects ``$HOME``.
+
+    Load-bearing, and subtle. The redirect below works by rebinding
+    module-level constants that were computed at import time — but it can only
+    rebind modules that are *already imported*. Much of this codebase imports
+    lazily inside functions (``from agentwire.__main__ import
+    build_agent_command`` inside a test helper), so without this the first
+    test to trigger such an import does it while ``$HOME`` already points at
+    that test's tmp directory. The module then computes
+    ``CONFIG_DIR = Path.home() / ".agentwire"`` against the *fake* home and
+    freezes it there — permanently, for the rest of the session, because
+    monkeypatch never patched it and so has nothing to restore.
+
+    The symptom is a constant stuck at some early test's tmp path, which is
+    exactly the kind of cross-test bleed this fixture exists to prevent. Doing
+    the imports up front means every constant is computed against the real
+    home, so the per-test walk both rebinds and restores it.
+
+    Best-effort: a submodule that cannot import (optional dependency, platform
+    guard) is skipped rather than failing collection.
+    """
+    import importlib
+    import pkgutil
+
+    import agentwire
+
+    for info in pkgutil.walk_packages(agentwire.__path__, prefix="agentwire."):
+        try:
+            importlib.import_module(info.name)
+        except Exception:
+            continue
+
+
+_import_every_agentwire_module()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agentwire_home(request, tmp_path_factory, monkeypatch):
+    """No test may read or write the real ``~/.agentwire`` — ever (#893).
+
+    Found the hard way: ``~/.agentwire/sessions/resumed/metadata.json`` was a
+    live record in the owner's config directory, written by this suite and
+    grown to 80 fabricated conversation ids — one appended per full-suite run,
+    because ``conversation_ids`` is a chain by design (#871). Beyond tests
+    mutating real user state being a defect on its own, it corrupted a
+    measurement: sizing #871's orphaned-history doctor check against the real
+    store surfaced 28 recorded ids with no transcript, *all* from that one
+    record, with zero genuine orphans behind them.
+
+    Two levers, because there are two ways a path gets computed:
+
+    1. **``$HOME``** — ``Path.home()`` resolves through ``expanduser``, which
+       reads the variable, so redirecting it catches everything computed at
+       *call* time, including modules imported later by a lazy import.
+    2. **A walk over loaded modules** — roughly forty constants across ~25
+       modules are computed at *import* time
+       (``COHORT_ROOT = Path.home() / ".agentwire" / "cohorts"`` and friends)
+       and are already frozen before any fixture runs. Rebinding them by
+       walking beats enumerating them: a hand-written list would rot the first
+       time someone adds a constant, which is exactly how this class of bug
+       recurs. ``test_home_isolation.py`` asserts the walk missed nothing.
+
+    Per-test rather than per-session, so no test can observe another's writes.
+    Tests that need their own location re-patch the same attributes via
+    ``monkeypatch``, which overrides this.
+    """
+    # Escape hatch for the rare test that must see the REAL deployment paths
+    # to assert on them — e.g. "role prompts are not in a directory macOS
+    # garbage-collects", which this fixture would otherwise make vacuous by
+    # relocating them into exactly such a directory. Read-only by intent, and
+    # not a hole: the session-scoped backstop below still fails the run if an
+    # opted-out test writes anything.
+    if request.node.get_closest_marker("real_agentwire_home"):
+        return REAL_AGENTWIRE_HOME
+
+    fake_home = tmp_path_factory.mktemp("home")
+    fake_config = fake_home / ".agentwire"
+    fake_config.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("AGENTWIRE_HOME", str(fake_config))
+
+    for module in _agentwire_modules():
+        for attr, value in list(vars(module).items()):
+            if not isinstance(value, Path):
+                continue
+            if value == REAL_AGENTWIRE_HOME:
+                monkeypatch.setattr(module, attr, fake_config, raising=False)
+            elif REAL_AGENTWIRE_HOME in value.parents:
+                relocated = fake_config / value.relative_to(REAL_AGENTWIRE_HOME)
+                monkeypatch.setattr(module, attr, relocated, raising=False)
+
+    # ``agentwire_dir()`` both resolves AND mkdirs, and callers bound it with
+    # ``from .utils.paths import agentwire_dir`` — a per-module copy that
+    # patching the definition site would not reach.
+    def _fake_agentwire_dir() -> Path:
+        fake_config.mkdir(parents=True, exist_ok=True)
+        return fake_config
+
+    for module in _agentwire_modules():
+        if callable(vars(module).get("agentwire_dir")):
+            monkeypatch.setattr(module, "agentwire_dir", _fake_agentwire_dir, raising=False)
+
+    return fake_config
+
+
+#: Populated by the audit hook below: (test id, path) for every write that
+#: escaped the redirect. Module-level so the hook, which cannot be removed
+#: once installed, stays a pure recorder.
+_REAL_HOME_WRITES: list = []
+_CURRENT_TEST: list = [None]
+
+#: Audit events that create, modify or delete a path. ``open`` is checked for
+#: a writing mode; the rest are unconditional.
+_WRITE_EVENTS = {
+    "os.mkdir", "os.rename", "os.remove", "os.rmdir", "os.link",
+    "os.symlink", "os.truncate", "os.chmod", "shutil.copyfile", "shutil.move",
+}
+
+
+def _install_real_home_audit_hook():
+    """Record any in-process write under the real ~/.agentwire.
+
+    Deliberately an audit hook rather than a before/after filesystem
+    snapshot. A snapshot cannot tell *this process* from the rest of the
+    machine, and on the owner's box ~/.agentwire is written continuously by
+    the live system — the watchdog, the message inbox, damage-control logs. A
+    snapshot-based guard flagged `logs/damage-control/<today>.jsonl` on its
+    first run, which was an agent's shell command in another process, not the
+    suite. A guard that cries wolf gets switched off, and then it is not a
+    guard.
+
+    An audit hook sees only this interpreter, so concurrent activity is
+    invisible to it, and it fires on the syscall — which means it names the
+    test that did it instead of reporting that *something*, *somewhere* in the
+    session escaped.
+    """
+    import sys
+
+    real = str(REAL_AGENTWIRE_HOME)
+
+    def hook(event, args):
+        if event == "open":
+            if len(args) < 2 or not args[1] or not any(c in str(args[1]) for c in "wax+"):
+                return
+            target = args[0]
+        elif event in _WRITE_EVENTS:
+            target = args[0] if args else None
+        else:
+            return
+        try:
+            path = str(target)
+        except Exception:
+            return
+        if path.startswith(real):
+            _REAL_HOME_WRITES.append((_CURRENT_TEST[0], event, path))
+
+    sys.addaudithook(hook)
+
+
+_install_real_home_audit_hook()
+
+
+@pytest.fixture(autouse=True)
+def _track_current_test(request):
+    """Name the test currently running, so a violation can be attributed."""
+    _CURRENT_TEST[0] = request.node.nodeid
+    yield
+    _CURRENT_TEST[0] = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _real_agentwire_home_untouched():
+    """Backstop: fail the run loudly if anything escaped the redirect (#893).
+
+    The redirect above is prevention; this is detection, and it exists because
+    the failure it guards against went unnoticed long enough to accumulate 80
+    fabricated conversation ids.
+    """
+    yield
+    if not _REAL_HOME_WRITES:
+        return
+    seen, lines = set(), []
+    for test_id, event, path in _REAL_HOME_WRITES:
+        key = (test_id, path)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(f"  {test_id or '<session>'}\n      {event}  {path}")
+    pytest.fail(
+        f"the test suite wrote into the REAL ~/.agentwire ({len(seen)} write(s), #893)\n"
+        + "\n".join(lines[:25]),
+        pytrace=False,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/home_guard.py
+++ b/tests/home_guard.py
@@ -1,0 +1,133 @@
+"""Detection half of the real-``~/.agentwire`` protection (#893).
+
+Lives in its own module rather than in ``conftest.py`` for a reason that bit
+this guard during development: pytest loads the root conftest as the top-level
+module ``conftest``, while a test doing ``import tests.conftest`` gets a
+*second, distinct* module object. Both copies then ran the installer, so two
+audit hooks recorded every write, and a flag set on one copy did not silence
+the other — the guard's own tests were suppressing one recorder while the other
+kept failing the run.
+
+That is the same second-copy-of-the-SSOT shape as #899, arriving by a different
+route. One owning module, imported by absolute name from both sides, is the
+fix: ``tests.home_guard`` resolves to a single object however conftest was
+loaded.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+#: The owner's real config directory, captured at import — before any test
+#: redirects ``$HOME``, so it keeps naming the real one.
+REAL_AGENTWIRE_HOME = Path.home() / ".agentwire"
+
+#: Writes under the real home that nothing sanctioned: the failures.
+WRITES: list = []
+
+#: Writes recorded inside :func:`sanctioned_real_home_write` — the evidence
+#: the hook fired, kept separate so a sanction proves detection instead of
+#: disabling it.
+SANCTIONED_WRITES: list = []
+
+_SANCTIONED = [0]
+_INSTALLED = [False]
+
+#: Audit events that create, modify or delete a path. ``open`` is handled
+#: separately because its intent has to be read from mode *or* flags.
+_WRITE_EVENTS = {
+    "os.mkdir", "os.rename", "os.replace", "os.remove", "os.rmdir", "os.link",
+    "os.symlink", "os.truncate", "os.chmod", "shutil.copyfile", "shutil.move",
+}
+
+_WRITING_FLAGS = (
+    getattr(os, "O_WRONLY", 0) | getattr(os, "O_RDWR", 0)
+    | getattr(os, "O_CREAT", 0) | getattr(os, "O_APPEND", 0)
+    | getattr(os, "O_TRUNC", 0)
+)
+
+
+@contextlib.contextmanager
+def sanctioned_real_home_write():
+    """Let a block write under the real home without failing the run.
+
+    Exists for exactly one caller: the tests that prove the hook can FAIL.
+    Those must perform genuine writes under the real home — a hook only ever
+    exercised against a tmp dir is how the ``os.open`` blindness survived —
+    which would otherwise trip the very backstop they exercise.
+
+    Narrow by construction: writes inside the block are still recorded, into
+    :data:`SANCTIONED_WRITES`, which those tests assert on. Nothing else in the
+    suite should use this.
+    """
+    _SANCTIONED[0] += 1
+    try:
+        yield SANCTIONED_WRITES
+    finally:
+        _SANCTIONED[0] -= 1
+
+
+def install() -> None:
+    """Install the audit hook once per interpreter.
+
+    An audit hook cannot be removed, so installing twice would double every
+    record. Idempotent for the same reason the module exists.
+    """
+    if _INSTALLED[0]:
+        return
+    _INSTALLED[0] = True
+
+    real = str(REAL_AGENTWIRE_HOME)
+
+    def hook(event, args):
+        if event == "open":
+            # (path, mode, flags). ``mode`` is the string only for
+            # builtins.open/io.open; the low-level ``os.open`` passes None and
+            # carries intent in ``flags``. Checking mode alone made the guard
+            # blind to os.open — which is how seven production sites under the
+            # config dir create files, including core.write_role_prompt (0o600
+            # so the prompt is never briefly world-readable).
+            if len(args) < 2:
+                return
+            mode, flags = args[1], (args[2] if len(args) > 2 else 0)
+            if mode:
+                if not any(c in str(mode) for c in "wax+"):
+                    return
+            elif not (isinstance(flags, int) and flags & _WRITING_FLAGS):
+                return
+            target = args[0]
+        elif event in _WRITE_EVENTS:
+            target = args[0] if args else None
+        else:
+            return
+        try:
+            path = str(target)
+        except Exception:
+            return
+        if not path.startswith(real):
+            return
+        entry = (os.environ.get("PYTEST_CURRENT_TEST", "<session>"), event, path)
+        (SANCTIONED_WRITES if _SANCTIONED[0] else WRITES).append(entry)
+
+    sys.addaudithook(hook)
+
+
+def report() -> str | None:
+    """A human-readable failure, or None if nothing escaped."""
+    if not WRITES:
+        return None
+    seen, lines = set(), []
+    for test_id, event, path in WRITES:
+        test_id = str(test_id).split(" (")[0]
+        key = (test_id, path)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(f"  {test_id}\n      {event}  {path}")
+    return (
+        f"the test suite wrote into the REAL ~/.agentwire ({len(seen)} write(s), #893)\n"
+        + "\n".join(lines[:25])
+    )

--- a/tests/unit/test_build_agent_command.py
+++ b/tests/unit/test_build_agent_command.py
@@ -292,10 +292,15 @@ class TestMirrorRolePromptRemote:
         assert agent.role_prompt_path.startswith(str(core.role_prompts_dir()))
 
 
+@pytest.mark.real_agentwire_home
 def test_default_prompt_dir_is_under_agentwire_config():
     """The whole point of #871's prompt move. Deliberately module-level: the
     classes above redirect CONFIG_DIR to a tmp dir that pytest itself happens
-    to put under /var/folders, which would make this vacuous."""
+    to put under /var/folders, which would make this vacuous.
+
+    Same reason it opts out of the #893 home redirect, which relocates the
+    config dir into precisely such a directory: this test asserts on the REAL
+    deployment path, and reads only."""
     from agentwire.core import CONFIG_DIR, role_prompts_dir
     assert role_prompts_dir().parent == CONFIG_DIR
     assert "/var/folders" not in str(role_prompts_dir())

--- a/tests/unit/test_control_plane_protection.py
+++ b/tests/unit/test_control_plane_protection.py
@@ -20,6 +20,14 @@ from agentwire.safety._core import (
 )
 from agentwire.safety_commands import load_patterns
 
+# This module is *about* the real control plane: it asserts that the owner's
+# actual `~/.agentwire` and `~/.claude` files are unwritable by the policed
+# agent, and its parameters are real absolute paths resolved at import. The
+# #893 home redirect would point the protection logic at a tmp directory while
+# these paths stayed real, making every case fail for the wrong reason. Reads
+# only — the audit-hook backstop still fails the run on any write.
+pytestmark = pytest.mark.real_agentwire_home
+
 CONTROL_PLANE_FILES = [
     os.path.expanduser("~/.agentwire/damagecontrol.yml"),
     "/some/repo/.damagecontrol.yml",

--- a/tests/unit/test_damage_control_bypass.py
+++ b/tests/unit/test_damage_control_bypass.py
@@ -19,6 +19,16 @@ import pytest
 
 from agentwire.safety._core import check_command, load_config
 
+# This corpus asserts on ``~``-form secret paths (``cat ~/.ssh/id_rsa``), so it
+# needs ``$HOME`` to look like a real home. The #893 redirect points HOME at a
+# pytest tmp dir, and on Linux that is under ``/tmp`` — which ``core.yaml``
+# allowlists ``allow: all``. An allowlist entry outranks ``zeroAccessPaths``, so
+# the tilde vectors resolved to ``allow`` and the corpus went green-to-red for a
+# reason that had nothing to do with the matcher. (macOS temp is
+# ``/private/var/folders``, which is not allowlisted — hence it only showed up
+# on CI.) Reads only; the audit backstop still catches any write.
+pytestmark = pytest.mark.real_agentwire_home
+
 REPO = Path(__file__).resolve().parent.parent.parent
 RULES_DIR = REPO / "agentwire" / "hooks" / "damage-control" / "rules"
 

--- a/tests/unit/test_history_migrate.py
+++ b/tests/unit/test_history_migrate.py
@@ -10,6 +10,7 @@ import os
 
 import pytest
 
+from agentwire import core
 from agentwire import history_migrate as hm
 from agentwire.history import encode_project_path
 
@@ -30,7 +31,7 @@ def projects(tmp_path, monkeypatch):
 @pytest.fixture
 def session_store(tmp_path, monkeypatch):
     """A throwaway ~/.agentwire with a recorded session named "s"."""
-    monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
     (tmp_path / "sessions" / "s").mkdir(parents=True)
     (tmp_path / "sessions" / "s" / "metadata.json").write_text("{}")
     return tmp_path
@@ -389,13 +390,13 @@ class TestResumable:
 class TestResolveSession:
     def test_unknown_session_says_so(self, projects, tmp_path, monkeypatch):
         """Not "predates #881" — that misreads a typo as a legacy session."""
-        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
         result = hm.resolve_session("never-existed")
         assert result["status"] == hm.UNDETERMINED
         assert result["detail"] == "no such session recorded"
 
     def test_undetermined_without_recorded_cwd(self, projects, tmp_path, monkeypatch):
-        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
         (tmp_path / "sessions" / "legacy").mkdir(parents=True)
         (tmp_path / "sessions" / "legacy" / "metadata.json").write_text("{}")
         monkeypatch.setattr(hm, "load_session_metadata", lambda name: {})
@@ -466,10 +467,10 @@ class TestScan:
             (sessions / name).mkdir(parents=True)
             (sessions / name / "metadata.json").write_text("{}")
         (sessions / "no-metadata").mkdir()
-        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path)
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
         assert hm.known_sessions() == ["alpha", "beta"]
         assert [r["session"] for r in hm.scan()] == ["alpha", "beta"]
 
     def test_no_sessions_dir_is_not_an_error(self, projects, tmp_path, monkeypatch):
-        monkeypatch.setattr(hm, "CONFIG_DIR", tmp_path / "absent")
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path / "absent")
         assert hm.scan() == []

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -20,13 +20,6 @@ import pytest
 REAL_HOME = Path.home() / ".agentwire"
 
 
-def _snapshot() -> set:
-    if not REAL_HOME.exists():
-        return set()
-    return {(str(p), p.stat().st_mtime_ns if p.exists() else None)
-            for p in REAL_HOME.rglob("*")}
-
-
 class TestRealHomeIsUntouched:
     def test_home_env_points_away_from_the_real_home(self):
         """The single lever that redirects every call-time ``Path.home()``.
@@ -61,15 +54,24 @@ class TestRealHomeIsUntouched:
         added another fabricated id.
         """
         from agentwire import core
+        from tests import home_guard
 
-        before = _snapshot()
+        before = len(home_guard.WRITES)
         agent = core.AgentCommand(
             command="claude", posture="bypass", roles=["orchestrator"],
             conversation_id="00000000-0000-4000-8000-000000000000",
             role_prompt_path=None,
         )
         core.record_session_launch("resumed", agent, Path.cwd(), role="orchestrator")
-        assert _snapshot() == before
+
+        # Asserted against the audit hook, NOT a before/after snapshot of the
+        # real home. This module used to snapshot, and it flaked for precisely
+        # the reason this PR argues the guard must be in-process: ~/.agentwire
+        # is written continuously by the live fleet, so a snapshot cannot tell
+        # this process from the rest of the machine. Sampling it three seconds
+        # apart on an idle box still showed entries changing. The argument and
+        # the implementation now agree.
+        assert home_guard.WRITES[before:] == []
 
         # ...and it did write, to the redirected location.
         assert (core.CONFIG_DIR / "sessions" / "resumed" / "metadata.json").is_file()
@@ -155,7 +157,8 @@ class TestTheAuditHookCanActuallyFail:
     in the mode check silently disabled detection for all of them.
 
     The earlier "can it fail" test exercised a ``_snapshot()`` helper local to
-    this module — not the hook — so the actual backstop was untested. These
+    this module — not the hook — so the actual backstop was untested (that
+    helper is gone; it had the flakiness this guard exists to avoid). These
     write for real, under the real home, and clean up after themselves; each
     asserts the hook recorded it.
     """

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -1,0 +1,172 @@
+"""The suite must never write into the real ~/.agentwire (#893).
+
+This is the regression pin for a defect found by accident: the record at
+``~/.agentwire/sessions/resumed/metadata.json`` was written by the test suite
+and had grown to 80 fabricated conversation ids, one chain entry per full-suite
+run. It was not merely untidy — it corrupted a measurement. Sizing #871's
+orphaned-history doctor check against the real store showed 28 recorded ids
+with no transcript, and every one of them came from that single polluted
+record. Genuinely orphaned: zero. A threshold calibrated on that would have
+been tuned entirely against noise the tests invented.
+
+These tests exercise the writers directly rather than asserting on the store's
+current contents, so they stay meaningful after the stale record is deleted.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REAL_HOME = Path.home() / ".agentwire"
+
+
+def _snapshot() -> set:
+    if not REAL_HOME.exists():
+        return set()
+    return {(str(p), p.stat().st_mtime_ns if p.exists() else None)
+            for p in REAL_HOME.rglob("*")}
+
+
+class TestRealHomeIsUntouched:
+    def test_home_env_points_away_from_the_real_home(self):
+        """The single lever that redirects every call-time ``Path.home()``.
+
+        ``Path.home()`` resolves through ``expanduser``, which reads ``$HOME``,
+        so redirecting the variable catches every path computed at call time —
+        the module-level constants frozen at import are handled separately.
+        """
+        import os
+
+        # The real home is where REAL_HOME (captured at import) still lives.
+        assert Path.home() != REAL_HOME.parent, "HOME still resolves to the real user home"
+        assert Path(os.environ["HOME"]) == Path.home()
+        # expanduser goes the same way, so `~`-relative paths are covered too.
+        assert Path("~/.agentwire").expanduser() != REAL_HOME
+
+    def test_a_freshly_computed_config_path_is_redirected(self):
+        """What a lazily-imported module would compute on first import."""
+        assert (Path.home() / ".agentwire") != REAL_HOME
+
+    def test_config_dir_is_not_the_real_one(self):
+        from agentwire import core
+
+        assert core.CONFIG_DIR != REAL_HOME
+        assert not str(core.CONFIG_DIR).startswith(str(REAL_HOME))
+
+    def test_recording_a_session_launch_writes_nothing_real(self):
+        """The exact writer that produced the polluted record.
+
+        ``cmd_history_resume`` calls ``record_session_launch``, which appends
+        to ``conversation_ids`` — a chain by design (#871), so every suite run
+        added another fabricated id.
+        """
+        from agentwire import core
+
+        before = _snapshot()
+        agent = core.AgentCommand(
+            command="claude", posture="bypass", roles=["orchestrator"],
+            conversation_id="00000000-0000-4000-8000-000000000000",
+            role_prompt_path=None,
+        )
+        core.record_session_launch("resumed", agent, Path.cwd(), role="orchestrator")
+        assert _snapshot() == before
+
+        # ...and it did write, to the redirected location.
+        assert (core.CONFIG_DIR / "sessions" / "resumed" / "metadata.json").is_file()
+
+    def test_no_agentwire_module_still_points_at_the_real_home(self):
+        """Static check: catches a NEW module constant the moment it appears.
+
+        Import-time constants (``Path.home() / ".agentwire" / ...``) are frozen
+        before any fixture runs, so redirecting ``$HOME`` alone does not move
+        them. Roughly forty exist across ~25 modules; enumerating them by hand
+        would rot immediately, so the isolation fixture rebinds them by walking
+        loaded modules, and this asserts the walk actually covered everything.
+        """
+        import sys
+
+        leaked = []
+        for module in list(sys.modules.values()):
+            name = getattr(module, "__name__", "")
+            if not name.startswith("agentwire"):
+                continue
+            for attr, value in list(vars(module).items()):
+                if isinstance(value, Path) and (
+                    value == REAL_HOME or REAL_HOME in value.parents
+                ):
+                    leaked.append(f"{name}.{attr} = {value}")
+        assert not leaked, "still pointing at the real ~/.agentwire:\n  " + "\n  ".join(leaked)
+
+
+class TestLazyImportsCannotFreezeAFakeHome:
+    """The subtle failure the redirect had to be fixed for.
+
+    Much of this codebase imports lazily inside functions. Before the eager
+    import in ``conftest``, the first test to trigger such an import did it
+    while ``$HOME`` already pointed at *that test's* tmp directory, so the
+    module computed ``CONFIG_DIR = Path.home() / ".agentwire"`` against the
+    fake home and froze there for the rest of the session — monkeypatch never
+    patched it, so there was nothing to restore. Every later test then read a
+    constant belonging to a long-finished test.
+    """
+
+    def test_lazily_imported_modules_are_loaded_up_front(self):
+        import sys
+
+        # ``agentwire.__main__`` is the one the old bug travelled through:
+        # test helpers do `from agentwire.__main__ import build_agent_command`.
+        assert "agentwire.__main__" in sys.modules
+        assert "agentwire.core" in sys.modules
+
+    def test_no_module_points_at_another_tests_home(self, _isolate_agentwire_home):
+        """Every redirected constant belongs to THIS test, not a previous one."""
+        import re
+        import sys
+
+        mine = str(_isolate_agentwire_home)
+        other_home = re.compile(r"/home\d+/\.agentwire")
+        stray = []
+        for module in list(sys.modules.values()):
+            if not getattr(module, "__name__", "").startswith("agentwire"):
+                continue
+            for attr, value in list(vars(module).items()):
+                if not isinstance(value, Path):
+                    continue
+                text = str(value)
+                if other_home.search(text) and not text.startswith(mine):
+                    stray.append(f"{module.__name__}.{attr} = {text}")
+        assert not stray, "constants frozen to another test's home:\n  " + "\n  ".join(stray)
+
+
+class TestGuardItself:
+    def test_snapshot_detects_a_change(self, tmp_path, monkeypatch):
+        """The guard must be capable of failing, not merely of passing."""
+        monkeypatch.setattr(f"{__name__}.REAL_HOME", tmp_path, raising=False)
+        import tests.unit.test_home_isolation as mod
+
+        monkeypatch.setattr(mod, "REAL_HOME", tmp_path)
+        before = mod._snapshot()
+        (tmp_path / "intruder.json").write_text("{}")
+        assert mod._snapshot() != before
+
+
+@pytest.mark.parametrize("subsystem,relative", [
+    ("inbox", "inbox"),
+    ("cohort ledger", "cohorts"),
+    ("usage-limit park state", "usage-limit"),
+    ("worktree registry", "worktrees.json"),
+    ("role prompts", "role-prompts"),
+])
+def test_subsystem_stores_are_redirected(subsystem, relative):
+    """~/.agentwire holds more than sessions/, and tests touch all of it."""
+    import agentwire.cohort as cohort
+    import agentwire.core as core
+    import agentwire.inbox as inbox
+    import agentwire.usage_limit as usage_limit
+
+    for mod, attr in (
+        (inbox, "INBOX_ROOT"), (cohort, "COHORT_ROOT"),
+        (usage_limit, "STATE_DIR"), (core, "ROLE_PROMPTS_DIR"),
+    ):
+        value = getattr(mod, attr)
+        assert REAL_HOME not in Path(value).parents, f"{attr} escapes to the real home"

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -138,16 +138,144 @@ class TestLazyImportsCannotFreezeAFakeHome:
         assert not stray, "constants frozen to another test's home:\n  " + "\n  ".join(stray)
 
 
-class TestGuardItself:
-    def test_snapshot_detects_a_change(self, tmp_path, monkeypatch):
-        """The guard must be capable of failing, not merely of passing."""
-        monkeypatch.setattr(f"{__name__}.REAL_HOME", tmp_path, raising=False)
-        import tests.unit.test_home_isolation as mod
+@pytest.mark.real_agentwire_home
+class TestTheAuditHookCanActuallyFail:
+    """The backstop must be provably capable of catching each write primitive.
 
-        monkeypatch.setattr(mod, "REAL_HOME", tmp_path)
-        before = mod._snapshot()
-        (tmp_path / "intruder.json").write_text("{}")
-        assert mod._snapshot() != before
+    This exists because the hook shipped with a hole that no test could see.
+    The ``open`` audit event is ``(path, mode, flags)``: ``mode`` is the string
+    only for ``builtins.open``/``io.open``, while the low-level ``os.open``
+    passes ``mode=None`` and carries the intent in ``flags``. The first version
+    checked only ``mode``, so it returned before recording — blind to
+    ``os.open`` entirely.
+
+    That is not a corner case. ``os.open`` is how seven production sites create
+    files under the config dir, including ``core.write_role_prompt``, which
+    uses it precisely so the prompt is never briefly world-readable. One miss
+    in the mode check silently disabled detection for all of them.
+
+    The earlier "can it fail" test exercised a ``_snapshot()`` helper local to
+    this module — not the hook — so the actual backstop was untested. These
+    write for real, under the real home, and clean up after themselves; each
+    asserts the hook recorded it.
+    """
+
+    def _probe(self, name):
+        from tests import home_guard
+
+        return home_guard.REAL_AGENTWIRE_HOME / name
+
+    def _recorded_since(self, mark):
+        from tests import home_guard
+
+        return home_guard.SANCTIONED_WRITES[mark:]
+
+    def _mark(self):
+        from tests import home_guard
+
+        return len(home_guard.SANCTIONED_WRITES)
+
+    @pytest.fixture(autouse=True)
+    def _sanctioned(self):
+        """These probes write for real; the sanction keeps the backstop from
+        failing the run over writes it is being asked to detect. They are still
+        recorded — into SANCTIONED_WRITES — so the assertions are real."""
+        from tests import home_guard
+
+        with home_guard.sanctioned_real_home_write():
+            yield
+
+    def test_catches_builtin_open_for_write(self):
+        target, mark = self._probe("zz-probe-open.json"), self._mark()
+        try:
+            with open(target, "w") as fh:
+                fh.write("{}")
+        finally:
+            target.unlink(missing_ok=True)
+        assert any(str(target) == p for _t, _e, p in self._recorded_since(mark))
+
+    def test_catches_os_open_which_reports_no_mode(self):
+        """The exact hole: mode is None, intent lives in flags."""
+        import os
+
+        target, mark = self._probe("zz-probe-osopen.json"), self._mark()
+        try:
+            fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            os.close(fd)
+        finally:
+            target.unlink(missing_ok=True)
+        assert any(str(target) == p for _t, _e, p in self._recorded_since(mark)), (
+            "os.open escaped the guard — this is the hole that shipped"
+        )
+
+    def test_catches_write_role_prompt_shaped_writes(self):
+        """What core.write_role_prompt actually does, end to end."""
+        import os
+
+        d, mark = self._probe("zz-probe-prompts"), self._mark()
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+            f = d / "conv.txt"
+            fd = os.open(f, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as fh:
+                fh.write("role prompt")
+        finally:
+            (d / "conv.txt").unlink(missing_ok=True)
+            if d.exists():
+                d.rmdir()
+        assert any(str(d) in p for _t, _e, p in self._recorded_since(mark))
+
+    def test_catches_path_write_text(self):
+        target, mark = self._probe("zz-probe-writetext.json"), self._mark()
+        try:
+            target.write_text("{}")
+        finally:
+            target.unlink(missing_ok=True)
+        assert any(str(target) == p for _t, _e, p in self._recorded_since(mark))
+
+    def test_catches_mkdir(self):
+        target, mark = self._probe("zz-probe-dir"), self._mark()
+        try:
+            target.mkdir()
+        finally:
+            if target.exists():
+                target.rmdir()
+        assert any(str(target) == p for _t, _e, p in self._recorded_since(mark))
+
+    def test_catches_unlink(self):
+        target, mark = self._probe("zz-probe-unlink.json"), self._mark()
+        target.write_text("{}")
+        mark = self._mark()
+        target.unlink()
+        assert any(str(target) == p for _t, _e, p in self._recorded_since(mark))
+
+    def test_catches_atomic_write_via_os_replace(self):
+        """``_atomic_write`` publishes with a rename; the temp file is os.open'd."""
+        from agentwire import core
+
+        target, mark = self._probe("zz-probe-atomic.json"), self._mark()
+        try:
+            core._atomic_write(target, "{}")
+        finally:
+            target.unlink(missing_ok=True)
+        assert any(str(target) in p for _t, _e, p in self._recorded_since(mark))
+
+    def test_ignores_reads(self):
+        """A guard that flags reads would flood and get switched off."""
+        from tests import home_guard
+
+        target = self._probe("zz-probe-read.json")
+        target.write_text("{}")
+        mark = self._mark()
+        target.read_text()
+        assert not self._recorded_since(mark), "a plain read was recorded as a write"
+        target.unlink()
+        assert home_guard.REAL_AGENTWIRE_HOME.exists()
+
+    def test_ignores_writes_outside_the_real_home(self, tmp_path):
+        mark = self._mark()
+        (tmp_path / "elsewhere.json").write_text("{}")
+        assert not self._recorded_since(mark)
 
 
 @pytest.mark.parametrize("subsystem,relative", [
@@ -165,8 +293,69 @@ def test_subsystem_stores_are_redirected(subsystem, relative):
     import agentwire.usage_limit as usage_limit
 
     for mod, attr in (
-        (inbox, "INBOX_ROOT"), (cohort, "COHORT_ROOT"),
-        (usage_limit, "STATE_DIR"), (core, "ROLE_PROMPTS_DIR"),
+        (inbox, "INBOX_ROOT"), (cohort, "COHORT_ROOT"), (usage_limit, "STATE_DIR"),
     ):
         value = getattr(mod, attr)
         assert REAL_HOME not in Path(value).parents, f"{attr} escapes to the real home"
+
+    # The role-prompt store is resolved LAZILY (#902 made it a function rather
+    # than an import-time constant, to dodge the same frozen-binding trap).
+    # A function is invisible to a walk over Path attributes, so this is the
+    # check that the redirect still reaches it — via CONFIG_DIR, at call time.
+    assert REAL_HOME not in core.role_prompts_dir().parents
+    assert REAL_HOME != core.role_prompts_dir()
+
+
+class TestComposesWithTheRolePromptSweepStub:
+    """Both conftest guards must hold at once (#893 + #884/#902).
+
+    They cover different halves and neither subsumes the other: #902's stub
+    PREVENTS one specific destructive operation (the role-prompt sweep's
+    deletion pass) from ever addressing the real store, while this PR's guard
+    DETECTS any test that writes there at all. Keeping only one would silently
+    drop a protection — and the sweep's is the kind nobody notices is gone
+    until something has already been deleted.
+
+    They also reinforce each other. The eager package import means
+    ``role_prompts`` is loaded before any redirect, so its paths resolve
+    through a patched ``CONFIG_DIR``; and the stub holds even where a redirect
+    might not reach.
+    """
+
+    def test_tick_is_stubbed_and_deletes_nothing(self):
+        from agentwire import role_prompts
+
+        result = role_prompts.tick()
+        assert result["deleted"] == []
+        assert result.get("skipped") == "disabled-in-tests"
+
+    def test_the_sweep_stub_does_not_trip_the_write_guard(self):
+        """A no-op stub must not look like a write to the real store."""
+        from agentwire import role_prompts
+        from tests import home_guard
+
+        before = len(home_guard.WRITES)
+        role_prompts.tick()
+        assert len(home_guard.WRITES) == before
+
+    def test_no_sweep_stamp_is_written_to_the_real_store(self):
+        """#902's reviewer's check: the stub held.
+
+        ``tick`` writes ``role-prompt-sweep.json`` next to the store when it
+        actually runs, so the stamp's absence from the REAL config dir is the
+        observable proof that no test swept it.
+        """
+        from agentwire import role_prompts
+        from tests import home_guard
+
+        role_prompts.tick()
+        stamp = home_guard.REAL_AGENTWIRE_HOME / "role-prompt-sweep.json"
+        assert not any(
+            str(stamp) == path for _t, _e, path in home_guard.WRITES
+        ), "a test wrote the sweep stamp into the real store"
+
+    def test_role_prompt_paths_resolve_inside_the_redirect(self, _isolate_agentwire_home):
+        """Where the sweep WOULD look is inside this test's tmp home."""
+        from agentwire import core
+
+        assert core.role_prompts_dir() == _isolate_agentwire_home / "role-prompts"

--- a/tests/unit/test_locking.py
+++ b/tests/unit/test_locking.py
@@ -5,8 +5,8 @@ import multiprocessing as mp
 import time
 from pathlib import Path
 
+import agentwire.locking as locking
 from agentwire.locking import (
-    LOCKS_DIR,
     _get_lock_path,
     session_lock,
 )
@@ -15,15 +15,15 @@ from agentwire.locking import (
 class TestLockPathSanitization:
     def test_simple_session(self):
         path = _get_lock_path("myapp")
-        assert path == LOCKS_DIR / "myapp.lock"
+        assert path == locking.LOCKS_DIR / "myapp.lock"
 
     def test_worktree_slash_replaced(self):
         path = _get_lock_path("myapp/feature")
-        assert path == LOCKS_DIR / "myapp--feature.lock"
+        assert path == locking.LOCKS_DIR / "myapp--feature.lock"
 
     def test_deep_worktree(self):
         path = _get_lock_path("myapp/feat/sub")
-        assert path == LOCKS_DIR / "myapp--feat--sub.lock"
+        assert path == locking.LOCKS_DIR / "myapp--feat--sub.lock"
 
 
 # --- Dead-holder recovery race regression (#491) -------------------------------

--- a/tests/unit/test_session_metadata_ssot.py
+++ b/tests/unit/test_session_metadata_ssot.py
@@ -14,6 +14,7 @@ writing to the old location and fails here.
 """
 
 import json
+import os
 
 import pytest
 
@@ -94,6 +95,47 @@ class TestEveryCallerRoutesThroughTheHelper:
         core.store_session_metadata("alpha@remote", {"role": "worker"})
         assert core.load_session_metadata("alpha") == {"role": "worker"}
         assert core.load_session_metadata("alpha@other") == {"role": "worker"}
+
+
+class TestContainment:
+    """A session name is operator input, and ``kill`` UNLINKS what this returns.
+
+    Pre-existing — the inlined copy in ``pane_cli`` had identical properties —
+    but consolidating is the moment the check can be written once rather than
+    at four call sites, so it lands with the consolidation.
+    """
+
+    @pytest.mark.parametrize("evil", [
+        "../../../evil", "..", "a/../../b", "../..", "foo/../../../bar",
+    ])
+    def test_traversal_is_refused(self, evil, tmp_path, monkeypatch):
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+        with pytest.raises(ValueError, match="escapes the session store"):
+            core.session_metadata_path(evil)
+
+    def test_traversal_is_refused_with_a_machine_suffix(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+        with pytest.raises(ValueError, match="escapes the session store"):
+            core.session_metadata_path("../../../evil@remote")
+
+    def test_kill_cannot_unlink_outside_the_store(self, tmp_path, monkeypatch):
+        """The concrete consequence: an unlink aimed outside the store."""
+        from agentwire import pane_cli
+
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path / "cfg")
+        victim = tmp_path / "precious.json"
+        victim.write_text("do not delete me")
+
+        # A name whose ../ segments climb out of sessions/ and land on victim.
+        escaping = os.path.relpath(victim.parent, tmp_path / "cfg" / "sessions")
+        with pytest.raises(ValueError):
+            pane_cli._drop_session_metadata(escaping)
+        assert victim.exists(), "kill unlinked a file outside the session store"
+
+    def test_ordinary_names_still_work(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+        for ok in ("alpha", "proj-branch", "a.b", "_claude-x", "web@remote"):
+            assert core.session_metadata_path(ok).parent.parent == core.sessions_dir()
 
 
 class TestSessionsDirIsAlsoShared:

--- a/tests/unit/test_session_metadata_ssot.py
+++ b/tests/unit/test_session_metadata_ssot.py
@@ -1,0 +1,148 @@
+"""``session_metadata_path`` must be the SSOT in fact, not by declaration (#899).
+
+The helper's docstring claimed "one implementation, both directions" while
+``load_session_metadata`` and ``agentwire kill`` each rebuilt the path by hand.
+That is this repo's most-repeated defect class — ``tmux_safe_name`` took four
+rounds (#865 → #868 → #870 → #878) and ``encode_project_path`` shipped a second
+incorrect copy beside its callers (#892). In every case the helper existed and
+some callers simply did not route through it, and in every case the divergence
+was invisible until something behaved wrongly in production.
+
+The pin is behavioural rather than textual: redirect the helper, and every
+reader and writer must follow it. A caller that hand-builds the path keeps
+writing to the old location and fails here.
+"""
+
+import json
+
+import pytest
+
+from agentwire import core
+
+
+@pytest.fixture
+def redirected(tmp_path, monkeypatch):
+    """Point the SSOT somewhere unguessable by string-building."""
+    store = tmp_path / "somewhere-else"
+
+    def fake_path(session_name: str):
+        return store / f"{session_name.split('@')[0]}.json"
+
+    monkeypatch.setattr(core, "session_metadata_path", fake_path)
+    return store
+
+
+class TestEveryCallerRoutesThroughTheHelper:
+    def test_store_writes_where_the_helper_says(self, redirected):
+        core.store_session_metadata("alpha", {"role": "worker"})
+        assert (redirected / "alpha.json").is_file()
+
+    def test_load_reads_where_the_helper_says(self, redirected):
+        core.store_session_metadata("alpha", {"role": "worker"})
+        assert core.load_session_metadata("alpha") == {"role": "worker"}
+
+    def test_load_does_not_fall_back_to_a_hand_built_path(self, redirected, monkeypatch):
+        """The exact failure: a reader that ignores the helper.
+
+        Written to the redirected store, but a *different* record is planted at
+        the conventional location. A hand-building reader returns the planted
+        one; a routed reader returns the real one.
+        """
+        core.store_session_metadata("alpha", {"role": "worker"})
+
+        decoy = core.CONFIG_DIR / "sessions" / "alpha" / "metadata.json"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        decoy.write_text(json.dumps({"role": "DECOY"}))
+
+        assert core.load_session_metadata("alpha")["role"] == "worker"
+
+    def test_kill_removes_the_record_the_helper_names(self, redirected, monkeypatch):
+        """``agentwire kill`` unlinks the record; it must unlink the real one."""
+        import subprocess
+
+        from agentwire import pane_cli
+
+        core.store_session_metadata("alpha", {"role": "worker"})
+        assert (redirected / "alpha.json").is_file()
+
+        decoy = core.CONFIG_DIR / "sessions" / "alpha" / "metadata.json"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        decoy.write_text(json.dumps({"role": "DECOY"}))
+
+        monkeypatch.setattr(pane_cli, "session_metadata_path", fake := core.session_metadata_path,
+                            raising=False)
+        monkeypatch.setattr(subprocess, "run",
+                            lambda *a, **k: subprocess.CompletedProcess(a, 0, b"", b""))
+        pane_cli._drop_session_metadata("alpha")
+
+        assert not (redirected / "alpha.json").exists(), "kill unlinked the wrong path"
+        assert decoy.exists(), "kill removed a record it does not own"
+        assert fake is core.session_metadata_path
+
+    def test_machine_suffix_is_stripped_once_in_one_place(self, tmp_path, monkeypatch):
+        """``name@machine`` keys the same record as ``name``.
+
+        Deliberately NOT using the ``redirected`` fixture: its stand-in does
+        its own ``split("@")``, so the assertion would pass even if the real
+        helper stopped stripping. Exercises the genuine implementation instead.
+        """
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+
+        assert core.session_metadata_path("alpha@remote") == core.session_metadata_path("alpha")
+        assert core.session_metadata_path("alpha").parent.name == "alpha"
+
+        core.store_session_metadata("alpha@remote", {"role": "worker"})
+        assert core.load_session_metadata("alpha") == {"role": "worker"}
+        assert core.load_session_metadata("alpha@other") == {"role": "worker"}
+
+
+class TestSessionsDirIsAlsoShared:
+    """The leaf had a helper; the ROOT was still built by hand in two places."""
+
+    def test_enumeration_follows_the_shared_root(self, tmp_path, monkeypatch):
+        from agentwire import history_migrate
+
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+        root = core.sessions_dir()
+        for name in ("beta", "gamma"):
+            (root / name).mkdir(parents=True)
+            (root / name / "metadata.json").write_text("{}")
+
+        assert history_migrate.known_sessions() == ["beta", "gamma"]
+
+    def test_sessions_dir_agrees_with_the_metadata_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+        assert core.session_metadata_path("alpha").parent.parent == core.sessions_dir()
+
+
+def test_no_module_hand_builds_the_metadata_path():
+    """Structural backstop: catch a NEW hand-built copy at review time.
+
+    The behavioural tests above only cover callers that exist. This one fails
+    the moment someone writes ``CONFIG_DIR / "sessions" / ...`` again, which is
+    how every prior round of this defect got in.
+    """
+    import pathlib
+    import re
+
+    # A Path join onto "sessions" — not the bare word, which appears all over
+    # the portal's JSON payloads and route names.
+    join = re.compile(r'/\s*"sessions"')
+    root = pathlib.Path(core.__file__).parent
+    offenders = []
+    for path in sorted(root.rglob("*.py")):
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            if not join.search(line) or line.lstrip().startswith("#"):
+                continue
+            # Only the ONE definition is exempt. This used to exempt any
+            # core.py line containing the pattern, which is how #898's
+            # recorded_sessions() slipped in with its own hand-built root —
+            # a blanket exemption on the file that owns the SSOT is a hole
+            # exactly where the SSOT lives.
+            if path.name == "core.py" and line.strip() == 'return CONFIG_DIR / "sessions"':
+                continue
+            offenders.append(f"{path.relative_to(root.parent)}:{number}: {line.strip()}")
+    assert not offenders, (
+        "hand-built session metadata path — route through core.sessions_dir() / "
+        "core.session_metadata_path() instead:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Both issues in one PR — they don't fight, and #899's structural fix is what one of #893's failures turned out to be.

Closes #893
Closes #899

---

## #893 — the suite mutated real user state

`~/.agentwire/sessions/resumed/metadata.json` had grown to **83** fabricated conversation ids by the time I started (the issue reported 36; my own suite runs today were feeding it). `cwd_at_launch` pointed at a pytest tmp dir, confirming the origin.

### The fix: two levers, because a path gets computed two ways

1. **`$HOME` is redirected per test.** `Path.home()` resolves through `expanduser`, which reads the variable — so this catches everything computed at *call* time, including modules imported later.
2. **A walk over loaded modules** rebinds the ~40 constants across ~25 modules computed at *import* time and already frozen before any fixture runs.

Walking rather than enumerating is deliberate: a hand-written list of forty constants would rot the first time someone adds one, which is precisely how this class of bug recurs. A test asserts the walk missed nothing, so a new constant is caught the moment it appears.

### The part that took a second attempt

My first version still leaked, and the mechanism is worth recording. Much of this codebase imports lazily inside functions (`from agentwire.__main__ import build_agent_command` inside a test helper). The first test to trigger such an import did it **while `$HOME` was already redirected**, so the module computed `CONFIG_DIR = Path.home() / ".agentwire"` against the *fake* home and froze there — permanently, for the whole session, because monkeypatch never patched it and had nothing to restore. Every later test then read a constant belonging to a long-finished test.

`conftest` now imports the whole package up front, before any redirect. There's a regression pin for it; removing the eager import turns it red.

### The backstop is an audit hook, not a filesystem snapshot

I wrote the snapshot version first and it was wrong. A before/after snapshot cannot tell *this process* from the rest of the machine, and on this box `~/.agentwire` is written continuously by the live system. Its very first run flagged `logs/damage-control/<today>.jsonl` — which was **my own shell command in another process**, not the suite. A guard that cries wolf gets switched off, and then it isn't a guard.

`sys.addaudithook` sees only this interpreter, so concurrent activity is invisible, and it fires on the syscall — meaning it names the exact test rather than reporting that *something, somewhere* in the session escaped.

### The escape hatch

Two places must assert on **real** deployment paths, and the redirect would have made them vacuous or wrong:

- role prompts not living in a macOS-GC'd dir (#871's whole point) — the redirect relocates the config dir into exactly such a dir
- control-plane protection of the owner's actual `~/.agentwire` / `~/.claude` files

Both get a `real_agentwire_home` marker. Read-only by intent, and not a hole — the audit backstop still fails the run if an opted-out test writes.

### Audit of the rest of the suite

You asked me to look while I was in there. Two escapes beyond `sessions/`:

- `test_control_plane_protection.py` — 22 cases, real paths resolved at import (marker).
- `test_locking.py` — cached `LOCKS_DIR` via `from ... import`, a **second copy** the redirect cannot rebind. Now reads the module attribute. That is #899's exact shape, in a test file.

The stale `resumed` record is **deleted** (backed up to my scratchpad first). Verified it does not come back after a full run.

---

## #899 — SSOT by declaration only

Four hand-builders, not two — the issue named `load_session_metadata` and `pane_cli.py:762`; the other two were **mine**, added in #894. Fixed all four.

Consolidating only the leaf would have left the **root** built by hand wherever something *enumerates* records rather than addressing one, so `core.sessions_dir()` lands alongside `session_metadata_path()` and everything routes through both. The `@machine` strip now happens in exactly one place.

`agentwire kill`'s unlink moved into a small `_drop_session_metadata` helper so the behaviour is testable rather than buried mid-teardown.

### Pins are behavioural, and each was verified red

Redirect the helper to an unguessable layout; every reader, writer and unlink must follow. A hand-builder keeps addressing the old path and fails.

| mutation | result |
|---|---|
| `load_session_metadata` hand-builds again | **3 red** |
| `kill` unlinks a hand-built path | **1 red** |
| `known_sessions` builds its own root | **1 red** |
| drop the `@machine` strip | **1 red** *(see below)* |

That last one **initially did not bite.** The test used the `redirected` fixture, whose stand-in did its own `split("@")` — so it would have passed even with the strip removed entirely. Vacuous. Rewritten against the real implementation, where it goes red properly. Worth flagging since it's the same fixture-shaped blind spot that makes a green test meaningless.

A structural test also fails on any *new* hand-built copy, since the behavioural ones only cover callers that exist today.

---

## Verification

**3424 passed**, ruff clean, audit backstop silent. `resumed` did not reappear.

## Scope

Did not touch `build_agent_command` or `AGENTWIRE_LAUNCH_CMD` — #901 is being fixed on `epic-871-restart-verb`. Changes to `core.py` are confined to the two path helpers and `load_session_metadata`.

Two notes for that session:

- `core.sessions_dir()` is available if the doctor check wants to enumerate records.
- The lazy-import trap above is worth knowing if you add fixtures that redirect paths: anything imported inside a function freezes its constants at first import, wherever that happens to land.

Built by [dotdev.dev](https://dotdev.dev)