### PR TITLE
voice-layer: Host allowlist on the bridge, clamp Content-Length at both ends (#977)

### DIFF
--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -15,6 +15,11 @@ page is served with. A tool-execution endpoint reachable from anywhere else on
 the network is precisely the unguarded surface this design is trying not to
 create.
 
+The loopback bind is **not** what keeps a remote page out, and reading it that
+way is how the hole in #977 got here: the attacker never sends the packet, the
+owner's browser does. A ``Host`` allowlist is the guard that actually
+corresponds to the threat — see :func:`allowed_hosts`.
+
 Two of the routes exist for the confirm gate's ordering:
 
 - ``/utterance`` — the audio-commit boundary and the transcription model's
@@ -46,6 +51,69 @@ from . import instructions as buddy_instructions
 DEFAULT_PORT = 8788
 
 _MAX_BODY = 64 * 1024
+
+#: The only names that may appear in a request's ``Host``. Loopback literals
+#: plus the name a human types for them — see :func:`allowed_hosts` for why the
+#: set is exactly this and no larger.
+LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "[::1]")
+
+
+def allowed_hosts(port: int) -> frozenset[str]:
+    """Every ``Host`` value this bridge will answer on ``port``.
+
+    Binding ``127.0.0.1`` does not make the bridge unreachable from the web,
+    because the attacker is not sending the packet — the OWNER'S BROWSER is.
+    A page on ``evil.com`` that rebinds its own name to ``127.0.0.1`` becomes
+    same-origin with the bridge, fetches ``/`` (served with no auth), reads the
+    ``TOKEN`` embedded in the page, and POSTs ``/tool`` with it. The one thing
+    it cannot forge is ``Host``: the browser sets it from the address bar, so
+    the rebound request says ``evil.com`` and the real client says a loopback
+    name.
+
+    **The false-reject half is the expensive one.** This is a screenless
+    channel: a refused local client is not an error the owner reads, it is a
+    buddy that stops working with no explanation. So the set is derived from
+    how the client ACTUALLY connects, not from a guess:
+
+    - ``client.py`` fetches ``/mint``, ``/tool``, ``/utterance`` and ``/anchor``
+      as RELATIVE paths, so ``Host`` is always whatever is in the address bar
+      — never a value the page chooses.
+    - ``serve()`` returns ``http://127.0.0.1:<port>/`` and ``agentwire buddy
+      serve`` prints exactly that, which makes ``127.0.0.1:<port>`` the common
+      case.
+    - ``localhost:<port>`` is what a human types instead, and ``[::1]:<port>``
+      is what a browser shows if it reaches for IPv6 first. The bind is
+      IPv4-only, so that last one normally fails at TCP rather than here — but
+      if it ever connects it is still the loopback, and refusing it would be a
+      false reject for no gain.
+    - A browser omits the port when it is the scheme default, so port 80 also
+      accepts the bare names. The bridge never defaults there, but ``--port
+      80`` is expressible and would otherwise refuse the only ``Host`` a
+      browser can send.
+
+    Matching is exact against this set (case-folded — ``Host`` is a hostname).
+    Anything else, including a name that RESOLVES to loopback, is foreign:
+    resolution is precisely what rebinding controls.
+
+    What this does not close, and is not claimed to: on a multi-user machine
+    any other local user can ``curl`` ``/`` and take the token, because
+    loopback is per-host, not per-user.
+    """
+    hosts = {f"{name}:{port}" for name in LOOPBACK_HOSTS}
+    if port == 80:
+        hosts |= set(LOOPBACK_HOSTS)
+    return frozenset(hosts)
+
+
+def host_allowed(header: str | None, port: int) -> bool:
+    """Whether a ``Host`` header value may be served on ``port``.
+
+    A missing header refuses. HTTP/1.0 permits omitting it, but nothing a
+    browser does omits it — so this costs no real client, while accepting an
+    absent ``Host`` would make the guard bypassable by anything hand-rolling a
+    request.
+    """
+    return (header or "").strip().lower() in allowed_hosts(port)
 
 
 class BuddyBridge:
