### PR TITLE
fix(safety): anchor the hand-written rule files so a report-back is not refused by its own text (#915)

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -2484,6 +2484,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1774,7 +1774,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2435,13 +2476,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -2271,23 +2271,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2303,6 +2314,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2316,7 +2329,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2336,6 +2352,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2376,7 +2394,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2399,10 +2417,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -2378,7 +2378,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1770,7 +1770,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2431,13 +2472,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -2480,6 +2480,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -2267,23 +2267,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2299,6 +2310,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2312,7 +2325,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2332,6 +2348,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2372,7 +2390,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2395,10 +2413,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -2374,7 +2374,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -2386,7 +2386,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -2492,6 +2492,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -2279,23 +2279,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2311,6 +2322,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2324,7 +2337,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2344,6 +2360,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2384,7 +2402,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2407,10 +2425,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1782,7 +1782,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2443,13 +2484,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -2380,7 +2380,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1776,7 +1776,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2437,13 +2478,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -2273,23 +2273,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2305,6 +2316,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2318,7 +2331,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2338,6 +2354,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2378,7 +2396,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2401,10 +2419,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -2486,6 +2486,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/hooks/damage-control/rules/agentwire.yaml
+++ b/agentwire/hooks/damage-control/rules/agentwire.yaml
@@ -10,27 +10,34 @@ bashToolPatterns:
   # Tmux session destruction
   - pattern: '\btmux\s+kill-server\b'
     reason: tmux kill-server (destroys ALL tmux sessions including AgentWire)
+    anchored: true
 
   - pattern: '\btmux\s+kill-session\s+.*\bagentwire'
     reason: tmux kill-session targeting AgentWire sessions
+    anchored: true
 
   - pattern: '\btmux\s+kill-session\s+.*-a\b'
     reason: tmux kill-session -a (kills all except current)
     ask: true
+    anchored: true
 
   # AgentWire CLI destructive commands (future-proofing)
   - pattern: '\bagentwire\s+destroy\b'
     reason: agentwire destroy (if implemented - destroys AgentWire state)
+    anchored: true
 
   - pattern: '\bagentwire\s+.*--force.*remove\b'
     reason: agentwire force remove operations
+    anchored: true
 
   # AgentWire directory destruction
   - pattern: '\brm\s+.*\.agentwire'
     reason: Removing .agentwire directory (destroys all AgentWire state)
+    anchored: true
 
   - pattern: '\brm\s+.*~/.agentwire'
     reason: Removing ~/.agentwire directory (destroys all AgentWire state)
+    anchored: true
 
   # Note: `agentwire tasks promote` (#720/#721) is blocked via
   # safety/_core.py's PROTECTED_COMMAND_PATTERNS instead of an ordinary

--- a/agentwire/hooks/damage-control/rules/aws.yaml
+++ b/agentwire/hooks/damage-control/rules/aws.yaml
@@ -6,33 +6,43 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\baws\s+s3\s+rm\s+.*--recursive'
     reason: aws s3 rm --recursive (deletes all objects)
+    anchored: true
 
   - pattern: '\baws\s+s3\s+rb\s+.*--force'
     reason: aws s3 rb --force (force removes bucket)
+    anchored: true
 
   - pattern: '\baws\s+ec2\s+terminate-instances\b'
     reason: aws ec2 terminate-instances
+    anchored: true
 
   - pattern: '\baws\s+rds\s+delete-db-instance\b'
     reason: aws rds delete-db-instance
+    anchored: true
 
   - pattern: '\baws\s+cloudformation\s+delete-stack\b'
     reason: aws cloudformation delete-stack (deletes infrastructure)
+    anchored: true
 
   - pattern: '\baws\s+dynamodb\s+delete-table\b'
     reason: aws dynamodb delete-table
+    anchored: true
 
   - pattern: '\baws\s+eks\s+delete-cluster\b'
     reason: aws eks delete-cluster
+    anchored: true
 
   - pattern: '\baws\s+lambda\s+delete-function\b'
     reason: aws lambda delete-function
+    anchored: true
 
   - pattern: '\baws\s+iam\s+delete-role\b'
     reason: aws iam delete-role
+    anchored: true
 
   - pattern: '\baws\s+iam\s+delete-user\b'
     reason: aws iam delete-user
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # AWS DEPLOYS (ask: true — ship code/infra, caught in unattended sessions)
@@ -41,13 +51,16 @@ bashToolPatterns:
     reason: aws cloudformation deploy (ships an infrastructure change)
     ask: true
     id: deploy.aws-cloudformation
+    anchored: true
 
   - pattern: '\baws\s+lambda\s+update-function-code\b'
     reason: aws lambda update-function-code (ships new function code)
     ask: true
     id: deploy.aws-lambda-update
+    anchored: true
 
   - pattern: '\baws\s+ecs\s+update-service\b'
     reason: aws ecs update-service (ships an ECS deployment)
     ask: true
     id: deploy.aws-ecs-update
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/cloud-hosting.yaml
+++ b/agentwire/hooks/damage-control/rules/cloud-hosting.yaml
@@ -7,84 +7,103 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bvercel\s+remove\s+.*--yes'
     reason: vercel remove --yes (removes deployment)
+    anchored: true
 
   - pattern: '\bvercel\s+projects\s+rm\b'
     reason: vercel projects rm (deletes project)
+    anchored: true
 
   - pattern: '\bvercel\s+env\s+rm\s+.*--yes'
     reason: vercel env rm --yes (removes env variables)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # NETLIFY DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bnetlify\s+sites:delete\b'
     reason: netlify sites:delete (deletes entire site)
+    anchored: true
 
   - pattern: '\bnetlify\s+functions:delete\b'
     reason: netlify functions:delete
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # CLOUDFLARE (wrangler) DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bwrangler\s+delete\b'
     reason: wrangler delete (deletes Worker)
+    anchored: true
 
   - pattern: '\bwrangler\s+r2\s+bucket\s+delete\b'
     reason: wrangler r2 bucket delete
+    anchored: true
 
   - pattern: '\bwrangler\s+kv:namespace\s+delete\b'
     reason: wrangler kv:namespace delete
+    anchored: true
 
   - pattern: '\bwrangler\s+d1\s+delete\b'
     reason: wrangler d1 delete (deletes database)
+    anchored: true
 
   - pattern: '\bwrangler\s+queues\s+delete\b'
     reason: wrangler queues delete
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # HEROKU DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bheroku\s+apps:destroy\b'
     reason: heroku apps:destroy
+    anchored: true
 
   - pattern: '\bheroku\s+pg:reset\b'
     reason: heroku pg:reset (resets database)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # FLY.IO DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bfly\s+apps\s+destroy\b'
     reason: fly apps destroy (Fly.io)
+    anchored: true
 
   - pattern: '\bfly\s+destroy\b'
     reason: fly destroy (Fly.io)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # DIGITALOCEAN (doctl) DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bdoctl\s+compute\s+droplet\s+delete\b'
     reason: doctl droplet delete (DigitalOcean)
+    anchored: true
 
   - pattern: '\bdoctl\s+databases\s+delete\b'
     reason: doctl databases delete (DigitalOcean)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # SUPABASE DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bsupabase\s+db\s+reset\b'
     reason: supabase db reset
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # GITHUB CLI DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bgh\s+repo\s+delete\b'
     reason: gh repo delete (deletes repository)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # PACKAGE REGISTRY DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bnpm\s+unpublish\b'
     reason: npm unpublish (removes package from registry)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # DEPLOYS (ask: true — outward-facing, caught in unattended sessions)
@@ -96,38 +115,46 @@ bashToolPatterns:
     reason: vercel deploy (ships a deployment)
     ask: true
     id: deploy.vercel
+    anchored: true
 
   - pattern: '\bvercel\s+(-[^\s]*\s+)*--prod\b'
     reason: vercel --prod (ships a production deployment)
     ask: true
     id: deploy.vercel-prod
+    anchored: true
 
   - pattern: '\bnetlify\s+deploy\b'
     reason: netlify deploy (ships a deployment)
     ask: true
     id: deploy.netlify
+    anchored: true
 
   - pattern: '\b(fly|flyctl)\s+deploy\b'
     reason: fly deploy (ships a Fly.io deployment)
     ask: true
     id: deploy.fly
+    anchored: true
 
   - pattern: '\bwrangler\s+(deploy|publish)\b'
     reason: wrangler deploy (ships a Cloudflare Worker)
     ask: true
     id: deploy.wrangler
+    anchored: true
 
   - pattern: '\brailway\s+(up|deploy)\b'
     reason: railway up (ships a Railway deployment)
     ask: true
     id: deploy.railway
+    anchored: true
 
   - pattern: '\brender\s+deploys?\s+create\b'
     reason: render deploys create (ships a Render deployment)
     ask: true
     id: deploy.render
+    anchored: true
 
   - pattern: '\bsupabase\s+functions\s+deploy\b'
     reason: supabase functions deploy (ships an edge function)
     ask: true
     id: deploy.supabase-functions
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/containers.yaml
+++ b/agentwire/hooks/damage-control/rules/containers.yaml
@@ -7,33 +7,38 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bdocker\s+system\s+prune\s+.*-a'
     reason: docker system prune -a (removes all unused data)
-
-  - pattern: '\bdocker\s+rm\s+.*-f.*\$\(docker\s+ps'
-    reason: docker rm -f $(docker ps) (force removes containers)
+    anchored: true
 
   - pattern: '\bdocker\s+rmi\s+.*-f'
     reason: docker rmi -f (force removes images)
+    anchored: true
 
   - pattern: '\bdocker\s+volume\s+rm\b'
     reason: docker volume rm (data loss)
+    anchored: true
 
   - pattern: '\bdocker\s+volume\s+prune\b'
     reason: docker volume prune (removes unused volumes)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # KUBERNETES (kubectl) DESTRUCTIVE OPERATIONS
   # ---------------------------------------------------------------------------
   - pattern: '\bkubectl\s+delete\s+namespace\b'
     reason: kubectl delete namespace
+    anchored: true
 
   - pattern: '\bkubectl\s+delete\s+all\s+--all'
     reason: kubectl delete all --all
+    anchored: true
 
   - pattern: '\bkubectl\s+delete\s+.*--all\s+--all-namespaces'
     reason: kubectl delete across all namespaces
+    anchored: true
 
   - pattern: '\bhelm\s+uninstall\b'
     reason: helm uninstall (removes release)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # CONTAINER REGISTRY PUBLISH / WORKLOAD DELETE (ask: true)
@@ -46,8 +51,10 @@ bashToolPatterns:
     reason: docker push (publishes an image to a registry)
     ask: true
     id: container.docker-push
+    anchored: true
 
   - pattern: '\bkubectl\s+delete\b'
     reason: kubectl delete (removes a Kubernetes resource)
     ask: true
     id: container.kubectl-delete
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/core.yaml
+++ b/agentwire/hooks/damage-control/rules/core.yaml
@@ -7,85 +7,97 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\brm\s+(-[^\s]*)*-[rRf]'
     reason: rm with recursive or force flags
+    anchored: true
 
   - pattern: '\brm\s+-[rRf]'
     reason: rm with recursive or force flags
+    anchored: true
 
   - pattern: '\brm\s+--recursive'
     reason: rm with --recursive flag
+    anchored: true
 
   - pattern: '\brm\s+--force'
     reason: rm with --force flag
+    anchored: true
 
   - pattern: '\bsudo\s+rm\b'
     reason: sudo rm
+    anchored: true
 
   - pattern: '\brmdir\b'
     reason: rmdir (use git clean or manual cleanup)
     bypassable: true
+    anchored: true
 
   - pattern: '\brm\s+[^-]'
     reason: rm file deletion (use git clean or manual cleanup)
     bypassable: true
+    anchored: true
 
   - pattern: '(?:^|[;&|])\s*trash\s+'
     reason: trash command (moves files to trash - use git clean or manual cleanup)
     bypassable: true
+    anchored: true
 
   # Non-``rm`` deletion paths that the literal-``rm`` rules miss.
   - pattern: '\bfind\b.*\s-delete\b'
     reason: find -delete (recursive deletion - use git clean or manual cleanup)
     bypassable: true
+    anchored: true
 
   - pattern: '\bfind\b.*-exec\s+rm\b'
     reason: find -exec rm (deletion via find - use git clean or manual cleanup)
     bypassable: true
-
-  - pattern: 'shutil\.rmtree'
-    reason: shutil.rmtree recursive delete (equivalent to rm -rf)
-
-  - pattern: '\bperl\b.*\bunlink\b'
-    reason: perl unlink delete (use git clean or manual cleanup)
-    bypassable: true
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # PERMISSION CHANGES
   # ---------------------------------------------------------------------------
   - pattern: '\bchmod\s+(-[^\s]+\s+)*777\b'
     reason: chmod 777 (world writable)
+    anchored: true
 
   - pattern: '\bchmod\s+-[Rr].*777'
     reason: recursive chmod 777
+    anchored: true
 
   - pattern: '\bchown\s+-[Rr].*\broot\b'
     reason: recursive chown to root
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # SYSTEM-LEVEL DESTRUCTION
   # ---------------------------------------------------------------------------
   - pattern: '\bmkfs\.'
     reason: filesystem format command
+    anchored: true
 
   - pattern: '\bdd\s+.*of=/dev/'
     reason: dd writing to device
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # PROCESS DESTRUCTION
   # ---------------------------------------------------------------------------
   - pattern: '\bkill\s+-9\s+-1\b'
     reason: kill all processes
+    anchored: true
 
   - pattern: '\bkillall\s+-9\b'
     reason: killall -9
+    anchored: true
 
   - pattern: '\bpkill\s+-9\b'
     reason: pkill -9
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # HISTORY/SHELL MANIPULATION
   # ---------------------------------------------------------------------------
   - pattern: '\bhistory\s+-c\b'
     reason: clearing shell history
+    anchored: true
 
 # ---------------------------------------------------------------------------
 # ZERO ACCESS PATHS - No read, write, or any access allowed

--- a/agentwire/hooks/damage-control/rules/databases.yaml
+++ b/agentwire/hooks/damage-control/rules/databases.yaml
@@ -32,12 +32,12 @@ bashToolPatterns:
     id: db.flyway-clean
     anchored: true
 
-  # ---------------------------------------------------------------------------
-  # SQL DESTRUCTIVE OPERATIONS (catastrophic - no WHERE clause)
-  # ---------------------------------------------------------------------------
-  # ---------------------------------------------------------------------------
-  # SQL OPERATIONS REQUIRING CONFIRMATION (ask: true)
-  # ---------------------------------------------------------------------------
+  # NOTE: the raw SQL statement rules (DROP TABLE / TRUNCATE / DELETE-without-
+  # WHERE) and the psql/mysql/mongosh raw-write rules used to live here. They
+  # moved to payloads.yaml (#915) — they match text inside a client's quoted
+  # payload, which is the shape that cannot be anchored, and this file is
+  # uniformly anchored.
+
   # ---------------------------------------------------------------------------
   # SCHEMA MIGRATIONS (ask: true — apply DDL/DML to a database)
   # ---------------------------------------------------------------------------
@@ -112,11 +112,8 @@ bashToolPatterns:
     id: db.liquibase-update
     anchored: true
 
-  # ---------------------------------------------------------------------------
-  # RAW DML / DDL VIA DB CLIENTS (ask: true)
-  # ---------------------------------------------------------------------------
-  # Catastrophic statements (DROP/TRUNCATE/DELETE-without-WHERE) are hard-blocked
-  # above regardless of client. These catch the remaining write statements only
-  # when an actual DB client is on the command line, so SELECT-only queries stay
-  # `allow`-tier. File-fed scripts (psql -f, mysql < file) can't be introspected
-  # by a regex and remain a residual gap — see the wiki coverage matrix.
+  # Raw DML/DDL via DB clients (psql/mysql/mongosh write statements) and the
+  # catastrophic statement rules both live in payloads.yaml now — see the note
+  # above. The residual gap they carry (file-fed scripts: `psql -f`,
+  # `mysql < file`, which a regex cannot introspect) is documented there and in
+  # the wiki coverage matrix.

--- a/agentwire/hooks/damage-control/rules/databases.yaml
+++ b/agentwire/hooks/damage-control/rules/databases.yaml
@@ -7,59 +7,37 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bredis-cli\s+FLUSHALL'
     reason: redis-cli FLUSHALL (wipes ALL data)
+    anchored: true
 
   - pattern: '\bredis-cli\s+FLUSHDB'
     reason: redis-cli FLUSHDB (wipes database)
-
-  - pattern: '\bmongosh.*dropDatabase'
-    reason: MongoDB dropDatabase
-
-  - pattern: '\bmongo.*dropDatabase'
-    reason: MongoDB dropDatabase
+    anchored: true
 
   - pattern: '\bdropdb\b'
     reason: PostgreSQL dropdb
+    anchored: true
 
   - pattern: '\bmysqladmin\s+drop\b'
     reason: MySQL drop database
+    anchored: true
 
   # Migration tools that DROP/recreate the schema (data loss) — hard block.
   - pattern: '\bprisma\s+migrate\s+reset\b'
     reason: prisma migrate reset (drops the database and re-applies migrations)
     id: db.prisma-reset
+    anchored: true
 
   - pattern: '\bflyway\s+clean\b'
     reason: flyway clean (drops all objects in the schema)
     id: db.flyway-clean
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # SQL DESTRUCTIVE OPERATIONS (catastrophic - no WHERE clause)
   # ---------------------------------------------------------------------------
-  - pattern: 'DELETE\s+FROM\s+\w+\s*;'
-    reason: DELETE without WHERE clause (will delete ALL rows)
-
-  - pattern: 'DELETE\s+FROM\s+\w+\s*$'
-    reason: DELETE without WHERE clause (will delete ALL rows)
-
-  - pattern: 'DELETE\s+\*\s+FROM'
-    reason: DELETE * (will delete ALL rows)
-
-  - pattern: '\bTRUNCATE\s+TABLE\b'
-    reason: TRUNCATE TABLE (will delete ALL rows)
-
-  - pattern: '\bDROP\s+TABLE\b'
-    reason: DROP TABLE
-
-  - pattern: '\bDROP\s+DATABASE\b'
-    reason: DROP DATABASE
-
   # ---------------------------------------------------------------------------
   # SQL OPERATIONS REQUIRING CONFIRMATION (ask: true)
   # ---------------------------------------------------------------------------
-  - pattern: '\bDELETE\s+FROM\s+\w+\s+WHERE\b.*\bid\s*='
-    reason: SQL DELETE with specific ID
-    ask: true
-
   # ---------------------------------------------------------------------------
   # SCHEMA MIGRATIONS (ask: true — apply DDL/DML to a database)
   # ---------------------------------------------------------------------------
@@ -72,56 +50,67 @@ bashToolPatterns:
     reason: prisma migrate (applies database migrations)
     ask: true
     id: db.prisma-migrate
+    anchored: true
 
   - pattern: '\bprisma\s+db\s+push\b'
     reason: prisma db push (pushes schema changes to the database)
     ask: true
     id: db.prisma-db-push
+    anchored: true
 
   - pattern: '\bsupabase\s+db\s+push\b'
     reason: supabase db push (applies local migrations to the linked database)
     ask: true
     id: db.supabase-db-push
+    anchored: true
 
   - pattern: '\bsupabase\s+migration\s+up\b'
     reason: supabase migration up (applies pending migrations)
     ask: true
     id: db.supabase-migration-up
+    anchored: true
 
   - pattern: '\balembic\s+(upgrade|downgrade)\b'
     reason: alembic upgrade/downgrade (applies/reverts SQLAlchemy migrations)
     ask: true
     id: db.alembic
+    anchored: true
 
   - pattern: '\bmanage\.py\s+migrate\b'
     reason: Django manage.py migrate (applies database migrations)
     ask: true
     id: db.django-migrate
+    anchored: true
 
   - pattern: '\b(rails|rake)\s+db:migrate\b'
     reason: rails db:migrate (applies ActiveRecord migrations)
     ask: true
     id: db.rails-migrate
+    anchored: true
 
   - pattern: '\bknex\s+migrate:(latest|up|down|rollback)\b'
     reason: knex migrate (applies/reverts Knex migrations)
     ask: true
     id: db.knex-migrate
+    anchored: true
 
   - pattern: '\bsequelize\s+db:migrate\b'
     reason: sequelize db:migrate (applies Sequelize migrations)
     ask: true
     id: db.sequelize-migrate
+    anchored: true
 
   - pattern: '\bflyway\s+migrate\b'
     reason: flyway migrate (applies pending migrations)
     ask: true
     id: db.flyway-migrate
+    anchored: true
 
   - pattern: '\bliquibase\s+update\b'
     reason: liquibase update (applies pending changesets)
     ask: true
     id: db.liquibase-update
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # RAW DML / DDL VIA DB CLIENTS (ask: true)
@@ -131,17 +120,3 @@ bashToolPatterns:
   # when an actual DB client is on the command line, so SELECT-only queries stay
   # `allow`-tier. File-fed scripts (psql -f, mysql < file) can't be introspected
   # by a regex and remain a residual gap — see the wiki coverage matrix.
-  - pattern: '\bpsql\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
-    reason: psql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
-    ask: true
-    id: db.psql-write
-
-  - pattern: '\b(mysql|mariadb)\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
-    reason: mysql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
-    ask: true
-    id: db.mysql-write
-
-  - pattern: '\bmongosh?\b.*\.(insertOne|insertMany|updateOne|updateMany|deleteOne|deleteMany|replaceOne|bulkWrite)\b'
-    reason: mongosh executing a write operation (insert/update/delete)
-    ask: true
-    id: db.mongosh-write

--- a/agentwire/hooks/damage-control/rules/firebase.yaml
+++ b/agentwire/hooks/damage-control/rules/firebase.yaml
@@ -6,15 +6,20 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bfirebase\s+projects:delete\b'
     reason: firebase projects:delete (deletes entire project)
+    anchored: true
 
   - pattern: '\bfirebase\s+firestore:delete\s+.*--all-collections'
     reason: firebase firestore:delete --all-collections (wipes all data)
+    anchored: true
 
   - pattern: '\bfirebase\s+database:remove\b'
     reason: firebase database:remove (wipes Realtime DB)
+    anchored: true
 
   - pattern: '\bfirebase\s+hosting:disable\b'
     reason: firebase hosting:disable
+    anchored: true
 
   - pattern: '\bfirebase\s+functions:delete\b'
     reason: firebase functions:delete
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/gcp.yaml
+++ b/agentwire/hooks/damage-control/rules/gcp.yaml
@@ -6,24 +6,31 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bgcloud\s+projects\s+delete\b'
     reason: gcloud projects delete (DELETES ENTIRE PROJECT)
+    anchored: true
 
   - pattern: '\bgcloud\s+compute\s+instances\s+delete\b'
     reason: gcloud compute instances delete
+    anchored: true
 
   - pattern: '\bgcloud\s+sql\s+instances\s+delete\b'
     reason: gcloud sql instances delete
+    anchored: true
 
   - pattern: '\bgcloud\s+container\s+clusters\s+delete\b'
     reason: gcloud container clusters delete (GKE)
+    anchored: true
 
   - pattern: '\bgcloud\s+storage\s+rm\s+.*-r'
     reason: gcloud storage rm -r (recursive delete)
+    anchored: true
 
   - pattern: '\bgcloud\s+functions\s+delete\b'
     reason: gcloud functions delete
+    anchored: true
 
   - pattern: '\bgcloud\s+iam\s+service-accounts\s+delete\b'
     reason: gcloud iam service-accounts delete
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # GCP DEPLOYS (ask: true — outward-facing, caught in unattended sessions)
@@ -34,8 +41,10 @@ bashToolPatterns:
     reason: gcloud run deploy (ships a Cloud Run service)
     ask: true
     id: deploy.gcloud-run
+    anchored: true
 
   - pattern: '\bgcloud\s+app\s+deploy\b'
     reason: gcloud app deploy (ships an App Engine version)
     ask: true
     id: deploy.gcloud-app
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/gws.yaml
+++ b/agentwire/hooks/damage-control/rules/gws.yaml
@@ -2,25 +2,32 @@ bashToolPatterns:
   # Permanent message deletion (bypasses trash)
   - pattern: '\bgws\s+gmail\s+users\.messages\.delete\b'
     reason: gws gmail delete (permanent, bypasses trash — use trash instead)
+    anchored: true
 
   - pattern: '\bgws\s+gmail\s+users\.messages\.batchDelete\b'
     reason: gws gmail batchDelete (permanently deletes multiple messages)
+    anchored: true
 
   # Drive permanent deletion
   - pattern: '\bgws\s+drive\s+files\.delete\b'
     reason: gws drive files.delete (permanent, bypasses trash)
+    anchored: true
 
   - pattern: '\bgws\s+drive\s+files\.emptyTrash\b'
     reason: gws drive emptyTrash (permanently deletes all trashed files)
+    anchored: true
 
   # Calendar destruction
   - pattern: '\bgws\s+calendar\s+calendars\.delete\b'
     reason: gws calendar delete (deletes entire calendar and all events)
+    anchored: true
 
   # Admin destructive operations
   - pattern: '\bgws\s+admin\s+users\.delete\b'
     reason: gws admin users.delete (permanently deletes a user account)
+    anchored: true
 
   - pattern: '\bgws\s+admin\s+users\.makeAdmin\b'
     reason: gws admin makeAdmin (grants admin privileges)
     ask: true
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/infrastructure.yaml
+++ b/agentwire/hooks/damage-control/rules/infrastructure.yaml
@@ -7,18 +7,23 @@ bashToolPatterns:
   # ---------------------------------------------------------------------------
   - pattern: '\bterraform\s+destroy\b'
     reason: terraform destroy (destroys all infrastructure)
+    anchored: true
 
   - pattern: '\bpulumi\s+destroy\b'
     reason: pulumi destroy (destroys all resources)
+    anchored: true
 
   - pattern: '\bserverless\s+remove\b'
     reason: serverless remove (removes stack)
+    anchored: true
 
   - pattern: '\bsls\s+remove\b'
     reason: sls remove (removes stack)
+    anchored: true
 
   - pattern: '\bsam\s+delete\b'
     reason: sam delete (deletes SAM application)
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # IaC DEPLOYS (ask: true — provision/ship infra, caught in unattended sessions)
@@ -29,23 +34,28 @@ bashToolPatterns:
     reason: pulumi up (provisions/updates infrastructure)
     ask: true
     id: deploy.pulumi-up
+    anchored: true
 
   - pattern: '\b(serverless|sls)\s+deploy\b'
     reason: serverless deploy (ships a Serverless Framework stack)
     ask: true
     id: deploy.serverless
+    anchored: true
 
   - pattern: '\bsam\s+deploy\b'
     reason: sam deploy (ships an AWS SAM application)
     ask: true
     id: deploy.sam
+    anchored: true
 
   - pattern: '\bcdk\s+deploy\b'
     reason: cdk deploy (ships an AWS CDK stack)
     ask: true
     id: deploy.cdk
+    anchored: true
 
   - pattern: '\bansible-playbook\b'
     reason: ansible-playbook (applies configuration to remote hosts)
     ask: true
     id: deploy.ansible
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/outbound.yaml
+++ b/agentwire/hooks/damage-control/rules/outbound.yaml
@@ -24,11 +24,13 @@ bashToolPatterns:
     reason: agentwire email (sends an external email via Resend)
     ask: true
     id: outbound.agentwire-email
+    anchored: true
 
   - pattern: '\bagentwire\s+quo\b'
     reason: agentwire quo (sends an external SMS via Quo/OpenPhone)
     ask: true
     id: outbound.agentwire-quo
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # TWILIO (SMS / messaging)
@@ -37,6 +39,7 @@ bashToolPatterns:
     reason: twilio messages create (sends an SMS/MMS)
     ask: true
     id: outbound.twilio-messages
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # AWS messaging (SES email, SNS publish)
@@ -45,11 +48,13 @@ bashToolPatterns:
     reason: aws ses send-email (sends an external email)
     ask: true
     id: outbound.aws-ses
+    anchored: true
 
   - pattern: '\baws\s+sns\s+publish\b'
     reason: aws sns publish (sends an SMS/notification)
     ask: true
     id: outbound.aws-sns
+    anchored: true
 
   # ---------------------------------------------------------------------------
   # GENERIC MAIL TRANSPORTS
@@ -58,8 +63,10 @@ bashToolPatterns:
     reason: sendmail (sends external email)
     ask: true
     id: outbound.sendmail
+    anchored: true
 
   - pattern: '\b(mail|mailx)\s+(-[^\s]*\s+)*-s\b'
     reason: mail -s (sends external email)
     ask: true
     id: outbound.mail
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/payloads.yaml
+++ b/agentwire/hooks/damage-control/rules/payloads.yaml
@@ -1,0 +1,118 @@
+# Wrapped-payload damage control rules
+#
+# Every rule here matches text that arrives INSIDE another command's quoted
+# argument -- a SQL statement handed to psql, a script handed to python -c /
+# perl -e / mongosh --eval, a $(...) substitution. They are the rules that fail
+# the anchoring shape test, so they live together in one uniformly UNANCHORED
+# file (#915).
+#
+# WHY A FILE AND NOT A PER-RULE FLAG. `anchored: true` swaps the haystack for
+# masked_subcommands(), which blanks every fully-quoted token containing
+# whitespace regardless of position. That is lossless for a command-prefix rule
+# and fatal here: masking removes exactly the text these rules exist to catch.
+# Anchoring is therefore decided per FILE, gated on the git.yaml shape test --
+# every rule command-prefix shaped AND the tool takes no inner-command payload
+# -- so there is no per-rule skip-list to keep in sync (see
+# ~/.claude/rules/architecture.md). remote.yaml is the other unanchored file:
+# ssh's payload is the same shape, and its rules are kept whole there because
+# they double-cover the local rules in core.yaml.
+#
+# Each rule carries an explicit `id:` pinned to the id it had before the move,
+# so `safety.disabled_rules` / `unattended_allow` entries keep working.
+#
+# DO NOT add `anchored: true` to anything in this file. The invariant is
+# enforced by tests/unit/test_damage_control_payload_anchoring.py.
+
+bashToolPatterns:
+
+  # ---------------------------------------------------------------------------
+  # INTERPRETER / CLIENT EVAL PAYLOADS
+  # ---------------------------------------------------------------------------
+
+  - pattern: 'shutil\.rmtree'
+    reason: shutil.rmtree recursive delete (equivalent to rm -rf)
+    id: core.shutil-rmtree-recursive-delete-equivalent-to-rm-rf
+    anchored: false
+
+  - pattern: '\bperl\b.*\bunlink\b'
+    reason: perl unlink delete (use git clean or manual cleanup)
+    bypassable: true
+    id: core.perl-unlink-delete-use-git-clean-or-manual-cleanup
+    anchored: false
+
+  - pattern: '\bmongosh.*dropDatabase'
+    reason: MongoDB dropDatabase
+    id: databases.mongodb-dropdatabase
+    anchored: false
+
+  - pattern: '\bmongo.*dropDatabase'
+    reason: MongoDB dropDatabase
+    id: databases.mongodb-dropdatabase-2
+    anchored: false
+
+  # ---------------------------------------------------------------------------
+  # SQL STATEMENTS
+  # ---------------------------------------------------------------------------
+
+  - pattern: 'DELETE\s+FROM\s+\w+\s*;'
+    reason: DELETE without WHERE clause (will delete ALL rows)
+    id: databases.delete-without-where-clause-will-delete-all-rows
+    anchored: false
+
+  - pattern: 'DELETE\s+FROM\s+\w+\s*$'
+    reason: DELETE without WHERE clause (will delete ALL rows)
+    id: databases.delete-without-where-clause-will-delete-all-rows-2
+    anchored: false
+
+  - pattern: 'DELETE\s+\*\s+FROM'
+    reason: DELETE * (will delete ALL rows)
+    id: databases.delete-will-delete-all-rows
+    anchored: false
+
+  - pattern: '\bTRUNCATE\s+TABLE\b'
+    reason: TRUNCATE TABLE (will delete ALL rows)
+    id: databases.truncate-table-will-delete-all-rows
+    anchored: false
+
+  - pattern: '\bDROP\s+TABLE\b'
+    reason: DROP TABLE
+    id: databases.drop-table
+    anchored: false
+
+  - pattern: '\bDROP\s+DATABASE\b'
+    reason: DROP DATABASE
+    id: databases.drop-database
+    anchored: false
+
+  - pattern: '\bDELETE\s+FROM\s+\w+\s+WHERE\b.*\bid\s*='
+    reason: SQL DELETE with specific ID
+    ask: true
+    id: databases.sql-delete-with-specific-id
+    anchored: false
+
+  - pattern: '\bpsql\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
+    reason: psql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
+    ask: true
+    id: db.psql-write
+    anchored: false
+
+  - pattern: '\b(mysql|mariadb)\b.*\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|CREATE\s+TABLE|GRANT\s+|REVOKE\s+)'
+    reason: mysql executing a write statement (INSERT/UPDATE/ALTER/CREATE/GRANT)
+    ask: true
+    id: db.mysql-write
+    anchored: false
+
+  - pattern: '\bmongosh?\b.*\.(insertOne|insertMany|updateOne|updateMany|deleteOne|deleteMany|replaceOne|bulkWrite)\b'
+    reason: mongosh executing a write operation (insert/update/delete)
+    ask: true
+    id: db.mongosh-write
+    anchored: false
+
+  # ---------------------------------------------------------------------------
+  # COMMAND SUBSTITUTION
+  # ---------------------------------------------------------------------------
+
+  - pattern: '\bdocker\s+rm\s+.*-f.*\$\(docker\s+ps'
+    reason: docker rm -f $(docker ps) (force removes containers)
+    id: containers.docker-rm-f-docker-ps-force-removes-containers
+    anchored: false

--- a/agentwire/hooks/damage-control/rules/publish.yaml
+++ b/agentwire/hooks/damage-control/rules/publish.yaml
@@ -13,28 +13,34 @@ bashToolPatterns:
     reason: cargo publish (publishes a crate to crates.io)
     ask: true
     id: publish.cargo
+    anchored: true
 
   - pattern: '\bpoetry\s+publish\b'
     reason: poetry publish (publishes a package to PyPI)
     ask: true
     id: publish.poetry
+    anchored: true
 
   - pattern: '\btwine\s+upload\b'
     reason: twine upload (publishes a package to PyPI)
     ask: true
     id: publish.twine
+    anchored: true
 
   - pattern: '\b(pnpm|yarn)\s+publish\b'
     reason: pnpm/yarn publish (publishes a package to npm registry)
     ask: true
     id: publish.pnpm-yarn
+    anchored: true
 
   - pattern: '\bgem\s+push\b'
     reason: gem push (publishes a gem to RubyGems)
     ask: true
     id: publish.gem
+    anchored: true
 
   - pattern: '\bmvn\s+(deploy|.*\bdeploy:deploy)\b'
     reason: mvn deploy (publishes artifacts to a Maven repository)
     ask: true
     id: publish.maven
+    anchored: true

--- a/agentwire/hooks/damage-control/rules/remote.yaml
+++ b/agentwire/hooks/damage-control/rules/remote.yaml
@@ -1,6 +1,24 @@
 # Remote execution damage control rules
 # SSH remote execution safeguards
 
+# WHY THIS WHOLE FILE IS UNANCHORED (#915)
+#
+# Every rule here is a WRAPPER rule: the dangerous command is ssh's quoted
+# payload (``ssh box "<destructive command>"``). `anchored: true` matches
+# against masked_subcommands(), which blanks any fully-quoted token containing
+# whitespace -- so anchoring would blank exactly the half these rules exist to
+# read, and `ssh prod "sudo rm -rf /var/lib"` would become ALLOW.
+#
+# These rules also DOUBLE-COVER the local rules in core.yaml: anchored
+# `core.sudo-rm` still blocks `sudo rm /etc/hosts` but loses the ssh-wrapped
+# form, and this file is the backstop that keeps it covered. Anchoring
+# core.yaml and remote.yaml together would take the wrapped forms from
+# double-covered to UNCOVERED. That is why anchoring is decided per FILE
+# against a shape test rather than per rule.
+#
+# DO NOT add `anchored: true` to anything in this file. Enforced by
+# tests/unit/test_damage_control_payload_anchoring.py.
+
 bashToolPatterns:
   # ---------------------------------------------------------------------------
   # REMOTE EXECUTION SAFEGUARDS
@@ -11,41 +29,53 @@ bashToolPatterns:
   # SSH with destructive commands
   - pattern: '\bssh\s+.*\brm\s+-[rRf]'
     reason: SSH remote rm with recursive/force flags
+    anchored: false
 
   - pattern: '\bssh\s+.*\bsudo\s+rm\b'
     reason: SSH remote sudo rm
+    anchored: false
 
   - pattern: '\bssh\s+.*\bmkfs\b'
     reason: SSH remote filesystem format
+    anchored: false
 
   - pattern: '\bssh\s+.*\bdd\s+.*of=/dev/'
     reason: SSH remote dd to device
+    anchored: false
 
   - pattern: '\bssh\s+.*\breboot\b'
     reason: SSH remote reboot
     ask: true
+    anchored: false
 
   - pattern: '\bssh\s+.*\bshutdown\b'
     reason: SSH remote shutdown
     ask: true
+    anchored: false
 
   - pattern: '\bssh\s+.*\bsystemctl\s+stop\b'
     reason: SSH remote service stop
     ask: true
+    anchored: false
 
   # Remote database operations
   - pattern: '\bssh\s+.*\bdropdb\b'
     reason: SSH remote PostgreSQL database drop
+    anchored: false
 
   - pattern: '\bssh\s+.*\bmysqladmin\s+drop\b'
     reason: SSH remote MySQL database drop
+    anchored: false
 
   - pattern: '\bssh\s+.*\bredis-cli\s+FLUSHALL\b'
     reason: SSH remote Redis FLUSHALL
+    anchored: false
 
   # Remote Docker destruction
   - pattern: '\bssh\s+.*\bdocker\s+system\s+prune\s+-a'
     reason: SSH remote docker system prune -a
+    anchored: false
 
   - pattern: '\bssh\s+.*\bdocker\s+rm\s+.*-f'
     reason: SSH remote docker rm -f
+    anchored: false

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -2479,6 +2479,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1769,7 +1769,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2430,13 +2471,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -2266,23 +2266,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2298,6 +2309,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2311,7 +2324,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2331,6 +2347,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2371,7 +2389,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2394,10 +2412,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -2373,7 +2373,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1738,7 +1738,48 @@ def normalize_subcommands(command: str) -> Tuple[List[str], Optional[str]]:
 
 _MASK = "\x00"
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_]\w+)\1")
-_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh"}
+# ``su -c`` runs its argument through a login shell, so it belongs here
+# for the same reason: the value is a command, not content.
+_SHELL_NAMES = {"sh", "bash", "zsh", "dash", "ksh", "su"}
+
+#: EXEC SURFACES (#915 review, class of #924).
+#:
+#: A quoted multi-word token is masked as content — right for ``git commit -m
+#: "<prose>"``, and WRONG when the token is the value of an option the tool
+#: EXECUTES. Once the rule files are anchored the raw haystack is no longer
+#: consulted, so masking such a payload takes it from BLOCK to allow with NO
+#: rule matching at all: no grant consulted, and no ``core.ambiguous-command``
+#: backstop either, because with no ``$(`` the ambiguity detector never fires.
+#:
+#: The distinguisher cannot be SYNTAX — ``$(`` is one route here, not the
+#: defining property — and it cannot be ADDITIVITY: emitting every masked token
+#: as its own entry fixes all of these and reinstates #915 for all prose,
+#: because a report payload becomes a command-position entry again. It has to be
+#: POSITION: is this token the value of an exec-surface option? That needs a
+#: table, and this is the minimal instance of #924's eventual one.
+#:
+#: Value = the option flags whose value is the payload. An EMPTY set means the
+#: payload arrives positionally (``tmux new-session -d '<cmd>'``, ``watch -n1
+#: '<cmd>'``, ``awk '<program>'``), so any content token on that command counts.
+#:
+#: Distinct from ``_SHELL_NAMES``, which means "this payload is a shell command"
+#: and so gets RE-PARSED into subcommands. Here the payload is executable text
+#: that merely contains a command (``python3 -c 'os.system("…")'``), so it is
+#: emitted as a haystack string instead of re-parsed as shell.
+#:
+#: Missing an exec surface degrades to exactly today's behaviour, not worse.
+_EXEC_SURFACES: Dict[str, set] = {
+    "python": {"-c"}, "python3": {"-c"}, "python2": {"-c"},
+    "perl": {"-e", "-E"},
+    "ruby": {"-e"},
+    "node": {"-e", "-p", "--eval"},
+    "deno": {"-e", "--eval"},
+    "php": {"-r"},
+    "make": {"-c"},
+    "tmux": set(),
+    "watch": set(),
+    "awk": set(), "gawk": set(), "mawk": set(),
+}
 _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
