### PR TITLE
voice-layer: reply etiquette for buddy requests + volunteered-report phrasing (#962)

### DIFF
--- a/agentwire/roles/orchestrator.md
+++ b/agentwire/roles/orchestrator.md
@@ -84,6 +84,16 @@ Make email better.
 - **Escalate to user** via `email_send()` / `quo_send()` for cross-device push when voice isn't enough
 - **Be concise** — status updates, not novels
 
+## Replying to the voice buddy
+
+A request whose body starts with `<voice>` was relayed from the owner **by voice**, via their voice buddy (the sender in the `[MSG from <sender> · …]` prefix, usually `buddy`). The owner is listening, not watching your terminal — an answer typed only into your own pane never reaches them. When you have the answer, reply by message to that sender:
+
+```
+agentwire msg send --to buddy --kind done "<one-or-two-sentence answer>"
+```
+
+Keep the reply to a sentence or two — it gets summarized aloud. Take the time the work needs first; the reply is expected when you have an answer, not instantly.
+
 ## What NOT to do
 
 - Don't do the implementation work yourself if workers/worktree sessions can handle it

--- a/agentwire/roles/worker-worktree.md
+++ b/agentwire/roles/worker-worktree.md
@@ -19,6 +19,16 @@ Verify as best you can from inside the worktree: run the test suite (e.g. `uv ru
 
 If you open a claude-in-chrome tab to verify your work (dev server, screenshots), track it immediately with `chrome_tab_track(tab_id=..., url=...)` — right after `tabs_create_mcp`. A tab you never close yourself is a browser leaked forever; teardown can only report it as orphaned, not close it (agentwire has no way to call `tabs_close_mcp` outside your own client). See "Finish" below.
 
+## Replying to the voice buddy
+
+A request whose body starts with `<voice>` was relayed from the owner **by voice**, via their voice buddy (the sender in the `[MSG from <sender> · …]` prefix, usually `buddy`). The owner is listening, not watching your terminal — an answer typed only into your own pane never reaches them. When you have the answer, reply by message to that sender:
+
+```
+agentwire msg send --to buddy --kind done "<one-or-two-sentence answer>"
+```
+
+Keep the reply to a sentence or two — it gets summarized aloud. Take the time the work needs first; the reply is expected when you have an answer, not instantly.
+
 ## Finish
 
 When the task is done:

--- a/agentwire/roles/worker.md
+++ b/agentwire/roles/worker.md
@@ -16,6 +16,16 @@ You're a worker executing a task for the parent/creator session — a pane shari
 - **Commit your work** — if the task involves code changes
 - **Report back politely** — if you need to ping the parent before your exit summary (status, a blocker), use `agentwire msg send --to <parent> --kind note "..."` (or `--kind done`). `msg` waits for the parent's input box to be empty, so it never clobbers a draft they're mid-typing. Reserve `session_send` for when something genuinely can't wait.
 
+## Replying to the voice buddy
+
+A request whose body starts with `<voice>` was relayed from the owner **by voice**, via their voice buddy (the sender in the `[MSG from <sender> · …]` prefix, usually `buddy`). The owner is listening, not watching your terminal — an answer typed only into your own pane never reaches them. When you have the answer, reply by message to that sender:
+
+```
+agentwire msg send --to buddy --kind done "<one-or-two-sentence answer>"
+```
+
+Keep the reply to a sentence or two — it gets summarized aloud. Take the time the work needs first; the reply is expected when you have an answer, not instantly.
+
 ## Exit Summary
 
 **If you're a pane** (sharing your creator's session): when you go idle, the system will prompt you to write a summary file. Follow the instructions and write it with these sections:

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -705,8 +705,26 @@ class Proposal:
         # that structural rather than a calling convention.
         return [
             *self.argv_prefix,
-            render_body(self.instruction, self.request_utterance, self.id),
+            render_body(
+                self.instruction,
+                self.request_utterance,
+                self.id,
+                reply_to=self._reply_target(),
+            ),
         ]
+
+    def _reply_target(self) -> str:
+        """The sender name from the frozen argv — who a reply should address.
+
+        Read from the frozen ``--from`` rather than passed separately, so the
+        nudge can never name anyone other than the identity the message
+        actually goes out under.
+        """
+        prefix = self.argv_prefix
+        for index, token in enumerate(prefix[:-1]):
+            if token == "--from":
+                return prefix[index + 1]
+        return ""
 
 
 # =============================================================================
@@ -798,7 +816,25 @@ def _clip(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
-def render_body(instruction: str, request_utterance: str, proposal_id: str) -> str:
+def reply_nudge(reply_to: str) -> str:
+    """The body's reply-path slot: the literal command that reaches the buddy.
+
+    #962's live failure: the recipient answered a buddy request IN ITS OWN
+    TERMINAL, and the reply never came back — the owner is listening, not
+    watching that pane, so an on-screen answer is a lost one. ``--from buddy``
+    and the ``<voice>`` marker say who asked; neither says how to answer. This
+    slot does, as a runnable command rather than prose, because the recipient
+    is an agent and the one thing it reliably does with a command is run it.
+
+    The role text (worker/orchestrator) states the same etiquette; the slot is
+    what covers recipients running with no agentwire role text at all.
+    """
+    return f'reply: agentwire msg send --to {_clip(reply_to, 40)} --kind done "<answer>"'
+
+
+def render_body(
+    instruction: str, request_utterance: str, proposal_id: str, *, reply_to: str = ""
+) -> str:
     """The fixed one-line shape every buddy write carries (§4b).
 
     Part one is what the buddy asked for; part two is what the owner actually
@@ -840,6 +876,18 @@ def render_body(instruction: str, request_utterance: str, proposal_id: str) -> s
         parts.append(f"said: \"{_clip(request_utterance, MAX_UTTERANCE_CHARS)}\"")
     parts.append(f"#{proposal_id}")
     body = " ┃ ".join(parts)
+    # The reply-path slot (#962) is DROPPABLE, whole-or-not-at-all: it rides
+    # only when the full body still fits MAX_BODY_CHARS, and it slots in
+    # BEFORE the id so the id is never what pays for it. Both halves priced:
+    # included, it makes the reply path a runnable command; dropped, the cost
+    # is a missing nudge — the role text still states the etiquette — never a
+    # half-truncated command or a clipped id. A budget bump here would need
+    # the pane re-measurement MAX_BODY_CHARS documents; a droppable slot does
+    # not.
+    if reply_to.strip():
+        with_nudge = " ┃ ".join([*parts[:-1], reply_nudge(reply_to), parts[-1]])
+        if len(with_nudge) <= MAX_BODY_CHARS:
+            body = with_nudge
     body = _clip(body, MAX_BODY_CHARS)
     # Explicit, not incidental — see the docstring. A body reaching the CLI as
     # a flag is a bug this repo has shipped twice.
@@ -1340,6 +1388,7 @@ __all__ = [
     "mint_nonce",
     "normalize",
     "render_body",
+    "reply_nudge",
     "request_utterance_from",
     "spoken_nonce",
 ]

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -122,7 +122,10 @@ session simply has not received it yet. Your messages go out with a leading \
 <voice> marker and a proposal id, so the recipient can see it came from you. \
 Delivery can defer while the recipient stays busy, and after too many failures \
 a message is dead-lettered — dropped, with the owner emailed. Both outcomes are \
-observable: buddy_sent shows each message you have sent and its current state.
+observable: buddy_sent shows each message you have sent and its current state. \
+Your messages also carry the reply path — the recipient is asked to answer you \
+by message, and when it does, that reply lands in buddy_inbox. A recipient may \
+still never reply; never promise the owner one.
 
 WHAT YOU SENT. Any question about a message you sent — what it said, whether \
 some word or detail ended up in it, what happened to it — is answered by \
@@ -151,8 +154,20 @@ silently retry, and do not reword a message to get past a refusal. If the result
 says "owner_should_wait", tell them to hold on rather than to say it again — those \
 are opposite instructions and giving the wrong one makes it worse.
 
-Do not volunteer status the owner did not ask for, and do not interrupt. You speak \
-when spoken to.
+VOLUNTEERING. Exactly one thing is worth raising unprompted: a session replying \
+to something you sent. When a reply comes in, open by naming who finished and \
+what it was about — "minecraft finished responding about the server crash" — \
+then give the shape of the answer, not a recital: "looks like there are four \
+main options to consider". A sentence or two, then hand the conversation back; \
+the owner will ask for the detail they want. A volunteered report that becomes \
+a monologue is worse than silence — the owner did not ask, cannot skim speech, \
+and cannot predict when you will stop.
+
+Ground every volunteered claim in the reply's recorded text from buddy_inbox — \
+what it actually says, never what you expect the answer to be. If you have not \
+read the reply's text, say only that a reply arrived and offer to read it. \
+Beyond that one case, do not volunteer status the owner did not ask for, and \
+never interrupt: nothing you have to report is worth speaking over the owner.
 </voice_mode>"""
 
 

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -163,9 +163,13 @@ the owner will ask for the detail they want. A volunteered report that becomes \
 a monologue is worse than silence — the owner did not ask, cannot skim speech, \
 and cannot predict when you will stop.
 
-Ground every volunteered claim in the reply's recorded text from buddy_inbox — \
-what it actually says, never what you expect the answer to be. If you have not \
-read the reply's text, say only that a reply arrived and offer to read it. \
+Ground every volunteered claim in output you actually read — the reply's \
+recorded text in buddy_inbox, or the session's own terminal via \
+fleet_session_output — never what you expect the answer to be. A plausible \
+summary of output you did not read sounds exactly like one you did, and in a \
+volunteered report the owner has no way to tell them apart, because they did \
+not ask. If you have not read it, say only that a reply arrived and offer to \
+look. \
 Beyond that one case, do not volunteer status the owner did not ask for, and \
 never interrupt: nothing you have to report is worth speaking over the owner.
 </voice_mode>"""

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -1144,6 +1144,44 @@ class TestAttribution:
         assert request in body
         assert spoken not in body
 
+    def test_the_body_tells_the_recipient_how_to_reply(self):
+        """#962: in the live test the recipient answered in its own terminal
+        and the reply never reached the buddy. The body itself must make the
+        reply path obvious — a request whose reply channel is implicit gets an
+        on-screen answer the owner never hears."""
+        body = confirm.render_body(
+            "restart the portal", "confirm tango", "a1b2c3", reply_to="buddy"
+        )
+        assert confirm.reply_nudge("buddy") in body
+        assert 'msg send --to buddy' in body
+        # The id stays last: the nudge slots in before it, never after.
+        assert body.endswith("#a1b2c3")
+
+    def test_the_nudge_is_dropped_whole_when_the_budget_cannot_fit_it(self):
+        """Both halves: a nudge that fits ships verbatim; one that does not is
+        dropped ENTIRELY, never truncated into half a command — and it is never
+        the proposal id that pays for it."""
+        body = confirm.render_body(
+            "x" * confirm.MAX_RENDERED_INSTRUCTION_CHARS,
+            "y" * confirm.MAX_UTTERANCE_CHARS,
+            "a1b2c3",
+            reply_to="buddy",
+        )
+        assert len(body) <= confirm.MAX_BODY_CHARS
+        assert "reply:" not in body, "an over-budget nudge must vanish, not clip"
+        assert body.endswith("#a1b2c3")
+
+    def test_the_frozen_argv_carries_the_nudge_named_after_the_sender(
+        self, convo, runner
+    ):
+        """End to end through Proposal.build_argv: the reply target is read
+        from the frozen --from, so the nudge names whoever actually sent it."""
+        proposal = convo.announced_proposal(instruction="check the server")
+        convo.approve(proposal)
+        convo.spine.confirm(proposal.token)
+        body = runner.calls[0][-1]
+        assert confirm.reply_nudge("buddy") in body
+
     def test_this_diff_does_not_touch_the_shared_kind_enum(self):
         """§4a is deferred to Slice 1b — deliberately, see write_tools' docstring.
 

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -380,11 +380,36 @@ class TestInstructions:
         assert "must_speak" in text
         assert "owner_should_wait" in text
 
-    def test_does_not_speak_unprompted(self):
-        """No proactive interruption in this slice — the persona must say so."""
+    def test_volunteers_replies_only_and_still_never_interrupts(self):
+        """#962: the one thing raised unprompted is a reply to something the
+        buddy sent. The old absolute ("you speak when spoken to") is now false
+        — the announcer's clock speaks replies — but general unprompted status
+        and interruption stay banned."""
+        text = instructions.build_instructions()
+        flowed = " ".join(text.split())
+        assert "VOLUNTEERING." in text
+        assert "You speak when spoken to." not in flowed, (
+            "stale absolute: contradicts the reply announcer"
+        )
+        assert "do not volunteer status the owner did not ask for" in flowed
+        assert "never interrupt" in flowed
+
+    def test_a_volunteered_report_is_shape_not_recital(self):
+        """The owner's example is 'looks like there are four main options', not
+        four paragraphs of options. A monologue the owner did not ask for and
+        cannot skim is worse than silence."""
         flowed = " ".join(instructions.build_instructions().split())
-        assert "do not interrupt" in flowed
-        assert "You speak when spoken to." in flowed
+        assert "shape of the answer" in flowed
+        assert "hand the conversation back" in flowed
+
+    def test_a_volunteered_claim_is_grounded_in_the_received_reply(self):
+        """Same confabulation failure the BOUNDARY section closes, and a
+        proactive channel is the more dangerous place for it: the owner did
+        not ask, so they have no prior to check the claim against."""
+        flowed = " ".join(instructions.build_instructions().split())
+        assert "never what you expect the answer to be" in flowed
+        assert "buddy_inbox" in flowed
+        assert "say only that a reply arrived" in flowed
 
 
 # =============================================================================

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -402,13 +402,17 @@ class TestInstructions:
         assert "shape of the answer" in flowed
         assert "hand the conversation back" in flowed
 
-    def test_a_volunteered_claim_is_grounded_in_the_received_reply(self):
+    def test_a_volunteered_claim_is_grounded_in_output_actually_read(self):
         """Same confabulation failure the BOUNDARY section closes, and a
         proactive channel is the more dangerous place for it: the owner did
-        not ask, so they have no prior to check the claim against."""
+        not ask, so they have no prior to check the claim against. The buddy
+        HAS real reading tools (buddy_inbox, fleet_session_output) — which
+        makes a plausible unread summary more tempting, not less, so the
+        persona must name both the instruments and the ban."""
         flowed = " ".join(instructions.build_instructions().split())
         assert "never what you expect the answer to be" in flowed
         assert "buddy_inbox" in flowed
+        assert "fleet_session_output" in flowed
         assert "say only that a reply arrived" in flowed
 
 


### PR DESCRIPTION
Worker E's half of #962: make sure a buddy request produces something to poll, and that what gets volunteered is worth hearing.

## Delivered body carries the reply path
`render_body` gains a droppable `reply:` slot — the literal command `reply: agentwire msg send --to <sender> --kind done "<answer>"`, with the sender read from the frozen `--from` (never a separately-passed name). Whole-or-not-at-all: it rides only when the full body still fits `MAX_BODY_CHARS` (300) and slots in before the `#id`, so the id never pays for it and an over-budget body just loses the nudge — the role text still carries the etiquette. No budget caps changed, no re-measurement needed; the dash assertion and #953's nonce exclusion are untouched.

## Role text states the etiquette
`worker.md`, `worker-worktree.md`, `orchestrator.md`: a `<voice>`-prefixed request came from the owner **by voice** — the owner is listening, not watching your terminal, so answer via `msg send --to buddy --kind done`, kept to a sentence or two.

## Volunteered-report phrasing (instructions.py)
The absolute "You speak when spoken to" is gone (worker D's clock makes it false). Replaced with a VOLUNTEERING section: exactly one thing is raised unprompted — a reply to something the buddy sent — phrased as who + what, then the *shape* of the answer ("looks like there are four main options"), then hand back. Every volunteered claim must be grounded in the reply's recorded text from `buddy_inbox`, never in the expected answer; an unread reply is announced as "a reply arrived", nothing more. General unprompted status and interruption stay banned.

## Verification
- 6 new tests, each watched fail before the fix; 3 mutations (budget check removed, `--from` extraction broken, grounding sentence deleted) each caught by exactly the intended test, with the mutation's landing asserted by scoped count.
- `uv run pytest tests/unit/` — 3449 passed. `uv run --no-sync ruff check agentwire/ tests/` — clean.

Note for the reviewer: the delivered body is rendered in `confirm.py` (not `write_tools.py`), so this PR touches `confirm.py` — outside my nominal file list, unowned by worker D (who owns `client.py` only).

`buddy_inbox` returns each reply's full `text`, so the buddy CAN ground a spoken summary in reply content — but only in whatever one-liner the recipient put in `msg send`.

Closes #962 (E's half; D's client-side clock is the other half)

Built by [dotdev.dev](https://dotdev.dev)