### PR TITLE
voice-layer: acted_session on approved verdicts, ledger keys on it (#967)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -630,26 +630,19 @@ OUTCOME_ROUTER_JS = """
 //
 // 2. "The owner acted on that session" retires its re-raise reminders. NOT
 //    the same predicate: a cancel is terminal but is not acting — retiring on
-//    it loses the second mention the ledger exists to produce. Until the
-//    verdict payload carries the acted-on session itself, this leg stays
-//    scoped to the one session-targeted write, correlated through the most
-//    recent session-message proposal (the send outcome deliberately carries
-//    no parameters — the argv is frozen at propose time).
+//    it loses the second mention the ledger exists to produce. The spine sets
+//    acted_session on APPROVED payloads only, from the proposal frozen at
+//    propose time, so this leg is as name-free as the gate leg. The old
+//    client-side guess — remember the last proposal's session — retired the
+//    WRONG session's reminders whenever two proposals interleaved.
 function createOutcomeRouter(deps) {
   var gate = deps.gate;
   var ledger = deps.ledger;
-  var lastProposedSession = null;
   return {
     route: function (name, result) {
-      if (!result) return;
-      if (name === "propose_session_message" && result.success && result.session) {
-        lastProposedSession = result.session;
-      }
-      if (!result.confirm_terminal) return;
+      if (!result || !result.confirm_terminal) return;
       gate.resolved();
-      if (name === "send_session_message" && result.success && lastProposedSession) {
-        ledger.actedOn(lastProposedSession);
-      }
+      if (result.acted_session) ledger.actedOn(result.acted_session);
     },
   };
 }

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1031,6 +1031,13 @@ class Verdict:
     #: msg-shaped "queued" claim, which is the only honest default for a write
     #: that enqueues rather than completes.
     success_say: str = ""
+    #: The session the approved write acted on, copied from the proposal
+    #: FROZEN at propose time — never from anything supplied at confirm. The
+    #: client's re-raise ledger keys on this to retire reminders; before it,
+    #: the client guessed by remembering the last proposal, which is wrong
+    #: whenever two proposals interleave. Empty means the write has no session
+    #: target, and the key is then omitted rather than shipped empty.
+    acted_session: str = ""
 
     @property
     def spoken(self) -> str:
@@ -1056,6 +1063,14 @@ class Verdict:
                     "say": self.success_say,
                     "must_speak": True,
                     "confirm_terminal": True,
+                    # Only APPROVED payloads carry acted_session: a cancel is
+                    # terminal but is not acting, and retiring a reminder on
+                    # it silently deletes the re-raise (#967).
+                    **(
+                        {"acted_session": self.acted_session}
+                        if self.acted_session
+                        else {}
+                    ),
                 }
             return {
                 "success": True,
@@ -1068,6 +1083,11 @@ class Verdict:
                 ),
                 "must_speak": True,
                 "confirm_terminal": True,
+                **(
+                    {"acted_session": self.acted_session}
+                    if self.acted_session
+                    else {}
+                ),
             }
         return {
             "success": False,
@@ -1355,6 +1375,7 @@ class ConfirmSpine:
             utterance=match.text,
             utterance_item_id=match.item_id,
             success_say=proposal.success_say,
+            acted_session=proposal.session,
         )
 
     def _claim(self, token: str) -> "tuple[Proposal | None, Verdict | None]":

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -1634,27 +1634,51 @@ class TestTheOutcomeRouter:
         assert report["resolved"] == 0
         assert report["actedOn"] == []
 
-    def test_a_queued_send_retires_the_proposed_sessions_reminder(self):
+    def test_a_queued_send_retires_the_acted_sessions_reminder(self):
         """#967's acted-on leg, against the real approved-verdict payload
-        shape: a QUEUED session-message send retires the reminders of the
-        session the last proposal named."""
+        shape: the payload's own acted_session — frozen at propose time —
+        names what to retire. No name check, no proposal memory."""
         approved = confirm.Verdict(
-            approved=True, reason="approved", utterance="confirm juniper"
+            approved=True,
+            reason="approved",
+            utterance="confirm juniper",
+            acted_session="reviewer",
         ).to_dict()
         assert approved["success"] is True and approved["confirm_terminal"] is True
         report = run_outcome_router(f"""
