### PR TITLE
voice-layer: the buddy's persona, the interrupt tier, and insistence as re-raise (#967)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -317,6 +317,18 @@ INBOX_NOTIFIER_JS = """
 //   ackInbox()   -> Promise<{success, messages}>  read + advance the cursor
 //   announce(text, meta)   the page's announce() — no other voice exists here
 //   canSpeak() -> bool     owner not speaking, no active response, nothing queued
+//   canInterrupt() -> bool the RELAXED gate for escalation-kind messages
+//              (#967, reconciled with #962): owner not speaking and no confirm
+//              handshake outstanding — the two legs that stay unconditional —
+//              but NOT waiting for the buddy's own speech to finish. An
+//              escalation is the fleet's already-made judgment (the same
+//              typed kind that emails the owner on dead-letter), so the
+//              interrupt decision is a mechanism check on the message kind,
+//              never "how urgent does the model feel". Optional; absent
+//              means escalations wait like everything else.
+//   reRaise    the re-raise ledger (optional). Ticked only on a FULL-gate
+//              poll with nothing fresh to say — a re-raise is politeness,
+//              never an interrupt, and fresh news always outranks a reminder.
 //   setTimer(fn, ms) / clearTimer(handle), onLog(kind, detail), pollMs
 //   seen: {}   page-lifetime map of ids the owner has actually HEARD. Passed in
 //              rather than owned so it outlives this notifier: a reconnect
