### PR TITLE
voice-layer: greet on Start talking + the buddy's clock (client half of #963/#962)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -299,6 +299,146 @@ function createAnnouncer(deps) {
 }
 """
 
+#: The buddy's clock (#962), same discipline as the announcer: a standalone
+#: factory with injected deps so the whole loop — peek, gate, coalesce,
+#: announce, ack-after-spoken — runs under ``node`` against a fake bridge and a
+#: fake timer. Spliced into the page by :func:`page`; exported by
+#: :func:`notifier_source` for the test harness.
+INBOX_NOTIFIER_JS = """
+// The buddy's clock. Before this, client.py contained no polling of any kind —
+// every action was downstream of the owner speaking, so the buddy could answer
+// a topic but never open one. This is the one clock: poll the buddy's spool,
+// and when a reply has arrived, volunteer it — through the injected
+// `announce`, which is the page's ONE speaking path (#950). The notice is a
+// bonus, never a contract: an empty spool produces silence, not chatter.
+//
+// Injected dependencies:
+//   fetchInbox() -> Promise<{success, messages}>  PEEK — never advances the cursor
+//   ackInbox()   -> Promise<{success, messages}>  read + advance the cursor
+//   announce(text, meta)   the page's announce() — no other voice exists here
+//   canSpeak() -> bool     owner not speaking, no active response, nothing queued
+//   setTimer(fn, ms) / clearTimer(handle), onLog(kind, detail), pollMs
+//   seen: {}   page-lifetime map of ids the owner has actually HEARD. Passed in
+//              rather than owned so it outlives this notifier: a reconnect
+//              builds a fresh notifier over the same map and cannot replay a
+//              spoken notice — while a notice announced but never SPOKEN is
+//              not in it, and is correctly said again.
+function createInboxNotifier(deps) {
+  var fetchInbox = deps.fetchInbox;
+  var ackInbox = deps.ackInbox;
+  var announce = deps.announce;
+  var canSpeak = deps.canSpeak;
+  var setTimer = deps.setTimer;
+  var clearTimer = deps.clearTimer;
+  var onLog = deps.onLog || function () {};
+  var pollMs = deps.pollMs;
+  var seen = deps.seen;
+
+  // Announced this session but not yet confirmed spoken. Per-notifier on
+  // purpose: if the session dies mid-announcement the map dies with it, so
+  // the unheard notice is retried — `seen` alone decides what is settled.
+  var inFlight = {};
+  // Acked-but-never-spoken messages (the peek/ack race — see noticeSpoken).
+  // The cursor has moved past them, so the spool will never return them
+  // again; this list is their only way back to the owner's ear.
+  var strays = [];
+  var timer = null;
+  var stopped = false;
+
+  function trimBody(text) {
+    var t = String(text || "").replace(/\\s+/g, " ").trim();
+    return t.length > 240 ? t.slice(0, 240) + "\\u2026" : t;
+  }
+
+  // Coalesce: several replies arriving together are ONE utterance, not a
+  // volley of interruptions. No promise language — "got back to you" states
+  // what happened, nothing about what will.
+  function composeNotice(messages) {
+    if (messages.length === 1) {
+      var m = messages[0];
+      return (m.from || "someone") + " got back to you: " + trimBody(m.text);
+    }
+    var parts = messages.map(function (msg) {
+      return "From " + (msg.from || "someone") + ": " + trimBody(msg.text);
+    });
+    return messages.length + " updates came in. " + parts.join(" ");
+  }
+
+  function pollOnce() {
+    return fetchInbox().then(function (res) {
+      if (!res || !res.success) {
+        onLog("inbox", "poll failed: " + ((res && res.error) || "no response"));
+        return;
+      }
+      // NEVER BARGE IN. A blocked tick marks nothing and loses nothing — the
+      // same replies are still unacked next tick. The gate is checked before
+      // anything is claimed, so waiting is free.
+      if (!canSpeak()) return;
+      var claimed = {};
+      var fresh = strays.splice(0).concat(res.messages || []).filter(function (m) {
+        if (!m || !m.id || seen[m.id] || inFlight[m.id] || claimed[m.id]) return false;
+        claimed[m.id] = true;
+        return true;
+      });
+      if (!fresh.length) return;
+      var ids = fresh.map(function (m) { return m.id; });
+      ids.forEach(function (id) { inFlight[id] = true; });
+      onLog("inbox", "volunteering " + fresh.length + " message(s)");
+      announce(composeNotice(fresh), { inboxIds: ids });
+    }).catch(function (err) {
+      onLog("inbox", "poll failed: " + err);
+    });
+  }
+
+  // ACK ONLY AFTER IT HAS ACTUALLY BEEN SPOKEN — the page calls this from the
+  // announcer's onSpoken, the moment there is evidence the owner heard it
+  // (model or fallback voice; either way, heard). The reverse order marks
+  // delivered a report the owner never heard.
+  function noticeSpoken(meta) {
+    if (!meta || !meta.inboxIds) return Promise.resolve();
+    meta.inboxIds.forEach(function (id) { seen[id] = true; });
+    return ackInbox().then(function (res) {
+      if (!res || !res.success) {
+        // Cursor not advanced: a page reload will re-read these. `seen`
+        // suppresses a replay for THIS page's lifetime, which is the right
+        // half to keep — re-reading is an annoyance, losing one is the bug.
+        onLog("inbox", "ack failed: " + ((res && res.error) || "no response"));
+        return;
+      }
+      // The ack read everything unread — including anything that landed
+      // between our peek and now. Those were acked but never spoken; queue
+      // them for the next tick's gate check rather than announcing here
+      // (announcing outside the gate is barging in by another door).
+      (res.messages || []).forEach(function (m) {
+        if (m && m.id && !seen[m.id] && !inFlight[m.id]) strays.push(m);
+      });
+    }).catch(function (err) {
+      onLog("inbox", "ack failed: " + err);
+    });
+  }
+
+  function schedule() {
+    if (stopped) return;
+    timer = setTimer(function () {
+      pollOnce().then(schedule, schedule);
+    }, pollMs);
+  }
+
+  return {
+    start: function () {
+      stopped = false;
+      pollOnce().then(schedule, schedule);
+    },
+    stop: function () {
+      stopped = true;
+      if (timer) { clearTimer(timer); timer = null; }
+    },
+    pollOnce: pollOnce,
+    noticeSpoken: noticeSpoken,
+  };
+}
+"""
+
 _PAGE = """<!doctype html>
 <html lang="en">
 <head>