@@ -2399,13 +2440,38 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 continue
             if is_content:
                 # A ``sh -c "…"`` payload is a command, not content — rescan.
+                #
+                # ANY word so far may be the shell, not just words[0]: a wrapper
+                # prefix (``env FOO=1 sh -c``, ``nohup sh -c``, ``timeout 5 sh
+                # -c``, ``xargs -I{} sh -c``, ``find . -exec sh -c``) puts the
+                # shell in the middle. Keying on words[0] alone meant every one
+                # of those payloads was masked away with nothing rescanning it —
+                # a BLOCK -> ALLOW regression once the rules are anchored, since
+                # the raw haystack is no longer consulted for them.
                 if (
                     words
                     and prev.startswith("-")
                     and "c" in prev
-                    and words[0].rsplit("/", 1)[-1] in _SHELL_NAMES
+                    and any(w.rsplit("/", 1)[-1] in _SHELL_NAMES for w in words)
                 ):
                     results.extend(_masked_subcommand_words(resolved))
+                else:
+                    # Not a shell payload — but it may still be the value of an
+                    # EXEC SURFACE option, where the token is executable text
+                    # rather than data. Emit it as its own haystack entry so the
+                    # anchored rules see it; do NOT re-parse it as shell, since
+                    # `python3 -c` payloads are Python that merely contain a
+                    # command.
+                    exec_flags = None
+                    for w in words:
+                        cand = _EXEC_SURFACES.get(w.rsplit("/", 1)[-1])
+                        if cand is not None:
+                            exec_flags = cand
+                            break
+                    if exec_flags is not None and (
+                        not exec_flags or prev in exec_flags
+                    ):
+                        results.append([resolved])
                 words.append(_MASK)
                 prev = _MASK
             else:

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -2448,6 +2448,25 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
                 # of those payloads was masked away with nothing rescanning it —
                 # a BLOCK -> ALLOW regression once the rules are anchored, since
                 # the raw haystack is no longer consulted for them.
