### PR TITLE
voice-layer: buddy_sent self-observation + the narrow epistemic boundary (#958, #956)

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1090,6 +1090,7 @@ class ConfirmSpine:
                 result = self._runner(argv) or {}
             except Exception as exc:  # a dispatch that raises must not read as sent
                 result = {"success": False, "error": str(exc)}
+            from . import outbox; outbox.record_write(proposal, argv, result)  # noqa: E702 — #958's ONE line in this file; never raises
             if not result.get("success", False):
                 # NOT _succeeded. The write did not happen, and a token in
                 # _succeeded makes the retry say "I already sent that one" —

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -193,6 +193,7 @@ import secrets
 import threading
 from dataclasses import dataclass, field
 
+from . import outbox
 from .transcript import TranscriptRing, Utterance
 
 #: How long a minted proposal stays confirmable, from the moment the buddy
@@ -1090,7 +1091,7 @@ class ConfirmSpine:
                 result = self._runner(argv) or {}
             except Exception as exc:  # a dispatch that raises must not read as sent
                 result = {"success": False, "error": str(exc)}
-            from . import outbox; outbox.record_write(proposal, argv, result)  # noqa: E702 — #958's ONE line in this file; never raises
+            outbox.record_write(proposal, argv, result)  # #958; never raises
             if not result.get("success", False):
                 # NOT _succeeded. The write did not happen, and a token in
                 # _succeeded makes the retry say "I already sent that one" —

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -115,6 +115,34 @@ is free, which may be a minute later. Say "queued it, it'll land when they're fr
 Never say "sent", "done", or "I've told them" — the owner cannot see whether it \
 arrived, and claiming it did when it has not is worse than saying nothing.
 
+WHAT HAPPENS TO A MESSAGE. When you pass a message it becomes a file in that \
+session's per-recipient file inbox, and it is pasted into their terminal only \
+when their input box is empty — that is why "queued, not sent" is true: a busy \
+session simply has not received it yet. Your messages go out with a leading \
+<voice> marker and a proposal id, so the recipient can see it came from you. \
+Delivery can defer while the recipient stays busy, and after too many failures \
+a message is dead-lettered — dropped, with the owner emailed. Both outcomes are \
+observable: buddy_sent shows each message you have sent and its current state.
+
+WHAT YOU SENT. Any question about a message you sent — what it said, whether \
+some word or detail ended up in it, what happened to it — is answered by \
+buddy_sent, which records the exact text that went out and its delivery state. \
+Call it and quote the recorded body word for word. Never answer from memory, \
+never describe what you meant to send, and never scrape the recipient's \
+terminal to find out what you said.
+
+BOUNDARY. You can observe what happened; you cannot observe how any of it is \
+implemented. When a question is answerable by a tool — what you sent, what a \
+session is doing, whether a message arrived — look it up rather than reasoning \
+it out; buddy_sent and fleet_session_output exist for exactly this. Only when \
+no tool can answer — why the system behaved a certain way, how delivery or the \
+confirm gate or transcription work under the hood — say plainly that you do \
+not know how that part is implemented, and offer to check what actually \
+happened instead. Never invent a mechanism, however plausible it sounds. And \
+if the owner says something looked wrong, never explain it away: an anomaly \
+they report gets investigated with tools, or an honest "I can't see that", \
+never a reassuring story about internals you cannot observe.
+
 NEVER GO SILENT. Whenever a tool result carries "must_speak", say it before you do \
 anything else, in your own natural phrasing, without softening what it means. The \
 owner cannot see your screen: if something was refused and you say nothing, they \

--- a/agentwire/voice_layer/outbox.py
+++ b/agentwire/voice_layer/outbox.py
@@ -1,0 +1,141 @@
+"""What the buddy has SENT — the write-side mirror of the delivery spool (#958).
+
+The buddy's tool surface had nine read tools: eight looking outward at the
+fleet, one at mail sent TO it — and nothing showing what it had sent. Asked
+"did the code word end up in the message you sent?" it held no instrument that
+could answer, scraped the recipient's terminal, and confabulated. This module
+is the instrument.
+
+**Recorded, not reconstructed.** :func:`record_write` is called from the one
+place a buddy write executes — ``ConfirmSpine.confirm``, right after the
+runner returns — and what it records is the executed argv itself. The body is
+``argv[-1]``, the exact rendered string the CLI received, never a re-render
+from the proposal: ``render_body`` is under active change (#953), and a
+reconstruction would quietly diverge from what actually went out, which is the
+precise failure this exists to end. Where the argv and the proposal disagree,
+the record sides with the argv.
+
+**Delivery state is computed at read time, never stored.** A message's state
+changes after the write returns — queued now, delivered or dead-lettered
+later — so a stored state is a lie with a timestamp. :func:`delivery_state`
+asks the recipient's real inbox (the same store ``agentwire msg inbox`` and
+``msg dead`` read): still pending → ``queued``; in the graveyard →
+``dead_lettered`` with the drop reason; neither → ``delivered``, because the
+drain removes a message from pending only by delivering it or dead-lettering
+it. A write whose dispatch failed short-circuits to ``dispatch_failed``.
+
+**Recording never raises.** It runs after the write has executed. An exception
+here would propagate to the dispatcher's catch-all, which tells the owner
+"nothing happened" about a message already sitting in the recipient's inbox —
+an under-claim on the one path where the system positively knows the write
+went out. A failed record is a gap in the log; a raised one is a false denial.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from . import delivery
+
+
+def outbox_path(buddy: str) -> Path:
+    """Append-only JSONL of writes *buddy* has executed, beside its spool."""
+    return delivery.session_state_dir(buddy) / "outbox.jsonl"
+
+
+def _flag_value(argv: list, flag: str) -> str:
+    try:
+        return str(argv[list(argv).index(flag) + 1])
+    except (ValueError, IndexError):
+        return ""
+
+
+def record_write(proposal, argv: list, result: dict) -> None:
+    """Record one executed write. Called post-execution; never raises."""
+    try:
+        argv = [str(a) for a in argv]
+        dispatched = bool((result or {}).get("success", False))
+        entry = {
+            "proposal_id": getattr(proposal, "id", "") or "",
+            "session": _flag_value(argv, "--to") or getattr(proposal, "session", ""),
+            "buddy": _flag_value(argv, "--from"),
+            "kind": _flag_value(argv, "--kind"),
+            "instruction": getattr(proposal, "instruction", "") or "",
+            "body": argv[-1] if argv else "",
+            "argv": argv,
+            "ts": time.time(),
+            "dispatched": dispatched,
+        }
+        if not dispatched:
+            entry["error"] = str((result or {}).get("error", ""))
+        path = outbox_path(entry["buddy"] or "unknown")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            fh.flush()
+    except Exception:
+        return
+
+
+def read_outbox(buddy: str, limit: "int | None" = None) -> list[dict]:
+    """Recorded writes for *buddy*, newest first."""
+    path = outbox_path(buddy)
+    if not path.exists():
+        return []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read().splitlines()
+    except OSError:
+        return []
+    entries: list[dict] = []
+    for line in raw:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict):
+            entries.append(entry)
+    entries.reverse()
+    return entries[:limit] if limit else entries
+
+
+def delivery_state(entry: dict) -> dict:
+    """The CURRENT state of one recorded write, from the recipient's inbox.
+
+    Matches by exact body first, then by the ``#<proposal-id>`` tag — the tag
+    survives a change in body shape (#953), so a divergence between the
+    recorded body and the enqueued text degrades to a looser match rather than
+    silently reading as ``delivered``.
+    """
+    if not entry.get("dispatched", False):
+        return {"state": "dispatch_failed", "detail": str(entry.get("error", ""))}
+
+    from .. import inbox  # deferred, matching write_tools — keeps import light
+
+    session = str(entry.get("session") or "").split("@")[0]
+    body = str(entry.get("body") or "")
+    proposal_id = str(entry.get("proposal_id") or "")
+    tag = f"#{proposal_id}" if proposal_id else ""
+
+    def matches(message) -> bool:
+        text = getattr(message, "text", "") or ""
+        return (body != "" and body == text) or (tag != "" and tag in text)
+
+    try:
+        if any(matches(m) for m in inbox.list_messages(session)):
+            return {"state": "queued"}
+        for m in inbox.list_dead(session):
+            if matches(m):
+                return {
+                    "state": "dead_lettered",
+                    "detail": getattr(m, "reason", "") or "",
+                }
+    except Exception as exc:
+        # An unreadable inbox is not knowledge. "unknown" is the honest state;
+        # guessing "delivered" here would be the confabulation with extra steps.
+        return {"state": "unknown", "detail": f"could not check the inbox: {exc}"}
+    return {"state": "delivered"}

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass, field
 from typing import Callable
 
 from ..mcp_core import run_agentwire_cmd
-from . import delivery
+from . import delivery, outbox
 
 # Session names as the inbox defines them, plus the optional `@machine` suffix
 # a remote session carries. Anchored: a partial match is how a fuzzy
@@ -210,6 +210,46 @@ def _buddy_inbox(args: dict) -> dict:
     }
 
 
+_MAX_SENT_LIMIT = 50
+
+
+def _buddy_sent(args: dict) -> dict:
+    """The buddy's OWN writes — what it has actually sent, verbatim (#958).
+
+    Reads the outbox the confirm spine appends to on every executed write, so
+    the ``body`` field here is the exact rendered string that went out — not a
+    description of it, and not a re-render. Delivery state is looked up live
+    against the recipient's inbox on every call, because it changes after the
+    write returns.
+    """
+    name = args.get("_buddy") or ""
+    if not name:
+        raise ToolError("buddy identity missing from tool context")
+    limit = _int_arg(args, "limit", 10, 1, _MAX_SENT_LIMIT)
+    proposal_id = args.get("proposal_id")
+    entries = outbox.read_outbox(name)
+    if isinstance(proposal_id, str) and proposal_id.strip():
+        wanted = proposal_id.strip()
+        entries = [e for e in entries if e.get("proposal_id") == wanted]
+    entries = entries[:limit]
+    return {
+        "success": True,
+        "count": len(entries),
+        "sent": [
+            {
+                "proposal_id": e.get("proposal_id", ""),
+                "session": e.get("session", ""),
+                "body": e.get("body", ""),
+                "instruction": e.get("instruction", ""),
+                "argv": e.get("argv", []),
+                "ts": e.get("ts", 0),
+                "delivery": outbox.delivery_state(e),
+            }
+            for e in entries
+        ],
+    }
+
+
 READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
     ReadOnlyTool(
         name="fleet_sessions",
@@ -320,6 +360,32 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
                 "unread_only": {
                     "type": "boolean",
                     "description": "Only unread messages. Default true.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
+    ReadOnlyTool(
+        name="buddy_sent",
+        description=(
+            "Messages YOU have sent, newest first: the exact body that went out, "
+            "who it went to, and its current delivery state (queued, delivered, "
+            "dead_lettered, or dispatch_failed). This is the answer to any "
+            "question about a message you sent — what it said, whether something "
+            "was in it, what happened to it. Quote the body from here; never "
+            "answer from memory or by reading the recipient's terminal."
+        ),
+        run=_buddy_sent,
+        parameters={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": f"How many recent sends to return (1-{_MAX_SENT_LIMIT}, default 10).",
+                },
+                "proposal_id": {
+                    "type": "string",
+                    "description": "Only the send with this proposal id.",
                 },
             },
             "additionalProperties": False,

--- a/tests/unit/test_voice_outbox.py
+++ b/tests/unit/test_voice_outbox.py
@@ -346,8 +346,12 @@ class TestNarrowBoundary:
         text = instructions.build_instructions()
         boundary = text[text.index("BOUNDARY.") :]
         first_para = boundary.split("\n\n")[0]
-        assert "look" in first_para.lower()
-        assert "buddy_sent" in first_para or "tool" in first_para.lower()
+        # "look it up" specifically — a bare "look" also matches "looked
+        # wrong" in the anomaly clause, which let a gutted observable
+        # direction pass (caught by mutation testing).
+        assert "look it up" in first_para
+        assert "buddy_sent" in first_para
+        assert "decline" not in first_para.lower()
 
     def test_never_reassures_past_an_owner_reported_anomaly(self):
         flowed = " ".join(instructions.build_instructions().split()).lower()

--- a/tests/unit/test_voice_outbox.py
+++ b/tests/unit/test_voice_outbox.py
@@ -1,0 +1,371 @@
+"""Tests for the buddy's self-observation surface (#958) and the narrow
+epistemic boundary that pairs with it (#956).
+
+The defect these guard: the buddy had nine read tools and not one showed what
+it SENT. Asked "did the code word end up in the message you sent?" it had no
+instrument that could answer, scraped the recipient's terminal instead, and
+confabulated. Two halves land together:
+
+1. **The outbox** (:mod:`agentwire.voice_layer.outbox`): every executed write
+   is recorded — proposal id, recipient, THE EXACT RENDERED BODY THAT RAN, the
+   argv, timestamp, dispatch outcome — and per-message delivery state is
+   computed from the recipient's real inbox, never stored and never guessed.
+2. **The boundary in the instructions**: decline ONLY where no instrument
+   exists; everywhere an instrument exists the instruction is LOOK. Both
+   directions are asserted, because a blanket refusal would make the buddy
+   *worse* — in a screenless channel "I don't know" is barely an upgrade on a
+   confident wrong answer.
+
+What matters most here is recorded-not-reconstructed: the body written to the
+outbox must be ``argv[-1]`` of what actually executed, not a re-render. Worker
+A is changing what ``render_body`` produces (#953); recording the executed
+string keeps this tool correct through that change unseen.
+"""
+
+import itertools
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import core, inbox
+from agentwire.voice_layer import confirm, delivery, instructions, tools, transcript
+from agentwire.voice_layer import outbox
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(inbox, "INBOX_ROOT", tmp_path / "inbox")
+    monkeypatch.setattr(inbox, "EVENTS_FILE", tmp_path / "inbox-events.jsonl")
+    monkeypatch.setattr(inbox, "live_sessions", lambda: {"orchestrator"})
+    return tmp_path
+
+
+def _argv(session="orchestrator", buddy="buddy", body="<voice> hello ┃ #abc123"):
+    return [
+        "msg", "send", "--to", session, "--from", buddy, "--kind", "request", body,
+    ]
+
+
+def _proposal(id="abc123", session="orchestrator", instruction="hello"):
+    return SimpleNamespace(id=id, session=session, instruction=instruction)
+
+
+# =============================================================================
+# Recording
+# =============================================================================
+
+
+class TestRecordWrite:
+    def test_records_the_executed_body_verbatim(self, isolate):
+        """The body in the record is argv[-1] — what RAN — not a re-render."""
+        argv = _argv(body="<voice> whatever confirm.py actually built ┃ #abc123")
+        outbox.record_write(_proposal(), argv, {"success": True})
+
+        entries = outbox.read_outbox("buddy")
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["body"] == argv[-1]
+        assert entry["argv"] == argv
+        assert entry["proposal_id"] == "abc123"
+        assert entry["session"] == "orchestrator"
+        assert entry["buddy"] == "buddy"
+        assert entry["dispatched"] is True
+        assert entry["ts"] > 0
+
+    def test_recipient_and_buddy_come_from_the_argv_not_the_proposal(self, isolate):
+        """The argv is what executed; the proposal is what was intended. If the
+        two ever disagree, the record must side with reality."""
+        argv = _argv(session="real-target", buddy="real-buddy")
+        outbox.record_write(_proposal(session="intended-target"), argv, {"success": True})
+        (entry,) = outbox.read_outbox("real-buddy")
+        assert entry["session"] == "real-target"
+
+    def test_failed_dispatch_is_recorded_with_its_error(self, isolate):
+        outbox.record_write(
+            _proposal(), _argv(), {"success": False, "error": "boom"}
+        )
+        (entry,) = outbox.read_outbox("buddy")
+        assert entry["dispatched"] is False
+        assert "boom" in entry["error"]
+
+    def test_recording_failure_never_raises(self, isolate, monkeypatch):
+        """The record happens AFTER the write executed. An exception here would
+        propagate to the dispatcher's catch-all, which tells the owner 'nothing
+        happened' about a message that is already in the recipient's inbox —
+        the exact over/under-claim this whole layer exists to prevent."""
+        monkeypatch.setattr(
+            outbox, "outbox_path", lambda buddy: (_ for _ in ()).throw(OSError("disk"))
+        )
+        outbox.record_write(_proposal(), _argv(), {"success": True})  # must not raise
+
+    def test_newest_first_and_limit(self, isolate):
+        for n in range(5):
+            outbox.record_write(
+                _proposal(id=f"id{n:04d}"), _argv(body=f"body {n} #id{n:04d}"),
+                {"success": True},
+            )
+        entries = outbox.read_outbox("buddy", limit=2)
+        assert [e["proposal_id"] for e in entries] == ["id0004", "id0003"]
+
+    def test_corrupt_lines_are_skipped_not_fatal(self, isolate):
+        outbox.record_write(_proposal(), _argv(), {"success": True})
+        with open(outbox.outbox_path("buddy"), "a", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+        outbox.record_write(_proposal(id="def456"), _argv(), {"success": True})
+        assert len(outbox.read_outbox("buddy")) == 2
+
+
+# =============================================================================
+# Delivery state — computed from the recipient's REAL inbox at read time
+# =============================================================================
+
+
+class TestDeliveryState:
+    def _entry(self, **over):
+        base = {
+            "proposal_id": "abc123",
+            "session": "orchestrator",
+            "body": "<voice> hello ┃ #abc123",
+            "dispatched": True,
+        }
+        base.update(over)
+        return base
+
+    def test_pending_message_reads_as_queued(self, isolate):
+        inbox.enqueue("orchestrator", "<voice> hello ┃ #abc123", kind="request", sender="buddy")
+        assert outbox.delivery_state(self._entry())["state"] == "queued"
+
+    def test_dead_lettered_message_reads_as_dead_lettered_with_reason(self, isolate):
+        msgs = inbox.enqueue(
+            "orchestrator", "<voice> hello ┃ #abc123", kind="request", sender="buddy"
+        )
+        msg = msgs[0]
+        msg.dead_ts = 1
+        msg.reason = "target_gone"
+        dead = inbox.dead_dir("orchestrator")
+        dead.mkdir(parents=True, exist_ok=True)
+        inbox._write_message(dead / f"{msg.id}.json", msg)
+        msg.path.unlink()
+        state = outbox.delivery_state(self._entry())
+        assert state["state"] == "dead_lettered"
+        assert "target_gone" in state.get("detail", "")
+
+    def test_neither_pending_nor_dead_reads_as_delivered(self, isolate):
+        assert outbox.delivery_state(self._entry())["state"] == "delivered"
+
+    def test_failed_dispatch_short_circuits(self, isolate):
+        state = outbox.delivery_state(self._entry(dispatched=False))
+        assert state["state"] == "dispatch_failed"
+
+    def test_matches_by_proposal_id_when_the_body_shape_changes(self, isolate):
+        """Worker A is rewriting render_body (#953). If the recorded body and
+        the enqueued text ever diverge in shape, the ``#<id>`` tag still keys
+        the match — the state must not silently flip to 'delivered'."""
+        inbox.enqueue(
+            "orchestrator", "some future body shape #abc123", kind="request", sender="buddy"
+        )
+        assert outbox.delivery_state(self._entry())["state"] == "queued"
+
+
+# =============================================================================
+# The spine records its writes — integration through the one-line call site
+# =============================================================================
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+class _Runner:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result or {"success": True}
+
+    def __call__(self, argv):
+        self.calls.append(list(argv))
+        return self.result
+
+
+class _Convo:
+    """Minimal client-ordered driver, same shape as test_voice_confirm's."""
+
+    _ids = itertools.count()
+
+    def __init__(self, spine, ring):
+        self.spine, self.ring, self.seq = spine, ring, 0
+
+    def _next(self):
+        self.seq += 1
+        return self.seq
+
+    def announced_proposal(self):
+        proposal = self.spine.propose(
+            tool="send_session_message",
+            session="orchestrator",
+            instruction="hello there",
+            argv_prefix=[
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", "request",
+            ],
+            params={},
+        )
+        self.spine.announce(proposal.id, self._next())
+        return proposal
+
+    def approve(self, proposal):
+        item_id = f"item_{next(self._ids)}"
+        self.ring.speech_started(item_id, self._next())
+        self.ring.commit(item_id, self._next())
+        self.ring.transcribe(item_id, f"confirm {confirm.spoken_nonce(proposal.nonce)}")
+
+
+class TestSpineRecords:
+    def _spine(self, runner):
+        ring = transcript.TranscriptRing()
+        spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner, clock=_Clock())
+        return spine, _Convo(spine, ring)
+
+    def test_an_approved_write_lands_in_the_outbox(self, isolate):
+        runner = _Runner()
+        spine, convo = self._spine(runner)
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        verdict = spine.confirm(proposal.token)
+        assert verdict.approved
+
+        (entry,) = outbox.read_outbox("buddy")
+        assert entry["body"] == runner.calls[0][-1]
+        assert entry["proposal_id"] == proposal.id
+        assert entry["dispatched"] is True
+
+    def test_a_failed_dispatch_is_recorded_as_failed(self, isolate):
+        runner = _Runner({"success": False, "error": "cli exploded"})
+        spine, convo = self._spine(runner)
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert not spine.confirm(proposal.token).approved
+        (entry,) = outbox.read_outbox("buddy")
+        assert entry["dispatched"] is False
+
+    def test_a_refused_confirm_records_nothing(self, isolate):
+        """The false-record direction: an outbox entry for a write that never
+        executed would let the buddy 'quote' a message that does not exist."""
+        runner = _Runner()
+        spine, convo = self._spine(runner)
+        proposal = convo.announced_proposal()
+        # No approval spoken.
+        assert not spine.confirm(proposal.token).approved
+        assert runner.calls == []
+        assert outbox.read_outbox("buddy") == []
+
+
+# =============================================================================
+# The buddy_sent tool
+# =============================================================================
+
+
+class TestBuddySentTool:
+    def test_answers_what_did_i_send_in_one_call(self, isolate):
+        """The triggering question. The rendered body comes back verbatim,
+        with delivery state, keyed by proposal id — no terminal scraping."""
+        argv = _argv(body="<voice> ship it ┃ said: \"confirm tango\" ┃ #abc123")
+        outbox.record_write(_proposal(), argv, {"success": True})
+        inbox.enqueue("orchestrator", argv[-1], kind="request", sender="buddy")
+
+        result = tools.dispatch("buddy_sent", {}, buddy="buddy")
+        assert result["success"] is True
+        (sent,) = result["sent"]
+        assert sent["body"] == argv[-1]
+        assert sent["proposal_id"] == "abc123"
+        assert sent["delivery"]["state"] == "queued"
+
+    def test_empty_outbox_is_a_real_answer_not_an_error(self, isolate):
+        result = tools.dispatch("buddy_sent", {}, buddy="buddy")
+        assert result["success"] is True
+        assert result["sent"] == []
+
+    def test_filters_by_proposal_id(self, isolate):
+        outbox.record_write(_proposal(id="aaa111"), _argv(body="one #aaa111"), {"success": True})
+        outbox.record_write(_proposal(id="bbb222"), _argv(body="two #bbb222"), {"success": True})
+        result = tools.dispatch("buddy_sent", {"proposal_id": "aaa111"}, buddy="buddy")
+        assert [s["proposal_id"] for s in result["sent"]] == ["aaa111"]
+
+    def test_limit_is_clamped_not_trusted(self, isolate):
+        for n in range(3):
+            outbox.record_write(_proposal(id=f"id{n:04d}"), _argv(), {"success": True})
+        result = tools.dispatch("buddy_sent", {"limit": 99999}, buddy="buddy")
+        assert result["success"] is True
+        result = tools.dispatch("buddy_sent", {"limit": 1}, buddy="buddy")
+        assert len(result["sent"]) == 1
+
+    def test_is_in_the_realtime_tool_defs(self):
+        assert "buddy_sent" in {t["name"] for t in tools.realtime_tool_defs()}
+
+
+# =============================================================================
+# Instructions: grounding + the NARROW boundary (#956)
+# =============================================================================
+
+
+class TestGrounding:
+    def test_states_what_a_message_is_once_it_leaves(self):
+        """The ecosystem model: file inbox, empty-box injection (WHY 'queued
+        not sent' is true), the leading voice marker, defer and dead-letter."""
+        flowed = " ".join(instructions.build_instructions().split())
+        assert "file inbox" in flowed
+        assert "input box is empty" in flowed
+        assert "<voice>" in flowed
+        assert "dead-letter" in flowed
+
+    def test_points_at_buddy_sent_for_questions_about_its_own_writes(self):
+        flowed = " ".join(instructions.build_instructions().split())
+        assert "buddy_sent" in flowed
+        assert "quote" in flowed
+
+
+class TestNarrowBoundary:
+    """#956, and it must be NARROW. Decline bites ONLY where no instrument
+    exists; everywhere else the instruction is LOOK. If both directions came
+    out as refusals the buddy would be worse than before the change."""
+
+    def test_the_decline_is_scoped_to_unobservable_internals(self):
+        flowed = " ".join(instructions.build_instructions().split())
+        assert "BOUNDARY." in instructions.build_instructions()
+        assert "implemented" in flowed
+        assert "invent" in flowed or "never describe" in flowed
+
+    def test_the_observable_direction_says_look_not_decline(self):
+        """The false-reject half: an observable question must be routed to an
+        instrument, in the same breath as the decline rule."""
+        text = instructions.build_instructions()
+        boundary = text[text.index("BOUNDARY.") :]
+        first_para = boundary.split("\n\n")[0]
+        assert "look" in first_para.lower()
+        assert "buddy_sent" in first_para or "tool" in first_para.lower()
+
+    def test_never_reassures_past_an_owner_reported_anomaly(self):
+        flowed = " ".join(instructions.build_instructions().split()).lower()
+        assert "anomal" in flowed or "looked wrong" in flowed
+        assert "explain it away" in flowed
+
+    def test_no_blanket_refusal_language(self):
+        """The boundary must not tell the buddy to decline questions about its
+        own actions — those are exactly the ones it now CAN answer."""
+        text = instructions.build_instructions()
+        boundary = text[text.index("BOUNDARY.") :].split("\n\n")[0].lower()
+        assert "what you sent" not in boundary or "look" in boundary
+        # The decline verbs must be bound to internals/implementation, never
+        # bare: every sentence containing a decline verb also names internals.
+        for sentence in boundary.replace("\n", " ").split(". "):
+            if "do not describe" in sentence or "don't know" in sentence:
+                assert (
+                    "implement" in sentence
+                    or "internals" in sentence
+                    or "observe" in sentence
+                ), sentence


### PR DESCRIPTION
The buddy had nine read tools and not one showed what it SENT. This adds the capability half (#958) and the boundary half (#956) together, since both rewrite `instructions.py`.

## Capability (#958)
- **New module `agentwire/voice_layer/outbox.py`** (worker-C-owned): per executed write records proposal id, recipient, **the exact rendered body that was executed** (`argv[-1]` — recorded, never reconstructed, so it stays correct through #953's `render_body` changes), the full argv, timestamp, and dispatch outcome. Recording never raises — it runs post-execution, and an exception there would tell the owner "nothing happened" about a message already enqueued.
- **Delivery state is computed at read time**, from the recipient's real inbox: pending → `queued`, graveyard → `dead_lettered` (+ drop reason), neither → `delivered`, failed dispatch → `dispatch_failed`, unreadable inbox → `unknown` (never a guess). Matches by exact body, falling back to the `#<proposal-id>` tag if the body shape changes.
- **New read tool `buddy_sent`** in `tools.py`: limit-clamped, optional proposal-id filter; makes the triggering question ("did the code word end up in the message you sent?") a one-call exact answer.
- **Ecosystem grounding in `instructions.py`**: what a message is once it leaves (per-recipient file inbox, injected only when the recipient's input box is empty — why "queued not sent" is true), the leading `<voice>` marker, that defer and dead-letter both exist and both are observable.

## Boundary (#956) — deliberately NARROW
The `BOUNDARY.` paragraph declines **only where no instrument exists** (how delivery/confirm/transcription are implemented). Everywhere a tool can answer, the instruction is LOOK — `buddy_sent`, `fleet_session_output` — and an owner-reported anomaly is investigated or met with "I can't see that", never explained away. Tests pin both directions: the observable path must say "look it up" and must not contain "decline"; decline verbs must be bound to internals in every sentence they appear in.

## ⚠️ ONE line in worker A's file — resolve at merge
`confirm.py` gets exactly one added line, immediately after the runner's try/except in `ConfirmSpine.confirm`:
```python
from . import outbox; outbox.record_write(proposal, argv, result)  # noqa: E702 — #958's ONE line in this file; never raises
```
Everything else lives in files worker C owns (`outbox.py` new, `tools.py`, `instructions.py`, `tests/unit/test_voice_outbox.py`).

## Verification
- Unit suite: **3409 → 3434** (25 new tests, all watched failing first).
- Mutation checks, each with a scoped landed-assertion: (1) body recorded from proposal instead of argv → caught; (2) call-site line deleted → caught; (3) pending check skipped in `delivery_state` → caught; (4) observable direction gutted to "decline to answer" → initially **missed** because a bare `"look"` substring matched "looked wrong" in the anomaly clause; test sharpened to pin `"look it up"` + `buddy_sent` + no `decline`, mutation re-run and caught.

Closes #958
Closes #956

Built by [dotdev.dev](https://dotdev.dev)