### PR TITLE
voice-layer: page-lifetime strays + confirm-outstanding gate leg (wave-2 D1/D2)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -323,6 +323,12 @@ INBOX_NOTIFIER_JS = """
 //              builds a fresh notifier over the same map and cannot replay a
 //              spoken notice — while a notice announced but never SPOKEN is
 //              not in it, and is correctly said again.
+//   strays: [] page-lifetime array of acked-but-never-spoken replies (the
+//              peek/ack race — see noticeSpoken). The cursor is already past
+//              them, so the spool will NEVER return them again: this array is
+//              their only way back to the owner's ear, and giving it to the
+//              notifier to own meant a stop() before the next gated tick took
+//              it to the grave. Passed in for the same reason `seen` is.
 function createInboxNotifier(deps) {
   var fetchInbox = deps.fetchInbox;
   var ackInbox = deps.ackInbox;
@@ -333,15 +339,12 @@ function createInboxNotifier(deps) {
   var onLog = deps.onLog || function () {};
   var pollMs = deps.pollMs;
   var seen = deps.seen;
+  var strays = deps.strays;
 
   // Announced this session but not yet confirmed spoken. Per-notifier on
   // purpose: if the session dies mid-announcement the map dies with it, so
   // the unheard notice is retried — `seen` alone decides what is settled.
   var inFlight = {};
-  // Acked-but-never-spoken messages (the peek/ack race — see noticeSpoken).
-  // The cursor has moved past them, so the spool will never return them
-  // again; this list is their only way back to the owner's ear.
-  var strays = [];
   var timer = null;
   var stopped = false;
 
@@ -439,6 +442,39 @@ function createInboxNotifier(deps) {
 }
 """
 
+#: The confirm-outstanding gate (#962 never-barge-in, wave-2 D2). A proposal
+#: SPOKEN but not yet answered is a handshake in progress: the buddy must not
+#: volunteer an inbox notice between "say confirm X" and the owner saying it.
+#: The interjection cannot corrupt the confirm — the nonce is unreachable from
+#: any delivered body since #953 — it is barging in, which #962 forbids on its
+#: own. Both halves of the guard are priced (the messaging drain's lesson): the
+#: false-accept is one rude interjection; the false-reject is a buddy that goes
+#: silently mute in a screenless channel, so the block EXPIRES on the
+#: proposal's own TTL rather than on an outcome the owner may never produce.
+#: Same injected-deps discipline as the announcer and the notifier, so the TTL
+#: behaviour runs under node; exported by :func:`confirm_gate_source`.
+CONFIRM_GATE_JS = """
+// "A proposal is outstanding" is a client-side mirror of the spine, driven by
+// the two edges the client actually observes: anchored() when the announcer
+// confirms the proposal was SPOKEN (the same evidence that starts the server
+// TTL), resolved() when a write tool returns a terminal outcome. An outcome
+// the owner never produces is covered by the TTL, never waited on.
+function createConfirmGate(deps) {
+  var now = deps.now;
+  var ttlMs = deps.ttlMs;
+  // -1 is "no proposal", not a zero timestamp — a proposal anchored at
+  // clock 0 is still a proposal.
+  var since = -1;
+  return {
+    anchored: function () { since = now(); },
+    resolved: function () { since = -1; },
+    outstanding: function () {
+      return since >= 0 && now() - since < ttlMs;
+    },
+  };
+}
+"""
+
 _PAGE = """<!doctype html>
 <html lang="en">
 <head>
@@ -502,6 +538,7 @@ _PAGE = """<!doctype html>
 <script>
 __ANNOUNCER__
 __NOTIFIER__
+__CONFIRM_GATE__
 
 const TOKEN = __TOKEN__;
 const CALLS_URL = "https://api.openai.com/v1/realtime/calls";
