### PR TITLE
chore(safety): regenerate damage-control hooks so the merge gate goes green

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -34,7 +34,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "0a6727fc00fcdff5949441157317b97f2fa3cde1ef43604b85c976118db6af1a", "generated_at": "2026-08-06T16:03:47Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "8d267c7ab802b4d315a1116d89370e70619caba6b88ff320291bf4e6dfaad3f4", "generated_at": "2026-08-09T23:11:32Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "0a6727fc00fcdff5949441157317b97f2fa3cde1ef43604b85c976118db6af1a", "generated_at": "2026-08-06T16:03:47Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "8d267c7ab802b4d315a1116d89370e70619caba6b88ff320291bf4e6dfaad3f4", "generated_at": "2026-08-09T23:11:32Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -42,7 +42,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "0a6727fc00fcdff5949441157317b97f2fa3cde1ef43604b85c976118db6af1a", "generated_at": "2026-08-06T16:03:47Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "8d267c7ab802b4d315a1116d89370e70619caba6b88ff320291bf4e6dfaad3f4", "generated_at": "2026-08-09T23:11:32Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "0a6727fc00fcdff5949441157317b97f2fa3cde1ef43604b85c976118db6af1a", "generated_at": "2026-08-06T16:03:47Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "8d267c7ab802b4d315a1116d89370e70619caba6b88ff320291bf4e6dfaad3f4", "generated_at": "2026-08-09T23:11:32Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "0a6727fc00fcdff5949441157317b97f2fa3cde1ef43604b85c976118db6af1a", "generated_at": "2026-08-06T16:03:47Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "8d267c7ab802b4d315a1116d89370e70619caba6b88ff320291bf4e6dfaad3f4", "generated_at": "2026-08-09T23:11:32Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """


### PR DESCRIPTION
`agentwire/safety/_core.py` changed in dcb6c16 (#936/#946) but the five generated hooks under `agentwire/hooks/damage-control/` were never regenerated. CI's **damage-control bypass corpus (merge gate)** job runs `uv run --no-sync python scripts/regen_damage_control_hooks.py --check` and has been RED on `main` ever since — three commits — and red on the two voice draft PRs, which merely inherit main.

## What this is

A **mechanical regeneration**, nothing else: `uv run python scripts/regen_damage_control_hooks.py`.

## What I verified

**Stamp-only — no body drift.** The complete diff is five lines, one `AGENTWIRE_HOOK_STAMP` line per file. Verified independently rather than by eyeballing: filtering every `+`/`-` line in `git diff -U0` through `grep -v 'AGENTWIRE_HOOK_STAMP = '` leaves **zero** lines. Every generated body is byte-identical, so no real rule drift shipped unregenerated. The new `core_sha256` (`8d267c7a…`) equals `shasum -a 256 agentwire/safety/_core.py`.

**CI's own invocations, run locally:**

- `uv run --no-sync python scripts/regen_damage_control_hooks.py --check` — reproduced RED before (all five `OUT OF SYNC`, exit 1), GREEN after (all five `up to date`, exit 0).
- `uv run --no-sync pytest -q tests/unit/test_damage_control_bypass.py tests/unit/test_damage_control_sync.py tests/unit/test_control_plane_protection.py` — **174 passed**.
- The full damage-control/safety suite (adds `test_damage_control_hooks`, `test_damage_control_payload_anchoring`, `test_safety_commands`, `test_safety_deployment`, `test_safety_disabled_rules`, `test_safety_escape_hatch`, `test_safety_heal`, `test_safety_kill_switch`) — **1799 passed, 36 skipped**. The bypass corpus is what this gate exists to protect, so it gets the wider run too.

## Why the gate fired with no functional drift

The stamp records a sha256 of the **whole** `_core.py`, not of the generated slice — so any edit anywhere in that file reds the check even when the emitted hook bodies are unchanged, exactly as happened here. That is fail-safe in the correct direction: it can produce a no-op regen commit like this one, but it can never let a real rule change ship un-regenerated. **Deliberately not changed in this PR** — narrowing the hash to the generated region would trade a cheap false alarm for a possible silent miss on the machine-global files.