@@ -187,12 +255,35 @@ def _handler_factory(bridge: BuddyBridge):
         def _json(self, code: int, payload: dict) -> None:
             self._send(code, json.dumps(payload).encode("utf-8"), "application/json")
 
+        def _host_ok(self) -> bool:
+            """Checked FIRST on every route, GET included.
+
+            ``/`` is served with no auth at all, so it is the request that
+            hands the token over — a guard that ran only on the authenticated
+            POSTs would be checking the door after the key was taken.
+
+            The port comes from the LISTENING SOCKET rather than from an
+            argument: ``serve()`` may be given port 0, and an allowlist built
+            from the requested port would then match nothing at all.
+
+            Two ``Host`` headers are refused outright rather than resolved to
+            the first: which one a proxy or parser believes is the ambiguity,
+            and no browser sends two.
+            """
+            values = self.headers.get_all("Host") or []
+            if len(values) != 1:
+                return False
+            return host_allowed(values[0], self.server.server_address[1])
+
         def _authed(self) -> bool:
             header = self.headers.get("Authorization", "")
             supplied = header[7:] if header.startswith("Bearer ") else ""
             return secrets.compare_digest(supplied, bridge.token)
 
         def do_GET(self):  # noqa: N802  (stdlib naming)
+            if not self._host_ok():
+                self._json(403, {"success": False, "error": "forbidden host"})
+                return
             path = self.path.split("?", 1)[0]
             if path == "/":
                 page = client.page(bridge.buddy, bridge.token).encode("utf-8")
@@ -201,12 +292,23 @@ def _handler_factory(bridge: BuddyBridge):
             self._json(404, {"success": False, "error": "not found"})
 
         def do_POST(self):  # noqa: N802
+            if not self._host_ok():
+                self._json(403, {"success": False, "error": "forbidden host"})
+                return
             path = self.path.split("?", 1)[0]
             if not self._authed():
                 self._json(401, {"success": False, "error": "unauthorized"})
                 return
             try:
-                length = min(int(self.headers.get("Content-Length") or 0), _MAX_BODY)
+                # Clamped at BOTH ends. ``min`` alone let a negative through,
+                # and a negative length is read-to-EOF: the handler parks
+                # until the client goes away — one leaked thread per request,
+                # on a threading server, reported by nothing. ``max`` alone
+                # would drop the 64K cap. (Which way round the two nest does
+                # not matter; that both are present does.)
+                length = max(
+                    0, min(int(self.headers.get("Content-Length") or 0), _MAX_BODY)
+                )
                 raw = self.rfile.read(length) if length else b"{}"
                 payload = json.loads(raw.decode("utf-8") or "{}")
             except (ValueError, json.JSONDecodeError):

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -301,11 +301,19 @@ def _handler_factory(bridge: BuddyBridge):
                 return
             try:
                 # Clamped at BOTH ends. ``min`` alone let a negative through,
-                # and a negative length is read-to-EOF: the handler parks
-                # until the client goes away — one leaked thread per request,
-                # on a threading server, reported by nothing. ``max`` alone
-                # would drop the 64K cap. (Which way round the two nest does
-                # not matter; that both are present does.)
+                # and ``read(-1)`` is read-to-EOF: the handler parked until
+                # the client went away, with the request never having to send
+                # a body at all. ``max`` alone would drop the 64K cap.
+                # (Which way round the two nest does not matter; that both are
+                # present does.)
+                #
+                # WHAT THIS DOES NOT CLOSE: the parked-thread class itself.
+                # A request declaring ``Content-Length: 60000`` and sending 2
+                # bytes still parks this thread in ``read(60000)`` until the
+                # client disconnects — measured, 5 requests, 5 parked threads,
+                # on this fixed code. Only the negative case is closed here.
+                # Closing the rest needs a read timeout on the connection, not
+                # a bound on the declared length.
                 length = max(
                     0, min(int(self.headers.get("Content-Length") or 0), _MAX_BODY)
                 )