@@ -540,8 +577,27 @@ const INBOX_POLL_MS = 5000;
 // Page-lifetime: ids the owner has actually HEARD. Never reset by stop() — a
 // reconnect must not replay every notice.
 const heardReplies = {};
+// Page-lifetime, like heardReplies: acked-but-never-spoken replies (the
+// peek/ack race). The cursor is already past them and the spool has no
+// ack-by-id, so this array is their only way back to the owner's ear — a
+// stop() or reconnect must not take it down with the notifier. A full page
+// unload still loses whatever is here; closing that residual needs an
+// ack-by-id the inbox does not offer.
+const strayReplies = [];
 let inboxNotifier = null;
 let ownerSpeaking = false;
+
+// The confirm handshake's gate leg (#962, wave-2 D2): closed while a spoken
+// proposal awaits the owner's confirm word, reopened by a terminal write-tool
+// outcome or by the proposal's own TTL — never left waiting on an answer the
+// owner may not give. Page-lifetime on purpose: the spine lives in the
+// bridge, so a proposal survives a stop(), and a reconnect inside the TTL
+// can still be answered.
+const confirmGate = createConfirmGate({
+  now: () => Date.now(),
+  // Mirrors confirm.PROPOSAL_TTL_S — the bound on the false-reject half.
+  ttlMs: 120000,
+});
 
 // --- the greeting (#963) ----------------------------------------------------
 // The buddy speaks first — and since #950 the write path is fail-closed on
@@ -666,6 +722,9 @@ function onSpoken(meta, how) {
     return;
   }
   if (!meta || !meta.anchor) return;
+  // The proposal is now HEARD and the confirm window is open — the same
+  // evidence that starts the server-side TTL closes the volunteering gate.
+  confirmGate.anchored();
   log("speak", "anchored proposal " + meta.anchor + " (" + how + ")", "tool");
   forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
 }
@@ -741,6 +800,16 @@ async function handleFunctionCall(item) {
   // A proposal rides along as `meta.anchor`: it is anchored when the announcer
   // confirms the text was actually SPOKEN, by the model or by the fallback
   // voice — never merely because some response.done happened to carry text.
+  // A terminal outcome from the write tools ends the confirm handshake and
+  // reopens the volunteering gate. A wait outcome (owner_should_wait —
+  // pending_transcript / not_announced) keeps the proposal live, so it keeps
+  // the gate closed; the TTL covers an owner who never answers at all.
+  if (
+    (item.name === "send_session_message" || item.name === "cancel_session_message")
+    && result && !result.owner_should_wait
+  ) {
+    confirmGate.resolved();
+  }
   const mustSpeak = !!(result && result.must_speak && result.say);
   sendFunctionCallOutput(item.call_id, result, mustSpeak);
   if (mustSpeak) {
@@ -821,12 +890,13 @@ async function start() {
       fetchInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: false } }),
       ackInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: true } }),
       announce: announce,
-      canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0,
+      canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0 && !confirmGate.outstanding(),
       setTimer: (fn, ms) => window.setTimeout(fn, ms),
       clearTimer: (handle) => window.clearTimeout(handle),
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
       pollMs: INBOX_POLL_MS,
       seen: heardReplies,
+      strays: strayReplies,
     });
     dc.addEventListener("open", () => { setStatus("listening"); $stop.disabled = false; });
     dc.addEventListener("close", () => setStatus("closed"));
