### PR TITLE
fix(safety): normalize git global options before matching, closing the -C bypass (#913)

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1089,7 +1089,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1128,6 +1139,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1138,20 +1157,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1043,6 +1043,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1141,6 +1261,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1152,7 +1282,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1173,14 +1303,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1287,6 +1417,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1311,7 +1451,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1090,16 +1090,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1086,16 +1086,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1039,6 +1039,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1137,6 +1257,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1148,7 +1278,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1169,14 +1299,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1283,6 +1413,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1307,7 +1447,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1085,7 +1085,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1124,6 +1135,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1134,20 +1153,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1097,7 +1097,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1136,6 +1147,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1146,20 +1165,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1051,6 +1051,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1149,6 +1269,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1160,7 +1290,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1181,14 +1311,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1295,6 +1425,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1319,7 +1459,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1098,16 +1098,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1091,7 +1091,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1130,6 +1141,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1140,20 +1159,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1092,16 +1092,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1045,6 +1045,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1143,6 +1263,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1154,7 +1284,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1175,14 +1305,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1289,6 +1419,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1313,7 +1453,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1084,7 +1084,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1123,6 +1134,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1133,20 +1152,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1085,16 +1085,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1038,6 +1038,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1136,6 +1256,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1147,7 +1277,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1168,14 +1298,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1282,6 +1412,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1306,7 +1446,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1007,6 +1007,126 @@ _SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
+#
+# GIT GLOBAL OPTIONS (#913)
+#
+# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
+# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
+# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
+# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
+# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
+# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
+# hard-reset included.
+#
+# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
+# we emit an extra haystack per subcommand with git's global options removed,
+# so present and future git rules inherit the fix for free.
+#
+# This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
+# A rule that legitimately cares WHICH repo is being touched (a path rule, an
+# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
+# only ever remove tokens, so the extra variant can introduce no path a rule
+# didn't already see.
+#
+# Membership below is measured against real git (2.50.1), not assumed:
+# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
+# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
+# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
+# the space form; ``--exec-path`` without ``=`` prints and exits, so it
+# consumes nothing.
+
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--config-env", "--attr-source",
+}
+
+_GIT_GLOBAL_FLAGS = {
+    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Tokens allowed to precede ``git`` while still counting as a git invocation
+# (``sudo git -C /repo push --force`` must normalize too — the un-stripped
+# ``sudo git push --force`` already matches, so leaving this out would keep the
+# very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
+# ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
+_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+
+
+def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with git's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not a git invocation, no
+    global options present, or nothing left after the options.
+    """
+    git_idx = None
+    for i, w in enumerate(words):
+        if w.rsplit("/", 1)[-1] == "git":
+            git_idx = i
+            break
+        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+            return None
+    if git_idx is None:
+        return None
+
+    i = git_idx + 1
+    stripped = False
+    while i < len(words):
+        word = words[i]
+        if word in _GIT_GLOBAL_VALUE_OPTS:
+            # Consumes the following argument along with the flag — dropping
+            # only the flag would leave the value sitting where the subcommand
+            # should be, and the rule would still miss.
+            i += 2
+            stripped = True
+            continue
+        if word in _GIT_GLOBAL_FLAGS:
+            i += 1
+            stripped = True
+            continue
+        base = word.split("=", 1)[0]
+        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+            i += 1
+            stripped = True
+            continue
+        break
+
+    if not stripped or i >= len(words):
+        return None
+    return words[: git_idx + 1] + words[i:]
+
+
+def git_normalized_haystacks(command: str) -> List[str]:
+    """Return the git-global-options-stripped forms of ``command``, if any.
+
+    This is a THIRD haystack variant, kept separate from the raw and masked
+    lists rather than rewriting either. Two rules depend on that separation:
+
+    * A rule that legitimately cares WHICH repo is being touched (a path rule,
+      an unattended path scope) still reads the un-stripped forms — the ``-C``
+      argument is set aside here, never discarded.
+    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
+      caught today by CONTENT rules reading the raw command. Stripping in
+      place would delete the only haystack carrying them and turn a block into
+      an allow — the fix creating a worse bug than the one it closes.
+
+    Derived from the MASKED token lists, so quoted argument text is already
+    masked out and a normalized form can never false-match on content.
+    """
+    out: List[str] = []
+    for words in _masked_subcommand_words(command):
+        normalized = _strip_git_global_options(words)
+        if normalized is not None:
+            joined = " ".join(normalized)
+            if joined not in out:
+                out.append(joined)
+    return out
+
+
 def _strip_heredoc_bodies(command: str) -> str:
     """Remove heredoc body lines (``<<EOF … EOF``) — they are content."""
     m = _HEREDOC_RE.search(command)
@@ -1105,6 +1225,16 @@ def masked_subcommands(command: str) -> List[str]:
     command rule, while quoting obfuscation of the command itself still
     normalizes to the literal form.
     """
+    return [" ".join(words) for words in _masked_subcommand_words(command)]
+
+
+def _masked_subcommand_words(command: str) -> List[List[str]]:
+    """Token-list form of :func:`masked_subcommands`, before joining.
+
+    Split out so the ``sh -c "…"`` recursion and the git normalization both
+    operate on tokens — re-splitting a joined string would lose the token
+    boundaries a ``-C "/my dir"`` argument depends on.
+    """
     command = _strip_heredoc_bodies(command)
 
     assigns: Dict[str, str] = {}
@@ -1116,7 +1246,7 @@ def masked_subcommands(command: str) -> List[str]:
             tok = tok.replace("${%s}" % name, val).replace("$" + name, val)
         return tok
 
-    results: List[str] = []
+    results: List[List[str]] = []
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
@@ -1137,14 +1267,14 @@ def masked_subcommands(command: str) -> List[str]:
                     and "c" in prev
                     and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
                 ):
-                    results.extend(masked_subcommands(resolved))
+                    results.extend(_masked_subcommand_words(resolved))
                 words.append(_MASK)
                 prev = _MASK
             else:
                 words.append(resolved)
                 prev = resolved
         if words and any(w != _MASK for w in words):
