### PR TITLE
voice-layer: tier the tool surface, declare writes, expand reads (#966)

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -687,6 +687,15 @@ class Proposal:
     #: :func:`request_utterance_from`. Empty means unknown, and the body's
     #: ``said:`` slot is then omitted rather than shipped empty.
     request_utterance: str = ""
+    #: Whether :meth:`build_argv` appends the rendered §4b body. The msg
+    #: handoff carries one; an argv-only write (every element validated at
+    #: freeze time, no free text) does not, and appending a body to it would
+    #: hand the CLI a positional argument it never asked for.
+    append_body: bool = True
+    #: What the buddy says when THIS write executes. Empty falls back to the
+    #: msg-shaped "queued" phrasing — see :meth:`Verdict.to_dict` for why the
+    #: two claims must differ (§3.6: never claim more than the write did).
+    success_say: str = ""
 
     @property
     def announced(self) -> bool:
@@ -703,6 +712,8 @@ class Proposal:
         # No parameters, deliberately: the approving utterance must never
         # reach the body again (#953), and a parameterless signature makes
         # that structural rather than a calling convention.
+        if not self.append_body:
+            return list(self.argv_prefix)
         return [
             *self.argv_prefix,
             render_body(
@@ -935,7 +946,7 @@ SPOKEN = {
     # "already SENT" was the same over-claim §3.6 forbids on the success path,
     # which says "queued" precisely because msg send queues. A refusal may not
     # claim more certainty than the success it refers back to.
-    "replayed": "I already passed that one on, so I'm not doing it again.",
+    "replayed": "I already did that one, so I'm not doing it again.",
     "refused": (
         "I didn't hear the confirmation phrase, so I haven't sent anything. "
         "Say confirm and then the word I gave you."
@@ -979,7 +990,7 @@ SPOKEN = {
     # decide, not re-propose. That is the honest instruction, and it is only
     # reachable by admitting what is unknown.
     "dispatch_failed": (
-        "The handoff failed and I can't tell whether it went out. "
+        "That failed partway and I can't tell whether it took effect. "
         "Check that session before asking me again."
     ),
 }
@@ -1016,6 +1027,10 @@ class Verdict:
     argv: "list[str] | None" = None
     #: The ring entry the approval matched, so it can be spent on success.
     utterance_item_id: str = ""
+    #: The proposal's own success line, when it declared one. Empty keeps the
+    #: msg-shaped "queued" claim, which is the only honest default for a write
+    #: that enqueues rather than completes.
+    success_say: str = ""
 
     @property
     def spoken(self) -> str:
@@ -1030,6 +1045,18 @@ class Verdict:
             # and can defer behind the box gates. From the owner's ear, "I told
             # the orchestrator" followed by nothing is worse than a silent
             # refusal, because success was affirmatively claimed.
+            if self.success_say:
+                # A write that COMPLETES when the runner returns says so
+                # plainly; "queued" would under-claim it the same way "sent"
+                # over-claims a queue (§3.6 cuts both ways).
+                return {
+                    "success": True,
+                    "reason": "done",
+                    "approved_by": self.utterance,
+                    "say": self.success_say,
+                    "must_speak": True,
+                    "confirm_terminal": True,
+                }
             return {
                 "success": True,
                 "reason": "queued",
@@ -1040,6 +1067,7 @@ class Verdict:
                     "Queued it — it'll land when that session is free."
                 ),
                 "must_speak": True,
+                "confirm_terminal": True,
             }
         return {
             "success": False,
@@ -1047,6 +1075,10 @@ class Verdict:
             "say": self.spoken,
             "must_speak": True,
             "owner_should_wait": self.reason in WAIT_OUTCOMES,
+            # Name-independent handshake signal: True exactly when this
+            # outcome ENDS the confirm exchange (the client's gate currently
+            # keys on tool names; this is the generic key to move it to).
+            "confirm_terminal": self.reason not in WAIT_OUTCOMES,
             **({"heard": self.utterance} if self.utterance else {}),
         }
 
@@ -1093,6 +1125,8 @@ class ConfirmSpine:
         instruction: str,
         argv_prefix: "list[str] | tuple[str, ...]",
         params: "dict | None" = None,
+        append_body: bool = True,
+        success_say: str = "",
     ) -> Proposal:
         """Mint a single-use, TTL-bounded proposal with the argv frozen.
 
@@ -1117,6 +1151,8 @@ class ConfirmSpine:
                 created_at=self._clock(),
                 params=dict(params or {}),
                 request_utterance=request_utterance_from(self._ring),
+                append_body=append_body,
+                success_say=success_say,
             )
             self._proposals[proposal.token] = proposal
         return proposal
@@ -1318,6 +1354,7 @@ class ConfirmSpine:
             reason="approved",
             utterance=match.text,
             utterance_item_id=match.item_id,
+            success_say=proposal.success_say,
         )
 
     def _claim(self, token: str) -> "tuple[Proposal | None, Verdict | None]":

--- a/agentwire/voice_layer/outbox.py
+++ b/agentwire/voice_layer/outbox.py
@@ -60,7 +60,8 @@ def record_write(proposal, argv: list, result: dict) -> None:
         entry = {
             "proposal_id": getattr(proposal, "id", "") or "",
             "session": _flag_value(argv, "--to") or getattr(proposal, "session", ""),
-            "buddy": _flag_value(argv, "--from"),
+            "buddy": _flag_value(argv, "--from")
+            or str(getattr(proposal, "params", {}).get("_buddy") or ""),
             "kind": _flag_value(argv, "--kind"),
             "instruction": getattr(proposal, "instruction", "") or "",
             "body": argv[-1] if argv else "",
@@ -113,6 +114,12 @@ def delivery_state(entry: dict) -> dict:
     """
     if not entry.get("dispatched", False):
         return {"state": "dispatch_failed", "detail": str(entry.get("error", ""))}
+
+    if not str(entry.get("kind") or ""):
+        # Not a message handoff (no --kind in the argv): the write completed
+        # when the CLI returned, so there is no queue to interrogate and
+        # "delivered" would be a category error. "executed" is the whole truth.
+        return {"state": "executed"}
 
     from .. import inbox  # deferred, matching write_tools — keeps import light
 

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -69,7 +69,7 @@ class BuddyBridge:
         # the conversation that proposed them.
         self.ring = transcript.TranscriptRing()
         self.spine = confirm.ConfirmSpine(
-            self.ring, runner=runner or write_tools.dispatch_msg_send
+            self.ring, runner=runner or write_tools.dispatch_write
         )
 
     def utterance(self, payload: dict) -> dict:

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -1,0 +1,150 @@
+"""The tier audit: every agentwire MCP capability, placed by a stated rule (#966).
+
+The buddy's surface used to be whatever a spike demo needed. This module is
+the replacement: EVERY tool name in ``agentwire/mcp_*.py`` appears in exactly
+one tier below, a test parses those modules and fails the moment a new tool
+ships untiered, and the rules are written down so the next tool's tier is
+DERIVABLE rather than argued.
+
+The rule
+========
+
+Classify by what the action touches, in order — the first clause that applies
+wins:
+
+**EXCLUDED (tier 3)** — never reachable from the buddy, by design and not by
+omission. A capability is excluded when it:
+
+(a) **creates or drives an agent session** — ``session_create``,
+    ``worktree_create``, ``pane_spawn``, ``session_fork``, ``session_send``
+    and kin. The buddy is an I/O layer, not a harness; #730 settled that
+    there is exactly one coding harness, and a buddy that can start or steer
+    sessions is a second one. ``session_send``/``pane_send`` paste into a live
+    prompt and press Enter — forcibly driving a session — where ``msg_send``
+    is the polite, guarded channel: the recipient acts on it inside its own
+    damage-control, posture and routing. That is why msg is a graded write and
+    send is excluded.
+(b) **is another output channel to the owner** — ``say``, ``notify_user``,
+    the listen/transcribe family. The buddy IS the voice channel; a second
+    path that speaks or toasts is #950 (two paths racing to speak) in
+    different clothing.
+(c) **publishes outward** — ``email_send``, ``quo_send``. An outward send
+    bypasses every session guard; the handoff route (message a real session,
+    which composes and sends under its own hooks) exists precisely for this.
+(d) **authors work product** — ``handoff_init``/``render``,
+    ``desktop_write_artifact``. The buddy never writes code, content or
+    artifacts; producing work makes it a place work happens.
+(e) **mutates infrastructure identity** — ``machine_add``/``remove``.
+
+**Reads (tier 1)** — anything that only observes. Expand freely: a read the
+buddy lacks is just a question it has to deflect.
+
+**Writes, graded by the cost of the worst WRONG execution** — voice adds
+mis-transcription as a first-class failure mode ("kill the worker" /
+"kill the worktree" differ by one phoneme), so the grade keys on what a wrong
+target or wrong verb costs, not on how scary the verb sounds:
+
+- **light (confirm-free)** — the wrong execution is undone by ONE action of
+  the same kind, destroys no state and no work, and causes no agent or human
+  to act: window arrangement, pane focus, the buddy's own bookkeeping. A
+  nonce here is not merely unnecessary — it is corrosive: a confirm phrase
+  for opening a window trains the owner to speak the nonce reflexively, and a
+  reflexive nonce is a dead gate (price BOTH halves of a guard).
+- **gated (nonce, through the confirm spine)** — everything else: the write
+  causes another agent or human to act, changes durable state, or destroys
+  something (a killed session, a purged queue, a removed worktree cannot be
+  un-done by one equal action). Destructive writes stay in this grade rather
+  than a third ceremony tier: the spine's spoken read-back of the exact
+  target plus the nonce IS the mis-transcription defence, and a third tier
+  would just be a second nonce.
+
+Tiering is capability classification; WIRING is a separate, smaller set.
+``tools.READ_ONLY_TOOLS`` and ``write_tools.WRITE_SPECS`` hold what is live;
+everything live must map into tier 1 or 2, and a test asserts the excluded
+names are absent from the realtime surface BY NAME. Light writes are graded
+but currently none are wired: the candidates (desktop arrangement, tab
+tracking) have no CLI verb, and the voice layer dispatches only through the
+CLI (see ``tools.py``'s module docstring for why).
+"""
+
+from __future__ import annotations
+
+#: Tier 1 — observe only. Direct dispatch, expand freely.
+TIER_READ = frozenset({
+    "sessions_list", "sessions_context", "session_output", "session_info",
+    "diff", "panes_list", "pane_output",
+    "worktree_list", "worktree_status",
+    "scheduler_status", "scheduler_board", "scheduler_live",
+    "scheduler_events", "scheduler_history", "scheduler_report",
+    "task_list", "task_show", "task_validate",
+    "machines_list", "services_list", "services_status",
+    "history_list", "history_show",
+    "lock_list", "portal_status", "tts_status", "stt_status",
+    "network_status", "tunnels_status",
+    "council_status", "council_list",
+    "msg_inbox", "msg_dead", "research_dir",
+    "projects_list", "roles_list", "role_show",
+    "wiki_query", "wiki_lint", "wiki_status",
+    "channels_list", "handoff_list", "chrome_tab_list",
+    "voices_list", "desktop_windows_list", "scratchpad_list",
+})
+
+#: Tier 2, light grade — ephemeral presentation or the buddy's own
+#: bookkeeping; wrong execution is undone by one equal action. Confirm-free
+#: when wired (none are yet — no CLI verb; see the module docstring).
+TIER_WRITE_LIGHT = frozenset({
+    "desktop_open_session", "desktop_open_panel", "desktop_open_artifact",
+    "desktop_close_window", "desktop_focus_window", "desktop_tile_window",
+    "desktop_minimize_all", "desktop_collage", "desktop_layout",
+    "chrome_tab_track", "chrome_tab_untrack",
+    "scratchpad_add", "pane_jump", "pane_resize", "msg_pull",
+})
+
+#: Tier 2, gated grade — causes agents/humans to act, changes durable state,
+#: or destroys something. Only ever reachable through the confirm spine.
+TIER_WRITE_GATED = frozenset({
+    "msg_send",
+    "session_kill", "pane_kill", "pane_detach",
+    "worktree_remove", "worktree_prune",
+    "lock_clean", "lock_remove",
+    "msg_purge", "msg_flush",
+    "scheduler_run", "scheduler_enable", "scheduler_disable",
+    "task_run",
+    "tunnels_up", "tunnels_down",
+})
+
+#: Tier 3 — permanently excluded, by the lettered clauses in the module
+#: docstring. A DESIGN DECISION, not an oversight.
+TIER_EXCLUDED = frozenset({
+    # (a) creates or drives an agent session — the harness boundary (#730)
+    "session_create", "session_recreate", "session_fork",
+    "session_send", "session_send_keys",
+    "pane_spawn", "pane_send", "pane_split",
+    "worktree_create", "history_resume", "wait_children",
+    "council_start", "council_stop", "council_ask",
+    "council_collect", "council_minutes",
+    # (b) another output channel to the owner (#950)
+    "say", "transcribe", "listen_start", "listen_stop", "listen_cancel",
+    "notify_user", "notify_parent", "notify_event",
+    # (c) publishes outward, past every session guard
+    "email_send", "quo_send",
+    # (d) authors work product
+    "handoff_init", "handoff_render", "desktop_write_artifact",
+    # (e) mutates infrastructure identity
+    "machine_add", "machine_remove",
+})
+
+ALL_TIERS = (TIER_READ, TIER_WRITE_LIGHT, TIER_WRITE_GATED, TIER_EXCLUDED)
+
+
+def tier_of(name: str) -> str:
+    """The tier of one MCP capability name, or ``"untiered"``."""
+    if name in TIER_READ:
+        return "read"
+    if name in TIER_WRITE_LIGHT:
+        return "write_light"
+    if name in TIER_WRITE_GATED:
+        return "write_gated"
+    if name in TIER_EXCLUDED:
+        return "excluded"
+    return "untiered"

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -12,14 +12,15 @@ parameters — the model chooses *which* tool, never *what runs*. A garbled
 session name fails the pattern check and returns an error the buddy can read
 back, which is the correct outcome: ask again.
 
-**Reads are direct; the one write is a handoff.** Anything routed through a
+**Reads are direct; writes go through the spine.** Anything routed through a
 Claude session inherits damage-control hooks, worktree isolation, posture and
 prompt routing. Anything the voice layer does directly inherits none of that,
-so reads happen here and the single write
-(:mod:`~agentwire.voice_layer.write_tools`) is a message to a session that
-already has those guards — never an action the buddy takes itself. Its write is
-additionally gated below the model by
-:mod:`~agentwire.voice_layer.confirm`. There is still deliberately no escape
+so reads happen here and writes (:mod:`~agentwire.voice_layer.write_tools`)
+are declared specs gated below the model by
+:mod:`~agentwire.voice_layer.confirm` — the canonical one being a message to
+a session that already has those guards. Which capabilities may ever appear
+here at all is ruled by the tier audit in
+:mod:`~agentwire.voice_layer.surface`. There is still deliberately no escape
 hatch: adding a capability means adding a tool, in a diff someone reviews.
 
 Everything dispatches through the ``agentwire`` CLI, which is the documented
@@ -37,6 +38,7 @@ from typing import Callable
 
 from ..mcp_core import run_agentwire_cmd
 from . import delivery, outbox
+from .confirm import strip_controls
 
 # Session names as the inbox defines them, plus the optional `@machine` suffix
 # a remote session carries. Anchored: a partial match is how a fuzzy
@@ -59,6 +61,8 @@ _REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 _MAX_OUTPUT_LINES = 200
 _MAX_PR_LIMIT = 50
+_MAX_QUERY_CHARS = 200
+_MAX_HISTORY_LIMIT = 50
 
 
 class ToolError(Exception):
@@ -93,6 +97,20 @@ def _int_arg(args: dict, key: str, default: int, lo: int, hi: int) -> int:
     except (TypeError, ValueError):
         return default
     return max(lo, min(hi, n))
+
+
+#: The one shared schema for tools whose only argument is a session name.
+_SESSION_PARAM = {
+    "type": "object",
+    "properties": {
+        "session": {
+            "type": "string",
+            "description": "Exact session name, as reported by fleet_sessions.",
+        },
+    },
+    "required": ["session"],
+    "additionalProperties": False,
+}
 
 
 @dataclass(frozen=True)
@@ -185,6 +203,94 @@ def _fleet_pull_requests(args: dict) -> dict:
         return {"success": True, "pull_requests": json.loads(result.stdout or "[]")}
     except json.JSONDecodeError:
         return {"success": False, "error": "gh returned unparseable JSON"}
+
+
+def _query_arg(args: dict, key: str = "query") -> str:
+    """A free-text search string, made safe as a positional CLI argument.
+
+    Model-supplied free text is the one class of value that cannot be
+    pattern-anchored, so it gets the freeze discipline instead: controls
+    stripped, length-bounded, and leading dashes removed so it can never reach
+    the CLI as a flag (the twice-shipped bug — see ``_SESSION_RE``'s comment).
+    """
+    value = args.get(key)
+    text = strip_controls(value).strip() if isinstance(value, str) else ""
+    text = text.lstrip("-").strip()
+    if not text:
+        raise ToolError("I need a few words to search for. Say what to look up.")
+    return text[:_MAX_QUERY_CHARS]
+
+
+def _fleet_session_info(args: dict) -> dict:
+    return run_agentwire_cmd(["info", "-s", _session_arg(args)])
+
+
+def _fleet_scheduler_status(args: dict) -> dict:
+    return run_agentwire_cmd(["scheduler", "status"])
+
+
+def _fleet_scheduler_history(args: dict) -> dict:
+    return run_agentwire_cmd(["scheduler", "history", "--json"])
+
+
+def _fleet_scheduler_live(args: dict) -> dict:
+    return run_agentwire_cmd(["scheduler", "live", "--json"])
+
+
+def _fleet_tasks(args: dict) -> dict:
+    argv = ["task", "list"]
+    if args.get("session") is not None:
+        argv.append(_session_arg(args))
+    return run_agentwire_cmd(argv)
+
+
+def _fleet_machines(args: dict) -> dict:
+    return run_agentwire_cmd(["machine", "list"])
+
+
+def _fleet_services(args: dict) -> dict:
+    return run_agentwire_cmd(["services", "status"])
+
+
+def _fleet_history(args: dict) -> dict:
+    limit = _int_arg(args, "limit", 20, 1, _MAX_HISTORY_LIMIT)
+    return run_agentwire_cmd(["history", "list", "-n", str(limit)])
+
+
+def _fleet_locks(args: dict) -> dict:
+    return run_agentwire_cmd(["lock", "list"])
+
+
+def _fleet_portal(args: dict) -> dict:
+    return run_agentwire_cmd(["portal", "status"])
+
+
+def _fleet_councils(args: dict) -> dict:
+    return run_agentwire_cmd(["council", "list"])
+
+
+def _fleet_wiki_search(args: dict) -> dict:
+    return run_agentwire_cmd(["wiki", "query", _query_arg(args)])
+
+
+def _fleet_session_inbox(args: dict) -> dict:
+    return run_agentwire_cmd(["msg", "inbox", "-s", _session_arg(args)])
+
+
+def _fleet_roles(args: dict) -> dict:
+    return run_agentwire_cmd(["roles", "list"])
+
+
+def _fleet_network(args: dict) -> dict:
+    return run_agentwire_cmd(["network", "status"], json_output=False, timeout=60)
+
+
+def _fleet_voice_health(args: dict) -> dict:
+    return {
+        "success": True,
+        "tts": run_agentwire_cmd(["tts", "status"]),
+        "stt": run_agentwire_cmd(["stt", "status"]),
+    }
 
 
 def _buddy_inbox(args: dict) -> dict:
@@ -391,6 +497,132 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
             "additionalProperties": False,
         },
     ),
+    ReadOnlyTool(
+        name="fleet_session_info",
+        description=(
+            "Details of ONE session: working directory, panes, posture, roles. "
+            "Use the exact name from fleet_sessions."
+        ),
+        run=_fleet_session_info,
+        parameters=_SESSION_PARAM,
+    ),
+    ReadOnlyTool(
+        name="fleet_scheduler_status",
+        description="Scheduler health: enabled/disabled, what is currently dispatching.",
+        run=_fleet_scheduler_status,
+    ),
+    ReadOnlyTool(
+        name="fleet_scheduler_history",
+        description="Recent scheduled-task runs and how they ended.",
+        run=_fleet_scheduler_history,
+    ),
+    ReadOnlyTool(
+        name="fleet_scheduler_live",
+        description="Scheduled tasks currently running, with their sessions.",
+        run=_fleet_scheduler_live,
+    ),
+    ReadOnlyTool(
+        name="fleet_tasks",
+        description=(
+            "Named tasks configured for a session's project. Without a session, "
+            "lists tasks for the current project context."
+        ),
+        run=_fleet_tasks,
+        parameters={
+            "type": "object",
+            "properties": {
+                "session": {
+                    "type": "string",
+                    "description": "Exact session name, as reported by fleet_sessions.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
+    ReadOnlyTool(
+        name="fleet_machines",
+        description="Registered remote machines and how to reach them.",
+        run=_fleet_machines,
+    ),
+    ReadOnlyTool(
+        name="fleet_services",
+        description="Configured services and whether each is up.",
+        run=_fleet_services,
+    ),
+    ReadOnlyTool(
+        name="fleet_history",
+        description="Recent past conversations across sessions, newest first.",
+        run=_fleet_history,
+        parameters={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": f"How many to return (1-{_MAX_HISTORY_LIMIT}, default 20).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
+    ReadOnlyTool(
+        name="fleet_locks",
+        description="Active session locks — who is holding what.",
+        run=_fleet_locks,
+    ),
+    ReadOnlyTool(
+        name="fleet_portal",
+        description="Portal server status: running, ports, connected clients.",
+        run=_fleet_portal,
+    ),
+    ReadOnlyTool(
+        name="fleet_councils",
+        description="Council sittings that exist and whether each is live.",
+        run=_fleet_councils,
+    ),
+    ReadOnlyTool(
+        name="fleet_wiki_search",
+        description=(
+            "Search the knowledge wiki for past investigations and gotchas. "
+            "Returns ranked page paths with snippets."
+        ),
+        run=_fleet_wiki_search,
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "A few words to search for.",
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    ),
+    ReadOnlyTool(
+        name="fleet_session_inbox",
+        description=(
+            "Peek ANOTHER session's pending messages without consuming them — "
+            "what is queued for it that it has not seen yet. Your own mail is "
+            "buddy_inbox, not this."
+        ),
+        run=_fleet_session_inbox,
+        parameters=_SESSION_PARAM,
+    ),
+    ReadOnlyTool(
+        name="fleet_roles",
+        description="Available session roles and what each one is for.",
+        run=_fleet_roles,
+    ),
+    ReadOnlyTool(
+        name="fleet_network",
+        description="Network reachability of the portal and registered machines.",
+        run=_fleet_network,
+    ),
+    ReadOnlyTool(
+        name="fleet_voice_health",
+        description="Health of the voice pipeline itself: TTS and STT backends.",
+        run=_fleet_voice_health,
+    ),
 )
 
 TOOLS_BY_NAME = {t.name: t for t in READ_ONLY_TOOLS}
@@ -439,7 +671,7 @@ def write_tools() -> "tuple[WriteTool, ...]":
 
 
 def all_tools() -> "tuple[object, ...]":
-    """Every tool the model may call: the read allowlist plus the one write."""
+    """Every tool the model may call: the read allowlist plus the gated writes."""
     return (*READ_ONLY_TOOLS, *write_tools())
 
 

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -1,8 +1,8 @@
-"""The buddy's ONE write: a message to a session that already has guards (spike).
+"""The buddy's writes: DECLARED specs, one generated propose/confirm/cancel path.
 
 Q2 is settled as **handoff, not a tool**. The buddy does not build a
 ``worktree_create`` argv, does not create sessions, does not own a checkout and
-does not appear in the topology. Its only write is
+does not appear in the topology. Its canonical write is
 ``agentwire msg send --to <session> --from <buddy> --kind request <body>``,
 addressed to a real Claude session which DOES have damage-control hooks,
 posture, worktree isolation and prompt routing.
@@ -15,39 +15,45 @@ matcher list. What the RECIPIENT does with the message runs inside a real Claude
 session with hooks. That is the whole point of handoff, and it is why the
 boundary holds by construction rather than by discipline.
 
-T1 ("spawn a worker") therefore adds no new authority when it lands: under
-handoff it is the same write with different words in the body. If it ever looks
-like it needs a tool that creates a session, the boundary has moved and the diff
-is wrong.
+**Why declarations and not triples (#966).** Each write used to be three
+hand-written functions with a hand-frozen ``argv_prefix``. Ten writes that way
+is nine more triples and nine more chances to freeze the argv wrong — and a
+mis-frozen argv is exactly how a model-supplied string reaches the CLI. A
+write is now a :class:`WriteSpec`: name, params schema, a ``freeze`` function
+that validates the model's arguments into a :class:`FrozenWrite`, and the
+spoken templates. :func:`gated_triple` generates the propose/confirm/cancel
+tools from it, so the invariants live in ONE place:
 
-**Why ``--kind request`` and not a new ``voice`` kind.** A ``voice`` kind is
-deferred to Slice 1b on purpose. It is the only part of this work that changes
-behaviour for sessions with nothing to do with voice, it touches a shared
-subsystem's escalation and dead-letter paths, and its blast radius is
-non-obvious — the adversarial review found two hand-written kind tuples
-(``doctor_cli``, ``session_cli``) that would silently stop reporting a
-dead-lettered buddy message, which is exactly the property the kind was being
-argued for. ``request`` is ALREADY in ``inbox.ESCALATE_KINDS``, so the
-dead-letter-emails-the-owner behaviour is achieved today, and prefix-level
-attribution comes from the §4b body. The split costs nothing functionally and
-buys the shared subsystem its own review.
+- the WHOLE argv is frozen at propose time, inside ``freeze``;
+- a proposal is single-use and consumed on success (the spine);
+- the approving utterance never reaches the body (#953 — the spine);
+- ``render_body``'s leading-dash assertion guards every body-carrying write;
+- an argv-only write (``append_body=False``) may contain NO free text — every
+  element must come out of a validator, which ``freeze`` is the one place to do.
+
+**The tier audit lives in** :mod:`~agentwire.voice_layer.surface` — which
+capabilities are reads, which are writes and at what grade, and which are
+excluded permanently. Read it before adding a spec here.
 
 **On the pull toward a bootstrap escape hatch.** When nothing is live there is
 an obvious, tempting fix: let the buddy start one orchestrator, just this once,
 so the handoff has somewhere to go. That is session-creation semantics through
-the back door and it is not built here. :func:`_live_recipient_check` refuses
-and the buddy says "nothing is listening" out loud, which is a correct and
-useful spoken answer (spec §5).
+the back door and it is not built here. :func:`_require_live` refuses and the
+buddy says "nothing is listening" out loud, which is a correct and useful
+spoken answer (spec §5).
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
 
 from ..mcp_core import run_agentwire_cmd
 from .confirm import spoken_nonce, strip_controls
 from .tools import ToolError, _session_arg
 
-#: The message kind a buddy write carries. See the module docstring: already in
-#: ``ESCALATE_KINDS``, so a dead-lettered buddy write emails the owner today.
+#: The message kind a buddy handoff carries. Already in ``ESCALATE_KINDS``, so
+#: a dead-lettered buddy write emails the owner today.
 WRITE_KIND = "request"
 
 #: An instruction longer than this is not a spoken instruction — it is a
@@ -57,13 +63,15 @@ WRITE_KIND = "request"
 MAX_INSTRUCTION_CHARS = 600
 
 
-def _live_recipient_check(session: str) -> None:
-    """Refuse a handoff to a session that positively is not there (spec §5).
+def _require_live(session: str, cannot: str) -> None:
+    """Refuse a write aimed at a session that positively is not there (spec §5).
 
     ``inbox.live_sessions()`` returns ``None`` when tmux itself is unreachable,
-    which is an outage rather than a gone recipient — we cannot prove anything,
-    so the ordinary ``msg send`` path handles it. Only POSITIVE knowledge (tmux
-    answered, the target is not in the list) refuses.
+    which is an outage rather than a gone target — we cannot prove anything, so
+    the write proceeds and the ordinary CLI path reports what it finds. Only
+    POSITIVE knowledge (tmux answered, the target is not in the list) refuses.
+
+    *cannot* names what the buddy cannot do instead, spoken verbatim.
     """
     from .. import inbox
 
@@ -73,8 +81,7 @@ def _live_recipient_check(session: str) -> None:
     if session.split("@")[0] not in live:
         raise ToolError(
             f"Nothing is listening — there's no live session called '{session}'. "
-            "Check what's actually running and say the name again. I can't start "
-            "a session; that has to be a real orchestrator."
+            f"Check what's actually running and say the name again. {cannot}"
         )
 
 
@@ -96,175 +103,241 @@ def _instruction_arg(args: dict) -> str:
     return text
 
 
-def propose_session_message(args: dict, spine) -> dict:
-    """Mint a proposal and its nonce. Writes nothing."""
-    session = _session_arg(args)
-    instruction = _instruction_arg(args)
+def _buddy_arg(args: dict) -> str:
     buddy = args.get("_buddy") or ""
     if not buddy:
         raise ToolError("buddy identity missing from tool context")
-    _live_recipient_check(session)
+    return buddy
 
-    proposal = spine.propose(
-        tool="send_session_message",
+
+@dataclass(frozen=True)
+class FrozenWrite:
+    """The output of a spec's ``freeze``: everything that will run, validated.
+
+    ``argv_prefix`` is complete and final. When ``append_body`` is True the
+    spine appends the §4b rendered body (instruction + request utterance +
+    proposal id) at execution; when False, the prefix IS the argv, so every
+    element must already have passed a validator — there is no free-text slot.
+    """
+
+    session: str
+    instruction: str
+    argv_prefix: tuple[str, ...]
+    append_body: bool = True
+    params: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WriteSpec:
+    """One gated write, as a declaration.
+
+    ``announce_template`` may use ``{session}``, ``{instruction}`` and
+    ``{phrase}``. ``fallback_template`` gets ONLY ``{session}`` and
+    ``{instruction}`` — the browser-voice fallback is not echo-cancelled, so
+    the nonce must be structurally unreachable from it (see the announce
+    payload below); a template asking for ``{phrase}`` fails at import.
+
+    ``success_say`` empty means the write QUEUES (the msg default and its
+    "queued" claim); non-empty means the write completes when the runner
+    returns, and this is what the buddy says. §3.6 both ways: never claim more
+    than the write did, never less.
+    """
+
+    name: str
+    action: str  # short verb phrase, e.g. "passing a message to a running session"
+    params_schema: dict
+    freeze: Callable[[dict], FrozenWrite]
+    announce_template: str
+    fallback_template: str
+    success_say: str = ""
+
+    def __post_init__(self):
+        if "{phrase}" in self.fallback_template or "{nonce}" in self.fallback_template:
+            raise ValueError(
+                f"WriteSpec {self.name}: the fallback template must not carry "
+                "the confirm phrase — the browser-voice channel can echo into "
+                "the approval window."
+            )
+
+
+def gated_triple(spec: WriteSpec) -> tuple:
+    """Generate the ``propose_/send_/cancel_<name>`` tool entries for *spec*.
+
+    The propose payload's shape is load-bearing and shared: ``say`` is LITERAL
+    TEXT TO UTTER (#950 — a directive here gets read aloud verbatim),
+    ``fallback_say`` is the echo-safe channel and never carries the nonce, and
+    ``anchor_proposal_id`` is what the client anchors to the spoken turn.
+    """
+
+    def propose(args: dict, spine, _spec=spec) -> dict:
+        frozen = _spec.freeze(args)
+        proposal = spine.propose(
+            tool=f"send_{_spec.name}",
+            session=frozen.session,
+            instruction=frozen.instruction,
+            argv_prefix=list(frozen.argv_prefix),
+            params={"session": frozen.session, **frozen.params},
+            append_body=frozen.append_body,
+            success_say=_spec.success_say,
+        )
+        phrase = f"confirm {spoken_nonce(proposal.nonce)}"
+        slots = {"session": frozen.session, "instruction": frozen.instruction}
+        return {
+            "success": True,
+            "confirm_token": proposal.token,
+            "proposal_id": proposal.id,
+            "session": frozen.session,
+            "message": frozen.instruction,
+            "confirm_phrase": phrase,
+            "needs_spoken_approval": True,
+            "must_speak": True,
+            "anchor_proposal_id": proposal.id,
+            "say": _spec.announce_template.format(phrase=phrase, **slots),
+            "fallback_say": _spec.fallback_template.format(**slots),
+            "model_guidance": (
+                "Say the code word clearly, as a word; do not spell it out. "
+                f"Do not call send_{_spec.name} until you have said the "
+                "proposal aloud and the owner has answered."
+            ),
+        }
+
+    def send(args: dict, spine, _spec=spec) -> dict:
+        token = args.get("confirm_token")
+        if not isinstance(token, str) or not token.strip():
+            raise ToolError(
+                "I need the confirm token from the proposal. Propose it first."
+            )
+        return spine.confirm(token.strip()).to_dict()
+
+    def cancel(args: dict, spine, _spec=spec) -> dict:
+        token = args.get("confirm_token")
+        if not isinstance(token, str) or not token.strip():
+            raise ToolError("I need the confirm token of the proposal being cancelled.")
+        return spine.cancel(token.strip()).to_dict()
+
+    token_schema = {
+        "type": "object",
+        "properties": {
+            "confirm_token": {
+                "type": "string",
+                "description": f"The confirm_token from propose_{spec.name}.",
+            },
+        },
+        "required": ["confirm_token"],
+        "additionalProperties": False,
+    }
+    return (
+        (
+            f"propose_{spec.name}",
+            (
+                f"STEP ONE of {spec.action}. Prepares it and returns a confirm "
+                "phrase. This does NOTHING yet. After calling it you must say "
+                "out loud what you are about to do and the exact confirm phrase "
+                "the owner has to speak."
+            ),
+            spec.params_schema,
+            propose,
+        ),
+        (
+            f"send_{spec.name}",
+            (
+                f"STEP TWO of {spec.action}. Executes it, but only if the owner "
+                "spoke the exact confirm phrase after you said it. That is "
+                "checked in code against the transcript, independently of you — "
+                "calling this on a 'yeah' or on your own impression will be "
+                "refused and will tell you why. Takes only the confirm_token."
+            ),
+            token_schema,
+            send,
+        ),
+        (
+            f"cancel_{spec.name}",
+            (
+                f"Drop a proposal for {spec.action} the owner declined or "
+                "changed their mind about. Does nothing and never fails."
+            ),
+            token_schema,
+            cancel,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The declared writes
+# ---------------------------------------------------------------------------
+
+
+def _freeze_session_message(args: dict) -> FrozenWrite:
+    session = _session_arg(args)
+    instruction = _instruction_arg(args)
+    buddy = _buddy_arg(args)
+    _require_live(
+        session,
+        cannot="I can't start a session; that has to be a real orchestrator.",
+    )
+    return FrozenWrite(
         session=session,
         instruction=instruction,
-        # Frozen here, at propose time — the WHOLE argv, body included. The
-        # body's said: slot carries the owner's request utterance captured by
-        # spine.propose from the transcript ring, never the approving
-        # utterance, which is a nonce and stays inside the gate (#953).
-        argv_prefix=[
+        # Frozen here, at propose time — the WHOLE argv. The body's said: slot
+        # carries the owner's request utterance captured by spine.propose from
+        # the transcript ring, never the approving utterance (#953).
+        argv_prefix=(
             "msg", "send", "--to", session, "--from", buddy, "--kind", WRITE_KIND,
-        ],
-        params={"session": session, "message": instruction},
+        ),
+        append_body=True,
+        params={"message": instruction, "_buddy": buddy},
     )
-    phrase = f"confirm {spoken_nonce(proposal.nonce)}"
-    return {
-        "success": True,
-        "confirm_token": proposal.token,
-        "proposal_id": proposal.id,
-        "session": session,
-        "message": instruction,
-        "confirm_phrase": phrase,
-        "needs_spoken_approval": True,
-        "must_speak": True,
-        # The client anchors the proposal to the response.done of the turn that
-        # speaks this, which is what makes "the approval postdates the proposal"
-        # mean "after the owner heard it".
-        "anchor_proposal_id": proposal.id,
-        # `say` is LITERAL TEXT TO UTTER, like every other must_speak payload.
-        # It used to be a directive to the model ("Tell the owner plainly
-        # what you are about to send…"), which conflated two kinds of value in
-        # one field with one consumer that cannot tell them apart: the
-        # announcer scripted the directive verbatim, the transcript-match
-        # disarm could then never fire (the directive's words appear in no
-        # correct announcement), and the fallback timer always spoke — over
-        # the model, and carrying the nonce (#950 defects 1 and 4).
-        #
-        # Its content is still the mechanism, not cosmetics: a stale word here
-        # is the scripted-instructions mechanism working exactly as designed,
-        # with the wrong script.
-        "say": (
-            f"I'm ready to send to {session}: '{instruction}'. "
-            f"To approve, say {phrase}."
-        ),
-        # What the BROWSER-VOICE fallback speaks instead of `say`.
-        # speechSynthesis output is not on the WebRTC path, so echo
-        # cancellation does not suppress it — anything this channel utters can
-        # re-enter the microphone and land in the USER transcript inside the
-        # approval window. So the nonce must not be reachable from here: an
-        # echo of this text cannot carry an approval, structurally. The owner
-        # who only heard the fallback asks for the code word, and the model —
-        # whose audio IS echo-cancelled — speaks it.
-        "fallback_say": (
-            f"I'm ready to send to {session}: '{instruction}'. "
-            f"Ask me for the code word when you want me to send it."
-        ),
-        # Model-facing behaviour, moved OUT of the spoken field. This rides
-        # back as function_call_output context; the announcer never utters it.
-        "model_guidance": (
-            "Say the code word clearly, as a word; do not spell it out. "
-            "Do not call send_session_message until you have said the "
-            "proposal aloud and the owner has answered."
-        ),
-    }
 
 
-def send_session_message(args: dict, spine) -> dict:
-    """Confirm a proposal and, if the owner spoke the nonce, hand it off.
-
-    Takes ONE argument. There is deliberately no session or message parameter:
-    everything determining what runs was frozen at propose time.
-    """
-    token = args.get("confirm_token")
-    if not isinstance(token, str) or not token.strip():
-        raise ToolError(
-            "I need the confirm token from the proposal. Propose the message first."
-        )
-    return spine.confirm(token.strip()).to_dict()
-
-
-def cancel_session_message(args: dict, spine) -> dict:
-    """Retire a proposal the owner declined. Never writes."""
-    token = args.get("confirm_token")
-    if not isinstance(token, str) or not token.strip():
-        raise ToolError("I need the confirm token of the message being cancelled.")
-    return spine.cancel(token.strip()).to_dict()
-
-
-WRITE_TOOL_SPECS = (
-    (
-        "propose_session_message",
-        (
-            "STEP ONE of passing a message to a running session. Prepares it and "
-            "returns a confirm phrase. This sends NOTHING. After calling it you "
-            "must say out loud what you are about to send, to whom, and the exact "
-            "confirm phrase the owner has to speak."
-        ),
-        {
-            "type": "object",
-            "properties": {
-                "session": {
-                    "type": "string",
-                    "description": (
-                        "Exact session name from fleet_sessions. Never a name you "
-                        "half-heard — read it back and ask instead."
-                    ),
-                },
-                "message": {
-                    "type": "string",
-                    "description": "What to pass on, in the owner's own terms.",
-                },
+SESSION_MESSAGE_SPEC = WriteSpec(
+    name="session_message",
+    action="passing a message to a running session",
+    params_schema={
+        "type": "object",
+        "properties": {
+            "session": {
+                "type": "string",
+                "description": (
+                    "Exact session name from fleet_sessions. Never a name you "
+                    "half-heard — read it back and ask instead."
+                ),
             },
-            "required": ["session", "message"],
-            "additionalProperties": False,
+            "message": {
+                "type": "string",
+                "description": "What to pass on, in the owner's own terms.",
+            },
         },
-        propose_session_message,
+        "required": ["session", "message"],
+        "additionalProperties": False,
+    },
+    freeze=_freeze_session_message,
+    announce_template=(
+        "I'm ready to send to {session}: '{instruction}'. To approve, say {phrase}."
     ),
-    (
-        "send_session_message",
-        (
-            "STEP TWO. Hands off the proposed message, but only if the owner spoke "
-            "the exact confirm phrase after you said it. That is checked in code "
-            "against the transcript, independently of you — calling this on a "
-            "'yeah' or on your own impression will be refused and will tell you "
-            "why. Takes only the confirm_token."
-        ),
-        {
-            "type": "object",
-            "properties": {
-                "confirm_token": {
-                    "type": "string",
-                    "description": "The confirm_token from propose_session_message.",
-                },
-            },
-            "required": ["confirm_token"],
-            "additionalProperties": False,
-        },
-        send_session_message,
-    ),
-    (
-        "cancel_session_message",
-        (
-            "Drop a proposed message the owner declined or changed their mind "
-            "about. Sends nothing and never fails."
-        ),
-        {
-            "type": "object",
-            "properties": {
-                "confirm_token": {
-                    "type": "string",
-                    "description": "The confirm_token of the proposal to drop.",
-                },
-            },
-            "required": ["confirm_token"],
-            "additionalProperties": False,
-        },
-        cancel_session_message,
+    # What the BROWSER-VOICE fallback speaks instead of `say`. speechSynthesis
+    # output is not on the WebRTC path, so echo cancellation does not suppress
+    # it — anything this channel utters can re-enter the microphone and land in
+    # the USER transcript inside the approval window. So the nonce is not
+    # reachable from here, structurally (WriteSpec.__post_init__ enforces it).
+    fallback_template=(
+        "I'm ready to send to {session}: '{instruction}'. "
+        "Ask me for the code word when you want me to send it."
     ),
 )
 
+#: Every declared gated write. Adding one is adding a spec here — the triple,
+#: the freeze discipline and the spoken payloads are generated.
+WRITE_SPECS: tuple[WriteSpec, ...] = (SESSION_MESSAGE_SPEC,)
 
-def dispatch_msg_send(argv: list[str]) -> dict:
+WRITE_TOOL_SPECS = tuple(
+    entry for spec in WRITE_SPECS for entry in gated_triple(spec)
+)
+
+#: name → callable, for callers (and tests) that address a generated tool
+#: directly rather than through ``tools.dispatch``.
+WRITE_TOOL_FNS = {name: fn for name, _desc, _schema, fn in WRITE_TOOL_SPECS}
+
+
+def dispatch_write(argv: list[str]) -> dict:
     """The runner ``ConfirmSpine`` calls on approval. One place, one command."""
     return run_agentwire_cmd(argv)

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -337,6 +337,10 @@ WRITE_TOOL_SPECS = tuple(
 #: directly rather than through ``tools.dispatch``.
 WRITE_TOOL_FNS = {name: fn for name, _desc, _schema, fn in WRITE_TOOL_SPECS}
 
+# The generated callables are this module's public functions — a caller may
+# say ``write_tools.propose_session_message`` without knowing the registry.
+globals().update(WRITE_TOOL_FNS)
+
 
 def dispatch_write(argv: list[str]) -> dict:
     """The runner ``ConfirmSpine`` calls on approval. One place, one command."""

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -913,7 +913,7 @@ class TestArgvFreezing:
     def test_confirm_ignores_every_argument_except_the_token(self, convo, runner):
         proposal = convo.announced_proposal(session="orchestrator")
         convo.approve(proposal)
-        result = write_tools.send_session_message(
+        result = write_tools.WRITE_TOOL_FNS["send_session_message"](
             {
                 "confirm_token": proposal.token,
                 "session": "victim-session",
@@ -1425,7 +1425,7 @@ class TestOutcomesAreDistinctAndSpoken:
         # reports success=False on a subprocess timeout, where the CLI may
         # already have enqueued — and pairing false certainty with "ask me
         # again" invites a re-propose that double-delivers.
-        assert "can't tell whether it went out" in verdict.spoken
+        assert "can't tell whether it took effect" in verdict.spoken
         assert "check that session" in verdict.spoken.lower()
         assert "nothing was sent" not in verdict.spoken
 
@@ -1443,7 +1443,7 @@ class TestWriteToolSurface:
     def test_propose_writes_nothing_and_returns_a_spoken_phrase(
         self, convo, runner, live
     ):
-        result = write_tools.propose_session_message(
+        result = write_tools.WRITE_TOOL_FNS["propose_session_message"](
             {"session": "orchestrator", "message": "restart the portal", "_buddy": "buddy"},
             convo.spine,
         )
@@ -1457,7 +1457,7 @@ class TestWriteToolSurface:
     def test_a_garbled_session_name_fails_closed(self, convo, runner, live):
         for bad in ("--help", "../etc/passwd", "", None):
             with pytest.raises(tools.ToolError):
-                write_tools.propose_session_message(
+                write_tools.WRITE_TOOL_FNS["propose_session_message"](
                     {"session": bad, "message": "hello", "_buddy": "buddy"}, convo.spine
                 )
         assert runner.calls == []
@@ -1468,7 +1468,7 @@ class TestWriteToolSurface:
         """Spec §5, and the refusal is words the buddy can say."""
         monkeypatch.setattr(inbox, "live_sessions", lambda: {"something-else"})
         with pytest.raises(tools.ToolError, match="Nothing is listening"):
-            write_tools.propose_session_message(
+            write_tools.WRITE_TOOL_FNS["propose_session_message"](
                 {"session": "orchestrator", "message": "hello", "_buddy": "buddy"},
                 convo.spine,
             )
@@ -1499,7 +1499,7 @@ class TestWriteToolSurface:
         self, convo, monkeypatch
     ):
         monkeypatch.setattr(inbox, "live_sessions", lambda: None)
-        result = write_tools.propose_session_message(
+        result = write_tools.WRITE_TOOL_FNS["propose_session_message"](
             {"session": "orchestrator", "message": "hello", "_buddy": "buddy"},
             convo.spine,
         )
@@ -1507,7 +1507,7 @@ class TestWriteToolSurface:
 
     def test_an_absurdly_long_instruction_is_refused(self, convo, live):
         with pytest.raises(tools.ToolError):
-            write_tools.propose_session_message(
+            write_tools.WRITE_TOOL_FNS["propose_session_message"](
                 {
                     "session": "orchestrator",
                     "message": "x" * (write_tools.MAX_INSTRUCTION_CHARS + 1),
@@ -1520,7 +1520,7 @@ class TestWriteToolSurface:
         self, convo, runner, live
     ):
         """Q2 settled as handoff: the only write is a message to a real session."""
-        proposed = write_tools.propose_session_message(
+        proposed = write_tools.WRITE_TOOL_FNS["propose_session_message"](
             {"session": "orchestrator", "message": "restart the portal", "_buddy": "buddy"},
             convo.spine,
         )
@@ -1529,7 +1529,7 @@ class TestWriteToolSurface:
         )
         convo.buddy_speaks(proposal)
         convo.approve(proposal)
-        write_tools.send_session_message(
+        write_tools.WRITE_TOOL_FNS["send_session_message"](
             {"confirm_token": proposed["confirm_token"]}, convo.spine
         )
         argv = runner.calls[0]
@@ -1542,7 +1542,7 @@ class TestWriteToolSurface:
     def test_cancel_never_writes(self, convo, runner, live):
         proposal = convo.announced_proposal()
         convo.approve(proposal)
-        result = write_tools.cancel_session_message(
+        result = write_tools.WRITE_TOOL_FNS["cancel_session_message"](
             {"confirm_token": proposal.token}, convo.spine
         )
         assert result["success"] is False
@@ -1558,7 +1558,7 @@ class TestWriteToolSurface:
         became words, and survived precisely because it lives in a prompt string
         no test exercised. Now one does.
         """
-        result = write_tools.propose_session_message(
+        result = write_tools.WRITE_TOOL_FNS["propose_session_message"](
             {"session": "orchestrator", "message": "restart it", "_buddy": "buddy"},
             convo.spine,
         )
@@ -1869,7 +1869,7 @@ class TestTheFallbackEchoCannotApprove:
         runner = RecordingRunner()
         spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner)
         convo = Conversation(ring, spine)
-        result = write_tools.propose_session_message(
+        result = write_tools.WRITE_TOOL_FNS["propose_session_message"](
             {"session": "orchestrator", "message": "restart the portal",
              "_buddy": "buddy"},
             spine,
@@ -1898,7 +1898,7 @@ class TestTheFallbackEchoCannotApprove:
             result, convo, runner = self._mint()
             echoed = self._chunks(result)[index]
             convo.says(echoed)
-            verdict = write_tools.send_session_message(
+            verdict = write_tools.WRITE_TOOL_FNS["send_session_message"](
                 {"confirm_token": result["confirm_token"]}, convo.spine
             )
             assert runner.calls == [], (

--- a/tests/unit/test_voice_outbox.py
+++ b/tests/unit/test_voice_outbox.py
@@ -126,6 +126,7 @@ class TestDeliveryState:
             "proposal_id": "abc123",
             "session": "orchestrator",
             "body": "<voice> hello ┃ #abc123",
+            "kind": "request",
             "dispatched": True,
         }
         base.update(over)

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -1,0 +1,367 @@
+"""#966: the tier audit, the declared-write mechanism, and the expanded reads.
+
+Three properties, each asserted structurally rather than by inspection:
+
+1. **The audit cannot drift.** Every ``@mcp.tool`` name in ``agentwire/mcp_*.py``
+   must appear in exactly one tier in ``voice_layer.surface`` — parsed from the
+   source at test time, so a new MCP tool fails this file until someone places
+   it, and a removed one fails until its tier entry goes too.
+2. **Tier 3 is unreachable BY NAME.** The harness boundary (#730) and the
+   other exclusion clauses are asserted against the live realtime surface, not
+   established by reading the diff.
+3. **A write is a declaration.** ``gated_triple`` turns a :class:`WriteSpec`
+   into a working propose/confirm/cancel path with the spine's invariants —
+   proven here with a spec that exists only in this test, including the
+   argv-only (``append_body=False``) shape no shipped spec uses yet.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+from pathlib import Path
+
+import pytest
+
+from agentwire.voice_layer import confirm, surface, tools, transcript, write_tools
+from agentwire.voice_layer.write_tools import FrozenWrite, WriteSpec, gated_triple
+
+# =============================================================================
+# Harness (mirrors test_voice_confirm's, minimally)
+# =============================================================================
+
+
+class RecordingRunner:
+    def __init__(self, result=None):
+        self.calls: list[list[str]] = []
+        self._result = result if result is not None else {"success": True}
+
+    def __call__(self, argv):
+        self.calls.append(list(argv))
+        return self._result
+
+
+class Conversation:
+    _ids = itertools.count()
+
+    def __init__(self, ring, spine):
+        self.ring = ring
+        self.spine = spine
+        self.seq = 0
+
+    def _next(self) -> int:
+        self.seq += 1
+        return self.seq
+
+    def says(self, text):
+        item_id = f"item_{next(self._ids)}"
+        self.ring.speech_started(item_id, self._next())
+        self.ring.commit(item_id, self._next())
+        self.ring.transcribe(item_id, text)
+        return item_id
+
+
+def _spine():
+    ring = transcript.TranscriptRing()
+    runner = RecordingRunner()
+    spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner)
+    return Conversation(ring, spine), runner
+
+
+# =============================================================================
+# 1. The tier audit cannot drift
+# =============================================================================
+
+_MCP_TOOL_RE = re.compile(r"@mcp\.tool\([^)]*\)\s*\ndef\s+(\w+)")
+
+
+def mcp_tool_names() -> set[str]:
+    package_root = Path(tools.__file__).resolve().parents[1]
+    names: set[str] = set()
+    for module in package_root.glob("mcp_*.py"):
+        names |= {m.group(1) for m in _MCP_TOOL_RE.finditer(module.read_text())}
+    assert names, "found no @mcp.tool definitions — the parse itself broke"
+    return names
+
+
+class TestTierAudit:
+    def test_every_mcp_tool_is_tiered(self):
+        """A new MCP tool fails here until someone places it in a tier."""
+        parsed = mcp_tool_names()
+        tiered = frozenset().union(*surface.ALL_TIERS)
+        assert parsed - tiered == set(), (
+            f"untiered MCP tools — place them in voice_layer/surface.py: "
+            f"{sorted(parsed - tiered)}"
+        )
+
+    def test_no_tier_entry_names_a_ghost(self):
+        """The reverse direction: a tier entry for a deleted tool is drift too."""
+        parsed = mcp_tool_names()
+        tiered = frozenset().union(*surface.ALL_TIERS)
+        assert tiered - parsed == set(), (
+            f"tiered names with no MCP tool behind them: {sorted(tiered - parsed)}"
+        )
+
+    def test_tiers_are_disjoint(self):
+        for a, b in itertools.combinations(surface.ALL_TIERS, 2):
+            assert a & b == set(), f"names in two tiers: {sorted(a & b)}"
+
+    def test_tier_of_covers_the_taxonomy(self):
+        assert surface.tier_of("sessions_list") == "read"
+        assert surface.tier_of("desktop_focus_window") == "write_light"
+        assert surface.tier_of("msg_send") == "write_gated"
+        assert surface.tier_of("session_create") == "excluded"
+        assert surface.tier_of("no_such_capability") == "untiered"
+
+
+class TestTierThreeIsUnreachableByName:
+    """The design decision, asserted — not inferred from an absence."""
+
+    def test_the_harness_boundary_names_are_excluded(self):
+        for name in ("session_create", "worktree_create", "pane_spawn",
+                     "session_fork", "session_send", "pane_send"):
+            assert name in surface.TIER_EXCLUDED, name
+
+    def test_no_excluded_capability_is_on_the_realtime_surface(self):
+        exposed = {t["name"] for t in tools.realtime_tool_defs()}
+        assert surface.TIER_EXCLUDED & exposed == set()
+        # Aliased exposure counts too: a voice tool named after an excluded
+        # capability (fleet_session_create, propose_worktree_create) is the
+        # same hole with a prefix.
+        for excluded in surface.TIER_EXCLUDED:
+            for name in exposed:
+                assert not name.endswith(excluded), (
+                    f"{name} exposes excluded capability {excluded}"
+                )
+
+    def test_every_wired_write_is_tiered_gated(self):
+        """A shipped WriteSpec must correspond to a TIER_WRITE_GATED capability."""
+        capability_of = {"session_message": "msg_send"}
+        for spec in write_tools.WRITE_SPECS:
+            capability = capability_of.get(spec.name)
+            assert capability is not None, (
+                f"WriteSpec {spec.name} has no declared capability mapping — "
+                "add it here so its tier is auditable"
+            )
+            assert capability in surface.TIER_WRITE_GATED
+
+    def test_every_wired_read_observes_a_tiered_read(self):
+        """No read tool may be named after a write or excluded capability."""
+        writes_and_excluded = (
+            surface.TIER_WRITE_LIGHT | surface.TIER_WRITE_GATED | surface.TIER_EXCLUDED
+        )
+        for tool in tools.READ_ONLY_TOOLS:
+            for capability in writes_and_excluded:
+                assert not tool.name.endswith(capability), (
+                    f"read tool {tool.name} shadows non-read capability {capability}"
+                )
+
+
+# =============================================================================
+# 3. A write is a declaration
+# =============================================================================
+
+PROBE_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def probe_spec(**overrides) -> WriteSpec:
+    fields = dict(
+        name="probe_action",
+        action="poking the probe",
+        params_schema=PROBE_SCHEMA,
+        freeze=lambda args: FrozenWrite(
+            session="target",
+            instruction="poke target",
+            argv_prefix=("info", "-s", "target"),
+            append_body=False,
+        ),
+        announce_template="Ready to poke {session}. To approve, say {phrase}.",
+        fallback_template=(
+            "Ready to poke {session}. Ask me for the code word when you want it."
+        ),
+        success_say="Done — poked it.",
+    )
+    fields.update(overrides)
+    return WriteSpec(**fields)
+
+
+class TestDeclaredWriteMechanism:
+    def _mint(self, spec):
+        convo, runner = _spine()
+        propose = gated_triple(spec)[0][3]
+        result = propose({"_buddy": "buddy"}, convo.spine)
+        convo.spine.announce(result["proposal_id"], convo._next())
+        return result, convo, runner
+
+    def test_a_spec_generates_a_complete_named_triple(self):
+        triple = gated_triple(probe_spec())
+        assert [t[0] for t in triple] == [
+            "propose_probe_action", "send_probe_action", "cancel_probe_action",
+        ]
+        for _name, description, schema, fn in triple:
+            assert description.strip() and callable(fn)
+            assert schema["type"] == "object"
+
+    def test_argv_only_write_executes_exactly_the_frozen_argv(self):
+        """append_body=False: the prefix IS the argv — nothing appended, ever."""
+        spec = probe_spec()
+        result, convo, runner = self._mint(spec)
+        convo.says(f"confirm {result['confirm_phrase'].split()[1]}")
+        send = gated_triple(spec)[1][3]
+        verdict = send({"confirm_token": result["confirm_token"]}, convo.spine)
+        assert runner.calls == [["info", "-s", "target"]]
+        assert verdict["success"] is True
+        assert verdict["reason"] == "done"
+        assert verdict["say"] == "Done — poked it."
+        # The completes-now claim carries neither of the queue-shaped keys.
+        assert "queued" not in verdict and "sent" not in verdict
+
+    def test_the_msg_write_still_appends_the_rendered_body(self):
+        """The default (append_body=True) path did not regress in the migration."""
+        convo, runner = _spine()
+        proposal = convo.spine.propose(
+            tool="send_session_message",
+            session="orchestrator",
+            instruction="restart the portal",
+            argv_prefix=["msg", "send", "--to", "orchestrator", "--from", "buddy",
+                         "--kind", write_tools.WRITE_KIND],
+        )
+        argv = proposal.build_argv()
+        assert argv[:2] == ["msg", "send"]
+        assert argv[-1].startswith(confirm.VOICE_MARKER)
+
+    def test_a_declared_write_is_single_use(self):
+        spec = probe_spec()
+        result, convo, runner = self._mint(spec)
+        convo.says(f"confirm {result['confirm_phrase'].split()[1]}")
+        send = gated_triple(spec)[1][3]
+        send({"confirm_token": result["confirm_token"]}, convo.spine)
+        replay = send({"confirm_token": result["confirm_token"]}, convo.spine)
+        assert replay["success"] is False
+        assert replay["reason"] == "replayed"
+        assert runner.calls == [["info", "-s", "target"]]
+
+    def test_cancel_retires_without_writing(self):
+        spec = probe_spec()
+        result, convo, runner = self._mint(spec)
+        cancel = gated_triple(spec)[2][3]
+        outcome = cancel({"confirm_token": result["confirm_token"]}, convo.spine)
+        assert outcome["success"] is False
+        assert runner.calls == []
+        convo.says(f"confirm {result['confirm_phrase'].split()[1]}")
+        send = gated_triple(spec)[1][3]
+        assert send({"confirm_token": result["confirm_token"]}, convo.spine)[
+            "success"] is False
+
+    def test_a_fallback_template_carrying_the_phrase_cannot_be_declared(self):
+        """The echo-safety property (#950) holds at declaration time."""
+        with pytest.raises(ValueError, match="fallback"):
+            probe_spec(
+                fallback_template="Ready. To approve, say {phrase}."
+            )
+
+    def test_the_fallback_never_carries_the_nonce(self):
+        result, _convo, _runner = self._mint(probe_spec())
+        nonce_word = result["confirm_phrase"].split()[1]
+        assert nonce_word not in result["fallback_say"]
+
+    def test_shipped_specs_pass_the_same_declaration_guards(self):
+        for spec in write_tools.WRITE_SPECS:
+            assert "{phrase}" not in spec.fallback_template
+            assert spec.params_schema.get("additionalProperties") is False
+
+    def test_confirm_terminal_marks_exactly_the_handshake_enders(self):
+        """The name-independent key the client's confirm gate can move to."""
+        spec = probe_spec()
+        result, convo, _runner = self._mint(spec)
+        send = gated_triple(spec)[1][3]
+        # No utterance at all → pending_transcript → the handshake stays open.
+        waiting = send({"confirm_token": result["confirm_token"]}, convo.spine)
+        assert waiting["reason"] == "pending_transcript"
+        assert waiting["confirm_terminal"] is False
+        convo.says(f"confirm {result['confirm_phrase'].split()[1]}")
+        done = send({"confirm_token": result["confirm_token"]}, convo.spine)
+        assert done["success"] is True
+        assert done["confirm_terminal"] is True
+
+
+# =============================================================================
+# The expanded reads: each one builds exactly its own argv
+# =============================================================================
+
+ARGV_CASES = [
+    ("fleet_session_info", {"session": "agentwire-dev"},
+     ["info", "-s", "agentwire-dev"]),
+    ("fleet_scheduler_status", {}, ["scheduler", "status"]),
+    ("fleet_scheduler_history", {}, ["scheduler", "history", "--json"]),
+    ("fleet_scheduler_live", {}, ["scheduler", "live", "--json"]),
+    ("fleet_tasks", {}, ["task", "list"]),
+    ("fleet_tasks", {"session": "proj"}, ["task", "list", "proj"]),
+    ("fleet_machines", {}, ["machine", "list"]),
+    ("fleet_services", {}, ["services", "status"]),
+    ("fleet_history", {}, ["history", "list", "-n", "20"]),
+    ("fleet_locks", {}, ["lock", "list"]),
+    ("fleet_portal", {}, ["portal", "status"]),
+    ("fleet_councils", {}, ["council", "list"]),
+    ("fleet_wiki_search", {"query": "tmux rename"},
+     ["wiki", "query", "tmux rename"]),
+    ("fleet_session_inbox", {"session": "worker-1"},
+     ["msg", "inbox", "-s", "worker-1"]),
+    ("fleet_roles", {}, ["roles", "list"]),
+    ("fleet_network", {}, ["network", "status"]),
+]
+
+
+class TestExpandedReads:
+    @pytest.fixture
+    def seen(self, monkeypatch):
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.run_agentwire_cmd",
+            lambda argv, **kw: calls.append(list(argv)) or {"success": True},
+        )
+        return calls
+
+    @pytest.mark.parametrize("name,args,expected", ARGV_CASES)
+    def test_each_read_builds_its_own_argv(self, seen, name, args, expected):
+        result = tools.dispatch(name, args, "buddy")
+        assert result.get("success") is not False, result
+        assert seen == [expected]
+
+    def test_voice_health_reads_both_backends(self, seen):
+        result = tools.dispatch("fleet_voice_health", {}, "buddy")
+        assert result["success"] is True
+        assert seen == [["tts", "status"], ["stt", "status"]]
+
+    @pytest.mark.parametrize(
+        "name", ["fleet_session_info", "fleet_session_inbox", "fleet_tasks"]
+    )
+    @pytest.mark.parametrize("bad", ["--help", "../etc/passwd", "worker one", ""])
+    def test_garbled_session_names_fail_closed_everywhere(self, seen, name, bad):
+        result = tools.dispatch(name, {"session": bad}, "buddy")
+        assert result["success"] is False
+        assert "valid session name" in result["error"]
+        assert seen == []
+
+    def test_wiki_query_cannot_reach_the_cli_as_a_flag(self, seen):
+        tools.dispatch("fleet_wiki_search", {"query": "--rm -rf everything"}, "b")
+        assert seen and seen[0][:2] == ["wiki", "query"]
+        assert not seen[0][2].startswith("-")
+
+    def test_wiki_query_is_stripped_and_bounded(self, seen):
+        tools.dispatch(
+            "fleet_wiki_search", {"query": "a\x1b[2Jb" + "c" * 500}, "b"
+        )
+        value = seen[0][2]
+        assert "\x1b" not in value
+        assert len(value) <= tools._MAX_QUERY_CHARS
+
+    def test_an_empty_query_is_refused_with_speech(self, seen):
+        result = tools.dispatch("fleet_wiki_search", {"query": "  ---  "}, "b")
+        assert result["success"] is False
+        assert result["must_speak"] is True
+        assert seen == []

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -274,6 +274,15 @@ class TestDeclaredWriteMechanism:
             assert "{phrase}" not in spec.fallback_template
             assert spec.params_schema.get("additionalProperties") is False
 
+    def test_an_argv_only_write_reads_as_executed_not_delivered(self):
+        """A kind-less outbox entry has no queue to interrogate; claiming
+        'delivered' for it would be a category error (§3.6)."""
+        from agentwire.voice_layer import outbox
+
+        entry = {"proposal_id": "abc123", "session": "target",
+                 "body": "target", "kind": "", "dispatched": True}
+        assert outbox.delivery_state(entry)["state"] == "executed"
+
     def test_confirm_terminal_marks_exactly_the_handshake_enders(self):
         """The name-independent key the client's confirm gate can move to."""
         spec = probe_spec()


### PR DESCRIPTION
Implements #966 in the ordered shape the issue demands: generalise the write gate FIRST, then tier, then add reads.

## 1. The write gate is now a declaration (`write_tools.py`)

- A gated write is a `WriteSpec` (name, params schema, `freeze` validator, spoken templates); `gated_triple()` generates the `propose_/send_/cancel_` tools from it. The invariants live once: whole argv frozen at propose (inside `freeze`), single-use consumed on success, approving utterance never reaches the body (#953), `render_body`'s leading-dash assertion intact.
- New argv-only shape: `FrozenWrite(append_body=False)` — the prefix IS the argv, no free-text slot exists. `Proposal`/`ConfirmSpine.propose` carry `append_body` and a per-write `success_say` (a write that completes says "done", never the msg-shaped "queued" — §3.6 cuts both ways).
- The msg handoff is migrated onto a spec (`SESSION_MESSAGE_SPEC`); its behaviour, tool names, and spoken payloads are unchanged (existing confirm suite passes as-is on the generated path).
- `WriteSpec.__post_init__` refuses a fallback template that could carry the nonce (#950 echo channel), at declaration time.

## 2. The tier audit (`surface.py`, checked in, drift-proof)

Every `@mcp.tool` name in `agentwire/mcp_*.py` — **107 measured**, not the issue's 131 — is placed in exactly one tier, with the rule written in the module docstring. A test parses the mcp modules at test time and fails in BOTH directions (untiered new tool / ghost entry for a deleted one). Counts: 45 reads · 15 light writes · 16 gated writes · 31 excluded.

**Grading rule (derived, as asked, not inherited):** grade by the cost of the worst WRONG execution under mis-transcription. *Light* (confirm-free): undone by one equal action, destroys nothing, causes nobody to act — a nonce here trains reflexive confirmation and kills the gate. *Gated* (nonce): causes agents/humans to act, changes durable state, or destroys something; destructive writes stay in this grade because the spine's spoken read-back + nonce IS the mis-transcription defence — a third ceremony tier would just be a second nonce. I kept the reversibility axis but keyed it on wrong-execution cost rather than the verb's scariness; that's the version that derives `desktop_open_window` ≠ `session_kill` without argument.

**Tier 3 exclusions are lettered clauses** (a: creates/drives sessions — the #730 harness boundary, incl. `session_send`/`pane_send` which forcibly drive a prompt where `msg_send` is the guarded channel; b: second output channel to the owner, #950; c: outward publication; d: authors work product; e: infra identity) and asserted **by name** against the live realtime surface, including aliased exposure (`fleet_<excluded>` fails too).

## 3. Reads: 10 → 26

New: session_info, scheduler status/history/live, tasks, machines, services, history, locks, portal, councils, wiki search, another session's inbox peek, roles, network, voice-pipeline health. Every one builds its own argv from validated parameters; free-text (wiki query) gets the freeze discipline: controls stripped, bounded, structurally unable to reach the CLI as a flag.

## Deliberately NOT in this PR

**No second live gated write.** `client.py:808` reopens the confirm-outstanding gate by *hard-coded tool names* (`send_session_message`/`cancel_session_message`); a second wired write would resolve its handshake without reopening the volunteering gate — a silent-loop defect in a screenless channel. Verdict payloads now carry a name-independent `confirm_terminal` flag so the client can move to a generic key; wiring `session_kill` etc. is a follow-up after that one-line client change (client.py is the other worker's file this wave).

Files outside my map, touched minimally (flagged per wave rules): `outbox.py` (buddy attribution fallback + `executed` state for kind-less writes), `server.py` (runner rename `dispatch_msg_send`→`dispatch_write`), `tests/unit/test_voice_outbox.py` (fixture gains the `kind` field every real entry records), `tests/unit/test_voice_body_delivery.py` untouched (generated fns are exported as module attributes instead).

## Verification

- 3532 unit tests pass (baseline 3482 + 50 new); known CI noise (3× TestRewriteSetIsComplete) not present in unit scope.
- `uv run --no-sync ruff check agentwire/ tests/` clean.
- Three mutations run post-commit, each asserted to land (count==1) and each caught by the intended test: append_body branch removed → argv-only tests red; a name untiered → drift test red; `session_create` un-excluded → boundary-by-name test red.

Closes #966

Built by [dotdev.dev](https://dotdev.dev)