### PR TITLE
fix(sessions): a transcript existing is not enough — dead ids (#901)

### DIFF
--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -400,7 +400,7 @@ def _conversation_flags_shell(conversation_id: str, resume_session_id: str | Non
     ``resumable(id, cwd) == exists(<encoded_cwd>/<id>.jsonl)`` — with the
     encoding mirrored from :data:`history.HISTORY_DIR_SHELL`.
 
-    Three cases, written as precedence (last assignment wins):
+    Four cases, written as precedence (last assignment wins):
 
     1. Nothing on disk → ``--session-id <new>``. First launch stays
        authoritative about the id, which is #871's whole point.
@@ -412,21 +412,47 @@ def _conversation_flags_shell(conversation_id: str, resume_session_id: str | Non
        *old* is gone by then, this falls back to case 1 rather than dying on
        "No conversation found" — degrade to a fresh conversation with the
        role intact, never to a bare shell.
+    4. A DEAD id → no conversation flag at all.
+
+    Case 4 is why the check is not a bare ``[ -f ]``. A transcript existing is
+    not enough, measured on real Claude Code 2.1.222: moving a running
+    session's history dir away leaves a 5-line metadata stub at the new key
+    (``last-prompt``/``ai-title``/``mode``/…) while the conversation stays
+    under the old one. On that file ``--resume`` answers "No conversation
+    found" AND ``--session-id`` still answers "already in use" — neither flag
+    will take it. Passing either would be a bare shell, so the line launches
+    with no conversation flag: claude mints its own id, the agent comes up
+    WITH ITS ROLE, and the record is merely stale (``doctor`` reports it as a
+    live session whose recorded conversation has no history). A stale record
+    beats a stranded session. ``history.holds_a_conversation`` is the Python
+    twin of this ``grep``.
     """
     hist = f"{_SID_VAR}_dir"
+    have = f"{_SID_VAR}_have"
     lines = [
         f"{hist}={HISTORY_DIR_SHELL}",
+        # A transcript EXISTING is not enough — see the note above.
+        f"""{have}() {{ [ -f "${hist}/$1.jsonl" ] && grep -q '"type":"user"' "${hist}/$1.jsonl"; }}""",
         f'{_SID_VAR}=(--session-id "{conversation_id}")',
     ]
     if resume_session_id:
         lines.append(
-            f'[ -f "${hist}/{resume_session_id}.jsonl" ] && '
+            f'{have} {resume_session_id} && '
             f'{_SID_VAR}=(--resume "{resume_session_id}" --fork-session '
             f'--session-id "{conversation_id}")'
         )
     lines.append(
-        f'[ -f "${hist}/{conversation_id}.jsonl" ] && '
+        f'{have} {conversation_id} && '
         f'{_SID_VAR}=(--resume "{conversation_id}")'
+    )
+    # Dead id: the file is there but holds no turn, so NEITHER flag will take
+    # it. Launch with no conversation flag at all rather than with one claude
+    # refuses — the agent comes up with its role and mints its own id, which
+    # `doctor` then reports as a session whose recorded conversation has no
+    # history. A stale record beats a bare shell.
+    lines.append(
+        f'[ -f "${hist}/{conversation_id}.jsonl" ] && ! {have} {conversation_id} && '
+        f'{_SID_VAR}=()'
     )
     return "; ".join(lines)
 

--- a/docs/wiki/sessions/conversation-identity.md
+++ b/docs/wiki/sessions/conversation-identity.md
@@ -53,9 +53,28 @@ predicate everything else uses (`resumable(id, cwd) == exists(<encoded_cwd>/<id>
 | on disk | flags |
 |---|---|
 | no transcript | `--session-id <new>` — first launch stays authoritative |
-| `<new>` exists | `--resume <new>` — re-entry continues the conversation |
-| explicit resume, `<old>` exists, `<new>` doesn't | `--resume <old> --fork-session --session-id <new>` |
+| `<new>` holds a conversation | `--resume <new>` — re-entry continues it |
+| explicit resume, `<old>` holds one, `<new>` doesn't | `--resume <old> --fork-session --session-id <new>` |
 | explicit resume, `<old>` gone too | `--session-id <new>` — fresh, role intact, never a bare shell |
+| a DEAD id (see below) | no conversation flag at all |
+
+**"The file exists" is not the predicate; "the file holds a turn" is.** Moving
+a running session's history directory away leaves a 5-line metadata stub at the
+new key — `last-prompt`, `ai-title`, `mode`, `permission-mode`,
+`file-history-snapshot` — while the conversation stays under the old one. The
+two flags disagree about that file, measured on Claude Code 2.1.222:
+
+```
+claude --resume <id>      ->  No conversation found with session ID: <id>
+claude --session-id <id>  ->  Error: Session ID <id> is already in use.
+```
+
+Neither will take it, so an `[ -f ]` check would have picked one refusal or the
+other and left a bare shell either way. The line launches with **no**
+conversation flag instead: claude mints its own id and the agent comes up *with
+its role*, leaving only the record stale — which `doctor` then reports as a live
+session whose recorded conversation has no history. `history.holds_a_conversation`
+is the Python twin of that `grep`.
 
 `core._conversation_flags_shell` writes that prelude; the cwd encoding is
 mirrored from `history.HISTORY_DIR_SHELL`, which is the shell twin of

--- a/tests/unit/test_launch_line_reentry.py
+++ b/tests/unit/test_launch_line_reentry.py
@@ -12,9 +12,11 @@ point: a single-launch test cannot see this bug, which is exactly why a green
 suite shipped it. ``claude`` is stubbed — by a stub that reproduces the two
 flag behaviours as MEASURED, not as assumed:
 
-- ``--session-id <id>`` refuses when ``<id>.jsonl`` already exists under the
+- ``--session-id <id>`` refuses when ``<id>.jsonl`` already EXISTS under the
   cwd's history key ("Session ID <id> is already in use.")
-- ``--resume <id>`` refuses when it does not.
+- ``--resume <id>`` refuses unless that file holds an actual TURN ("No
+  conversation found with session ID"). The two flags disagree on a
+  metadata-only stub, which is what makes such an id dead to both.
 - the transcript is written on the first turn, keyed by the PHYSICAL cwd.
 """
 
@@ -41,6 +43,13 @@ from agentwire.roles import RoleConfig
 # flags travel in an array); bash covers the Linux side and CI.
 SHELLS = [s for s in ("zsh", "bash") if shutil.which(s)]
 
+#: What makes a transcript a conversation rather than a metadata stub.
+TURN = '{"type":"user","message":{"role":"user"}}\n'
+#: The 5-line file a restart of a MOVED session leaves at the new key. Neither
+#: flag will take an id in this state — see TestDeadIds.
+STUB = ('{"type":"last-prompt"}\n{"type":"ai-title"}\n'
+        '{"type":"mode","mode":"normal"}\n')
+
 STUB_CLAUDE = '''#!/usr/bin/env python3
 """Stand-in for `claude`, reproducing the measured behaviour of the two
 conversation flags. Logs every invocation so the test can assert on which
@@ -65,13 +74,29 @@ sid, resume = flag("--session-id"), flag("--resume")
 with open(os.path.join(os.environ["HOME"], "invocations.jsonl"), "a") as fh:
     fh.write(json.dumps({"argv": args, "cwd": os.getcwd()}) + "\\n")
 
-if sid and os.path.exists(os.path.join(hist, sid + ".jsonl")):
+
+def transcript(cid):
+    return os.path.join(hist, cid + ".jsonl")
+
+
+def has_turns(cid):
+    """--resume needs an actual turn; --session-id only needs the file. The
+    two flags disagreeing is what makes a metadata stub a DEAD id."""
+    try:
+        with open(transcript(cid)) as fh:
+            return any('"type":"user"' in line for line in fh)
+    except IOError:
+        return False
+
+
+if sid and os.path.exists(transcript(sid)):
     sys.exit("Error: Session ID %s is already in use." % sid)
-if resume and not os.path.exists(os.path.join(hist, resume + ".jsonl")):
+if resume and not has_turns(resume):
     sys.exit("No conversation found with session ID %s" % resume)
 
 os.makedirs(hist, exist_ok=True)                  # the first turn writes it
-open(os.path.join(hist, (sid or resume) + ".jsonl"), "a").close()
+with open(transcript(sid or resume or "self-minted"), "a") as fh:
+    fh.write('{"type":"user","message":{"role":"user"}}\\n')
 '''
 
 
@@ -197,7 +222,7 @@ class TestReEntry:
         cid = agent.conversation_id
         hist = sandbox.home / ".claude" / "projects"
         (hist / _key(sandbox.work)).mkdir(parents=True, exist_ok=True)
-        (hist / _key(sandbox.work) / "old-conversation.jsonl").touch()
+        (hist / _key(sandbox.work) / "old-conversation.jsonl").write_text(TURN)
 
         launch(sandbox, shell, agent)
         launch(sandbox, shell, agent)
@@ -274,3 +299,57 @@ class TestGeneratedLine:
         from agentwire.history import HISTORY_DIR_SHELL
 
         assert HISTORY_DIR_SHELL in build_agent_command("bypass").command
+
+
+@pytest.mark.parametrize("shell", SHELLS)
+class TestDeadIds:
+    """A transcript that exists but holds no turn is dead to BOTH flags.
+
+    Measured on real Claude Code 2.1.222, in the state a restart of a moved
+    session leaves behind — a metadata stub at the new key while the
+    conversation stays under the old one:
+
+        claude --resume <id>      -> "No conversation found with session ID"
+        claude --session-id <id>  -> "Session ID <id> is already in use."
+
+    So an `[ -f ]` check is not enough: whichever flag the line picked, claude
+    would refuse to start and the pane would sit at a bare shell — #901 again,
+    reached by a different route.
+    """
+
+    def test_a_stub_launches_with_no_conversation_flag(self, sandbox, shell):
+        agent = build_agent_command("bypass")
+        d = sandbox.home / ".claude" / "projects" / _key(sandbox.work)
+        d.mkdir(parents=True)
+        (d / f"{agent.conversation_id}.jsonl").write_text(STUB)
+
+        result = launch(sandbox, shell, agent)
+
+        assert result.returncode == 0, result.stderr
+        assert conversation_flags(invocations(sandbox)[0]) == []
+
+    def test_the_role_still_survives_a_dead_id(self, sandbox, shell):
+        """The degradation is the RECORD going stale, never the role."""
+        role = RoleConfig(name="worker", instructions="ROLE-MARKER")
+        agent = build_agent_command("bypass", [role])
+        d = sandbox.home / ".claude" / "projects" / _key(sandbox.work)
+        d.mkdir(parents=True)
+        (d / f"{agent.conversation_id}.jsonl").write_text(STUB)
+
+        launch(sandbox, shell, agent)
+
+        assert "ROLE-MARKER" in invocations(sandbox)[0]["argv"]
+
+    def test_a_stub_for_the_resume_target_does_not_break_the_launch(self, sandbox, shell):
+        """`restart` degrades to fresh rather than resuming a dead id."""
+        agent = build_agent_command("bypass", resume_session_id="stubbed-old")
+        d = sandbox.home / ".claude" / "projects" / _key(sandbox.work)
+        d.mkdir(parents=True)
+        (d / "stubbed-old.jsonl").write_text(STUB)
+
+        result = launch(sandbox, shell, agent)
+
+        assert result.returncode == 0, result.stderr
+        assert conversation_flags(invocations(sandbox)[0]) == [
+            "--session-id", agent.conversation_id,
+        ]


### PR DESCRIPTION
Follow-up to #908 (merged), from a state I hit while verifying #898 against a real session. Same bug class, reached by a different route.

## What #908 missed

Moving a running session's history directory away leaves a **5-line metadata stub** at the new key — `last-prompt`, `ai-title`, `mode`, `permission-mode`, `file-history-snapshot` — while the conversation stays under the old one. The two flags disagree about that file. Measured on Claude Code 2.1.222, on the real artifact:

```
claude --resume <id>      ->  No conversation found with session ID: <id>
claude --session-id <id>  ->  Error: Session ID <id> is already in use.
```

**Neither flag will take it.** #908's `[ -f ]` check would have picked one refusal or the other and left a bare shell either way — which is #901 all over again.

## The fix

Two parts:

1. The check requires an actual turn (`grep -q '"type":"user"'`), not just the file. So a stub no longer masquerades as a resumable conversation.
2. A fourth branch: a **dead id launches with no conversation flag at all**. claude mints its own id, the agent comes up **with its role**, and the only damage is a stale record — which `doctor` reports as a live session whose recorded conversation has no history (that check is #898). A stale record beats a stranded session.

| on disk | flags |
|---|---|
| no transcript | `--session-id <new>` |
| `<new>` holds a conversation | `--resume <new>` |
| explicit resume, `<old>` holds one | `--resume <old> --fork-session --session-id <new>` |
| explicit resume, `<old>` gone | `--session-id <new>` |
| **dead id** | *(none)* |

## Verification

Against the real on-disk state that produced the finding — a directory holding one stub and one real transcript — the prelude picks `[]` for the stub, `--resume` for the real transcript, and `--session-id` for an unknown id.

Three new tests cover the dead-id branch, including that the **role survives it** (the degradation must never be #881's silent role loss), and the empty-array expansion is checked in both zsh and bash — `"${a[@]}"` on an empty array is zero words in both, including bash 3.2 as shipped on macOS.

74 tests in the touched files pass, ruff clean.

Refs #901