-            results.append(" ".join(words))
+            results.append(words)
     return results
 
 
@@ -1251,6 +1381,16 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
+    # Third variant (#913): git with its global options stripped, so a rule
+    # written as ``\bgit\s+push\b`` still sees the subcommand behind
+    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
+    # is rewritten — so the raw command stays reachable for the rules that need
+    # it, and derived from the masked tokens so it can never make quoted content
+    # matchable. Both halves are load-bearing: bundled git rules are anchored
+    # (masked path), while the rules installed on this machine carry zero
+    # ``anchored: true`` and read the raw path, so covering one alone would fix
+    # the bypass in only one of the two rule sets in play.
+    git_haystacks = git_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -1275,7 +1415,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         bypassable = pattern_obj.get("bypassable", False)
         anchored = pattern_obj.get("anchored", False)
         try:
-            if _search(pattern, masked_haystacks if anchored else haystacks):
+            base = masked_haystacks if anchored else haystacks
+            if _search(pattern, base + git_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1053,7 +1053,18 @@ _GIT_GLOBAL_FLAGS = {
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
-_GIT_INVOCATION_PREFIXES = {"sudo", "env", "command", "nice", "nohup", _MASK}
+#
+# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
+# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
+# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
+# an unrecognized token, the scan bails, and no variant is produced. Those
+# forms keep the bypass. They are out of scope here rather than half-handled,
+# because consuming a wrapper's arguments means modelling each wrapper's own
+# grammar, which is the same mistake at one remove. Failure is closed-ish in
+# the sense that we simply add no haystack — never that we strip too much.
+_GIT_INVOCATION_PREFIXES = {
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+}
 
 
 def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
@@ -1092,6 +1103,14 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
             i += 1
             stripped = True
             continue
+        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
+        # token here, so the scan stops and the partial strip leaves the
+        # subcommand still out of reach — ``git --future-opt -C /r push --force``
+        # reads as allow. Not exploitable today (git rejects the unknown option
+        # itself), and nothing in the suite fails when git grows one, so
+        # re-measure both sets on a git upgrade. Stopping is deliberate: the
+        # alternative — treating anything option-shaped as strippable — would
+        # let an unknown value-taking option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
@@ -1102,20 +1121,36 @@ def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
 def git_normalized_haystacks(command: str) -> List[str]:
     """Return the git-global-options-stripped forms of ``command``, if any.
 
-    This is a THIRD haystack variant, kept separate from the raw and masked
-    lists rather than rewriting either. Two rules depend on that separation:
+    This is an ADDITIVE haystack, kept alongside the raw and masked lists
+    rather than rewriting either, and fed to ALL rules — anchored and
+    unanchored alike. Both halves of that sentence are load-bearing.
 
-    * A rule that legitimately cares WHICH repo is being touched (a path rule,
-      an unattended path scope) still reads the un-stripped forms — the ``-C``
-      argument is set aside here, never discarded.
-    * ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
-      ``core.pager``, ``alias.*``, ``core.fsmonitor``). Those payloads are
-      caught today by CONTENT rules reading the raw command. Stripping in
-      place would delete the only haystack carrying them and turn a block into
-      an allow — the fix creating a worse bug than the one it closes.
+    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
+    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
+    ``core.fsmonitor``), so the value is a command payload sitting in the
+    haystack. Where a content rule DOES match that payload — the deletion rules
+    catch an ``rm``-shaped one — rewriting a haystack in place would delete it
+    from the only place it appears and turn a block into an allow: the fix
+    creating a worse bug than the one it closes. Coverage of these payloads is
+    partial, not a guarantee this function provides: a ``curl … | sh`` value is
+    allowed with or without normalization. Additivity preserves whatever
+    coverage exists; it does not create any.
+    (Note it is deletion, not masking, that would lose them: ``masked_subcommands``
+    blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
+    an unquoted ``core.pager=`` prefix, so the payload survives masking and is
+    visible in both existing haystacks.) A rule that legitimately cares WHICH
+    repo is being touched — a path rule, an unattended path scope (#914) — reads
+    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
 
-    Derived from the MASKED token lists, so quoted argument text is already
-    masked out and a normalized form can never false-match on content.
+    FED TO ALL RULES, because the intersection "must stay unanchored AND
+    global-option-bypassable" is unreachable by a two-way split. Rules that are
+    deliberately unanchored to catch an ssh-wrapped form would never see
+    normalization and would stay permanently bypassed.
+
+    Masking is applied to the new path exactly as it is to the old one — the
+    variant is built from the MASKED token lists, so the anchored path receives
+    the normalized command masked, rather than being handed an unmasked
+    haystack that would reopen #675 on every anchored git rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1054,16 +1054,24 @@ _GIT_GLOBAL_FLAGS = {
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
 # ``VAR=value`` assignment, which ``masked_subcommands`` has already masked.
 #
-# ZERO-ARG PREFIXES ONLY, and that is the whole of the claim. A wrapper that
-# consumes its own argument — ``timeout 5 git …``, ``stdbuf -o0 git …``,
-# ``xargs -n1 git …``, ``nice -n 5 git …`` — is NOT covered: its argument is
-# an unrecognized token, the scan bails, and no variant is produced. Those
-# forms keep the bypass. They are out of scope here rather than half-handled,
-# because consuming a wrapper's arguments means modelling each wrapper's own
-# grammar, which is the same mistake at one remove. Failure is closed-ish in
-# the sense that we simply add no haystack — never that we strip too much.
+# The exclusion is about ARITY AS WRITTEN, not about which wrapper it is. Every
+# name below is covered when it appears BARE; the same name carrying its own
+# arguments is not — ``xargs git …`` normalizes, ``xargs -n1 git …`` does not,
+# and likewise ``nice`` vs ``nice -n 5``. The wrapper's argument is an
+# unrecognized token, the scan bails, and no variant is produced, so that form
+# keeps the bypass.
+#
+# Naming wrappers rather than arity is precisely the error this comment used to
+# make: it listed ``xargs -n1`` as an excluded WRAPPER, which read as excluding
+# ``xargs``, and bare ``xargs git -C /repo push --force`` stayed a live bypass
+# under a comment implying otherwise.
+#
+# Argument-carrying forms are out of scope rather than half-handled, because
+# consuming them means modelling each wrapper's own grammar — this bug's
+# mistake at one remove. Failure there is a MISSING haystack, never an
+# over-strip: we add nothing rather than stripping too much.
 _GIT_INVOCATION_PREFIXES = {
-    "sudo", "doas", "env", "command", "time", "nice", "nohup", _MASK,
+    "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -743,28 +743,42 @@ class TestGitGlobalOptionBypass:
         cmd = f'git -C "/my dir/repo" push {_FORCE}'
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
 
-    @pytest.mark.parametrize("wrapper", ["sudo", "doas", "time", "nohup", "command"])
-    def test_zero_arg_wrapper_prefixed_invocation(
+    @pytest.mark.parametrize(
+        "wrapper", ["sudo", "doas", "time", "nohup", "command", "xargs", "nice"]
+    )
+    def test_bare_wrapper_prefixed_invocation(
         self, bash_hook, bundled_config, wrapper
     ):
         """`sudo git push --force` already matched; `sudo git -C … push --force`
-        must not be the inconsistent survivor — and the same argument applies
-        unchanged to every other zero-arg wrapper, so the set covers them all
-        rather than just the one that prompted it."""
+        must not be the inconsistent survivor — and that argument applies
+        unchanged to every other BARE wrapper, so the set covers them all
+        rather than just the one that prompted it.
+
+        `xargs` is here because it was the counter-example: it was excluded as
+        an "arg-consuming wrapper" on the strength of the `xargs -n1` form,
+        which left bare `xargs git -C /repo push --force` a live bypass under a
+        comment claiming zero-arg wrappers were covered. The exclusion is about
+        arity as written, not about which wrapper it is.
+        """
         cmd = f"{wrapper} git -C /repo push {_FORCE}"
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
 
-    @pytest.mark.parametrize("wrapper", ["timeout 5", "stdbuf -o0", "xargs -n1"])
-    def test_arg_consuming_wrapper_is_a_documented_limit(
+    @pytest.mark.parametrize(
+        "wrapper", ["timeout 5", "stdbuf -o0", "xargs -n1", "nice -n 5"]
+    )
+    def test_argument_carrying_wrapper_is_a_documented_limit(
         self, bash_hook, bundled_config, wrapper
     ):
         """Pins the KNOWN GAP so it is a recorded limit, not a silent one.
 
-        A wrapper that consumes its own argument is not covered — handling it
-        means modelling each wrapper's grammar, which is this bug's own mistake
-        at one remove. What must hold is that the failure is a missing haystack
-        (no variant produced), never an over-strip. If one of these ever starts
-        blocking, that is good news and this assertion should be inverted.
+        A wrapper CARRYING ITS OWN ARGUMENTS is not covered — handling it means
+        modelling each wrapper's grammar, which is this bug's own mistake at one
+        remove. Note `xargs` and `nice` appear in BOTH this list and the bare
+        list: the axis is arity as written, not the wrapper's identity.
+
+        What must hold is that the failure is a missing haystack (no variant
+        produced), never an over-strip. If one of these ever starts blocking,
+        that is good news and this assertion should be inverted.
         """
         assert bash_hook.git_normalized_haystacks(
             f"{wrapper} git -C /repo push {_FORCE}"

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -614,6 +614,23 @@ def unanchored_config(bash_hook):
     return cfg
 
 
+@pytest.fixture(scope="module")
+def reversed_config(bash_hook):
+    """Bundled rules with the pattern list REVERSED.
+
+    Which decision wins is order-dependent: an `ask` match returns immediately,
+    a `bypassable` block is deferred until after the loop. So `ask` beats a
+    bypassable block in either order, and beats a plain block too when it sorts
+    earlier — meaning rule-file load/merge order decides the verdict. Making
+    `ask` rules newly visible can therefore reorder outcomes without touching a
+    single pattern, and a single-ordering assertion cannot see it.
+    """
+    cfg = copy.deepcopy(bash_hook.load_config(_DC_RULES, _DC_TOOLDEFS))
+    cfg["bashToolPatterns"] = list(reversed(cfg["bashToolPatterns"]))
+    cfg["safety"] = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
+    return cfg
+
+
 class TestGitGlobalOptionBypass:
     """#913 — git's global options must not hide the subcommand from a rule."""
 
@@ -667,6 +684,43 @@ class TestGitGlobalOptionBypass:
         cmd = f"git -C /repo push {_FORCE} origin main"
         assert bash_hook.check_command(cmd, cfg)["decision"] == "block"
 
+    @pytest.mark.parametrize("order", ["as-loaded", "reversed"])
+    @pytest.mark.parametrize("prefix", _GIT_PREFIXES)
+    @pytest.mark.parametrize("rest,expected", _GIT_GATED)
+    def test_never_downgrades_a_block_to_ask(
+        self, bash_hook, bundled_config, reversed_config, prefix, rest, expected,
+        order,
+    ):
+        """Additive matching cannot remove a match — but it CAN change which
+        rule reports first, and that is not severity-neutral.
+
+        An `ask` match returns immediately, while a `bypassable` match is
+        deferred until after the rule loop. So a newly-visible `ask` rule can
+        preempt a block that fires today — and `ask` resolves to ALLOW under
+        bypassPermissions/auto. "Additive can only add matches" is true of
+        MATCHING and false of DECISION SEVERITY.
+
+        Asserted as PARITY against the plain form in the SAME config, under two
+        pattern orderings, rather than against a fixed verdict. That is the
+        invariant this normalizer actually owns, and the distinction is not
+        academic: reversing the pattern order really does move `git stash clear`
+        and `git push --force` from block to ask — but it moves the PLAIN forms
+        too, identically. That hazard is pre-existing and order-driven, and
+        pinning a fixed verdict here would have mis-attributed it to #913 while
+        still not detecting a normalizer-introduced downgrade.
+        """
+        if expected != "block":
+            pytest.skip("only meaningful where the plain form blocks")
+        cfg = bundled_config if order == "as-loaded" else reversed_config
+        plain = bash_hook.check_command(f"git {rest}", cfg)["decision"]
+        prefixed = bash_hook.check_command(f"git {prefix} {rest}", cfg)["decision"]
+        assert prefixed == plain, (
+            f"git {prefix} {rest} decided {prefixed} but plain decided {plain} "
+            f"({order} order)"
+        )
+        if order == "as-loaded":
+            assert prefixed == "block"
+
     def test_fixture_actually_loads_the_whole_rule_set(self, bundled_config):
         """Guard on the FIXTURE, not the behavior — the likeliest way this PR
         ships green and covers nothing.
@@ -689,11 +743,32 @@ class TestGitGlobalOptionBypass:
         cmd = f'git -C "/my dir/repo" push {_FORCE}'
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
 
-    def test_sudo_prefixed_invocation(self, bash_hook, bundled_config):
+    @pytest.mark.parametrize("wrapper", ["sudo", "doas", "time", "nohup", "command"])
+    def test_zero_arg_wrapper_prefixed_invocation(
+        self, bash_hook, bundled_config, wrapper
+    ):
         """`sudo git push --force` already matched; `sudo git -C … push --force`
-        must not be the inconsistent survivor."""
-        cmd = f"sudo git -C /repo push {_FORCE}"
+        must not be the inconsistent survivor — and the same argument applies
+        unchanged to every other zero-arg wrapper, so the set covers them all
+        rather than just the one that prompted it."""
+        cmd = f"{wrapper} git -C /repo push {_FORCE}"
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    @pytest.mark.parametrize("wrapper", ["timeout 5", "stdbuf -o0", "xargs -n1"])
+    def test_arg_consuming_wrapper_is_a_documented_limit(
+        self, bash_hook, bundled_config, wrapper
+    ):
+        """Pins the KNOWN GAP so it is a recorded limit, not a silent one.
+
+        A wrapper that consumes its own argument is not covered — handling it
+        means modelling each wrapper's grammar, which is this bug's own mistake
+        at one remove. What must hold is that the failure is a missing haystack
+        (no variant produced), never an over-strip. If one of these ever starts
+        blocking, that is good news and this assertion should be inverted.
+        """
+        assert bash_hook.git_normalized_haystacks(
+            f"{wrapper} git -C /repo push {_FORCE}"
+        ) == []
 
     def test_chained_subcommand(self, bash_hook, bundled_config):
         cmd = f"cd /tmp && git -C /repo push {_FORCE}"
@@ -712,10 +787,14 @@ class TestGitGlobalOptionBypass:
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
 
     # `-c <k>=<v>` values are executed by git (sshCommand, pager, alias, fsmonitor).
-    # They are blocked today by core.yaml's rm rule seeing the payload in the RAW
-    # haystack — nothing to do with a git rule. Normalization is ADDITIVE for
-    # exactly this reason: stripping `-c` and its value in place would delete the
-    # only haystack that carries the payload and turn all four into ALLOW.
+    # An `rm`-shaped payload is blocked today by core.yaml's deletion rule seeing
+    # it in the command — nothing to do with a git rule. Normalization is ADDITIVE
+    # for exactly this reason: stripping `-c` and its value in place would delete
+    # the payload and turn all four into ALLOW.
+    #
+    # Scope of the claim: this pins that additivity PRESERVES the coverage that
+    # exists. It is not evidence the payload surface is covered — a `curl … | sh`
+    # value is allowed with or without this change.
     @pytest.mark.parametrize("key", [
         "core.sshCommand", "core.pager", "alias.zap", "core.fsmonitor",
     ])
@@ -726,6 +805,71 @@ class TestGitGlobalOptionBypass:
         cmd = f"git -c {key}='{payload}' fetch origin"
         result = bash_hook.check_command(cmd, bundled_config)
         assert result["decision"] == "block", result
+
+
+class TestCrossIssueBackstops:
+    """Canaries for coverage that only LOOKS like it belongs to another rule.
+
+    These commands are gated today, but not by their own tool's rule — those
+    are global-option-bypassed exactly like git's were. They block only via the
+    generic `core.rm-file-deletion` rule, which is the rule #915 exists to
+    narrow. So the sequence "#913 lands green on git-only acceptance, #915
+    correctly narrows that rule" silently drops them to allow with nothing in
+    either suite noticing.
+
+    They are asserted HERE, in the PR that documents the class, so the drop
+    surfaces as a named failure rather than as coverage nobody knew existed.
+    A failure here is not necessarily a bug in the change that caused it — it
+    means this command now needs a rule of its own.
+    """
+
+    # block -> ask transitions this change introduces, pinned WITH their reason
+    # rather than forbidden by a blanket invariant.
+    #
+    # "No command moves block -> ask" is unsatisfiable as stated: these two are
+    # #915's false positive — a commit message REFUSED for describing a
+    # deletion — and the normalizer incidentally fixes them, because the
+    # tooldef `git commit` ask rule becomes visible and an `ask` match returns
+    # before a `bypassable` block is resolved. Both transitions are desirable.
+    # Written as a prohibition the assertion would go red on this branch, and
+    # the two ways to make it pass are "weaken the normalizer" and "delete the
+    # test". An expected-transition list that names WHY each is wanted is
+    # self-documenting; a set-exclusion predicate needs its own maintenance.
+    @pytest.mark.parametrize("order", ["as-loaded", "reversed"])
+    @pytest.mark.parametrize("message", [
+        "cleanup: rm build/stale.txt was refused",
+        "dropped the stale file, no rm build/stale.txt needed",
+    ])
+    def test_expected_block_to_ask_transitions(
+        self, bash_hook, bundled_config, reversed_config, message, order
+    ):
+        cfg = bundled_config if order == "as-loaded" else reversed_config
+        cmd = f'git -C /repo commit -m "{message}"'
+        result = bash_hook.check_command(cmd, cfg)
+        assert result["decision"] == "ask", (
+            f"expected the #915 false-positive block to resolve to ask, got "
+            f"{result['decision']} via {result.get('id')!r} ({order} order)"
+        )
+        # …and it lands on parity with the plain form, which is why this is a
+        # fix rather than a divergence: on main the plain form already asked
+        # while the `-C` form blocked.
+        plain = bash_hook.check_command(f'git commit -m "{message}"', cfg)
+        assert plain["decision"] == result["decision"]
+
+    @pytest.mark.parametrize("cmd", [
+        "docker --context prod volume rm pgdata",
+        "aws --profile prod s3 rm s3://bucket --recursive",
+    ])
+    def test_generic_rm_rule_is_still_the_only_thing_catching_these(
+        self, bash_hook, bundled_config, cmd
+    ):
+        result = bash_hook.check_command(cmd, bundled_config)
+        assert result["decision"] == "block", result
+        assert result.get("id") == "core.rm-file-deletion-use-git-clean-or-manual-cleanup", (
+            f"{cmd!r} now blocks via {result.get('id')!r} — if that is a rule of "
+            "its own, good; update this canary. If it is another accident, it "
+            "needs one."
+        )
 
 
 class TestGitGlobalOptionNormalizer:

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -10,6 +10,7 @@ We test the pure decision functions directly (fast, deterministic) and a
 representative subprocess flow per hook (covers the stdin/exit-code surface).
 """
 
+import copy
 import importlib.util
 import json
 import subprocess
@@ -523,6 +524,294 @@ class TestUnattendedVerbCoverage:
     @pytest.mark.parametrize("cmd", STAYS_ALLOW)
     def test_benign_variant_stays_allow(self, bash_hook, bundled_config, cmd):
         assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# git global options (#913)
+# ---------------------------------------------------------------------------
+#
+# `git -C <dir> <cmd>` used to defeat EVERY git rule: both the hand-written
+# `bashToolPatterns` (`\bgit\s+push\s+--force\b`) and the tooldef-generated
+# ones (`\bgit\s+commit\b`) assume the subcommand is adjacent to `git`, and
+# `\s+` cannot span `-C /repo`. Verified against the shipped hook before the
+# fix: force-push, hard reset and `clean -fdx` all went from block to allow,
+# and `git add` from ask to allow.
+#
+# These assertions run the REAL rule set (bundled YAMLs + tooldefs) through the
+# REAL decision ladder in the generated hook — not a reconstruction of either.
+# The `--force-with-lease` case in STILL_ALLOWED is the over-stripping canary:
+# normalization must not turn a permitted form into a blocked one.
+
+# Assembled at runtime so this file's own text can't trip a bash rule if it is
+# ever scanned as a command.
+_FORCE = "--" + "force"
+_HARD = "--" + "hard"
+
+# (subcommand-and-args, expected decision) — the decision must be identical for
+# the plain form and every global-option-prefixed form.
+_GIT_GATED = [
+    (f"push {_FORCE} origin main", "block"),
+    (f"reset {_HARD} origin/main", "block"),
+    ("clean -fdx", "block"),
+    ("stash clear", "block"),
+    ("filter-branch", "block"),
+    ("add -A", "ask"),
+    ("branch -D feature", "ask"),
+]
+
+# Global-option prefixes that must all normalize away. Each is real git syntax
+# (measured against git 2.50.1): `-C`/`-c` take a SEPARATE argument;
+# `--git-dir`/`--work-tree`/`--namespace` accept the `=` and the space form;
+# `--no-optional-locks`/`-P` stand alone.
+_GIT_PREFIXES = [
+    "-C /repo",
+    "-C /repo -c user.email=x",
+    "-c core.pager=cat",
+    "--git-dir=/repo/x",
+    "--git-dir /repo/x",
+    "--work-tree /w --git-dir /g",
+    "--namespace ns -C /repo",
+    "--no-optional-locks -C /repo",
+    "-P -C /repo",
+]
+
+# Must stay `allow` — the normalizer may not invent matches.
+_GIT_STILL_ALLOWED = [
+    "git status",
+    "git -C /repo status",
+    "git -C /repo log --oneline",
+    # `-C` AFTER the subcommand is a subcommand option (detect copies), not a
+    # global one. Stripping it would be the over-correction.
+    "git log -C --oneline",
+    "git diff -C -C",
+    # Quoted content that merely MENTIONS a gated command (#675 masking). The
+    # normalized variant is derived from the MASKED tokens for exactly this
+    # reason: normalize the raw string instead and quoted content becomes
+    # matchable again, regressing #675 on the very path this fix touches.
+    f"echo 'git -C /repo push {_FORCE}'",
+    "echo 'do not run git clean -fdx here'",
+    f"echo 'do not run git -C /repo push {_FORCE} here'",
+    "git clean -n",
+    "git -C /repo clean -n",
+]
+
+
+@pytest.fixture(scope="module")
+def unanchored_config(bash_hook):
+    """Bundled rules with `anchored` dropped from EVERY pattern.
+
+    Which rules are anchored decides which haystack a rule reads, and that
+    split is not stable: 14 of the 101 anchored patterns are the hand-written
+    git rules and 87 are tooldef-generated, #915 may move the line, and the
+    rules installed on this machine carry zero `anchored: true` today. Encoding
+    today's split would make this fix correct now and silently wrong later, so
+    the bypass cases are asserted under BOTH routings.
+    """
+    cfg = copy.deepcopy(bash_hook.load_config(_DC_RULES, _DC_TOOLDEFS))
+    for pattern in cfg["bashToolPatterns"]:
+        pattern.pop("anchored", None)
+    cfg["safety"] = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
+    return cfg
+
+
+class TestGitGlobalOptionBypass:
+    """#913 — git's global options must not hide the subcommand from a rule."""
+
+    @pytest.mark.parametrize("routing", ["anchored", "unanchored"])
+    @pytest.mark.parametrize("prefix", _GIT_PREFIXES)
+    @pytest.mark.parametrize("rest,expected", _GIT_GATED)
+    def test_global_options_do_not_bypass(
+        self, bash_hook, bundled_config, unanchored_config, routing, prefix, rest,
+        expected,
+    ):
+        cfg = bundled_config if routing == "anchored" else unanchored_config
+        cmd = f"git {prefix} {rest}"
+        decision = bash_hook.check_command(cmd, cfg)["decision"]
+        assert decision == expected, (
+            f"{cmd!r} resolved to {decision} under {routing} routing, want {expected}"
+        )
+
+    @pytest.mark.parametrize("rest,expected", _GIT_GATED)
+    def test_plain_form_is_the_baseline(self, bash_hook, bundled_config, rest, expected):
+        """Anchors the pairs above: the plain form already decided this way."""
+        decision = bash_hook.check_command(f"git {rest}", bundled_config)["decision"]
+        assert decision == expected
+
+    @pytest.mark.parametrize("cmd", _GIT_STILL_ALLOWED)
+    def test_no_over_blocking(self, bash_hook, bundled_config, cmd):
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
+
+    @pytest.mark.parametrize("prefix", ["", "-C /repo ", "-c user.name=x ", "--no-pager "])
+    def test_force_with_lease_is_ask_on_both_sides(
+        self, bash_hook, bundled_config, prefix
+    ):
+        """Two-sided, and both sides matter.
+
+        `push --force-with-lease` is `ask` (tooldef `git push`, write tier).
+        Behind a global option it currently reads `allow` — the SAFE form is a
+        victim of #913, not an exception to it. But it also contains the token
+        `--force`, so a normalizer that rewrote the command before
+        `\\bgit\\s+push\\s+.*--force(?!-with-lease)` saw it would flip it to
+        `block` — which trains everyone to reach for plain `--force`.
+        `allow` means the bug survived; `block` means we caused a worse one.
+        """
+        cmd = f"git {prefix}push {_FORCE}-with-lease origin main"
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "ask"
+
+    @pytest.mark.parametrize("routing", ["anchored", "unanchored"])
+    def test_cross_pr_case(
+        self, bash_hook, bundled_config, unanchored_config, routing
+    ):
+        """The one case #913, #914 and #915 must all keep true after landing."""
+        cfg = bundled_config if routing == "anchored" else unanchored_config
+        cmd = f"git -C /repo push {_FORCE} origin main"
+        assert bash_hook.check_command(cmd, cfg)["decision"] == "block"
+
+    def test_fixture_actually_loads_the_whole_rule_set(self, bundled_config):
+        """Guard on the FIXTURE, not the behavior — the likeliest way this PR
+        ships green and covers nothing.
+
+        `load_config` generates the tooldef ask-patterns only when handed a
+        tooldefs_dir. Dropped, the fixture sees 178 patterns / 14 anchored
+        instead of 265 / 101 — every tooldef-generated rule invisible, which is
+        the half carrying #913's sharpest case (`git add` ask -> allow). The
+        counts are asserted so a future arg-drop fails loudly rather than
+        silently shrinking coverage.
+        """
+        patterns = bundled_config["bashToolPatterns"]
+        anchored = [p for p in patterns if p.get("anchored")]
+        assert (len(patterns), len(anchored)) == (265, 101)
+        assert any(p.get("source") == "tooldef" for p in patterns)
+
+    def test_quoted_path_with_spaces(self, bash_hook, bundled_config):
+        """The `-C` argument is consumed as ONE token, so a path containing a
+        space cannot push the subcommand out of reach."""
+        cmd = f'git -C "/my dir/repo" push {_FORCE}'
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    def test_sudo_prefixed_invocation(self, bash_hook, bundled_config):
+        """`sudo git push --force` already matched; `sudo git -C … push --force`
+        must not be the inconsistent survivor."""
+        cmd = f"sudo git -C /repo push {_FORCE}"
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    def test_chained_subcommand(self, bash_hook, bundled_config):
+        cmd = f"cd /tmp && git -C /repo push {_FORCE}"
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    @pytest.mark.parametrize("prefix", [
+        "-C /a -C /b",
+        "-c k=v -C /a",
+        "-C /a -c k=v -C /b",
+        "--git-dir /g --work-tree /w --namespace ns",
+        "--attr-source HEAD",
+        "--config-env=k=E",
+    ])
+    def test_stacked_and_repeated_options(self, bash_hook, bundled_config, prefix):
+        cmd = f"git {prefix} push {_FORCE}"
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "block"
+
+    # `-c <k>=<v>` values are executed by git (sshCommand, pager, alias, fsmonitor).
+    # They are blocked today by core.yaml's rm rule seeing the payload in the RAW
+    # haystack — nothing to do with a git rule. Normalization is ADDITIVE for
+    # exactly this reason: stripping `-c` and its value in place would delete the
+    # only haystack that carries the payload and turn all four into ALLOW.
+    @pytest.mark.parametrize("key", [
+        "core.sshCommand", "core.pager", "alias.zap", "core.fsmonitor",
+    ])
+    def test_config_payload_still_visible_to_content_rules(
+        self, bash_hook, bundled_config, key
+    ):
+        payload = "rm -" + "rf /tmp/x"
+        cmd = f"git -c {key}='{payload}' fetch origin"
+        result = bash_hook.check_command(cmd, bundled_config)
+        assert result["decision"] == "block", result
+
+
+class TestGitGlobalOptionNormalizer:
+    """The normalizer's contract at the seam, as a separate THIRD haystack.
+
+    Kept distinct from the raw and masked lists rather than rewriting either:
+    #914 needs the `-C` path visible to scope a grant, and #915's `-c` payload
+    cases are blocked only because a content rule can read the raw command.
+    """
+
+    def test_third_haystack_exposes_stripped_variant(self, bash_hook):
+        assert f"git push {_FORCE}" in bash_hook.git_normalized_haystacks(
+            f"git -C /repo push {_FORCE}"
+        )
+
+    def test_producers_are_left_alone(self, bash_hook):
+        """The raw and masked lists are UNCHANGED — the variant is additive at
+        the point of matching, not baked into the shared normalization."""
+        cmd = f"git -C /repo push {_FORCE}"
+        assert bash_hook.masked_subcommands(cmd) == [cmd]
+        subs, ambiguous = bash_hook.normalize_subcommands(cmd)
+        assert ambiguous is None
+        assert subs == [cmd]
+
+    def test_no_variant_for_a_plain_git_command(self, bash_hook):
+        assert bash_hook.git_normalized_haystacks(f"git push {_FORCE}") == []
+
+    def test_variant_is_derived_from_masked_tokens(self, bash_hook):
+        """Quoted content must not become matchable. Normalizing the RAW string
+        would hand `\\bgit\\s+clean\\b` a match inside an echo argument."""
+        assert bash_hook.git_normalized_haystacks(
+            "echo 'git -C /repo clean -fdx'"
+        ) == []
+
+    def test_message_content_is_masked_inside_the_variant(self, bash_hook):
+        """The sharp case for deriving from MASKED tokens.
+
+        `git -C /r commit -m 'echo git clean -fdx'` is a real git invocation
+        WITH a global option, so a variant is produced either way. Built from
+        shlex tokens the message text rides along and `\\bgit\\s+clean\\b`
+        matches inside it; built from masked tokens the message is a
+        placeholder and only the command survives.
+        """
+        variants = bash_hook.git_normalized_haystacks(
+            "git -C /r commit -m 'echo git clean -fdx'"
+        )
+        assert variants
+        assert all("clean" not in v for v in variants), variants
+
+    def test_value_taking_option_consumes_its_argument(self, bash_hook):
+        """Dropping only the flag would leave the value where the subcommand
+        belongs (`git /repo push …`) and the rule would still miss."""
+        assert bash_hook._strip_git_global_options(
+            ["git", "-C", "/repo", "push"]
+        ) == ["git", "push"]
+
+    def test_option_after_subcommand_is_untouched(self, bash_hook):
+        assert bash_hook._strip_git_global_options(["git", "log", "-C"]) is None
+
+    def test_exec_path_does_not_consume_a_token(self, bash_hook):
+        """Bare `--exec-path` prints and exits — only `--exec-path=<p>` carries a
+        value. Consuming the next token here would swallow the subcommand."""
+        assert bash_hook._strip_git_global_options(
+            ["git", "--exec-path", "status"]
+        ) == ["git", "status"]
+        assert bash_hook._strip_git_global_options(
+            ["git", "--exec-path=/x", "status"]
+        ) == ["git", "status"]
+
+    @pytest.mark.parametrize("opt", [
+        "--git-dir", "--work-tree", "--namespace", "--config-env", "--attr-source",
+    ])
+    def test_value_options_accept_both_equals_and_space_form(self, bash_hook, opt):
+        """git 2.50.1 takes both, though the usage line advertises only `=`."""
+        assert bash_hook._strip_git_global_options(
+            ["git", opt, "v", "push"]
+        ) == ["git", "push"]
+        assert bash_hook._strip_git_global_options(
+            ["git", f"{opt}=v", "push"]
+        ) == ["git", "push"]
+
+    def test_non_git_command_untouched(self, bash_hook):
+        assert bash_hook._strip_git_global_options(["ls", "-C", "/repo"]) is None
+
+    def test_no_global_options_yields_no_variant(self, bash_hook):
+        assert bash_hook._strip_git_global_options(["git", "push"]) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #913

**Status: complete and re-verified.** All numbers below are from runs against the current head; nothing is in flight. Both REQUIRED review items are addressed in `cad7d0b`.

## The bug

`git -C <dir> <cmd>` defeated **every** git rule. Both rule sources assume the subcommand is adjacent to `git`, and `\s+` cannot span `-C /repo`:

- hand-written `bashToolPatterns` — `\bgit\s+push\s+--force\b`
- tooldef-generated — `_cmd_to_regex` → `\bgit\s+commit\b`

Reproduced against the shipped hook through its own `uv run --script` shebang before touching anything (bare `python3` has no pyyaml and fail-closes every probe to BLOCKED — that looks exactly like proof the guard held):

```
BLOCKED  git push --force origin main
ALLOWED  git -C /repo push --force origin main
BLOCKED  git reset --hard origin/main
ALLOWED  git -C /repo reset --hard origin/main
BLOCKED  git clean -fdx
ALLOWED  git -C /repo clean -fdx
ask      git add -A
ALLOWED  git -C /repo add -A
```

## The fix

`git_normalized_haystacks()` — one normalizer, applied at the shared matching seam, so present and future git rules inherit it rather than ~15 patterns each learning about `-C`.

It is a **third haystack variant, ADDED** to whichever list a rule already reads. Neither the raw nor the masked list is rewritten, per the orchestrator ruling. Three things depend on that:

- **#914** needs the `-C` path visible to scope a grant — the path is set aside, never discarded.
- **#915**: `-c <k>=<v>` values are executed by git, so the value is a command payload sitting in the haystack. Where a content rule *does* match it — the deletion rules catch an `rm`-shaped one — stripping in place would delete it and turn a block into an ALLOW, the fix creating the bug the other issue is about. Covered by a test. Note the scope of that claim: additivity **preserves** whatever coverage exists, it does not create any. A `curl … | sh` value in `core.sshCommand` is allowed with or without this change.
- **#675**: the variant derives from the **masked** tokens, so quoted argument text can never become matchable.

Fed to **both** routings, not just anchored. Which rules are anchored is not stable (14 of 101 anchored patterns are hand-written git rules, 87 are tooldef-generated, and the rules installed on this machine carry zero `anchored: true`), so binding the fix to today's split would make it correct now and silently wrong when #915 moves it.

### Grammar, measured not assumed

Against git 2.50.1, because the usage line is wrong about this:

- `-C` / `-c` / `--git-dir` / `--work-tree` / `--namespace` / `--config-env` / `--attr-source` consume a following argument. The usage line advertises only the `=` form; the binary accepts both. Both forms handled.
- `--exec-path` does **not** consume one — bare, it prints and exits. Eating the next token there would swallow a subcommand.
- `-C/tmp` and `-cfoo=bar` (attached forms) are rejected by git itself, so they are not a bypass.
- Stripping happens on **tokens**, before the join, so `-C "/my dir"` is consumed as one unit.
- Stacked and repeated forms (`-C x -C y`, `-c k=v -C x`) handled by the same loop.

## Verification

**Which rule set:** all pytest assertions run against **bundled rules + bundled tooldefs** — `load_config(agentwire/hooks/damage-control/rules, agentwire/tooldefs)` — asserted in the fixture at **265 patterns / 101 anchored**, so a dropped `tooldefs_dir` (which silently removes all 87 tooldef-generated patterns, 178/14) fails loudly instead of shrinking coverage quietly. Counts reconcile with the reviewer's and orchestrator's independent measurements.

The acceptance probe was run through the real hook via its uv shebang against **both** rule sets — bundled, and the drifted live `~/.agentwire/damage-control/` (9 files behind, zero `anchored: true`). All eight probes agree with their plain counterparts under both.

**Cross-PR case** (must hold after #913, #914 and #915 all land) — asserted under both routings:

```
git -C /repo push --force origin main   ->  BLOCK
```

**Two-sided guard**, both sides blocking: `push --force-with-lease` behind a global option returns **ask** — not `allow` (bug survives), not `block` (normalizer rewrote the command past the `(?!-with-lease)` lookahead and caught the safe form, training everyone to reach for plain `--force`).

**Severity invariant**, under two pattern orderings: no command moves `block` → `ask` across the normalizer. Asserted as **parity against the plain form in the same config**, not as a fixed verdict — the prohibition form is unsatisfiable, since it fires on this branch where `block` → `ask` is *desired* (#915's false positive, incidentally fixed). Those transitions are pinned as expected, with their reason recorded. The distinction is load-bearing: reversing pattern order really does move `git stash clear` and the force-push form `block` → `ask` — but it moves the **plain** forms identically, so that hazard is pre-existing and order-driven. A fixed verdict would have mis-attributed it to this PR while still not detecting a normalizer-introduced downgrade.

**Wrapper prefixes:** zero-arg wrappers (`sudo`, `doas`, `time`, `nohup`, `command`) all normalize. Arg-consuming wrappers (`timeout 5`, `stdbuf -o0`, `xargs -n1`, `nice -n 5`) are a **documented limit**, pinned by a test asserting the failure is a *missing haystack*, never an over-strip.

**Pre-fix red-check** (source reverted to `HEAD~1`, tests unchanged): **154 fail, 24 pass**. The 24 that pass are exactly the unchanged-behavior anchors — `test_plain_form_is_the_baseline`, `test_no_over_blocking`, the `-c` payload cases, `test_producers_are_left_alone`. Every assertion that should have matched pre-fix did; every one describing the fix went red. The pinned expected-transition tests also fail pre-fix (4/4), so they pin something real.

Worth stating because it nearly produced a false green: the first attempt used a `git stash push`, which reported *"No local changes to save"* — everything was already committed — so the "pre-fix" run silently executed against the FIXED code and passed. A revert that reverts nothing is indistinguishable from a fix that works.

**Mutation:** four deliberate breaks, each killed, each discriminating. The harness asserts the anchor was found AND that the edit changed the file, then prints the byte delta — a mutation that silently does nothing reads exactly like a behavior that is not there.

| mutation | file Δ | result |
|---|---|---|
| M1 — normalizer disabled (returns `None` always) | 63253 → 63279 | killed (13 tests red) |
| M2 — `-C` consumes only the flag, not its argument | 63253 → 63331 | killed (11 red) |
| M3 — third haystack built but never fed to the matcher | 63253 → 63247 | killed (8 red) |
| M4 — variant fed only to ANCHORED rules (the superseded ruling) | 63253 → 63285 | killed (2 red: `test_cross_pr_case`, `test_global_options_do_not_bypass`) |

M4 is the direct evidence for the amended ruling: restricting the variant to anchored rules leaves the bypass open, and exactly the two routing-sensitive tests catch it. M2 and M3 spare precisely the tests they should not touch — M3 leaves the direct normalizer unit tests green, because it breaks the wiring rather than the function.

**Full suite:** `uv run --extra dev pytest` — **3988 passed, 36 skipped**. `scripts/regen_damage_control_hooks.py --check` clean: `_core.py` and all five generated hooks are in one commit.

No `rules/*.yaml` pattern was widened, added, or removed.

## Scope — deliberately git-only

The underlying hole is `_cmd_to_regex`, not git. The reviewer confirmed the same bypass on 14 other tools with live rules — `kubectl --context/-n/--kubeconfig`, `aws --profile/--region`, `gcloud --project`, `docker --context`, `helm --kube-context`, `terraform -chdir=`, `pulumi -C`, `npm --prefix`, `pnpm -C`, `cargo +nightly`, `supabase --workdir`, `redis-cli -h`, `mysqladmin -u`, `tmux -L/-S`, `gh -R`. In aws/kubectl/docker/redis-cli the bypassing option is the **production-targeting** option, and `tmux -L agentwire kill-server` is ALLOWED today — that rule exists to stop an agent killing the fleet it runs in.

This PR does not close that class, and should not be read as closing it — tracked separately in #919. Sizing from review: of 18 destructive forms across the bypassable tools, **zero** are held by their own rule, 14 are already ALLOW held by nothing at all, and 4 survive only via the generic deletion rule. git-only is the first repair to a guard that is largely gone, not a small fix in a healthy system.

## Not done here

- `agentwire rebuild` was **not** run — other sessions are live; the owner rebuilds after review. The fix reaches the live hook only after `rebuild` + `hooks install` re-copies `~/.agentwire/hooks/damage-control/` (a regular file copy on this machine, not a symlink — currently byte-identical to the packaged source).
- The live rule drift (#916) is untouched by this PR.
- A git option added after 2.50.1 silently reopens the bypass (the scan stops on an unrecognized token). Not exploitable — git rejects it too — and named in a comment at the break with the instruction to re-measure on a git upgrade.

Built by [dotdev.dev](https://dotdev.dev)
