### PR TITLE
fix(voice-layer): announcement transcripts log as a distinct kind, not a second buddy line

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -249,9 +249,16 @@ function createAnnouncer(deps) {
       // still playing" — the deferral signal must not outlive it.
       if (current) current.sawCreate = false;
     },
+    // Returns true ONLY when this transcript is the model speaking the
+    // CURRENT scripted announcement — i.e. exactly when it disarms. The page's
+    // transcript log keys its kind off this verdict (#957): a true verdict
+    // logs as "heard" (the ASR of a text announce() already logged), anything
+    // else stays a plain buddy line. After the FALLBACK fires, `current` is
+    // cleared, so a late model utterance of the same text — the genuine
+    // double-speak (#950) — verdicts false and keeps its two-line signature.
     onResponseDone: function (transcript) {
       responseActive = false;
-      if (!current) { pump(); return; }
+      if (!current) { pump(); return false; }
       // The ONLY disarm: positive evidence that the reason was spoken.
       if (carriedTheReason(transcript, current.text)) {
         var done = current;
@@ -261,11 +268,13 @@ function createAnnouncer(deps) {
         // thing the anchor may key on.
         onSpoken(done.meta, "model");
         pump();
+        return true;
       }
       // Otherwise leave the timer armed. A response that said something else
       // is not evidence the owner heard the refusal — and it has FINISHED, so
       // it is no longer a reason to defer either.
-      else if (current) current.sawCreate = false;
+      current.sawCreate = false;
+      return false;
     },
     // Test/inspection surface.
     pending: function () { return (current ? 1 : 0) + queue.length; },
@@ -315,6 +324,11 @@ _PAGE = """<!doctype html>
   .you .who { color: var(--accent-2); }
   .buddy .who { color: var(--accent); }
   .tool { color: var(--muted); font-family: ui-monospace, monospace; font-size: 12.5px; }
+  /* The spoken-transcript kind (#957): the model's ASR of a scripted
+     announcement already logged above it. Muted + italic so a normal
+     announcement pair cannot be misread as the buddy speaking twice. */
+  .heard { color: var(--muted); font-style: italic; }
+  .heard .who { color: var(--muted); }
   .err { color: #ff7b72; }
 </style>
 </head>
@@ -618,11 +632,18 @@ async function start() {
           responseActive = false;
           const output = (payload.response && payload.response.output) || [];
           const said = spokenText(output);
-          if (said) log("buddy", said, "buddy");
           // The anchor is driven from the announcer's own confirmation that
           // the proposal text was spoken (see onSpoken below), NOT from "the
           // next response.done carrying any text".
-          if (announcer) announcer.onResponseDone(said);
+          const saidOurScript =
+            announcer ? announcer.onResponseDone(said) === true : false;
+          // #957: the ASR of an announcement announce() already logged gets
+          // the distinct "heard" kind — one utterance, two visibly different
+          // entries (and a scripted-vs-spoken divergence stays inspectable).
+          // Anything else keeps the plain buddy kind, INCLUDING the model
+          // re-speaking a text the fallback already uttered — so a genuine
+          // double-speak (#950) still reads as the same line twice.
+          if (said) log(saidOurScript ? "heard" : "buddy", said, saidOurScript ? "heard" : "buddy");
 
           const calls = output.filter((i) => i.type === "function_call");
           // Sequential, never concurrent — two dispatches would race their own

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -404,6 +404,72 @@ class TestTheFallbackIsArmedNotTriggered:
         assert report["spoken"] == ["first reason", "second reason"]
 
 
+class TestOneAnnouncementLogsOnce:
+    """#957. Every scripted announcement logged twice — announce() logged the
+    scripted text, then response.done logged the model's ASR of having said it
+    — rendering identically to the #950 double-speak defect on every utterance.
+
+    Fix is kind-splitting, not suppression: the response.done transcript is
+    classified by the announcer's OWN disarm verdict (onResponseDone returns
+    true only when this transcript is the model speaking the current scripted
+    announcement) and logged under a distinct "heard" kind. Everything else —
+    including the model re-speaking an announcement the FALLBACK already
+    uttered, the genuine double-speak — stays a plain buddy line, so the #950
+    signature remains visible.
+    """
+
+    def test_a_matching_done_classifies_as_our_script(self):
+        """The ASR transcript loses punctuation (the em-dash evidence in the
+        issue) — classification is the same overlap test as the disarm."""
+        report = run_announcer("""
+            announcer.announce("Queued it — it'll land when the box is free.");
+            logs.push("ours: " + announcer.onResponseDone("Queued it  it'll land when the box is free"));
+        """)
+        assert "ours: true" in report["logs"]
+
+    def test_an_unrelated_done_does_not(self):
+        report = run_announcer("""
+            announcer.announce("Say confirm tango to approve.");
+            logs.push("ours: " + announcer.onResponseDone("Sure, what next?"));
+        """)
+        assert "ours: false" in report["logs"]
+
+    def test_a_done_with_nothing_current_does_not(self):
+        report = run_announcer("""
+            logs.push("ours: " + announcer.onResponseDone("I'm ready to send it."));
+        """)
+        assert "ours: false" in report["logs"]
+
+    def test_a_genuine_double_speak_still_reads_as_two(self):
+        """THE requirement (#957 acceptance): model audio AND browser fallback
+        both uttering the announcement must remain distinguishable from normal
+        operation. The fallback fired first (clearing `current`), then the
+        model's transcript of the same text arrived — that transcript must NOT
+        classify as the scripted announcement, so the page logs it as a second
+        plain buddy line and the #950 signature stays visible. Collapsing it
+        would trade a false positive for a false negative on a closed
+        severity-1 defect."""
+        report = run_announcer("""
+            announcer.announce("Say confirm tango to approve.");
+            fireTimers();   // fallback speaks — the first voice
+            logs.push("ours: " + announcer.onResponseDone("Say confirm tango to approve."));
+        """)
+        assert report["spoken"] == ["Say confirm tango to approve."]
+        assert "ours: false" in report["logs"]
+
+    def test_the_page_logs_the_transcript_under_the_verdict_driven_kind(self):
+        """The wiring: the response.done log site keys the kind off the
+        announcer's verdict, and the scripted announce() log keeps the plain
+        buddy kind — two visibly different kinds for one utterance."""
+        page = client.page("buddy", "tok")
+        assert "announcer.onResponseDone(said) === true" in page
+        assert 'log(saidOurScript ? "heard" : "buddy", said, saidOurScript ? "heard" : "buddy");' in page
+        # The scripted-text log site is unchanged — kind "buddy".
+        assert 'log("buddy", text, "buddy");' in page
+        # And the heard kind is actually styled distinctly, not just named.
+        assert ".heard" in page
+
+
 class TestThePageEmbedsTheRealThing:
     def test_the_page_contains_the_announcer_verbatim(self):
         """The tests above run ``announcer_source()``; the page must embed the


### PR DESCRIPTION
Every scripted announcement appeared twice in the buddy transcript: `announce()` logged the scripted text (client.py:408) and the `response.done` handler logged the model's ASR of having spoken it (client.py:621). Display-only, but it rendered identically to the closed #950 double-speak defect on every utterance — a regression would be invisible.

**Chose option 2 (distinct kinds), not suppression.** A divergence between scripted text and spoken transcript is exactly what `carriedTheReason` exists to check, and it's worth seeing. The classification comes for free: `onResponseDone` now returns `true` exactly when it disarmed on the current announcement, and the page logs that transcript under a muted-italic `heard` kind instead of a second `buddy` line.

**The inverse acceptance criterion holds structurally:** after the browser fallback fires, `current` is cleared, so the model's late utterance of the same text (the genuine #950 double-speak) verdicts `false` and logs as a plain second buddy line — the signature survives. Pinned by `test_a_genuine_double_speak_still_reads_as_two`, and verified by mutation: flipping the no-current verdict to `true` (scoped landing check inside the `onResponseDone` body) fails that test.

Tests: announcer suite 37 → 42 (5 new, all watched red first); full unit suite 3414 passed.

Closes #957

Built by [dotdev.dev](https://dotdev.dev)