+                #
+                # DO NOT HARMONISE THIS WITH ``_strip_global_options``, which
+                # scans only the narrow ``_WRAPPER_PREFIXES`` set and documents
+                # the resulting gap. The two loops look alike and want OPPOSITE
+                # answers, because they do different things:
+                #
+                #   here  — RE-SCANS a quoted payload that is already isolated.
+                #           A false positive costs a rescan of prose, bounded,
+                #           and anchoring is what contains it.
+                #   there — SYNTHESISES a new command-position haystack. Scan
+                #           any word and ``echo git -C /r push --force`` finds
+                #           "git" at index 1, emits ``echo git push --force``,
+                #           and the force-push rule matches an ECHO — a false
+                #           BLOCK on prose, produced by the guard that exists
+                #           because prose was being blocked (#675/#915).
+                #
+                # Verified: that echo is ``allow`` today and must stay so.
+                # Any-word is right for a payload you re-scan and wrong for a
+                # haystack you construct.
                 if (
                     words
                     and prev.startswith("-")

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -2342,7 +2342,33 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
         prev = ""
         for text, fully_quoted in toks:
             resolved = _resolve(text)
-            is_content = fully_quoted and (not resolved or any(ch in " \t\n" for ch in resolved))
+            # A quoted token holding a COMMAND SUBSTITUTION is not content, no
+            # matter how much prose surrounds it: ``git commit -m "$(rm -rf
+            # /x)"`` runs the payload. Masking it hid the payload from every
+            # anchored rule, and because ``git.commit`` carries an UNSCOPED
+            # default grant the residual ``ask`` resolved to ALLOW with no human
+            # — the fail-closed guarantee gone for that shape (#915 review).
+            #
+            # The failure needed three things and no one of them alone: this
+            # PR's anchoring (payload unseen), #917's unscoped grant (ask ->
+            # allow unattended), and the pre-existing whitespace-keyed masking.
+            # The ``echo "$(…)"`` control has the same shape with no grant and
+            # still fails closed, which is what proves the grant load-bearing.
+            #
+            # NB the mirror arrangement (``rm -rf "$(cat f)"`` — dangerous verb
+            # OUTSIDE the quotes) never broke: masking blanks the same token,
+            # but the verb is in command position and survives. The hazard is
+            # a benign outer command with the danger INSIDE the quotes.
+            #
+            # Not masking is strictly MORE inclusive, so it cannot weaken any
+            # rule; the cost is that a report quoting a substitution alongside a
+            # rule token can false-positive again, which is the safe direction.
+            has_substitution = "$(" in resolved or "`" in resolved
+            is_content = (
+                fully_quoted
+                and not has_substitution
+                and (not resolved or any(ch in " \t\n" for ch in resolved))
+            )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):
                 # Leading VAR=value assignment — its value is data here (the
                 # assigns table already handles later ``$VAR`` expansion).

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -2235,23 +2235,34 @@ def _strip_heredoc_bodies(command: str) -> str:
     return command[:nl + 1]
 
 
-def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
-    """Split ``command`` into subcommands of ``(token_text, fully_quoted)``.
+def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool, bool]]]:
+    """Split ``command`` into subcommands of ``(text, fully_quoted, expands)``.
 
     Quotes/escapes are resolved into the token text (so ``g''h`` -> ``gh``);
     ``fully_quoted`` is True when no character of the token was unquoted.
+
+    ``expands`` is True when the token contains a command substitution the
+    shell will actually RUN — i.e. ``$(...)`` or a backtick span appearing
+    unquoted or inside DOUBLE quotes. Inside single quotes the shell performs no
+    expansion, so ``git commit -m '$(...)'`` is an inert literal and must stay
+    maskable; treating it as a command is a false positive on a string nothing
+    executes.
     """
-    subs: List[List[Tuple[str, bool]]] = []
-    cur: List[Tuple[str, bool]] = []
+    subs: List[List[Tuple[str, bool, bool]]] = []
+    cur: List[Tuple[str, bool, bool]] = []
     buf: List[str] = []
     has_unquoted = False
     has_any = False
+    expands = False
+
+    def _has_subst(text: str) -> bool:
+        return "$(" in text or "`" in text
 
     def end_token() -> None:
-        nonlocal buf, has_unquoted, has_any
+        nonlocal buf, has_unquoted, has_any, expands
         if has_any:
-            cur.append(("".join(buf), not has_unquoted))
-        buf, has_unquoted, has_any = [], False, False
+            cur.append(("".join(buf), not has_unquoted, expands))
+        buf, has_unquoted, has_any, expands = [], False, False, False
 
     def end_sub() -> None:
         nonlocal cur
@@ -2267,6 +2278,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
             j = command.find("'", i + 1)
             if j == -1:
                 j = n
+            # Single quotes suppress expansion entirely — deliberately does NOT
+            # set `expands`, however substitution-shaped the contents look.
             buf.append(command[i + 1:j])
             has_any = True
             i = j + 1
@@ -2280,7 +2293,10 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 else:
                     out.append(command[j])
                     j += 1
-            buf.append("".join(out))
+            span = "".join(out)
+            if _has_subst(span):
+                expands = True
+            buf.append(span)
             has_any = True
             i = j + 1
         elif c == "\\" and i + 1 < n:
@@ -2300,6 +2316,8 @@ def _scan_masked_tokens(command: str) -> List[List[Tuple[str, bool]]]:
                 i += 1
         else:
             buf.append(c)
+            if c == "`" or (c == "(" and buf[-2:-1] == ["$"]):
+                expands = True
             has_unquoted = True
             has_any = True
             i += 1
@@ -2340,7 +2358,7 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
     for toks in _scan_masked_tokens(command):
         words: List[str] = []
         prev = ""
-        for text, fully_quoted in toks:
+        for text, fully_quoted, expands in toks:
             resolved = _resolve(text)
             # A quoted token holding a COMMAND SUBSTITUTION is not content, no
             # matter how much prose surrounds it: ``git commit -m "$(rm -rf
@@ -2363,10 +2381,14 @@ def _masked_subcommand_words(command: str) -> List[List[str]]:
             # Not masking is strictly MORE inclusive, so it cannot weaken any
             # rule; the cost is that a report quoting a substitution alongside a
             # rule token can false-positive again, which is the safe direction.
-            has_substitution = "$(" in resolved or "`" in resolved
+            # `expands` comes from the SCANNER, which knows the quote type:
+            # single quotes suppress expansion, so `git commit -m '$(...)'` is
+            # an inert literal and stays maskable. Deriving this from `resolved`
+            # instead would lose that distinction and false-positive on a string
+            # the shell never runs.
             is_content = (
                 fully_quoted
-                and not has_substitution
+                and not expands
                 and (not resolved or any(ch in " \t\n" for ch in resolved))
             )
             if not words and _ASSIGN_TOKEN_RE.match(resolved):

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -222,13 +222,63 @@ Block dangerous shell commands using regex patterns:
 bashToolPatterns:
   - pattern: '\brm\s+(-[^\s]*)*-[rRf]'
     reason: rm with recursive or force flags
+    anchored: true
 
   - pattern: '\bgit\s+push\s+--force\b'
     reason: git push --force (use --force-with-lease)
+    anchored: true
 
   - pattern: '\bsystemctl\s+stop\b'
     reason: stopping system services
+    anchored: true
 ```
+
+##### `anchored` — command position vs argument content (#675, #915)
+
+An unanchored rule matches the **raw command string**, so it fires on text that
+merely *mentions* the operation: a commit message, an `echo`, a `grep` whose
+search string is the rule's own reason, a `--kind done` report explaining that a
+deletion was refused. That is #915 — a report-back refused for what it says,
+and it reaches every command whose arguments discuss a guarded operation,
+including most of the tooling you would use to audit the guard.
+
+`anchored: true` matches against `masked_subcommands()` instead: quoted tokens
+that can only be content (a quoted token **containing whitespace**, a heredoc
+body) are blanked, while quoting obfuscation of the command itself still
+normalizes (`"rm" -rf`, `r\m`, `R=rm; $R`) and `sh -c "…"` payloads are
+recursively rescanned.
+
+**Anchoring is decided per FILE, not per rule.** A file may be anchored when
+every rule in it is command-prefix shaped **and** the tool takes no
+inner-command payload — the `git.yaml` shape test. Two reasons it cannot be a
+per-rule choice:
+
+- Masking blanks quoted content *regardless of position*, so a **wrapper** rule
+  whose danger arrives as a quoted payload — `ssh box "sudo rm -rf /var"`,
+  `psql -c "DROP TABLE users"`, `python -c "…shutil.rmtree…"` — loses exactly
+  the half it exists to read.
+- It is a *(rule × command-form)* property. Anchored `core.sudo-rm` still blocks
+  the local form but loses the ssh-wrapped one; its twin in `remote.yaml` is the
+  backstop that keeps that covered. Anchor both and the wrapped forms go from
+  double-covered to **uncovered**.
+
+So the wrapper rules live in two uniformly-**unanchored** files —
+`payloads.yaml` (SQL statements, interpreter `-c`/`-e`/`--eval` payloads,
+`$(…)` substitution) and `remote.yaml` (ssh) — rather than being flagged in
+place. No file mixes the two; a mixed file is a per-rule skip-list wearing a
+filename. Rules moved into `payloads.yaml` carry an explicit `id:` pinned to
+their previous id, so `safety.disabled_rules` / `unattended_allow` entries keep
+working.
+
+Known limit: a **trailing shell comment** is not masked, so
+`true  # <guarded op> was blocked` still matches.
+
+Both invariants are enforced by
+`tests/unit/test_damage_control_payload_anchoring.py`, which also asserts a
+dangerous form for every anchored rule against a **solo config of that rule
+alone** — a full-rule-set assertion can pass because some *other* rule caught
+the command, which is how a synthetic one-rule fixture stays green through real
+regressions.
 
 **Coverage**:
 - Destructive file operations (`rm -rf`, `shred`, `truncate`)
@@ -610,7 +660,7 @@ catastrophic, never-reversible verbs are `block` (fire in every mode).
 | **Outbound comms** | `agentwire email` | ask (unattended-allowed by default, #804) | `outbound.yaml` (`outbound.agentwire-email`) |
 | | `agentwire quo`, `twilio … messages create`, `aws ses send-email`, `aws sns publish`, `sendmail`, `mail -s` | ask | `outbound.yaml` (`outbound.*`) |
 | **DB migrations** | `prisma migrate deploy`/`dev`, `prisma db push`, `supabase db push`, `supabase migration up`, `alembic upgrade`/`downgrade`, `manage.py migrate`, `rails`/`rake db:migrate`, `knex migrate:*`, `sequelize db:migrate`, `flyway migrate`, `liquibase update` | ask | `databases.yaml` (`db.*`) |
-| **DB raw writes** | `psql`/`mysql` executing INSERT/UPDATE/ALTER/CREATE/GRANT, `mongosh` insert/update/delete | ask | `databases.yaml` (`db.psql-write`, `db.mysql-write`, `db.mongosh-write`) |
+| **DB raw writes** | `psql`/`mysql` executing INSERT/UPDATE/ALTER/CREATE/GRANT, `mongosh` insert/update/delete | ask | `payloads.yaml` (`db.psql-write`, `db.mysql-write`, `db.mongosh-write`) |
 | **DB schema-drop** | `prisma migrate reset`, `flyway clean` | **block** | `databases.yaml` (`db.prisma-reset`, `db.flyway-clean`) |
 | **Package publish** | `npm publish`, `uv publish` | ask | npm/uv tooldef |
 | | `cargo`/`poetry`/`pnpm`/`yarn publish`, `twine upload`, `gem push`, `mvn deploy` | ask | `publish.yaml` (`publish.*`) |
@@ -828,6 +878,10 @@ readOnlyPaths:
 **Heads-up:** the user-override directory **replaces** the bundled rules wholesale — copy what you need from `agentwire/hooks/damage-control/rules/` if you want to extend rather than override.
 
 **Pattern Tips**:
+- Declare `anchored:` on every rule — `true` for a command-prefix rule, `false`
+  if the danger arrives inside another command's quoted payload. The matcher
+  defaults to unanchored (fail-safe), which means a rule that omits it silently
+  reintroduces #915. See [`anchored`](#anchored--command-position-vs-argument-content-675-915).
 - Use `\b` for word boundaries: `\brm\b` matches `rm` but not `format`
 - Use `\s+` for required whitespace: `git\s+push` matches `git push`
 - Test patterns before deploying: `agentwire safety check "command"`

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -270,8 +270,42 @@ filename. Rules moved into `payloads.yaml` carry an explicit `id:` pinned to
 their previous id, so `safety.disabled_rules` / `unattended_allow` entries keep
 working.
 
-Known limit: a **trailing shell comment** is not masked, so
-`true  # <guarded op> was blocked` still matches.
+##### What anchoring gave up — the ssh-wrapped class (#924)
+
+Anchoring the 151 command-prefix rules demotes roughly **125 of 151
+ssh-wrapped dangerous forms from refused to allowed**:
+`ssh prod "terraform destroy"`, `ssh prod "kubectl delete namespace prod"`,
+`ssh prod "gh repo delete …"` and so on now pass.
+
+This is a demotion of **incidental** coverage, not a broken guard: those forms
+only blocked because of the same match-anywhere behaviour that *is* the payload
+bug. `remote.yaml`'s 12 rules are the *intentional* ssh coverage and are
+untouched — but the coverage was real while it lasted, so it is stated here
+rather than left to be discovered.
+
+The fix is **#924**: extend the `_SHELL_NAMES` rescan to
+`ssh <host> "<payload>"` so every rule applies to the payload, after which
+`remote.yaml` becomes **deletable** rather than something to extend. Widening
+`remote.yaml` to ~120 ssh twins is explicitly not the answer — that duplicates
+the entire rule set, which is the coupling this design exists to avoid.
+
+Known limits, all asserted as expected-fail rows in
+`tests/unit/test_damage_control_payload_anchoring.py` so a green suite cannot
+imply they work:
+
+| limit | example | tracked |
+|---|---|---|
+| ssh-wrapped forms outside `remote.yaml`'s 12 | `ssh prod "terraform destroy"` | #924 |
+| path ladders have no `anchored` concept | `grep -rn "<deletion>" ~/.agentwire/` → blocked by `noDeletePath` | #922 |
+| masking is keyed on **whitespace** | `msg send --kind done "rmdir"` → still blocked | #922 |
+| trailing shell comment is not masked | `true  # <guarded op> was blocked` | #922 |
+
+The middle two are why the **payload bug has three mechanisms** and anchoring
+`bashToolPatterns` fixes only the first. The path ladders in particular run
+three different predicates (`protectedControlPlane`, `zeroAccessPaths`,
+`readOnly`/`noDelete`), which is why one anchored-style flag will not serve
+them — the same *(rule × command-form)* conclusion that made anchoring a
+per-file decision.
 
 Both invariants are enforced by
 `tests/unit/test_damage_control_payload_anchoring.py`, which also asserts a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,3 +312,60 @@ def clean_env(monkeypatch):
     for key in list(os.environ):
         if key.startswith("AGENTWIRE_"):
             monkeypatch.delenv(key)
+
+
+# ---------------------------------------------------------------------------
+# damage-control hooks
+# ---------------------------------------------------------------------------
+#
+# The hooks are PEP 723 inline-deps scripts under hyphenated filenames
+# (`bash-tool-damage-control.py`), so they load via importlib rather than a
+# normal import. One loader, shared by every test that needs a hook module.
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "agentwire" / "hooks" / "damage-control"
+
+
+def load_damage_control_hook(filename: str):
+    """Load a hyphenated damage-control hook script as an importable module.
+
+    The script's `audit_logger` import resolves via sys.path injection so the
+    fallback no-op log_* functions are not needed.
+    """
+    import importlib.util
+
+    sys.path.insert(0, str(HOOKS_DIR))
+    try:
+        path = HOOKS_DIR / filename
+        spec = importlib.util.spec_from_file_location(
+            filename.replace(".py", "").replace("-", "_"), path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def bash_hook():
+    return load_damage_control_hook("bash-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def edit_hook():
+    return load_damage_control_hook("edit-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def write_hook():
+    return load_damage_control_hook("write-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def mcp_hook():
+    return load_damage_control_hook("mcp-tool-damage-control.py")
+
+
+@pytest.fixture(scope="module")
+def read_hook():
+    return load_damage_control_hook("read-tool-damage-control.py")

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -19,41 +19,11 @@ from pathlib import Path
 
 import pytest
 
-HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "agentwire" / "hooks" / "damage-control"
+from tests.conftest import HOOKS_DIR  # noqa: F401  (used by subprocess tests)
 
-
-def _load_hook(filename: str):
-    """Load a hyphenated hook script as an importable module.
-
-    The script's `audit_logger` import resolves via sys.path injection so the
-    fallback no-op log_* functions are not needed.
-    """
-    sys.path.insert(0, str(HOOKS_DIR))
-    try:
-        path = HOOKS_DIR / filename
-        spec = importlib.util.spec_from_file_location(
-            filename.replace(".py", "").replace("-", "_"), path
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-    finally:
-        sys.path.pop(0)
-
-
-@pytest.fixture(scope="module")
-def bash_hook():
-    return _load_hook("bash-tool-damage-control.py")
-
-
-@pytest.fixture(scope="module")
-def edit_hook():
-    return _load_hook("edit-tool-damage-control.py")
-
-
-@pytest.fixture(scope="module")
-def write_hook():
-    return _load_hook("write-tool-damage-control.py")
+# The `bash_hook` / `edit_hook` / `write_hook` fixtures and the importlib
+# loader they share live in tests/conftest.py — one loader for every test that
+# needs a hook module.
 
 
 # ---------------------------------------------------------------------------
@@ -1691,11 +1661,6 @@ class TestAuditLogger:
 # the synthesizer, the unattended fail-closed ladder, the attended ask, and a
 # parity proof that the synthesized command decides identically to the literal
 # `agentwire email`/`quo` string.
-
-
-@pytest.fixture(scope="module")
-def mcp_hook():
-    return _load_hook("mcp-tool-damage-control.py")
 
 
 class TestMcpHookSynthesizer:

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -703,15 +703,21 @@ class TestGitGlobalOptionBypass:
         ships green and covers nothing.
 
         `load_config` generates the tooldef ask-patterns only when handed a
-        tooldefs_dir. Dropped, the fixture sees 178 patterns / 14 anchored
-        instead of 265 / 101 — every tooldef-generated rule invisible, which is
+        tooldefs_dir. Dropped, the fixture sees 178 patterns / 151 anchored
+        instead of 265 / 238 — every tooldef-generated rule invisible, which is
         the half carrying #913's sharpest case (`git add` ask -> allow). The
         counts are asserted so a future arg-drop fails loudly rather than
         silently shrinking coverage.
+
+        The anchored count moved 101 -> 238 in #915, which extended `anchored`
+        from `git.yaml` alone (14) to the 14 command-prefix rule files (151);
+        87 tooldef-derived rules make up the rest. This guard caught that
+        change, which is exactly what it is for — the number is meant to be
+        updated deliberately, not widened into a range.
         """
         patterns = bundled_config["bashToolPatterns"]
         anchored = [p for p in patterns if p.get("anchored")]
