### PR TITLE
fix(safety): one data-table normalizer closes the global-option bypass for the whole tool class (#919)

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1779,47 +1779,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1841,73 +1912,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1918,8 +2030,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1929,11 +2042,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2195,16 +2308,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2230,7 +2345,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -1858,11 +1858,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1888,6 +1925,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1854,11 +1854,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1884,6 +1921,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -1775,47 +1775,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1837,73 +1908,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1914,8 +2026,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1925,11 +2038,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2191,16 +2304,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2226,7 +2341,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1787,47 +1787,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1849,73 +1920,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1926,8 +2038,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1937,11 +2050,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2203,16 +2316,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2238,7 +2353,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -1866,11 +1866,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1896,6 +1933,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1860,11 +1860,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1890,6 +1927,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -1781,47 +1781,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1843,73 +1914,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1920,8 +2032,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1931,11 +2044,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2197,16 +2310,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2232,7 +2347,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1853,11 +1853,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1883,6 +1920,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -1774,47 +1774,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1836,73 +1907,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1913,8 +2025,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1924,11 +2037,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2190,16 +2303,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2225,7 +2340,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1822,11 +1822,48 @@ def _grammar(
     }
 
 
+# THIS TABLE LIVES IN CODE, NOT IN A ``rules/*.yaml``, AND THAT IS A
+# DEPLOYMENT REQUIREMENT RATHER THAN A STYLE CHOICE. ``heal_damage_control``
+# treats the two classes differently: hook scripts self-heal when STALE
+# (drift check, then copy), while rules and tooldefs are install-missing-only
+# (``if not target.exists()``), so an EXISTING rule file is never brought
+# forward by any command. A table shipped as YAML would merge green, pass
+# review — and be INERT on day one on every installation that already has the
+# file, with no supported way to update it. #918 deploys because it touched
+# only ``_core.py`` and the generated hooks; #675's anchoring does not, because
+# it lives in ``rules/git.yaml``. Same repo, same merge, opposite outcomes,
+# decided purely by which file the fix landed in. Do not move this to YAML.
+#
 # Measured, not read off a usage line. git's own usage advertises only the
 # ``=`` form while the binary accepts both, and ``--exec-path`` looks
 # value-taking and is not — so each row below was established by running the
 # binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
 # subcommand still ran (option is bare) or was swallowed (option took it).
+#
+# WHICH BINARY, because a ``measured`` row is only as good as the thing
+# measured, and "measured against a static build I downloaded" is a different
+# claim from "measured against what the operator runs". Measured 2026-08-06:
+#
+#   already on the machine  git 2.50.1 (/usr/bin/git, Apple), tmux 3.5a
+#                           (homebrew), gcloud 560.0.0, npm 10.8.2, supabase
+#                           2.105.0 — these ARE what the operator runs
+#   downloaded static build kubectl v1.36.3 (dl.k8s.io), helm 3.16.4
+#                           (get.helm.sh), terraform 1.10.5
+#                           (releases.hashicorp.com), pulumi 3.145.0
+#                           (get.pulumi.com), docker 27.4.1
+#                           (download.docker.com/mac/static)
+#   pkg payload, expanded   aws-cli 2.36.17 (awscli.amazonaws.com/AWSCLIV2.pkg,
+#                           expanded with pkgutil, never installed)
+#   homebrew bottle, unpacked  redis-cli 8.10.0, mysqladmin 9.7.1 (brew fetch,
+#                           tar-extracted; never brew install)
+#   rustup, scratchpad-only cargo 1.97.1 via the rustup shim, with CARGO_HOME
+#                           and RUSTUP_HOME pointed at a temp dir
+#   NOT MEASURED            pnpm — the corepack shim on this machine dies with
+#                           ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING
+#
+# Nothing was installed on the host and nothing was placed on the host PATH.
+# Re-measuring a row on a tool upgrade means re-running the same differential
+# probe; the version in each row says what it was measured against.
 _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
     # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
     # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
@@ -1852,6 +1889,168 @@ _GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
         flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
         short_cluster=True,
     ),
+    # kubectl v1.36.3 (pflag). The bypassing option here is the
+    # production-TARGETING one: the guard held for the default context and
+    # dropped for the named remote cluster.
+    "kubectl": _grammar(
+        _MEASURED, "v1.36.3",
+        value=("--context", "-n", "--namespace", "--kubeconfig", "--cluster",
+               "--user", "--token", "--server", "-s", "--as", "--as-group",
+               "--as-uid", "--request-timeout", "--certificate-authority",
+               "--client-key", "--client-certificate", "--cache-dir",
+               "--tls-server-name", "--username", "--password", "-v", "--v",
+               "--profile", "--profile-output", "--log-flush-frequency",
+               "--kuberc"),
+        flag=("--insecure-skip-tls-verify", "--warnings-as-errors",
+              "--disable-compression", "--match-server-version"),
+        short_cluster=True,
+    ),
+    # docker 27.4.1 (pflag). `--context prod` / `-H tcp://prod:2375` are how a
+    # local command reaches a production daemon.
+    "docker": _grammar(
+        _MEASURED, "27.4.1",
+        value=("--context", "-c", "--host", "-H", "--config", "--log-level",
+               "-l", "--tlscacert", "--tlscert", "--tlskey"),
+        flag=("--tls", "--tlsverify", "--debug", "-D"),
+        short_cluster=True,
+    ),
+    # aws-cli 2.36.17 (argparse). No short global options, so no clustering.
+    # `--output` and `--color` LOOK bare to a naive probe — an invalid value
+    # produces the same "invalid choice" text as an unknown subcommand — and
+    # are value-taking; the parser's own "expected one argument" settles it.
+    "aws": _grammar(
+        _MEASURED, "2.36.17",
+        value=("--profile", "--region", "--endpoint-url", "--output", "--query",
+               "--ca-bundle", "--cli-read-timeout", "--cli-connect-timeout",
+               "--color"),
+        flag=("--debug", "--no-verify-ssl", "--no-paginate", "--no-sign-request",
+              "--no-cli-pager", "--no-cli-auto-prompt"),
+    ),
+    # Google Cloud SDK 560.0.0. `--verbosity` is value-taking for the same
+    # reason as aws's `--output`.
+    "gcloud": _grammar(
+        _MEASURED, "560.0.0",
+        value=("--project", "--account", "--configuration", "--billing-project",
+               "--impersonate-service-account", "--access-token-file",
+               "--verbosity", "--format", "--trace-token"),
+        flag=("--quiet", "-q", "--log-http", "--no-user-output-enabled"),
+    ),
+    # helm 3.16.4 (pflag).
+    "helm": _grammar(
+        _MEASURED, "3.16.4",
+        value=("--kube-context", "--kubeconfig", "--namespace", "-n",
+               "--kube-apiserver", "--kube-token", "--registry-config",
+               "--repository-cache", "--repository-config", "--burst-limit",
+               "--kube-as-user", "--kube-as-group", "--kube-ca-file",
+               "--kube-tls-server-name", "--qps"),
+        flag=("--debug", "--kube-insecure-skip-tls-verify"),
+        short_cluster=True,
+    ),
+    # terraform 1.10.5. `-chdir=DIR` is the ONLY value-taking global option and
+    # it exists in the `=` form only — a bare `-chdir /infra` is not accepted,
+    # so it must not eat the next token.
+    #
+    # `-help` and `-version` are deliberately ABSENT though they are real
+    # global flags: both short-circuit execution, so `terraform -help destroy`
+    # prints help and destroys nothing. Stripping them would normalize a help
+    # invocation into `terraform destroy` and BLOCK it — a false positive on a
+    # command people actually type. Omitting them only costs a variant.
+    "terraform": _grammar(
+        _MEASURED, "1.10.5",
+        value_eq_only=("-chdir",),
+    ),
+    # pulumi 3.145.0 (pflag) — `-C /infra` is the cwd override.
+    "pulumi": _grammar(
+        _MEASURED, "3.145.0",
+        value=("-C", "--cwd", "--color", "--profiling", "--tracing",
+               "--memprofilerate", "-v", "--verbose"),
+        flag=("--logtostderr", "--non-interactive", "-e", "--emoji", "-Q",
+              "--fully-qualify-stack-names", "--logflow",
+              "--disable-integrity-checking"),
+        short_cluster=True,
+    ),
+    # npm 10.8.2. npm treats ANY unrecognized `--long` as a config key, so this
+    # row is the measured subset rather than a closed grammar; an unlisted
+    # config key bails the scan and simply yields no variant.
+    "npm": _grammar(
+        _MEASURED, "10.8.2",
+        value=("--prefix", "-C", "--userconfig", "--globalconfig", "--cache",
+               "--registry", "--loglevel", "--workspace", "-w"),
+        flag=("-g", "--global", "--no-workspaces", "--silent", "-s", "--json"),
+        short_cluster=True,
+    ),
+    # pnpm — DOCUMENTED, not measured. The binary on this machine is broken
+    # (corepack shim dies with ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING), and the
+    # ruling on #919 is not to install tools on the owner's machine to measure
+    # them. `short_cluster` is left FALSE rather than guessed from the
+    # getopt-shaped tools: an unverified True would strip clusters pnpm may
+    # reject. Falsified by the `pnpm -C /srv publish` corpus row.
+    "pnpm": _grammar(
+        _DOCUMENTED, "pnpm 9.x/10.x docs",
+        value=("-C", "--dir", "--filter", "--loglevel", "--reporter"),
+        flag=("-w", "--workspace-root", "--stream", "--silent"),
+    ),
+    # cargo 1.97.1, invoked through the rustup shim (which is how `cargo` is
+    # reached on any machine with rustup installed). `+nightly` is a TOOLCHAIN
+    # SELECTOR, not an option — hence `plus_selector` rather than a flag entry.
+    # `-Z` is omitted: it is nightly-only, so its arity is not measurable on a
+    # stable toolchain and a guess here could swallow a subcommand.
+    "cargo": _grammar(
+        _MEASURED, "1.97.1",
+        value=("--config", "--color"),
+        flag=("--frozen", "--locked", "--offline", "-q", "--quiet", "-v",
+              "--verbose"),
+        plus_selector=True,
+    ),
+    # supabase 2.105.0 (cobra).
+    "supabase": _grammar(
+        _MEASURED, "2.105.0",
+        value=("--workdir", "--dns-resolver", "--network-id", "--output", "-o"),
+        flag=("--debug", "--experimental", "--create-ticket"),
+        short_cluster=True,
+    ),
+    # redis-cli 8.10.0. Hand-rolled argv comparison, NOT getopt: `-hprod.redis`
+    # is rejected ("Unrecognized option or bad number of args for: '-hzzhost'")
+    # and `--user=x` is not accepted either. So short_cluster is FALSE here
+    # even though every other short-option tool in this table sets it True —
+    # which is the argument for measuring the property per tool.
+    "redis-cli": _grammar(
+        _MEASURED, "8.10.0",
+        value=("-h", "-p", "-s", "-a", "-u", "-n", "-t", "-r", "-i", "--user",
+               "--pass"),
+        flag=("-x", "--tls", "--no-raw", "--scan"),
+    ),
+    # mysqladmin 9.7.1 (getopt): `-uroot` and `-furoot` both parse. Arity from
+    # the parser's own "option '-u' requires an argument", since mysqladmin
+    # connects before it validates the command and so has no usable
+    # subcommand-survived marker.
+    #
+    # `-p` is deliberately ABSENT: its value is OPTIONAL and attached-only
+    # (`-psecret`, but bare `-p` prompts). Neither category models that, and
+    # the wrong one would eat the command. `mysqladmin -psecret drop db` bails
+    # the cluster scan and yields no variant — an under-strip, recorded here.
+    #
+    # KNOWN LIMIT: mysql's long options accept unique-prefix abbreviation
+    # (`--us=root`), which no exact-match table can enumerate. Those forms keep
+    # the bypass.
+    "mysqladmin": _grammar(
+        _MEASURED, "9.7.1",
+        value=("-u", "-h", "-P", "-S", "--user", "--host", "--port", "--socket",
+               "--protocol"),
+        flag=("-f", "--force", "-s", "--silent", "-C", "--compress", "-w",
+              "--wait", "--no-defaults"),
+        short_cluster=True,
+    ),
+    # NOT IN THIS TABLE, and deliberately:
+    #
+    #   gh — `gh -R owner/name repo delete` is NOT a bypass. Measured: `gh -R
+    #   cli/cli repo view` -> "unknown shorthand flag: 'R' in -R", and `gh
+    #   --repo …` -> "unknown flag: --repo". Both are per-COMMAND flags, so the
+    #   command never runs and there is nothing to normalize. It was listed as
+    #   a bypass in #913's review notes and in #919's issue body (which is why
+    #   that issue says 15 tools and this table has 14 plus git); the reviewer
+    #   disproved it. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a
+    #   future rebuild-from-notes cannot quietly re-add it.
 }
 
 # Tokens allowed to precede the tool while still counting as an invocation

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -1743,47 +1743,118 @@ _ASSIGN_TOKEN_RE = re.compile(r"^[A-Za-z_]\w*=")
 
 
 #
