### PR TITLE
fix(voice-layer): the delivered body carries the request utterance, never the nonce

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -27,7 +27,9 @@ that clause they conclude "gate passed, so the write happened". It did not:
 ``msg send`` queues, and delivery is at the recipient's next safe boundary.
 
 The ``said:`` clause caveat is there because §4b's entire purpose is that the
-verbatim utterance is authorizing evidence a recipient can CHECK, and a
+verbatim REQUEST utterance (captured at propose — never the approving one,
+which is a nonce and stays inside the gate, #953) is evidence a recipient can
+CHECK the paraphrase against, and a
 recipient reading ``said:`` will treat it as what the human said. Anything
 resident in the bridge's browser page holds the per-run bearer token and can
 POST arbitrary text to ``/utterance``, so the evidence property is weaker than
@@ -604,6 +606,35 @@ def matches_nonce(text: str, nonce: str) -> bool:
     return classify(text, nonce) == APPROVED
 
 
+def request_utterance_from(ring) -> str:
+    """The owner's REQUEST sentence, read from the ring at propose time (#953).
+
+    This is what fills the body's ``said:`` slot. It used to be the APPROVING
+    utterance — which the gate guarantees is ``confirm <nonce>``, so the slot
+    shipped the nonce to the recipient on every approved write and carried
+    none of the paraphrase-check content §4b built it for. The request
+    utterance is the newest complete entry at propose time: the sentence that
+    asked for the message, spoken BEFORE this proposal's nonce existed, so it
+    cannot contain it by construction.
+
+    One selection rule, and it is selection rather than redaction: an entry
+    containing a confirm word is skipped. A stale ``confirm <word>`` from a
+    PRIOR proposal (wrong-nonce, expired, retried) can sit newest in the ring,
+    and it is not a request — it is the one remaining path a nonce string
+    could re-enter the body through. Skipping falls back to the next-newest
+    entry, and an empty result drops the slot entirely (:func:`render_body`),
+    so the false-reject half costs a missing annotation, never a blocked or
+    garbled write.
+    """
+    for entry in reversed(ring.snapshot()):
+        if not entry.complete:
+            continue
+        if any(t in _CONFIRM_WORDS for t in normalize(entry.text).split()):
+            continue
+        return entry.text
+    return ""
+
+
 def carries_denial(text: str) -> bool:
     """Does *text* contain a refusal? Scanned over utterances AFTER an approval."""
     return _denial_tokens(normalize(text).split())
@@ -630,12 +661,13 @@ class Proposal:
     the tool call is what makes "postdates the proposal" mean "after the owner
     heard it".
 
-    **On the one thing not frozen at propose time.** The argv is frozen at
-    propose AND the delivered body carries the verbatim authorizing utterance,
-    which does not exist until confirm. Both hold, because the confirm-time
-    addition is not an input: the utterance comes from the transcription ring
-    and the id from this store. Confirm's entire model-supplied surface is one
-    token string.
+    **Everything is frozen at propose time — including the body.** It used to
+    be that the body carried the confirm-time approving utterance; #953 killed
+    that, because the approving utterance is ``confirm <nonce>`` by
+    construction, so the slot shipped the nonce and verified nothing. The
+    ``said:`` slot now carries ``request_utterance``, captured from the
+    transcript ring at propose. Confirm's entire model-supplied surface is one
+    token string, and it no longer reaches the body at all.
     """
 
     id: str
@@ -650,6 +682,10 @@ class Proposal:
     anchored_at: float = 0.0
     attempts: int = 0
     params: dict = field(default_factory=dict)
+    #: The owner's request sentence at propose time — see
+    #: :func:`request_utterance_from`. Empty means unknown, and the body's
+    #: ``said:`` slot is then omitted rather than shipped empty.
+    request_utterance: str = ""
 
     @property
     def announced(self) -> bool:
@@ -662,8 +698,14 @@ class Proposal:
         started = self.anchored_at or self.created_at
         return now >= started + ttl
 
-    def build_argv(self, utterance: str) -> list[str]:
-        return [*self.argv_prefix, render_body(self.instruction, utterance, self.id)]
+    def build_argv(self) -> list[str]:
+        # No parameters, deliberately: the approving utterance must never
+        # reach the body again (#953), and a parameterless signature makes
+        # that structural rather than a calling convention.
+        return [
+            *self.argv_prefix,
+            render_body(self.instruction, self.request_utterance, self.id),
+        ]
 
 
 # =============================================================================
@@ -755,13 +797,19 @@ def _clip(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
-def render_body(instruction: str, utterance: str, proposal_id: str) -> str:
-    """The fixed one-line two-part shape every buddy write carries (§4b).
+def render_body(instruction: str, request_utterance: str, proposal_id: str) -> str:
+    """The fixed one-line shape every buddy write carries (§4b).
 
     Part one is what the buddy asked for; part two is what the owner actually
-    said to authorize it, verbatim, plus the proposal id. The recipient can
+    said when REQUESTING it, verbatim, plus the proposal id. The recipient can
     check the paraphrase rather than trust it — and can see it when the buddy
-    got it wrong. Free, because the gate already had to capture that utterance.
+    got it wrong.
+
+    **The request utterance, never the approving one (#953).** The approving
+    utterance is ``confirm <nonce>`` by construction — content-free for the
+    paraphrase check, and a leak of the nonce into the recipient's scrollback
+    on every write. When no request utterance was captured, the slot is
+    OMITTED: a slot whose expected content is empty must not survive.
 
     **The body never begins with a dash, and that is a safety property, not an
     accident of layout.** ``instruction`` is model-supplied and ``_clip`` does
@@ -786,11 +834,11 @@ def render_body(instruction: str, utterance: str, proposal_id: str) -> str:
     position on screen the kind slot would have occupied, and touches no shared
     code. Slice 1 does not claim kind-slot attribution; that arrives with 1b.
     """
-    body = (
-        f"{VOICE_MARKER} {_clip(instruction, MAX_RENDERED_INSTRUCTION_CHARS)} "
-        f"┃ said: \"{_clip(utterance, MAX_UTTERANCE_CHARS)}\" "
-        f"┃ #{proposal_id}"
-    )
+    parts = [f"{VOICE_MARKER} {_clip(instruction, MAX_RENDERED_INSTRUCTION_CHARS)}"]
+    if request_utterance.strip():
+        parts.append(f"said: \"{_clip(request_utterance, MAX_UTTERANCE_CHARS)}\"")
+    parts.append(f"#{proposal_id}")
+    body = " ┃ ".join(parts)
     body = _clip(body, MAX_BODY_CHARS)
     # Explicit, not incidental — see the docstring. A body reaching the CLI as
     # a flag is a bug this repo has shipped twice.
@@ -1019,6 +1067,7 @@ class ConfirmSpine:
                 argv_prefix=tuple(argv_prefix),
                 created_at=self._clock(),
                 params=dict(params or {}),
+                request_utterance=request_utterance_from(self._ring),
             )
             self._proposals[proposal.token] = proposal
         return proposal