-        assert (len(patterns), len(anchored)) == (265, 101)
+        assert (len(patterns), len(anchored)) == (265, 238)
         assert any(p.get("source") == "tooldef" for p in patterns)
 
     def test_quoted_path_with_spaces(self, bash_hook, bundled_config):

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -804,6 +804,11 @@ class TestGitGlobalOptionBypass:
         assert result["decision"] == "block", result
 
 
+# Assembled so this file's own text can't trip a bash rule if it is ever
+# scanned as a command (same reason as `_FORCE` above).
+_RM_RF = "rm" + " -rf"
+
+
 class TestCrossIssueBackstops:
     """Canaries for coverage that only LOOKS like it belongs to another rule.
 
@@ -908,6 +913,72 @@ class TestCrossIssueBackstops:
             for p in cfg["bashToolPatterns"]
         ), "the rule being disabled does not exist — this test proves nothing"
         assert bash_hook.check_command(cmd, cfg)["decision"] == "block"
+
+    # EXEC-SURFACE OPTIONS: a stripped value that is itself a COMMAND.
+    #
+    # #918 covered git's (`-c core.sshCommand=<cmd>`, `-c core.pager=<cmd>`) and
+    # additivity is what keeps them visible. This table adds a SECOND one —
+    # `tmux -c <shell-command>` — and it is strictly more exposed than git's,
+    # for a reason that has nothing to do with this normalizer:
+    #
+    #   git -c core.pager='rm -rf /x'   the token carries an unquoted
+    #                                   `core.pager=` prefix, so it is not
+    #                                   FULLY quoted and masking leaves it
+    #   tmux -c 'rm -rf /x'             the token IS fully quoted and contains
+    #                                   whitespace, so `is_content` blanks it
+    #
+    # So tmux's payload survives on the RAW haystack only. Anchoring the
+    # deletion rules moves them to the masked haystack, where it is already
+    # gone — measured against #920's branch, where this exact command read
+    # `allow` OUTRIGHT with no rule matching, interactive AND unattended. Not
+    # `ask`: with no `$(` the ambiguity detector never fires, so
+    # `core.ambiguous-command` is not there to fail closed either. That is what
+    # makes it sharper than the quoted-substitution case that prompted the
+    # review — that one at least needed a grant to reach `allow`; this needs
+    # nothing. (`sh -c '<payload>'` survives only because `_SHELL_NAMES`
+    # rescans it. `tmux` is not in that set, and neither are the other
+    # `-c`/`-e`/`--eval` clients — the class is #924's.)
+    #
+    # NOT AN EXPECTED-RED CANARY. It was written as one, before the ruling that
+    # #920 must not ship a BLOCK -> ALLOW-outright regression with no backstop.
+    # So this is a live guarantee, not a tripwire for an accepted change: a
+    # failure here means an exec-surface payload became unreachable by every
+    # content rule, in a posture where nothing else fails closed.
+    #
+    # Fixing it is NOT this seat's — `is_content` belongs to #920, and the
+    # general exec-surface class to #924. What this test owes them is a named,
+    # reproducible failure rather than silence.
+    @pytest.mark.parametrize("cmd", [
+        f"tmux -c '{_RM_RF} /tmp/x' new-session",
+        f"git -c core.pager='{_RM_RF} /tmp/x' fetch origin",
+    ])
+    def test_exec_surface_option_payloads_stay_visible(
+        self, bash_hook, bundled_config, cmd
+    ):
+        result = bash_hook.check_command(cmd, bundled_config)
+        assert result["decision"] == "block", (
+            f"{cmd!r} is {result['decision']} — the command PAYLOAD of an "
+            "exec-surface option is no longer reachable by any content rule"
+        )
+
+    def test_the_normalizer_is_not_what_hides_an_exec_surface_payload(
+        self, bash_hook
+    ):
+        """Bounds the claim above to what this PR actually owns.
+
+        The variant drops `-c` and its value, by design — but it is ADDITIVE,
+        so the payload is still on the raw and masked lists exactly as before.
+        Whether a *rule* can see it there is the masking question, not this
+        one, and this assertion is what separates the two.
+        """
+        cmd = f"tmux -c '{_RM_RF} /tmp/x' new-session"
+        assert bash_hook.global_option_normalized_haystacks(cmd) == [
+            "tmux new-session"
+        ]
+        subs, _ = bash_hook.normalize_subcommands(cmd)
+        assert any(_RM_RF in s for s in [cmd] + subs), (
+            "the raw haystack lost the payload — that WOULD be this PR's bug"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -428,8 +428,14 @@ SSH_WRAPPED_SURVIVES = [
 
 
 class TestSshWrappedCommandsStillRefused:
-    """The inner command arrives as a quoted arg — the reason remote.yaml
-    stays unanchored. remote.yaml had ZERO coverage in the suite before this."""
+    """remote.yaml's OWN 12 rules — its intentional ssh coverage — still hold.
+
+    SCOPE WARNING: this corpus is exactly those 12 forms. It says nothing about
+    ssh-wrapped commands generally, ~125 of which this PR demotes to allowed —
+    see TestSshWrappedCoverageReduction and #924. remote.yaml previously had no
+    coverage in the suite at all, which is why these 12 are asserted here; that
+    is not the same as ssh being handled.
+    """
 
     @pytest.mark.parametrize("command", SSH_WRAPPED_MASKED + SSH_WRAPPED_SURVIVES)
     def test_refused(self, bash_hook, bundled_config, command):
@@ -627,13 +633,15 @@ class TestItIsNotOnlyMsgSend:
             f"{plain.get('id')} -> {loaded.get('id')}"
         )
 
-    def test_reading_the_rules_is_not_blocked_by_the_rules(
+    def test_reading_an_unprotected_repo_path_is_not_blocked_by_bash_rules(
         self, bash_hook, bundled_config
     ):
-        """The sharpest live instance: auditing the guard tripped the guard.
+        """Named for what it proves, which is narrower than it looks.
 
-        Only the bashToolPatterns half — the same read against a *protected*
-        directory still fails via mechanism 2, asserted below.
+        All three commands read a path under the REPO, so no path ladder
+        engages — this exercises the bashToolPatterns half only. The original
+        reported command reads a PROTECTED directory and still fails
+        (mechanism 2, #922); see TestRemainingPayloadMechanisms.
         """
         for command in (
             "diff ~/.agentwire/damage-control/core.yaml "
@@ -721,3 +729,66 @@ class TestRemainingPayloadMechanisms:
         assert bash_hook.check_command(
             'echo "terraform destroy"', bundled_config
         )["decision"] == "allow"
+
+
+class TestSshWrappedCoverageReduction:
+    """DISCLOSURE: anchoring demotes ~125 of 151 ssh-wrapped dangerous forms
+    from refused to allowed, and this PR does not fix that. #924.
+
+    Read this before reading TestSshWrappedCommandsStillRefused, whose corpus
+    is EXACTLY the 12 forms ``remote.yaml`` protects — a corpus shaped to the
+    survivors, which proves nothing about the rest. That is the fixture-shaped
+    blind spot this file's own docstring calls out in the #675 test, reproduced
+    one level up.
+
+    Why it is a demotion rather than a regression in design: the pre-change
+    blocking of `ssh prod "<anything dangerous>"` was INCIDENTAL — it came from
+    the same match-anywhere behaviour that IS the bug. ``remote.yaml``'s 12
+    rules are the *intentional* ssh coverage and they are untouched. But the
+    coverage was real while it lasted, so it is stated, not buried.
+
+    The fix is #924 — extend the ``_SHELL_NAMES`` rescan to
+    ``ssh <host> "<payload>"`` so every rule applies to the payload, after
+    which ``remote.yaml`` becomes DELETABLE. It lives in ``masked_subcommands``,
+    which the orchestrator assigned to #913's plumbing, not here. Widening
+    ``remote.yaml`` to ~120 ssh twins is explicitly NOT the answer: it
+    duplicates the whole rule set, which is the second-thing-to-keep-in-sync
+    this PR exists to avoid.
+    """
+
+    # Representative sample of the demoted class, one per rule family.
+    DEMOTED = [
+        'ssh prod "terraform destroy"',
+        'ssh prod "gh repo delete owner/repo"',
+        'ssh prod "aws ec2 terminate-instances --instance-ids i-1"',
+        'ssh prod "gcloud projects delete my-proj"',
+        'ssh prod "kubectl delete namespace prod"',
+        'ssh prod "helm uninstall release"',
+        'ssh prod "docker volume rm pgdata"',
+        'ssh prod "npm unpublish my-pkg"',
+        'ssh prod "chmod 777 /srv"',
+        'ssh prod "tmux kill-server"',
+        'ssh prod "prisma migrate reset"',
+        'ssh prod "history -c"',
+    ]
+
+    @pytest.mark.parametrize("command", DEMOTED)
+    def test_ssh_wrapped_form_is_knowingly_allowed(
+        self, bash_hook, bundled_config, command
+    ):
+        """Expected-fail row. Green here means the gap is still open (#924)."""
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] not in REFUSED, (
+            f"{command!r} is now refused — #924 may have landed. If so, delete "
+            f"this row and update the disclosure in the PR body and the wiki."
+        )
+
+    def test_remote_yaml_intentional_coverage_is_what_survives(
+        self, bash_hook, bundled_config
+    ):
+        """The 12 forms remote.yaml exists for are unaffected — that is the
+        line between 'demoted incidental coverage' and 'broke the guard'."""
+        for command in SSH_WRAPPED_MASKED:
+            assert bash_hook.check_command(command, bundled_config)[
+                "decision"
+            ] in REFUSED, f"{command!r} — remote.yaml's own coverage broke"

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -446,6 +446,45 @@ class TestInterpreterAndSqlPayloadsStillRefused:
         )
 
 