-# GIT GLOBAL OPTIONS (#913)
+# GLOBAL OPTIONS BEFORE THE SUBCOMMAND (#913 for git, #919 for the class)
 #
-# Every git rule — both the hand-written ``bashToolPatterns`` in the rule YAMLs
-# (``\bgit\s+push\s+--force\b``) and the tooldef-generated ones from
-# ``_cmd_to_regex`` (``\bgit\s+commit\b``) — assumes the subcommand sits
-# adjacent to ``git``. It doesn't have to: ``git -C <dir> <cmd>`` is the
-# idiomatic way to operate on a repo without ``cd``, and ``\s+`` cannot span
-# ``-C /repo``. That single assumption defeated EVERY git rule, force-push and
-# hard-reset included.
+# Every rule that names a tool — both the hand-written ``bashToolPatterns`` in
+# the rule YAMLs (``\bgit\s+push\s+--force\b``, ``\btmux\s+kill-server\b``) and
+# the tooldef-generated ones from ``_cmd_to_regex`` (``\bgit\s+commit\b``) —
+# assumes the subcommand sits adjacent to the tool name. It doesn't have to:
+# ``git -C <dir> <cmd>`` is the idiomatic way to operate on a repo without
+# ``cd``, and ``\s+`` cannot span ``-C /repo``. That single assumption defeated
+# EVERY git rule (#913), and then every rule for fourteen more tools (#919) —
+# including ``tmux -L agentwire kill-server``, whose rule exists to stop an
+# agent destroying the fleet it is running inside, and the
+# production-TARGETING options of aws/kubectl/docker/redis-cli, where the guard
+# held for the default target and dropped for the named remote one.
 #
-# Rather than teach ~15 patterns about ``-C`` (and miss the next one written),
-# we emit an extra haystack per subcommand with git's global options removed,
-# so present and future git rules inherit the fix for free.
+# ONE normalizer, driven by a DATA TABLE. Not a generalized regex (a guess
+# about grammars nobody measured) and not fifteen per-tool normalizers (that is
+# "model each wrapper's own grammar", the mistake #918 declined to make, at one
+# remove). Adding a sixteenth tool is a table row.
 #
 # This is strictly ADDITIVE — the un-stripped forms stay in the haystack list.
-# A rule that legitimately cares WHICH repo is being touched (a path rule, an
-# allowlist check) still sees ``-C /repo`` in the raw command; stripping can
-# only ever remove tokens, so the extra variant can introduce no path a rule
-# didn't already see.
+# A rule that legitimately cares WHICH repo/cluster/profile is being targeted
+# (a path rule, an allowlist check) still sees ``-C /repo`` in the raw command;
+# stripping can only ever remove tokens, so the extra variant can introduce no
+# path a rule didn't already see.
 #
-# Membership below is measured against real git (2.50.1), not assumed:
-# ``-C``/``-c`` require a SEPARATE argument (``-C/tmp`` is rejected by git, so
-# the attached form is not a bypass); ``--git-dir``/``--work-tree``/
-# ``--namespace``/``--config-env``/``--attr-source`` accept both the ``=`` and
-# the space form; ``--exec-path`` without ``=`` prints and exits, so it
-# consumes nothing.
+# PROVENANCE IS PART OF THE ROW, because both directions of a wrong arity guess
+# FAIL OPEN and neither is visible:
+#
+#   marked value-taking but actually bare -> the SUBCOMMAND is eaten  -> allow
+#   marked bare but actually value-taking -> the VALUE stays inline   -> allow
+#
+# There is no conservative direction to lean, and a wrong row never surfaces as
+# a spurious block — only as an ALLOW where a corpus row expected a block, and
+# only if that corpus row exists. So an unverified row cannot be made safe,
+# only HONEST: every row names how its grammar was established, and
+# ``test_every_table_row_has_corpus_coverage`` fails a row that no command in
+# the acceptance corpus would contradict.
 