@@ -1083,7 +1132,7 @@ class ConfirmSpine:
         with self._lock:
             self._proposals.pop(token, None)
 
-        argv = proposal.build_argv(verdict.utterance)
+        argv = proposal.build_argv()
         verdict.argv = argv
         if self._runner is not None:
             try:
@@ -1289,5 +1338,6 @@ __all__ = [
     "mint_nonce",
     "normalize",
     "render_body",
+    "request_utterance_from",
     "spoken_nonce",
 ]

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -109,9 +109,10 @@ def propose_session_message(args: dict, spine) -> dict:
         tool="send_session_message",
         session=session,
         instruction=instruction,
-        # Frozen here, at propose time. The body is the LAST element and is the
-        # only thing completed at confirm — from the transcript ring and the
-        # proposal id, never from anything a model says. See confirm.Proposal.
+        # Frozen here, at propose time — the WHOLE argv, body included. The
+        # body's said: slot carries the owner's request utterance captured by
+        # spine.propose from the transcript ring, never the approving
+        # utterance, which is a nonce and stays inside the gate (#953).
         argv_prefix=[
             "msg", "send", "--to", session, "--from", buddy, "--kind", WRITE_KIND,
         ],

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -924,32 +924,31 @@ class TestArgvFreezing:
         assert result["success"] is True
         assert "victim-session" not in " ".join(runner.calls[0])
 
