### PR TITLE
fix(voice-layer): the timer-armed fallback can no longer approve its own proposal

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -109,7 +109,8 @@ function createAnnouncer(deps) {
   var fallbackMs = deps.fallbackMs || 6000;
 
   var queue = [];
-  var current = null;       // { text, meta, timer }
+  // { text, fallbackText, meta, timer, sawCreate, deferred }
+  var current = null;
   var responseActive = false;
 
   // The model is told to say it exactly, but "exactly" is prompt compliance and
@@ -151,13 +152,35 @@ function createAnnouncer(deps) {
   // "on failure, speak".
   function armFallback(item) {
     item.timer = setTimer(function () {
+      // ONE bounded deferral, on one narrow signal: a response was CREATED
+      // after our announce went out and has not finished. That response is
+      // plausibly the model speaking this very announcement, still mid-audio
+      // — firing now is the two-voices defect (#950 defect 1). Deferring can
+      // only DELAY speech, never suppress it: the flag is per-item, checked
+      // once, and the re-armed timer speaks unconditionally. A response
+      // created BEFORE the announce (the not_announced recursion's state)
+      // never defers — sawCreate is only set while this item is current.
+      if (item.sawCreate && !item.deferred) {
+        item.deferred = true;
+        onLog("fallback", "deferred once — a response is mid-flight");
+        armFallback(item);
+        return;
+      }
       onLog("fallback", "no spoken confirmation within " + fallbackMs + "ms");
       if (current === item) current = null;
       // The owner DID hear it — in a robot voice, but they heard it. Anything
       // keyed on "was this spoken" (the proposal anchor) must be told so here,
       // or the fallback that GUARANTEES speech becomes the reason a proposal
       // is never anchored and the owner's correct nonce is refused forever.
-      try { speak(item.text, function () { onSpoken(item.meta, "fallback"); }); }
+      //
+      // What this channel UTTERS is `fallbackText` when the payload carries
+      // one. speechSynthesis is outside the WebRTC path, so echo cancellation
+      // does not cover it — its audio can re-enter the mic and land in the
+      // USER transcript. A payload whose spoken text must not be echoable
+      // into an approval (a proposal carrying its nonce) supplies a
+      // fallback-safe variant; everything else falls through to `text`.
+      var say = item.fallbackText || item.text;
+      try { speak(say, function () { onSpoken(item.meta, "fallback"); }); }
       catch (e) { onSpoken(item.meta, "fallback"); }
       pump();
     }, fallbackMs);
@@ -175,10 +198,16 @@ function createAnnouncer(deps) {
     // Armed FIRST, before anything that could fail silently.
     armFallback(item);
 
-    // Best-effort cancel. response.cancel against an already-finished response
-    // is an error — ignore it and carry on: the timer is what guarantees the
-    // announcement, so nothing here needs to succeed for the owner to be told.
-    send({ type: "response.cancel" });
+    // Cancel ONLY when our mirror says a response is active. The mirror is
+    // stale by construction, and both stale directions are priced: stale-true
+    // sends a cancel with nothing active (the server errors, and the client
+    // suppresses that specific error rather than announcing it); stale-false
+    // skips the cancel, our create is rejected server-side, and the TIMER
+    // still speaks — nothing here needs to succeed for the owner to be told.
+    // The unconditional cancel was one edge of a closed loop: cancel with
+    // nothing active → error event → spoken error notice → another cancel
+    // (#950 defect 2).
+    if (responseActive) send({ type: "response.cancel" });
 
     send({
       type: "response.create",
@@ -191,16 +220,35 @@ function createAnnouncer(deps) {
   }
 
   return {
-    announce: function (text, meta) {
+    announce: function (text, meta, fallbackText) {
       if (!text) return;
-      queue.push({ text: String(text), meta: meta || null, timer: null });
+      queue.push({
+        text: String(text),
+        fallbackText: fallbackText ? String(fallbackText) : null,
+        meta: meta || null,
+        timer: null,
+        sawCreate: false,
+        deferred: false,
+      });
       pump();
     },
-    onResponseCreated: function () { responseActive = true; },
+    onResponseCreated: function () {
+      responseActive = true;
+      // A response beginning while this item is current is the one signal
+      // that its audio may be OURS mid-flight — see the deferral in
+      // armFallback. Only ever set while current, so a response that predates
+      // the announce cannot defer it.
+      if (current) current.sawCreate = true;
+    },
     // A cancelled response only clears the in-flight flag. It must NEVER
     // disarm or count as spoken: a cancelled turn can carry partial audio that
     // said something else, and our OWN cancel produces one.
-    onResponseCancelled: function () { responseActive = false; },
+    onResponseCancelled: function () {
+      responseActive = false;
+      // Whatever was in flight is dead, so it can no longer be "our audio
+      // still playing" — the deferral signal must not outlive it.
+      if (current) current.sawCreate = false;
+    },
     onResponseDone: function (transcript) {
       responseActive = false;
       if (!current) { pump(); return; }
@@ -215,7 +263,9 @@ function createAnnouncer(deps) {
         pump();
       }
       // Otherwise leave the timer armed. A response that said something else
-      // is not evidence the owner heard the refusal.
+      // is not evidence the owner heard the refusal — and it has FINISHED, so
+      // it is no longer a reason to defer either.
+      else if (current) current.sawCreate = false;
     },
     // Test/inspection surface.
     pending: function () { return (current ? 1 : 0) + queue.length; },
@@ -351,12 +401,26 @@ function forward(path, body) {
 }
 
 // Everything the owner must HEAR goes through here. Never `log()` alone for
-// anything that changes what they should do next.
-function announce(text, meta) {
+// anything that changes what they should do next. `fallbackText`, when given,
+// is what the browser-voice fallback utters instead of `text` — the
+// un-echo-cancelled channel gets the echo-safe variant.
+function announce(text, meta, fallbackText) {
   log("buddy", text, "buddy");
-  if (announcer) announcer.announce(text, meta);
-  else { try { window.speechSynthesis.speak(new SpeechSynthesisUtterance(text)); } catch (e) {} }
+  if (announcer) announcer.announce(text, meta, fallbackText);
+  else {
+    try {
+      window.speechSynthesis.speak(
+        new SpeechSynthesisUtterance(fallbackText || text));
+    } catch (e) {}
+  }
 }
+
+// One spoken error notice at a time. An error event while a previous notice
+// is still unspoken logs but does not announce — the first is the actionable
+// signal, and announcing each one is the other edge of the announce → error →
+// announce loop (#950 defect 2). Cleared when the notice is actually SPOKEN
+// (see onSpoken), so a later, distinct error can announce again.
+let errorNoticePending = false;
 
 // The proposal anchor. Driven ONLY by evidence the proposal was spoken:
 // `how` is "model" (a response.done carried the text) or "fallback" (the
@@ -371,6 +435,7 @@ function announce(text, meta) {
 // made it wrong was the fallback firing, which is the mechanism added to
 // GUARANTEE speech.
 function onSpoken(meta, how) {
+  if (meta && meta.errorNotice) { errorNoticePending = false; return; }
   if (!meta || !meta.anchor) return;
   log("speak", "anchored proposal " + meta.anchor + " (" + how + ")", "tool");
   forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
@@ -450,8 +515,12 @@ async function handleFunctionCall(item) {
   const mustSpeak = !!(result && result.must_speak && result.say);
   sendFunctionCallOutput(item.call_id, result, mustSpeak);
   if (mustSpeak) {
+    // `say` is literal text to utter — the one payload that used to carry a
+    // model DIRECTIVE here got read aloud verbatim (#950 root cause).
+    // `fallback_say`, when present, is the echo-safe text for the
+    // browser-voice channel (it never carries a nonce).
     announce(result.say, result.anchor_proposal_id
-      ? { anchor: result.anchor_proposal_id } : null);
+      ? { anchor: result.anchor_proposal_id } : null, result.fallback_say);
   }
 }
 
@@ -505,7 +574,10 @@ async function start() {
           // believing they were told: say so on screen and in the log.
           log("error", "browser voice FAILED: " + (event && event.error), "err");
         };
-        window.speechSynthesis.cancel();
+        // No cancel() first: speechSynthesis queues natively, and cancelling
+        // here killed the PREVIOUS announcement mid-utterance — under a burst
+        // each notice interrupted the last and every one logged
+        // "browser voice FAILED: interrupted" (#950 defect 3).
         window.speechSynthesis.speak(utterance);
       },
       onSpoken,
@@ -607,12 +679,23 @@ async function start() {
           }
           break;
 
-        case "error":
+        case "error": {
           // Was DOM-only, i.e. silent to the ear. An error the owner cannot
           // hear about is one they will keep talking into.
           log("error", JSON.stringify(payload), "err");
-          announce("The voice service reported an error, so I may have missed that.");
+          // Our OWN best-effort cancel produces this one when the response it
+          // aimed at already finished. Announcing an error the announcer
+          // itself generated is the announce → cancel → error → announce loop
+          // (#950 defect 2): nothing was missed, nothing to say.
+          const code = payload.error && payload.error.code;
+          if (code === "response_cancel_not_active") break;
+          if (!errorNoticePending) {
+            errorNoticePending = true;
+            announce("The voice service reported an error, so I may have missed that.",
+              { errorNotice: true });
+          }
           break;
+        }
       }
     });
 

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -726,6 +726,10 @@ function stop() {
   audioEl = null;
   responseActive = false;
   announcer = null;
+  // A notice pending when the session died was never going to be spoken by
+  // it — carrying the flag into the next session would suppress that
+  // session's FIRST error notice, silently.
+  errorNoticePending = false;
   $start.disabled = false;
   $stop.disabled = true;
   setStatus("idle");

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -546,9 +546,27 @@ def classify(text: str, nonce: str) -> str:
     if not positions:
         return NO_MATCH
 
+    # The announcement frame, not an approval. The buddy's own proposal line
+    # is "… To approve, say confirm <nonce>." — and speechSynthesis audio is
+    # outside WebRTC echo cancellation, so a fragment of it can land in the
+    # USER transcript (#950 defect 4). The structural fix is that the fallback
+    # channel never carries the nonce; this is defence in depth for the frame
+    # itself: "confirm" immediately preceded by "say", in an utterance that
+    # also frames with "approve", is quoted instruction, and no human phrases
+    # an approval that way. Deliberately NARROW — both conditions — because
+    # the false-reject half is priced too: refusing a bare "say confirm
+    # tango" from an owner parroting the advice line would loop them against
+    # advice that says exactly those words. What this does NOT establish: an
+    # echo chunked down to bare "confirm <nonce>" (frame lost) still
+    # approves; only the nonce-free fallback text closes that.
+    def _quoted_frame(index: int) -> bool:
+        return index > 0 and tokens[index - 1] == "say" and "approve" in tokens
+
     for index in positions:
         rest = tokens[index + 1:]
         if not rest or rest[0] != target:
+            continue
+        if _quoted_frame(index):
             continue
         # Found "confirm <nonce>". A denial anywhere in the utterance — before
         # or after — is a take-back, and outranks the phrase.
@@ -794,9 +812,12 @@ SPOKEN = {
     # saying it yet" is itself swallowed by the response it is describing, the
     # owner hears nothing, waits, and the conversation deadlocks on two parties
     # each waiting for the other. The announcer must not special-case it, must
-    # not skip the cancel for it, and must not treat "a response is in flight"
-    # as a reason to defer — see client.py's createAnnouncer, where the
-    # fallback timer is armed before anything that can fail.
+    # not skip the cancel for it (the cancel is gated on the in-flight mirror,
+    # which is TRUE in exactly this state), and a response already in flight
+    # BEFORE the announce must never defer its fallback — see client.py's
+    # createAnnouncer: the timer is armed before anything that can fail, and
+    # the one bounded deferral keys only on a response created AFTER the
+    # announce, which can delay speech but never suppress it.
     "not_announced": (
         "Hang on — I haven't finished telling you what I'd send yet."
     ),

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -511,6 +511,13 @@ APPROVED = "approved"
 DENIED = "denied"
 WRONG_NONCE = "wrong_nonce"
 NO_MATCH = "no_match"
+#: The RIGHT nonce, inside the buddy's own announcement frame ("to approve,
+#: say confirm tango"). Its own outcome rather than folded into WRONG_NONCE,
+#: because the spoken reason is the owner's entire diagnostic and "that was a
+#: different code word" is false here — the word was right, the FRAMING is
+#: what refused it, and sending the owner to re-ask for a code they already
+#: have fixes the one thing that was not broken.
+QUOTED_FRAME = "quoted_frame"
 
 
 def classify(text: str, nonce: str) -> str:
@@ -562,11 +569,13 @@ def classify(text: str, nonce: str) -> str:
     def _quoted_frame(index: int) -> bool:
         return index > 0 and tokens[index - 1] == "say" and "approve" in tokens
 
+    quoted = False
     for index in positions:
         rest = tokens[index + 1:]
         if not rest or rest[0] != target:
             continue
         if _quoted_frame(index):
+            quoted = True
             continue
         # Found "confirm <nonce>". A denial anywhere in the utterance — before
         # or after — is a take-back, and outranks the phrase.
@@ -578,6 +587,11 @@ def classify(text: str, nonce: str) -> str:
     # phrase at all", and the owner's next move differs.
     if _denial_tokens(tokens):
         return DENIED
+    # Before the wrong-nonce scan, or a quoted correct nonce falls through to
+    # it (the target IS in NONCE_WORDS) and reports "different code word"
+    # about the right one.
+    if quoted:
+        return QUOTED_FRAME
     for index in positions:
         rest = tokens[index + 1:]
         if rest and rest[0] in NONCE_WORDS:
@@ -833,6 +847,15 @@ SPOKEN = {
         "That was a different code word, so I haven't sent anything. "
         "Ask me what the word was and I'll say it again."
     ),
+    # The right word inside the announcement frame ("to approve, say confirm
+    # tango"). NOT wrong_nonce: telling this owner their code word was wrong
+    # sends them to re-ask for the one thing they already have. The word was
+    # right; the phrasing read as my own announcement quoted back.
+    "quoted_frame": (
+        "That sounded like my own announcement coming back, so I haven't "
+        "sent anything. The word was right — just say confirm and the word, "
+        "on its own."
+    ),
     # Covers "no" AND "wait"/"hold on", so it must not assert the owner said
     # the word "no" — a reason that misinforms is the defect §3.4 is about.
     "denied": (
@@ -880,8 +903,8 @@ WAIT_OUTCOMES = frozenset({"pending_transcript", "not_announced"})
 REASONS = frozenset(
     {
         "no_proposal", "expired", "not_announced", "replayed", "refused",
-        "wrong_nonce", "denied", "pending_transcript", "too_many_attempts",
-        "dispatch_failed",
+        "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
+        "too_many_attempts", "dispatch_failed",
     }
 )
 
@@ -1124,6 +1147,7 @@ class ConfirmSpine:
         # recovery ran through this loop.
         match = None
         wrong_nonce = None
+        quoted = None
         for entry in reversed(usable):
             outcome = classify(entry.text, proposal.nonce)
             if outcome == DENIED:
@@ -1133,10 +1157,19 @@ class ConfirmSpine:
                 return Verdict(approved=False, reason="denied", utterance=entry.text)
             if outcome == WRONG_NONCE and wrong_nonce is None:
                 wrong_nonce = entry
+            if outcome == QUOTED_FRAME and quoted is None:
+                quoted = entry
             if outcome == APPROVED:
                 match = entry
                 break
         if match is None:
+            if quoted is not None:
+                # The right word, quoted inside the announcement frame. More
+                # specific than wrong_nonce, and the spoken advice differs:
+                # the owner does not need a new code, only a bare phrasing.
+                return Verdict(
+                    approved=False, reason="quoted_frame", utterance=quoted.text
+                )
             if wrong_nonce is not None:
                 # "Right shape, wrong code" needs "ask me what the code was",
                 # not "say it again" — repeating the wrong word loops forever.
@@ -1247,6 +1280,7 @@ __all__ = [
     "DENIED",
     "NONCE_WORDS",
     "NO_MATCH",
+    "QUOTED_FRAME",
     "VOICE_MARKER",
     "WRONG_NONCE",
     "carries_denial",

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -131,18 +131,40 @@ def propose_session_message(args: dict, spine) -> dict:
         # speaks this, which is what makes "the approval postdates the proposal"
         # mean "after the owner heard it".
         "anchor_proposal_id": proposal.id,
-        # Scripted text, so its CONTENT is the mechanism. A stale word here is
-        # not cosmetic — it is the scripted-instructions mechanism working
-        # exactly as designed, with the wrong script. (This string carried
-        # "say the two digits separately" from the digit-nonce design long
-        # after the alphabet became words, because it lives in a prompt string
-        # rather than in logic any test exercised.)
+        # `say` is LITERAL TEXT TO UTTER, like every other must_speak payload.
+        # It used to be a directive to the model ("Tell the owner plainly
+        # what you are about to send…"), which conflated two kinds of value in
+        # one field with one consumer that cannot tell them apart: the
+        # announcer scripted the directive verbatim, the transcript-match
+        # disarm could then never fire (the directive's words appear in no
+        # correct announcement), and the fallback timer always spoke — over
+        # the model, and carrying the nonce (#950 defects 1 and 4).
+        #
+        # Its content is still the mechanism, not cosmetics: a stale word here
+        # is the scripted-instructions mechanism working exactly as designed,
+        # with the wrong script.
         "say": (
-            f"Tell the owner plainly what you are about to send — the actual words, "
-            f"'{instruction}', and that it is going to {session} — then say: "
-            f"to approve, say {phrase}. Say the code word clearly, as a word; "
-            f"do not spell it out. Do not call send_session_message until you "
-            f"have said this and they have answered."
+            f"I'm ready to send to {session}: '{instruction}'. "
+            f"To approve, say {phrase}."
+        ),
+        # What the BROWSER-VOICE fallback speaks instead of `say`.
+        # speechSynthesis output is not on the WebRTC path, so echo
+        # cancellation does not suppress it — anything this channel utters can
+        # re-enter the microphone and land in the USER transcript inside the
+        # approval window. So the nonce must not be reachable from here: an
+        # echo of this text cannot carry an approval, structurally. The owner
+        # who only heard the fallback asks for the code word, and the model —
+        # whose audio IS echo-cancelled — speaks it.
+        "fallback_say": (
+            f"I'm ready to send to {session}: '{instruction}'. "
+            f"Ask me for the code word when you want me to send it."
+        ),
+        # Model-facing behaviour, moved OUT of the spoken field. This rides
+        # back as function_call_output context; the announcer never utters it.
+        "model_guidance": (
+            "Say the code word clearly, as a word; do not spell it out. "
+            "Do not call send_session_message until you have said the "
+            "proposal aloud and the owner has answered."
         ),
     }
 

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -470,8 +470,19 @@ response is in flight, so the output lands and **no response is created** — th
 VAD is producing its own responses.
 
 So refusals go through an announcer in `client.py`: cancel the in-flight
-response (an error from cancelling an already-finished one is ignored), issue a
-scripted `response.create`, and verify against the following `response.done`.
+response (only when the client's mirror says one is active — the error a
+no-target cancel generates is suppressed rather than announced, or the error
+handler feeds itself; #950), issue a scripted `response.create`, and verify
+against the following `response.done`.
+
+Two #950 lessons live on this path. **`say` is literal text to utter, never a
+directive to the model** — the one payload that carried a directive got read
+aloud verbatim, the transcript-match disarm could then never fire, and the
+timer double-spoke every proposal. And **the `speechSynthesis` channel is
+outside WebRTC echo cancellation**, so its audio can re-enter the microphone
+and land in the *user* transcript: whatever it utters is a string the confirm
+gate may be fed. A proposal therefore ships a separate `fallback_say` with no
+nonce in it — an echo of the fallback cannot carry an approval, structurally.
 
 **The `speechSynthesis` fallback is armed by a timer, not triggered by a
 detected failure**, and that is the part that decides whether this property is

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -311,6 +311,89 @@ class TestTheFallbackIsArmedNotTriggered:
         assert len(creates(report)) == 1
         assert report["spoken"] == ["That expired before you confirmed it."]
 
+    def test_the_fallback_utters_the_fallback_text_not_the_say_text(self):
+        """#950 defect 4. speechSynthesis is outside WebRTC echo cancellation,
+        so whatever this channel utters can re-enter the mic and land in the
+        USER transcript. A proposal's `say` carries the nonce; its fallback
+        variant must not — and the announcer must route the right text to the
+        right channel."""
+        report = run_announcer("""
+            announcer.announce("I'm ready to send it. To approve, say confirm tango.",
+                               { anchor: "a1b2c3" },
+                               "I'm ready to send it. Ask me for the code word.");
+            fireTimers();
+        """)
+        assert report["spoken"] == ["I'm ready to send it. Ask me for the code word."]
+        assert report["anchored"] == [{"meta": {"anchor": "a1b2c3"}, "how": "fallback"}]
+
+    def test_the_disarm_still_verifies_against_the_say_text(self):
+        """The transcript check verifies what the MODEL was scripted to say,
+        regardless of the fallback variant riding along."""
+        report = run_announcer("""
+            const say = "I'm ready to send it. To approve, say confirm tango.";
+            announcer.announce(say, { anchor: "a1b2c3" }, "different fallback words");
+            announcer.onResponseDone(say);
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["anchored"] == [{"meta": {"anchor": "a1b2c3"}, "how": "model"}]
+
+    def test_a_response_created_after_the_announce_defers_the_timer_once(self):
+        """#950 defect 1's residual: at the timeout, a response that began
+        AFTER our announce may be the model still mid-audio on this very text.
+        One bounded deferral — it can delay speech, never suppress it."""
+        report = run_announcer("""
+            announcer.announce("a long announcement still being spoken");
+            announcer.onResponseCreated();   // plausibly our scripted turn
+            fireTimers();                    // defers, does not speak
+        """)
+        assert report["spoken"] == []
+        assert report["armedTimers"] == 1, "must re-arm, not give up"
+
+        report = run_announcer("""
+            announcer.announce("a long announcement still being spoken");
+            announcer.onResponseCreated();
+            fireTimers();                    // the one deferral
+            fireTimers();                    // second firing MUST speak
+        """)
+        assert report["spoken"] == ["a long announcement still being spoken"]
+
+    def test_a_response_in_flight_before_the_announce_never_defers(self):
+        """The not_announced recursion's exact state. A pre-existing response
+        is not evidence our text is being spoken, and deferring on it would
+        delay the one announcement that must be prompt."""
+        report = run_announcer("""
+            announcer.onResponseCreated();   // in flight BEFORE the announce
+            announcer.announce("Hang on — I haven't finished telling you yet.");
+            fireTimers();
+        """)
+        assert report["spoken"] == ["Hang on — I haven't finished telling you yet."]
+
+    def test_a_finished_or_cancelled_response_stops_deferring(self):
+        """Once the in-flight response ended without carrying the text, there
+        is no audio left to wait for — the next firing speaks."""
+        report = run_announcer("""
+            announcer.announce("the reason");
+            announcer.onResponseCreated();
+            announcer.onResponseDone("something else entirely");
+            fireTimers();
+        """)
+        assert report["spoken"] == ["the reason"]
+
+    def test_the_cancel_is_sent_only_when_a_response_is_active(self):
+        """#950 defect 2's first edge: an unconditional cancel with nothing
+        active errors server-side, and an error handler that speaks turns that
+        into a loop. Idle → no cancel; active → cancel."""
+        idle = run_announcer("""
+            announcer.announce("a refusal");
+        """)
+        assert len(cancels(idle)) == 0
+        active = run_announcer("""
+            announcer.onResponseCreated();
+            announcer.announce("a refusal");
+        """)
+        assert len(cancels(active)) == 1
+
     def test_queued_refusals_all_get_spoken(self):
         report = run_announcer("""
             announcer.announce("first reason");
@@ -450,6 +533,47 @@ class TestThePageEmbedsTheRealThing:
             lowered = text.lower()
             assert "two digits" not in lowered
             assert "confirm four seven" not in lowered
+
+    def test_the_error_handler_cannot_feed_itself(self):
+        """#950 defect 2, both edges, pinned on the page source: the error our
+        own best-effort cancel generates is never announced, and only one
+        error notice may be pending at a time. Plus defect 3: no cancel()
+        before speak() — it killed the previous utterance mid-word."""
+        page = client.page("buddy", "tok")
+        assert 'if (code === "response_cancel_not_active") break;' in page
+        assert "errorNoticePending" in page
+        assert "window.speechSynthesis.cancel()" not in page
+
+    def test_the_proposal_say_field_is_speech_not_a_directive(self):
+        """#950 root cause: one field carrying two kinds of value. `say` must
+        now be literal first-person speech that the disarm check can match,
+        and the model-facing directive must live in a key the announcer never
+        reads."""
+        from unittest.mock import patch
+
+        from agentwire import inbox
+        from agentwire.voice_layer import confirm as confirm_mod
+        from agentwire.voice_layer import transcript, write_tools
+
+        spine = confirm_mod.ConfirmSpine(transcript.TranscriptRing(), wait_s=0.0)
+        with patch.object(inbox, "live_sessions", lambda: {"orchestrator"}):
+            result = write_tools.propose_session_message(
+                {"session": "orchestrator", "message": "restart it",
+                 "_buddy": "buddy"},
+                spine,
+            )
+        for directive in ("tell the owner", "do not call", "spell it out"):
+            assert directive not in result["say"].lower()
+            assert directive not in result["fallback_say"].lower()
+        # And the model speaking `say` verbatim genuinely disarms the timer —
+        # the mechanism the directive-in-say defect broke.
+        report = run_announcer(f"""
+            const say = {json.dumps(result["say"])};
+            announcer.announce(say, null, {json.dumps(result["fallback_say"])});
+            announcer.onResponseDone(say);
+            fireTimers();
+        """)
+        assert report["spoken"] == []
 
     def test_the_client_has_no_silent_catch(self):
         """The four silent paths §3.5 names. ``catch { return; }`` was the

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -544,6 +544,16 @@ class TestThePageEmbedsTheRealThing:
         assert "errorNoticePending" in page
         assert "window.speechSynthesis.cancel()" not in page
 
+    def test_stop_resets_the_error_notice_gate(self):
+        """The reset must live INSIDE stop(), pinned — a notice pending when a
+        session died was never going to be spoken by it, and carrying the flag
+        into the next session suppresses that session's FIRST error notice,
+        silently. Unpinned, a refactor drops the reset and nothing notices:
+        the exact unexercised-protection shape the quoted-frame guard had."""
+        page = client.page("buddy", "tok")
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "errorNoticePending = false;" in stop_body
+
     def test_the_proposal_say_field_is_speech_not_a_directive(self):
         """#950 root cause: one field carrying two kinds of value. `say` must
         now be literal first-person speech that the disarm check can match,

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -1227,8 +1227,13 @@ class TestOutcomesAreDistinctAndSpoken:
         assert observed == confirm.REASONS, confirm.REASONS - observed
 
     def _hard_to_reach_outcomes(self, convo, clock) -> set:
-        """The three outcomes the ordinary scenario table does not produce."""
+        """The outcomes the ordinary scenario table does not produce."""
         seen = set()
+
+        # quoted_frame: the announcement frame echoed back with the RIGHT word.
+        quoted = convo.announced_proposal()
+        convo.says(f"to approve say confirm {quoted.nonce}")
+        seen.add(convo.spine.confirm(quoted.token).reason)
 
         # too_many_attempts: the attempt that hits the cap must SAY it retired.
         capped = convo.announced_proposal()
@@ -1710,6 +1715,88 @@ def _flat(text: str) -> str:
     """
     lines = [line.lstrip().removeprefix("> ").removeprefix(">") for line in text.splitlines()]
     return " ".join(" ".join(lines).split())
+
+
+class TestTheQuotedFrameGuard:
+    """The defence-in-depth guard in classify(), pinned on BOTH halves.
+
+    This guard is the sole cover for a residual the PR documents —
+    model-channel echo under failed AEC — and until this class existed,
+    deleting it changed no test in the repository. A claimed protection
+    nothing exercises is worse than an unclaimed one: a refactor removes it
+    silently while the comment above it keeps asserting the coverage.
+
+    Both halves, because a guard has two costs. Pinning only the refusal
+    invites someone to WIDEN it later — and the guard is deliberately narrow
+    (say-preceded AND approve-framed, both required), because in this channel
+    a wrongly refused approval is not a safe failure: the owner says the
+    right word, nothing happens, and there is no screen to explain why.
+    """
+
+    def test_the_announcement_frame_echoed_back_is_refused(self):
+        assert confirm.classify(
+            "to approve say confirm tango", "tango"
+        ) == confirm.QUOTED_FRAME
+        assert confirm.classify(
+            "I'm ready to send it. To approve, say confirm tango.", "tango"
+        ) == confirm.QUOTED_FRAME
+
+    def test_the_ordinary_approval_still_approves(self):
+        assert confirm.classify("confirm tango", "tango") == confirm.APPROVED
+
+    def test_say_preceded_without_the_approve_frame_still_approves(self):
+        """Half the guard's condition is not the guard. An owner parroting
+        the advice line says exactly this, and refusing it would loop them
+        against advice that coaches those very words."""
+        assert confirm.classify("say confirm tango", "tango") == confirm.APPROVED
+
+    def test_approve_framed_without_say_preceding_still_approves(self):
+        """The other half alone is not the guard either — "approve" in an
+        utterance is ordinary speech, not the announcement frame."""
+        assert confirm.classify(
+            "I approve, confirm tango", "tango"
+        ) == confirm.APPROVED
+
+    def test_a_denial_outranks_the_quoted_frame(self):
+        assert confirm.classify(
+            "no — to approve say confirm tango", "tango"
+        ) == confirm.DENIED
+
+    def test_a_quoted_frame_for_another_nonce_is_not_this_outcome(self):
+        """The frame quoting a DIFFERENT word is a different problem — the
+        owner needs this proposal's code, so wrong_nonce's advice is right."""
+        assert confirm.classify(
+            "to approve say confirm harbor", "tango"
+        ) == confirm.WRONG_NONCE
+
+    def test_the_spine_speaks_the_accurate_reason_not_wrong_nonce(self, convo, runner):
+        """The nit that mattered: this used to classify wrong_nonce, and the
+        spoken line — the owner's ENTIRE diagnostic in a screenless channel —
+        told them their code word was wrong when it was right, sending them
+        to fix the one thing that was not broken. The string itself is
+        pinned: it must affirm the word was right and coach the bare
+        phrasing."""
+        proposal = convo.announced_proposal()
+        convo.says(f"to approve say confirm {proposal.nonce}")
+        verdict = convo.spine.confirm(proposal.token)
+        assert runner.calls == []
+        assert verdict.approved is False
+        assert verdict.reason == "quoted_frame"
+        assert verdict.spoken == (
+            "That sounded like my own announcement coming back, so I haven't "
+            "sent anything. The word was right — just say confirm and the "
+            "word, on its own."
+        )
+
+    def test_a_bare_approval_after_the_echo_still_approves(self, convo, runner):
+        """The recovery the spoken advice coaches must actually work: echo
+        lands, owner says the bare phrase, the write goes."""
+        proposal = convo.announced_proposal()
+        convo.says(f"to approve say confirm {proposal.nonce}")
+        convo.says(f"confirm {proposal.nonce}")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.approved is True
+        assert len(runner.calls) == 1
 
 
 class TestTheFallbackEchoCannotApprove:

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -29,6 +29,7 @@ a guard; the runner is injected rather than stubbed at the subprocess layer.
 """
 
 import itertools
+import re
 import threading
 import time
 
@@ -1709,6 +1710,79 @@ def _flat(text: str) -> str:
     """
     lines = [line.lstrip().removeprefix("> ").removeprefix(">") for line in text.splitlines()]
     return " ".join(" ".join(lines).split())
+
+
+class TestTheFallbackEchoCannotApprove:
+    """Issue #950 defect 4: the confirm-gate bypass.
+
+    ``speechSynthesis`` output is NOT on the WebRTC audio path, so the
+    browser's echo cancellation does not suppress it — the fallback's own
+    audio re-enters the microphone and lands in the USER transcript inside
+    the valid approval window. Nothing in the gate distinguishes an echoed
+    utterance from a spoken one, so whatever the fallback channel utters is
+    a string the gate may be fed verbatim.
+
+    The property under test: **no fragment of what the fallback channel
+    speaks can approve the proposal it announces.** Fragments, not just the
+    whole text — the echo is lossy and adversarially timed (VAD chunks on
+    pauses, the model's overlapping voice masks parts of it, the cascade
+    garbles others), so the guard must hold for every piece individually.
+    Testing only the full echo would pass by luck: the full directive
+    happens to contain "do not", which the denial grammar catches, while
+    the one chunk that matters — "to approve, say confirm <nonce>" —
+    approves cleanly on its own.
+    """
+
+    def _mint(self, ring_cls=transcript.TranscriptRing):
+        ring = ring_cls()
+        runner = RecordingRunner()
+        spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner)
+        convo = Conversation(ring, spine)
+        result = write_tools.propose_session_message(
+            {"session": "orchestrator", "message": "restart the portal",
+             "_buddy": "buddy"},
+            spine,
+        )
+        # Anchor: the proposal was spoken (by whichever voice), so the echo
+        # lands squarely inside the valid approval window.
+        spine.announce(result["proposal_id"], convo._next())
+        return result, convo, runner
+
+    @staticmethod
+    def _fallback_speech(result):
+        # Exactly what the client's fallback channel utters: the announcer
+        # speaks the dedicated fallback text when the payload carries one,
+        # else the say text — mirroring `speak(item.fallbackText || item.text)`.
+        return result.get("fallback_say") or result["say"]
+
+    def _chunks(self, result):
+        spoken = self._fallback_speech(result)
+        pieces = [c.strip() for c in re.split(r"[.;:—,]", spoken) if c.strip()]
+        return [spoken, *pieces]
+
+    def test_no_fragment_of_the_fallback_output_approves(self, monkeypatch):
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"orchestrator"})
+        probe, _, _ = self._mint()
+        for index in range(len(self._chunks(probe))):
+            result, convo, runner = self._mint()
+            echoed = self._chunks(result)[index]
+            convo.says(echoed)
+            verdict = write_tools.send_session_message(
+                {"confirm_token": result["confirm_token"]}, convo.spine
+            )
+            assert runner.calls == [], (
+                f"echoed fragment {echoed!r} WROTE with no human speaking"
+            )
+            assert verdict["success"] is False, echoed
+
+    def test_the_fallback_channel_never_carries_the_nonce(self, monkeypatch):
+        """The structural fix: the nonce must not be reachable from the
+        un-echo-cancelled channel at all. A guard downstream is defence in
+        depth; this is the property that makes the echo harmless."""
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"orchestrator"})
+        result, _, _ = self._mint()
+        nonce = result["confirm_phrase"].split()[1]
+        assert nonce not in confirm.normalize(self._fallback_speech(result))
 
 
 class TestHonestLimit:


### PR DESCRIPTION
First-live-mic-test defects from #950, all four, with the confirm-gate bypass (defect 4) as the load-bearing one.

## The regression test that matters

`TestTheFallbackEchoCannotApprove` plays the fallback channel's own output back into the user transcript — **fragment by fragment**, not just whole — and asserts the frozen argv never ran. It was RED on the unfixed code for the right reason: an echoed fragment (`say confirm cobalt`) executed the write with no human speaking. Fragment-level matters: the *full* directive echo happened to DENY (it contains "do not", which the denial grammar catches), so a whole-echo-only fixture would have been green on the broken code — the wrong fixture the issue warned about.

## Fixes

1. **`say` split** (root cause): `say` is now literal first-person speech ("I'm ready to send to X: '…'. To approve, say confirm tango."); the model directive moved to `model_guidance`, which the announcer never reads. The transcript-match disarm can now actually fire, which kills the always-double-speak (defect 1).
2. **`fallback_say`** (defect 4, structural): the speechSynthesis channel is outside WebRTC echo cancellation, so it never carries the nonce. An echo of the fallback cannot approve, by construction. Defence in depth: `classify()` treats `say confirm <nonce>` in an approve-framed utterance as quoted instruction — deliberately narrow (both conditions) so a human parroting the advice line can't livelock. Stated residual: an echo chunked down to bare `confirm <nonce>` with the frame lost is only covered by the nonce-free fallback text, and a model-channel echo under failed AEC is a residual no transcript-level guard closes.
3. **Error cascade cut at both edges** (defect 2): `response.cancel` only when the mirror says a response is active; `response_cancel_not_active` is logged, never announced; at most one error notice pending at a time (cleared when spoken). Defect 3: no `speechSynthesis.cancel()` before `speak()` — the queue is native.
4. **Bounded deferral, not disarm-on-audio-start**: the issue's proposed "disarm on evidence audio started" reopens the client.py:133 hole — unrelated VAD audio starting disarms exactly the dropped-announcement case the timer exists for. Instead the timer defers **once** when a response began *after* the announce and hasn't finished; it can delay speech, never suppress it.

## must_speak audit (every producer)

- `write_tools.propose_session_message` — was the conflation; fixed.
- `confirm.Verdict.to_dict` (success + the whole `SPOKEN` refusal map) — already literal, and already nonce-free by design ("the word I gave you").
- `tools.dispatch` `spoken_error` / `no_confirm_gate` — already literal spoken prose.
- The client's own `announce()` literals — already literal, pinned by the existing literal-set test.

Full unit suite: 3400 passed. Voice files: 266.

Closes #950

Built by [dotdev.dev](https://dotdev.dev)

## Round 2 (review follow-up)

- **The `_quoted_frame` guard is now mutation-tested.** Verified the gap first: with the guard deleted at 9148d28, the four voice files ran 266 passed and the full suite 3400 passed — identical to unmutated, confirming no test distinguished its presence. Now `TestTheQuotedFrameGuard` pins BOTH halves — the refusal (announcement frame echoed back) and the false-reject boundary (`confirm <nonce>`, `say confirm <nonce>` without the approve frame, and approve-framed without say-preceding all still APPROVE, because the narrowness is load-bearing in a screenless channel). Deleting the guard now fails 3 tests (full suite: 3 failed / 3405 passed); restored: 3408 passed.
- **`quoted_frame` is its own outcome** with its own pinned spoken line. It used to fall through to `wrong_nonce`, telling an owner who said the right word that their code was wrong — the spoken reason is the entire diagnostic in this channel. The new line affirms the word was right and coaches the bare phrasing, and a test proves that recovery actually approves.
- **`errorNoticePending` resets in `stop()`** — a notice pending when a session died would otherwise suppress the next session's first error notice.

## Accepted property (on the record, not a defect)

**With model audio completely dead, the write path is unapprovable.** The nonce is reachable only via the model's echo-cancelled voice; the fallback deliberately never speaks it. An owner who only ever hears the browser voice can hear every proposal and every refusal but cannot approve one — "why won't it send" under total model-audio failure is this property working, and the resolution is restoring model audio, not weakening the fallback. Fail-closed is the intended trade: the alternative was a fallback whose own audio could approve its own proposal.
