### PR TITLE
voice-layer: wave-3 blockers — dispatch-path exclusion, msg_pull gated, interrupt class pinned

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -424,7 +424,9 @@ function createInboxNotifier(deps) {
           var reminder = reRaise.dueText();
           if (reminder) {
             onLog("reraise", "second mention");
-            announce(reminder, { reRaise: true });
+            // The ids ride along so the page can commit the second mention
+            // from onSpoken — dueText consumes nothing (see the ledger).
+            announce(reminder.text, { reRaise: true, reRaiseIds: reminder.ids });
           }
         }
         return;
@@ -554,20 +556,36 @@ function createReRaiseLedger(deps) {
     resolve: function (id) {
       if (items[id]) items[id].resolved = true;
     },
-    // The one output: text for everything due, or null. Marks what it returns
-    // as re-raised, so a due item speaks exactly once — the CALLER decides
-    // when a gap is a gap (the notifier's full gate), this only decides what
-    // is due.
+    // The one output: { text, ids } for everything due, or null. Marks
+    // NOTHING — the caller announces it, and only evidence the owner HEARD
+    // it (the page's onSpoken) commits the second mention via spoken(ids).
+    // Consuming at compose time was the ack-before-spoken shape #962 D1 was:
+    // a stop() or a cancelled announcement between compose and speech
+    // silently lost the one reminder this ledger exists to produce. Between
+    // announce and spoken the full gate stays closed (canSpeak requires an
+    // empty announcer queue), so a due item cannot be composed twice in
+    // flight; a withdrawn announcement simply comes due again — the retry
+    // is the point.
     dueText: function () {
-      var due = Object.keys(items).map(function (id) { return items[id]; })
-        .filter(function (it) {
-          return !it.resolved && !it.reRaised && now() - it.at >= dueMs;
-        });
-      if (!due.length) return null;
-      due.forEach(function (it) { it.reRaised = true; });
-      var parts = due.map(function (it) { return it.from + " asked: " + it.text; });
-      return "Still open from earlier — " + parts.join(" And ") +
-        " Nothing has gone their way since. Second mention, so I'll leave it with you.";
+      var ids = Object.keys(items).filter(function (id) {
+        var it = items[id];
+        return !it.resolved && !it.reRaised && now() - it.at >= dueMs;
+      });
+      if (!ids.length) return null;
+      var parts = ids.map(function (id) {
+        return items[id].from + " asked: " + items[id].text;
+      });
+      return {
+        text: "Still open from earlier — " + parts.join(" And ") +
+          " Nothing has gone their way since. Second mention, so I'll leave it with you.",
+        ids: ids,
+      };
+    },
+    // The reminder was confirmed spoken — NOW the second mention is spent.
+    spoken: function (ids) {
+      (ids || []).forEach(function (id) {
+        if (items[id]) items[id].reRaised = true;
+      });
     },
     pending: function () {
       return Object.keys(items).filter(function (id) {
@@ -902,6 +920,13 @@ let errorNoticePending = false;
 // GUARANTEE speech.
 function onSpoken(meta, how) {
   if (meta && meta.errorNotice) { errorNoticePending = false; return; }
+  if (meta && meta.reRaise) {
+    // The second mention is spent only NOW — the same ack-after-spoken
+    // discipline as inbox notices (#962): a reminder announced but never
+    // spoken comes due again instead of dying marked-but-unheard.
+    reRaiseLedger.spoken(meta.reRaiseIds || []);
+    return;
+  }
   if (meta && meta.inboxIds) {
     // A volunteered inbox notice was heard — NOW it may be acked (#962), and
     // NOW anything in it that asks for action enters the re-raise ledger

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -24,6 +24,18 @@ omission. A capability is excluded when it:
     is the polite, guarded channel: the recipient acts on it inside its own
     damage-control, posture and routing. That is why msg is a graded write and
     send is excluded.
+
+    The clause keys on the DISPATCH PATH, not the tool's name: anything that
+    reaches ``agentwire ensure`` — ``task_run``, ``scheduler_run`` — is (a),
+    because ensure creates the session when it is missing and then drives it
+    with prompts to completion. The tempting carve-out ("the task content is
+    owner-authored, in the protected ``.agentwire.tasks.yml``, behind a
+    nonce") was considered and REJECTED: authorship of the prompt does not
+    change who instantiated and drove the session, and the exclusion is not
+    "this is expensive" but "this is not this layer's job at all". A test
+    walks every tool's argv into the CLI call graph and fails any tier-1/2
+    tool whose path can create a session, so the next ensure-shaped verb
+    cannot land under an innocuous name.
 (b) **is another output channel to the owner** — ``say``, ``notify_user``,
     the listen/transcribe family. The buddy IS the voice channel; a second
     path that speaks or toasts is #950 (two paths racing to speak) in
@@ -97,7 +109,7 @@ TIER_WRITE_LIGHT = frozenset({
     "desktop_close_window", "desktop_focus_window", "desktop_tile_window",
     "desktop_minimize_all", "desktop_collage", "desktop_layout",
     "chrome_tab_track", "chrome_tab_untrack",
-    "scratchpad_add", "pane_jump", "pane_resize", "msg_pull",
+    "scratchpad_add", "pane_jump", "pane_resize",
 })
 
 #: Tier 2, gated grade — causes agents/humans to act, changes durable state,
@@ -107,20 +119,28 @@ TIER_WRITE_GATED = frozenset({
     "session_kill", "pane_kill", "pane_detach",
     "worktree_remove", "worktree_prune",
     "lock_clean", "lock_remove",
-    "msg_purge", "msg_flush",
-    "scheduler_run", "scheduler_enable", "scheduler_disable",
-    "task_run",
+    # msg_pull reads AND REMOVES another session's ingest messages (it takes
+    # a session param). The name reads like a fetch; the effect is a consume
+    # with no one-action undo — a mis-heard target silently destroys a
+    # Briefing-Mode anchor's queued pointers, and nothing tells anyone.
+    "msg_pull", "msg_purge", "msg_flush",
+    "scheduler_enable", "scheduler_disable",
     "tunnels_up", "tunnels_down",
 })
 
 #: Tier 3 — permanently excluded, by the lettered clauses in the module
 #: docstring. A DESIGN DECISION, not an oversight.
 TIER_EXCLUDED = frozenset({
-    # (a) creates or drives an agent session — the harness boundary (#730)
+    # (a) creates or drives an agent session — the harness boundary (#730).
+    # task_run and scheduler_run dispatch through `agentwire ensure`, which
+    # creates the session if missing and drives it with prompts — clause (a)
+    # by dispatch path, whatever the verb sounds like (see the docstring for
+    # the rejected owner-authored-content carve-out).
     "session_create", "session_recreate", "session_fork",
     "session_send", "session_send_keys",
     "pane_spawn", "pane_send", "pane_split",
     "worktree_create", "history_resume", "wait_children",
+    "task_run", "scheduler_run",
     "council_start", "council_stop", "council_ask",
     "council_collect", "council_minutes",
     # (b) another output channel to the owner (#950)

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -312,8 +312,13 @@ session by that name — which one did you mean?").
 **Does not — and this is where the risk lives:**
 - ❌ No spawning, no session creation, no worktrees. Ever. See [Cold fleet](#cold-fleet-the-buddy-never-starts-an-orchestrator).
 - ❌ No acting directly on the fleet — every write is a request to a session.
-- ❌ Never speaks while the owner is speaking, and never inside a confirm
-  handshake — unconditional for every tier, including escalations.
+- ❌ Never speaks while the owner is speaking — unconditional for every tier,
+  including escalations. And never inside a confirm handshake, where the
+  protected window opens at the anchor — the moment the proposal's
+  announcement is confirmed spoken — and closes on the outcome or the TTL.
+  (Before the anchor, an escalation can still pre-empt the proposal
+  announcement itself; that is recoverable — an unanchored proposal is
+  unconfirmable and the fallback timer re-speaks — not protected.)
 
 There is deliberately **no escape hatch**. Adding a capability means adding a
 tool, in a diff someone reviews.
@@ -1087,8 +1092,11 @@ undecided. A next session that picks an answer silently is the failure mode.
       judgment, it keys on the **typed message kind** already in the inbox:
       `kind: escalation` is interrupt-class, everything else waits for a gap.
       The reconciliation with #962's never-barge-in: that rule splits into
-      legs, and only one is relaxed. **Never while the owner is speaking** and
-      **never inside a confirm handshake** stay unconditional for every tier;
+      legs, and only one is relaxed. **Never while the owner is speaking**
+      stays unconditional for every tier, and **never inside a confirm
+      handshake** holds from the proposal's anchor (announcement confirmed
+      spoken) to its outcome or TTL — the window `confirmGate.outstanding()`
+      actually measures;
       an escalation is allowed to skip only the "wait for the buddy's own
       chatter to finish" leg (`canInterrupt()` beside `canSpeak()` in the
       notifier — it pre-empts via the announcer's existing cancel, adding no

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -1194,6 +1194,28 @@ class TestTheInterruptTier:
         assert "held: 0" in report["logs"]
         assert len(report["announced"]) == 1
 
+    def test_the_interrupt_class_is_exactly_escalation(self):
+        """The wave-3 surviving mutant: widening the tier to include
+        kind:request passed the whole suite, because the waits test used
+        kind:done. This pins the CLASS boundary, not one member of it —
+        every non-escalation kind the msg channel ships (done, note,
+        request, ingest) must WAIT for the full gate, and each is
+        volunteered once it opens. `request` matters most: it is the kind
+        every buddy write emits, and the commonest actionable one."""
+        for kind in ("done", "note", "request", "ingest"):
+            report = run_notifier(f"""
+                spool = [{{ id: "m1", from: "reviewer", kind: "{kind}",
+                           text: "need a call" }}];
+                speakable = false;
+                interruptable = true;
+                await notifier.pollOnce();
+                logs.push("held: " + announcedCalls.length);
+                speakable = true;
+                await notifier.pollOnce();
+            """)
+            assert "held: 0" in report["logs"], f"kind {kind} rode the interrupt tier"
+            assert len(report["announced"]) == 1, f"kind {kind} was lost by waiting"
+
     def test_a_mixed_batch_under_interrupt_takes_only_the_escalation(self):
         """And the skipped ordinary message is NOT buried by the ack: acking
         the spoken escalation advances the cursor past everything, so the
@@ -1290,7 +1312,12 @@ const ledger = createReRaiseLedger({
   onLog: (kind, detail) => logs.push(kind + ": " + detail),
 });
 const texts = [];
-function tick() { const t = ledger.dueText(); if (t) texts.push(t); return t; }
+// The happy path: the composed reminder gets spoken, which is what spends it.
+function tick() {
+  const t = ledger.dueText();
+  if (t) { texts.push(t.text); ledger.spoken(t.ids); }
+  return t;
+}
 function report() {
   return JSON.stringify({ texts, logs, pending: ledger.pending() });
 }
@@ -1401,6 +1428,27 @@ class TestTheReRaiseLedger:
         """)
         assert len(report["texts"][0]) < 300
 
+    def test_an_unspoken_reminder_comes_due_again(self):
+        """The wave-3 D3 observation, fixed: composing the reminder spends
+        nothing. If the announcement dies before it is spoken (stop(), a
+        cancelled announce), the same reminder comes due again; only
+        spoken(ids) — the page's onSpoken evidence — closes it. Consuming at
+        compose time was the ack-before-spoken shape that was a real defect
+        in #962 D1."""
+        report = run_reraise("""
+            ledger.register("m1", { from: "reviewer", text: "need a call" });
+            clock = 500000;
+            const first = ledger.dueText();          // composed, never spoken
+            const second = ledger.dueText();         // still due — not spent
+            texts.push(second.text);
+            ledger.spoken(second.ids);               // NOW it is spent
+            if (ledger.dueText() !== null) texts.push("BUG: third mention");
+            logs.push("same: " + (first.text === second.text));
+        """)
+        assert report["texts"] == [report["texts"][0]]  # exactly one close
+        assert "same: true" in report["logs"]
+        assert report["pending"] == 0
+
     def test_the_reminder_is_speakable_and_names_the_close(self):
         """The owner cannot skim speech: the reminder must say it is the
         second and last mention, so they know the buddy will now drop it."""
@@ -1430,7 +1478,8 @@ class TestReRaiseThroughTheNotifier:
         """)
         assert len(report["announced"]) == 1
         assert "Still open" in report["announced"][0]["text"]
-        assert report["announced"][0]["meta"] == {"reRaise": True}
+        assert report["announced"][0]["meta"] == {"reRaise": True,
+                                                  "reRaiseIds": ["m1"]}
 
     def test_fresh_news_outranks_the_reminder(self):
         report = run_notifier("""
@@ -1463,8 +1512,8 @@ class TestReRaiseThroughTheNotifier:
 
     def test_a_blocked_tick_does_not_burn_the_reminder(self):
         """Both halves: blocked is silent, and the SAME reminder still fires
-        on the next open tick — dueText marks re-raised only when the text is
-        actually taken."""
+        on the next open tick — dueText marks nothing; only spoken evidence
+        (the page's onSpoken) spends the second mention."""
         report = run_notifier("""
             let clock = 0;
             ledger = createReRaiseLedger({ now: () => clock, dueMs: 120000 });
@@ -1521,6 +1570,16 @@ class TestThePersonaAndInterruptWiring:
         assert '"request"' in register_at and '"escalation"' in register_at
         # And nowhere else on the page registers.
         assert page.count("reRaiseLedger.register(") == 1
+
+    def test_the_reminder_is_spent_only_from_on_spoken(self):
+        """The commit side of mark-on-spoken: exactly one spoken() call site
+        on the page, inside onSpoken's reRaise branch — the announce path
+        never spends the mention it is still trying to deliver."""
+        page = client.page("buddy", "tok")
+        assert page.count("reRaiseLedger.spoken(") == 1
+        onspoken = page.split("function onSpoken(meta, how)", 1)[1].split(
+            "function send(", 1)[0]
+        assert "reRaiseLedger.spoken(meta.reRaiseIds || [])" in onspoken
 
     def test_the_ledger_survives_stop(self):
         """Page-lifetime, like heardReplies: stop() must not touch it, or a

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -17,6 +17,7 @@ Three properties, each asserted structurally rather than by inspection:
 
 from __future__ import annotations
 
+import ast
 import itertools
 import re
 from pathlib import Path
@@ -106,6 +107,13 @@ class TestTierAudit:
         for a, b in itertools.combinations(surface.ALL_TIERS, 2):
             assert a & b == set(), f"names in two tiers: {sorted(a & b)}"
 
+    def test_a_destructive_consume_is_gated_not_light(self):
+        """B2 of the wave-3 review: msg_pull takes a session param and reads
+        AND REMOVES that session's ingest messages — no one-action undo. The
+        light grade came from the name reading like a fetch; the grade keys
+        on the effect."""
+        assert surface.tier_of("msg_pull") == "write_gated"
+
     def test_tier_of_covers_the_taxonomy(self):
         assert surface.tier_of("sessions_list") == "read"
         assert surface.tier_of("desktop_focus_window") == "write_light"
@@ -155,6 +163,206 @@ class TestTierThreeIsUnreachableByName:
                 assert not tool.name.endswith(capability), (
                     f"read tool {tool.name} shadows non-read capability {capability}"
                 )
+
+
+# =============================================================================
+# 2b. No tiered-in tool's dispatch path can create a session
+# =============================================================================
+#
+# The wave-3 lesson: `task_run` and `scheduler_run` sat GATED while both
+# dispatch through `agentwire ensure` — which creates the session when it is
+# missing and then drives it — clause (a) under names that don't look like it.
+# A by-name exclusion list cannot catch the next one, so this analyzer keys on
+# the DISPATCH PATH: it walks every MCP tool's argv into the CLI registrars,
+# resolves the handler function, and asks the package-wide call graph whether
+# that handler can reach session creation. The creation markers are the SSOT
+# helpers themselves (``build_agent_command``, ``create_and_register_worktree``
+# — CLAUDE.md: every launch site routes through them) plus a spawned
+# ``["agentwire", "ensure", ...]`` subprocess (the scheduler's dispatch shape).
+
+
+def _call_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+_CREATION_MARKER_CALLS = {"build_agent_command", "create_and_register_worktree"}
+
+
+def _spawns_ensure(fn: ast.AST) -> bool:
+    """A literal ["agentwire", "ensure", ...] anywhere in the function body."""
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.List, ast.Tuple)):
+            vals = [e.value for e in node.elts if isinstance(e, ast.Constant)]
+            if any(a == "agentwire" and b == "ensure"
+                   for a, b in zip(vals, vals[1:])):
+                return True
+    return False
+
+
+def session_creating_functions() -> set[str]:
+    """Fixpoint over the package call graph: names that can reach creation.
+
+    Conservative on name collisions (same-named functions union their edges);
+    over-flagging surfaces as a failure here and gets resolved by a human,
+    which is the correct direction for a harness-boundary check.
+    """
+    package_root = Path(tools.__file__).resolve().parents[1]
+    funcs: dict[str, set[str]] = {}
+    marked: set[str] = set()
+    for path in package_root.rglob("*.py"):
+        if path.name.startswith("mcp_"):
+            continue  # the MCP layer is the SUBJECT of the check, not its map
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                calls = {n for sub in ast.walk(node)
+                         if isinstance(sub, ast.Call) and (n := _call_name(sub))}
+                funcs.setdefault(node.name, set()).update(calls)
+                if calls & _CREATION_MARKER_CALLS or _spawns_ensure(node):
+                    marked.add(node.name)
+    creating = set(marked)
+    changed = True
+    while changed:
+        changed = False
+        for name, calls in funcs.items():
+            if name not in creating and calls & creating:
+                creating.add(name)
+                changed = True
+    return creating
+
+
+def cli_verb_tree() -> dict:
+    """verb -> {"func": handler|None, "children": {subverb: handler}},
+    parsed from every ``*_cli.py`` registrar (add_parser / add_subparsers /
+    set_defaults(func=...) — the uniform registrar shape per CLAUDE.md #495).
+    """
+    package_root = Path(tools.__file__).resolve().parents[1]
+    tree: dict = {}
+    for path in package_root.glob("*_cli.py"):
+        module = ast.parse(path.read_text())
+        parser_parent: dict[str, str | None] = {}
+        parser_verb: dict[str, str] = {}
+        sub_owner: dict[str, str] = {}
+        parser_func: dict[str, str] = {}
+        for node in ast.walk(module):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                target = node.targets[0]
+                if not isinstance(target, ast.Name):
+                    continue
+                name = _call_name(node.value)
+                base = node.value.func.value if isinstance(
+                    node.value.func, ast.Attribute) else None
+                if (name == "add_parser" and node.value.args
+                        and isinstance(node.value.args[0], ast.Constant)):
+                    parser_parent[target.id] = base.id if isinstance(
+                        base, ast.Name) else None
+                    parser_verb[target.id] = node.value.args[0].value
+                elif name == "add_subparsers" and isinstance(base, ast.Name):
+                    sub_owner[target.id] = base.id
+            elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                call = node.value
+                if _call_name(call) == "set_defaults" and isinstance(
+                        call.func.value, ast.Name):
+                    for kw in call.keywords:
+                        if kw.arg == "func" and isinstance(kw.value, ast.Name):
+                            parser_func[call.func.value.id] = kw.value.id
+        for var, verb in parser_verb.items():
+            parent = parser_parent.get(var)
+            func = parser_func.get(var)
+            if parent in sub_owner:
+                owner_verb = parser_verb.get(sub_owner[parent])
+                if owner_verb:
+                    tree.setdefault(owner_verb, {"func": None, "children": {}})[
+                        "children"][verb] = func
+                    continue
+            tree.setdefault(verb, {"func": None, "children": {}})
+            if func:
+                tree[verb]["func"] = func
+    assert tree, "parsed no CLI registrars — the analyzer itself broke"
+    return tree
+
+
+def mcp_tool_argvs() -> dict[str, list[list]]:
+    """tool name -> the constant-string argv literals its body builds."""
+    package_root = Path(tools.__file__).resolve().parents[1]
+    out: dict[str, list[list]] = {}
+    for path in package_root.glob("mcp_*.py"):
+        for node in ast.parse(path.read_text()).body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not any((isinstance(d, ast.Call) and _call_name(d) == "tool")
+                       or (isinstance(d, ast.Attribute) and d.attr == "tool")
+                       for d in node.decorator_list):
+                continue
+            argvs = []
+            for sub in ast.walk(node):
+                if (isinstance(sub, ast.List) and sub.elts
+                        and isinstance(sub.elts[0], ast.Constant)
+                        and isinstance(sub.elts[0].value, str)):
+                    argvs.append([e.value if isinstance(e, ast.Constant) else None
+                                  for e in sub.elts])
+            out[node.name] = argvs
+    return out
+
+
+#: Dispatches that reach a creating HANDLER in a mode that cannot create:
+#: handler -> the mode flags that select its non-creating branches. Keyed on
+#: the argv shape (the dispatch), never on the MCP tool's name — a new tool
+#: hitting cmd_worktree without one of these flags still fails the check.
+_NON_CREATING_MODES = {
+    "cmd_worktree": {"--list", "--status", "--remove", "--prune", "--dangling"},
+}
+
+
+def session_creating_tools() -> dict[str, str]:
+    """MCP tool -> the creating CLI handler its dispatch path reaches."""
+    creating = session_creating_functions()
+    verbs = cli_verb_tree()
+    flagged: dict[str, str] = {}
+    for tool, argvs in mcp_tool_argvs().items():
+        for argv in argvs:
+            entry = verbs.get(argv[0])
+            if not entry:
+                continue
+            func = entry["func"]
+            if len(argv) > 1 and argv[1] in entry["children"]:
+                func = entry["children"][argv[1]]
+            if func not in creating:
+                continue
+            if any(t in _NON_CREATING_MODES.get(func, ()) for t in argv if t):
+                continue
+            flagged[tool] = func
+    return flagged
+
+
+class TestNoTieredInToolCanCreateASession:
+    def test_the_analyzer_sees_the_known_creators(self):
+        """Must-fail control: an analyzer that goes blind would pass the main
+        assertion vacuously. ensure, the scheduler's forced run, and the raw
+        creation verbs must all register as session-creating."""
+        creating = session_creating_functions()
+        for fn in ("cmd_ensure", "cmd_new", "cmd_worktree",
+                   "cmd_scheduler_run", "cmd_spawn"):
+            assert fn in creating, fn
+        flagged = session_creating_tools()
+        # The two wave-3 escapees, caught by path — not by their names.
+        assert flagged.get("task_run") == "cmd_ensure"
+        assert flagged.get("scheduler_run") == "cmd_scheduler_run"
+
+    def test_every_session_creating_dispatch_path_is_excluded(self):
+        """Clause (a) by dispatch path: any MCP tool whose argv reaches a
+        handler that can create a session must sit in TIER_EXCLUDED."""
+        offenders = {
+            tool: fn for tool, fn in session_creating_tools().items()
+            if tool not in surface.TIER_EXCLUDED
+        }
+        assert offenders == {}, (
+            f"tools whose dispatch path can create a session but are not "
+            f"excluded: {offenders} — clause (a) keys on the path, not the name"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up commit for the wave-3 combination review on #974 (comment 5233915674). All three blockers plus two of the non-blocking items; one ruling stated without a change.

## B1 — task_run / scheduler_run: EXCLUDED (option a)

Ruling: **exclude, no carve-out.** Both dispatch through `agentwire ensure`, which creates the session when missing and then drives it — clause (a) by dispatch path. The owner-authored-content argument (protected `.agentwire.tasks.yml`, nonce) was considered and rejected **in the rule text itself**: authorship of the prompt does not change who instantiated and drove the session, and the exclusion is "not this layer's job", not "too expensive". The rejected carve-out is written into surface.py's clause (a) so the next reader derives the same tier the table shows.

The test that would have caught it: `TestNoTieredInToolCanCreateASession` walks every MCP tool's argv literals into the CLI registrar tree (add_parser/set_defaults, the uniform #495 shape), resolves the handler, and asks a package-wide call-graph fixpoint whether it can reach session creation (markers: `build_agent_command`, `create_and_register_worktree`, a spawned `["agentwire","ensure",...]`). Keyed on the dispatch path, not the name; a must-fail control pins that the analyzer still sees cmd_ensure/cmd_new/cmd_worktree/cmd_scheduler_run/cmd_spawn, so it can't go blind and pass vacuously. The worktree read/teardown tools dispatch `cmd_worktree` in its flag modes (`--list/--status/--remove/--prune/--dangling`) — exempted by argv shape, so a new tool hitting cmd_worktree without a mode flag still fails.

## B2 — msg_pull: light → gated

It reads AND REMOVES another session's ingest messages (takes a session param); worst wrong execution destroys a Briefing-Mode anchor's queued pointers with no one-action undo. The mis-grade was name-shaped ("pull" reads like a fetch) — the tier comment now states the effect. **Sibling audit: none found.** msg_inbox is a genuine peek (verified in both the MCP docstring and `cmd_msg_inbox`); `research_dir`'s `["research","ensure"]` only mkdirs the dropbox; the 13 remaining light tools are one-equal-action presentation/bookkeeping.

## B3 — the interrupt class is pinned

`test_the_interrupt_class_is_exactly_escalation` drives every non-escalation kind the msg channel ships (`done`, `note`, `request`, `ingest`) through the interrupt-only gate: each waits, and each is volunteered at the next full gate. The wave-3 surviving mutant (isUrgent widened to `request`) was re-applied and dies on exactly this test. The class is asserted, not one member.

## Non-blocking items

- **Doc sentence narrowed** (both places): the confirm-handshake protection window opens at the **anchor** (announcement confirmed spoken) and closes on outcome/TTL; pre-anchor pre-emption is named as recoverable, not protected. Never-while-owner-speaks stays unconditional. No code change — the anchor-onset window is the right design (an unanchored proposal is unconfirmable, so nothing protectable exists yet).
- **`dueText` ack-before-spoken: fixed.** It did lose the mention on a stop — compose marked `reRaised` before any speech evidence, so a stop()/cancelled announce between compose and speech spent the one reminder the ledger exists to produce (same shape as #962 D1). Now `dueText` returns `{text, ids}` and marks nothing; the page commits via `reRaiseLedger.spoken(ids)` from onSpoken. Double-compose in flight is blocked by the full gate's `announcer.pending() === 0` leg (already pinned). Mutation-verified.
- **`refused`/`wrong_nonce` reopening the volunteering gate: ruling — keep as-is.** The retry window is owner-paced and unbounded; holding the gate closed through it converts one mis-hearing into a mute buddy for the full TTL, while the false-accept is a single polite interjection that structurally cannot corrupt the confirm (the nonce is unreachable from delivered bodies since #953). Both halves priced; the cheap failure wins. Not a small fix to invert, so not done here.

## The count, measured

**108 tools, 46 reads** (post-fix tiers: 46 read / 14 light / 15 gated / 33 excluded — total 108). Method: an AST walk of `agentwire/mcp_*.py` counting functions carrying an `@mcp.tool(...)` decorator, cross-checked against the suite's `@mcp\.tool\([^)]*\)\s*\ndef\s+(\w+)` regex — both return the identical 108-name set. This confirms the reviewer's re-parse and the PR-prose miscount (107/45); #966's 131 came from a regex that also matched plain defs. No count prose exists in surface.py or the wiki page to correct.

## Verification

- Every mutation landed-asserted (count==1, scoped) and reverted via cp backup: B1 regression, B2 regression, the B3 mutant, and consume-at-compose — each caught by exactly its new test.
- `uv run pytest tests/unit/ -q`: **3589 passed** (baseline 3583 + 6 new).
- `uv run --no-sync ruff check agentwire/ tests/`: clean.
- response.create pin untouched (still exactly 2, pinned test passing). No rebuild, no portal restart, no 8788.

Closes #966

Built by [dotdev.dev](https://dotdev.dev)