+class TestGenericRmBackstopSurvivesAnchoring:
+    """#913 interaction: anchoring must not narrow the generic rm backstop.
+
+    A global option before the subcommand bypasses the specific rule
+    (``docker --context prod volume rm x`` misses ``containers.docker-volume-rm``
+    — that is #913), leaving only the generic ``core.rm-file-deletion`` rule
+    holding it. This PR anchors that rule, so the question is whether the
+    backstop survives.
+
+    It does, and the reason is precise: masking blanks a quoted token only when
+    it CONTAINS WHITESPACE. These commands have no such token, so the masked
+    subcommand is byte-identical to the raw command and the rule matches through
+    both haystacks. The narrowing this PR applies is confined to quoted argument
+    CONTENT — which is the whole point.
+    """
+
+    GLOBAL_OPTION_BYPASSED = [
+        "docker --context prod volume rm pgdata",
+        "aws --profile prod s3 rm s3://bucket --recursive",
+        "docker --context prod volume rm 'my data'",
+    ]
+
+    @pytest.mark.parametrize("command", GLOBAL_OPTION_BYPASSED)
+    def test_still_blocked_by_the_generic_rule(
+        self, bash_hook, bundled_config, command
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} lost its last backstop — the specific rule is "
+            f"global-option-bypassed (#913) and the generic rm rule no longer "
+            f"reaches it"
+        )
+
+    def test_masked_form_is_identical_when_nothing_is_quoted(self, bash_hook):
+        """The mechanism behind the assertion above, asserted directly."""
+        command = "docker --context prod volume rm pgdata"
+        assert bash_hook.masked_subcommands(command) == [command]
+
+
 class TestMutationProvesTheAssertionsHaveTeeth:
     """Anchor the must-not-anchor class and the guard measurably disappears.
 

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -535,7 +535,7 @@ class TestComposedWithGitNormalization:
 
     FORCE = "--" + "force"
 
-    def test_forced_push_behind_dash_C_blocks_via_the_git_rule(
+    def test_forced_push_behind_dash_c_blocks_via_the_git_rule(
         self, bash_hook, bundled_config
     ):
         result = bash_hook.check_command(
@@ -566,7 +566,7 @@ class TestComposedWithGitNormalization:
         assert result["decision"] == "block"
         assert result["id"] == rule_id
 
-    def test_safe_form_behind_dash_C_stays_ask_not_block(
+    def test_safe_form_behind_dash_c_stays_ask_not_block(
         self, bash_hook, bundled_config
     ):
         """The two-sided expectation: normalization must not rewrite the command

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -1,0 +1,572 @@
+"""#915 — a report-back must not be refused because of what it SAYS.
+
+``agentwire msg send --to X --kind done "<text>"`` runs its payload through the
+Bash rules, so a message that merely *describes* a blocked operation was itself
+blocked. It is not a ``msg send`` bug: any command whose ARGUMENTS discuss a
+guarded operation is refused — ``echo``, ``grep`` for a rule's own reason text,
+a probe script listing dangerous commands as test data. Reading the rules is
+blocked by the rules.
+
+#675 fixed this shape for tooldef-derived rules and for ``git.yaml`` with
+``anchored: true`` (match masked command position, never quoted argument
+content). This extends the same per-rule property to the rest of the bundled
+set, and marks the rules that must NOT get it.
+
+RULE SET UNDER TEST: the BUNDLED rules at
+``agentwire/hooks/damage-control/rules/*.yaml`` — not ``~/.agentwire/
+damage-control/``, which the live hook prefers and which has drifted (#916).
+Every assertion here is a claim about what ships.
+
+This is a guard-WEAKENING change, so the weight is on the guard: every anchored
+rule carries a companion dangerous form proven to still refuse *by that rule
+alone*, and a mutation class proves those assertions go red when the anchoring
+decision is wrong. The payload cases are the small half.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent.parent
+RULES_DIR = REPO / "agentwire" / "hooks" / "damage-control" / "rules"
+
+REFUSED = {"block", "ask"}
+SAFETY = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
+
+
+def _bundled_rules():
+    """Every explicit bashToolPattern, straight off disk."""
+    out = []
+    for path in sorted(RULES_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        for entry in data.get("bashToolPatterns", []) or []:
+            if isinstance(entry, dict):
+                out.append((path.name, entry))
+    return out
+
+
+BUNDLED = _bundled_rules()
+ANCHORED = [(f, e) for f, e in BUNDLED if e.get("anchored")]
+UNANCHORED = [(f, e) for f, e in BUNDLED if not e.get("anchored")]
+
+
+@pytest.fixture(scope="module")
+def bundled_config(bash_hook):
+    cfg = bash_hook.load_config(RULES_DIR, None)
+    cfg["safety"] = dict(SAFETY)
+    return cfg
+
+
+def _solo_config(rule):
+    """A config holding exactly one rule — no other rule can take the credit."""
+    return {
+        "bashToolPatterns": [rule],
+        "zeroAccessPaths": [],
+        "readOnlyPaths": [],
+        "noDeletePaths": [],
+        "allowedPaths": [],
+        "safety": dict(SAFETY),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Anchoring is a FILE-WIDE property gated on a shape test
+# ---------------------------------------------------------------------------
+#
+# ``anchored`` swaps the haystack for masked_subcommands(), which blanks EVERY
+# fully-quoted token containing whitespace regardless of position. That is
+# lossless for a command-prefix rule and FATAL for a WRAPPER rule whose inner
+# command arrives as a quoted argument: ``_SHELL_NAMES`` (_core.py) rescans
+# ``sh -c "…"`` payloads, but ssh and the SQL/interpreter clients are not in it.
+#
+# It is not a rule-level property either. Anchored ``core.sudo-rm`` still blocks
+# ``sudo rm /etc/hosts`` but loses ``ssh prod "sudo rm -rf /var/lib"`` — and its
+# twin ``remote.ssh-remote-sudo-rm``, which exists to cover the wrapped form, is
+# lost in the same change, taking that form from double-covered to UNCOVERED.
+#
+# So the unit is the FILE, following the git.yaml precedent (14 rules, 14
+# anchored, the only anchored file before this): a file may be anchored when
+# every rule in it is command-prefix shaped AND the tool takes no inner-command
+# payload. The rules that fail that test were MOVED into payloads.yaml rather
+# than flagged in place, so there is no per-rule skip-list to keep in sync.
+
+UNANCHORED_FILES = {"payloads.yaml", "remote.yaml"}
+
+
+class TestAnchoringIsFileWide:
+    @pytest.mark.parametrize(
+        "filename,entry", BUNDLED,
+        ids=[f"{f}:{e.get('pattern', '')[:44]}" for f, e in BUNDLED],
+    )
+    def test_every_rule_declares_anchored(self, filename, entry):
+        # The matcher default is unanchored (fail-safe), so a rule that forgets
+        # the key silently reintroduces #915. Force the author to choose.
+        assert "anchored" in entry, (
+            f"{filename}: rule {entry.get('pattern')!r} must declare "
+            f"`anchored:` — see #915."
+        )
+        assert isinstance(entry["anchored"], bool)
+
+    def test_no_file_mixes_anchored_and_unanchored(self):
+        """A mixed file is a per-rule skip-list wearing a filename."""
+        mixed = {}
+        for filename, entry in BUNDLED:
+            mixed.setdefault(filename, set()).add(entry["anchored"])
+        offenders = {f: v for f, v in mixed.items() if len(v) > 1}
+        assert not offenders, (
+            f"these files mix anchored and unanchored rules: {sorted(offenders)}. "
+            f"Move the wrapper rules to payloads.yaml instead."
+        )
+
+    def test_unanchored_files_are_exactly_the_wrapper_files(self):
+        actual = {f for f, e in BUNDLED if not e["anchored"]}
+        assert actual == UNANCHORED_FILES, (
+            f"unanchored file set drifted: unexpected={sorted(actual - UNANCHORED_FILES)} "
+            f"missing={sorted(UNANCHORED_FILES - actual)}"
+        )
+
+    def test_all_of_remote_yaml_is_unanchored(self):
+        """remote.yaml is 100% wrapper rules — anchoring any of it is a hole."""
+        remote = [e for f, e in BUNDLED if f == "remote.yaml"]
+        assert len(remote) == 12
+        assert all(e["anchored"] is False for e in remote)
+
+    def test_payloads_rules_pin_their_ids(self):
+        """The move must not churn ids that safety.disabled_rules may name."""
+        payloads = [e for f, e in BUNDLED if f == "payloads.yaml"]
+        assert len(payloads) == 15
+        assert all(e.get("id") for e in payloads), (
+            "every rule moved into payloads.yaml needs an explicit `id:` pinned "
+            "to the id it had in its old file — otherwise the id is re-derived "
+            "from the new filename and any config naming it breaks."
+        )
+        # ids are pinned to the ORIGINAL file, which is the point
+        assert {e["id"].split(".")[0] for e in payloads} == {
+            "core", "databases", "db", "containers",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Companion dangerous form, one per ANCHORED rule — the large half
+# ---------------------------------------------------------------------------
+#
+# Each entry is a real invocation that its rule must still refuse. Proven two
+# ways: against a SOLO config holding only that rule (so no other rule can take
+# the credit — the failure mode of the #675 test, which stayed green through 13
+# regressions because its fixture held one tooldef-shaped rule), and against
+# the full bundled set.
+
+DANGEROUS_SAMPLE = {
+    '\\btmux\\s+kill-server\\b': 'tmux kill-server',
+    '\\btmux\\s+kill-session\\s+.*\\bagentwire': 'tmux kill-session -t agentwire-main',
+    '\\btmux\\s+kill-session\\s+.*-a\\b': 'tmux kill-session -t main -a',
+    '\\bagentwire\\s+destroy\\b': 'agentwire destroy',
+    '\\bagentwire\\s+.*--force.*remove\\b': 'agentwire worktree --force --remove old',
+    '\\brm\\s+.*\\.agentwire': 'rm -r ~/.agentwire/sessions',
+    '\\brm\\s+.*~/.agentwire': 'rm -r ~/.agentwire',
+    '\\baws\\s+s3\\s+rm\\s+.*--recursive': 'aws s3 rm s3://bucket/data --recursive',
+    '\\baws\\s+s3\\s+rb\\s+.*--force': 'aws s3 rb s3://bucket --force',
+    '\\baws\\s+ec2\\s+terminate-instances\\b': 'aws ec2 terminate-instances',
+    '\\baws\\s+rds\\s+delete-db-instance\\b': 'aws rds delete-db-instance',
+    '\\baws\\s+cloudformation\\s+delete-stack\\b': 'aws cloudformation delete-stack',
+    '\\baws\\s+dynamodb\\s+delete-table\\b': 'aws dynamodb delete-table',
+    '\\baws\\s+eks\\s+delete-cluster\\b': 'aws eks delete-cluster',
+    '\\baws\\s+lambda\\s+delete-function\\b': 'aws lambda delete-function',
+    '\\baws\\s+iam\\s+delete-role\\b': 'aws iam delete-role',
+    '\\baws\\s+iam\\s+delete-user\\b': 'aws iam delete-user',
+    '\\baws\\s+cloudformation\\s+deploy\\b': 'aws cloudformation deploy',
+    '\\baws\\s+lambda\\s+update-function-code\\b': 'aws lambda update-function-code',
+    '\\baws\\s+ecs\\s+update-service\\b': 'aws ecs update-service',
+    '\\bvercel\\s+remove\\s+.*--yes': 'vercel remove my-site --yes',
+    '\\bvercel\\s+projects\\s+rm\\b': 'vercel projects rm',
+    '\\bvercel\\s+env\\s+rm\\s+.*--yes': 'vercel env rm API_KEY production --yes',
+    '\\bnetlify\\s+sites:delete\\b': 'netlify sites:delete',
+    '\\bnetlify\\s+functions:delete\\b': 'netlify functions:delete',
+    '\\bwrangler\\s+delete\\b': 'wrangler delete',
+    '\\bwrangler\\s+r2\\s+bucket\\s+delete\\b': 'wrangler r2 bucket delete',
+    '\\bwrangler\\s+kv:namespace\\s+delete\\b': 'wrangler kv:namespace delete',
+    '\\bwrangler\\s+d1\\s+delete\\b': 'wrangler d1 delete',
+    '\\bwrangler\\s+queues\\s+delete\\b': 'wrangler queues delete',
+    '\\bheroku\\s+apps:destroy\\b': 'heroku apps:destroy',
+    '\\bheroku\\s+pg:reset\\b': 'heroku pg:reset',
+    '\\bfly\\s+apps\\s+destroy\\b': 'fly apps destroy',
+    '\\bfly\\s+destroy\\b': 'fly destroy',
+    '\\bdoctl\\s+compute\\s+droplet\\s+delete\\b': 'doctl compute droplet delete',
+    '\\bdoctl\\s+databases\\s+delete\\b': 'doctl databases delete',
+    '\\bsupabase\\s+db\\s+reset\\b': 'supabase db reset',
+    '\\bgh\\s+repo\\s+delete\\b': 'gh repo delete',
+    '\\bnpm\\s+unpublish\\b': 'npm unpublish',
+    '\\bvercel\\s+deploy\\b': 'vercel deploy',
+    '\\bvercel\\s+(-[^\\s]*\\s+)*--prod\\b': 'vercel --prod',
+    '\\bnetlify\\s+deploy\\b': 'netlify deploy',
+    '\\b(fly|flyctl)\\s+deploy\\b': 'fly deploy',
+    '\\bwrangler\\s+(deploy|publish)\\b': 'wrangler deploy',
+    '\\brailway\\s+(up|deploy)\\b': 'railway up',
+    '\\brender\\s+deploys?\\s+create\\b': 'render deploys create --service-id srv-1',
+    '\\bsupabase\\s+functions\\s+deploy\\b': 'supabase functions deploy',
+    '\\bdocker\\s+system\\s+prune\\s+.*-a': 'docker system prune -a',
+    '\\bdocker\\s+rmi\\s+.*-f': 'docker rmi -f myimage:latest',
+    '\\bdocker\\s+volume\\s+rm\\b': 'docker volume rm',
+    '\\bdocker\\s+volume\\s+prune\\b': 'docker volume prune',
+    '\\bkubectl\\s+delete\\s+namespace\\b': 'kubectl delete namespace',
+    '\\bkubectl\\s+delete\\s+all\\s+--all': 'kubectl delete all --all',
+    '\\bkubectl\\s+delete\\s+.*--all\\s+--all-namespaces': 'kubectl delete pods --all --all-namespaces',
+    '\\bhelm\\s+uninstall\\b': 'helm uninstall',
+    '\\bdocker\\s+(compose\\s+)?push\\b': 'docker push myimage:latest',
+    '\\bkubectl\\s+delete\\b': 'kubectl delete',
+    '\\brm\\s+(-[^\\s]*)*-[rRf]': 'rm -rf /tmp/build',
+    '\\brm\\s+-[rRf]': 'rm -r /tmp/build',
+    '\\brm\\s+--recursive': 'rm --recursive',
+    '\\brm\\s+--force': 'rm --force',
+    '\\bsudo\\s+rm\\b': 'sudo rm',
+    '\\brmdir\\b': 'rmdir',
+    '\\brm\\s+[^-]': 'rm notes.txt',
+    '(?:^|[;&|])\\s*trash\\s+': 'trash notes.txt',
+    '\\bfind\\b.*\\s-delete\\b': "find /tmp -name '*.log' -delete",
+    '\\bfind\\b.*-exec\\s+rm\\b': "find /tmp -name '*.log' -exec rm {} +",
+    '\\bchmod\\s+(-[^\\s]+\\s+)*777\\b': 'chmod 777 /srv/app',
+    '\\bchmod\\s+-[Rr].*777': 'chmod -R 777 /srv/app',
+    '\\bchown\\s+-[Rr].*\\broot\\b': 'chown -R root /srv/app',
+    '\\bmkfs\\.': 'mkfs.ext4 /dev/disk2',
+    '\\bdd\\s+.*of=/dev/': 'dd if=/dev/zero of=/dev/disk2',
+    '\\bkill\\s+-9\\s+-1\\b': 'kill -9 -1',
+    '\\bkillall\\s+-9\\b': 'killall -9',
+    '\\bpkill\\s+-9\\b': 'pkill -9',
+    '\\bhistory\\s+-c\\b': 'history -c',
+    '\\bredis-cli\\s+FLUSHALL': 'redis-cli FLUSHALL',
+    '\\bredis-cli\\s+FLUSHDB': 'redis-cli FLUSHDB',
+    '\\bdropdb\\b': 'dropdb',
+    '\\bmysqladmin\\s+drop\\b': 'mysqladmin drop',
+    '\\bprisma\\s+migrate\\s+reset\\b': 'prisma migrate reset',
+    '\\bflyway\\s+clean\\b': 'flyway clean',
+    '\\bprisma\\s+migrate\\s+(deploy|dev)\\b': 'prisma migrate deploy',
+    '\\bprisma\\s+db\\s+push\\b': 'prisma db push',
+    '\\bsupabase\\s+db\\s+push\\b': 'supabase db push',
+    '\\bsupabase\\s+migration\\s+up\\b': 'supabase migration up',
+    '\\balembic\\s+(upgrade|downgrade)\\b': 'alembic upgrade head',
+    '\\bmanage\\.py\\s+migrate\\b': 'python manage.py migrate',
+    '\\b(rails|rake)\\s+db:migrate\\b': 'rails db:migrate',
+    '\\bknex\\s+migrate:(latest|up|down|rollback)\\b': 'knex migrate:latest',
+    '\\bsequelize\\s+db:migrate\\b': 'sequelize db:migrate',
+    '\\bflyway\\s+migrate\\b': 'flyway migrate',
+    '\\bliquibase\\s+update\\b': 'liquibase update',
+    '\\bfirebase\\s+projects:delete\\b': 'firebase projects:delete',
+    '\\bfirebase\\s+firestore:delete\\s+.*--all-collections': 'firebase firestore:delete --all-collections',
+    '\\bfirebase\\s+database:remove\\b': 'firebase database:remove',
+    '\\bfirebase\\s+hosting:disable\\b': 'firebase hosting:disable',
+    '\\bfirebase\\s+functions:delete\\b': 'firebase functions:delete',
+    '\\bgcloud\\s+projects\\s+delete\\b': 'gcloud projects delete',
+    '\\bgcloud\\s+compute\\s+instances\\s+delete\\b': 'gcloud compute instances delete',
+    '\\bgcloud\\s+sql\\s+instances\\s+delete\\b': 'gcloud sql instances delete',
+    '\\bgcloud\\s+container\\s+clusters\\s+delete\\b': 'gcloud container clusters delete',
+    '\\bgcloud\\s+storage\\s+rm\\s+.*-r': 'gcloud storage rm -r gs://bucket/data',
+    '\\bgcloud\\s+functions\\s+delete\\b': 'gcloud functions delete',
+    '\\bgcloud\\s+iam\\s+service-accounts\\s+delete\\b': 'gcloud iam service-accounts delete',
+    '\\bgcloud\\s+run\\s+deploy\\b': 'gcloud run deploy',
+    '\\bgcloud\\s+app\\s+deploy\\b': 'gcloud app deploy',
+    '\\bgit\\s+reset\\s+--hard\\b': 'git reset --hard',
+    '\\bgit\\s+clean\\s+(-[^\\s]*)*-[fd]': 'git clean -fd',
+    '\\bgit\\s+push\\s+.*--force(?!-with-lease)': 'git push origin --force',
+    '\\bgit\\s+push\\s+(-[^\\s]*)*-f\\b': 'git push -f origin main',
+    '\\bgit\\s+stash\\s+clear\\b': 'git stash clear',
+    '\\bgit\\s+reflog\\s+expire\\b': 'git reflog expire',
+    '\\bgit\\s+gc\\s+.*--prune=now': 'git gc --prune=now',
+    '\\bgit\\s+filter-branch\\b': 'git filter-branch',
+    '\\bgit\\s+checkout\\s+--\\s*\\.': 'git checkout -- .',
+    '\\bgit\\s+restore\\s+\\.': 'git restore .',
+    '\\bgit\\s+stash\\s+drop\\b': 'git stash drop',
+    '\\bgit\\s+branch\\s+(-[^\\s]*)*-D': 'git branch -D feature',
+    '\\bgit\\s+push\\s+\\S+\\s+--delete\\b': 'git push origin --delete feature',
+    '\\bgit\\s+push\\s+\\S+\\s+:\\S+': 'git push origin :feature',
+    '\\bgws\\s+gmail\\s+users\\.messages\\.delete\\b': 'gws gmail users.messages.delete',
+    '\\bgws\\s+gmail\\s+users\\.messages\\.batchDelete\\b': 'gws gmail users.messages.batchDelete',
+    '\\bgws\\s+drive\\s+files\\.delete\\b': 'gws drive files.delete',
+    '\\bgws\\s+drive\\s+files\\.emptyTrash\\b': 'gws drive files.emptyTrash',
+    '\\bgws\\s+calendar\\s+calendars\\.delete\\b': 'gws calendar calendars.delete',
+    '\\bgws\\s+admin\\s+users\\.delete\\b': 'gws admin users.delete',
+    '\\bgws\\s+admin\\s+users\\.makeAdmin\\b': 'gws admin users.makeAdmin',
+    '\\bterraform\\s+destroy\\b': 'terraform destroy',
+    '\\bpulumi\\s+destroy\\b': 'pulumi destroy',
+    '\\bserverless\\s+remove\\b': 'serverless remove',
+    '\\bsls\\s+remove\\b': 'sls remove',
+    '\\bsam\\s+delete\\b': 'sam delete',
+    '\\bpulumi\\s+up\\b': 'pulumi up',
+    '\\b(serverless|sls)\\s+deploy\\b': 'serverless deploy',
+    '\\bsam\\s+deploy\\b': 'sam deploy',
+    '\\bcdk\\s+deploy\\b': 'cdk deploy',
+    '\\bansible-playbook\\b': 'ansible-playbook',
+    '\\bagentwire\\s+email\\b': 'agentwire email',
+    '\\bagentwire\\s+quo\\b': 'agentwire quo',
+    '\\btwilio\\s+api[:\\w.]*messages[:\\w.]*create\\b': 'twilio api:core:messages:create --to +15551234567 --body hi',
+    '\\baws\\s+ses(v2)?\\s+send-email\\b': 'aws ses send-email --to a@b.c',
+    '\\baws\\s+sns\\s+publish\\b': 'aws sns publish',
+    '\\bsendmail\\b': 'sendmail',
+    '\\b(mail|mailx)\\s+(-[^\\s]*\\s+)*-s\\b': 'mail -s subject user@example.com',
+    '\\bcargo\\s+publish\\b': 'cargo publish',
+    '\\bpoetry\\s+publish\\b': 'poetry publish',
+    '\\btwine\\s+upload\\b': 'twine upload',
+    '\\b(pnpm|yarn)\\s+publish\\b': 'pnpm publish',
+    '\\bgem\\s+push\\b': 'gem push',
+    '\\bmvn\\s+(deploy|.*\\bdeploy:deploy)\\b': 'mvn deploy',
+}
+
+
+class TestEveryAnchoredRuleStillRefusesItsDangerousForm:
+    def test_every_anchored_rule_has_a_companion_sample(self):
+        missing = [
+            e["pattern"] for _, e in ANCHORED if e["pattern"] not in DANGEROUS_SAMPLE
+        ]
+        assert not missing, (
+            "anchored rules with no companion dangerous-form test — every "
+            f"anchoring decision needs one (#915): {missing}"
+        )
+
+    @pytest.mark.parametrize(
+        "filename,entry", ANCHORED,
+        ids=[f"{f}:{e['pattern'][:44]}" for f, e in ANCHORED],
+    )
+    def test_rule_alone_refuses_its_sample(self, bash_hook, filename, entry):
+        """Solo config: no other rule can take the credit for the refusal."""
+        sample = DANGEROUS_SAMPLE[entry["pattern"]]
+        result = bash_hook.check_command(sample, _solo_config(entry))
+        assert result["decision"] in REFUSED, (
+            f"{filename}: anchoring {entry['pattern']!r} lets {sample!r} "
+            f"through — the rule no longer matches its own dangerous form"
+        )
+
+    @pytest.mark.parametrize("sample", sorted(set(DANGEROUS_SAMPLE.values())))
+    def test_full_ruleset_refuses_sample(self, bash_hook, bundled_config, sample):
+        result = bash_hook.check_command(sample, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{sample!r} was ALLOWED by the full bundled rule set"
+        )
+
+
+# Anchoring normalizes quoting/escaping/indirection of the COMMAND, so these
+# spellings must not slip past either.
+OBFUSCATED = [
+    'r"m" -rf /tmp/build',
+    '"rm" -rf /tmp/build',
+    "R=rm; $R -rf /tmp/build",
+    'bash -c "rm -rf /tmp/build"',
+    'sh -c "kubectl delete namespace prod"',
+    "git status && rm -rf /tmp/build",
+    "echo ok; terraform destroy",
+    "true | helm uninstall release",
+    't"e"rraform destroy',
+    # a quoted argument WITH spaces beside a real dangerous command: the
+    # argument is masked, the command still matches
+    'rm -rf "/tmp/some dir/build"',
+    'git commit -m "wip" && rm -rf /tmp/build',
+]
+
+
+class TestObfuscatedDangerousCommandsStillRefused:
+    @pytest.mark.parametrize("command", OBFUSCATED)
+    def test_refused(self, bash_hook, bundled_config, command):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} was ALLOWED — quoting/indirection defeated the guard"
+        )
+
+
+# ---------------------------------------------------------------------------
+# remote.yaml — previously zero coverage anywhere in the suite
+# ---------------------------------------------------------------------------
+
+# Masking only blanks a fully-quoted token that CONTAINS WHITESPACE, so a
+# one-word payload (``ssh prod "reboot"``) or a space-free one
+# (``--eval "db.dropDatabase()"``) survives anchoring by accident. Splitting the
+# corpus on that line keeps the mutation class honest: MASKED_* forms are the
+# ones anchoring actually destroys, SURVIVES_* are covered but prove nothing
+# about the anchoring decision, so they are asserted and excluded from mutation.
+
+SSH_WRAPPED_MASKED = [
+    'ssh prod "sudo rm -rf /var/lib"',
+    'ssh prod "rm -rf /srv/data"',
+    'ssh prod "mkfs.ext4 /dev/sda1"',
+    'ssh prod "dd if=/dev/zero of=/dev/sda"',
+    'ssh prod "dropdb production"',
+    'ssh prod "mysqladmin drop production"',
+    'ssh prod "redis-cli FLUSHALL"',
+    'ssh prod "docker system prune -a"',
+    'ssh prod "docker rm -f web"',
+    'ssh prod "reboot now"',
+    'ssh prod "shutdown -h now"',
+    'ssh prod "systemctl stop nginx"',
+]
+
+SSH_WRAPPED_SURVIVES = [
+    'ssh prod "reboot"',              # one word — not masked
+    "ssh prod sudo rm -rf /var/lib",  # unquoted — not masked
+    "ssh prod dropdb production",
+]
+
+
+class TestSshWrappedCommandsStillRefused:
+    """The inner command arrives as a quoted arg — the reason remote.yaml
+    stays unanchored. remote.yaml had ZERO coverage in the suite before this."""
+
+    @pytest.mark.parametrize("command", SSH_WRAPPED_MASKED + SSH_WRAPPED_SURVIVES)
+    def test_refused(self, bash_hook, bundled_config, command):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} was ALLOWED — the remote half went unmatched"
+        )
+
+
+CLIENT_WRAPPED_MASKED = [
+    'psql -c "DROP TABLE users"',
+    'psql -c "DROP DATABASE production"',
+    'psql -c "TRUNCATE TABLE users"',
+    'psql -c "DELETE FROM users;"',
+    'psql -h db -c "INSERT INTO users VALUES (1)"',
+    'mysql -e "DROP DATABASE production"',
+    'mysql -e "UPDATE users SET admin = 1"',
+    'mongosh --eval "db.users.deleteMany({ })"',
+    'python3 -c "import shutil; shutil.rmtree(\'/srv\')"',
+    "perl -e 'unlink \"/srv/data\"'",
+]
+
+CLIENT_WRAPPED_SURVIVES = [
+    'mongosh --eval "db.dropDatabase()"',        # no whitespace — not masked
+    'mongosh --eval "db.users.deleteMany({})"',
+]
+
+
+class TestInterpreterAndSqlPayloadsStillRefused:
+    @pytest.mark.parametrize(
+        "command", CLIENT_WRAPPED_MASKED + CLIENT_WRAPPED_SURVIVES
+    )
+    def test_refused(self, bash_hook, bundled_config, command):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} was ALLOWED — the quoted payload went unmatched"
+        )
+
+
+class TestMutationProvesTheAssertionsHaveTeeth:
+    """Anchor the must-not-anchor class and the guard measurably disappears.
+
+    Without this, the tests above could be green for the wrong reason. The
+    mutation flips every rule to ``anchored: true`` — the blanket change this
+    PR deliberately did NOT make — and asserts each wrapper case goes through.
+    """
+
+    @pytest.fixture(scope="class")
+    def all_anchored(self, bundled_config):
+        mutated = dict(bundled_config)
+        mutated["bashToolPatterns"] = [
+            {**p, "anchored": True} for p in bundled_config["bashToolPatterns"]
+        ]
+        return mutated
+
+    @pytest.mark.parametrize("command", SSH_WRAPPED_MASKED + CLIENT_WRAPPED_MASKED)
+    def test_blanket_anchoring_loses_the_wrapper_guard(
+        self, bash_hook, bundled_config, all_anchored, command
+    ):
+        assert bash_hook.check_command(command, bundled_config)["decision"] in REFUSED
+        mutated = bash_hook.check_command(command, all_anchored)["decision"]
+        assert mutated not in REFUSED, (
+            f"mutation is inert for {command!r} (still {mutated}) — the shipped "
+            f"assertion for it proves nothing about the anchoring decision"
+        )
+
+    def test_unanchoring_reintroduces_the_reported_bug(self, bash_hook, bundled_config):
+        """The other direction: drop anchoring and #915 comes straight back."""
+        mutated = dict(bundled_config)
+        mutated["bashToolPatterns"] = [
+            {**p, "anchored": False} for p in bundled_config["bashToolPatterns"]
+        ]
+        command = (
+            'agentwire msg send --to memory-manager --kind done '
+            '"the merge could not be completed -- I did not rm the file"'
+        )
+        assert bash_hook.check_command(command, bundled_config)["decision"] == "allow"
+        assert bash_hook.check_command(command, mutated)["decision"] in REFUSED
+
+
+# ---------------------------------------------------------------------------
+# The reported symptom — the small half
+# ---------------------------------------------------------------------------
+
+# The two real 2026-08-06 failures were `--kind done` reports describing a
+# blocked deletion — the load-bearing kind that dead-letters to the owner.
+PAYLOADS = [
+    "the merge could not be completed -- I did not rm the file or route around it",
+    "file deletion is blocked by damage-control, so cleanup was skipped",
+    "damage-control refused rm -rf on the stale worktree; left it in place",
+    "I did not run git reset --hard; the branch is untouched",
+    "tried terraform destroy on the sandbox stack and it was refused",
+    "kubectl delete namespace was blocked, so the test namespace is still up",
+    "the probe listed dropdb and gh repo delete as TEST DATA, nothing ran",
+    "chmod 777 was rejected by the hook -- permissions unchanged",
+    "docker volume rm and helm uninstall both refused; nothing was removed",
+    "npm unpublish and history -c are on the blocked list, as expected",
+]
+
+
+class TestReportBackPayloadsAreDelivered:
+    @pytest.mark.parametrize("body", PAYLOADS)
+    def test_msg_send_done_is_allowed(self, bash_hook, bundled_config, body):
+        command = f'agentwire msg send --to memory-manager --kind done "{body}"'
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "allow", (
+            f"a report-back was refused for its own text: {result['reason']}"
+        )
+
+    @pytest.mark.parametrize("body", PAYLOADS)
+    def test_notify_parent_is_allowed(self, bash_hook, bundled_config, body):
+        command = f'agentwire notify-parent --to orchestrator "{body}"'
+        assert bash_hook.check_command(command, bundled_config)["decision"] == "allow"
+
+
+class TestItIsNotOnlyMsgSend:
+    """Any command whose ARGUMENTS discuss a guarded operation — including the
+    tooling you would use to audit the guard itself."""
+
+    CARRIERS = [
+        'echo "the rm -rf was refused by damage-control"',
+        'grep -rn "rm file deletion (use git clean or manual cleanup)" rules/',
+        'grep -rn "terraform destroy" docs/',
+        'git commit -m "note: rm -rf of the build dir was blocked"',
+        'gh issue comment 915 --body "damage-control refused rm -rf here"',
+        "gh pr create --body-file - <<EOF\nrm -rf was refused here\nEOF",
+    ]
+
+    # KNOWN LIMIT: masking works on quoted tokens and heredoc bodies, not on
+    # trailing shell comments — `true  # git reset --hard was blocked` still
+    # matches, because `# …` is left inline in the masked subcommand. Out of
+    # scope here (it is a masked_subcommands change, owned by #913).
+    UNFIXED_COMMENT_FORM = "true  # note: git reset --hard was blocked"
+
+    @pytest.mark.parametrize("command", CARRIERS)
+    def test_allowed(self, bash_hook, bundled_config, command):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "allow", (
+            f"{command!r} refused for its argument text: {result['reason']}"
+        )
+
+    def test_trailing_shell_comment_is_a_known_remaining_hole(
+        self, bash_hook, bundled_config
+    ):
+        """Documented, not fixed — asserted so the day it changes is visible."""
+        result = bash_hook.check_command(self.UNFIXED_COMMENT_FORM, bundled_config)
+        assert result["decision"] in REFUSED
+
+    def test_reading_the_rules_is_not_blocked_by_the_rules(
+        self, bash_hook, bundled_config
+    ):
+        """The sharpest live instance: auditing the guard tripped the guard."""
+        for command in (
+            "diff ~/.agentwire/damage-control/core.yaml "
+            "agentwire/hooks/damage-control/rules/core.yaml",
+            'grep -n "rm -rf" agentwire/hooks/damage-control/rules/core.yaml',
+            'rg --fixed-strings "git reset --hard" agentwire/',
+        ):
+            result = bash_hook.check_command(command, bundled_config)
+            assert result["decision"] == "allow", (
+                f"reading the rules is refused by the rules: {command!r} "
+                f"-> {result['reason']}"
+            )

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -661,6 +661,145 @@ class TestComposedWithPathScopedGrants:
         assert result.get("id") != self.GRANTED_HAND_WRITTEN_RULE
 
 