@@ -361,6 +501,7 @@ _PAGE = """<!doctype html>
 <div id="log"></div>
 <script>
 __ANNOUNCER__
+__NOTIFIER__
 
 const TOKEN = __TOKEN__;
 const CALLS_URL = "https://api.openai.com/v1/realtime/calls";
@@ -387,6 +528,20 @@ const commitSeq = {};        // item_id -> the seq at which its audio committed
 let forwardChain = Promise.resolve();
 let announcer = null;
 let parseFailuresAnnounced = 0;
+
+// --- the buddy's clock (#962) -----------------------------------------------
+// How often to peek at the spool. 5 seconds: a reply is a human-scale event —
+// the acceptance bound is "volunteered within a bounded interval", and 5s is
+// far inside conversational patience while keeping the cost at one tiny POST
+// to the LOCAL bridge per tick. Sub-second buys nothing (the notice still
+// waits for a gap in the conversation); minutes would make the volunteer
+// feature feel dead.
+const INBOX_POLL_MS = 5000;
+// Page-lifetime: ids the owner has actually HEARD. Never reset by stop() — a
+// reconnect must not replay every notice.
+const heardReplies = {};
+let inboxNotifier = null;
+let ownerSpeaking = false;
 
 // --- the greeting (#963) ----------------------------------------------------
 // The buddy speaks first — and since #950 the write path is fail-closed on
@@ -495,6 +650,11 @@ let errorNoticePending = false;
 // GUARANTEE speech.
 function onSpoken(meta, how) {
   if (meta && meta.errorNotice) { errorNoticePending = false; return; }
+  if (meta && meta.inboxIds) {
+    // A volunteered inbox notice was heard — NOW it may be acked (#962).
+    if (inboxNotifier) inboxNotifier.noticeSpoken(meta);
+    return;
+  }
   if (meta && meta.greeting) {
     // The health check's verdict (#963). "fallback" here means the model
     // never spoke the greeting — model audio is dead and, with #950's
@@ -654,6 +814,20 @@ async function start() {
       clearTimer: (handle) => window.clearTimeout(handle),
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
     });
+    // The buddy's clock (#962). Its only voice is announce(); its gate is the
+    // same state the announcer tracks — the owner not speaking, no response in
+    // flight, nothing already queued to be said.
+    inboxNotifier = createInboxNotifier({
+      fetchInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: false } }),
+      ackInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: true } }),
+      announce: announce,
+      canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0,
+      setTimer: (fn, ms) => window.setTimeout(fn, ms),
+      clearTimer: (handle) => window.clearTimeout(handle),
+      onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
+      pollMs: INBOX_POLL_MS,
+      seen: heardReplies,
+    });
     dc.addEventListener("open", () => { setStatus("listening"); $stop.disabled = false; });
     dc.addEventListener("close", () => setStatus("closed"));
     dc.addEventListener("message", (e) => {
@@ -675,6 +849,9 @@ async function start() {
         case "session.created":
           sessionReady = true;
           maybeGreet();
+          // Start the clock only once the session is real — and after the
+          // greeting is queued, so the first tick defers behind it.
+          if (inboxNotifier) inboxNotifier.start();
           break;
         case "response.created":
           responseActive = true;
@@ -736,6 +913,7 @@ async function start() {
           // good; one queued or mid-flight is withdrawn — cancelled, never
           // queued behind them (#963). Native barge-in cuts any audio already
           // playing; this kills the QUEUE and the fallback TIMER.
+          ownerSpeaking = true;
           greeted = true;
           if (announcer) announcer.cancel((m) => !!(m && m.greeting));
           if (payload.item_id) {
@@ -749,6 +927,7 @@ async function start() {
         // The commit still matters — it binds the item and makes the ordering
         // choice inspectable — but it never gates.
         case "input_audio_buffer.committed":
+          ownerSpeaking = false;
           if (payload.item_id) {
             const seq = nextSeq();
             commitSeq[payload.item_id] = seq;
@@ -818,6 +997,10 @@ function stop() {
   // reconnect must stay quiet (#963).
   sessionReady = false;
   audioAttached = false;
+  ownerSpeaking = false;
+  // The clock dies with the session; `heardReplies` deliberately survives, so
+  // the fresh notifier after a reconnect cannot replay a spoken notice (#962).
+  if (inboxNotifier) { inboxNotifier.stop(); inboxNotifier = null; }
   // A notice pending when the session died was never going to be spoken by
   // it — carrying the flag into the next session would suppress that
   // session's FIRST error notice, silently.
@@ -845,10 +1028,20 @@ def announcer_source() -> str:
     return ANNOUNCER_JS
 
 
+def notifier_source() -> str:
+    """The inbox-notifier factory on its own, for the node-driven tests.
+
+    Same rule as :func:`announcer_source`: the code under test is
+    byte-identical to the code in the page.
+    """
+    return INBOX_NOTIFIER_JS
+
+
 def page(buddy: str, token: str) -> str:
     """Render the client page for one buddy + one run token."""
     return (
         _PAGE.replace("__ANNOUNCER__", ANNOUNCER_JS)
+        .replace("__NOTIFIER__", INBOX_NOTIFIER_JS)
         .replace("__BUDDY__", html.escape(buddy))
         .replace("__TOKEN__", json.dumps(token))
     )

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -232,6 +232,22 @@ function createAnnouncer(deps) {
       });
       pump();
     },
+    // Withdraw announcements whose meta matches, queued or current (#963: the
+    // owner speaking first CANCELS the greeting; queueing it behind them would
+    // greet someone who has already moved on). A withdrawn item's fallback is
+    // disarmed and onSpoken never fires for it — it was never heard, and
+    // nothing downstream may believe it was. Note what this does NOT
+    // establish: it cannot recall audio the model has already emitted; native
+    // barge-in covers that, this covers the QUEUE and the TIMER.
+    cancel: function (match) {
+      queue = queue.filter(function (it) { return !match(it.meta); });
+      if (current && match(current.meta)) {
+        disarm(current);
+        if (responseActive) send({ type: "response.cancel" });
+        current = null;
+        pump();
+      }
+    },
     onResponseCreated: function () {
       responseActive = true;
       // A response beginning while this item is current is the one signal
@@ -372,6 +388,35 @@ let forwardChain = Promise.resolve();
 let announcer = null;
 let parseFailuresAnnounced = 0;
 
+// --- the greeting (#963) ----------------------------------------------------
+// The buddy speaks first — and since #950 the write path is fail-closed on
+// model audio, so a HEARD greeting proves the whole approval path at second
+// zero. That is why the greeting must be spoken by the MODEL: a fallback-
+// spoken greeting confirms the browser voice while the model's is dead and
+// nothing can ever be approved. The announcer's fallback stays armed (silence
+// is still unacceptable) but its text is MODEL_AUDIO_DEAD — the browser voice
+// surfaces the failure instead of impersonating health.
+const GREETING = "Hey, I'm listening. What's on your mind?";
+const MODEL_AUDIO_DEAD = "Heads up: my main voice isn't working, so nothing can be approved. Try stopping and starting again.";
+// Page-lifetime, never reset by stop(): a dropped and re-established
+// connection must not re-greet. Also set by the owner speaking first — a late
+// greeting after they've started talking is worse than none.
+let greeted = false;
+let sessionReady = false;   // the server's session.created arrived
+let audioAttached = false;  // pc.ontrack wired the model's audio to a sink
+
+// Channel-open is NOT readiness: session.created is the server saying the
+// session exists, and the audio element is what makes model speech audible.
+// Whichever lands last fires the greeting. What this does NOT establish: that
+// audio actually PLAYS — the disarm keys on the model's transcript, so a muted
+// tab still reads as healthy. That gap is inherent to every announcement, not
+// introduced here.
+function maybeGreet() {
+  if (greeted || !sessionReady || !audioAttached) return;
+  greeted = true;
+  announce(GREETING, { greeting: true }, MODEL_AUDIO_DEAD);
+}
+
 function nextSeq() { return ++seqCounter; }
 
 function setStatus(text) { $status.textContent = text; }
@@ -450,6 +495,16 @@ let errorNoticePending = false;
 // GUARANTEE speech.
 function onSpoken(meta, how) {
   if (meta && meta.errorNotice) { errorNoticePending = false; return; }
+  if (meta && meta.greeting) {
+    // The health check's verdict (#963). "fallback" here means the model
+    // never spoke the greeting — model audio is dead and, with #950's
+    // fail-closed write path, nothing can be approved. The browser voice has
+    // already said MODEL_AUDIO_DEAD aloud; this is the on-screen record.
+    if (how === "fallback") {
+      log("error", "model audio is DEAD — the write path cannot approve anything", "err");
+    }
+    return;
+  }
   if (!meta || !meta.anchor) return;
   log("speak", "anchored proposal " + meta.anchor + " (" + how + ")", "tool");
   forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
@@ -564,7 +619,7 @@ async function start() {
 
     audioEl = new Audio();
     audioEl.autoplay = true;
-    pc.ontrack = (e) => { audioEl.srcObject = e.streams[0]; };
+    pc.ontrack = (e) => { audioEl.srcObject = e.streams[0]; audioAttached = true; maybeGreet(); };
 
     dc = pc.createDataChannel("oai-events");
     announcer = createAnnouncer({
@@ -615,6 +670,12 @@ async function start() {
         return;
       }
       switch (payload.type) {
+        // The server's own readiness signal — the session exists and can take
+        // a response.create. One leg of the greeting gate (#963).
+        case "session.created":
+          sessionReady = true;
+          maybeGreet();
+          break;
         case "response.created":
           responseActive = true;
           if (announcer) announcer.onResponseCreated();
@@ -671,6 +732,12 @@ async function start() {
         // approval for a proposal the owner never heard stated. That is the
         // hole the clock change exists to close, and the commit reopens it.
         case "input_audio_buffer.speech_started":
+          // The owner is talking. A greeting not yet fired is suppressed for
+          // good; one queued or mid-flight is withdrawn — cancelled, never
+          // queued behind them (#963). Native barge-in cuts any audio already
+          // playing; this kills the QUEUE and the fallback TIMER.
+          greeted = true;
+          if (announcer) announcer.cancel((m) => !!(m && m.greeting));
           if (payload.item_id) {
             const startSeq = nextSeq();
             speechSeq[payload.item_id] = startSeq;
@@ -747,6 +814,10 @@ function stop() {
   audioEl = null;
   responseActive = false;
   announcer = null;
+  // Session-scoped readiness resets; `greeted` deliberately does NOT — a
+  // reconnect must stay quiet (#963).
+  sessionReady = false;
+  audioAttached = false;
   // A notice pending when the session died was never going to be spoken by
   // it — carrying the flag into the next session would suppress that
   // session's FIRST error notice, silently.

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -596,6 +596,238 @@ class TestTheGreeting:
         assert "approve" in warning.group(1).lower()
 
 
+# The buddy's clock (#962): a fake bridge with real cursor semantics — fetch
+# peeks from the cursor, ack advances it past everything unread — plus a fake
+# timer queue and a shared `seen` map so a reconnect (a second notifier over
+# the same page state) is a scenario the test can build.
+_NOTIFIER_HARNESS = """
+const announcedCalls = [];
+const logs = [];
+const seen = {};
+let spool = [];
+let cursor = 0;
+let speakable = true;
+let timers = [];
+let nextHandle = 1;
+
+function fetchInbox() {
+  return Promise.resolve({ success: true, messages: spool.slice(cursor) });
+}
+function ackInbox() {
+  const msgs = spool.slice(cursor);
+  cursor = spool.length;
+  return Promise.resolve({ success: true, messages: msgs });
+}
+function makeNotifier(overrides) {
+  return createInboxNotifier(Object.assign({
+    fetchInbox, ackInbox,
+    announce: (text, meta) => announcedCalls.push({ text, meta }),
+    canSpeak: () => speakable,
+    setTimer: (fn, ms) => { const h = nextHandle++; timers.push({ h, fn, ms }); return h; },
+    clearTimer: (h) => { timers = timers.filter((t) => t.h !== h); },
+    onLog: (kind, detail) => logs.push(kind + ": " + detail),
+    pollMs: 5000,
+    seen,
+  }, overrides || {}));
+}
+let notifier = makeNotifier();
+function report() {
+  return JSON.stringify({
+    announced: announcedCalls, logs, cursor, seen, armedTimers: timers.length,
+  });
+}
+"""
+
+
+def run_notifier(script: str) -> dict:
+    program = "\n".join(
+        [
+            client.notifier_source(),
+            _NOTIFIER_HARNESS,
+            textwrap.dedent(script),
+            "console.log(report());",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", program],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestTheBuddyClock:
+    """#962. The notifier is the buddy's one clock: it polls the spool and
+    volunteers replies — through the injected announce(), never its own
+    speaking path."""
+
+    def test_three_replies_are_one_utterance(self):
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "minecraft", kind: "done", text: "finished; 4 options" },
+              { id: "m2", from: "billing", kind: "note", text: "deploy went out" },
+              { id: "m3", from: "docs", kind: "done", text: "draft ready" },
+            ];
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        text = report["announced"][0]["text"]
+        for who in ("minecraft", "billing", "docs"):
+            assert who in text
+        assert report["announced"][0]["meta"]["inboxIds"] == ["m1", "m2", "m3"]
+
+    def test_it_never_barges_in_and_loses_nothing_by_waiting(self):
+        """Both halves of the gate: blocked while the owner is busy, and the
+        very same reply is volunteered on the next tick — a wrongly-silent
+        clock is a silent loop, not a safe failure."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            speakable = false;
+            await notifier.pollOnce();
+            logs.push("blocked: " + announcedCalls.length);
+            speakable = true;
+            await notifier.pollOnce();
+        """)
+        assert "blocked: 0" in report["logs"]
+        assert len(report["announced"]) == 1
+
+    def test_ack_happens_only_after_it_was_spoken(self):
+        """The cohort-teardown lesson: collect the report, THEN kill the
+        child. Acking on read marks delivered a report the owner never
+        heard."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            logs.push("cursor after announce: " + cursor);
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+        """)
+        assert "cursor after announce: 0" in report["logs"]
+        assert report["cursor"] == 1
+        assert report["seen"] == {"m1": True}
+
+    def test_a_pending_notice_is_not_reannounced_by_the_next_tick(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            await notifier.pollOnce();   // still unacked — must not repeat
+        """)
+        assert len(report["announced"]) == 1
+
+    def test_a_spoken_reply_is_never_replayed_across_a_reconnect(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+            cursor = 0;                  // even if the spool is re-read whole
+            notifier = makeNotifier();   // the reconnect
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+
+    def test_an_announced_but_unheard_reply_is_retried_after_reconnect(self):
+        """The other half: announced is not heard. A session that died before
+        speaking must not count the notice delivered — the new notifier says
+        it again."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();   // announced… and the session dies
+            notifier = makeNotifier();   // never spoken, never acked
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+
+    def test_a_reply_landing_between_speak_and_ack_is_not_silently_acked(self):
+        """ack advances the cursor past EVERYTHING unread, including a message
+        that arrived after the peek. That message was never spoken — it must
+        surface on a later tick, not vanish behind the cursor."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            spool.push({ id: "m2", from: "billing", kind: "note", text: "late arrival" });
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        assert "billing" in report["announced"][1]["text"]
+        assert report["announced"][1]["meta"]["inboxIds"] == ["m2"]
+
+    def test_an_empty_inbox_is_silence(self):
+        """The recipient never replying produces silence — no follow-up, no
+        apology, no chatter."""
+        report = run_notifier("""
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+        """)
+        assert report["announced"] == []
+
+    def test_a_failed_poll_is_logged_not_spoken_and_not_fatal(self):
+        report = run_notifier("""
+            notifier = makeNotifier({
+              fetchInbox: () => Promise.resolve({ success: false, error: "bridge down" }),
+            });
+            await notifier.pollOnce();
+        """)
+        assert report["announced"] == []
+        assert any("bridge down" in line for line in report["logs"])
+
+    def test_start_arms_the_loop_and_stop_disarms_it(self):
+        report = run_notifier("""
+            notifier.start();
+            await new Promise((r) => setImmediate(r));
+            logs.push("armed after start: " + timers.length);
+            notifier.stop();
+            logs.push("armed after stop: " + timers.length);
+        """)
+        assert "armed after start: 1" in report["logs"]
+        assert "armed after stop: 0" in report["logs"]
+
+    def test_the_page_wires_the_notifier_through_announce_only(self):
+        """No second speaking path (#950): the notifier's announce dep IS the
+        page's announce, the poll interval is a named constant, and the
+        response.create count is unchanged."""
+        page = client.page("buddy", "tok")
+        assert client.notifier_source().strip() in page
+        assert "const INBOX_POLL_MS" in page
+        assert "createInboxNotifier({" in page
+        assert "announce: announce," in page
+        assert page.count('type: "response.create"') == 2
+
+    def test_the_page_gates_on_owner_and_response_state(self):
+        page = client.page("buddy", "tok")
+        assert (
+            "canSpeak: () => !ownerSpeaking && !responseActive"
+            " && !!announcer && announcer.pending() === 0," in page
+        )
+        started = page.split('case "input_audio_buffer.speech_started":', 1)[1]
+        assert "ownerSpeaking = true;" in started.split("break;", 1)[0]
+        committed = page.split('case "input_audio_buffer.committed":', 1)[1]
+        assert "ownerSpeaking = false;" in committed.split("break;", 1)[0]
+
+    def test_the_page_polls_the_inbox_tool_and_acks_via_on_spoken(self):
+        page = client.page("buddy", "tok")
+        assert (
+            'fetchInbox: () => post("/tool", { name: "buddy_inbox",'
+            " arguments: { ack: false } })," in page
+        )
+        assert (
+            'ackInbox: () => post("/tool", { name: "buddy_inbox",'
+            " arguments: { ack: true } })," in page
+        )
+        # onSpoken routes a spoken notice back to the notifier for the ack.
+        onspoken_body = page.split("function onSpoken(meta, how)", 1)[1]
+        assert "meta.inboxIds" in onspoken_body.split("function send", 1)[0]
+
+    def test_heard_replies_survive_stop_but_the_notifier_does_not(self):
+        page = client.page("buddy", "tok")
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "inboxNotifier.stop();" in stop_body
+        assert "heardReplies =" not in stop_body
+        assert "heardReplies[" not in stop_body
+
+
 class TestThePageEmbedsTheRealThing:
     def test_the_page_contains_the_announcer_verbatim(self):
         """The tests above run ``announcer_source()``; the page must embed the

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -470,6 +470,132 @@ class TestOneAnnouncementLogsOnce:
         assert ".heard" in page
 
 
+class TestTheGreeting:
+    """#963. On connect the buddy speaks first — and the greeting doubles as
+    the health check for the fail-closed write path (#950): heard greeting =
+    model audio works = approvals can work. So the greeting must be spoken by
+    the MODEL; the browser fallback proving "a voice works" would prove exactly
+    the wrong voice. Resolution of that tension with the announcer's
+    default-fallback design: the fallback stays armed (silence is still
+    unacceptable) but its text is a WARNING that model audio is dead, riding
+    the existing fallbackText channel — the failure is surfaced, not papered
+    over."""
+
+    def test_a_model_spoken_greeting_disarms_and_reports_model(self):
+        report = run_announcer("""
+            announcer.announce("Hey, I'm listening. What's on your mind?",
+                               { greeting: true },
+                               "warning text");
+            announcer.onResponseDone("Hey I'm listening, what's on your mind?");
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["anchored"] == [{"meta": {"greeting": True}, "how": "model"}]
+
+    def test_dead_model_audio_surfaces_the_warning_not_the_greeting(self):
+        """THE non-cosmetic case: model audio dead. The browser voice must NOT
+        utter the greeting (that confirms the wrong voice while the write path
+        is silently unusable) — it utters the warning that names the failure."""
+        report = run_announcer("""
+            announcer.announce("Hey, I'm listening. What's on your mind?",
+                               { greeting: true },
+                               "Heads up, my main voice is not working.");
+            fireTimers();
+        """)
+        assert report["spoken"] == ["Heads up, my main voice is not working."]
+        assert report["anchored"] == [
+            {"meta": {"greeting": True}, "how": "fallback"}
+        ]
+
+    def test_cancel_withdraws_a_queued_greeting_entirely(self):
+        """The owner speaking first cancels the greeting, not queues behind it.
+        A withdrawn item must never be spoken by either voice and never reach
+        onSpoken."""
+        report = run_announcer("""
+            announcer.onResponseCreated();  // something else is speaking
+            announcer.announce("first item", null);
+            announcer.announce("the greeting", { greeting: true }, "warning");
+            announcer.cancel(function (m) { return m && m.greeting; });
+            announcer.onResponseDone("first item");
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["pending"] == 0
+        # only the first item's spoken evidence — the greeting never reports.
+        assert report["anchored"] == [{"meta": None, "how": "model"}]
+
+    def test_cancel_of_the_current_greeting_disarms_its_fallback(self):
+        """Cancelling mid-flight: the timer must be disarmed (or the fallback
+        speaks a greeting the owner already talked over), and a later
+        response.done carrying the greeting text must not count as spoken."""
+        report = run_announcer("""
+            announcer.announce("the greeting", { greeting: true }, "warning");
+            announcer.onResponseCreated();     // model begins speaking it
+            announcer.cancel(function (m) { return m && m.greeting; });
+            announcer.onResponseDone("the greeting");   // partial audio's ASR
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["anchored"] == []
+        assert report["armedTimers"] == 0
+
+    def test_cancel_leaves_unrelated_announcements_alone(self):
+        report = run_announcer("""
+            announcer.announce("a refusal that must still speak");
+            announcer.cancel(function (m) { return m && m.greeting; });
+            fireTimers();
+        """)
+        assert report["spoken"] == ["a refusal that must still speak"]
+
+    def test_the_page_greets_only_when_genuinely_ready(self):
+        """Channel-open is not readiness: the greet site requires the server's
+        session.created AND the audio track being attached, and fires once."""
+        page = client.page("buddy", "tok")
+        greet_body = page.split("function maybeGreet() {", 1)[1].split("\n}", 1)[0]
+        assert "if (greeted || !sessionReady || !audioAttached) return;" in greet_body
+        assert "greeted = true;" in greet_body
+        assert 'case "session.created":' in page
+        # both readiness legs re-check, whichever lands last.
+        assert page.count("maybeGreet()") >= 2
+
+    def test_the_page_never_regreets_on_reconnect(self):
+        """`greeted` is page-lifetime: stop() resets session state but must
+        NOT reset it — a dropped and re-established connection stays quiet."""
+        page = client.page("buddy", "tok")
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "greeted = false" not in stop_body
+        assert "greeted = true" not in stop_body
+
+    def test_the_owner_speaking_cancels_the_greeting_on_the_page(self):
+        """speech_started both suppresses a not-yet-fired greeting and
+        withdraws a queued/current one."""
+        page = client.page("buddy", "tok")
+        started = page.split('case "input_audio_buffer.speech_started":', 1)[1]
+        started = started.split("break;", 1)[0]
+        assert "greeted = true;" in started
+        assert "announcer.cancel(" in started
+
+    def test_the_greeting_rides_announce_not_a_new_speaking_path(self):
+        """#950's constraint, pinned: response.create appears exactly twice in
+        the page — the announcer's pump and maybeCreateResponse. The greeting
+        (and everything else new) adds no third."""
+        page = client.page("buddy", "tok")
+        assert page.count('type: "response.create"') == 2
+        assert "announce(GREETING" in page
+
+    def test_the_greeting_literals_are_speakable(self):
+        page = client.page("buddy", "tok")
+        import re
+
+        greeting = re.search(r'const GREETING = "([^"]+)";', page)
+        warning = re.search(r'const MODEL_AUDIO_DEAD = "([^"]+)";', page)
+        assert greeting and warning
+        for line in (greeting.group(1), warning.group(1)):
+            assert "`" not in line and "_" not in line, line
+        # the warning names the consequence — the owner cannot see a screen.
+        assert "approve" in warning.group(1).lower()
+
+
 class TestThePageEmbedsTheRealThing:
     def test_the_page_contains_the_announcer_verbatim(self):
         """The tests above run ``announcer_source()``; the page must embed the


### PR DESCRIPTION
Client half of both issues, on top of voice-confirm-spine.

**#963 — the greeting.** Fires through `announce()` once the session is genuinely ready (`session.created` AND the audio track attached — channel-open is not readiness). The fail-closed tension is resolved by riding the existing `fallbackText` channel rather than disabling the fallback: the announcer's timer stays armed (silence stays unacceptable), but for the greeting the browser voice utters `MODEL_AUDIO_DEAD` — a warning naming the failure and its consequence — never the greeting itself. So a heard greeting proves model audio and the whole approval path; a robot-voice warning surfaces a dead write path at second zero. Cost stated plainly: the greeting itself is never fallback-spoken; what you get instead is the diagnostic. The owner speaking first withdraws the greeting via the new `announcer.cancel(match)` (queue + fallback timer; native barge-in covers audio already playing), and `greeted` is page-lifetime so a reconnect stays quiet.

**#962 — the clock.** `createInboxNotifier`, the same injected-deps factory pattern as the announcer, exercised under node against a fake bridge with real cursor semantics. Peek (`buddy_inbox ack:false`) every `INBOX_POLL_MS` (5s — one tiny local POST per tick, far inside conversational patience); gate on `!ownerSpeaking && !responseActive && announcer.pending() === 0` (a blocked tick claims nothing and loses nothing); coalesce all fresh replies into one utterance; ack (`ack:true`) only from the announcer's `onSpoken`. `heardReplies` is marked at spoken-time and survives `stop()`, so a reconnect never replays a spoken notice and *does* retry an announced-but-unheard one. Messages the ack swept past without being spoken are re-queued as strays for the next gated tick. No promise language in the notice.

No new speaking path: `response.create` still appears exactly twice in the page (announcer pump + `maybeCreateResponse`), pinned by test.

Verified in-worktree: `uv run pytest tests/unit/` — 3468 passed; `uv run --no-sync ruff check agentwire/ tests/` clean. 4 mutation checks (greet-once flag, cancel-disarm, barge-in gate, ack-on-read) each landed (scoped assert) and each went red.

Closes #963
Closes #962

Built by [dotdev.dev](https://dotdev.dev)