@@ -998,7 +1068,11 @@ function stop() {
   sessionReady = false;
   audioAttached = false;
   ownerSpeaking = false;
-  // The clock dies with the session; `heardReplies` deliberately survives, so
+  // The clock dies with the session; `heardReplies` and `strayReplies`
+  // deliberately survive (a stray is cursor-past — losing the array loses the
+  // message for good), and `confirmGate` survives too: the spine lives in the
+  // bridge, so a proposal outlasts a stop() and its TTL is what reopens the
+  // gate. `heardReplies` survives so
   // the fresh notifier after a reconnect cannot replay a spoken notice (#962).
   if (inboxNotifier) { inboxNotifier.stop(); inboxNotifier = null; }
   // A notice pending when the session died was never going to be spoken by
@@ -1037,11 +1111,21 @@ def notifier_source() -> str:
     return INBOX_NOTIFIER_JS
 
 
+def confirm_gate_source() -> str:
+    """The confirm-outstanding gate on its own, for the node-driven tests.
+
+    Same rule as :func:`announcer_source`: the code under test is
+    byte-identical to the code in the page.
+    """
+    return CONFIRM_GATE_JS
+
+
 def page(buddy: str, token: str) -> str:
     """Render the client page for one buddy + one run token."""
     return (
         _PAGE.replace("__ANNOUNCER__", ANNOUNCER_JS)
         .replace("__NOTIFIER__", INBOX_NOTIFIER_JS)
+        .replace("__CONFIRM_GATE__", CONFIRM_GATE_JS)
         .replace("__BUDDY__", html.escape(buddy))
         .replace("__TOKEN__", json.dumps(token))
     )

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -604,6 +604,7 @@ _NOTIFIER_HARNESS = """
 const announcedCalls = [];
 const logs = [];
 const seen = {};
+const strays = [];
 let spool = [];
 let cursor = 0;
 let speakable = true;
@@ -628,12 +629,14 @@ function makeNotifier(overrides) {
     onLog: (kind, detail) => logs.push(kind + ": " + detail),
     pollMs: 5000,
     seen,
+    strays,
   }, overrides || {}));
 }
 let notifier = makeNotifier();
 function report() {
   return JSON.stringify({
     announced: announcedCalls, logs, cursor, seen, armedTimers: timers.length,
+    strays: strays.length,
   });
 }
 """
@@ -754,6 +757,25 @@ class TestTheBuddyClock:
         assert "billing" in report["announced"][1]["text"]
         assert report["announced"][1]["meta"]["inboxIds"] == ["m2"]
 
+    def test_a_stray_reply_survives_stop_before_the_next_tick(self):
+        """The wave-2 D1 construction: a reply lands between the peek and the
+        ack, the cursor advances past it, and the owner clicks Stop before the
+        next gated tick. The stray's home must outlive the notifier — the
+        spool will never return that message again (there is no ack-by-id),
+        so a per-notifier array is its grave."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            spool.push({ id: "m2", from: "billing", kind: "note", text: "late arrival" });
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+            notifier.stop();             // owner clicks Stop with the stray pending
+            notifier = makeNotifier();   // the reconnect
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        assert "billing" in report["announced"][1]["text"]
+        assert report["announced"][1]["meta"]["inboxIds"] == ["m2"]
+
     def test_an_empty_inbox_is_silence(self):
         """The recipient never replying produces silence — no follow-up, no
         apology, no chatter."""
@@ -799,7 +821,8 @@ class TestTheBuddyClock:
         page = client.page("buddy", "tok")
         assert (
             "canSpeak: () => !ownerSpeaking && !responseActive"
-            " && !!announcer && announcer.pending() === 0," in page
+            " && !!announcer && announcer.pending() === 0"
+            " && !confirmGate.outstanding()," in page
         )
         started = page.split('case "input_audio_buffer.speech_started":', 1)[1]
         assert "ownerSpeaking = true;" in started.split("break;", 1)[0]
@@ -826,6 +849,114 @@ class TestTheBuddyClock:
         assert "inboxNotifier.stop();" in stop_body
         assert "heardReplies =" not in stop_body
         assert "heardReplies[" not in stop_body
+
+    def test_strays_get_the_same_page_lifetime_home_as_heard_replies(self):
+        """D1: the page owns the strays array and passes it in like `seen`;
+        stop() must not touch it — a stray is cursor-past, so this array is
+        the only route left to the owner's ear."""
+        page = client.page("buddy", "tok")
+        assert "const strayReplies = [];" in page
+        wiring = page.split("createInboxNotifier({", 1)[1].split("});", 1)[0]
+        assert "strays: strayReplies," in wiring
+        # Pin the operations, not the mentions: stop() must not reassign or
+        # mutate the array (a comment naming it is fine).
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "strayReplies =" not in stop_body
+        assert "strayReplies." not in stop_body
+
+
+_CONFIRM_GATE_HARNESS = """
+let clock = 0;
+const gate = createConfirmGate({ now: () => clock, ttlMs: 120000 });
+function report() { return JSON.stringify({ outstanding: gate.outstanding() }); }
+"""
+
+
+def run_confirm_gate(script: str) -> dict:
+    program = "\n".join(
+        [
+            client.confirm_gate_source(),
+            _CONFIRM_GATE_HARNESS,
+            textwrap.dedent(script),
+            "console.log(report());",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", program],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestTheConfirmGate:
+    """D2 (#962 never-barge-in): a spoken proposal awaiting the owner's
+    confirm word closes the volunteering gate — and BOTH halves are priced:
+    the block is real, and it expires with the proposal's TTL so an
+    unanswered proposal cannot silence the buddy forever."""
+
+    def test_no_proposal_means_the_gate_is_open(self):
+        assert run_confirm_gate("")["outstanding"] is False
+
+    def test_an_anchored_proposal_closes_the_gate(self):
+        assert run_confirm_gate("gate.anchored();")["outstanding"] is True
+
+    def test_a_resolved_proposal_reopens_it(self):
+        report = run_confirm_gate("""
+            gate.anchored();
+            gate.resolved();
+        """)
+        assert report["outstanding"] is False
+
+    def test_the_ttl_bounds_the_false_reject(self):
+        """The wrongful-no half: an owner who never answers must not mute
+        volunteering forever. The gate expires on the proposal's own TTL."""
+        report = run_confirm_gate("""
+            gate.anchored();
+            clock = 119999;
+            if (!gate.outstanding()) throw new Error("expired early");
+            clock = 120000;
+        """)
+        assert report["outstanding"] is False
+
+    def test_a_new_proposal_restarts_the_clock(self):
+        report = run_confirm_gate("""
+            gate.anchored();
+            clock = 100000;
+            gate.anchored();
+            clock = 200000;   // 100s after the second anchor, 200s after the first
+        """)
+        assert report["outstanding"] is True
+
+    def test_the_page_wires_the_gate_to_the_anchor_and_the_outcome(self):
+        """The gate's edges on the page: closed when the proposal is SPOKEN
+        (the onSpoken anchor branch), reopened only by a terminal outcome of
+        the write tools — a wait outcome (owner_should_wait) keeps the
+        proposal live, so it must not reopen the gate."""
+        page = client.page("buddy", "tok")
+        assert client.confirm_gate_source().strip() in page
+        # ttl mirrors confirm.PROPOSAL_TTL_S — the false-reject bound.
+        assert "ttlMs: 120000" in page
+        anchor_branch = page.split("if (!meta || !meta.anchor) return;", 1)[1]
+        assert "confirmGate.anchored();" in anchor_branch.split("}", 1)[0]
+        dispatch = page.split("async function handleFunctionCall(item)", 1)[1]
+        resolved_at = dispatch.split("confirmGate.resolved();", 1)[0]
+        assert '"send_session_message"' in resolved_at
+        assert '"cancel_session_message"' in resolved_at
+        assert "owner_should_wait" in resolved_at
+
+    def test_the_gate_survives_stop_because_the_proposal_does(self):
+        """The spine lives in the bridge, not the page: a reconnect inside
+        the TTL can still be answered, so stop() leaves the gate alone and
+        the TTL is what reopens it."""
+        page = client.page("buddy", "tok")
+        # Operations, not mentions: stop() must not resolve or re-anchor.
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "confirmGate.resolved" not in stop_body
+        assert "confirmGate.anchored" not in stop_body
 
 
 class TestThePageEmbedsTheRealThing:

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -943,6 +943,10 @@ class TestTheConfirmGate:
         anchor_branch = page.split("if (!meta || !meta.anchor) return;", 1)[1]
         assert "confirmGate.anchored();" in anchor_branch.split("}", 1)[0]
         dispatch = page.split("async function handleFunctionCall(item)", 1)[1]
+        dispatch = dispatch.split("function spokenText", 1)[0]
+        # The call must exist — split() on a missing token returns the whole
+        # string and every assertion below goes green on comments alone.
+        assert "confirmGate.resolved();" in dispatch
         resolved_at = dispatch.split("confirmGate.resolved();", 1)[0]
         assert '"send_session_message"' in resolved_at
         assert '"cancel_session_message"' in resolved_at


### PR DESCRIPTION
Follow-up to the wave-2 combination review on #965 (comment 5233469392). Fixes both defects; addresses #962's ack-only-after-heard and never-barge-in hazards.

## D1 — a reply acked but never heard could be lost forever

**Shape chosen: page-lifetime strays, because ack-by-id does not exist.** The reviewer's preferred shape (never cursor-advance past an unspoken message) requires an ack-to-id the inbox does not offer: `buddy_inbox` takes only `ack: bool`, and `delivery.read_spool(ack=True)` unconditionally writes the cursor to the spool **tail** (`delivery.py:166-167`). So `strays` now gets the same home `heardReplies` already has — a page-level `const strayReplies = []` injected into the notifier like `seen` — and `stop()`/reconnect no longer takes it to the grave.

**Finding worth its own follow-up:** the cursor is already id-based (`{"last_id": ...}`), so an `ack_through: <id>` parameter on `buddy_inbox`/`read_spool` would be a small change that closes the loss window *structurally* — the cursor would simply never pass an unspoken message. **Residual with the shape shipped here:** a full page unload (not stop — navigation/close) with strays pending still loses them; only ack-by-id removes that.

The new test constructs the exact race: reply lands between peek and ack, `stop()`, reconnect — the stray must still be volunteered (`test_a_stray_reply_survives_stop_before_the_next_tick`).

## D2 — the buddy could interrupt its own confirm handshake

A fourth gate leg, at etiquette weight: `createConfirmGate` (same injected-deps factory discipline as the announcer/notifier, node-tested) — `anchored()` on the onSpoken anchor edge (the same evidence that starts the server TTL), `resolved()` on a terminal `send_session_message`/`cancel_session_message` result (`owner_should_wait` outcomes keep it closed), and `outstanding()` expires at 120 s mirroring `confirm.PROPOSAL_TTL_S`. Both halves priced: the false-reject (owner never answers → buddy mute forever, invisible in a screenless channel) is bounded by the TTL, tested by `test_the_ttl_bounds_the_false_reject`. The gate survives `stop()` deliberately — the spine lives in the bridge, so a proposal outlives the page session and its TTL is what reopens the gate.

## Method

- All 9 new/changed tests watched red against b4446fb before implementation; 75/75 in the file after.
- Full suite **3482 passed** (baseline 3473 + 9); CI's own lint (`uv run --no-sync ruff check agentwire/ tests/`) clean.
- 4 mutations, each landing-asserted by a scoped (not whole-file) check, each reverted from a `cp` backup (never `git checkout`): per-notifier strays → D1 race test red; gate leg removed from canSpeak → gate pin red; TTL bound removed → TTL test red; `confirmGate.resolved()` deleted → **initially survived** (my page test split on a missing token and went green on comments), strengthened the test to assert the call's presence, re-ran → red.
- No second speaking path: `response.create` literal count still exactly 2, pin tests green.

Closes nothing on its own — review follow-up to #962/#965.

Built by [dotdev.dev](https://dotdev.dev)