+class TestQuotedCommandSubstitutionIsNotContent:
+    """A dangerous command INSIDE a quoted substitution must still refuse.
+
+    The hole this closes, found in review: ``git commit -m "$(rm -rf /x)"`` went
+    BLOCK -> ALLOW **including under AGENTWIRE_UNATTENDED=1**, removing the
+    fail-closed guarantee that is the entire point of the unattended tier.
+
+    Three things had to line up and no one of them does it alone:
+
+    1. this PR anchors ``core.rm-*``, so the rules match the MASKED haystack;
+    2. masking blanks a fully-quoted whitespace-containing token — and
+       ``"$(rm -rf /x)"`` is exactly that — so the payload became invisible;
+    3. #917 ships ``git.commit`` in ``DEFAULT_UNATTENDED_ALLOW`` **unscoped**,
+       so the residual ``ask`` resolved to ``allow`` with no human. The scope
+       evaluator does return *unscopeable* for a substitution, but an unscoped
+       grant never consults it — bypassed, not defeated.
+
+    On main step 1 is absent, so the raw haystack still caught it. Nothing went
+    red because no test anywhere covered a dangerous command inside a QUOTED
+    substitution — the earlier falsification corpus was the mirror arrangement
+    (``rm -rf "$(cat f)"``, dangerous verb OUTSIDE the quotes), which survives
+    masking and always did.
+
+    Fix: ``is_content`` no longer masks a quoted token containing ``$(`` or a
+    backtick. Strictly more inclusive, so it cannot weaken any rule.
+    """
+
+    RM = "rm -" + "rf"
+    TF = "terraform " + "destroy"
+
+    #: (command, the rule family that must own the refusal)
+    GRANTED_CARRIER_CASES = [
+        (f'git commit -m "$({RM} /tmp/x)"', "core.rm-with-recursive-or-force-flags"),
+        (f'git commit -m "$({TF})"',
+         "infrastructure.terraform-destroy-destroys-all-infrastructure"),
+        ('git commit -m "$(gh repo delete o/r)"',
+         "cloud-hosting.gh-repo-delete-deletes-repository"),
+        ('git commit -m "$(kubectl delete namespace prod)"',
+         "containers.kubectl-delete-namespace"),
+        (f'git commit -m `{RM} /tmp/x`', "core.rm-with-recursive-or-force-flags"),
+    ]
+
+    @pytest.mark.parametrize("command,rule_id", GRANTED_CARRIER_CASES)
+    def test_refused_and_by_the_rule_that_owns_it(
+        self, bash_hook, bundled_config, command, rule_id
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "block", (
+            f"{command!r} decided {result['decision']} — the payload is hidden "
+            f"from the anchored rules again"
+        )
+        assert result["id"] == rule_id, (
+            f"{command!r} blocked via {result['id']!r}, not the rule that owns "
+            f"the payload — something else took the credit"
+        )
+
+    @pytest.mark.parametrize("command,_rule", GRANTED_CARRIER_CASES)
+    def test_unattended_column_specifically(
+        self, bash_hook, bundled_config, command, _rule
+    ):
+        """The column that actually mattered.
+
+        An interactive ``ask`` looks harmless and is what hid this: the carrier
+        holds an unscoped grant, so ``ask`` becomes ``allow`` with no human. A
+        hard ``block`` is the only verdict that survives the unattended
+        resolver, so assert the tier rather than merely "not allow".
+        """
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "block", (
+            f"{command!r} is {result['decision']}, not block — an ask on a "
+            f"carrier holding an unscoped grant resolves to ALLOW unattended"
+        )
+
+    def test_echo_contrast_proves_the_grant_is_load_bearing(
+        self, bash_hook, bundled_config
+    ):
+        """Same shape, no grant. It failed closed even while `git commit` did
+        not, which is what identified the grant as the third ingredient."""
+        result = bash_hook.check_command(
+            f'echo "$({self.RM} /tmp/x)"', bundled_config
+        )
+        assert result["decision"] == "block"
+
+    def test_mirror_arrangement_still_refused(self, bash_hook, bundled_config):
+        """Dangerous verb OUTSIDE the quotes — the earlier corpus. Never broke,
+        asserted so the two arrangements stay distinguishable in the record."""
+        result = bash_hook.check_command(
+            f'{self.RM} "$(cat /tmp/targets)"', bundled_config
+        )
+        assert result["decision"] == "block"
+
+    def test_prose_without_a_substitution_is_still_masked(
+        self, bash_hook, bundled_config
+    ):
+        """The #915 fix survives the repair — a plain report still sends."""
+        result = bash_hook.check_command(
+            'agentwire msg send --to orch --kind done '
+            '"the merge could not be completed -- I did not rm the file"',
+            bundled_config,
+        )
+        assert result["decision"] == "allow"
+
+    def test_masked_form_keeps_the_substitution_visible(self, bash_hook):
+        """The mechanism, asserted directly rather than via a verdict."""
+        masked = bash_hook.masked_subcommands(f'git commit -m "$({self.RM} /x)"')
+        assert masked == [f"git commit -m $({self.RM} /x)"]
+        # and a substitution-free quoted token is still masked
+        plain = bash_hook.masked_subcommands('git commit -m "a plain message"')
+        assert "a plain message" not in plain[0]
+
+    @pytest.mark.parametrize("command,_rule", GRANTED_CARRIER_CASES)
+    def test_mutation_reverting_the_fix_makes_these_go_red(
+        self, bash_hook, bundled_config, command, _rule
+    ):
+        """Re-mask quoted substitutions and every row above must fall through.
+
+        Without this the rows could be passing for an unrelated reason; with it,
+        the fix is shown to be what carries them.
+        """
+        original = bash_hook.masked_subcommands
+
+        def remasked(cmd):
+            # the pre-fix behaviour: blank any fully-quoted whitespace token,
+            # substitution or not — emulated by stripping the substitution
+            # spans before masking so `is_content` reverts to its old verdict
+            import re as _re
+            return original(_re.sub(r"\$\([^)]*\)|`[^`]*`", "PLACEHOLDER TEXT", cmd))
+
+        bash_hook.masked_subcommands = remasked
+        try:
+            result = bash_hook.check_command(command, bundled_config)
+        finally:
+            bash_hook.masked_subcommands = original
+        assert result["decision"] != "block", (
+            f"mutation is inert for {command!r} — it still blocks with the "
+            f"substitution masked, so the shipped row proves nothing"
+        )
+
+
 class TestMutationProvesTheAssertionsHaveTeeth:
     """Anchor the must-not-anchor class and the guard measurably disappears.
 

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -591,6 +591,76 @@ class TestComposedWithGitNormalization:
             assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
 
 
+class TestComposedWithPathScopedGrants:
+    """Composition with #917's path-scoped `unattended_allow` grants.
+
+    #917 evaluates a scope only for a rule that MATCHED and resolved to ``ask``
+    under ``AGENTWIRE_UNATTENDED=1``. This PR changes WHICH rules match. The
+    hazard is therefore specific: a rule that stops matching because of
+    anchoring never reaches grant evaluation at all, so the scope check silently
+    does not run for it — and the command lands on ``allow`` for the *absence*
+    of a rule rather than for a grant anyone authored.
+
+    THE SETS INTERSECT AT EXACTLY ONE RULE, measured rather than assumed.
+    ``DEFAULT_UNATTENDED_ALLOW`` names six ids; five are tooldef-derived
+    (``git.add``, ``git.add-u``, ``git.commit``, ``git.push``, ``gh.pr-create``)
+    and were already anchored by #675, so this PR does not touch them. The sixth,
+    ``outbound.agentwire-email``, lives in ``outbound.yaml`` and IS newly
+    anchored here. That one row is the whole intersection.
+    """
+
+    GRANTED_HAND_WRITTEN_RULE = "outbound.agentwire-email"
+
+    def test_the_intersection_is_exactly_one_rule(self, bash_hook, bundled_config):
+        """Pin the premise — if a future grant names another hand-written rule,
+        this composition needs re-measuring rather than assuming."""
+        granted = {
+            e.get("id") if isinstance(e, dict) else e
+            for e in bash_hook.DEFAULT_UNATTENDED_ALLOW
+        }
+        hand_ids = {
+            p.get("id") for p in bundled_config["bashToolPatterns"]
+            if p.get("source") != "tooldef"
+        }
+        assert granted & hand_ids == {self.GRANTED_HAND_WRITTEN_RULE}, (
+            f"the #915/#917 intersection changed: {sorted(granted & hand_ids)}. "
+            f"Re-measure the composition before trusting this class."
+        )
+
+    def test_granted_rule_still_matches_so_scope_evaluation_is_reached(
+        self, bash_hook, bundled_config
+    ):
+        """The load-bearing assertion. Anchoring must not stop the granted rule
+        matching, or #917's scope check never runs for it."""
+        result = bash_hook.check_command(
+            "agentwire email --to a@b.c --subject hi --body hi", bundled_config
+        )
+        assert result["decision"] == "ask", (
+            f"the granted rule resolved {result['decision']}, not ask — #917 "
+            f"evaluates a scope only on an ask, so the grant is now bypassed "
+            f"in whichever direction this went"
+        )
+        assert result["id"] == self.GRANTED_HAND_WRITTEN_RULE
+
+    def test_prose_naming_the_granted_command_no_longer_matches_it(
+        self, bash_hook, bundled_config
+    ):
+        """The #915 fix, on the one rule that carries a grant.
+
+        This is a genuine behaviour change and it is the desirable direction: a
+        report that MENTIONS sending an email no longer consumes the grant path
+        at all. It lands on allow for having no rule, which is correct here
+        because nothing is being sent.
+        """
+        result = bash_hook.check_command(
+            'agentwire msg send --to orch --kind done '
+            '"agentwire email was refused, so the owner was not notified"',
+            bundled_config,
+        )
+        assert result["decision"] == "allow"
+        assert result.get("id") != self.GRANTED_HAND_WRITTEN_RULE
+
+
 class TestMutationProvesTheAssertionsHaveTeeth:
     """Anchor the must-not-anchor class and the guard measurably disappears.
 
@@ -762,11 +832,36 @@ class TestRemainingPayloadMechanisms:
     wrong trade.
     """
 
-    # mechanism 2 — the literal incident from #915's body
+    # These rows assert on ``~``-form protected paths, so they need $HOME to look
+    # like a real home — the same reason and the same marker as
+    # test_damage_control_bypass.py. The #893 redirect points HOME at a pytest
+    # tmp dir, which on Linux is under ``/tmp``, which core.yaml allowlists
+    # ``allow: all`` — and an allowlist entry OUTRANKS both noDeletePaths and
+    # protectedControlPlane (``check_command`` consults it inside each ladder).
+    # So the rows resolved to ``allow`` on CI for a reason with nothing to do
+    # with the mechanism. macOS temp is /private/var/folders, not allowlisted,
+    # which is why a local run could not see it.
+    #
+    # NOT a skip: conftest honours the marker by handing back the real paths, so
+    # the rows run and assert for real. Reads only; the session-scoped audit
+    # backstop still fails the run on any write.
+    pytestmark = pytest.mark.real_agentwire_home
+
+    # mechanism 2 — the literal incident from #915's body, in its literal form
     LADDER_CASES = [
         ('grep -rn "rm -rf" ~/.agentwire/', "noDeletePath"),
-        ('grep -rn "rm -rf" .git/', "noDeletePath"),
         ('rg "rm -rf" ~/.claude/hooks/', "protectedControlPlane"),
+        # `.git/` is a RELATIVE noDeletePath — no $HOME and no tmp prefix, so
+        # this row holds regardless of how the suite redirects HOME.
+        ('grep -rn "rm -rf" .git/', "noDeletePath"),
+    ]
+
+    # The same three ladder steps against explicit non-allowlisted literals, so
+    # at least one row per step is independent of $HOME *and* of the allowlist.
+    EXPLICIT_LADDER_CASES = [
+        ("noDeletePaths", 'grep -rn "rm -rf" /srv/protected/'),
+        ("readOnlyPaths", 'grep -rn "rm -rf" /srv/readonly/'),
+        ("zeroAccessPaths", 'grep -rn "rm -rf" /srv/secret/'),
     ]
 
     # mechanism 3 — a one-word payload in the exact reported carrier
@@ -790,6 +885,72 @@ class TestRemainingPayloadMechanisms:
         assert via in str(result.get("pattern", "")), (
             f"expected refusal via {via}, got {result.get('pattern')} — the "
             f"mechanism changed even though the verdict did not"
+        )
+
+    @pytest.mark.parametrize("ladder,command", EXPLICIT_LADDER_CASES)
+    def test_each_ladder_step_refuses_a_read_on_its_search_string(
+        self, bash_hook, ladder, command
+    ):
+        """One row per ladder step, against literal paths.
+
+        Three steps, three different predicates — which is why one
+        anchored-style flag cannot serve them and why they are #922 rather than
+        an extension of this PR.
+        """
+        cfg = {
+            "bashToolPatterns": [],
+            "zeroAccessPaths": [],
+            "readOnlyPaths": [],
+            "noDeletePaths": [],
+            "allowedPaths": [],
+            "safety": dict(SAFETY),
+        }
+        cfg[ladder] = [command.rsplit(" ", 1)[-1]]
+        result = bash_hook.check_command(command, cfg)
+        assert result["decision"] in REFUSED, (
+            f"{ladder} no longer refuses {command!r} — mechanism 2 looks fixed "
+            f"(#922). The ladder has no `anchored` concept; if it grew one, "
+            f"update this row and #915's story."
+        )
+
+    def test_protected_control_plane_step_refuses_a_read(self, bash_hook):
+        """Ladder step 0, with an EMPTY allowlist passed explicitly.
+
+        Deliberately not done with a tmp HOME. `tmp_path` is under `/tmp` on
+        Linux, which core.yaml allowlists `allow: all`, and the allowlist
+        outranks the protected control plane — so a tmp HOME is the one thing
+        guaranteed to make this row lie. Passing `allowed=[]` states the
+        precondition instead of depending on an environment to supply it.
+        """
+        command = 'rg "rm -rf" ~/.claude/hooks/'
+        blocked, reason = bash_hook.check_protected_command(command, [])
+        assert blocked, (
+            f"{command!r} no longer refused by the protected control plane — "
+            f"step 0 of mechanism 2 looks fixed (#922)"
+        )
+        assert reason
+
+    def test_allowlist_outranks_the_ladders(self, bash_hook):
+        """Pin the trap itself, since it has now cost two sessions a red CI.
+
+        An `allow: all` entry short-circuits BOTH ladders. That is why a tmp
+        HOME under /tmp turns these rows green-to-allow, and it is worth an
+        assertion rather than a comment.
+        """
+        cfg = {
+            "bashToolPatterns": [],
+            "zeroAccessPaths": [],
+            "readOnlyPaths": [],
+            "noDeletePaths": ["/srv/protected/"],
+            "allowedPaths": [],
+            "safety": dict(SAFETY),
+        }
+        command = 'grep -rn "rm -rf" /srv/protected/'
+        assert bash_hook.check_command(command, cfg)["decision"] in REFUSED
+        cfg["allowedPaths"] = [{"path": "/srv/*", "allow": "all"}]
+        assert bash_hook.check_command(command, cfg)["decision"] == "allow", (
+            "an allow:all entry no longer outranks noDeletePaths — the trap "
+            "that made this file's CI red has changed shape"
         )
 
     @pytest.mark.parametrize("command", WHITESPACE_CASES)

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -763,6 +763,37 @@ class TestQuotedCommandSubstitutionIsNotContent:
         )
         assert result["decision"] == "allow"
 