--- a/tests/unit/test_voice_bridge_host.py
+++ b/tests/unit/test_voice_bridge_host.py
@@ -1,0 +1,338 @@
+"""The bridge's Host guard and its body-length guard (#977).
+
+Both are about a request the bearer token does not defend against.
+
+**The Host guard.** The bridge binds ``127.0.0.1`` and mints a per-run bearer
+token, and neither of those stops a REMOTE page from driving it. DNS rebinding
+is the attack: a page served from ``evil.com`` re-resolves that name to
+``127.0.0.1``, so the browser treats ``http://evil.com:8788/`` as same-origin,
+fetches ``/`` — which is served with no auth at all — reads the ``TOKEN``
+embedded in the page, and POSTs ``/tool`` with it. The loopback bind never
+sees a foreign packet; the BROWSER is the confused deputy. What separates the
+attack from the real client is the ``Host`` header, which the browser sets from
+the address bar and script cannot forge.
+
+So these tests drive **raw sockets**, not ``http.client``: the whole subject is
+a header ``http.client`` writes for you, and a test that lets the library set
+``Host`` is asserting on its own fixture.
+
+Both halves of the guard are priced, and the false-reject half is the
+expensive one — a legitimate local client refused in a screenless channel is a
+buddy that goes silently dead. So the accepted set is asserted explicitly,
+against how the client ACTUALLY connects: ``client.py`` fetches ``/tool``,
+``/mint``, ``/utterance``, ``/anchor`` as **relative paths**, so the Host on
+every request is whatever the owner typed in the address bar — the
+``127.0.0.1:<port>`` the CLI prints, or the ``localhost:<port>`` a human types
+instead, in whatever case they typed it.
+
+**The body-length guard.** ``rfile.read(-5)`` reads to EOF, so a negative
+``Content-Length`` parks a handler thread until the client goes away — one
+leaked thread per request, and on a threading server nothing else reports it.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+from agentwire import core
+from agentwire.voice_layer import server
+
+TOKEN = "test-token"
+
+
+class _Bridge(server.BuddyBridge):
+    """A bridge that records whether a tool ever reached dispatch.
+
+    The Host guard's claim is that a foreign-Host request is refused *before
+    routing*. A 403 alone cannot show that — this can.
+    """
+
+    def __init__(self):
+        super().__init__("buddy", TOKEN, runner=lambda *a, **k: {"success": True})
+        self.dispatched: list[str] = []
+
+    def tool_call(self, payload: dict) -> dict:
+        self.dispatched.append(str(payload.get("name")))
+        return {"success": True}
+
+
+@pytest.fixture
+def bridge_server(tmp_path, monkeypatch):
+    """A real bridge on a real ephemeral port. Port 0: a fixed port collides."""
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+    bridge = _Bridge()
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), server._handler_factory(bridge))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield bridge, httpd.server_address[1]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def raw(port: int, request: str, *, timeout: float = 5.0) -> str:
+    """Send a request byte-for-byte and read the whole response.
+
+    ``timeout`` is the assertion in the negative-Content-Length test: a handler
+    parked in ``read(-5)`` never answers, and the read here raises instead of
+    hanging the suite.
+    """
+    with socket.create_connection(("127.0.0.1", port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        sock.sendall(request.replace("\n", "\r\n").encode("utf-8"))
+        chunks = []
+        while True:
+            block = sock.recv(65536)
+            if not block:
+                break
+            chunks.append(block)
+            # The bridge answers with Connection: close semantics under
+            # HTTP/1.0, but a 1.1 keep-alive response would leave us blocked
+            # on recv until the timeout — stop once the body is complete.
+            joined = b"".join(chunks)
+            head, _, body = joined.partition(b"\r\n\r\n")
+            length = _content_length(head.decode("latin-1"))
+            if length is not None and len(body) >= length:
+                break
+        return b"".join(chunks).decode("utf-8", "replace")
+
+
+def _content_length(head: str) -> int | None:
+    for line in head.split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return None
+    return None
+
+
+def status(response: str) -> int:
+    return int(response.split(" ", 2)[1])
+
+
+# =============================================================================
+# The Host allowlist — the false-REJECT half
+# =============================================================================
+
+
+class TestLegitimateClientsAreServed:
+    """What must keep working. A Host guard that refuses the real client is a
+    silent outage in a channel with no screen to show the error on."""
+
+    def test_the_url_the_cli_actually_prints_is_served(self, bridge_server):
+        """``serve()`` returns ``http://127.0.0.1:<port>/`` and ``buddy serve``
+        prints exactly that — so this Host is the common case, not a variant."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: 127.0.0.1:{port}\n\n")
+        assert status(response) == 200
+        assert TOKEN in response
+
+    def test_localhost_is_served(self, bridge_server):
+        """Nobody types four octets. ``localhost`` resolves to the same bind
+        and the browser sends it verbatim."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: localhost:{port}\n\n")
+        assert status(response) == 200
+        assert TOKEN in response
+
+    def test_the_host_header_is_matched_case_insensitively(self, bridge_server):
+        """Host is a hostname: case is not significant, and a browser passes
+        through whatever case was typed. Case-sensitive matching would refuse
+        a legitimate client for the way they capitalised it."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: LocalHost:{port}\n\n")
+        assert status(response) == 200
+
+    def test_ipv6_loopback_literal_is_served(self, bridge_server):
+        """A browser resolving ``localhost`` may reach for ``::1`` first and
+        will show the literal in the bar if it does. The bind is IPv4-only so
+        this normally fails at TCP rather than here — but if it ever connects,
+        it is the loopback and refusing it is a false reject."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: [::1]:{port}\n\n")
+        assert status(response) == 200
+
+    def test_an_authorized_post_on_an_allowed_host_still_dispatches(
+        self, bridge_server
+    ):
+        """The must-fail control for every refusal test below: if POST were
+        broken outright, they would all pass for the wrong reason."""
+        bridge, port = bridge_server
+        body = '{"name": "fleet_sessions", "arguments": {}}'
+        response = raw(
+            port,
+            f"POST /tool HTTP/1.1\nHost: 127.0.0.1:{port}\n"
+            f"Authorization: Bearer {TOKEN}\n"
+            f"Content-Length: {len(body)}\n\n{body}",
+        )
+        assert status(response) == 200
+        assert bridge.dispatched == ["fleet_sessions"]
+
+
+# =============================================================================
+# The Host allowlist — the false-ACCEPT half
+# =============================================================================
+
+
+class TestForeignHostsAreRefused:
+    def test_get_root_refuses_a_foreign_host_and_leaks_no_token(
+        self, bridge_server
+    ):
+        """The whole attack in one request: ``/`` is served with NO auth, so
+        this response is where the token is stolen."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: evil.com:{port}\n\n")
+        assert status(response) == 403
+        assert TOKEN not in response
+
+    def test_a_rebound_name_on_the_right_port_is_still_foreign(
+        self, bridge_server
+    ):
+        """DNS rebinding means the NAME resolves to 127.0.0.1 — the packet is
+        indistinguishable from the real client's at every layer except this
+        header. Matching on the port alone would accept it."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: buddy.evil.com:{port}\n\n")
+        assert status(response) == 403
+
+    def test_a_foreign_host_post_never_reaches_dispatch(self, bridge_server):
+        """With a VALID token — the stolen one. The refusal must land before
+        routing, not after."""
+        bridge, port = bridge_server
+        body = '{"name": "fleet_sessions", "arguments": {}}'
+        response = raw(
+            port,
+            f"POST /tool HTTP/1.1\nHost: evil.com:{port}\n"
+            f"Authorization: Bearer {TOKEN}\n"
+            f"Content-Length: {len(body)}\n\n{body}",
+        )
+        assert status(response) == 403
+        assert bridge.dispatched == []
+
+    @pytest.mark.parametrize("route", ["/mint", "/utterance", "/anchor"])
+    def test_every_post_route_is_guarded(self, bridge_server, route):
+        """Not just ``/tool``: ``/mint`` spends the owner's API key, and the
+        two ordering routes feed the confirm gate's predicate."""
+        _, port = bridge_server
+        response = raw(
+            port,
+            f"POST {route} HTTP/1.1\nHost: evil.com:{port}\n"
+            f"Authorization: Bearer {TOKEN}\nContent-Length: 2\n\n{{}}",
+        )
+        assert status(response) == 403
+
+    def test_a_right_name_on_a_wrong_port_is_refused(self, bridge_server):
+        """Another bridge — or another local service the browser has been
+        rebound at — is not this one."""
+        _, port = bridge_server
+        response = raw(port, f"GET / HTTP/1.1\nHost: 127.0.0.1:{port + 1}\n\n")
+        assert status(response) == 403
+
+    def test_two_host_headers_are_refused_even_when_one_is_loopback(
+        self, bridge_server
+    ):
+        """Which of two ``Host`` headers a parser believes is the whole point
+        of request smuggling, and resolving to "the first one" is a choice, not
+        a rule. No browser sends two, so refusing costs no real client."""
+        _, port = bridge_server
+        response = raw(
+            port,
+            f"GET / HTTP/1.1\nHost: 127.0.0.1:{port}\nHost: evil.com:{port}\n\n",
+        )
+        assert status(response) == 403
+        assert TOKEN not in response
+
+    def test_a_missing_host_is_refused(self, bridge_server):
+        """HTTP/1.0 permits omitting it. Nothing the browser does omits it, so
+        refusing costs no real client — and accepting an absent Host would make
+        the guard trivially bypassable by anything that is not a browser."""
+        _, port = bridge_server
+        response = raw(port, "GET / HTTP/1.0\n\n")
+        assert status(response) == 403
+        assert TOKEN not in response
+
+
+class TestHostPredicate:
+    """The predicate on its own — the wire tests above cover one port each."""
+
+    def test_the_accepted_set_is_exactly_the_loopback_names(self):
+        for host in ("127.0.0.1", "localhost", "[::1]"):
+            assert server.host_allowed(f"{host}:8788", 8788)
+
+    @pytest.mark.parametrize(
+        "header",
+        ["", "evil.com:8788", "127.0.0.1:8789", "127.0.0.1", "127.0.0.1:", "::1:8788"],
+    )
+    def test_everything_else_is_refused(self, header):
+        assert not server.host_allowed(header, 8788)
+
+    def test_a_bare_host_is_accepted_only_on_port_80(self):
+        """Browsers omit the default port. The bridge never defaults to 80, but
+        ``--port 80`` is expressible, and a guard that refuses the only Host a
+        browser can send there is a guaranteed false reject."""
+        assert server.host_allowed("localhost", 80)
+        assert not server.host_allowed("localhost", 8788)
+
+
+# =============================================================================
+# The body-length guard
+# =============================================================================
+
+
+class TestBodyLength:
+    def test_content_length_minus_one_does_not_park_the_thread(self, bridge_server):
+        """``min(int(hdr), _MAX_BODY)`` passes a negative straight through, and
+        ``-1`` is the value ``read()`` DEFINES as read-to-EOF: the handler
+        blocks until the client disconnects, and on a threading server that is
+        one leaked thread per request with nothing reporting it. Measured, not
+        assumed — an unfixed bridge holds this connection open indefinitely
+        (verified at 3s, thread count +1), so the assertion is that a response
+        arrives AT ALL and ``raw()``'s timeout is the failure.
+
+        Note this is ``-1`` and not the issue's ``-5``: see the test below."""
+        _, port = bridge_server
+        response = raw(
+            port,
+            f"POST /tool HTTP/1.1\nHost: 127.0.0.1:{port}\n"
+            f"Authorization: Bearer {TOKEN}\nContent-Length: -1\n\n",
+            timeout=5.0,
+        )
+        assert status(response) in (200, 400)
+
+    def test_other_negative_lengths_answer_too(self, bridge_server):
+        """A control that is GREEN BEFORE THE FIX, deliberately kept and
+        labelled. ``read(-5)`` raises ``ValueError`` ("read length must be
+        non-negative or -1"), which the existing ``except`` turns into a 400 —
+        so the issue's own repro value never hung, and a suite that pinned the
+        bug on ``-5`` alone would have shipped a green light over a live
+        thread leak. After ``max(0, …)`` both values take the same path."""
+        _, port = bridge_server
+        response = raw(
+            port,
+            f"POST /tool HTTP/1.1\nHost: 127.0.0.1:{port}\n"
+            f"Authorization: Bearer {TOKEN}\nContent-Length: -5\n\n",
+            timeout=5.0,
+        )
+        assert status(response) in (200, 400)
+
+    def test_an_oversized_body_is_still_truncated(self, bridge_server):
+        """The existing 64K cap must survive the fix. Clamping at both ends is
+        two guards, and dropping either one is a silent regression: this is the
+        one that catches ``max(0, int(...))`` written without the ``min``."""
+        _, port = bridge_server
+        body = '{"name": "x", "pad": "' + "a" * (server._MAX_BODY * 2) + '"}'
+        response = raw(
+            port,
+            f"POST /tool HTTP/1.1\nHost: 127.0.0.1:{port}\n"
+            f"Authorization: Bearer {TOKEN}\n"
+            f"Content-Length: {len(body)}\n\n{body}",
+        )
+        # Truncated at the cap, so the JSON no longer parses.
+        assert status(response) == 400