-            router.route("propose_session_message",
-                {{ success: true, session: "reviewer" }});
             router.route("send_session_message", {json.dumps(approved)});
         """)
         assert report["resolved"] == 1
         assert report["actedOn"] == ["reviewer"]
 
+    def test_interleaved_proposals_retire_the_confirmed_one(self):
+        """The case the old last-proposal correlation got wrong: propose to
+        alpha, propose to beta, then confirm ALPHA's write. The client-side
+        guess remembered only beta, so it retired beta's reminders — the
+        false-accept (beta's re-raise silently never happens) AND the
+        false-reject (alpha keeps nagging about something done) in one move.
+        The payload's frozen acted_session cannot make that mistake."""
+        approved_alpha = confirm.Verdict(
+            approved=True, reason="approved", acted_session="alpha"
+        ).to_dict()
+        report = run_outcome_router(f"""
+            router.route("propose_session_message",
+                {{ success: true, session: "alpha" }});
+            router.route("propose_session_message",
+                {{ success: true, session: "beta" }});
+            router.route("send_session_message", {json.dumps(approved_alpha)});
+        """)
+        assert report["resolved"] == 1
+        assert report["actedOn"] == ["alpha"]
+
     def test_a_session_message_cancel_reopens_but_never_retires(self):
         """The priced false-accept: a cancel is terminal but is NOT acting —
-        retiring on it silently loses the re-raise the ledger exists for."""
+        retiring on it silently loses the re-raise the ledger exists for.
+        The cancel payload carries no acted_session, so even with a prior
+        proposal in flight nothing retires."""
         denied = confirm.Verdict(approved=False, reason="denied").to_dict()
         assert denied["confirm_terminal"] is True
+        assert "acted_session" not in denied
         report = run_outcome_router(f"""
             router.route("propose_session_message",
                 {{ success: true, session: "reviewer" }});
@@ -1662,6 +1686,22 @@ class TestTheOutcomeRouter:
         """)
         assert report["resolved"] == 1
         assert report["actedOn"] == []
+
+    def test_a_second_gated_writes_approval_retires_its_own_session(self):
+        """The genericisation's payoff: a write declared from the outside
+        (#966) retires its OWN frozen session's reminders with no client-side
+        knowledge of its name — the same property the gate leg already has."""
+        approved = confirm.Verdict(
+            approved=True,
+            reason="approved",
+            success_say="Beacon lit.",
+            acted_session="watchtower",
+        ).to_dict()
+        report = run_outcome_router(f"""
+            router.route("send_beacon_flare", {json.dumps(approved)});
+        """)
+        assert report["resolved"] == 1
+        assert report["actedOn"] == ["watchtower"]
 
     def test_a_payloadless_result_routes_nowhere(self):
         report = run_outcome_router("""

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -1349,6 +1349,46 @@ class TestOutcomesAreDistinctAndSpoken:
             assert payload["must_speak"] is True, label
             assert payload["say"].strip(), label
 
+    def test_approved_payload_carries_the_frozen_acted_session(self, convo, runner):
+        """#967's missing key: the client used to GUESS which session a
+        confirmed write acted on by remembering the last proposal — wrong the
+        moment two proposals interleave. The spine knows exactly, from the
+        proposal frozen at propose time, so the approved payload says so."""
+        proposal = convo.announced_proposal(session="orchestrator")
+        convo.approve(proposal)
+        payload = convo.spine.confirm(proposal.token).to_dict()
+        assert payload["success"] is True
+        assert payload["acted_session"] == "orchestrator"
+
+    def test_acted_session_rides_the_success_say_branch_too(self):
+        payload = confirm.Verdict(
+            approved=True,
+            reason="approved",
+            success_say="Lit it.",
+            acted_session="watchtower",
+        ).to_dict()
+        assert payload["reason"] == "done"
+        assert payload["acted_session"] == "watchtower"
+
+    def test_a_sessionless_write_omits_acted_session(self):
+        """Absent, not empty: an empty string retiring reminders keyed to a
+        session named "" is nonsense, and the client keys on truthiness."""
+        payload = confirm.Verdict(approved=True, reason="approved").to_dict()
+        assert "acted_session" not in payload
+
+    def test_no_refusal_carries_acted_session(self, convo, clock):
+        """The priced false-accept, at the payload layer: a cancel or refusal
+        retiring a reminder means the re-raise silently never happens. No
+        non-approved payload may carry the key — including cancel."""
+        outcomes = dict(self._outcomes(convo, clock))
+        outcomes["cancelled"] = convo.spine.cancel(
+            convo.announced_proposal(session="orchestrator").token
+        )
+        for label, verdict in outcomes.items():
+            payload = verdict.to_dict()
+            assert payload["success"] is False, label
+            assert "acted_session" not in payload, label
+
     def test_success_says_queued_and_never_sent(self, convo, runner):
         """§3.6. ``msg send`` queues; delivery is at the next safe boundary and
         can defer. Claiming "sent" is worse than silence, because it is a claim.


### PR DESCRIPTION
Lands the key the outcome-router genericisation (#972/#973) asked for and correctly refused to add itself.

**What:** `Verdict.to_dict` now stamps `acted_session` on APPROVED payloads only (both branches — `success_say` and queued), copied in `_judge` from the proposal's session FROZEN at propose time. Absent on cancels, refusals, and any write with no session target (absent, not empty — the client keys on truthiness). The client's outcome router drops the `send_session_message` name check and the `lastProposedSession` correlation entirely: `if (result.acted_session) reRaiseLedger.actedOn(result.acted_session)`.

**The interleaved case was measurably broken before this change:** the old router, fed propose(alpha) → propose(beta) → confirm of ALPHA's write, retired `["beta"]` (verified by running the scenario under node against the pre-change source). That's both priced failures at once — beta's re-raise silently never happens (false accept) and alpha keeps nagging about something done (false reject). Pinned by `test_interleaved_proposals_retire_the_confirmed_one`.

**Both halves priced in tests:** cancel/refusal payloads never carry the key (pinned across the whole outcome map + explicit cancel), and a mutant planting `acted_session` on the refusal branch is caught by 3 tests. A second declared write (#966) retires its own frozen session with no client-side name knowledge.

Invariants held: reads only frozen propose-time state; render_body and the outbox untouched (#953); response.create pin untouched; page wiring tests (router is the only dispatcher) still pass.

Tests: 3583 passed (baseline 3577, +6 new). ruff clean.

Refs #967

Built by [dotdev.dev](https://dotdev.dev)