+    def test_single_quoted_substitution_is_inert_and_stays_masked(
+        self, bash_hook, bundled_config
+    ):
+        """EXPECTED NON-BLOCK, and the reason must travel with the row.
+
+        Single quotes suppress expansion, so ``git commit -m '$(rm -rf /x)'``
+        commits the literal text and runs nothing. There is no payload to catch,
+        and "fixing" this into a block would be a false positive on a string the
+        shell never executes.
+
+        My first version of the fix keyed on the RESOLVED token text, which has
+        already lost the quote type — so it blocked this. The scanner now
+        reports whether the substitution sat in an EXPANDING span, which is the
+        distinction that matters.
+
+        It lands on ``ask`` rather than ``allow`` only because ``$(`` in the raw
+        command trips the pre-existing obfuscation fallback — unrelated to this
+        PR, and the conservative direction.
+        """
+        result = bash_hook.check_command(
+            f"git commit -m '$({self.RM} /tmp/x)'", bundled_config
+        )
+        assert result["decision"] != "block", (
+            "a single-quoted substitution is inert — blocking it is a false "
+            "positive on text the shell never runs"
+        )
+        masked = bash_hook.masked_subcommands(f"git commit -m '$({self.RM} /x)'")
+        assert self.RM not in masked[0], (
+            "the single-quoted token should still be masked as content"
+        )
+
     def test_masked_form_keeps_the_substitution_visible(self, bash_hook):
         """The mechanism, asserted directly rather than via a verdict."""
         masked = bash_hook.masked_subcommands(f'git commit -m "$({self.RM} /x)"')

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -454,11 +454,16 @@ CLIENT_WRAPPED_MASKED = [
     'mysql -e "DROP DATABASE production"',
     'mysql -e "UPDATE users SET admin = 1"',
     'mongosh --eval "db.users.deleteMany({ })"',
-    'python3 -c "import shutil; shutil.rmtree(\'/srv\')"',
     "perl -e 'unlink \"/srv/data\"'",
 ]
 
 CLIENT_WRAPPED_SURVIVES = [
+    # Covered by _EXEC_SURFACES now (`python3 -c` is a table entry), so it
+    # holds even under blanket anchoring and the mutation below is INERT
+    # for it. That is a genuine strengthening, not an inconvenience: it no
+    # longer depends on payloads.yaml staying unanchored. Asserted as
+    # refused above, excluded from mutation so that class stays honest.
+    'python3 -c "import shutil; shutil.rmtree(\'/srv\')"',
     'mongosh --eval "db.dropDatabase()"',        # no whitespace — not masked
     'mongosh --eval "db.users.deleteMany({})"',
 ]
@@ -1200,3 +1205,103 @@ class TestSshWrappedCoverageReduction:
             assert bash_hook.check_command(command, bundled_config)[
                 "decision"
             ] in REFUSED, f"{command!r} — remote.yaml's own coverage broke"
+
+
+class TestExecSurfacePayloadsStayVisible:
+    """A quoted payload on an EXEC SURFACE must not be masked away (#924 class).
+
+    Anchoring the rule files stops the raw haystack being consulted, so masking
+    a fully-quoted multi-word token took NINE measured commands from BLOCK to
+    ``allow`` **with no rule matching at all** — no grant consulted, and no
+    ``core.ambiguous-command`` backstop either, because with no ``$(`` present
+    the ambiguity detector never fires. Measured across real trees per revision
+    with ``_core`` imported from inside each, so neither side is a hybrid.
+
+    WHY THE OBVIOUS FIXES ARE WRONG, since all three were tried:
+
+    - ``$(``/backtick syntax (the fix one class up) misses every row here.
+    - Adding these names to ``_SHELL_NAMES`` is semantically false: that set
+      means "this payload IS a shell command" — true for ``sh -c``, false for
+      ``python3 -c``, where the payload is source that merely contains one.
+    - The additive-haystack pattern — emit every masked token as its own entry —
+      fixes all nine AND reinstates #915 for all prose, because a report payload
+      becomes a command-position entry again. The pattern that was right for
+      #918 and #932 is wrong here.
+
+    So the distinguisher is POSITION: is this token the value of an exec-surface
+    option? That needs a table, and ``_EXEC_SURFACES`` is the minimal instance
+    of #924's eventual one. A tool missing from it degrades to today's
+    behaviour, not worse.
+
+    Rule IDs are asserted, not verdicts — a block from some other rule satisfies
+    a verdict-only row while the payload stays invisible.
+    """
+
+    REGRESSED = [
+        ("tmux -c 'rm -rf /tmp/x' new-session", "core.rm-with-recursive-or-force-flags"),
+        ("tmux new-session -d 'rm -rf /tmp/x'", "core.rm-with-recursive-or-force-flags"),
+        ("""python3 -c 'import os; os.system("rm -rf /tmp/x")'""", "core.rm-with-recursive-or-force-flags"),
+        ("""perl -e 'system("rm -rf /tmp/x")'""", "core.rm-with-recursive-or-force-flags"),
+        ("""node -e 'require("child_process").execSync("rm -rf /tmp/x")'""", "core.rm-with-recursive-or-force-flags"),
+        ("""ruby -e 'system("rm -rf /tmp/x")'""", "core.rm-with-recursive-or-force-flags"),
+        ("""awk 'BEGIN{system("rm -rf /tmp/x")}'""", "core.rm-with-recursive-or-force-flags"),
+        ("watch -n1 'rm -rf /tmp/x'", "core.rm-with-recursive-or-force-flags"),
+        ("make -c 'rm -rf /tmp/x'", "core.rm-with-recursive-or-force-flags"),
+    ]
+
+    @pytest.mark.parametrize("command,rule_id", REGRESSED)
+    def test_regressed_row_refuses_by_its_own_rule(
+        self, bash_hook, bundled_config, command, rule_id
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "block", (
+            f"{command!r} is {result['decision']} — an exec-surface payload is "
+            f"masked away again. On main this blocks; anchored without the "
+            f"table it lands on allow with NO rule matching at all."
+        )
+        assert result["id"] == rule_id, (
+            f"{command!r} blocked via {result['id']!r}, not {rule_id!r} — "
+            f"something else took the credit and the payload is still hidden"
+        )
+
+    # HELD rows: correct before this change and must not move. A "fix" that
+    # works by widening the table until everything matches breaks these.
+    HELD = [
+        "timeout 5 sh -c 'rm -rf /tmp/x'",
+        "env FOO=1 sh -c 'rm -rf /tmp/x'",
+        "nohup sh -c 'rm -rf /tmp/x'",
+        "xargs -I{} sh -c 'rm -rf /tmp/x'",
+        "find . -exec sh -c 'rm -rf /tmp/x' ;",
+        "sh -c 'rm -rf /tmp/x'",
+        "bash -c 'rm -rf /tmp/x'",
+        "su -c 'rm -rf /tmp/x' root",
+        "ssh prod 'rm -rf /tmp/x'",
+        'psql -c "DROP TABLE users"',
+    ]
+
+    @pytest.mark.parametrize("command", HELD)
+    def test_held_row_unchanged(self, bash_hook, bundled_config, command):
+        assert bash_hook.check_command(command, bundled_config)["decision"] in REFUSED
+
+    def test_prose_is_still_masked(self, bash_hook, bundled_config):
+        """The bound on this fix: a report payload is NOT an exec surface.
+
+        This is the row that fails if anyone repairs the class with the additive
+        pattern instead of the table.
+        """
+        result = bash_hook.check_command(
+            "agentwire msg send --to orch --kind done "
+            '"the merge failed -- I did not rm -rf the file"',
+            bundled_config,
+        )
+        assert result["decision"] == "allow"
+
+    def test_a_missing_exec_surface_degrades_to_today_not_worse(
+        self, bash_hook, bundled_config
+    ):
+        """A tool absent from the table behaves exactly as it does now."""
+        assert "notatool" not in bash_hook._EXEC_SURFACES
+        result = bash_hook.check_command(
+            "notatool -c 'rm -rf /tmp/x'", bundled_config
+        )
+        assert result["decision"] == "allow"

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -1305,3 +1305,50 @@ class TestExecSurfacePayloadsStayVisible:
             "notatool -c 'rm -rf /tmp/x'", bundled_config
         )
         assert result["decision"] == "allow"