--- a/tests/unit/test_voice_bridge_host.py
+++ b/tests/unit/test_voice_bridge_host.py
@@ -290,11 +290,16 @@ class TestBodyLength:
     def test_content_length_minus_one_does_not_park_the_thread(self, bridge_server):
         """``min(int(hdr), _MAX_BODY)`` passes a negative straight through, and
         ``-1`` is the value ``read()`` DEFINES as read-to-EOF: the handler
-        blocks until the client disconnects, and on a threading server that is
-        one leaked thread per request with nothing reporting it. Measured, not
-        assumed — an unfixed bridge holds this connection open indefinitely
-        (verified at 3s, thread count +1), so the assertion is that a response
-        arrives AT ALL and ``raw()``'s timeout is the failure.
+        blocks until the client disconnects, having sent no body at all.
+        Measured, not assumed — an unfixed bridge holds this connection open
+        indefinitely (verified at 3s, thread count +1), so the assertion is
+        that a response arrives AT ALL and ``raw()``'s timeout is the failure.
+
+        The scope of this test is exactly the negative case. A parked handler
+        is still reachable by OVER-DECLARING a positive length (``60000``
+        declared, 2 bytes sent — measured at 5 parked threads on the fixed
+        code); that needs a read timeout on the connection and has no test
+        here.
 
         Note this is ``-1`` and not the issue's ``-5``: see the test below."""
         _, port = bridge_server