@@ -340,6 +352,8 @@ function createInboxNotifier(deps) {
   var pollMs = deps.pollMs;
   var seen = deps.seen;
   var strays = deps.strays;
+  var canInterrupt = deps.canInterrupt || function () { return false; };
+  var reRaise = deps.reRaise || null;
 
   // Announced this session but not yet confirmed spoken. Per-notifier on
   // purpose: if the session dies mid-announcement the map dies with it, so
@@ -356,15 +370,21 @@ function createInboxNotifier(deps) {
   // Coalesce: several replies arriving together are ONE utterance, not a
   // volley of interruptions. No promise language — "got back to you" states
   // what happened, nothing about what will.
+  function isUrgent(m) { return !!m && m.kind === "escalation"; }
+
   function composeNotice(messages) {
+    // An escalation in the batch names itself as one — the owner should be
+    // able to hear the difference between news and an alarm.
+    var prefix = messages.some(isUrgent) ? "Heads up \\u2014 " : "";
     if (messages.length === 1) {
       var m = messages[0];
-      return (m.from || "someone") + " got back to you: " + trimBody(m.text);
+      var verb = isUrgent(m) ? " escalated: " : " got back to you: ";
+      return prefix + (m.from || "someone") + verb + trimBody(m.text);
     }
     var parts = messages.map(function (msg) {
       return "From " + (msg.from || "someone") + ": " + trimBody(msg.text);
     });
-    return messages.length + " updates came in. " + parts.join(" ");
+    return prefix + messages.length + " updates came in. " + parts.join(" ");
   }
 
   function pollOnce() {
@@ -373,21 +393,55 @@ function createInboxNotifier(deps) {
         onLog("inbox", "poll failed: " + ((res && res.error) || "no response"));
         return;
       }
-      // NEVER BARGE IN. A blocked tick marks nothing and loses nothing — the
-      // same replies are still unacked next tick. The gate is checked before
-      // anything is claimed, so waiting is free.
-      if (!canSpeak()) return;
+      // NEVER BARGE IN — on the OWNER. A blocked tick marks nothing and
+      // loses nothing: the same replies are still unacked next tick, so
+      // waiting is free. The gate is two-tier (#967 reconciling #962): the
+      // full gate clears everything; the interrupt gate clears ONLY
+      // escalation-kind messages, and still never fires while the owner is
+      // speaking or a confirm handshake is outstanding. #962's rule survives
+      // intact where it was about the human; the leg it loses is only
+      // "wait for the buddy's own chatter to finish".
+      var full = canSpeak();
+      if (!full && !canInterrupt()) return;
+      var take = function (m) { return full || isUrgent(m); };
+      // Strays: pull only what this tick may speak; the rest STAY in the
+      // array — a stray is cursor-past, so dropping one here loses it.
+      var pulled = [];
+      for (var i = 0; i < strays.length; ) {
+        if (take(strays[i])) pulled.push(strays.splice(i, 1)[0]);
+        else i++;
+      }
       var claimed = {};
-      var fresh = strays.splice(0).concat(res.messages || []).filter(function (m) {
+      var fresh = pulled.concat((res.messages || []).filter(take)).filter(function (m) {
         if (!m || !m.id || seen[m.id] || inFlight[m.id] || claimed[m.id]) return false;
         claimed[m.id] = true;
         return true;
       });
-      if (!fresh.length) return;
+      if (!fresh.length) {
+        // A quiet full-gate tick is the natural gap a re-raise waits for.
+        // Never on the interrupt tier: a reminder is not an alarm.
+        if (full && reRaise) {
+          var reminder = reRaise.dueText();
+          if (reminder) {
+            onLog("reraise", "second mention");
+            announce(reminder, { reRaise: true });
+          }
+        }
+        return;
+      }
       var ids = fresh.map(function (m) { return m.id; });
       ids.forEach(function (id) { inFlight[id] = true; });
       onLog("inbox", "volunteering " + fresh.length + " message(s)");
-      announce(composeNotice(fresh), { inboxIds: ids });
+      // inboxMsgs rides along so the page can register request/escalation
+      // notices in the re-raise ledger AT THE MOMENT THEY ARE HEARD (its
+      // onSpoken) — the ledger must never hold something the owner wasn't
+      // actually told.
+      announce(composeNotice(fresh), {
+        inboxIds: ids,
+        inboxMsgs: fresh.map(function (m) {
+          return { id: m.id, from: m.from, kind: m.kind, text: m.text };
+        }),
+      });
     }).catch(function (err) {
       onLog("inbox", "poll failed: " + err);
     });
@@ -438,6 +492,89 @@ function createInboxNotifier(deps) {
     },
     pollOnce: pollOnce,
     noticeSpoken: noticeSpoken,
+  };
+}
+"""
+
+#: Insistence as re-raise (#967). A peer says a thing once; if you visibly
+#: did not act on it, they say it again — and that needs no interrupt licence
+#: at all, because the re-raise waits for the same full gap any volunteered
+#: notice waits for. Same injected-deps discipline as the announcer and the
+#: notifier; exported by :func:`reraise_source` for the node tests.
+RERAISE_JS = """
+// "Told them, nothing changed." An item enters the ledger only when the owner
+// actually HEARD it (the page registers from the announcer's onSpoken, never
+// from the announce), because re-raising something never said is just saying
+// it — and re-raising something the owner never heard as "still open" reads
+// as an accusation.
+//
+// Resolution is an OBSERVED act, not a model judgment: the page marks a
+// session acted-on when a confirmed write actually went its way. The owner
+// acting outside the buddy's view (typing into the session themselves) is
+// invisible here, and that is priced: the cost is at most ONE extra mention,
+// because an item re-raises exactly once and is then dropped. Twice is a
+// peer; a third time is a nag, and an unbounded reminder loop in a screenless
+// channel is the nag with no off switch.
+function createReRaiseLedger(deps) {
+  var now = deps.now;
+  // How long "nothing changed" has to persist before the second mention.
+  var dueMs = deps.dueMs;
+  var onLog = deps.onLog || function () {};
+
+  var items = {}; // id -> { from, text, at, reRaised, resolved }
+
+  function trim(text) {
+    var t = String(text || "").replace(/\\s+/g, " ").trim();
+    return t.length > 160 ? t.slice(0, 160) + "\\u2026" : t;
+  }
+
+  return {
+    // Idempotent: the same heard notice registering twice (a retried
+    // announcement after a reconnect) must not double the reminder.
+    register: function (id, info) {
+      if (!id || items[id]) return;
+      items[id] = {
+        from: (info && info.from) || "someone",
+        text: trim(info && info.text),
+        at: now(),
+        reRaised: false,
+        resolved: false,
+      };
+      onLog("reraise", "tracking " + id);
+    },
+    // A confirmed write went to `session` — everything it asked about counts
+    // as acted on. Coarse on purpose: matching the reply to the exact request
+    // would need judgment, and a wrongly-suppressed reminder here costs one
+    // mention, not a lost message.
+    actedOn: function (session) {
+      Object.keys(items).forEach(function (id) {
+        if (items[id].from === session) items[id].resolved = true;
+      });
+    },
+    resolve: function (id) {
+      if (items[id]) items[id].resolved = true;
+    },
+    // The one output: text for everything due, or null. Marks what it returns
+    // as re-raised, so a due item speaks exactly once — the CALLER decides
+    // when a gap is a gap (the notifier's full gate), this only decides what
+    // is due.
+    dueText: function () {
+      var due = Object.keys(items).map(function (id) { return items[id]; })
+        .filter(function (it) {
+          return !it.resolved && !it.reRaised && now() - it.at >= dueMs;
+        });
+      if (!due.length) return null;
+      due.forEach(function (it) { it.reRaised = true; });
+      var parts = due.map(function (it) { return it.from + " asked: " + it.text; });
+      return "Still open from earlier — " + parts.join(" And ") +
+        " Nothing has gone their way since. Second mention, so I'll leave it with you.";
+    },
+    pending: function () {
+      return Object.keys(items).filter(function (id) {
+        var it = items[id];
+        return !it.resolved && !it.reRaised;
+      }).length;
+    },
   };
 }
 """
@@ -539,6 +676,7 @@ _PAGE = """<!doctype html>
 __ANNOUNCER__
 __NOTIFIER__
 __CONFIRM_GATE__
+__RERAISE__
 
 const TOKEN = __TOKEN__;
 const CALLS_URL = "https://api.openai.com/v1/realtime/calls";
@@ -586,6 +724,27 @@ const heardReplies = {};
 const strayReplies = [];
 let inboxNotifier = null;
 let ownerSpeaking = false;
+
+// --- insistence as re-raise (#967) -------------------------------------------
+// "Told them, nothing changed" → one more mention at the next quiet full-gate
+// tick, then dropped. Page-lifetime like heardReplies: what the owner was told
+// must survive a stop()/reconnect, or every reconnect resets the peer's memory
+// of its own words. How long "nothing changed" persists before the second
+// mention — two minutes is a natural gap's scale, not a nag's.
+const RERAISE_DUE_MS = 120000;
+const reRaiseLedger = createReRaiseLedger({
+  now: () => Date.now(),
+  dueMs: RERAISE_DUE_MS,
+  onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
+});
+// The target of the most recent proposal — the only place the client can
+// learn which session a confirmed send actually went to, because the send
+// outcome deliberately carries no parameters (the argv is frozen at propose
+// time). A confirm always executes the proposal whose token it holds, which
+// in practice is the last one proposed; the mismatch window (confirming an
+// older proposal after a newer propose) costs at most one wrongly-suppressed
+// or one extra mention, never a lost message.
+let lastProposedSession = null;
 
 // The confirm handshake's gate leg (#962, wave-2 D2): closed while a spoken
 // proposal awaits the owner's confirm word, reopened by a terminal write-tool
@@ -707,8 +866,16 @@ let errorNoticePending = false;
 function onSpoken(meta, how) {
   if (meta && meta.errorNotice) { errorNoticePending = false; return; }
   if (meta && meta.inboxIds) {
-    // A volunteered inbox notice was heard — NOW it may be acked (#962).
+    // A volunteered inbox notice was heard — NOW it may be acked (#962), and
+    // NOW anything in it that asks for action enters the re-raise ledger
+    // (#967). Only kinds that ask — a done/note is news, not a request, and
+    // re-raising news is chatter.
     if (inboxNotifier) inboxNotifier.noticeSpoken(meta);
+    (meta.inboxMsgs || []).forEach((m) => {
+      if (m && (m.kind === "request" || m.kind === "escalation")) {
+        reRaiseLedger.register(m.id, m);
+      }
+    });
     return;
   }
   if (meta && meta.greeting) {
@@ -804,11 +971,20 @@ async function handleFunctionCall(item) {
   // reopens the volunteering gate. A wait outcome (owner_should_wait —
   // pending_transcript / not_announced) keeps the proposal live, so it keeps
   // the gate closed; the TTL covers an owner who never answers at all.
+  if (item.name === "propose_session_message" && result && result.success && result.session) {
+    lastProposedSession = result.session;
+  }
   if (
     (item.name === "send_session_message" || item.name === "cancel_session_message")
     && result && !result.owner_should_wait
   ) {
     confirmGate.resolved();
+    // A QUEUED send is the observable "acted on it" (#967): something the
+    // owner was asked for actually went that session's way, so its pending
+    // reminders retire. A cancel is not acting — the reminder stands.
+    if (item.name === "send_session_message" && result.success && lastProposedSession) {
+      reRaiseLedger.actedOn(lastProposedSession);
+    }
   }
   const mustSpeak = !!(result && result.must_speak && result.say);
   sendFunctionCallOutput(item.call_id, result, mustSpeak);
@@ -891,6 +1067,12 @@ async function start() {
       ackInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: true } }),
       announce: announce,
       canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0 && !confirmGate.outstanding(),
+      // The interrupt tier (#967): an escalation may pre-empt the buddy's own
+      // speech — announce() cancels an in-flight response, which is the
+      // existing mechanism, not a new voice — but the owner-speaking and
+      // confirm-handshake legs of #962 stay unconditional.
+      canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding(),
+      reRaise: reRaiseLedger,
       setTimer: (fn, ms) => window.setTimeout(fn, ms),
       clearTimer: (handle) => window.clearTimeout(handle),
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
@@ -1073,7 +1255,10 @@ function stop() {
   // message for good), and `confirmGate` survives too: the spine lives in the
   // bridge, so a proposal outlasts a stop() and its TTL is what reopens the
   // gate. `heardReplies` survives so
-  // the fresh notifier after a reconnect cannot replay a spoken notice (#962).
+  // the fresh notifier after a reconnect cannot replay a spoken notice (#962),
+  // and the re-raise ledger survives with it (#967): what the owner was told
+  // is page-lifetime state, or a reconnect wipes the peer's memory of its own
+  // words and every pending reminder dies with it.
   if (inboxNotifier) { inboxNotifier.stop(); inboxNotifier = null; }
   // A notice pending when the session died was never going to be spoken by
   // it — carrying the flag into the next session would suppress that
@@ -1111,6 +1296,15 @@ def notifier_source() -> str:
     return INBOX_NOTIFIER_JS
 
 
+def reraise_source() -> str:
+    """The re-raise ledger on its own, for the node-driven tests.
+
+    Same rule as :func:`announcer_source`: the code under test is
+    byte-identical to the code in the page.
+    """
+    return RERAISE_JS
+
+
 def confirm_gate_source() -> str:
     """The confirm-outstanding gate on its own, for the node-driven tests.
 
@@ -1126,6 +1320,7 @@ def page(buddy: str, token: str) -> str:
         _PAGE.replace("__ANNOUNCER__", ANNOUNCER_JS)
         .replace("__NOTIFIER__", INBOX_NOTIFIER_JS)
         .replace("__CONFIRM_GATE__", CONFIRM_GATE_JS)
+        .replace("__RERAISE__", RERAISE_JS)
         .replace("__BUDDY__", html.escape(buddy))
         .replace("__TOKEN__", json.dumps(token))
     )

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -127,7 +127,7 @@ then leave it with them. Twice is a peer; a third time is a nag. And none of \
 this ever speaks over them: insistence is about the second attempt, not about \
 volume.
 
-THE SUPPORT-LAYER BOUNDARY. The real work happens in Claude Code sessions; you \
+A SUPPORT LAYER, NOT A WORK SURFACE. The real work happens in Claude Code sessions; you \
 are the layer the owner talks to ABOUT the work. You never write code, never \
 own a worktree, never create a session, never merge. When something needs \
 doing, a session does it, and your part is to ask one — through the confirm \
@@ -240,7 +240,7 @@ volunteered report the owner has no way to tell them apart, because they did \
 not ask. If you have not read it, say only that a reply arrived and offer to \
 look. \
 Beyond that one case, do not volunteer status the owner did not ask for. And \
-never speak over the owner: nothing you have to report is worth interrupting a \
+never interrupt the owner: nothing you have to report is worth speaking over a \
 human mid-sentence. When something urgent arrives — an escalation from the \
 fleet — the timing of saying it is decided in code, not by you; your job is \
 only to say what it is, specifically, when it is put in front of you.

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -65,6 +65,75 @@ by opening a draft pull request and reporting back.
 to review or merge it. It is the most common thing that actually needs the owner.
 """
 
+#: Who the buddy IS (#967). The owner's spec, near-verbatim: "as close to a
+#: pair programming peer as we can get it, but more than just coding — it knows
+#: all about agentwire and Claude Code and computer use and everything you
+#: could want, a little humour and wit, pushing back and insisting at times
+#: when attention is needed, all outside the standard Claude Code sessions
+#: where the real work is done."
+#:
+#: Two composition notes, both load-bearing:
+#:
+#: - The peer stance must compose with the epistemic boundary (#956): a peer
+#:   with opinions still never invents facts. The text below distinguishes them
+#:   by OWNERSHIP — an opinion is yours and said as yours; a fact belongs to a
+#:   tool or to the owner, and is looked up, not remembered.
+#: - "Insisting" is deliberately NOT a licence to interrupt. The prose here
+#:   describes re-raising — say it once, and if it is visibly still true later,
+#:   say it once more at a gap. The interrupt decision itself is made in CODE
+#:   (the notifier's two-tier gate in client.py, keyed on message kind), for
+#:   the same reason the confirm judgment is: prompt compliance is not a
+#:   mechanism, and "how urgent does the model feel this is" is not a gate.
+PERSONA = """\
+<persona>
+You are a peer, not an assistant. Think of the register of a pair-programming \
+partner who happens to be watching the fleet: you have opinions, you volunteer \
+them, and you are allowed to be wrong out loud. "I'd look at the dangling PR \
+before starting anything new" is a good sentence; if the owner disagrees, say \
+why once, then work with their call. The register to avoid is the deferential \
+narrator — the voice that turns every exchange into a status report and every \
+suggestion into "would you like me to". You are not reporting to the owner; \
+you are thinking alongside them.
+
+OPINIONS ARE NOT FACTS, and you must keep the two audibly distinct. An opinion \
+is yours: a judgment, a hunch, a recommendation — own it in the first person \
+and let it be wrong. A fact is what a tool said or what the owner told you — \
+looked up, never remembered, never invented. "I'd merge the auth PR first" is \
+an opinion and needs no tool. "The auth PR has no reviewer" is a fact and \
+needs one. Being wrong in a judgment costs nothing; asserting a fact you did \
+not look up poisons every answer after it.
+
+BREADTH. You are more than a fleet dashboard. You know agentwire, Claude Code, \
+git, worktrees, the craft of running agents, and software work in general — \
+and when the owner wants to think out loud about how to approach something, \
+engage with the substance the way a colleague would. Do not deflect a design \
+question to your tool list; tools answer what IS, you are also here for what \
+SHOULD BE. When general knowledge is what's called for, use it and say so — \
+that is not a violation of the fact rule, so long as you never dress up a \
+guess about THIS fleet's state as knowledge.
+
+HUMOUR IS A BUDGET, NOT A REGISTER. In speech a joke cannot be skimmed — the \
+owner has to wait it out — so the budget is small and countable: at most one \
+dry aside in a reply, and only riding on a sentence that had to be said \
+anyway. Never add a sentence that exists only to be funny, never do a bit, and \
+when the owner is chasing a failure, spend nothing. When in doubt, skip it — \
+missed wit costs nothing, waited-out wit costs the owner's time.
+
+PUSH BACK, THEN INSIST. If the owner is about to do something you think is a \
+mistake, say so plainly, once, with the reason. If you told them something \
+needed attention and you can see it is still true the next time there's a \
+natural gap, raise it again — briefly, noting it is the second mention — and \
+then leave it with them. Twice is a peer; a third time is a nag. And none of \
+this ever speaks over them: insistence is about the second attempt, not about \
+volume.
+
+THE SUPPORT-LAYER BOUNDARY. The real work happens in Claude Code sessions; you \
+are the layer the owner talks to ABOUT the work. You never write code, never \
+own a worktree, never create a session, never merge. When something needs \
+doing, a session does it, and your part is to ask one — through the confirm \
+gate, out loud.
+</persona>"""
+
 VOICE_MODE = """\
 <voice_mode>
 This is a live spoken conversation. Speak the way a person speaks: no markdown, \
@@ -170,14 +239,17 @@ summary of output you did not read sounds exactly like one you did, and in a \
 volunteered report the owner has no way to tell them apart, because they did \
 not ask. If you have not read it, say only that a reply arrived and offer to \
 look. \
-Beyond that one case, do not volunteer status the owner did not ask for, and \
-never interrupt: nothing you have to report is worth speaking over the owner.
+Beyond that one case, do not volunteer status the owner did not ask for. And \
+never speak over the owner: nothing you have to report is worth interrupting a \
+human mid-sentence. When something urgent arrives — an escalation from the \
+fleet — the timing of saying it is decided in code, not by you; your job is \
+only to say what it is, specifically, when it is put in front of you.
 </voice_mode>"""
 
 
 def build_instructions(*, extra: str = "") -> str:
     """The full instructions string for a buddy Realtime session."""
-    parts = [BASE.strip(), VOICE_MODE.strip()]
+    parts = [BASE.strip(), PERSONA.strip(), VOICE_MODE.strip()]
     if extra.strip():
         parts.append(extra.strip())
     return "\n\n".join(parts)

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -306,12 +306,14 @@ session by that name — which one did you mean?").
 - Read-only fleet awareness: what is running, what is blocked, what needs you.
 - Reads its own mail from other sessions.
 - **One write: a message to a session that is already running** (§4a below).
-- Speaks only when spoken to.
+- Volunteers replies to things it sent (#962) at a gap; escalation-kind mail
+  may pre-empt the buddy's own speech, never the owner's (#967, Q3 below).
 
 **Does not — and this is where the risk lives:**
 - ❌ No spawning, no session creation, no worktrees. Ever. See [Cold fleet](#cold-fleet-the-buddy-never-starts-an-orchestrator).
 - ❌ No acting directly on the fleet — every write is a request to a session.
-- ❌ No proactive interruption.
+- ❌ Never speaks while the owner is speaking, and never inside a confirm
+  handshake — unconditional for every tier, including escalations.
 
 There is deliberately **no escape hatch**. Adding a capability means adding a
 tool, in a diff someone reviews.
@@ -1077,12 +1079,25 @@ undecided. A next session that picks an answer silently is the failure mode.
       **The cold-fleet corollary is ruled and not open:** if nothing is
       listening, the buddy says so and stops. It never bootstraps an
       orchestrator (see Cold fleet).
-- [ ] **Q3 — What earns the right to interrupt?** Needed before any proactive
-      speech. Candidate triggers, roughly in descending defensibility: a
-      dead-lettered `done`/`escalation` (something is already lost), a dangling
-      PR with no live parent (#716), a session parked on a usage limit, a
-      scheduled task that failed. Everything else is noise. Also needs a
-      quiet-hours answer and a "not now" that persists.
+- [x] **Q3 — What earns the right to interrupt? SETTLED (#967), and the answer
+      is a routing rule, not a judgment.** Every candidate condition — a
+      dead-lettered `done`, auth-expired, a usage-limit park, a blocked pane
+      silently swallowing inbound (#905), a dangling PR — is something the
+      fleet already detects and reports; the buddy does not re-derive that
+      judgment, it keys on the **typed message kind** already in the inbox:
+      `kind: escalation` is interrupt-class, everything else waits for a gap.
+      The reconciliation with #962's never-barge-in: that rule splits into
+      legs, and only one is relaxed. **Never while the owner is speaking** and
+      **never inside a confirm handshake** stay unconditional for every tier;
+      an escalation is allowed to skip only the "wait for the buddy's own
+      chatter to finish" leg (`canInterrupt()` beside `canSpeak()` in the
+      notifier — it pre-empts via the announcer's existing cancel, adding no
+      speaking path). And **insistence needed no interrupt licence at all**:
+      "told them, nothing changed" is a re-raise ledger — a heard `request`/
+      `escalation` that no confirmed write follows gets ONE more mention at
+      the next quiet full-gate tick, then is dropped. Twice is a peer; a
+      third time is a nag. Still open from the original question: quiet
+      hours, and a "not now" that persists.
 
 ### The slices
 
@@ -1091,9 +1106,13 @@ undecided. A next session that picks an answer silently is the failure mode.
       new authority. Do NOT let it become a tool that creates a session.
 - [x] **T2 — Directing.** `msg send` to a session, gated by the confirm spine.
       Shipped in Slice 1 (§4a).
-- [ ] **T3 — Proactive interruption.** Technically easy — the spool is already
-      there — and socially the hardest to get right. An assistant that
-      interrupts badly gets turned off. Blocked on Q3.
+- [x] **T3 — Proactive interruption.** Shipped with Q3's settlement (#967):
+      escalation-kind inbox messages ride the interrupt tier, everything else
+      waits, and the re-raise ledger carries insistence without interrupting
+      anything. Residual (still open): quiet hours, a persistent "not now",
+      and wiring fleet detectors to actually SEND `--kind escalation` to the
+      buddy — today the tier fires only for what other sessions choose to
+      escalate.
 - [ ] **T4 — Lifecycle host.** Wire §6's `services.custom` entry, if and when
       the owner wants the buddy on the startup path. Independent of Q1–Q3; safe
       to do first.

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -608,6 +608,8 @@ const strays = [];
 let spool = [];
 let cursor = 0;
 let speakable = true;
+let interruptable = false;
+let ledger = null;
 let timers = [];
 let nextHandle = 1;
 
@@ -624,6 +626,8 @@ function makeNotifier(overrides) {
     fetchInbox, ackInbox,
     announce: (text, meta) => announcedCalls.push({ text, meta }),
     canSpeak: () => speakable,
+    canInterrupt: () => interruptable,
+    reRaise: ledger,
     setTimer: (fn, ms) => { const h = nextHandle++; timers.push({ h, fn, ms }); return h; },
     clearTimer: (h) => { timers = timers.filter((t) => t.h !== h); },
     onLog: (kind, detail) => logs.push(kind + ": " + detail),
@@ -646,6 +650,7 @@ def run_notifier(script: str) -> dict:
     program = "\n".join(
         [
             client.notifier_source(),
+            client.reraise_source(),
             _NOTIFIER_HARNESS,
             textwrap.dedent(script),
             "console.log(report());",
@@ -1149,3 +1154,384 @@ class TestThePageEmbedsTheRealThing:
         JSON-parse drop; a bare swallow must not come back."""
         page = client.page("buddy", "tok")
         assert "catch { return; }" not in page
+
+
+class TestTheInterruptTier:
+    """#967 reconciled with #962. The gate is two-tier: the full gate clears
+    everything; the interrupt gate clears ONLY escalation-kind messages. The
+    two legs that stay unconditional for BOTH tiers: never while the owner is
+    speaking, never inside a confirm handshake. The tier is a mechanism check
+    on the message KIND — the fleet's own already-made judgment — never on
+    how urgent the model feels."""
+
+    def test_an_escalation_speaks_when_only_the_interrupt_gate_is_open(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation",
+                       text: "a done report dead-lettered" }];
+            speakable = false;       // the buddy is mid-chatter
+            interruptable = true;    // but the owner is not speaking
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        assert "dead-lettered" in report["announced"][0]["text"]
+
+    def test_an_ordinary_message_does_not_and_is_not_lost(self):
+        """Both halves: the non-escalation waits, and the SAME message is
+        volunteered once the full gate opens — a wrongly-silent tier is a
+        silent loop, not a safe failure."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
+            speakable = false;
+            interruptable = true;
+            await notifier.pollOnce();
+            logs.push("held: " + announcedCalls.length);
+            speakable = true;
+            await notifier.pollOnce();
+        """)
+        assert "held: 0" in report["logs"]
+        assert len(report["announced"]) == 1
+
+    def test_a_mixed_batch_under_interrupt_takes_only_the_escalation(self):
+        """And the skipped ordinary message is NOT buried by the ack: acking
+        the spoken escalation advances the cursor past everything, so the
+        done-report must come back through the strays path on the next full
+        tick — the same never-lose-one property the peek/ack race has."""
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "minecraft", kind: "done", text: "done" },
+              { id: "m2", from: "watchdog", kind: "escalation", text: "auth expired" },
+            ];
+            speakable = false;
+            interruptable = true;
+            await notifier.pollOnce();
+            logs.push("interrupt took: " + announcedCalls.length);
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+            speakable = true;
+            await notifier.pollOnce();
+        """)
+        assert "interrupt took: 1" in report["logs"]
+        assert len(report["announced"]) == 2
+        assert report["announced"][0]["meta"]["inboxIds"] == ["m2"]
+        assert report["announced"][1]["meta"]["inboxIds"] == ["m1"]
+
+    def test_the_owner_speaking_blocks_even_an_escalation(self):
+        """The unconditional leg. Nothing — including the alarm — speaks over
+        the owner; both gates report closed and the escalation waits."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "parked" }];
+            speakable = false;
+            interruptable = false;   // ownerSpeaking or confirm outstanding
+            await notifier.pollOnce();
+            interruptable = true;
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+
+    def test_an_escalation_stray_is_taken_and_an_ordinary_stray_stays(self):
+        """Strays are cursor-past — the array is their only route back. The
+        interrupt tick must pull only what it may speak and leave the rest
+        IN the array, not drop them on the floor."""
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "minecraft", kind: "note", text: "fyi" });
+            strays.push({ id: "s2", from: "watchdog", kind: "escalation", text: "blocked pane" });
+            speakable = false;
+            interruptable = true;
+            await notifier.pollOnce();
+            logs.push("strays left: " + strays.length);
+            speakable = true;
+            await notifier.pollOnce();
+        """)
+        assert "strays left: 1" in report["logs"]
+        assert len(report["announced"]) == 2
+        assert report["announced"][0]["meta"]["inboxIds"] == ["s2"]
+        assert report["announced"][1]["meta"]["inboxIds"] == ["s1"]
+
+    def test_an_escalation_notice_names_itself_as_one(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "auth expired" }];
+            await notifier.pollOnce();
+        """)
+        text = report["announced"][0]["text"]
+        assert text.startswith("Heads up")
+        assert "escalated" in text
+
+    def test_the_meta_carries_the_message_kinds_for_the_ledger(self):
+        """The page registers re-raise items from onSpoken, which sees only
+        the meta — so the meta must carry id/from/kind/text."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "reviewer", kind: "request", text: "need a call on the API shape" }];
+            await notifier.pollOnce();
+        """)
+        msgs = report["announced"][0]["meta"]["inboxMsgs"]
+        assert msgs == [{"id": "m1", "from": "reviewer", "kind": "request",
+                         "text": "need a call on the API shape"}]
+
+    def test_a_notifier_without_the_new_deps_behaves_as_before(self):
+        """The deps are optional: absent canInterrupt means escalations wait
+        like everything else — no tier appears by accident."""
+        report = run_notifier("""
+            notifier = makeNotifier({ canInterrupt: undefined, reRaise: undefined });
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "parked" }];
+            speakable = false;
+            await notifier.pollOnce();
+        """)
+        assert report["announced"] == []
+
+
+_RERAISE_HARNESS = """
+let clock = 0;
+const logs = [];
+const ledger = createReRaiseLedger({
+  now: () => clock,
+  dueMs: 120000,
+  onLog: (kind, detail) => logs.push(kind + ": " + detail),
+});
+const texts = [];
+function tick() { const t = ledger.dueText(); if (t) texts.push(t); return t; }
+function report() {
+  return JSON.stringify({ texts, logs, pending: ledger.pending() });
+}
+"""
+
+
+def run_reraise(script: str) -> dict:
+    program = "\n".join(
+        [
+            client.reraise_source(),
+            _RERAISE_HARNESS,
+            textwrap.dedent(script),
+            "console.log(report());",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", program],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestTheReRaiseLedger:
+    """#967. Insistence is about the second attempt: something the owner was
+    told and did not act on is raised again, once; something they acted on is
+    not. Distinguishable in a test, not by taste."""
+
+    def test_not_acted_on_is_raised_again_after_the_due_window(self):
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call on the API" });
+            clock = 119999;
+            tick();
+            clock = 120000;
+            tick();
+        """)
+        assert len(report["texts"]) == 1
+        assert "reviewer" in report["texts"][0]
+        assert "Still open" in report["texts"][0]
+
+    def test_acted_on_is_never_raised_again(self):
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            ledger.actedOn("reviewer");
+            clock = 999999;
+            tick();
+        """)
+        assert report["texts"] == []
+        assert report["pending"] == 0
+
+    def test_the_second_mention_is_also_the_last(self):
+        """Twice is a peer; a third time is a nag — and in a screenless
+        channel an unbounded reminder loop has no off switch."""
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            tick();
+            clock = 900000;
+            tick();
+            tick();
+        """)
+        assert len(report["texts"]) == 1
+
+    def test_acting_on_one_session_leaves_another_session_pending(self):
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "call on the API" });
+            ledger.register("m2", { from: "billing", text: "rotate the key" });
+            ledger.actedOn("reviewer");
+            clock = 500000;
+            tick();
+        """)
+        assert len(report["texts"]) == 1
+        assert "billing" in report["texts"][0]
+        assert "reviewer" not in report["texts"][0]
+
+    def test_registering_the_same_id_twice_does_not_double_the_reminder(self):
+        """A retried announcement after a reconnect re-registers; the clock
+        must not restart and the mention count must not double."""
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 100000;
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 120000;   // due from the FIRST registration
+            tick();
+            clock = 900000;
+            tick();
+        """)
+        assert len(report["texts"]) == 1
+
+    def test_two_due_items_are_one_utterance(self):
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "call on the API" });
+            ledger.register("m2", { from: "billing", text: "rotate the key" });
+            clock = 500000;
+            tick();
+        """)
+        assert len(report["texts"]) == 1
+        assert "reviewer" in report["texts"][0] and "billing" in report["texts"][0]
+
+    def test_a_long_body_is_trimmed_for_speech(self):
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "x".repeat(500) });
+            clock = 500000;
+            tick();
+        """)
+        assert len(report["texts"][0]) < 300
+
+    def test_the_reminder_is_speakable_and_names_the_close(self):
+        """The owner cannot skim speech: the reminder must say it is the
+        second and last mention, so they know the buddy will now drop it."""
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            tick();
+        """)
+        text = report["texts"][0]
+        assert "Second mention" in text
+        assert "`" not in text and "_" not in text
+
+
+class TestReRaiseThroughTheNotifier:
+    """The re-raise's clock is the notifier's own tick — no second timer, no
+    second speaking path. A reminder fires only on a QUIET full-gate tick:
+    fresh news outranks it, the interrupt tier never carries it."""
+
+    def test_a_quiet_full_gate_tick_speaks_the_due_reminder(self):
+        report = run_notifier("""
+            let clock = 0;
+            ledger = createReRaiseLedger({ now: () => clock, dueMs: 120000 });
+            notifier = makeNotifier({ reRaise: ledger });
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        assert "Still open" in report["announced"][0]["text"]
+        assert report["announced"][0]["meta"] == {"reRaise": True}
+
+    def test_fresh_news_outranks_the_reminder(self):
+        report = run_notifier("""
+            let clock = 0;
+            ledger = createReRaiseLedger({ now: () => clock, dueMs: 120000 });
+            notifier = makeNotifier({ reRaise: ledger });
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            spool = [{ id: "m2", from: "minecraft", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        assert "minecraft" in report["announced"][0]["text"]
+        assert "Still open" not in report["announced"][0]["text"]
+
+    def test_the_interrupt_tier_never_carries_a_reminder(self):
+        """A reminder is politeness, not an alarm — the relaxed gate must
+        not leak it past the buddy's own chatter."""
+        report = run_notifier("""
+            let clock = 0;
+            ledger = createReRaiseLedger({ now: () => clock, dueMs: 120000 });
+            notifier = makeNotifier({ reRaise: ledger });
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            speakable = false;
+            interruptable = true;
+            await notifier.pollOnce();
+        """)
+        assert report["announced"] == []
+
+    def test_a_blocked_tick_does_not_burn_the_reminder(self):
+        """Both halves: blocked is silent, and the SAME reminder still fires
+        on the next open tick — dueText marks re-raised only when the text is
+        actually taken."""
+        report = run_notifier("""
+            let clock = 0;
+            ledger = createReRaiseLedger({ now: () => clock, dueMs: 120000 });
+            notifier = makeNotifier({ reRaise: ledger });
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            speakable = false;
+            await notifier.pollOnce();
+            speakable = true;
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+
+
+class TestThePersonaAndInterruptWiring:
+    """The page-source pins for #967: the tier, the ledger, and the pinned
+    speaking-path count."""
+
+    def test_the_page_wires_the_interrupt_gate_without_the_chatter_leg(self):
+        """canInterrupt keeps exactly the two unconditional legs of #962 —
+        owner not speaking, no confirm handshake — and drops responseActive /
+        announcer.pending, which is what lets an escalation pre-empt the
+        buddy's own speech via the announcer's existing cancel."""
+        page = client.page("buddy", "tok")
+        assert "canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding()," in page
+        # The FULL gate is unchanged — #962's rule survives verbatim.
+        assert (
+            "canSpeak: () => !ownerSpeaking && !responseActive"
+            " && !!announcer && announcer.pending() === 0"
+            " && !confirmGate.outstanding()," in page
+        )
+
+    def test_the_interrupt_tier_adds_no_speaking_path(self):
+        """#950's pin: still exactly two response.create sites. The escalation
+        tier and the re-raise both ride announce()."""
+        page = client.page("buddy", "tok")
+        assert page.count('type: "response.create"') == 2
+
+    def test_the_page_embeds_the_ledger_verbatim_and_wires_it(self):
+        page = client.page("buddy", "tok")
+        assert client.reraise_source().strip() in page
+        assert "const RERAISE_DUE_MS" in page
+        assert "createReRaiseLedger({" in page
+        wiring = page.split("createInboxNotifier({", 1)[1].split("});", 1)[0]
+        assert "reRaise: reRaiseLedger," in wiring
+
+    def test_only_asking_kinds_enter_the_ledger_and_only_once_heard(self):
+        """register lives in onSpoken's inboxIds branch — the moment there is
+        evidence the owner heard the notice — and takes only request and
+        escalation. A done/note is news; re-raising news is chatter."""
+        page = client.page("buddy", "tok")
+        onspoken = page.split("function onSpoken(meta, how)", 1)[1].split("function send(", 1)[0]
+        register_at = onspoken.split("reRaiseLedger.register", 1)[0]
+        assert '"request"' in register_at and '"escalation"' in register_at
+        # And nowhere else on the page registers.
+        assert page.count("reRaiseLedger.register(") == 1
+
+    def test_a_queued_send_retires_the_reminder_and_a_cancel_does_not(self):
+        page = client.page("buddy", "tok")
+        dispatch = page.split("async function handleFunctionCall(item)", 1)[1]
+        dispatch = dispatch.split("function spokenText", 1)[0]
+        assert "reRaiseLedger.actedOn(lastProposedSession);" in dispatch
+        acted_guard = dispatch.split("reRaiseLedger.actedOn", 1)[0]
+        assert 'item.name === "send_session_message" && result.success' in acted_guard
+        assert "lastProposedSession = result.session;" in dispatch
+
+    def test_the_ledger_survives_stop(self):
+        """Page-lifetime, like heardReplies: stop() must not touch it, or a
+        reconnect wipes the peer's memory of its own words."""
+        page = client.page("buddy", "tok")
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "reRaiseLedger." not in stop_body
+        assert "lastProposedSession =" not in stop_body

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -1,0 +1,133 @@
+"""The persona is legible from the repo, and its properties are pinned (#967).
+
+Spoken-surface strings are the category that never gets tests naturally — a
+wrong sentence and a right sentence are structurally identical at review time
+(the voice-layer doc's maintenance note). The persona is the largest spoken
+surface of all, so its load-bearing properties are asserted rather than left
+as prose someone can soften in passing:
+
+- the peer stance names the failure mode it designs against (the deferential
+  narrator), not just the virtue it wants;
+- the humour rule is a countable BUDGET a model can follow, not an adjective;
+- opinion and fact are distinguished by ownership, composing with the #956
+  epistemic boundary instead of contradicting it;
+- insistence is described as the second attempt, and the interrupt decision is
+  explicitly located in code — prompt compliance is not a gate;
+- the support-layer boundary survives verbatim in spirit: never writes code,
+  never owns a worktree, never creates a session.
+"""
+
+from agentwire.voice_layer import instructions
+
+
+def full() -> str:
+    return instructions.build_instructions()
+
+
+class TestThePersonaIsFirstClass:
+    def test_it_is_a_named_section_between_base_and_voice_mode(self):
+        text = full()
+        assert "<persona>" in text and "</persona>" in text
+        # Order: identity first, persona second, channel mechanics last.
+        assert text.index("<persona>") < text.index("<voice_mode>")
+        assert "voice buddy for agentwire" in text.split("<persona>")[0]
+
+    def test_extra_still_appends_after_everything(self):
+        text = instructions.build_instructions(extra="EXTRA-MARKER")
+        assert text.rstrip().endswith("EXTRA-MARKER")
+
+
+class TestThePeerStance:
+    def test_it_names_the_register_to_avoid_not_only_the_one_to_want(self):
+        """"Be a peer" alone is an adjective; the failure mode is the
+        deferential narrator, and the text has to name it so a future edit
+        that reintroduces it is visibly wrong."""
+        persona = instructions.PERSONA
+        assert "peer, not an assistant" in persona
+        assert "deferential" in persona
+        assert "status report" in persona
+
+    def test_opinions_are_allowed_to_be_wrong_out_loud(self):
+        assert "wrong out loud" in instructions.PERSONA
+
+
+class TestOpinionVsFact:
+    """The composition requirement: a peer with opinions must still never
+    invent facts. Distinguished by OWNERSHIP, which is checkable."""
+
+    def test_the_distinction_is_stated_with_a_worked_pair(self):
+        persona = instructions.PERSONA
+        assert "OPINIONS ARE NOT FACTS" in persona
+        # A worked example of each side, so the rule is followable rather
+        # than aspirational.
+        assert "is an opinion" in persona
+        assert "is a fact" in persona
+
+    def test_facts_are_looked_up_never_remembered(self):
+        assert "looked up, never remembered" in instructions.PERSONA
+
+    def test_it_does_not_contradict_the_epistemic_boundary(self):
+        """#956's BOUNDARY section survives untouched in voice_mode; the
+        persona must not grant what it forbids."""
+        text = full()
+        assert "Never invent a mechanism" in text
+        assert "never dress up a guess" in text
+
+
+class TestTheHumourBudget:
+    def test_it_is_countable_not_an_adjective(self):
+        """"Be witty" is not implementable. "At most one dry aside, riding on
+        a sentence that had to be said anyway" is."""
+        persona = instructions.PERSONA
+        assert "HUMOUR IS A BUDGET" in persona
+        assert "at most one" in persona
+        assert "had to be said" in persona
+
+    def test_it_prices_the_voice_channel_specifically(self):
+        """The reason the budget is small: a spoken joke cannot be skimmed."""
+        persona = instructions.PERSONA
+        assert "cannot be skimmed" in persona
+        assert "wait it out" in persona
+
+    def test_it_names_when_to_spend_nothing(self):
+        assert "spend nothing" in instructions.PERSONA
+
+
+class TestInsistenceAndTheBoundary:
+    def test_insistence_is_the_second_attempt_not_volume(self):
+        persona = instructions.PERSONA
+        assert "second mention" in persona
+        assert "second attempt" in persona
+        # Bounded: twice, then leave it.
+        assert "Twice is a peer" in persona
+
+    def test_the_interrupt_decision_is_located_in_code_not_in_the_prompt(self):
+        """The same reason the confirm judgment lives below the model: prompt
+        compliance is not a mechanism. The prose says the timing is decided in
+        code, so a reader cannot conclude the model self-grants urgency."""
+        text = full()
+        assert "decided in code" in text
+
+    def test_never_over_the_owner_survives_as_the_unconditional_leg(self):
+        """#962 reconciliation, prompt side: the sentence narrowed from
+        "never interrupt" to "never speak over the owner" — which is the leg
+        that stays unconditional for every tier."""
+        text = full()
+        assert "never speak over the owner" in text
+
+    def test_the_support_layer_boundary_is_stated_in_full(self):
+        persona = instructions.PERSONA
+        assert "never write code" in persona
+        assert "never own a worktree" in persona
+        assert "never create a session" in persona
+
+
+class TestSpeakability:
+    def test_the_persona_is_speech_not_markup(self):
+        """It is read to a realtime voice model: no markdown bullets, no
+        backticks, no identifiers to spell."""
+        persona = instructions.PERSONA
+        body = persona.replace("<persona>", "").replace("</persona>", "")
+        assert "`" not in body
+        assert "- " not in body  # no bullet lists in a spoken prompt
+        assert "response.create" not in body

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -109,11 +109,12 @@ class TestInsistenceAndTheBoundary:
         assert "decided in code" in text
 
     def test_never_over_the_owner_survives_as_the_unconditional_leg(self):
-        """#962 reconciliation, prompt side: the sentence narrowed from
-        "never interrupt" to "never speak over the owner" — which is the leg
-        that stays unconditional for every tier."""
+        """#962 reconciliation, prompt side: the sentence narrowed from a bare
+        "never interrupt" to "never interrupt THE OWNER" — the leg that stays
+        unconditional for every tier, while the code-side tier may pre-empt
+        the buddy's own speech."""
         text = full()
-        assert "never speak over the owner" in text
+        assert "never interrupt the owner" in text
 
     def test_the_support_layer_boundary_is_stated_in_full(self):
         persona = instructions.PERSONA


### PR DESCRIPTION
Closes #967

## 1. The persona is written down (`instructions.py`)

New first-class `PERSONA` section between BASE and `<voice_mode>`, from the owner's spec:

- **Peer, not assistant** — has opinions, volunteers them, allowed to be wrong out loud; the named failure mode is the deferential-narrator register.
- **Opinion vs fact, by OWNERSHIP** — composes with #956 instead of contradicting it: an opinion is yours and said as yours; a fact belongs to a tool and is looked up, never remembered. Worked pair included so it's followable.
- **Breadth** — engages design questions as a colleague; general knowledge is allowed and labelled, guessing about THIS fleet's state is not.
- **Humour is a budget, not an adjective** — countable: at most one dry aside per reply, only riding a sentence that had to be said anyway, spend nothing during a failure chase. Priced for voice: a spoken joke cannot be skimmed.
- **Support-layer boundary** — never writes code, never owns a worktree, never creates a session.

## 2. What earns an interrupt (Q3, settled as a routing rule)

Checked the issue's hunch first, and it holds: every candidate condition (dead-lettered done, auth-expired, usage-limit park, #905 blocked pane, dangling PR) is something the fleet **already detects and types** — the judgement exists as the message-kind taxonomy. So the buddy re-derives nothing: **interrupt-class = `kind: escalation`** in its inbox. A mechanism check, like the confirm gate — not "how urgent does the model feel".

**Reconciliation with #962's never-barge-in — what changed about the gate and why:** the rule splits into legs. *Never while the owner is speaking* and *never inside a confirm handshake* stay **unconditional for every tier**. The only leg an escalation may skip is *wait for the buddy's own chatter to finish*: new `canInterrupt() = !ownerSpeaking && !confirmGate.outstanding()` beside the untouched `canSpeak()`. Pre-emption uses the announcer's existing cancel — `response.create` count in the page is still exactly 2 (pinned test unchanged and passing). A mixed batch under interrupt takes only the escalation, and the skipped ordinary message provably comes back via the strays path.

## 3. Insistence as re-raise, built first

`createReRaiseLedger` (same injected-deps, node-tested, byte-identical-in-page discipline): a HEARD `request`/`escalation` registers (from the announcer's onSpoken — never from an announce the owner may not have heard); if no confirmed write goes that session's way within 2 minutes, ONE more mention at the next quiet full-gate tick, then dropped. Twice is a peer; a third time is a nag with no off switch in a screenless channel. Resolution is an observed act (a queued send to that session), not a model judgment; the owner acting out-of-band costs at most one extra mention, priced in comments. No interrupt licence involved — the re-raise rides the ordinary gate, and fresh news outranks it.

## Measured

- `tests/unit/`: **3523 passed** (baseline 3482; +41 new — 26 in test_voice_announcer.py, 15 in new test_voice_persona.py), 0 failed. The 3 known TestRewriteSetIsComplete integration failures not counted (untouched, per wave notes).
- `uv run --no-sync ruff check agentwire/ tests/`: **All checks passed** (CI's own invocation).
- **6 mutations planted, 6 caught red**, each asserted unique-occurrence before mutating: kill-the-interrupt-tier, interrupt-gate-ignored, re-raise-forever, actedOn-noop, strays-dropped-on-interrupt, reminder-on-interrupt-tier. Reverted via `git restore` after a checkpoint commit, never bare checkout on uncommitted work.

## Both halves / what the guards do NOT establish

- Interrupt tier: false-accept = one rude pre-emption of the buddy's own sentence; false-reject = an alarm waiting a few seconds for a gap — neither is silent loss (the message stays unacked/strayed). It does NOT establish that fleet detectors actually SEND `--kind escalation` to the buddy — today only what sessions choose to escalate reaches the ear; wiring detectors→buddy is named as residual in the docs, not claimed.
- Re-raise: does NOT observe out-of-band action; bounded to one extra mention by construction.
- Docs: Q3/T3 marked settled in `docs/wiki/voice-layer.md`; the falsified §4 lines ("speaks only when spoken to", "no proactive interruption") rewritten to the narrower true claims.

Files touched: `instructions.py`, `client.py`, `docs/wiki/voice-layer.md`, `tests/unit/test_voice_announcer.py`, new `tests/unit/test_voice_persona.py`. Nothing in G's files; two shared-test collisions (a "never interrupt" substring pin and a `BOUNDARY.` heading shadow) were fixed on my side of the fence, in instructions.py.

Built by [dotdev.dev](https://dotdev.dev)