-    def test_exactly_one_field_completes_at_confirm_and_it_is_the_utterance(
+    def test_nothing_completes_at_confirm_the_whole_argv_is_frozen(
         self, convo, runner
     ):
         """The precise shape of guarantee (a), enforced rather than described.
 
-        Frozen at PROPOSE: the command, ``--to``, ``--from``, ``--kind``, the
-        instruction, the proposal id and the nonce. Completed at CONFIRM:
-        exactly one thing — the verbatim utterance inside the body — and it is
-        read from the transcript ring, whose only writer is
-        ``BuddyBridge.utterance`` (``POST /utterance``). No tool writes it.
+        Everything is frozen at PROPOSE: the command, ``--to``, ``--from``,
+        ``--kind``, the instruction, the proposal id, the nonce, and — since
+        #953 — the body's ``said:`` slot too, which carries the request
+        utterance captured at propose. Confirm adds NOTHING to the argv:
+        ``build_argv`` takes no parameters, so the approving utterance has no
+        path back into the delivered body.
 
         If this test ever has to be relaxed, §3.7's honest limit must be
         NARROWED to match, not qualified.
         """
+        convo.says("please tell the orchestrator to restart the portal")
         proposal = convo.announced_proposal(
             session="orchestrator", instruction="restart the portal"
         )
-        # What the argv would be for two DIFFERENT authorizing utterances.
-        first = proposal.build_argv("confirm tango")
-        second = proposal.build_argv("something else entirely")
-
-        # Everything but the body element is byte-identical.
-        assert first[:-1] == second[:-1] == list(proposal.argv_prefix)
-        # And the body differs only in the quoted `said:` clause.
-        assert first[-1].split("┃ said:")[0] == second[-1].split("┃ said:")[0]
-        assert first[-1].rsplit("┃", 1)[1] == second[-1].rsplit("┃", 1)[1]
+        frozen = proposal.build_argv()
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        # What ran is byte-identical to what was buildable before approval.
+        assert runner.calls[0] == frozen
+        assert frozen[:-1] == list(proposal.argv_prefix)
 
     def test_no_tool_can_write_into_the_transcript_ring(self, convo, runner, monkeypatch):
         """The other half of the claim: the conversational model's only
@@ -966,13 +965,13 @@ class TestArgvFreezing:
             tools.dispatch(name, args, "buddy", convo.spine)
         assert [(u.item_id, u.text) for u in convo.ring.snapshot()] == before
 
-    def test_the_only_confirm_time_addition_is_machine_derived(self, convo, runner):
+    def test_the_body_carries_the_id_and_never_the_nonce(self, convo, runner):
         proposal = convo.announced_proposal(instruction="restart the portal")
         convo.approve(proposal)
         convo.spine.confirm(proposal.token)
         body = runner.calls[0][-1]
         assert body.startswith(f"{confirm.VOICE_MARKER} restart the portal")
-        assert proposal.nonce in body
+        assert proposal.nonce not in body  # #953: the nonce stays in the gate
         assert proposal.id in body
 
 
@@ -1131,12 +1130,19 @@ class TestAttribution:
     def test_the_verbatim_utterance_is_the_transcription_models_words(
         self, convo, runner
     ):
-        """Not the buddy's paraphrase — the recipient can see a mis-paraphrase."""
+        """Not the buddy's paraphrase — the recipient can see a mis-paraphrase.
+
+        Since #953 the verbatim utterance in the body is the REQUEST, not the
+        approval: the approval is a nonce and never leaves the gate."""
+        request = "okay, get the portal restarted for me"
+        convo.says(request)
         proposal = convo.announced_proposal(instruction="restart the portal")
         spoken = f"okay, confirm {confirm.spoken_nonce(proposal.nonce)}"
         convo.says(spoken)
         convo.spine.confirm(proposal.token)
-        assert spoken in runner.calls[0][-1]
+        body = runner.calls[0][-1]
+        assert request in body
+        assert spoken not in body
 
     def test_this_diff_does_not_touch_the_shared_kind_enum(self):
         """§4a is deferred to Slice 1b — deliberately, see write_tools' docstring.
@@ -1931,3 +1937,66 @@ class TestHonestLimit:
                         f"{path.name} asserts '{claim}' without qualification"
                     )
                     start = index + len(claim)
+
+
+class TestTheNonceNeverLeavesTheGate:
+    """Issue #953: the approving utterance is ``confirm <nonce>`` by
+    construction, so putting it in the delivered body ships the nonce to the
+    recipient's scrollback on EVERY approved write — and carries none of the
+    verification §4b built the slot for. The slot now carries the owner's
+    REQUEST utterance, captured at propose time, which a recipient genuinely
+    can check the paraphrase against.
+    """
+
+    def test_the_delivered_body_never_contains_the_nonce(self, convo, runner):
+        convo.says("tell the orchestrator to restart the portal")
+        proposal = convo.announced_proposal(instruction="restart the portal")
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        body = runner.calls[0][-1]
+        assert proposal.nonce not in body
+        assert "confirm" not in body
+
+    def test_the_slot_carries_the_request_utterance_verbatim(self, convo, runner):
+        """§4b's actual intent: content a recipient can check the paraphrase
+        against — the transcription model's words, not the buddy's."""
+        spoken = "hey, tell the orchestrator to restart the portal"
+        convo.says(spoken)
+        proposal = convo.announced_proposal(instruction="restart the portal")
+        convo.approve(proposal)
+        convo.spine.confirm(proposal.token)
+        assert f'said: "{spoken}"' in runner.calls[0][-1]
+
+    def test_with_no_request_utterance_the_slot_is_gone_not_empty(self):
+        """A slot whose expected content is empty must not survive (#953
+        acceptance). Marker, instruction and id still deliver."""
+        body = confirm.render_body("restart the portal", "", "a1b2c3")
+        assert "said:" not in body
+        assert body.startswith(f"{confirm.VOICE_MARKER} restart the portal")
+        assert body.endswith("#a1b2c3")
+
+    def test_a_stale_confirm_phrase_is_never_selected_as_the_request(
+        self, convo, runner
+    ):
+        """The one path a nonce could re-enter: a prior proposal's approval or
+        wrong-nonce utterance sitting newest in the ring at propose time. That
+        is not a request, so selection skips it — falling back to the real
+        request sentence, false-reject half covered by the fallback below."""
+        convo.says("tell the orchestrator to restart the portal")
+        convo.says("confirm walrus")
+        proposal = convo.announced_proposal(instruction="restart the portal")
+        convo.approve(proposal)
+        convo.spine.confirm(proposal.token)
+        body = runner.calls[0][-1]
+        assert "walrus" not in body
+        assert 'said: "tell the orchestrator to restart the portal"' in body
+
+    def test_an_empty_ring_at_propose_still_delivers(self, convo, runner):
+        """The false-reject half: a missing request utterance must not block
+        or garble the write — the slot is simply absent."""
+        proposal = convo.announced_proposal(instruction="restart the portal")
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        body = runner.calls[0][-1]
+        assert "said:" not in body
+        assert proposal.nonce not in body


### PR DESCRIPTION
## What

`render_body`'s `said:` slot carried the APPROVING utterance, which the gate guarantees is `confirm <nonce>` — so every buddy write shipped the nonce to the recipient's scrollback and the slot never carried the paraphrase-check content §4b built it for.

The slot now carries the owner's **request** utterance, captured at propose time from the transcript ring (`request_utterance_from`): the newest complete entry, skipping confirm-shaped entries — a stale `confirm <word>` from a prior proposal is not a request and was the one remaining re-entry path for a nonce string. Selection, not redaction. When nothing qualifies, the slot is **omitted entirely** (a slot whose expected content is empty must not survive).

Consequences:
- `Proposal.build_argv()` now takes **no parameters** — the whole argv, body included, is frozen at propose. The approving utterance has no path back into the body, structurally.
- This proposal's own nonce cannot appear in the request utterance by construction: it is minted after the sentence was spoken.
- The dash assertion in `render_body` is unchanged and the marker still leads; body still one line, still capped.

## Premise check (as asked)

The orchestrator's claim — the field can *never* carry verification — is very slightly overstated: containment matching means "confirm tango, and tell him it's urgent" approves and carries incidental content. But it always carries the nonce too, and the request sentence (the thing a recipient can check the paraphrase against) lives elsewhere. The fix direction is unaffected.

What this does NOT establish: the captured request utterance is best-effort evidence — the newest non-confirm-shaped utterance may be an unrelated sentence, and `render_body` itself would still render whatever a future caller passed it; the structural guarantee lives in `build_argv`'s parameterless signature.

## Tests

All five new tests in `TestTheNonceNeverLeavesTheGate` watched RED against current code first (the leak reproduced: `said: "confirm quartz"` in the delivered body). Three pre-existing tests pinned the leaky behavior and were rewritten to the new invariant. Three mutations (drop the confirm-shaped skip; ship the empty slot; re-feed the approving utterance at confirm) each asserted-landed and each went red.

Measured: before 3409 passed / 5 failed (the new reds); after 3414 passed, 0 failed.

Closes #953

Built by [dotdev.dev](https://dotdev.dev)