### PR DESCRIPTION
Closes #977. Into `voice-confirm-spine`, never `main`.

## The hole

The loopback bind was never the guard. The attacker does not send the packet — **the owner's browser does**. A page on `evil.com` that rebinds its own name to `127.0.0.1` is same-origin with the bridge; it fetches `/` (served with **no auth at all**), reads the `TOKEN` embedded in the page template, and POSTs `/tool` with it. The one thing it cannot forge is `Host`, which the browser sets from the address bar.

So: an exact `Host` allowlist, checked **first on every route, GET included** — a guard that ran only on the authenticated POSTs would be checking the door after the key was taken.

## The accepted set, and why it is complete

Priced explicitly, because in a screenless channel a **wrongful refusal is a buddy that dies with no error the owner can read** — the expensive half. The set is derived from how `client.py` actually connects, not assumed:

| Accepted `Host` | Why |
|---|---|
| `127.0.0.1:<port>` | `serve()` returns `http://127.0.0.1:<port>/` and `agentwire buddy serve` prints exactly that. The common case. |
| `localhost:<port>` | What a human types instead of four octets. |
| `[::1]:<port>` | What a browser shows if it reaches for IPv6 first. The bind is IPv4-only so this normally fails at TCP rather than here — but if it ever connects it is the loopback, and refusing would be a false reject for no gain. |
| bare `127.0.0.1` / `localhost` / `[::1]`, **only when port == 80** | A browser omits the scheme-default port. The bridge never defaults to 80, but `--port 80` is expressible and would otherwise refuse the only `Host` a browser can send there. |