-_GIT_GLOBAL_VALUE_OPTS = {
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-    "--config-env", "--attr-source",
+_MEASURED = "measured"      # probed against the real binary, version recorded
+_DOCUMENTED = "documented"  # binary not runnable here; from the official docs
+
+
+def _grammar(
+    provenance: str,
+    version: str,
+    value: Tuple[str, ...] = (),
+    flag: Tuple[str, ...] = (),
+    value_eq_only: Tuple[str, ...] = (),
+    short_cluster: bool = False,
+    plus_selector: bool = False,
+) -> Dict[str, Any]:
+    """One tool's global-option grammar.
+
+    ``value``          option consumes a SEPARATE following argument (the ``=``
+                       form is handled generically for these too).
+    ``flag``           stands alone, consumes nothing.
+    ``value_eq_only``  ONLY the ``--opt=value`` form exists (terraform's
+                       ``-chdir=DIR``); a bare one must not eat the next token.
+    ``short_cluster``  getopt/pflag-style short options: ``-Lname`` (attached)
+                       and ``-2Lname`` (bundled) are accepted. THIS IS PER
+                       TOOL, not a global convention: git REJECTS ``-C/tmp``
+                       (measured), which is why #918 could ignore attached
+                       forms — correct for git and wrong for tmux, where the
+                       fleet-kill bypass has three spellings, not one.
+    ``plus_selector``  a leading ``+token`` selector (cargo's ``+nightly``).
+    ``provenance``     ``_MEASURED`` or ``_DOCUMENTED`` — see the note above;
+                       required, because an unmarked row is the failure mode.
+    """
+    return {
+        "value": frozenset(value),
+        "flag": frozenset(flag),
+        "value_eq_only": frozenset(value_eq_only),
+        "short_cluster": short_cluster,
+        "plus_selector": plus_selector,
+        "provenance": provenance,
+        "version": version,
+    }
+
+
+# Measured, not read off a usage line. git's own usage advertises only the
+# ``=`` form while the binary accepts both, and ``--exec-path`` looks
+# value-taking and is not — so each row below was established by running the
+# binary: ``TOOL <opt> <harmless-subcommand>`` and asking whether the
+# subcommand still ran (option is bare) or was swallowed (option took it).
+_GLOBAL_OPTION_TABLE: Dict[str, Dict[str, Any]] = {
+    # git 2.50.1 (Apple Git-155). ``-C``/``-c`` need a SEPARATE argument —
+    # ``-C/tmp`` is rejected by git itself, so no short-cluster handling.
+    # ``--exec-path`` bare prints and exits: eating the next token there would
+    # swallow a subcommand.
+    "git": _grammar(
+        _MEASURED, "2.50.1",
+        value=("-C", "-c", "--git-dir", "--work-tree", "--namespace",
+               "--config-env", "--attr-source"),
+        flag=("-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
+              "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
+              "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
+              "--noglob-pathspecs", "--icase-pathspecs", "--html-path",
+              "--man-path", "--info-path"),
+    ),
+    # tmux 3.5a — getopt, so ``-Lname`` and ``-2Lname`` parse identically to
+    # ``-L name``. Confirmed by the socket path coming back in tmux's own
+    # "error connecting to /private/tmp/tmux-501/<name>" for all three forms,
+    # against a control run that shows no socket name at all.
+    "tmux": _grammar(
+        _MEASURED, "3.5a",
+        value=("-c", "-f", "-L", "-S", "-T"),
+        flag=("-2", "-C", "-l", "-N", "-u", "-U", "-v", "-V"),
+        short_cluster=True,
+    ),
 }
 
-_GIT_GLOBAL_FLAGS = {
-    "-p", "-P", "--paginate", "--no-pager", "--bare", "--exec-path",
-    "--no-optional-locks", "--no-replace-objects", "--no-lazy-fetch",
-    "--no-advice", "--literal-pathspecs", "--glob-pathspecs",
-    "--noglob-pathspecs", "--icase-pathspecs", "--html-path", "--man-path",
-    "--info-path",
-}
-
-# Tokens allowed to precede ``git`` while still counting as a git invocation
+# Tokens allowed to precede the tool while still counting as an invocation
 # (``sudo git -C /repo push --force`` must normalize too — the un-stripped
 # ``sudo git push --force`` already matches, so leaving this out would keep the
 # very inconsistency the rule is meant to remove). ``_MASK`` covers a leading
@@ -1805,73 +1876,114 @@ _GIT_GLOBAL_FLAGS = {
 # consuming them means modelling each wrapper's own grammar — this bug's
 # mistake at one remove. Failure there is a MISSING haystack, never an
 # over-strip: we add nothing rather than stripping too much.
-_GIT_INVOCATION_PREFIXES = {
+_WRAPPER_PREFIXES = {
     "sudo", "doas", "env", "command", "time", "nice", "nohup", "xargs", _MASK,
 }
 
 
-def _strip_git_global_options(words: List[str]) -> Optional[List[str]]:
-    """Return ``words`` with git's global options removed, or ``None``.
+def _short_cluster_span(word: str, grammar: Dict[str, Any]) -> Optional[int]:
+    """Tokens consumed by a bundled/attached short-option cluster, or ``None``.
 
-    ``None`` means "no normalized variant to add": not a git invocation, no
-    global options present, or nothing left after the options.
+    ``-Lname`` is one token (the value rides along); ``-uL name`` is two (the
+    value-taking option ends the cluster). An unrecognized character bails the
+    whole cluster rather than guessing — a guess here can swallow a subcommand.
     """
-    git_idx = None
+    if not word.startswith("-") or word.startswith("--") or len(word) < 2:
+        return None
+    chars = word[1:]
+    for idx, ch in enumerate(chars):
+        opt = "-" + ch
+        if opt in grammar["value"]:
+            # Anything left in the cluster IS the value; otherwise it is the
+            # next token.
+            return 1 if idx < len(chars) - 1 else 2
+        if opt in grammar["flag"]:
+            continue
+        return None
+    return 1
+
+
+def _strip_global_options(words: List[str]) -> Optional[List[str]]:
+    """Return ``words`` with the tool's global options removed, or ``None``.
+
+    ``None`` means "no normalized variant to add": not an invocation of a tool
+    in the table, no global options present, or nothing left after the options.
+    """
+    tool_idx = None
+    grammar = None
     for i, w in enumerate(words):
-        if w.rsplit("/", 1)[-1] == "git":
-            git_idx = i
+        candidate = _GLOBAL_OPTION_TABLE.get(w.rsplit("/", 1)[-1])
+        if candidate is not None:
+            tool_idx = i
+            grammar = candidate
             break
-        if w not in _GIT_INVOCATION_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
+        if w not in _WRAPPER_PREFIXES and not _ASSIGN_TOKEN_RE.match(w):
             return None
-    if git_idx is None:
+    if grammar is None:
         return None
 
-    i = git_idx + 1
+    i = tool_idx + 1
     stripped = False
     while i < len(words):
         word = words[i]
-        if word in _GIT_GLOBAL_VALUE_OPTS:
+        if grammar["plus_selector"] and len(word) > 1 and word.startswith("+"):
+            i += 1
+            stripped = True
+            continue
+        if word in grammar["value"]:
             # Consumes the following argument along with the flag — dropping
             # only the flag would leave the value sitting where the subcommand
             # should be, and the rule would still miss.
             i += 2
             stripped = True
             continue
-        if word in _GIT_GLOBAL_FLAGS:
+        if word in grammar["flag"]:
             i += 1
             stripped = True
             continue
         base = word.split("=", 1)[0]
-        if "=" in word and (base in _GIT_GLOBAL_VALUE_OPTS or base in _GIT_GLOBAL_FLAGS):
+        if "=" in word and (
+            base in grammar["value"]
+            or base in grammar["flag"]
+            or base in grammar["value_eq_only"]
+        ):
             i += 1
             stripped = True
             continue
-        # MAINTENANCE EDGE: an option git adds after 2.50.1 is an unrecognized
-        # token here, so the scan stops and the partial strip leaves the
-        # subcommand still out of reach — ``git --future-opt -C /r push --force``
-        # reads as allow. Not exploitable today (git rejects the unknown option
-        # itself), and nothing in the suite fails when git grows one, so
-        # re-measure both sets on a git upgrade. Stopping is deliberate: the
-        # alternative — treating anything option-shaped as strippable — would
-        # let an unknown value-taking option swallow the subcommand.
+        if grammar["short_cluster"]:
+            span = _short_cluster_span(word, grammar)
+            if span is not None:
+                i += span
+                stripped = True
+                continue
+        # MAINTENANCE EDGE: an option a tool adds after the measured version is
+        # an unrecognized token here, so the scan stops and the partial strip
+        # leaves the subcommand still out of reach — ``git --future-opt -C /r
+        # push --force`` reads as allow. Not exploitable today (the tool
+        # rejects the unknown option itself), and nothing in the suite fails
+        # when a tool grows one, so re-measure a row on a tool upgrade.
+        # Stopping is deliberate: the alternative — treating anything
+        # option-shaped as strippable — would let an unknown value-taking
+        # option swallow the subcommand.
         break
 
     if not stripped or i >= len(words):
         return None
-    return words[: git_idx + 1] + words[i:]
+    return words[: tool_idx + 1] + words[i:]
 
 
-def git_normalized_haystacks(command: str) -> List[str]:
-    """Return the git-global-options-stripped forms of ``command``, if any.
+def global_option_normalized_haystacks(command: str) -> List[str]:
+    """Return the global-options-stripped forms of ``command``, if any.
 
     This is an ADDITIVE haystack, kept alongside the raw and masked lists
     rather than rewriting either, and fed to ALL rules — anchored and
     unanchored alike. Both halves of that sentence are load-bearing.
 
-    ADDITIVE, because stripping is DELETION. ``-c <k>=<v>`` values are executed
-    by git (``core.sshCommand``, ``core.pager``, ``alias.*``,
-    ``core.fsmonitor``), so the value is a command payload sitting in the
-    haystack. Where a content rule DOES match that payload — the deletion rules
+    ADDITIVE, because stripping is DELETION. Some stripped values are COMMAND
+    PAYLOADS: ``-c <k>=<v>`` values are executed by git (``core.sshCommand``,
+    ``core.pager``, ``alias.*``, ``core.fsmonitor``), and ``tmux -c
+    '<shell-command>'`` is executed by tmux, so the value is a command sitting
+    in the haystack. Where a content rule DOES match that payload — the deletion rules
     catch an ``rm``-shaped one — rewriting a haystack in place would delete it
     from the only place it appears and turn a block into an allow: the fix
     creating a worse bug than the one it closes. Coverage of these payloads is
@@ -1882,8 +1994,9 @@ def git_normalized_haystacks(command: str) -> List[str]:
     blanks a token only when it is FULLY quoted, and ``core.pager='…'`` carries
     an unquoted ``core.pager=`` prefix, so the payload survives masking and is
     visible in both existing haystacks.) A rule that legitimately cares WHICH
-    repo is being touched — a path rule, an unattended path scope (#914) — reads
-    those same un-stripped forms: the ``-C`` argument is set aside, not discarded.
+    repo, cluster, profile or socket is being targeted — a path rule, an
+    unattended path scope (#914) — reads those same un-stripped forms: the
+    ``-C``/``--context``/``-L`` argument is set aside, not discarded.
 
     FED TO ALL RULES, because the intersection "must stay unanchored AND
     global-option-bypassable" is unreachable by a two-way split. Rules that are
@@ -1893,11 +2006,11 @@ def git_normalized_haystacks(command: str) -> List[str]:
     Masking is applied to the new path exactly as it is to the old one — the
     variant is built from the MASKED token lists, so the anchored path receives
     the normalized command masked, rather than being handed an unmasked
-    haystack that would reopen #675 on every anchored git rule.
+    haystack that would reopen #675 on every anchored rule.
     """
     out: List[str] = []
     for words in _masked_subcommand_words(command):
-        normalized = _strip_git_global_options(words)
+        normalized = _strip_global_options(words)
         if normalized is not None:
             joined = " ".join(normalized)
             if joined not in out:
@@ -2159,16 +2272,18 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
     # Anchored (command-prefix) rules match only masked subcommands, so quoted
     # argument text — commit messages, echo strings — can't false-match (#675).
     masked_haystacks = masked_subcommands(command)
-    # Third variant (#913): git with its global options stripped, so a rule
-    # written as ``\bgit\s+push\b`` still sees the subcommand behind
-    # ``git -C <dir>``. ADDED to whichever list a rule already reads — neither
-    # is rewritten — so the raw command stays reachable for the rules that need
-    # it, and derived from the masked tokens so it can never make quoted content
-    # matchable. Both halves are load-bearing: bundled git rules are anchored
-    # (masked path), while the rules installed on this machine carry zero
-    # ``anchored: true`` and read the raw path, so covering one alone would fix
-    # the bypass in only one of the two rule sets in play.
-    git_haystacks = git_normalized_haystacks(command)
+    # Third variant (#913 git, #919 the class): the tool with its global
+    # options stripped, so a rule written as ``\bgit\s+push\b`` or
+    # ``\btmux\s+kill-server\b`` still sees the subcommand behind
+    # ``git -C <dir>`` / ``tmux -L <socket>``. ADDED to whichever list a rule
+    # already reads — neither is rewritten — so the raw command stays reachable
+    # for the rules that need it, and derived from the masked tokens so it can
+    # never make quoted content matchable. Both halves are load-bearing:
+    # bundled git rules are anchored (masked path), while the rules installed
+    # on this machine carry zero ``anchored: true`` and read the raw path, so
+    # covering one alone would fix the bypass in only one of the two rule sets
+    # in play.
+    normalized_haystacks = global_option_normalized_haystacks(command)
 
     def _search(pat: str, hays: List[str]) -> bool:
         for hay in hays:
@@ -2194,7 +2309,7 @@ def check_command(command: str, config: Dict[str, Any]) -> Dict[str, Any]:
         anchored = pattern_obj.get("anchored", False)
         try:
             base = masked_haystacks if anchored else haystacks
-            if _search(pattern, base + git_haystacks):
+            if _search(pattern, base + normalized_haystacks):
                 if should_ask:
                     return {
                         "decision": "ask",

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -239,6 +239,55 @@ bashToolPatterns:
 - Docker destructive operations (`system prune`, `rm -v /`)
 - Package manager risks (`apt-get autoremove`, `npm uninstall -g`)
 
+#### 1a. Global options before the subcommand (#913, #919)
+
+Every pattern above names a tool and then its subcommand — `\bgit\s+push\b`,
+`\btmux\s+kill-server\b` — and `\s+` cannot span a global option. So for a long
+time `git -C /repo push --force`, `tmux -L agentwire kill-server` and
+`kubectl --context prod delete namespace prod` were all **allowed**, while their
+plain forms blocked. In `aws`/`kubectl`/`docker`/`redis-cli` the bypassing option
+is the *production-targeting* one, which inverts the guard: it held for the
+default target and dropped for the named remote one.
+
+The fix is one normalizer at the shared matching seam, driven by a per-tool data
+table (`_GLOBAL_OPTION_TABLE` in `agentwire/safety/_core.py`). Rules do not need
+to know about it: `global_option_normalized_haystacks()` emits an **extra**
+haystack per subcommand with the tool's global options removed, and present and
+future rules inherit the fix.
+
+Four properties are load-bearing:
+
+- **Additive.** A third haystack *added* to whichever list a rule already reads.
+  Neither the raw nor the masked list is rewritten — some stripped values are
+  command payloads (`git -c core.sshCommand=<cmd>`, `tmux -c <shell-command>`),
+  and deleting them in place would turn a block into an allow.
+- **Fed to both routings**, anchored and unanchored. Which rules are anchored is
+  not stable, and the intersection *must-stay-unanchored ∩ bypassable* is
+  reachable only if unanchored rules see it too.
+- **Derived from the masked tokens**, so quoted argument text can never become
+  matchable (#675): `echo 'tmux -L x kill-server'` stays allowed.
+- **Per-tool grammar, measured against the binary.** git's usage line advertises
+  only the `=` form while the binary accepts both, and `--exec-path` looks
+  value-taking and is not. The `short_cluster` property matters most: tmux is
+  getopt-based and accepts `-Lname` and `-2Lname`, while git *rejects* `-C/tmp` —
+  so the fleet-kill bypass has three spellings and git's answer is the wrong
+  default for the class.
+
+**Adding a tool is a table row, not a patch.** Each row records `provenance`
+(`measured` against a named binary version, or `documented` where the binary was
+not available) because *both directions* of a wrong arity guess fail open — mark
+an option value-taking when it is bare and the subcommand is eaten; mark it bare
+when it takes a value and the value stays inline. Neither shows up as a spurious
+block, so a wrong row is silent. That is why every row must also carry at least
+one acceptance-corpus command in `tests/unit/test_damage_control_hooks.py`
+(enforced by `test_every_row_has_corpus_coverage`): a row nothing exercises
+asserts a grammar nothing can contradict.
+
+Known limits, recorded rather than hidden: argument-consuming wrappers
+(`timeout 5 git …`), mysql-style unique-prefix long-option abbreviation
+(`mysqladmin --us=root`), and any option a tool adds after the measured version.
+All fail by producing *no* variant — an under-strip, never an over-strip.
+
 #### 2. zeroAccessPaths (Complete blocks)
 
 Paths that cannot be accessed at all (read, write, edit, delete):
@@ -657,6 +706,13 @@ Protects:
 - `tmux kill-server` - would kill all sessions
 - `tmux kill-session -t agentwire-*` - would kill AgentWire workers
 - Allows: `tmux list-sessions`, `tmux attach`, killing non-AgentWire sessions
+
+**Socket options no longer bypass this (#919).** Every session on this machine
+runs on a *named* socket, so `tmux -L agentwire kill-server` was the spelling
+that mattered — and it was allowed, along with the attached (`-Lagentwire`) and
+bundled (`-2Lagentwire`) forms that tmux's getopt parsing also accepts. All
+three now normalize to `tmux kill-server` before matching. See
+[Global options before the subcommand](#1a-global-options-before-the-subcommand-913-919).
 
 ### Session File Protection
 

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -787,7 +787,7 @@ class TestGitGlobalOptionBypass:
         produced), never an over-strip. If one of these ever starts blocking,
         that is good news and this assertion should be inverted.
         """
-        assert bash_hook.git_normalized_haystacks(
+        assert bash_hook.global_option_normalized_haystacks(
             f"{wrapper} git -C /repo push {_FORCE}"
         ) == []
 
@@ -893,6 +893,191 @@ class TestCrossIssueBackstops:
         )
 
 
+# ---------------------------------------------------------------------------
+# tmux global options (#919, first of the class)
+# ---------------------------------------------------------------------------
+#
+# `tmux -L agentwire kill-server` was ALLOWED. That rule exists to stop an
+# agent destroying the fleet it is running inside, and every session on this
+# machine runs on a NAMED socket — so the guard held for the spelling nobody
+# uses and dropped for the one the fleet actually runs under.
+#
+# tmux is getopt-based, so the bypass has THREE spellings, not one:
+#   tmux -L agentwire kill-server     separate
+#   tmux -Lagentwire kill-server      ATTACHED
+#   tmux -2Lagentwire kill-server     BUNDLED flag + attached value
+# git REJECTS the attached form (`git -C/tmp` -> "unknown option"), which is
+# why #918 could ignore attached forms and document that as correct. Correct
+# for git, wrong here — hence `short_cluster` is a per-tool property of the
+# table rather than a convention inherited from whichever tool was fixed first.
+
+_KILL_SERVER = "kill-" + "server"
+
+# Expectations are the MEASURED plain-form verdicts, not the ones that would
+# be nice: `kill-session -a` is an `ask` rule in agentwire.yaml, and writing
+# `block` here would have made the corpus disagree with the rule set rather
+# than with the bug.
+_TMUX_GATED = [
+    (_KILL_SERVER, "block"),
+    (f"kill-session -t agentwire-{'dev'}", "block"),
+    ("kill-session -a", "ask"),
+]
+
+# Measured against tmux 3.5a: `-L`/`-S`/`-f`/`-c`/`-T` take a value in all
+# three spellings; `-2`/`-u`/`-C` stand alone.
+_TMUX_PREFIXES = [
+    "-L agentwire",
+    "-Lagentwire",
+    "-2Lagentwire",
+    "-uLagentwire",
+    "-S /tmp/tmux-501/default",
+    "-S/tmp/tmux-501/default",
+    "-f /tmp/tmux.conf -L agentwire",
+    "-2 -L agentwire",
+    "-2",
+]
+
+_TMUX_STILL_ALLOWED = [
+    "tmux list-sessions",
+    "tmux -L agentwire list-sessions",
+    "tmux -L agentwire display-message -p '#S'",
+    "tmux kill-session -t scratch",
+    "tmux -L agentwire kill-session -t scratch",
+    # Quoted content that merely MENTIONS the gated command (#675 masking).
+    f"echo 'tmux -L agentwire {_KILL_SERVER}'",
+]
+
+
+class TestTmuxGlobalOptionBypass:
+    """#919 — the fleet-kill rule must survive a socket option."""
+
+    @pytest.mark.parametrize("routing", ["anchored", "unanchored"])
+    @pytest.mark.parametrize("prefix", _TMUX_PREFIXES)
+    @pytest.mark.parametrize("rest,expected", _TMUX_GATED)
+    def test_global_options_do_not_bypass(
+        self, bash_hook, bundled_config, unanchored_config, routing, prefix, rest,
+        expected,
+    ):
+        cfg = bundled_config if routing == "anchored" else unanchored_config
+        cmd = f"tmux {prefix} {rest}"
+        decision = bash_hook.check_command(cmd, cfg)["decision"]
+        assert decision == expected, (
+            f"{cmd!r} resolved to {decision} under {routing} routing, want {expected}"
+        )
+
+    @pytest.mark.parametrize("rest,expected", _TMUX_GATED)
+    def test_plain_form_is_the_baseline(self, bash_hook, bundled_config, rest, expected):
+        """Anchors the pairs above: the plain form already decided this way."""
+        assert bash_hook.check_command(f"tmux {rest}", bundled_config)["decision"] == expected
+
+    @pytest.mark.parametrize("cmd", _TMUX_STILL_ALLOWED)
+    def test_no_over_blocking(self, bash_hook, bundled_config, cmd):
+        assert bash_hook.check_command(cmd, bundled_config)["decision"] == "allow"
+
+    @pytest.mark.parametrize("prefix", _TMUX_PREFIXES)
+    def test_blocks_via_the_tmux_rule_not_something_else(
+        self, bash_hook, bundled_config, prefix
+    ):
+        """Assert the RULE ID, not just the verdict.
+
+        Two commands can both read `block` before and after while the rule
+        producing it changes — which is how a fix can look like it landed while
+        the intended rule is still bypassed and some generic rule is carrying
+        the verdict (see TestCrossIssueBackstops for that failure in the wild).
+        """
+        result = bash_hook.check_command(f"tmux {prefix} {_KILL_SERVER}", bundled_config)
+        plain = bash_hook.check_command(f"tmux {_KILL_SERVER}", bundled_config)
+        assert result.get("id") == plain.get("id"), result
+        assert result.get("id", "").startswith("agentwire.tmux-kill-server"), result
+
+    @pytest.mark.parametrize("order", ["as-loaded", "reversed"])
+    @pytest.mark.parametrize("prefix", _TMUX_PREFIXES)
+    @pytest.mark.parametrize("rest,expected", _TMUX_GATED)
+    def test_never_downgrades_a_block_to_ask(
+        self, bash_hook, bundled_config, reversed_config, prefix, rest, expected, order,
+    ):
+        """Parity with the plain form in the SAME config — see the git twin for
+        why a fixed verdict is the wrong invariant here."""
+        cfg = bundled_config if order == "as-loaded" else reversed_config
+        plain = bash_hook.check_command(f"tmux {rest}", cfg)["decision"]
+        prefixed = bash_hook.check_command(f"tmux {prefix} {rest}", cfg)["decision"]
+        assert prefixed == plain, (
+            f"tmux {prefix} {rest} decided {prefixed} but plain decided {plain} "
+            f"({order} order)"
+        )
+
+
+class TestShortOptionClusterIsPerTool:
+    """`short_cluster` is measured per tool, never inherited.
+
+    git rejects `-C/tmp` (git 2.50.1: "unknown option"), so #918 correctly
+    ignored attached forms. tmux accepts `-Lname` and `-2Lname` (tmux 3.5a,
+    confirmed by the socket path coming back in its own connect error for all
+    three spellings). Reading git's answer as the class's answer ships a tmux
+    fix that leaves two of the three spellings open.
+    """
+
+    def test_tmux_attached_short_option_is_normalized(self, bash_hook):
+        assert bash_hook._strip_global_options(
+            ["tmux", "-Lagentwire", _KILL_SERVER]
+        ) == ["tmux", _KILL_SERVER]
+
+    def test_tmux_bundled_flag_then_attached_value(self, bash_hook):
+        assert bash_hook._strip_global_options(
+            ["tmux", "-2Lagentwire", _KILL_SERVER]
+        ) == ["tmux", _KILL_SERVER]
+
+    def test_tmux_bundled_flag_then_separate_value(self, bash_hook):
+        assert bash_hook._strip_global_options(
+            ["tmux", "-uL", "agentwire", _KILL_SERVER]
+        ) == ["tmux", _KILL_SERVER]
+
+    def test_git_attached_form_is_not_treated_as_a_bypass(self, bash_hook):
+        """git rejects it, so there is nothing to normalize — and inventing a
+        variant here would block a command that cannot run."""
+        assert bash_hook._strip_global_options(
+            ["git", "-C/tmp", "push"]
+        ) is None
+
+    def test_unknown_cluster_character_bails_rather_than_guesses(self, bash_hook):
+        """A cluster with an unrecognized letter produces NO variant.
+
+        Guessing would let an unknown value-taking option swallow the
+        subcommand — the same failure the maintenance-edge comment describes,
+        arrived at from the other side.
+        """
+        assert bash_hook._strip_global_options(
+            ["tmux", "-Zq", _KILL_SERVER]
+        ) is None
+
+
+class TestGlobalOptionTableProvenance:
+    """Every row states how its grammar was established, and every row is
+    falsifiable by at least one acceptance-corpus command.
+
+    Both halves matter and the second is the load-bearing one. A wrong arity
+    guess FAILS OPEN in both directions — mark an option value-taking when it
+    is bare and the subcommand gets eaten; mark it bare when it takes a value
+    and the value stays inline — and neither shows up as a spurious block. So
+    nothing ever goes red on its own: a table row with no corpus entry asserts
+    a grammar nobody measured and nothing in this suite can contradict it.
+    """
+
+    def test_every_row_declares_provenance_and_version(self, bash_hook):
+        for tool, grammar in bash_hook._GLOBAL_OPTION_TABLE.items():
+            assert grammar["provenance"] in (
+                bash_hook._MEASURED, bash_hook._DOCUMENTED
+            ), f"{tool} has no provenance"
+            assert grammar["version"], f"{tool} names no measured/documented version"
+
+    def test_every_row_has_at_least_one_option(self, bash_hook):
+        for tool, grammar in bash_hook._GLOBAL_OPTION_TABLE.items():
+            assert (
+                grammar["value"] or grammar["flag"] or grammar["value_eq_only"]
+                or grammar["plus_selector"]
+            ), f"{tool} is an empty row — it claims a grammar it does not describe"
+
+
 class TestGitGlobalOptionNormalizer:
     """The normalizer's contract at the seam, as a separate THIRD haystack.
 
@@ -902,7 +1087,7 @@ class TestGitGlobalOptionNormalizer:
     """
 
     def test_third_haystack_exposes_stripped_variant(self, bash_hook):
-        assert f"git push {_FORCE}" in bash_hook.git_normalized_haystacks(
+        assert f"git push {_FORCE}" in bash_hook.global_option_normalized_haystacks(
             f"git -C /repo push {_FORCE}"
         )
 
@@ -916,12 +1101,12 @@ class TestGitGlobalOptionNormalizer:
         assert subs == [cmd]
 
     def test_no_variant_for_a_plain_git_command(self, bash_hook):
-        assert bash_hook.git_normalized_haystacks(f"git push {_FORCE}") == []
+        assert bash_hook.global_option_normalized_haystacks(f"git push {_FORCE}") == []
 
     def test_variant_is_derived_from_masked_tokens(self, bash_hook):
         """Quoted content must not become matchable. Normalizing the RAW string
         would hand `\\bgit\\s+clean\\b` a match inside an echo argument."""
-        assert bash_hook.git_normalized_haystacks(
+        assert bash_hook.global_option_normalized_haystacks(
             "echo 'git -C /repo clean -fdx'"
         ) == []
 
@@ -934,7 +1119,7 @@ class TestGitGlobalOptionNormalizer:
         matches inside it; built from masked tokens the message is a
         placeholder and only the command survives.
         """
-        variants = bash_hook.git_normalized_haystacks(
+        variants = bash_hook.global_option_normalized_haystacks(
             "git -C /r commit -m 'echo git clean -fdx'"
         )
         assert variants
@@ -943,20 +1128,20 @@ class TestGitGlobalOptionNormalizer:
     def test_value_taking_option_consumes_its_argument(self, bash_hook):
         """Dropping only the flag would leave the value where the subcommand
         belongs (`git /repo push …`) and the rule would still miss."""
-        assert bash_hook._strip_git_global_options(
+        assert bash_hook._strip_global_options(
             ["git", "-C", "/repo", "push"]
         ) == ["git", "push"]
 
     def test_option_after_subcommand_is_untouched(self, bash_hook):
-        assert bash_hook._strip_git_global_options(["git", "log", "-C"]) is None
+        assert bash_hook._strip_global_options(["git", "log", "-C"]) is None
 
     def test_exec_path_does_not_consume_a_token(self, bash_hook):
         """Bare `--exec-path` prints and exits — only `--exec-path=<p>` carries a
         value. Consuming the next token here would swallow the subcommand."""
-        assert bash_hook._strip_git_global_options(
+        assert bash_hook._strip_global_options(
             ["git", "--exec-path", "status"]
         ) == ["git", "status"]
-        assert bash_hook._strip_git_global_options(
+        assert bash_hook._strip_global_options(
             ["git", "--exec-path=/x", "status"]
         ) == ["git", "status"]
 
@@ -965,18 +1150,18 @@ class TestGitGlobalOptionNormalizer:
     ])
     def test_value_options_accept_both_equals_and_space_form(self, bash_hook, opt):
         """git 2.50.1 takes both, though the usage line advertises only `=`."""
-        assert bash_hook._strip_git_global_options(
+        assert bash_hook._strip_global_options(
             ["git", opt, "v", "push"]
         ) == ["git", "push"]
-        assert bash_hook._strip_git_global_options(
+        assert bash_hook._strip_global_options(
             ["git", f"{opt}=v", "push"]
         ) == ["git", "push"]
 
     def test_non_git_command_untouched(self, bash_hook):
-        assert bash_hook._strip_git_global_options(["ls", "-C", "/repo"]) is None
+        assert bash_hook._strip_global_options(["ls", "-C", "/repo"]) is None
 
     def test_no_global_options_yields_no_variant(self, bash_hook):
-        assert bash_hook._strip_git_global_options(["git", "push"]) is None
+        assert bash_hook._strip_global_options(["git", "push"]) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -877,20 +877,61 @@ class TestCrossIssueBackstops:
         plain = bash_hook.check_command(f'git commit -m "{message}"', cfg)
         assert plain["decision"] == result["decision"]
 
+    # UPDATED BY #919, which is the outcome the canary was written to detect.
+    #
+    # #918 pinned these two as blocking ONLY via the generic
+    # `core.rm-file-deletion` rule — the rule #915 exists to narrow — and said
+    # in as many words: "if that is a rule of its own, good; update this
+    # canary". It now is. `containers.docker-volume-rm` and
+    # `aws.aws-s3-rm-recursive` were global-option-bypassed and are not any
+    # more, so the #915 ordering hazard these commands represented is gone:
+    # narrowing the generic rule can no longer drop them to allow.
+    #
+    # Asserted as "blocks via ITS OWN tool rule", not merely "blocks" — the
+    # whole point of the canary was that the verdict looked right while the
+    # rule behind it was the wrong one.
+    @pytest.mark.parametrize("cmd,rule_id", [
+        ("docker --context prod volume rm pgdata",
+         "containers.docker-volume-rm-data-loss"),
+        ("aws --profile prod s3 rm s3://bucket --recursive",
+         "aws.aws-s3-rm-recursive-deletes-all-objects"),
+    ])
+    def test_each_now_blocks_via_its_own_tool_rule(
+        self, bash_hook, bundled_config, cmd, rule_id
+    ):
+        result = bash_hook.check_command(cmd, bundled_config)
+        assert result["decision"] == "block", result
+        assert result.get("id") == rule_id, (
+            f"{cmd!r} blocks via {result.get('id')!r}, not its own tool rule "
+            f"{rule_id!r} — if that is another accident, it still needs one."
+        )
+
     @pytest.mark.parametrize("cmd", [
         "docker --context prod volume rm pgdata",
         "aws --profile prod s3 rm s3://bucket --recursive",
     ])
-    def test_generic_rm_rule_is_still_the_only_thing_catching_these(
+    def test_survives_the_generic_deletion_rule_being_narrowed(
         self, bash_hook, bundled_config, cmd
     ):
-        result = bash_hook.check_command(cmd, bundled_config)
-        assert result["decision"] == "block", result
-        assert result.get("id") == "core.rm-file-deletion-use-git-clean-or-manual-cleanup", (
-            f"{cmd!r} now blocks via {result.get('id')!r} — if that is a rule of "
-            "its own, good; update this canary. If it is another accident, it "
-            "needs one."
-        )
+        """The #915 interaction, asserted directly rather than inferred.
+
+        Simulates #915 landing — the generic `core.rm-file-deletion` rule
+        disabled — and requires these to keep blocking. Before #919 they went
+        straight to allow, and nothing in either PR's suite would have noticed,
+        because each PR was correct about its own scope.
+        """
+        cfg = copy.deepcopy(bundled_config)
+        cfg["safety"] = dict(cfg.get("safety", {}))
+        cfg["safety"]["disabled_rules"] = [
+            "core.rm-file-deletion-use-git-clean-or-manual-cleanup"
+        ]
+        # The simulation must actually simulate something: on the pre-#919
+        # code this same config turns both commands into `allow`.
+        assert any(
+            p.get("id") == "core.rm-file-deletion-use-git-clean-or-manual-cleanup"
+            for p in cfg["bashToolPatterns"]
+        ), "the rule being disabled does not exist — this test proves nothing"
+        assert bash_hook.check_command(cmd, cfg)["decision"] == "block"
 
 
 # ---------------------------------------------------------------------------
@@ -1039,6 +1080,22 @@ class TestShortOptionClusterIsPerTool:
             ["git", "-C/tmp", "push"]
         ) is None
 
+    def test_terraform_chdir_exists_only_in_the_equals_form(self, bash_hook):
+        """Measured against terraform 1.10.5: `-chdir=DIR` parses and a bare
+        `-chdir /infra` does not, so a bare one must NOT eat the next token.
+
+        Added because the mutation battery found this exact wrong row surviving
+        — the corpus exercises `-chdir=/infra` only, so the space-form arity was
+        asserted nowhere and `value_eq_only` could have been plain `value` with
+        every test still green.
+        """
+        assert bash_hook._strip_global_options(
+            ["terraform", "-chdir=/infra", "destroy"]
+        ) == ["terraform", "destroy"]
+        assert bash_hook._strip_global_options(
+            ["terraform", "-chdir", "/infra", "destroy"]
+        ) is None
+
     def test_unknown_cluster_character_bails_rather_than_guesses(self, bash_hook):
         """A cluster with an unrecognized letter produces NO variant.
 
@@ -1076,6 +1133,329 @@ class TestGlobalOptionTableProvenance:
                 grammar["value"] or grammar["flag"] or grammar["value_eq_only"]
                 or grammar["plus_selector"]
             ), f"{tool} is an empty row — it claims a grammar it does not describe"
+
+    def test_every_row_has_corpus_coverage(self, bash_hook):
+        """The load-bearing half. A row nothing exercises is UNFALSIFIABLE.
+
+        A wrong row cannot go red on its own — the failure mode is silence, so
+        the only detector is a corpus command whose expected verdict the wrong
+        row would break. This is enforced rather than reviewed because it costs
+        nothing to add a row and the omission is invisible.
+        """
+        covered = {cmd.split()[0] for _, _, cmd, _, _ in _CORPUS}
+        missing = set(bash_hook._GLOBAL_OPTION_TABLE) - covered
+        assert not missing, (
+            f"table rows with no acceptance-corpus command: {sorted(missing)} — "
+            "each asserts a grammar nothing in this suite can contradict"
+        )
+
+    def test_documented_rows_are_named(self, bash_hook):
+        """Pins WHICH rows are doc-derived, so a row cannot be quietly demoted
+        to a guess (or quietly promoted without a measurement)."""
+        documented = {
+            t for t, g in bash_hook._GLOBAL_OPTION_TABLE.items()
+            if g["provenance"] == bash_hook._DOCUMENTED
+        }
+        assert documented == {"pnpm"}, documented
+
+    def test_table_ships_in_code_not_in_a_rules_yaml(self, bash_hook):
+        """A DEPLOYMENT assertion, not a layering one.
+
+        `heal_damage_control` self-heals STALE hook scripts but installs rules
+        and tooldefs missing-only (`if not target.exists()`), so an existing
+        rule file is never brought forward by any command. A table shipped as
+        YAML would merge green and be INERT on day one on every installation
+        that already has the file. #918 deploys because it touched `_core.py`
+        and the generated hooks; #675's anchoring does not, because it lives in
+        `rules/git.yaml`.
+
+        So: the table is reachable from the hook module, and no rule file
+        carries a `globalOptions`-shaped key that a future refactor might have
+        moved it into.
+        """
+        assert bash_hook._GLOBAL_OPTION_TABLE
+        for path in sorted(_DC_RULES.glob("*.yaml")):
+            text = path.read_text()
+            assert "globalOption" not in text and "global_option" not in text, (
+                f"{path.name} carries global-option data — it would not reach "
+                "existing installs (see this test's docstring)"
+            )
+
+    def test_gh_is_not_a_bypass_and_has_no_row(self, bash_hook):
+        """`gh -R o/n repo delete` was reported as a bypass in #913's review
+        notes and in #919's issue body. It is not: measured, `gh -R cli/cli
+        repo view` -> "unknown shorthand flag: 'R' in -R", so the command never
+        runs. Pinned so a rebuild from those notes cannot re-add it.
+        """
+        assert "gh" not in bash_hook._GLOBAL_OPTION_TABLE
+        assert bash_hook._strip_global_options(
+            ["gh", "-R", "o/n", "repo", "delete"]
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# the acceptance corpus (#919)
+# ---------------------------------------------------------------------------
+#
+# Transcribed from the calibrated corpus held by the #913/#918 review seat, not
+# rebuilt from notes — rebuilding is how the disproved `gh -R` row would have
+# come back. Each entry is (label, tool, bypass command, plain baseline,
+# expected verdict), and BOTH halves are asserted: the baseline pins that the
+# rule set decides this way at all, and the bypass pins that the global option
+# no longer hides it.
+#
+# The expected verdicts are the MEASURED plain-form verdicts. Where a tool's
+# rule is `ask` rather than `block` (npm publish, cargo publish, pnpm publish)
+# the corpus says `ask` — an aspirational `block` would make the corpus
+# disagree with the rule set instead of with the bug.
+
+_RM = "rm"
+_RECURSIVE = "--recursive"
+_PRUNE_ALL = "prune -a"
+
+_CORPUS = [
+    ("kubectl --context", "kubectl",
+     "kubectl --context prod delete namespace prod",
+     "kubectl delete namespace prod", "block"),
+    ("kubectl -n", "kubectl",
+     "kubectl -n kube-system delete namespace prod",
+     "kubectl delete namespace prod", "block"),
+    ("kubectl --kubeconfig", "kubectl",
+     "kubectl --kubeconfig /tmp/kc delete namespace prod",
+     "kubectl delete namespace prod", "block"),
+    ("aws --profile", "aws",
+     "aws --profile prod ec2 terminate-instances --ids i",
+     "aws ec2 terminate-instances --ids i", "block"),
+    ("aws --region", "aws",
+     "aws --region us-east-1 ec2 terminate-instances --ids i",
+     "aws ec2 terminate-instances --ids i", "block"),
+    ("aws s3 rb", "aws",
+     f"aws --profile prod s3 rb s3://b {_FORCE}",
+     f"aws s3 rb s3://b {_FORCE}", "block"),
+    ("gcloud --project", "gcloud",
+     "gcloud --project foo projects delete p",
+     "gcloud projects delete p", "block"),
+    ("gcloud --account", "gcloud",
+     "gcloud --account a@b.c projects delete p",
+     "gcloud projects delete p", "block"),
+    ("docker --context", "docker",
+     f"docker --context prod system {_PRUNE_ALL}",
+     f"docker system {_PRUNE_ALL}", "block"),
+    ("docker -H", "docker",
+     f"docker -H tcp://prod:2375 system {_PRUNE_ALL}",
+     f"docker system {_PRUNE_ALL}", "block"),
+    ("helm --kube-context", "helm",
+     "helm --kube-context prod uninstall rel",
+     "helm uninstall rel", "block"),
+    ("terraform -chdir=", "terraform",
+     "terraform -chdir=/infra destroy -auto-approve",
+     "terraform destroy -auto-approve", "block"),
+    ("pulumi -C", "pulumi",
+     "pulumi -C /infra destroy --yes",
+     "pulumi destroy --yes", "block"),
+    ("npm --prefix", "npm",
+     f"npm --prefix /srv unpublish pkg {_FORCE}",
+     f"npm unpublish pkg {_FORCE}", "block"),
+    ("supabase --workdir", "supabase",
+     "supabase --workdir /srv db reset",
+     "supabase db reset", "block"),
+    ("redis-cli -h", "redis-cli",
+     "redis-cli -h prod.redis -p 6379 FLUSHALL",
+     "redis-cli FLUSHALL", "block"),
+    ("mysqladmin -u", "mysqladmin",
+     "mysqladmin -u root -h prod drop mydb",
+     "mysqladmin drop mydb", "block"),
+    ("tmux -L", "tmux",
+     f"tmux -L agentwire {_KILL_SERVER}", f"tmux {_KILL_SERVER}", "block"),
+    ("tmux -S", "tmux",
+     f"tmux -S /tmp/tmux-501/default {_KILL_SERVER}",
+     f"tmux {_KILL_SERVER}", "block"),
+    # tmux is getopt-based, so the attached and bundled spellings are real
+    # commands, not typos. A git-shaped table (attached forms ignored, correct
+    # FOR GIT) leaves the fleet-kill rule bypassed in two of its three
+    # spellings while the separate-form row goes green.
+    ("tmux -L attached", "tmux",
+     f"tmux -Lagentwire {_KILL_SERVER}", f"tmux {_KILL_SERVER}", "block"),
+    ("tmux -2L bundled", "tmux",
+     f"tmux -2Lagentwire {_KILL_SERVER}", f"tmux {_KILL_SERVER}", "block"),
+    ("pnpm -C", "pnpm", "pnpm -C /srv publish", "pnpm publish", "ask"),
+    ("cargo +toolchain", "cargo", "cargo +nightly publish", "cargo publish", "ask"),
+    ("git -C", "git",
+     f"git -C /repo push {_FORCE} origin main",
+     f"git push {_FORCE} origin main", "block"),
+]
+
+
+class TestAcceptanceCorpus:
+    """#919 — every measured baseline/bypass pair, under BOTH routings.
+
+    Run twice, once as loaded and once with `anchored` popped from every
+    pattern: the bypass is routing-independent, so a fix that reaches only one
+    haystack shows up immediately as a disagreement between the two runs.
+    """
+
+    @pytest.mark.parametrize("label,tool,bypass,plain,expected", _CORPUS,
+                             ids=[c[0] for c in _CORPUS])
+    def test_baseline_decides_this_way_at_all(
+        self, bash_hook, bundled_config, label, tool, bypass, plain, expected
+    ):
+        decision = bash_hook.check_command(plain, bundled_config)["decision"]
+        assert decision == expected, (
+            f"baseline {plain!r} is {decision}, not {expected} — the corpus "
+            "disagrees with the rule set, so its bypass row proves nothing"
+        )
+
+    @pytest.mark.parametrize("routing", ["anchored", "unanchored"])
+    @pytest.mark.parametrize("label,tool,bypass,plain,expected", _CORPUS,
+                             ids=[c[0] for c in _CORPUS])
+    def test_global_option_does_not_bypass(
+        self, bash_hook, bundled_config, unanchored_config, routing, label, tool,
+        bypass, plain, expected,
+    ):
+        cfg = bundled_config if routing == "anchored" else unanchored_config
+        decision = bash_hook.check_command(bypass, cfg)["decision"]
+        assert decision == expected, (
+            f"{bypass!r} resolved to {decision} under {routing} routing, "
+            f"want {expected}"
+        )
+
+    @pytest.mark.parametrize("routing", ["anchored", "unanchored"])
+    @pytest.mark.parametrize("label,tool,bypass,plain,expected", _CORPUS,
+                             ids=[c[0] for c in _CORPUS])
+    def test_bypass_lands_on_the_same_rule_as_the_baseline(
+        self, bash_hook, bundled_config, unanchored_config, routing, label, tool,
+        bypass, plain, expected,
+    ):
+        """Assert the RULE ID, not just the verdict.
+
+        Two commands can read `block` before and after while the rule producing
+        it changes — which is exactly how `docker --context prod volume rm` and
+        `aws --profile prod s3 rm --recursive` looked covered while their own
+        rules were bypassed and a generic deletion rule carried the verdict.
+        """
+        cfg = bundled_config if routing == "anchored" else unanchored_config
+        got = bash_hook.check_command(bypass, cfg)
+        want = bash_hook.check_command(plain, cfg)
+        assert got.get("id") == want.get("id"), (
+            f"{bypass!r} decided via {got.get('id')!r} but the plain form "
+            f"decided via {want.get('id')!r} ({routing} routing)"
+        )
+
+    @pytest.mark.parametrize("label,tool,bypass,plain,expected", _CORPUS,
+                             ids=[c[0] for c in _CORPUS])
+    def test_row_is_not_vacuous(
+        self, bash_hook, bundled_config, label, tool, bypass, plain, expected, monkeypatch
+    ):
+        """NON-VACUITY FLOOR: prove each row is carried by ITS OWN table entry.
+
+        A corpus row that passes because some other rule happens to catch the
+        command is indistinguishable from a row the fix actually closed — until
+        the day that other rule is narrowed and the row silently keeps passing.
+        (`docker --context prod volume rm` was exactly that: it blocked, via
+        the generic deletion rule, while `containers.docker-volume-rm` was
+        bypassed.)
+
+        So: delete this tool's row from the table and require the verdict OR
+        the rule ID to move. Rule ID as well as verdict, because a command that
+        keeps blocking through a different rule has NOT been proven by its row.
+        """
+        with_row = bash_hook.check_command(bypass, bundled_config)
+        table = dict(bash_hook._GLOBAL_OPTION_TABLE)
+        table.pop(tool)
+        monkeypatch.setattr(bash_hook, "_GLOBAL_OPTION_TABLE", table)
+        without_row = bash_hook.check_command(bypass, bundled_config)
+        assert (with_row["decision"], with_row.get("id")) != (
+            without_row["decision"], without_row.get("id")
+        ), (
+            f"{label}: removing the {tool!r} table row changes nothing about "
+            f"{bypass!r} ({with_row['decision']} via {with_row.get('id')!r}) — "
+            "this row proves the table entry, not the fix"
+        )
+
+    @pytest.mark.parametrize("order", ["as-loaded", "reversed"])
+    @pytest.mark.parametrize("label,tool,bypass,plain,expected", _CORPUS,
+                             ids=[c[0] for c in _CORPUS])
+    def test_never_downgrades_a_block_to_ask(
+        self, bash_hook, bundled_config, reversed_config, order, label, tool,
+        bypass, plain, expected,
+    ):
+        """Parity against the plain form in the SAME config, under two pattern
+        orderings — the invariant this normalizer owns. See the git twin for
+        why a fixed verdict is the wrong assertion."""
+        cfg = bundled_config if order == "as-loaded" else reversed_config
+        assert (
+            bash_hook.check_command(bypass, cfg)["decision"]
+            == bash_hook.check_command(plain, cfg)["decision"]
+        ), f"{label}: prefixed and plain disagree under {order} order"
+
+
+# Near-miss SAFE forms — the general shape of #918's `--force-with-lease`
+# guard. A normalizer that rewrites before a rule sees it can start blocking
+# the safe form, which trains everyone to reach for the dangerous one.
+#
+# Searched mechanically rather than assumed: across all 15 rule files and all
+# tooldefs there is exactly ONE negative-lookahead rule
+# (`\bgit\s+push\s+.*--force(?!-with-lease)`) and exactly ONE tooldef declaring
+# a safe variant of a blocked command (`git push --force-with-lease`), both
+# already covered by #918. So the general form of the guard needs no lookahead
+# twin per tool: assert the prefixed decision EQUALS the plain decision.
+_SAFE_NEAR_MISSES = [
+    "kubectl --context prod get pods",
+    "kubectl --context prod delete pod mypod",
+    "aws --profile prod s3 ls s3://bucket",
+    f"aws --profile prod s3 {_RM} s3://bucket/one-key",
+    "gcloud --project foo projects list",
+    "docker --context prod system prune",
+    "docker --context prod ps -a",
+    "helm --kube-context prod list",
+    "terraform -chdir=/infra plan",
+    "pulumi -C /infra preview",
+    "npm --prefix /srv install",
+    "supabase --workdir /srv db diff",
+    "redis-cli -h prod.redis -p 6379 GET mykey",
+    "mysqladmin -u root -h prod status",
+    "tmux -L agentwire list-sessions",
+    "cargo +nightly build",
+    "pnpm -C /srv install",
+]
+
+
+class TestSafeNearMissesKeepTheirPlainVerdict:
+    """The two-sided guard, generalised.
+
+    `docker --context prod system prune` (no `-a`) must decide exactly as
+    `docker system prune` does. Blocking it would be the normalizer catching
+    the safe form; allowing it where the plain form blocks would mean the
+    variant went missing.
+    """
+
+    @pytest.mark.parametrize("cmd", _SAFE_NEAR_MISSES)
+    def test_parity_with_the_plain_form(self, bash_hook, bundled_config, cmd):
+        words = cmd.split()
+        tool = words[0]
+        grammar = bash_hook._GLOBAL_OPTION_TABLE[tool]
+        # Rebuild the same command with the global options removed, so the
+        # comparison is against the form the rules were written for.
+        stripped = bash_hook._strip_global_options(words)
+        assert stripped is not None, f"{cmd!r} produced no variant to compare"
+        plain = " ".join(stripped)
+        assert grammar  # the row under test
+        assert (
+            bash_hook.check_command(cmd, bundled_config)["decision"]
+            == bash_hook.check_command(plain, bundled_config)["decision"]
+        ), f"{cmd!r} and {plain!r} disagree"
+
+    @pytest.mark.parametrize("cmd", _SAFE_NEAR_MISSES)
+    def test_safe_forms_are_not_newly_blocked(self, bash_hook, bundled_config, cmd):
+        """Stronger than parity where the plain form is allowed: name the
+        commands that must stay runnable, so a future over-strip is a named
+        failure rather than a quiet tax on everyone's workflow."""
+        decision = bash_hook.check_command(cmd, bundled_config)["decision"]
+        plain_decision = bash_hook.check_command(
+            " ".join(bash_hook._strip_global_options(cmd.split())), bundled_config
+        )["decision"]
+        if plain_decision == "allow":
+            assert decision == "allow", f"{cmd!r} is newly {decision}"
 
 
 class TestGitGlobalOptionNormalizer:


### PR DESCRIPTION
Closes #919

Generalises #918's git-only fix to the whole class.

**Base: `1736abd`** (#918 and then #917 merged while this was being written; every number below was re-taken on that base). The first rebase carried #918's late review change forward by hand — `xargs` is a BARE wrapper prefix, and the arity-as-written comment that replaced the "zero-arg wrappers" framing.

## #915 is unblocked

The reason this issue was a gate rather than a backlog item. #918 pinned two commands as blocking **only** via the generic `core.rm-file-deletion` rule — the rule #915 exists to narrow — and said in as many words *"if that is a rule of its own, good; update this canary"*. It now is:

| command | blocked by, before | blocked by, now |
|---|---|---|
| `docker --context prod volume rm pgdata` | `core.rm-file-deletion…` | `containers.docker-volume-rm-data-loss` |
| `aws --profile prod s3 rm … --recursive` | `core.rm-file-deletion…` | `aws.aws-s3-rm-recursive-deletes-all-objects` |

`test_survives_the_generic_deletion_rule_being_narrowed` simulates #915 landing — generic rule disabled — and requires both to keep blocking, after first asserting that the rule being disabled actually exists, so the simulation cannot pass by simulating nothing. **#915 can now narrow that rule without a hidden regression, and needs no explicit coverage for this pair.**

## The bug

A global option between the tool and its subcommand defeated every rule for that tool. `\s+` cannot span `--context prod`, and both rule sources assume adjacency:

- hand-written `bashToolPatterns` — `\btmux\s+kill-server\b`
- tooldef-generated — `_cmd_to_regex` → `\bkubectl\s+delete\b`

Two are worse than anything in #913:

- **`tmux -L agentwire kill-server` was ALLOWED.** That rule exists to stop an agent destroying the fleet it runs inside — and every session on this machine runs on a *named* socket, so the guard held for the spelling nobody uses and dropped for the one the fleet actually runs under.
- **In aws/kubectl/docker/redis-cli the bypassing option is the production-TARGETING option.** The guard held for the default target and dropped for the named remote one. It was weakest exactly where it mattered most.

## The fix — one normalizer, one data table

`_GLOBAL_OPTION_TABLE` in `agentwire/safety/_core.py`: tool → its global options, each classified by arity, plus the syntax properties that turn out not to be shared. `_strip_global_options()` is the single implementation; `global_option_normalized_haystacks()` is the seam. Adding a sixteenth tool is a table row, not a patch.

Not a generalized `_cmd_to_regex` (a guess about grammars nobody measured) and not fifteen per-tool normalizers ("model each wrapper's own grammar" — the mistake #918 declined to make, at one remove).

#918's proven properties are kept exactly, because none of them are git-specific: **additive** (a third haystack alongside raw and masked, never an in-place rewrite), **derived from the MASKED tokens** so quoted argument text can never become matchable, and **fed to BOTH routings**.

Renamed rather than shimmed, per the repo's no-backwards-compatibility rule: `git_normalized_haystacks` → `global_option_normalized_haystacks`, `_strip_git_global_options` → `_strip_global_options`.

## Sequencing

Two commits, tmux first and separable, per the orchestrator's ruling:

1. `f2b219f` — the table machinery + **git and tmux rows**. Mergeable alone if the rest needs another review round.
2. `0740f8f` — the remaining **13 rows** + the acceptance corpus + the wiki section.

## The row a git-shaped table misses

tmux is getopt-based and accepts attached and bundled short forms, so the fleet-kill bypass has **three** spellings:

```
tmux -L agentwire kill-server      separate
tmux -Lagentwire kill-server       ATTACHED
tmux -2Lagentwire kill-server      BUNDLED flag + attached value
```

git **rejects** the attached form (`git -C/tmp` → "unknown option"), which is why #918 ignores attached forms and documents that as correct. Correct for git, wrong here. So `short_cluster` is a per-tool measured property, not a convention inherited from whichever tool was fixed first. Caught by the reviewer before a line was written; all three spellings are corpus rows.

redis-cli is the counter-example that makes the point: it is the one *other* short-option tool where `short_cluster` is **False** — it compares argv by hand rather than using getopt, and rejects `-hprod.redis` outright.

## Grammar: measured against the binary

14 of 15 rows are **measured**, one is **documented**. No tool was installed on the owner's machine: static builds (kubectl, helm, terraform, pulumi, docker), the aws-cli pkg payload expanded in place, Homebrew bottles unpacked (redis-cli, mysqladmin), and a rustup toolchain with `CARGO_HOME`/`RUSTUP_HOME` pointed at the session scratchpad. Everything ran out of that scratchpad, never on the host PATH, and is gone with the session — the no-install ruling was about host state, and it holds.

Which binary, since a `measured` row is only as good as the thing measured — "measured against a static build I downloaded" is a different claim from "measured against what the operator runs". The same breakdown is recorded above the table in `_core.py`.

| tool | version | provenance |
|---|---|---|
| git | 2.50.1 | measured (#918) — **operator's own binary** (`/usr/bin/git`) |
| tmux | 3.5a | measured — **operator's own binary** (homebrew) |
| kubectl | v1.36.3 | measured — static build from dl.k8s.io |
| docker | 27.4.1 | measured — static build from download.docker.com |
| aws | 2.36.17 | measured — AWSCLIV2.pkg payload expanded with `pkgutil`, never installed |
| gcloud | 560.0.0 | measured — **operator's own binary** |
| helm | 3.16.4 | measured — static build from get.helm.sh |
| terraform | 1.10.5 | measured — static build from releases.hashicorp.com |
| pulumi | 3.145.0 | measured — static build from get.pulumi.com |
| npm | 10.8.2 | measured — **operator's own binary** |
| cargo | 1.97.1 | measured — rustup shim, `CARGO_HOME`/`RUSTUP_HOME` in the scratchpad |
| supabase | 2.105.0 | measured — **operator's own binary** |
| redis-cli | 8.10.0 | measured — homebrew bottle unpacked (`brew fetch`, never `brew install`) |
| mysqladmin | 9.7.1 | measured — homebrew bottle unpacked |
| **pnpm** | **9.x/10.x docs** | **DOCUMENTED** — the binary here is broken (corepack shim dies with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`). `short_cluster` is left **False** rather than guessed from the getopt-shaped tools |

`test_documented_rows_are_named` pins that list to `{"pnpm"}`, so a row cannot be quietly demoted to a guess or promoted without a measurement.

Traps the docs would have produced:

- **aws `--output`, `--color` and gcloud `--verbosity` look bare** to a differential probe — an invalid *value* produces the same "invalid choice" text as an unknown subcommand. The parser's own "expected one argument" settles it. They are value-taking.
- **terraform `-chdir` exists in the `=` form only.** A bare `-chdir /infra` is not accepted, so it must not eat the next token — hence a third arity category, `value_eq_only`.
- **kubectl routes an unknown subcommand to the PLUGIN path** ("flags cannot be placed before plugin name"), so the probe technique that worked for every other cobra tool reported *every* kubectl global option as unmeasurable. The fix was to probe with a real, offline subcommand (`version --client`) instead.
- **`gh -R` is not a bypass at all.** Measured: `gh -R cli/cli repo view` → "unknown shorthand flag: 'R' in -R". It is a per-command flag, so the command never runs. It was listed as a bypass in #913's review notes and in #919's issue body — which is why that issue says 15 tools and this table has 14 plus git. Pinned by `test_gh_is_not_a_bypass_and_has_no_row` so a rebuild-from-notes cannot re-add it.
- **supabase very nearly went in as a wrong row.** My first shell-loop probe said its global flags are rejected before the subcommand; the second said accepted. Cause: **zsh does not word-split an unquoted parameter expansion**, so `supabase $a` passed one argument containing spaces and every result from those loops was an artifact (it is what created a tmux socket literally named `zzsockzz zzsentinelzz`). Every measurement in the table comes from `subprocess` with an explicit argv list. Two runs disagreeing is what surfaced it — a single run would have shipped the wrong row silently.

### Options deliberately left OUT of rows

Under-stripping produces *no variant* — never an over-strip — so omission is the safe direction and each is recorded:

- **terraform `-help` / `-version`**: real global flags, but they short-circuit execution. `terraform -help destroy` prints help and destroys nothing; stripping it would normalize to `terraform destroy` and **block a command people actually type**.
- **cargo `-Z`**: nightly-only, so its arity is not measurable on a stable toolchain.
- **mysqladmin `-p`**: optional value, attached-only (`-psecret` vs bare `-p` prompting). Neither category models that.

## Where the table lives, and why that is a deployment question

`_GLOBAL_OPTION_TABLE` is in `agentwire/safety/_core.py`, **not** in a `rules/*.yaml`. `heal_damage_control` self-heals hook scripts when they go stale, but installs rules and tooldefs *missing-only* (`if not target.exists()`), so an existing rule file is never brought forward by any command. A table shipped as YAML would merge green, pass review, and be **inert on day one** on every installation that already has the file. #918 deploys because it touched only `_core.py` and the generated hooks; #675's anchoring does not, because it lives in `rules/git.yaml` — same repo, same merge process, opposite outcomes, decided purely by which file the fix landed in. Recorded at the table and pinned by `test_table_ships_in_code_not_in_a_rules_yaml`.

## Provenance is enforced, not documented

Both directions of a wrong arity guess **fail open**, and the reviewer verified this against #918's shipped `_strip_git_global_options` rather than taking it on faith:

```
marked value-taking but actually bare -> the SUBCOMMAND is eaten -> ALLOW
marked bare but actually value-taking -> the VALUE stays inline  -> ALLOW
safe commands under either wrong guess -> still ALLOW, never a false positive
```

So a wrong row never surfaces as a spurious block. It surfaces only as an ALLOW where a corpus row expected a BLOCK — **and only if that row exists**. A documented row with no corpus entry is unfalsifiable. Hence `test_every_row_has_corpus_coverage` fails a table row that no corpus command exercises, and `test_row_is_not_vacuous` goes further: for each of the 24 corpus rows it **deletes that tool's table row** and requires the decision *or the rule ID* to move. Rule ID as well as decision, because a command that keeps blocking through a different rule has not been proven by its row — that is precisely how `docker --context prod volume rm` looked covered while `containers.docker-volume-rm` was bypassed.

## The two-sided guard

Searched mechanically rather than reasoned about: across all 15 rule files and all tooldefs there is **exactly one** negative-lookahead rule (`\bgit\s+push\s+.*--force(?!-with-lease)`) and **exactly one** tooldef declaring a safe variant of a blocked command (`git push --force-with-lease`). Both are already covered by #918, and `push --force-with-lease` behind a global option still returns **ask** — not allow (bug survives), not block (safe form caught, and everyone learns to reach for plain `--force`).

The general form needs no lookahead twin per tool: assert the prefixed decision **equals** the plain decision in the same config. 17 near-miss safe forms (`docker --context prod system prune` without `-a`, `kubectl --context prod delete pod`, `aws --profile prod s3 rm` without `--recursive`, `redis-cli -h prod GET key`, …) are asserted both ways: parity with their plain form, and — where the plain form is allowed — that they are not newly blocked.

## Verification

**Rule set**: every assertion runs against **bundled rules + bundled tooldefs**, asserted in the fixture at **265 patterns / 101 anchored**. A dropped `tooldefs_dir` silently removes all 87 tooldef-generated patterns (178/14) and would shrink coverage while staying green.

**Acceptance corpus** — the reviewer's calibrated corpus, run against this branch:

```
46/46  [PRE-FIX]                 (calibration against cad7d0b: reproduces the broken baseline exactly)
46/46  [POST-FIX]
46/46  [POST-FIX, unanchored]
```

Transcribed into `tests/unit/test_damage_control_hooks.py` as 24 rows (rebuilding from notes is how the disproved `gh -R` row would have come back), each asserted four ways: baseline verdict, bypass verdict under both routings, **rule-ID parity** with the baseline, and non-vacuity.

**Pre-fix red checks**, `agentwire/` reverted with this PR's tests unchanged, both re-taken on base `1736abd`:

- *whole PR* (source = `1736abd`): **347 failed, 449 passed**.
- *commit 2 alone* (source = commit 1, `f2b219f`): **171 failed, 625 passed**. Of the corpus's per-row bypass assertions exactly **10 pass** — the git and tmux rows, precisely what commit 1 already covers. All 13 new tool rows are red.
- On the pre-rebase base, commit 1 measured **120 failed, 9 passed**, and the 9 were exactly the unchanged-behaviour anchors: the three plain tmux baselines and the six still-allowed forms.

**Mutation battery** — each mutation asserts the anchor was found AND the file actually changed (a mutation that silently edits nothing reads exactly like a refuted claim), then prints the byte delta:

| mutation | file Δ | result |
|---|---|---|
| M1 normalizer always returns nothing | 114747 -> 114762 | killed (534 red) |
| M2 value option consumes the flag but not its argument | 114747 -> 114815 | killed (417 red) |
| M3 variant built but never fed to the matcher | 114747 -> 114724 | killed (532 red) |
| M4 short-option clusters ignored (git's answer applied to every tool) | 114747 -> 114757 | killed (69 red) |
| M5 variant fed only to ANCHORED rules (the superseded ruling) | 114747 -> 114769 | killed (344 red) |
| M6 one table row dropped (kubectl) | 114747 -> 114756 | killed (26 red) |
| M7 cargo's +toolchain selector ignored | 114747 -> 114757 | killed (9 red) |
| M8 terraform's -chdir treated as a plain value option (eats next token) | 114747 -> 114739 | killed (1 red) |

M8 is the one worth reading: it **survived the first run** (nothing red). The corpus exercises `terraform -chdir=/infra` only, so nothing asserted the space-form arity and `value_eq_only` could have been plain `value` with every test green. `test_terraform_chdir_exists_only_in_the_equals_form` was added to pin the measurement, and M8 dies. A surviving mutation is the harness working.

**Cross-PR row still holds**, asserted under both routings:

```
git -C /repo push --force origin main   ->  BLOCK   (via git.git-push-force-use-force-with-lease)
```

**The #915 interaction, closed rather than deferred.** #918 pinned `docker --context prod volume rm pgdata` and `aws --profile prod s3 rm --recursive` as blocking *only* via the generic `core.rm-file-deletion` rule — the rule #915 exists to narrow — and said in as many words "if that is a rule of its own, good; update this canary". It now is: both block via `containers.docker-volume-rm-data-loss` and `aws.aws-s3-rm-recursive-deletes-all-objects`. `test_survives_the_generic_deletion_rule_being_narrowed` simulates #915 landing by disabling the generic rule and requires them to keep blocking — with an assertion that the rule being disabled actually exists, so the simulation cannot pass by simulating nothing. **#919 is no longer a blocker for #915.**

**Full suite** on base `1736abd`: `uv run --extra dev pytest` — **4437 passed, 36 skipped**. `scripts/regen_damage_control_hooks.py --check` clean; `_core.py` and all five generated hooks move together in each commit.

No `rules/*.yaml` pattern was widened, added, or removed.

## Known limits, recorded rather than hidden

All fail by producing **no** variant — an under-strip, never an over-strip:

- Argument-consuming wrappers (`timeout 5 kubectl …`, `xargs -n1 docker …`) — inherited from #918, pinned by a test asserting the failure is a missing haystack.
- mysql-style unique-prefix long-option abbreviation (`mysqladmin --us=root drop db`), which no exact-match table can enumerate.
- npm treats any unrecognized `--long` as a config key, so its row is a measured subset rather than a closed grammar.
- An option a tool adds after the measured version. Re-measure a row on a tool upgrade; the version is in the row.

## Not done here

- `agentwire rebuild` was **not** run — ten sessions are live. The fix reaches the live hook only after `rebuild` + `hooks install`.
- The live rule drift (#916) is untouched.

Built by [dotdev.dev](https://dotdev.dev)