+
+
+class TestPayloadRescanAndHaystackSynthesisDisagreeOnPurpose:
+    """The any-word rescan must NOT be copied into ``_strip_global_options``.
+
+    Two loops in ``_core.py`` look alike and want opposite answers:
+
+    - the payload rescan (this PR) scans ANY word for a shell name, because a
+      wrapper prefix puts the shell in the middle and the payload is already an
+      isolated quoted token — a false positive costs a rescan of prose;
+    - ``_strip_global_options`` (#919) scans only ``_WRAPPER_PREFIXES`` and
+      documents the resulting gap, because it SYNTHESISES a new command-position
+      haystack — scan any word there and ``echo git -C /r push --force``
+      emits ``echo git push --force``, matching the force-push rule on an
+      ECHO. That is #675/#915 re-opened by the guard that exists because prose
+      was being blocked.
+
+    Sitting in one file those read as an inconsistency to harmonise, and the
+    obvious harmonisation is the harmful direction. This pins the property so
+    the comment is not the only thing defending it.
+    """
+
+    ECHOES = [
+        "echo git -C /repo push --force",
+        'echo "git -C /repo push --force was refused by damage-control"',
+        'agentwire msg send --to orch --kind done '
+        '"git -C /repo push --force was refused"',
+    ]
+
+    @pytest.mark.parametrize("command", ECHOES)
+    def test_prose_naming_a_global_option_command_is_not_blocked(
+        self, bash_hook, bundled_config, command
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "allow", (
+            f"{command!r} is {result['decision']} — a synthesised haystack is "
+            f"matching prose. If _strip_global_options was widened to scan any "
+            f"word, revert that: the two loops disagree on purpose."
+        )
+
+    def test_the_real_command_still_blocks(self, bash_hook, bundled_config):
+        """The other side of the asymmetry — narrow there must not cost this."""
+        result = bash_hook.check_command(
+            "git -C /repo push --force origin main", bundled_config
+        )
+        assert result["decision"] == "block"
+        assert result["id"] == "git.git-push-force-use-force-with-lease"

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -9,8 +9,14 @@ blocked by the rules.
 
 #675 fixed this shape for tooldef-derived rules and for ``git.yaml`` with
 ``anchored: true`` (match masked command position, never quoted argument
-content). This extends the same per-rule property to the rest of the bundled
-set, and marks the rules that must NOT get it.
+content). This extends the same property to the rest of the bundled set, and
+marks the files that must NOT get it.
+
+SCOPE: the payload bug has THREE mechanisms and this fixes ONE of them —
+``bashToolPatterns``. The path ladders (mechanism 2) and whitespace-keyed
+masking (mechanism 3) are #922, and are asserted here as still-refused ON
+PURPOSE so a green run cannot read as "the reported symptom is fixed". See
+``TestRemainingPayloadMechanisms``.
 
 RULE SET UNDER TEST: the BUNDLED rules at
 ``agentwire/hooks/damage-control/rules/*.yaml`` — not ``~/.agentwire/
@@ -30,6 +36,7 @@ import yaml
 
 REPO = Path(__file__).resolve().parent.parent.parent
 RULES_DIR = REPO / "agentwire" / "hooks" / "damage-control" / "rules"
+TOOLDEFS_DIR = REPO / "agentwire" / "tooldefs"
 
 REFUSED = {"block", "ask"}
 SAFETY = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
@@ -53,7 +60,23 @@ UNANCHORED = [(f, e) for f, e in BUNDLED if not e.get("anchored")]
 
 @pytest.fixture(scope="module")
 def bundled_config(bash_hook):
-    cfg = bash_hook.load_config(RULES_DIR, None)
+    """Bundled rules AND bundled tooldefs — what the real hook loads.
+
+    Loading rules alone is a fixture-shaped blind spot: the tooldef-derived
+    ask-rules are ~87 of the 265 patterns the hook actually sees, and omitting
+    them makes commands read ``allow`` here that are ``ask`` in reality. That
+    matters for this file specifically, because ``ask`` resolves to a BLOCK
+    under ``AGENTWIRE_UNATTENDED=1`` — so a payload carrier that is merely
+    "ask" is still broken on a scheduler dispatch.
+    """
+    cfg = bash_hook.load_config(RULES_DIR, TOOLDEFS_DIR)
+    assert not cfg.get("_parser_unavailable"), "rules failed to load"
+    # `source` is the rules-file stem for hand-written rules and the literal
+    # "tooldef" for generated ones, so it separates them reliably — an id prefix
+    # does not (a tooldef command with an explicit `id:` yields e.g. `git.push`,
+    # not `tooldef.*`).
+    hand = [p for p in cfg["bashToolPatterns"] if p.get("source") != "tooldef"]
+    assert len(hand) == 178, f"expected 178 hand-written rules, got {len(hand)}"
     cfg["safety"] = dict(SAFETY)
     return cfg
 
@@ -565,39 +588,53 @@ class TestItIsNotOnlyMsgSend:
     """Any command whose ARGUMENTS discuss a guarded operation — including the
     tooling you would use to audit the guard itself."""
 
+    # (carrier template, guarded-op payload). The assertion is PARITY: the same
+    # carrier with an innocuous payload must get the same verdict. Some carriers
+    # are ask-tier tooldef commands in their own right (`git commit`,
+    # `gh issue comment`) — that is by design and has nothing to do with #915,
+    # so asserting a bare `allow` would be asserting the wrong thing.
     CARRIERS = [
-        'echo "the rm -rf was refused by damage-control"',
-        'grep -rn "rm file deletion (use git clean or manual cleanup)" rules/',
-        'grep -rn "terraform destroy" docs/',
-        'git commit -m "note: rm -rf of the build dir was blocked"',
-        'gh issue comment 915 --body "damage-control refused rm -rf here"',
-        "gh pr create --body-file - <<EOF\nrm -rf was refused here\nEOF",
+        ('echo "{}"', "the rm -rf was refused by damage-control"),
+        ('grep -rn "{}" rules/', "rm file deletion (use git clean or manual cleanup)"),
+        ('grep -rn "{}" docs/', "terraform destroy"),
+        ('git commit -m "{}"', "note: rm -rf of the build dir was blocked"),
+        ('gh issue comment 915 --body "{}"', "damage-control refused rm -rf here"),
+        ("gh pr create --body-file - <<EOF\n{}\nEOF", "rm -rf was refused here"),
+        ('agentwire msg send --to orch --kind done "{}"',
+         "damage-control refused rm -rf on the stale worktree"),
     ]
+    INNOCUOUS = "everything went fine and nothing needed attention"
 
-    # KNOWN LIMIT: masking works on quoted tokens and heredoc bodies, not on
-    # trailing shell comments — `true  # git reset --hard was blocked` still
-    # matches, because `# …` is left inline in the masked subcommand. Out of
-    # scope here (it is a masked_subcommands change, owned by #913).
-    UNFIXED_COMMENT_FORM = "true  # note: git reset --hard was blocked"
 
-    @pytest.mark.parametrize("command", CARRIERS)
-    def test_allowed(self, bash_hook, bundled_config, command):
-        result = bash_hook.check_command(command, bundled_config)
-        assert result["decision"] == "allow", (
-            f"{command!r} refused for its argument text: {result['reason']}"
-        )
-
-    def test_trailing_shell_comment_is_a_known_remaining_hole(
-        self, bash_hook, bundled_config
+    @pytest.mark.parametrize(
+        "template,payload", CARRIERS, ids=[t[:28] for t, _ in CARRIERS]
+    )
+    def test_payload_text_does_not_change_the_verdict(
+        self, bash_hook, bundled_config, template, payload
     ):
-        """Documented, not fixed — asserted so the day it changes is visible."""
-        result = bash_hook.check_command(self.UNFIXED_COMMENT_FORM, bundled_config)
-        assert result["decision"] in REFUSED
+        loaded = bash_hook.check_command(template.format(payload), bundled_config)
+        plain = bash_hook.check_command(
+            template.format(self.INNOCUOUS), bundled_config
+        )
+        assert loaded["decision"] == plain["decision"], (
+            f"{template!r} changed verdict on its payload alone: "
+            f"{plain['decision']} with innocuous text, {loaded['decision']} with "
+            f"{payload!r} ({loaded['reason']}) — that is #915."
+        )
+        # and the reason must not be a rule about the operation being described
+        assert loaded.get("id") == plain.get("id"), (
+            f"{template!r} attributed to a different rule on payload alone: "
+            f"{plain.get('id')} -> {loaded.get('id')}"
+        )
 
     def test_reading_the_rules_is_not_blocked_by_the_rules(
         self, bash_hook, bundled_config
     ):
-        """The sharpest live instance: auditing the guard tripped the guard."""
+        """The sharpest live instance: auditing the guard tripped the guard.
+
+        Only the bashToolPatterns half — the same read against a *protected*
+        directory still fails via mechanism 2, asserted below.
+        """
         for command in (
             "diff ~/.agentwire/damage-control/core.yaml "
             "agentwire/hooks/damage-control/rules/core.yaml",
@@ -609,3 +646,78 @@ class TestItIsNotOnlyMsgSend:
                 f"reading the rules is refused by the rules: {command!r} "
                 f"-> {result['reason']}"
             )
+
+
+# ---------------------------------------------------------------------------
+# What this PR does NOT fix — tracked as #922
+# ---------------------------------------------------------------------------
+
+
+class TestRemainingPayloadMechanisms:
+    """The payload bug has THREE mechanisms; anchoring fixes ONE.
+
+    These are asserted as still-refused ON PURPOSE. A green suite must not be
+    readable as "the reported symptom is fixed" — it is not, and #915's own
+    headline example (a read whose search string mentions a deletion) is in
+    here. The day one of these starts passing, the assertion fails and someone
+    has to come update the story deliberately.
+
+    - **Mechanism 2 — the path ladders.** ``zeroAccessPaths`` /
+      ``readOnlyPaths`` / ``noDeletePaths`` iterate the RAW haystacks and have
+      no ``anchored`` concept at all, so a read whose SEARCH STRING mentions a
+      deletion is refused when the directory being read is protected.
+    - **Mechanism 3 — masking is keyed on WHITESPACE.** ``masked_subcommands``
+      blanks a fully-quoted token only when it contains whitespace, so a
+      single-word quoted payload is never masked.
+
+    Both are #922. They are deliberately out of scope here because this is a
+    guard-WEAKENING change and the governing question is *what else did this
+    just permit* — the path ladders gate reads of secrets, not just deletions,
+    so widening the blast radius to three ladder steps in the same diff is the
+    wrong trade.
+    """
+
+    # mechanism 2 — the literal incident from #915's body
+    LADDER_CASES = [
+        ('grep -rn "rm -rf" ~/.agentwire/', "noDeletePath"),
+        ('grep -rn "rm -rf" .git/', "noDeletePath"),
+        ('rg "rm -rf" ~/.claude/hooks/', "protectedControlPlane"),
+    ]
+
+    # mechanism 3 — a one-word payload in the exact reported carrier
+    WHITESPACE_CASES = [
+        'agentwire msg send --to orch --kind done "rmdir"',
+        'ssh prod "reboot"',
+        'mongosh --eval "db.dropDatabase()"',
+        # masking works on trailing comments no better than on one-word tokens
+        "true  # note: git reset --hard was blocked",
+    ]
+
+    @pytest.mark.parametrize("command,via", LADDER_CASES)
+    def test_path_ladder_still_refuses_a_read_that_mentions_a_deletion(
+        self, bash_hook, bundled_config, command, via
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} now passes — mechanism 2 looks fixed. If that is "
+            f"intentional (#922), update this test and #915's story."
+        )
+        assert via in str(result.get("pattern", "")), (
+            f"expected refusal via {via}, got {result.get('pattern')} — the "
+            f"mechanism changed even though the verdict did not"
+        )
+
+    @pytest.mark.parametrize("command", WHITESPACE_CASES)
+    def test_single_word_payload_is_never_masked(
+        self, bash_hook, bundled_config, command
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] in REFUSED, (
+            f"{command!r} now passes — mechanism 3 looks fixed (#922)."
+        )
+
+    def test_the_masking_control_case_does_pass(self, bash_hook, bundled_config):
+        """Two words, so it IS masked — the boundary mechanism 3 sits on."""
+        assert bash_hook.check_command(
+            'echo "terraform destroy"', bundled_config
+        )["decision"] == "allow"

--- a/tests/unit/test_damage_control_payload_anchoring.py
+++ b/tests/unit/test_damage_control_payload_anchoring.py
@@ -514,6 +514,83 @@ class TestGenericRmBackstopSurvivesAnchoring:
         assert bash_hook.masked_subcommands(command) == [command]
 
 
+class TestComposedWithGitNormalization:
+    """The cross-PR row neither #913 nor #915 could assert alone.
+
+    #918 added ``git_normalized_haystacks`` — additive, derived from the MASKED
+    tokens, fed to BOTH routings. That last property is what makes it compose
+    with anchoring: an anchored ``git.yaml`` rule is matched against masked
+    subcommands, and the normalized haystack is built from those same tokens, so
+    stripping ``-C <path>`` exposes the subcommand to a rule that would
+    otherwise never see it.
+
+    Before both landed, ``git -C /repo push --force`` was ALLOW: #913's bypass
+    hid it from ``\\bgit\\s+push``, and anchoring alone does not help because
+    ``-C /repo`` stays inline in the masked subcommand.
+
+    The rule ID is asserted, not just the verdict — a block from the generic
+    deletion rule or from an unrelated ask rule would satisfy a verdict-only
+    assertion while the git rule stayed bypassed.
+    """
+
+    FORCE = "--" + "force"
+
+    def test_forced_push_behind_dash_C_blocks_via_the_git_rule(
+        self, bash_hook, bundled_config
+    ):
+        result = bash_hook.check_command(
+            f"git -C /repo push {self.FORCE} origin main", bundled_config
+        )
+        assert result["decision"] == "block", (
+            f"the cross-PR case is {result['decision']} — #913's bypass is open "
+            f"again, or normalization stopped reaching anchored rules"
+        )
+        assert result["id"] == "git.git-push-force-use-force-with-lease", (
+            f"blocked, but by {result['id']!r} rather than the git rule — the "
+            f"git rule is still bypassed and something else took the credit"
+        )
+
+    @pytest.mark.parametrize(
+        "command,rule_id",
+        [
+            ("git -C /repo reset --hard HEAD~3", "git.git-reset-hard-use-soft-or-stash"),
+            ("git -C /repo clean -fd", "git.git-clean-with-force-directory-flags"),
+            ("git -C /repo stash clear", "git.git-stash-clear-deletes-all-stashes"),
+            ("git -C /repo filter-branch", "git.git-filter-branch-rewrites-entire-history"),
+        ],
+    )
+    def test_other_anchored_git_rules_also_reached(
+        self, bash_hook, bundled_config, command, rule_id
+    ):
+        result = bash_hook.check_command(command, bundled_config)
+        assert result["decision"] == "block"
+        assert result["id"] == rule_id
+
+    def test_safe_form_behind_dash_C_stays_ask_not_block(
+        self, bash_hook, bundled_config
+    ):
+        """The two-sided expectation: normalization must not rewrite the command
+        before the ``(?!-with-lease)`` lookahead sees it. A block here would
+        catch the SAFE form and train everyone toward the plain flag."""
+        result = bash_hook.check_command(
+            "git -C /repo push --force-with-lease origin main", bundled_config
+        )
+        assert result["decision"] == "ask", (
+            f"--force-with-lease behind -C decided {result['decision']}; must be "
+            f"ask — not allow (bypass survives), not block (lookahead defeated)"
+        )
+
+    def test_payload_prose_survives_normalization(self, bash_hook, bundled_config):
+        """#918 derives its haystack from the MASKED tokens, so quoted argument
+        text cannot become matchable — #915's fix is not undone by it."""
+        for body in (
+            "I did not rm the file",
+            "git reset --hard was refused by damage-control",
+        ):
+            cmd = f'agentwire msg send --to orch --kind done "{body}"'
+            assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
+
+
 class TestMutationProvesTheAssertionsHaveTeeth:
     """Anchor the must-not-anchor class and the guard measurably disappears.
 


### PR DESCRIPTION
> **SCOPE — read first.** The payload bug has **three mechanisms**. This PR
> fixes **one** of them (`bashToolPatterns`). It does **not** fix the reported
> symptom in #915's body — that one is mechanism 2 and still refuses.
> Mechanisms 2 and 3 are **#922**, and are asserted here as *still refused on
> purpose* so this PR going green cannot be read as the symptom being fixed.

A report-back can be refused because of what it *says*. The payload of
`agentwire msg send --to X --kind done "<text>"` runs through the Bash command
rules, so a message that merely **describes** a blocked operation is itself
blocked. It fired twice for real on 2026-08-06, both on `--kind done` — the
load-bearing kind that dead-letters to the owner's email.

It is **not a `msg send` bug**: the class is *any command whose arguments
discuss the guarded operation*, which includes most of the tooling you would use
to audit the guard. This work hit it seven more times, including on the commit
message for the fix itself, which had to be written through a file.

## What this fixes, and what it doesn't

| | mechanism | status |
|---|---|---|
| 1 | `bashToolPatterns` match quoted argument content | **fixed here** |
| 2 | path ladders (`zeroAccessPaths` / `readOnlyPaths` / `noDeletePaths`) iterate RAW haystacks, no `anchored` concept | **#922** — `grep -rn "<deletion>" ~/.agentwire/` still blocks via `noDeletePath`. This is #915's own headline example. |
| 3 | masking is keyed on **whitespace**, so a one-word quoted token is never masked | **#922** — `msg send --kind done "rmdir"` still blocks, in the exact reported carrier |

Separately, anchoring **gives something up** — see "What this gave up" below.

2 and 3 are deliberately out of scope: this is a guard-**weakening** change where
the governing question is *what else did this just permit*, and the path ladders
gate reads of **secrets**, not just deletions. `TestRemainingPayloadMechanisms`
pins all of them as refused, with the masking boundary (`echo "terraform
destroy"` → allow) as the control, so the day one starts passing someone has to
update the story deliberately.

## Which rule set — every number below is BUNDLED, not live

**Measured against `agentwire/hooks/damage-control/rules/*.yaml` + `agentwire/tooldefs/*.yaml` from this checkout**, with the load asserted in the
fixture (265 patterns = 178 hand-written + 87 tooldef-derived; 14 hand-written
anchored before this PR). Reconciles exactly with the two independent
measurements on the issue.

**This is "verified against what ships", NOT "verified locally"** — the two are
still different claims on this machine. The live hook resolves user-dir-first
and reads `~/.agentwire/damage-control/`, which is 9 files behind bundled —
138 rules / 0 anchored (#916), so **#675 is not in force here at all**; the
tooldef id drift was healed by hand, the rules were not.

### ⚠️ `agentwire hooks install` does NOT deploy this fix

I said earlier that it would. It does not, and the correction matters because
running it would look like a successful deploy. `heal_damage_control` is
**install-missing-only** for rules (`safety_commands.py`: "never overwrite an
existing (possibly hand-customized) rule file"). Simulated against the real live
directory, read-only:

```
would be ADDED:    ['payloads.yaml']
would be UPDATED:  []                     <- install-missing-only
post-install hand-written rules: 153
post-install anchored:             0      <- the fix is NOT live
DUPLICATE patterns after install: 10      <- with COLLIDING rule ids
a --kind done report describing a deletion: still BLOCK
```

So the operator sees `✓ Installed rule payloads.yaml` and reasonably concludes
the fix shipped, while every rule is still unanchored and the reported bug is
still live. Worse, `payloads.yaml` lands *alongside* a stale `databases.yaml`
that still contains the same 15 rules, producing 10 duplicate patterns — and
because `payloads.yaml` pins explicit ids (which `_assign_rule_id` honours
without a uniqueness check), those duplicates carry **identical rule ids**.

**Deploying this requires actually overwriting the 9 drifted files — i.e. #916,
not `hooks install`.** That is a host action; a worktree cannot do it, and the
rule files are protected control plane, so an agent cannot either.

The duplicate-id-on-partial-sync hazard is a real gap in `heal_damage_control`
and is being raised separately rather than bolted onto this PR.

Base: rebased onto `main` @ 65ca04f (#918 merged), so CI sees the composed
behaviour.

## Mechanism

`anchored: true` (#675) matches against `masked_subcommands()` — command
position only. It was applied to tooldef-derived rules and `git.yaml`, nothing
else. This extends it to the remaining hand-written files.

**Anchoring is decided per FILE against the `git.yaml` shape test** — every rule
command-prefix shaped AND the tool takes no inner-command payload — not per
rule. It is a *(rule × command-form)* property: anchored `core.sudo-rm` still
blocks the local form but loses `ssh prod "sudo rm -rf /var/lib"`, and its twin
in `remote.yaml` is the backstop. Anchor both and wrapped forms go from
double-covered to **uncovered**.

So the 15 rules failing the shape test **moved** into a new `payloads.yaml`
(uniformly unanchored) rather than being flagged in place — no per-rule
skip-list anywhere. Each pins an explicit `id:` to its previous id: **178 ids
before, 178 after, none lost or gained.**

| | files | rules |
|---|---|---|
| anchored | 14 | 151 |
| unanchored | `payloads.yaml`, `remote.yaml` | 27 |

No file mixes the two — a mixed file is a skip-list wearing a filename.
Enforced by a test.

## Audit

All 178 hand-written patterns driven through the ladder inside a `msg send`
payload: **162 of 178 tripped before, 26 after** — all 26 in the two unanchored
files. (The issue guessed "`rm` is unlikely to be the only one": it was 162.)

**What I left, and why.** Those 27 still refuse prose naming them. Anchoring
them deletes the guard — measured, not assumed. The SSOT fix is extending the
`_SHELL_NAMES` rescan to `ssh <host> "…"` and the `-c`/`-e`/`--eval` clients,
which is `masked_subcommands` — owned by #913/#919.

## Guard strength

**Differential**, every rule's dangerous form × 6 obfuscation variants:

```
1068 verdicts compared
REGRESSIONS (refused -> allowed): 0
got stronger (allowed -> refused): 1
```

**Per-rule companion tests.** All 151 anchored rules assert a dangerous form
refused by a **solo config of that rule alone** — no other rule can take the
credit. That is the exact failure mode of the existing `TestAnchoredRules`,
whose synthetic one-rule fixture never loads the real YAMLs.

**Mutation, shown not claimed.** Flipping every rule to `anchored: true` — the
blanket change deliberately not made — must send each wrapper case to ALLOW; an
inert mutation fails the test. It caught two of my own inert cases
(`ssh prod "reboot"`, `--eval "db.dropDatabase()"` survive by accident, which is
mechanism 3). Reverse mutation asserts #915 returns.

**`remote.yaml`** had zero coverage in the suite. Now 15 cases — but read the scope warning on that corpus below before reading it as "ssh is handled".

Full suite **4597 passed, 36 skipped**. The three issue probes pass through the real shipped
hook under its own uv shebang, `AGENTWIRE_DIR` pointed at an empty dir so
`_resolve_rules_dir` falls back to bundled.

## Two corrections I made to my own work

- **My test fixture was short 87 rules.** It loaded rules without tooldefs, so
  three carriers read `allow` that are `ask` in reality — and `ask` is a BLOCK
  under `AGENTWIRE_UNATTENDED=1`, so `allow` was the wrong assertion anyway.
  Carrier tests now assert **parity**: the same carrier with an innocuous
  payload must get the same verdict *and* the same attributing rule. That also
  reads the issue's `gh` row correctly — the asymmetry is rule-ordering, not a
  spec to copy.
- All headline numbers above are **post-`payloads.yaml`-restructure and
  tooldef-inclusive re-runs**, not carried over from the earlier per-rule-flag
  version.

## Sequencing: measured, not assumed

The four sole-backstop commands **do not regress** — verified HEAD~1 vs HEAD:

```
BEFORE AFTER   command
block  block   docker --context prod volume rm pgdata
block  block   aws --profile prod s3 rm s3://b --recursive
block  block   gcloud --project p storage rm -r gs://b
block  block   vercel --scope team projects rm site
```

This PR **reuses `anchored`** rather than rewriting the generic deletion pattern
positionally, so masking is a no-op on commands containing no quoted whitespace
— `masked_subcommands('docker --context prod volume rm pgdata')` is byte-identical
to the input. Per the amended ruling that makes #919 **not** a blocker.
`TestGenericRmBackstopSurvivesAnchoring` pins all four plus the mechanism, so if
that ever changes it fails loudly.

My own 18-form survey, measured here: **0** caught by their own rule, **4**
surviving via a generic rule, **14** already ALLOW before this PR, **0 lost**.

**#915 + #918 composed** — no longer a hand-built merge; #918 is merged and
this branch is rebased onto it, so this is the branch's actual base and CI runs
it. `TestComposedWithGitNormalization` asserts the cross-PR row **by rule ID**,
not by verdict — a block from the generic deletion rule or an unrelated ask rule
would satisfy a verdict-only assertion while the git rule stayed bypassed:

```
git -C /repo push --force origin main   -> block via git.git-push-force-use-force-with-lease
git -C /repo reset --hard HEAD~3        -> block via git.git-reset-hard-use-soft-or-stash
git -C /repo clean -fd                  -> block via git.git-clean-with-force-directory-flags
git -C /repo push --force-with-lease    -> ask   (not allow: bypass survives; not block: lookahead defeated)
```

Why they compose: #918's `git_normalized_haystacks` is additive, derived from
the **masked** tokens, and fed to both routings. Because it is built from the
same tokens an anchored rule matches against, stripping `-C <path>` exposes the
subcommand to a rule that would otherwise never see it — and because it is
derived from masked tokens, quoted payload text can never become matchable, so
it does not undo this PR. Asserted both directions.

**#918's fixture guard fired on this change and was right to.** The anchored
count moved 101 → 238 (git.yaml's 14 plus 137 newly anchored, plus 87
tooldef-derived). Updated deliberately with the arithmetic in the docstring,
not widened into a range — a range would defeat the guard's purpose.

That test is **#913's lineage** (it arrived on `main` with 65ca04f), not the
reviewer's. I mis-credited it to review-915 at first; corrected, and flagged in
a PR comment so its actual owner sees the change rather than it resting on a
reviewer's nod.

**No rows started firing, which is a finding not a formality.** Neither suite
carries a row marked as not-reaching-the-rule; the 36 skips are #918's parity
test skipping its ask-tier parameters by design, which anchoring cannot flip.
#918's normalizer is git-specific, so it does not reach the ssh-wrapped (#924),
path-ladder or whitespace-masking (#922) classes — every expected-fail row
still fails, as it should.

## What this gave up — the ssh-wrapped class (#924)

Anchoring the 151 command-prefix rules demotes **125 of 151 ssh-wrapped
dangerous forms from refused to allowed**.

The two independent measurements reconcile exactly: 125 lost + 11 held (mine)
and 121 lost + 15 held (the reviewer's) both total **136**. The delta is exactly
four — `ssh prod "dropdb"`, `"rmdir"`, `"sendmail"`, `"ansible-playbook"` —
single-word payloads that are never masked, so they survive by the mechanism-3
whitespace accident rather than by any rule intending to hold them. The reviewer
classified by measured verdict; I classified by whether a rule means to hold
them. It is a counting convention, not a behavioural disagreement, and the
reviewer's call was that mine is the more honest denominator: a guard nobody
wrote is not coverage.

```
ssh prod "terraform destroy"                 block -> allow
ssh prod "kubectl delete namespace prod"        block -> allow
ssh prod "gh repo delete owner/repo"            block -> allow
ssh prod "docker volume rm pgdata"           block -> allow
...
```

**Why it is a demotion, not a broken guard:** those forms only blocked because
of the same match-anywhere behaviour that *is* the payload bug. `remote.yaml`'s
12 rules are the *intentional* ssh coverage and are untouched. But it was real
coverage, so it is stated rather than left to be found.

**How my suite missed it, which is the more useful part:** my
`SSH_WRAPPED_MASKED` corpus is *exactly* the 12 forms `remote.yaml` protects — a
corpus shaped to the survivors. The suite was green through a 125-case
reduction. That is the same fixture-shaped blind spot my own docstring calls out
in the #675 test, reproduced one level up. `TestSshWrappedCommandsStillRefused`
now carries a scope warning, and `TestSshWrappedCoverageReduction` pins 12 rule
families as **expected-fail rows** — green there means the gap is still open.

**The fix is #924**, not this PR: extend the `_SHELL_NAMES` rescan to
`ssh <host> "<payload>"` so every rule applies to the payload, after which
`remote.yaml` becomes **deletable**. That lives in `masked_subcommands` —
#913's plumbing. Widening `remote.yaml` to ~120 ssh twins is explicitly not the
answer: it duplicates the whole rule set, which is the coupling this PR's own
header argues against.

## Also found, not fixed here

- **`git push origin -f` is unguarded** in the bundled rules — the rule requires
  the flag before the remote. Pre-existing and guard-*strengthening*, so it does
  not belong in a guard-weakening diff.

Closes #915

Built by [dotdev.dev](https://dotdev.dev)