**Why that is complete:** every fetch in `client.py` (`/mint`, `/tool`, `/utterance`, `/anchor`) is a **relative path**. The page never chooses a `Host` — it is always whatever is in the address bar, which is one of the rows above. There is no other client: no proxy, no remote caller, no portal coupling (deliberately).

Matching is exact and case-folded (`Host` is a hostname; a browser passes through the case that was typed). A name that *resolves* to loopback is still foreign — resolution is precisely what rebinding controls. Missing `Host` refuses (HTTP/1.0 permits omitting it; nothing a browser does omits it). Two `Host` headers refuse outright rather than resolving to the first.

**Not closed, and not claimed to be:** on a multi-user machine any other local user can `curl /` and take the token. Loopback is per-host, not per-user. (The wiki's §Serving text is the docs wave's, not this one's.)

## The Content-Length nit — and a correction to the issue

The issue's repro value is off. `rfile.read(-5)` **raises** `ValueError("read length must be non-negative or -1")`, which the existing `except` turns into a 400 — it never hung. The value that actually parks a handler thread is exactly **`-1`**, which `read()` defines as read-to-EOF: measured at 3s with no response and thread count +1 on the unfixed bridge. A suite that had pinned the bug on `-5` would have shipped a green light over a live thread leak, so both values are tested and the `-5` one is labelled as green-before-the-fix.

Fixed with `max(0, min(…, _MAX_BODY))` — clamped at both ends; dropping either is a regression and each has its own test.

## Method

- Every test **watched failing first**, including the `-1` hang (fails by socket timeout).
- **Every mutation re-verified to turn a test red**: guard dropped from `do_GET`, dropped from `do_POST`, `.lower()` dropped, `localhost` dropped from the set, `[::1]` dropped, the port-80 branch dropped, `max(0, …)` dropped, the cap dropped, the duplicate-`Host` check relaxed. Two mutants survived the first pass — a semantically identical clamp reorder (my comment overclaimed; corrected) and the untested duplicate-`Host` check (test added).
- Tests drive **raw sockets**, not `http.client`: the subject is a header `http.client` writes for you, and a test that lets the library set `Host` asserts on its own fixture.
- CI's own invocation: `uv run --extra dev pytest` → **1 failed, 5630 passed, 36 skipped**. The one failure is `test_session_metadata_ssot.py::test_no_module_hand_builds_the_metadata_path`, **pre-existing on this branch** (confirmed by stashing this change) and in `voice_layer/delivery.py` + `identity.py` — files this worker does not own. `ruff check agentwire/ tests/` clean.

## Files

`agentwire/voice_layer/server.py` and the new `tests/unit/test_voice_bridge_host.py`. Nothing else — `confirm.py` is a sibling's this wave, `client.py` next wave's.

Built by [dotdev.dev](https://dotdev.dev)