### PR TITLE
voice-layer W1: confirm grammar — mask overreach, never-confirm, and the false-reject set (#976)

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -381,6 +381,15 @@ _NEVER_GAP_WORDS = frozenset(
 #: ONE rule, one place: the pair is deliberately NOT also in
 #: :data:`_DENIAL_BIGRAMS`. Two spellings of one rule drift apart, and the
 #: zero-gap case is just this rule with an empty run.
+#:
+#: **The second half is ``confirm`` alone, not :data:`_CONFIRM_WORDS`, and that
+#: is deliberate** — a reader will otherwise assume the pair tracks that tuple.
+#: "never confirmed tango" approves, and should: the past tense is a STATEMENT
+#: about what happened ("I never confirmed tango, did I?"), not an imperative
+#: retraction. Only the bare imperative retracts, which is the same
+#: exact-token reasoning that keeps ``waiting``/``waited`` out of the ``wait``
+#: rule. Adding ``confirmed`` here would buy no retraction anyone speaks and
+#: would deny ordinary speech about a past approval.
 _GAPPED_DENIAL_BIGRAMS = {("never", "confirm"): _NEVER_GAP_WORDS}
 
 #: Pairs that SUPPRESS a single-word denial.

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -327,6 +327,42 @@ _FILLERS = frozenset({"uh", "um", "er", "erm", "ah", "hmm", "like", "you", "know
 #: ``("scrap", "that")`` and ``("hold", "off")`` are added: closed retraction
 #: phrases one word from entries already here, so they were plain misses and
 #: cost nothing.
+_DENIAL_BIGRAMS = frozenset(
+    {("do", "not"), ("never", "mind"), ("hold", "on"), ("hang", "on"),
+     ("hold", "off"), ("forget", "it"), ("forget", "that"),
+     ("scrap", "that"), ("belay", "that")}
+)
+
+#: Words tolerated BETWEEN the two halves of a gapped bigram.
+#:
+#: **"Adjacent" was already a fiction and that is what made this a blocker.**
+#: ``_denial_tokens`` strips ``_FILLERS`` before matching, so every entry in
+#: this grammar has always been "adjacent modulo a skip set" — which is why
+#: "never, uh, confirm tango" denied while "never ever confirm tango"
+#: APPROVED. Shipping the pair as strictly adjacent stated a rule the matcher
+#: did not implement, and the gap it left was the commonest intensifier in the
+#: language. Also measured: really / once / actually / seriously, and
+#: ``carries_denial("never ever confirm that")`` was False, so the
+#: post-approval scan was blind to it too and the write EXECUTED.
+#:
+#: Closed class on purpose: degree adverbs, nothing else. An open gap ("any
+#: word between never and confirm") would deny "I would never send that
+#: without checking — confirm tango", which is an approval.
+#:
+#: **This enumeration sits on the FAIL-OPEN side, and unlike ``_FILLERS`` it
+#: cannot be moved off it.** An unlisted gap word ends the run and the
+#: utterance approves — "never absolutely confirm tango" would approve if
+#: ``absolutely`` were missing. What bounds it is that the class is closed and
+#: small; what does not bound it is anything structural. That is the honest
+#: shape of this entry, stated rather than implied.
+_NEVER_GAP_WORDS = frozenset(
+    {"ever", "once", "again", "really", "actually", "seriously", "truly",
+     "honestly", "literally", "absolutely", "definitely", "certainly",
+     "just", "simply", "please"}
+)
+
+#: Ordered pairs matched with a bounded, closed gap between them.
+#:
 #: ``("never", "confirm")`` closes the one place the "a missed retraction is
 #: safe" fallback does not hold. ``never`` is kept OUT of the word list above
 #: for good reason — it is among the commonest words in English — and the
@@ -338,14 +374,14 @@ _FILLERS = frozenset({"uh", "um", "er", "erm", "ah", "hmm", "like", "you", "know
 #: confirm tango".
 #:
 #: Safe by the closed-phrase rule rather than by intuition: no genuine approval
-#: places those two tokens ADJACENT IN THAT ORDER. ``never`` anywhere else in
-#: the utterance stays the ordinary word it was excluded for being — "confirm
-#: tango, I never got the other one" still approves.
-_DENIAL_BIGRAMS = frozenset(
-    {("do", "not"), ("never", "mind"), ("never", "confirm"), ("hold", "on"),
-     ("hang", "on"), ("hold", "off"), ("forget", "it"), ("forget", "that"),
-     ("scrap", "that"), ("belay", "that")}
-)
+#: places those two tokens in that order separated only by a degree adverb.
+#: ``never`` anywhere else stays the ordinary word it was excluded for being —
+#: "confirm tango, I never got the other one" still approves.
+#:
+#: ONE rule, one place: the pair is deliberately NOT also in
+#: :data:`_DENIAL_BIGRAMS`. Two spellings of one rule drift apart, and the
+#: zero-gap case is just this rule with an empty run.
+_GAPPED_DENIAL_BIGRAMS = {("never", "confirm"): _NEVER_GAP_WORDS}
 
 #: Pairs that SUPPRESS a single-word denial.
 #:
@@ -503,7 +539,28 @@ def _denial_tokens(tokens: "list[str]") -> bool:
     for index in range(len(masked) - 1):
         if tuple(masked[index:index + 2]) in _DENIAL_BIGRAMS:
             return True
+    if _gapped_bigram(masked):
+        return True
     return any(token in _DENIAL_WORDS for token in masked)
+
+
+def _gapped_bigram(masked: "list[str]") -> bool:
+    """Does *masked* contain a :data:`_GAPPED_DENIAL_BIGRAMS` pair?
+
+    The run of tolerated words between the two halves is closed and ends at the
+    first word outside it — including a masked-out ``""``, so an exception's
+    suppression still stops this rule rather than being skipped through.
+    """
+    for (first, second), gap_words in _GAPPED_DENIAL_BIGRAMS.items():
+        for index, token in enumerate(masked):
+            if token != first:
+                continue
+            for follower in masked[index + 1:]:
+                if follower == second:
+                    return True
+                if follower not in gap_words:
+                    break
+    return False
 
 
 _CONFIRM_WORDS = ("confirm", "confirmed")
@@ -1344,10 +1401,21 @@ class ConfirmSpine:
         # write went out with a take-back mid-transcription. Re-reading makes
         # the bound "everything the owner had started by the time this confirm
         # reached its verdict" — still bounded, and still strictly before the
-        # verdict. The false-reject price is one pending_transcript wait, which
-        # the owner is told to sit through and which resolves on the next
-        # confirm; the widened `found` seqs are subsumed, since high_seq
+        # verdict. The widened `found` seqs are subsumed, since high_seq
         # advances on every ring event.
+        #
+        # THE PRICE, stated at its true size. It is not "one pending_transcript
+        # wait": `unheard_between` has no staleness bound, so an utterance that
+        # never completes — a cough, a VAD blip, TTS bleed, any speech_started
+        # with no transcript to follow — sits in this window and refuses every
+        # confirm until the TTL expires it. And it refuses as a WAIT outcome,
+        # so no attempt is burned, `too_many_attempts` never fires, and the
+        # owner hears "give me a second" for up to 120s and then "that one
+        # expired" — a spoken loop, which in a screenless channel is the
+        # expensive failure. The bound belongs in TranscriptRing (age the
+        # entry, or cap the wait), NOT here: this function cannot tell a
+        # never-completing entry from a slow one without reading the ring's
+        # own clock. Pinned in the tests as a residual, not as a design.
         ceiling = max(self._ring.high_seq, anchor)
         found = self._ring.await_utterance_after(anchor, self._wait_s)
         ceiling = max(ceiling, self._ring.high_seq)
@@ -1479,8 +1547,12 @@ class ConfirmSpine:
         # unbounded scan lets an utterance from much later — including one that
         # arrives during a RETRY's bounded await — retroactively deny an
         # approval, and report "You said no" about something the owner said in
-        # a different context. `ceiling` is the ring's high-water mark as of
-        # this confirm's entry.
+        # a different context. `ceiling` covers everything the owner had
+        # started by the time this confirm reached its verdict: it is read
+        # before the await AND again after it (see `confirm`), so an utterance
+        # begun DURING the await is inside the window. Saying "as of this
+        # confirm's entry" here described the old, narrower bound and would
+        # have let the widened window be reviewed as the one it replaced.
         later = [
             entry
             for entry in self._ring.after(

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -111,8 +111,11 @@ contradict the honest limit above two paragraphs later.
 the transcriber renders inconsistently makes a CORRECT approval fail every
 time, and the taxonomy then tells the owner to say it again — so they repeat and
 fail identically. That is a livelock, and it is worse than the false-accept the
-strictness was buying. Hence :data:`NONCE_WORDS` (one spelling each, no digits)
-and containment rather than whole-utterance matching. See :func:`classify`.
+strictness was buying. Hence :data:`NONCE_WORDS` (one TRANSCRIBER RENDERING
+each — which is a stronger claim than one spelling, and the difference cost two
+of the original twenty words) and containment rather than whole-utterance
+matching, with disfluencies skipped between the confirm word and the nonce.
+See :func:`classify`.
 
 The nonce carries a second property worth naming: **the owner cannot say a
 nonce they have not heard**, which independently covers most of the barge-in
@@ -227,10 +230,30 @@ MAX_CONFIRM_ATTEMPTS = 5
 #:
 #: These are one-word, unambiguously spelled, and mutually distinct under
 #: ordinary mis-hearing. Chosen for how they SOUND, not for how they look.
+#:
+#: **"One spelling each" is a claim about the TRANSCRIBER, not about the
+#: orthography**, and two of the original twenty failed it in the same way the
+#: digits did — not by mis-firing, but by livelocking:
+#:
+#: - ``harbor`` — a Whisper-lineage model emits en-GB ``harbour`` freely.
+#: - ``ripcord`` — a compound, and ``rip cord`` is an ordinary segmentation.
+#:
+#: Neither variant is in this tuple, so the outcome is not even
+#: ``wrong_nonce``: it is ``no_match``, whose spoken advice is "say confirm and
+#: then the word I gave you". The owner repeats the identical utterance, fails
+#: identically, and the proposal retires at :data:`MAX_CONFIRM_ATTEMPTS`. That
+#: is the digit failure exactly, reached through spelling rather than digits.
+#:
+#: They are REMOVED rather than aliased. A variant-folding map beside
+#: :data:`_NUMBER_WORDS` would fail only in the safe direction, but it can only
+#: fold token-for-token — ``rip cord`` is two tokens and needs a compound-merge
+#: pass — and folding a spelling for a word we no longer mint is machinery with
+#: nothing to do. The selection rule replaces both: **one morpheme, no
+#: en-US/en-GB split.**
 NONCE_WORDS = (
-    "tango", "harbor", "violet", "cobalt", "meadow", "falcon", "amber",
+    "tango", "banjo", "violet", "cobalt", "meadow", "falcon", "amber",
     "kestrel", "juniper", "onyx", "saffron", "walrus", "domino", "pelican",
-    "quartz", "thistle", "vertigo", "narwhal", "gumbo", "ripcord",
+    "quartz", "thistle", "vertigo", "narwhal", "gumbo", "lantern",
 )
 
 #: Digit spellings, kept for normalization only. Nothing MINTS a digit nonce;
@@ -304,9 +327,23 @@ _FILLERS = frozenset({"uh", "um", "er", "erm", "ah", "hmm", "like", "you", "know
 #: ``("scrap", "that")`` and ``("hold", "off")`` are added: closed retraction
 #: phrases one word from entries already here, so they were plain misses and
 #: cost nothing.
+#: ``("never", "confirm")`` closes the one place the "a missed retraction is
+#: safe" fallback does not hold. ``never`` is kept OUT of the word list above
+#: for good reason — it is among the commonest words in English — and the
+#: general argument for tolerating that is "the write still needs a nonce, so
+#: the owner can simply not say it". **That argument fails on this exact
+#: utterance**: "never confirm tango" IS the retraction and it CONTAINS the
+#: nonce, so the fallback the exclusion leans on is the very thing being
+#: spoken. Measured before the fix: APPROVED, along with "you should never
+#: confirm tango".
+#:
+#: Safe by the closed-phrase rule rather than by intuition: no genuine approval
+#: places those two tokens ADJACENT IN THAT ORDER. ``never`` anywhere else in
+#: the utterance stays the ordinary word it was excluded for being — "confirm
+#: tango, I never got the other one" still approves.
 _DENIAL_BIGRAMS = frozenset(
-    {("do", "not"), ("never", "mind"), ("hold", "on"), ("hang", "on"),
-     ("hold", "off"), ("forget", "it"), ("forget", "that"),
+    {("do", "not"), ("never", "mind"), ("never", "confirm"), ("hold", "on"),
+     ("hang", "on"), ("hold", "off"), ("forget", "it"), ("forget", "that"),
      ("scrap", "that"), ("belay", "that")}
 )
 
@@ -327,15 +364,43 @@ _DENIAL_BIGRAMS = frozenset(
 #:
 #: The intuition is "don't forget X has no reading meaning cancel" — arguable,
 #: and it survived eleven adversarial phrasings. But the checkable reason is
-#: better: **this exception suppresses exactly ONE token** — the ``dont`` at
-#: that index — and cannot mask a denial signal anywhere else, because the word
-#: loop continues past it and the bigram loop has already run. So its
-#: incompleteness has nothing to be incomplete ABOUT.
+#: better: **an exception suppresses exactly the tokens of its own span** —
+#: here the ``dont`` and the ``forget`` — and cannot mask a denial signal
+#: anywhere else, because the word loop continues past it and the bigram loop
+#: has already run. So its incompleteness has nothing to be incomplete ABOUT.
+#:
+#: **That sentence was false in the code for one round, and it is the whole
+#: safety argument.** The masking loop computed ``len(trio or pair)`` — and
+#: ``trio`` is non-empty whenever any token remains — so a matched TWO-token
+#: exception masked THREE tokens and ate the word after its own span.
+#: Measured: "confirm tango, don't forget — hold on" and "confirm tango, don't
+#: forget, cancel the other one" both APPROVED, and ``carries_denial("don't
+#: forget, wait")`` was False, so the post-approval scan was blind to it too.
+#: The span is now taken from the rule that actually matched. An exception's
+#: mask is only ever as safe as its length.
 #:
 #: That is the form a future exception should be argued in. Its one known miss,
 #: "don't forget, on second thought skip it", contains no grammar word at all
 #: and is the stated §3.7 residual, not a gap in this entry.
-_DENIAL_EXCEPTIONS = frozenset({("dont", "forget")})
+#:
+#: ``("cant", "wait")`` is the second entry and clears the same bar. It is a
+#: CLOSED idiom — "can't wait" has no reading meaning "hold off" — and it is a
+#: measured false reject: "confirm tango, tell them I can't wait to see it"
+#: DENIED on the bare ``wait``. Post-normalization ``cant`` is a distinct
+#: token, so the pair is expressible without touching ``wait`` itself, and the
+#: mask covers those two tokens only: any other retraction in the utterance
+#: still denies, including a second bare ``wait``.
+#:
+#: Its price, stated rather than assumed: a hesitated hold spelled "can't —
+#: wait!" normalizes to the same two tokens and is suppressed. That is a real
+#: false accept, and it is accepted for the same reason the ``("hold","on")``
+#: ordering is: the idiom is common in ordinary speech and the hold spelling is
+#: rare, and a lone ``wait`` anywhere else in the utterance still denies.
+#:
+#: Note the anchor sits at the TAIL here (``wait``), not the head. An exception
+#: must CONTAIN a denial trigger or it suppresses nothing; requiring it first
+#: would be a rule about spelling rather than about what is being suppressed.
+_DENIAL_EXCEPTIONS = frozenset({("dont", "forget"), ("cant", "wait")})
 
 #: Trigrams that suppress a BIGRAM denial. "do not forget the other branch" is
 #: the uncontracted twin of the ``("dont", "forget")`` exception above, and it
@@ -419,9 +484,21 @@ def _denial_tokens(tokens: "list[str]") -> bool:
     for index in range(len(masked)):
         pair = tuple(masked[index:index + 2])
         trio = tuple(masked[index:index + 3])
-        if pair in _DENIAL_EXCEPTIONS or trio in _DENIAL_BIGRAM_EXCEPTIONS:
-            for offset in range(index, min(index + len(trio or pair), len(masked))):
-                masked[offset] = ""
+        # The span comes from the rule that MATCHED, never from whichever slice
+        # happened to be longer. `len(trio or pair)` was 3 whenever a third
+        # token existed, so a two-token exception masked the word after its own
+        # span — and that word was allowed to be a denial trigger. See
+        # _DENIAL_EXCEPTIONS: the "suppresses exactly its own span" claim is the
+        # entire argument for these entries being safe, so the length is not an
+        # implementation detail of the loop.
+        if trio in _DENIAL_BIGRAM_EXCEPTIONS:
+            span = 3
+        elif pair in _DENIAL_EXCEPTIONS:
+            span = 2
+        else:
+            continue
+        for offset in range(index, index + span):
+            masked[offset] = ""
 
     for index in range(len(masked) - 1):
         if tuple(masked[index:index + 2]) in _DENIAL_BIGRAMS:
@@ -569,12 +646,30 @@ def classify(text: str, nonce: str) -> str:
     # advice that says exactly those words. What this does NOT establish: an
     # echo chunked down to bare "confirm <nonce>" (frame lost) still
     # approves; only the nonce-free fallback text closes that.
+    # Fillers are skipped BETWEEN the confirm word and the nonce, for the same
+    # reason the denial grammar strips them before matching: "confirm, uh,
+    # tango" is the phrase, said by someone hesitating before a code word,
+    # which is exactly how people say code words. Requiring strict adjacency
+    # refused a CORRECT approval and burned an attempt against the budget —
+    # the false-reject half, and in this channel that is a silent loop.
+    #
+    # Safe by the file's own asymmetry argument: BOTH content words are still
+    # required, in order. What is skipped is a closed set of disfluencies, and
+    # an unlisted one fails CLOSED (no match, re-propose) rather than open. The
+    # widening it does buy is real and small: "confirm — you know, tango was
+    # the word" now approves. Containment already approves any utterance
+    # carrying "confirm <nonce>", so this adds only the filler-separated
+    # spelling of the same thing.
+    def _rest_after(index: int) -> "list[str]":
+        return [t for t in tokens[index + 1:] if t not in _FILLERS]
+
     def _quoted_frame(index: int) -> bool:
-        return index > 0 and tokens[index - 1] == "say" and "approve" in tokens
+        preceding = [t for t in tokens[:index] if t not in _FILLERS]
+        return bool(preceding) and preceding[-1] == "say" and "approve" in tokens
 
     quoted = False
     for index in positions:
-        rest = tokens[index + 1:]
+        rest = _rest_after(index)
         if not rest or rest[0] != target:
             continue
         if _quoted_frame(index):
@@ -596,7 +691,7 @@ def classify(text: str, nonce: str) -> str:
     if quoted:
         return QUOTED_FRAME
     for index in positions:
-        rest = tokens[index + 1:]
+        rest = _rest_after(index)
         if rest and rest[0] in NONCE_WORDS:
             return WRONG_NONCE
     return NO_MATCH
@@ -973,6 +1068,14 @@ SPOKEN = {
     "pending_transcript": (
         "Give me a second — I'm still catching up on what you said. Don't repeat it yet."
     ),
+    # A duplicate confirm on a token already being processed. It must NOT say
+    # "nothing was sent" — the first confirm may be inside the runner as this
+    # is spoken — and it must not send the owner to re-propose, which is how a
+    # duplicate becomes a double delivery. Wait, then hear the real outcome.
+    "in_flight": (
+        "Hang on — I'm already working on that one. "
+        "I'll tell you how it went in a moment; don't repeat it yet."
+    ),
     "too_many_attempts": (
         "I've got that wrong too many times, so I've dropped it. Ask me again from the top."
     ),
@@ -997,7 +1100,11 @@ SPOKEN = {
 
 #: Outcomes whose correct owner response is to WAIT rather than to speak again.
 #: Named so the persona and the tests can both reason about it.
-WAIT_OUTCOMES = frozenset({"pending_transcript", "not_announced"})
+#: ``in_flight`` belongs here on both counts the flag drives: the owner's
+#: correct move is to wait, and ``confirm_terminal`` must stay False — closing
+#: the gate on a duplicate would close it out from under the confirm that is
+#: actually running.
+WAIT_OUTCOMES = frozenset({"pending_transcript", "not_announced", "in_flight"})
 
 #: Every reason :class:`ConfirmSpine` can return. The SSOT for the taxonomy.
 #:
@@ -1012,7 +1119,7 @@ REASONS = frozenset(
     {
         "no_proposal", "expired", "not_announced", "replayed", "refused",
         "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
-        "too_many_attempts", "dispatch_failed",
+        "too_many_attempts", "dispatch_failed", "in_flight",
     }
 )
 
@@ -1134,6 +1241,8 @@ class ConfirmSpine:
         #: Tokens whose write was attempted and FAILED. Kept apart from
         #: _succeeded so a retry is told the truth rather than "already sent".
         self._failed: set[str] = set()
+        #: Tokens claimed by a confirm that has not returned yet. See _claim.
+        self._in_flight: set[str] = set()
 
     # -- propose ------------------------------------------------------------
 
@@ -1209,13 +1318,39 @@ class ConfirmSpine:
         if refusal is not None:
             return refusal
 
+        try:
+            return self._confirm_claimed(proposal, token)
+        finally:
+            # Released on EVERY exit, including a raising runner. A marker left
+            # set is a proposal wedged for its whole TTL, answering every retry
+            # with "still working on that one" — a silent loop, which is the
+            # expensive failure in a channel with no screen.
+            with self._lock:
+                self._in_flight.discard(token)
+
+    def _confirm_claimed(self, proposal: Proposal, token: str) -> Verdict:
         anchor = proposal.anchor_seq or 0
-        # Snapshot the conversation's high-water mark BEFORE the await, so the
-        # post-approval denial scan is bounded to what the owner had actually
-        # said by the time this confirm started.
+        # The high-water mark is read TWICE: once before the await, and again
+        # after it, taking the larger. The post-approval scan must be bounded —
+        # an unbounded ring tail lets an utterance from a different context
+        # retroactively deny — but bounding it to the PRE-await snapshot left
+        # the guard closed only for utterances the owner had already started
+        # when confirm was entered.
+        #
+        # The hole that leaves: a denial the owner BEGINS during the ≤2.5s
+        # await records its speech_started above the snapshot and carries no
+        # transcript yet, so `after` (which filters on complete) cannot see it
+        # and `unheard_between` excluded it for exceeding the ceiling. The
+        # write went out with a take-back mid-transcription. Re-reading makes
+        # the bound "everything the owner had started by the time this confirm
+        # reached its verdict" — still bounded, and still strictly before the
+        # verdict. The false-reject price is one pending_transcript wait, which
+        # the owner is told to sit through and which resolves on the next
+        # confirm; the widened `found` seqs are subsumed, since high_seq
+        # advances on every ring event.
         ceiling = max(self._ring.high_seq, anchor)
         found = self._ring.await_utterance_after(anchor, self._wait_s)
-        ceiling = max(ceiling, *(u.speech_started_seq for u in found)) if found else ceiling
+        ceiling = max(ceiling, self._ring.high_seq)
         verdict = self._judge(proposal, found, ceiling)
 
         if not verdict.approved:
@@ -1379,7 +1514,25 @@ class ConfirmSpine:
         )
 
     def _claim(self, token: str) -> "tuple[Proposal | None, Verdict | None]":
+        """Take exclusive ownership of *token*, or say why not.
+
+        **Single use is a property of this method, not of the timing.** The
+        proposal used to be consumed at the far side of the await and the
+        judge, so two confirms carrying one token could both pass here and both
+        reach the runner. It was not reproducible — client dispatch is
+        sequential per response and the judge window is sub-timeslice — but
+        each ``response.done`` spawns its own async IIFE and the bridge is a
+        ``ThreadingHTTPServer``, so the sequencing that made it safe is nowhere
+        in the code. This module's standard is guarantee by construction.
+
+        The marker also fixes what the second confirm was TOLD. Arriving while
+        the runner was mid-dispatch, it found the proposal already popped and
+        reported ``no_proposal`` — "tell me again what you'd like sent" —
+        inviting a re-propose of a write that was in the act of going out.
+        """
         with self._lock:
+            if token in self._in_flight:
+                return None, Verdict(approved=False, reason="in_flight")
             if token in self._failed:
                 return None, Verdict(approved=False, reason="dispatch_failed")
             if token in self._succeeded:
@@ -1401,6 +1554,7 @@ class ConfirmSpine:
                 return None, Verdict(approved=False, reason="no_proposal")
             if not proposal.announced:
                 return None, Verdict(approved=False, reason="not_announced")
+            self._in_flight.add(token)
             return proposal, None
 
     def _penalize(self, token: str) -> bool:

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -473,6 +473,26 @@ class TestNonceGrammar:
         # or the two spellings of it drift apart.
         assert ("never", "confirm") not in confirm._DENIAL_BIGRAMS
 
+    def test_an_exception_mask_ends_the_gap_run_rather_than_being_skipped(self):
+        """The one sentence in ``_gapped_bigram``'s docstring nothing pinned.
+
+        It claims the run ends at a masked-out ``""``, "so an exception's
+        suppression still stops this rule rather than being skipped through".
+        Making the run SKIP the ``""`` instead left the whole suite green —
+        a load-bearing docstring sentence with no test, which is the exact
+        shape of the round-1 blocker.
+
+        Direction matters and is stated: the skip variant is STRICTER, so this
+        pins the false-reject side. What it protects is the composition rule
+        the exceptions are built on — a suppressed span stays suppressed for
+        every downstream rule, not just for the ones that already ran.
+        """
+        for text in (
+            "never, don't forget, confirm tango",
+            "never, do not forget, confirm tango",
+        ):
+            assert confirm.classify(text, "tango") == confirm.APPROVED, text
+
     def test_never_apart_from_confirm_is_still_ordinary_speech(self):
         """The false-reject price of the bigram above, pinned.
 

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -226,8 +226,191 @@ class TestNonceGrammar:
 
     def test_a_wrong_nonce_is_its_own_outcome(self):
         """"repeat it" and "ask what the code was" are different advice."""
-        assert confirm.classify("confirm harbor", "tango") == confirm.WRONG_NONCE
+        assert confirm.classify("confirm violet", "tango") == confirm.WRONG_NONCE
         assert confirm.classify("confirm tango", "tango") == confirm.APPROVED
+
+    def test_no_nonce_word_has_a_second_transcriber_rendering(self):
+        """The premise :func:`test_the_alphabet_has_one_spelling_per_word`
+        states but does not test.
+
+        That test checks ORTHOGRAPHY — alpha, lowercase, normalize-stable —
+        which every word here passes by construction. It proves the fixture's
+        own definition, not the property the docstring claims: that a
+        Whisper-lineage transcriber emits ONE rendering for the word.
+
+        Two shipped words failed that, and both livelocked rather than
+        misfiring — neither variant is in the alphabet, so the outcome is
+        ``no_match`` ("say confirm and then the word I gave you"), the owner
+        repeats identically, and the proposal retires at
+        ``MAX_CONFIRM_ATTEMPTS``:
+
+        - ``harbor`` — en-GB ``harbour`` is an ordinary rendering.
+        - ``ripcord`` — a compound; ``rip cord`` is an ordinary segmentation.
+
+        This enumeration DOES sit on the fail-open side (an unlisted
+        variant-prone word ships), and saying so is the point: the pin below
+        is a regression anchor for two measured failures, not a proof of
+        coverage. What bounds the class is the selection rule stated in
+        :data:`confirm.NONCE_WORDS` — one morpheme, no en-US/en-GB split.
+        """
+        variant_prone = {
+            # measured, and the reason this test exists
+            "harbor", "harbour", "ripcord", "rip", "cord",
+            # the same two classes, spelled out so the rule is legible
+            "color", "colour", "gray", "grey", "meter", "metre",
+            "airplane", "aeroplane", "donut", "doughnut",
+            "backup", "sunset", "keyboard", "rainfall",
+        }
+        assert "harbor" in variant_prone and "ripcord" in variant_prone
+        for word in confirm.NONCE_WORDS:
+            assert word not in variant_prone, word
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "confirm, uh, tango",
+            "confirm um tango",
+            "confirm, you know, tango",
+            "confirm... er, tango, thanks",
+        ],
+    )
+    def test_a_filler_between_confirm_and_the_nonce_still_approves(self, text):
+        """The false-reject half, in the one place the grammar forgot it.
+
+        The denial grammar strips ``_FILLERS`` before matching; the approval
+        path required ``rest[0] == target`` with no skipping. So hesitating
+        before a code word — which is exactly how people say code words —
+        refused a CORRECT approval and burned an attempt.
+
+        The tested templates above place fillers before and after the phrase,
+        never BETWEEN it, so the gap was fixture-shaped rather than argued.
+        """
+        assert confirm.classify(text, "tango") == confirm.APPROVED, text
+
+    def test_only_fillers_are_skipped_between_confirm_and_the_nonce(self):
+        """The control that keeps the fix from being "skip anything".
+
+        Both content words are still required, adjacent modulo disfluency.
+        A real word between them is a different utterance, not a hesitation.
+        """
+        assert confirm.classify("confirm that tango", "tango") == confirm.NO_MATCH
+        assert confirm.classify("confirm the tango step", "tango") == confirm.NO_MATCH
+        # and the wrong-nonce scan uses the same skipping, or a hesitated
+        # wrong code word reports "say it again" instead of "ask me the word".
+        assert confirm.classify("confirm, uh, violet", "tango") == confirm.WRONG_NONCE
+
+    def test_an_exception_never_masks_the_token_after_its_own_span(self):
+        """BLOCKER: the masking loop ate one token too many.
+
+        ``trio`` is non-empty whenever any token remains, so
+        ``len(trio or pair)`` was 3 even when the 2-token exception
+        ``("dont","forget")`` was what matched — the exception swallowed the
+        word AFTER its own span, and that word was allowed to be a denial
+        trigger. Reproduced through the real pipeline: both of these APPROVED.
+
+        This falsified the load-bearing claim in
+        :data:`confirm._DENIAL_EXCEPTIONS` — "suppresses exactly ONE token …
+        cannot mask a denial signal anywhere else" — which is the entire
+        argument for the entry being safe.
+        """
+        assert confirm.classify(
+            "confirm tango, don't forget — hold on", "tango"
+        ) == confirm.DENIED
+        assert confirm.classify(
+            "confirm tango, don't forget, cancel the other one", "tango"
+        ) == confirm.DENIED
+        assert confirm.carries_denial("don't forget, wait") is True
+
+    def test_a_denial_trigger_following_any_exception_still_denies(self):
+        """The composition, generatively — the shape the existing generative
+        test structurally cannot reach.
+
+        ``test_an_unknown_word_after_a_denial_trigger_still_denies`` always
+        places the trigger FIRST, so no arrangement it generates puts a
+        trigger inside an exception's over-long mask. This one puts every
+        trigger immediately after every exception, in both the contracted and
+        uncontracted spelling, since normalization does not merge them.
+        """
+        triggers = sorted(confirm._DENIAL_WORDS) + [
+            " ".join(bigram) for bigram in sorted(confirm._DENIAL_BIGRAMS)
+        ]
+        for exception in ("don't forget", "do not forget"):
+            for trigger in triggers:
+                text = f"confirm tango, {exception} {trigger}"
+                assert confirm.classify(text, "tango") == confirm.DENIED, text
+
+    def test_the_exception_still_suppresses_its_own_span(self):
+        """The other half: narrowing the mask must not kill the exception.
+
+        "don't forget X" is not a retraction, and it was measured DENYING
+        real approvals before the exception existed.
+        """
+        for text in (
+            "confirm tango, don't forget the other branch",
+            "confirm tango, do not forget the other branch",
+            "confirm tango, don't forget",
+        ):
+            assert confirm.classify(text, "tango") == confirm.APPROVED, text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "never confirm tango",
+            "Never confirm tango.",
+            "you should never confirm tango",
+            "never, uh, confirm tango",
+        ],
+    )
+    def test_never_confirm_is_a_retraction(self, text):
+        """BLOCKER: the inversion class, reached through ``never``.
+
+        ``never`` is deliberately absent from :data:`confirm._DENIAL_WORDS`
+        (recovered only as ``("never","mind")``) because it is among the
+        commonest words in English. The general fallback for a missed
+        retraction — "the write still needs a nonce, so the owner can simply
+        not say it" — does not apply to THIS utterance: it IS the retraction
+        and it CONTAINS the nonce.
+
+        ``("never","confirm")`` is a closed ordered bigram: no genuine
+        approval says those two tokens adjacent in that order.
+        """
+        assert confirm.classify(text, "tango") == confirm.DENIED, (
+            f"{text!r} normalized to {confirm.normalize(text)!r}"
+        )
+
+    def test_never_apart_from_confirm_is_still_ordinary_speech(self):
+        """The false-reject price of the bigram above, pinned.
+
+        Only the adjacent, ordered pair fires. ``never`` elsewhere in the
+        utterance is the ordinary word it was excluded for being.
+        """
+        for text in (
+            "confirm tango, I never got the other one",
+            "confirm tango, I never said that",
+            "confirm tango, that never happened",
+        ):
+            assert confirm.classify(text, "tango") == confirm.APPROVED, text
+
+    def test_the_cant_wait_idiom_does_not_read_as_a_hold(self):
+        """A closed idiom, suppressed on the file's own enumerate-the-safe-side
+        rule: post-normalization ``cant`` is a distinct token, and "can't wait"
+        has no reading meaning "hold off"."""
+        assert confirm.classify(
+            "confirm tango, tell them I can't wait to see it", "tango"
+        ) == confirm.APPROVED
+        assert confirm.carries_denial("can't wait to see it") is False
+
+    def test_suppressing_cant_wait_does_not_suppress_a_real_hold(self):
+        """Its false-accept price, bounded: the suppression covers exactly
+        those two tokens, so any other retraction in the utterance still
+        denies — including a second bare ``wait``."""
+        for text in (
+            "confirm tango, I can't wait — actually stop",
+            "confirm tango, can't wait, no",
+            "confirm tango, can't wait, hold on",
+            "wait, confirm tango, I can't wait to see it",
+        ):
+            assert confirm.classify(text, "tango") == confirm.DENIED, text
 
     def test_an_absent_nonce_is_no_match(self):
         for text in ("confirm", "confirm it", "confirm that one"):
@@ -483,16 +666,21 @@ class TestNonceGrammar:
         assert not hasattr(confirm, "_BARE_DEICTICS")
         assert not hasattr(confirm, "_CONDITIONAL_DENIAL_EXCEPTIONS")
 
-        # What remains is two closed phrases, spelled out so any change to them
-        # shows up in this test's own diff.
-        assert confirm._DENIAL_EXCEPTIONS == frozenset({("dont", "forget")})
+        # What remains is three closed phrases, spelled out so any change to
+        # them shows up in this test's own diff.
+        assert confirm._DENIAL_EXCEPTIONS == frozenset(
+            {("dont", "forget"), ("cant", "wait")}
+        )
         assert confirm._DENIAL_BIGRAM_EXCEPTIONS == frozenset(
             {("do", "not", "forget")}
         )
-        # Each must be anchored on a real denial trigger, or it suppresses
-        # nothing and is dead weight pretending to be policy.
-        for first, _ in confirm._DENIAL_EXCEPTIONS:
-            assert first in confirm._DENIAL_WORDS, first
+        # Each must CONTAIN a real denial trigger, or it suppresses nothing and
+        # is dead weight pretending to be policy. Position is not fixed: the
+        # trigger anchors ``dont forget`` at the head and ``cant wait`` at the
+        # tail, and requiring the head would have rejected the second for the
+        # wrong reason.
+        for pair in confirm._DENIAL_EXCEPTIONS:
+            assert any(token in confirm._DENIAL_WORDS for token in pair), pair
         for first, second, _third in confirm._DENIAL_BIGRAM_EXCEPTIONS:
             assert (first, second) in confirm._DENIAL_BIGRAMS
 
@@ -858,6 +1046,63 @@ class TestBoundedAwait:
         assert convo.spine.confirm(proposal.token).approved is False
         assert runner.calls == []
 
+    def test_a_denial_that_STARTS_during_the_await_still_blocks(self, runner):
+        """The half of the ``unheard_between`` guarantee the ceiling excluded.
+
+        ``ceiling`` was snapshotted BEFORE the ≤2.5s await and widened only by
+        the sequences of entries that came back in ``found``. A denial the
+        owner BEGINS during the await lands its ``speech_started`` above that
+        snapshot and carries no transcript, so it is in neither set:
+        ``after`` filters on ``complete`` and ``unheard_between`` excludes it
+        for exceeding the ceiling. The write executed while a take-back was
+        mid-transcription — the exact hazard the guard claims to close, closed
+        only for utterances started BEFORE confirm was entered.
+
+        The fixture has to be able to CONSTRUCT that shape, which the
+        ``wait_s=0`` spine provably cannot: with no await there is no window
+        for an utterance to start inside. Real threads, and the ordering is
+        forced rather than raced — the denial's ``speech_started`` is emitted
+        BEFORE the approval's transcript, so the await is still blocked when
+        the sequence advances and the wakeup happens after it.
+        """
+        ring = transcript.TranscriptRing()
+        spine = confirm.ConfirmSpine(ring, wait_s=2.0, runner=runner)
+        convo = Conversation(ring, spine)
+
+        proposal = convo.announced_proposal()
+        approval = convo.says("", transcribe=False)  # spoken; no transcript yet
+        phrase = f"confirm {confirm.spoken_nonce(proposal.nonce)}"
+
+        denial_item = "item_denial_mid_await"
+
+        def speak_during_the_await():
+            time.sleep(0.15)                        # confirm is inside the await
+            ring.speech_started(denial_item, convo._next())
+            ring.transcribe(approval, phrase)       # ...and only then does it wake
+
+        thread = threading.Thread(target=speak_during_the_await)
+        thread.start()
+        verdict = spine.confirm(proposal.token)
+        thread.join()
+
+        approved_entry = next(
+            e for e in ring.snapshot() if e.item_id == approval
+        )
+        started = next(e for e in ring.snapshot() if e.item_id == denial_item)
+        assert started.speech_started_seq > approved_entry.speech_started_seq, (
+            "fixture must start the denial after the approval, or it proves nothing"
+        )
+
+        assert verdict.approved is False
+        assert verdict.reason == "pending_transcript"
+        assert runner.calls == []
+
+        # And the false-reject half: once it lands harmless, the approval goes.
+        ring.commit(denial_item, convo._next())
+        ring.transcribe(denial_item, "thanks, that's the one")
+        assert spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
     def test_a_timeout_is_distinguishable_from_a_rejection(self, convo, runner):
         """The two demand OPPOSITE behaviour, so they must never collapse."""
         timing = convo.announced_proposal()
@@ -872,6 +1117,100 @@ class TestBoundedAwait:
         assert timing_verdict.spoken != rejected_verdict.spoken
         assert timing_verdict.to_dict()["owner_should_wait"] is True
         assert rejected_verdict.to_dict()["owner_should_wait"] is False
+
+
+class TestSingleUseIsClaimedNotJudged:
+    """Single-use has to be a property of the CLAIM, not of the timing.
+
+    ``_claim`` neither removed the proposal nor marked it in flight, so
+    consumption happened after the await and the judge. Two confirms carrying
+    the same token could both pass the claim and both reach the runner. It was
+    not reproducible in 250 threaded trials — client dispatch is sequential per
+    response and the judge window is sub-timeslice — but "not observed" is the
+    argument this module refuses everywhere else: each ``response.done`` spawns
+    its own async IIFE and the bridge is a ``ThreadingHTTPServer``, so nothing
+    in the code guarantees the sequencing that made it safe.
+
+    The related wart is fixed by the same marker: a confirm arriving while the
+    runner is mid-dispatch used to report ``no_proposal`` — "tell me again what
+    you'd like sent" — which invites a re-propose that DOUBLE-SENDS.
+    """
+
+    def test_a_second_confirm_during_dispatch_is_refused_not_told_to_re_propose(
+        self, convo
+    ):
+        """The re-entrant construction: the second confirm arrives from inside
+        the runner, i.e. strictly while the first one is dispatching."""
+        nested: list[str] = []
+        calls: list[list[str]] = []
+
+        def reentrant_runner(argv):
+            calls.append(list(argv))
+            nested.append(convo.spine.confirm(proposal.token).reason)
+            return {"success": True}
+
+        convo.spine._runner = reentrant_runner
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(calls) == 1, "the duplicate must not reach the runner"
+        assert nested == ["in_flight"], nested
+
+    def test_a_confirm_while_another_is_awaiting_never_reaches_the_runner(
+        self, runner
+    ):
+        """The claim is held across the AWAIT too, not only across dispatch —
+        which is where the two-thread window is widest (up to 2.5s)."""
+        ring = transcript.TranscriptRing()
+        spine = confirm.ConfirmSpine(ring, wait_s=1.0, runner=runner)
+        convo = Conversation(ring, spine)
+        proposal = convo.announced_proposal()
+
+        verdicts: list[confirm.Verdict] = []
+        thread = threading.Thread(
+            target=lambda: verdicts.append(spine.confirm(proposal.token))
+        )
+        thread.start()
+        time.sleep(0.15)  # the first confirm is inside its bounded await
+        duplicate = spine.confirm(proposal.token)
+        thread.join()
+
+        assert duplicate.reason == "in_flight"
+        assert runner.calls == []
+        # The duplicate is a WAIT outcome: the owner's move is to wait, and the
+        # gate must stay open for the confirm that is actually running.
+        assert duplicate.to_dict()["owner_should_wait"] is True
+        assert duplicate.to_dict()["confirm_terminal"] is False
+
+    def test_the_claim_is_released_on_every_exit(self, convo, runner):
+        """The other half. A marker that is not released is a proposal wedged
+        for its whole TTL, reported as "still working on it" forever — a
+        silent loop in a channel with no screen."""
+        proposal = convo.announced_proposal()
+        assert convo.spine.confirm(proposal.token).reason == "pending_transcript"
+        convo.says("that is not the phrase")
+        assert convo.spine.confirm(proposal.token).reason == "refused"
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+        # And after success it is replayed — the marker must not shadow that.
+        assert convo.spine.confirm(proposal.token).reason == "replayed"
+        assert len(runner.calls) == 1
+
+    def test_a_dispatch_that_raises_still_releases_the_claim(self, ring, clock):
+        def exploding(argv):
+            raise RuntimeError("boom")
+
+        spine = confirm.ConfirmSpine(
+            ring, wait_s=0.0, runner=exploding, clock=clock
+        )
+        convo = Conversation(ring, spine)
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert spine.confirm(proposal.token).reason == "dispatch_failed"
+        # Not in_flight: the failure is reported honestly on the retry.
+        assert spine.confirm(proposal.token).reason == "dispatch_failed"
 
 
 # =============================================================================
@@ -1303,6 +1642,26 @@ class TestOutcomesAreDistinctAndSpoken:
         proposal = sub.announced_proposal()
         sub.approve(proposal)
         seen.add(spine.confirm(proposal.token).reason)
+
+        # in_flight: a duplicate confirm arriving while the first is dispatching.
+        # Last, and on its own sequence range, so its ring entries cannot sit
+        # newer than another case's approval.
+        nested = []
+        busy_spine = confirm.ConfirmSpine(
+            convo.ring,
+            wait_s=0.0,
+            runner=lambda argv: (
+                nested.append(busy_spine.confirm(busy.token).reason),
+                {"success": True},
+            )[1],
+            clock=clock,
+        )
+        busy_convo = Conversation(convo.ring, busy_spine)
+        busy_convo.seq = sub.seq + 500
+        busy = busy_convo.announced_proposal()
+        busy_convo.approve(busy)
+        busy_spine.confirm(busy.token)
+        seen |= set(nested)
         return seen
 
     def test_the_attempt_that_retires_the_proposal_says_so(self, convo, runner):
@@ -1850,8 +2209,18 @@ class TestTheQuotedFrameGuard:
         """The frame quoting a DIFFERENT word is a different problem — the
         owner needs this proposal's code, so wrong_nonce's advice is right."""
         assert confirm.classify(
-            "to approve say confirm harbor", "tango"
+            "to approve say confirm violet", "tango"
         ) == confirm.WRONG_NONCE
+
+    def test_a_hesitated_frame_is_still_the_frame(self):
+        """The frame lookback skips fillers for the same reason the approval
+        path does — the TTS echo is chunked by VAD and a disfluency can land
+        between "say" and "confirm". Narrow as ever: both conditions still
+        required."""
+        assert confirm.classify(
+            "to approve, say, uh, confirm tango", "tango"
+        ) == confirm.QUOTED_FRAME
+        assert confirm.classify("say, uh, confirm tango", "tango") == confirm.APPROVED
 
     def test_the_spine_speaks_the_accurate_reason_not_wrong_nonce(self, convo, runner):
         """The nit that mattered: this used to classify wrong_nonce, and the

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -321,6 +321,29 @@ class TestNonceGrammar:
         ) == confirm.DENIED
         assert confirm.carries_denial("don't forget, wait") is True
 
+    #: Every exception, as a raw utterance a transcriber would actually emit.
+    #: Hand-written because normalization is one-way — nothing derives "don't"
+    #: from ``dont`` — but CHECKED against the live sets below in both
+    #: directions, so an exception added without a spelling here fails this
+    #: control loudly instead of escaping it.
+    EXCEPTION_SPELLINGS = ("don't forget", "can't wait", "do not forget")
+
+    def test_the_exception_spellings_cover_every_live_exception(self):
+        """The control's own coverage, asserted rather than trusted.
+
+        The first version of this test hardcoded ``("don't forget", "do not
+        forget")`` while its docstring claimed "every exception" — and the
+        entry this PR ADDS, ``("cant","wait")``, was not in it. No live defect
+        (the cross-product denies), but the control did not cover the thing it
+        shipped with, and the next exception would have escaped it silently.
+        """
+        spelled = {
+            tuple(confirm.normalize(phrase).split())
+            for phrase in self.EXCEPTION_SPELLINGS
+        }
+        live = confirm._DENIAL_EXCEPTIONS | confirm._DENIAL_BIGRAM_EXCEPTIONS
+        assert spelled == live, live ^ spelled
+
     def test_a_denial_trigger_following_any_exception_still_denies(self):
         """The composition, generatively — the shape the existing generative
         test structurally cannot reach.
@@ -328,13 +351,16 @@ class TestNonceGrammar:
         ``test_an_unknown_word_after_a_denial_trigger_still_denies`` always
         places the trigger FIRST, so no arrangement it generates puts a
         trigger inside an exception's over-long mask. This one puts every
-        trigger immediately after every exception, in both the contracted and
-        uncontracted spelling, since normalization does not merge them.
+        trigger immediately after every exception, and BOTH sides are derived
+        from the live tables: a new exception or a new trigger — including a
+        gapped one — enters this cross-product automatically.
         """
-        triggers = sorted(confirm._DENIAL_WORDS) + [
-            " ".join(bigram) for bigram in sorted(confirm._DENIAL_BIGRAMS)
-        ]
-        for exception in ("don't forget", "do not forget"):
+        triggers = sorted(confirm._DENIAL_WORDS)
+        triggers += [" ".join(bigram) for bigram in sorted(confirm._DENIAL_BIGRAMS)]
+        for (first, second), gap_words in confirm._GAPPED_DENIAL_BIGRAMS.items():
+            triggers.append(f"{first} {second}")
+            triggers += [f"{first} {gap} {second}" for gap in sorted(gap_words)]
+        for exception in self.EXCEPTION_SPELLINGS:
             for trigger in triggers:
                 text = f"confirm tango, {exception} {trigger}"
                 assert confirm.classify(text, "tango") == confirm.DENIED, text
@@ -377,6 +403,75 @@ class TestNonceGrammar:
         assert confirm.classify(text, "tango") == confirm.DENIED, (
             f"{text!r} normalized to {confirm.normalize(text)!r}"
         )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "never ever confirm tango",
+            "never really confirm tango",
+            "never once confirm tango",
+            "never actually confirm tango",
+            "never, seriously, confirm tango",
+            "you should never ever confirm tango",
+            "never ever, uh, confirm tango",
+            "never ever ever confirm tango",
+        ],
+    )
+    def test_an_intensified_never_confirm_is_still_a_retraction(self, text):
+        """The blocker's own shape, one word wider.
+
+        ``("never","confirm")`` as an ADJACENT pair left "never ever confirm
+        tango" approving — the identical inversion, reached by the commonest
+        intensifier there is. The entry was never really "adjacent tokens"
+        anyway: ``_denial_tokens`` strips ``_FILLERS`` first, which is why
+        "never, uh, confirm tango" denies. So it is "adjacent modulo a skip
+        set", and this widens the skip set rather than inventing a mechanism.
+        """
+        assert confirm.classify(text, "tango") == confirm.DENIED, (
+            f"{text!r} normalized to {confirm.normalize(text)!r}"
+        )
+
+    def test_the_post_approval_scan_sees_the_intensified_form_too(self):
+        """``carries_denial`` was blind to it as well, which is what let it
+        through AFTER the approval had already matched."""
+        for text in ("never ever confirm that", "never actually confirm it"):
+            assert confirm.carries_denial(text) is True, text
+
+    def test_only_a_closed_gap_set_is_skipped_between_never_and_confirm(self):
+        """The false-reject bound.
+
+        An UNBOUNDED "never … confirm" rule would deny "I would never send
+        that without checking — confirm tango", which is an approval. The gap
+        is a closed set of degree adverbs, and any other word ends the run.
+        """
+        for text in (
+            "confirm tango, I never asked you to confirm anything",
+            "confirm tango, I would never send that without checking",
+            "confirm tango, I never got the other one",
+        ):
+            assert confirm.classify(text, "tango") == confirm.APPROVED, text
+
+    def test_the_never_gap_set_is_closed_class_and_fails_open(self):
+        """The enumeration's SIDE, stated rather than assumed.
+
+        Unlike ``_FILLERS`` (skipping one can only make a denial easier to
+        match, so an unlisted filler fails closed), this set sits on the
+        fail-open side: an unlisted gap word ends the run and the utterance
+        approves. What bounds it is that the class is closed — degree adverbs
+        and nothing else — and the file says so out loud rather than implying
+        coverage.
+        """
+        assert confirm._GAPPED_DENIAL_BIGRAMS == {
+            ("never", "confirm"): confirm._NEVER_GAP_WORDS
+        }
+        # No open-class word may enter the gap set: a noun or verb there turns
+        # "never" back into the ordinary word it was excluded for being.
+        for word in confirm._NEVER_GAP_WORDS:
+            assert word.isalpha() and word.islower(), word
+            assert word not in confirm._DENIAL_WORDS, word
+        # And the pair itself is not ALSO a plain bigram — one rule, one place,
+        # or the two spellings of it drift apart.
+        assert ("never", "confirm") not in confirm._DENIAL_BIGRAMS
 
     def test_never_apart_from_confirm_is_still_ordinary_speech(self):
         """The false-reject price of the bigram above, pinned.
@@ -902,6 +997,24 @@ class TestGateRefusals:
         assert convo.spine.confirm(proposal.token).approved is True
         assert len(runner.calls) == 1
 
+    def test_an_intensified_never_confirm_after_the_approval_does_not_write(
+        self, convo, runner
+    ):
+        """The spine-level repro of the reviewer's blocker.
+
+        The owner approves, then takes it back with "never ever confirm that"
+        before the model gets round to calling confirm. The post-approval scan
+        runs the same grammar, so an adjacency-only entry let the write
+        EXECUTE — the take-back was spoken, in time, and did not count.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says("never ever confirm that")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.approved is False
+        assert verdict.reason == "denied"
+        assert runner.calls == []
+
     def test_an_approval_followed_by_a_denial_does_not_write(self, convo, runner):
         proposal = convo.announced_proposal()
         convo.approve(proposal)
@@ -1117,6 +1230,73 @@ class TestBoundedAwait:
         assert timing_verdict.spoken != rejected_verdict.spoken
         assert timing_verdict.to_dict()["owner_should_wait"] is True
         assert rejected_verdict.to_dict()["owner_should_wait"] is False
+
+
+class TestTheUnheardWindowHasNoStalenessBound:
+    """The widened ceiling's real price, pinned as behaviour.
+
+    Re-reading ``high_seq`` after the await is the intended safety gain — a
+    denial STARTED during the await now blocks. But ``unheard_between`` has no
+    staleness bound of its own, so the cost is not "one ``pending_transcript``
+    wait" as the first version of this PR claimed: **any** ``speech_started``
+    that never completes — a cough, a VAD blip, TTS bleed — sits in the window
+    and refuses every confirm until the TTL expires the proposal.
+
+    It is a spoken LOOP, not a refusal: ``pending_transcript`` is a WAIT
+    outcome, so it burns no attempt, so ``too_many_attempts`` never fires and
+    the owner is never told the proposal died. They are told "give me a second"
+    for up to the 120s TTL and then, on the next try, "that one expired".
+
+    Pinned rather than fixed here: the bound belongs in
+    ``TranscriptRing.unheard_between`` (``transcript.py``), which another
+    worker owns this wave. Nothing in the suite saw this shape —
+    ``test_a_denial_that_lands_as_harmless_lets_the_approval_through`` asserts
+    only the case where the utterance DOES complete.
+    """
+
+    def test_one_never_completing_utterance_refuses_every_confirm_until_ttl(
+        self, convo, clock, runner
+    ):
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.starts_speaking()  # cough / VAD blip: no commit, no transcript
+
+        for _ in range(confirm.MAX_CONFIRM_ATTEMPTS + 1):
+            verdict = convo.spine.confirm(proposal.token)
+            assert verdict.reason == "pending_transcript"
+        assert runner.calls == []
+
+        # No attempt is burned, so the retirement path that would at least SAY
+        # something never fires. The proposal is alive and unusable.
+        live = {p.token: p for p in convo.spine.pending()}
+        assert live[proposal.token].attempts == 0
+
+        # It ends by expiring, up to PROPOSAL_TTL_S later, with nothing having
+        # told the owner anything but "give me a second".
+        clock.advance(confirm.PROPOSAL_TTL_S + 1)
+        assert convo.spine.confirm(proposal.token).reason == "expired"
+        assert runner.calls == []
+
+    def test_the_module_states_this_residual_rather_than_the_cheaper_one(self):
+        """The prose half. A guarantee stated broader than the code gets
+        rounded back up — so the claim is NARROWED at the site, not qualified.
+        """
+        source = _flat(_confirm_source())
+        for clause in (
+            "has no staleness bound",
+            "never completes",
+            "until the TTL expires it",
+        ):
+            assert clause in source, clause
+
+    def test_no_stale_sentence_survives_at_the_use_site(self):
+        """The comment at the scan and the comment at the read must describe
+        the SAME ceiling. A correct paragraph at one site does not repair a
+        false sentence at the other — that is how the widened window would be
+        reviewed as the old one."""
+        source = _flat(_confirm_source())
+        assert "high-water mark as of this confirm's entry" not in source
+        assert "everything the owner had started by the time this confirm" in source
 
 
 class TestSingleUseIsClaimedNotJudged:
@@ -2158,6 +2338,22 @@ def _flat(text: str) -> str:
     """
     lines = [line.lstrip().removeprefix("> ").removeprefix(">") for line in text.splitlines()]
     return " ".join(" ".join(lines).split())
+
+
+def _confirm_source() -> str:
+    """``confirm.py`` with comment markers stripped, for prose assertions.
+
+    A sentence written across several ``#`` lines is one sentence, and a
+    comment beside the code is exactly where the stale claim lived. Stripping
+    the markers lets an assertion match either home.
+    """
+    from pathlib import Path
+
+    lines = [
+        line.lstrip().removeprefix("#:").removeprefix("#").strip()
+        for line in Path(confirm.__file__).read_text(encoding="utf-8").splitlines()
+    ]
+    return "\n".join(lines)
 
 
 class TestTheQuotedFrameGuard:


### PR DESCRIPTION
Closes #976

`agentwire/voice_layer/confirm.py` + `tests/unit/test_voice_confirm.py` only. Into `voice-confirm-spine`, never `main`.

Every test below was **watched failing first** — 18 reds, each one the real defect and not a fixture artefact (the await red was `approved=True` with a denial mid-transcription; the duplicate-confirm red was `no_proposal`).

## Blockers

**1. Exception mask ate the token after its own span.** `len(trio or pair)` is 3 whenever any third token exists, so the 2-token `("dont","forget")` masked 3. Reproduced: `classify("confirm tango, don't forget — hold on")` → **approved**, `classify("confirm tango, don't forget, cancel the other one")` → **approved**, `carries_denial("don't forget, wait")` → **False**. The span now comes from the rule that matched. This is not a loop detail — "suppresses exactly its own span" is the entire safety argument for the entry, and the code falsified it.

Controls: a generative composition test placing **every** denial word and bigram immediately after **both** exception spellings (the existing generative test always puts the trigger first, so it structurally could not reach this), plus the reverse half — the exception must still suppress "don't forget the other branch".

**2. `never confirm X` approved.** `("never","confirm")` added as a closed ordered bigram. `never` stays out of `_DENIAL_WORDS`; only the adjacent ordered pair fires.

## The false-reject half — priced

The screenless rule: a wrongful refusal is a silent loop, so each change is priced in both directions.

| Change | False-accept price | False-reject price |
|---|---|---|
| `("never","confirm")` bigram | none — no genuine approval says those two tokens adjacent in that order | **residual, unclosed**: `never` non-adjacent still approves ("I never asked you to confirm tango"). Pinned: "confirm tango, I never got the other one" still approves. |
| Mask span narrowed | none — strictly less suppression | a denial trigger that used to be swallowed now denies. That is the fix, and "don't forget X" still approves. |
| `harbor`/`ripcord` → `banjo`/`lantern` | none | closes a **deterministic livelock**: neither variant is in the alphabet, so `confirm harbour` was `no_match` ("say the word I gave you"), the owner repeats identically, proposal retires at 5. Removed rather than aliased — `rip cord` is two tokens and needs a compound merge, and folding a spelling for a word we no longer mint is machinery with nothing to do. The regression pin **fails open** and the test says so; the selection rule (one morpheme, no en-US/en-GB split) is what bounds the class. |
| Fillers skipped between `confirm` and the nonce | real and small: "confirm — you know, tango was the word" now approves. Containment already approves any utterance carrying `confirm <nonce>`; this adds the filler-separated spelling of the same thing. Both content words still required, in order; a non-filler between them still refuses (controlled). | removes a refusal of a **correct** approval that also burned an attempt. Hesitating before a code word is how people say code words. |
| `("cant","wait")` exception | a hesitated hold spelled "can't — wait!" normalizes identically and is suppressed. Bounded: the mask covers those two tokens only, so any other retraction — including a second bare `wait` — still denies (controlled). | "confirm tango, tell them I can't wait to see it" no longer denies. |
| `high_seq` re-read after the await | none — it can only refuse more | one `pending_transcript` wait, which the owner is told to sit through and which resolves on the next confirm. The other half is tested: once the utterance lands harmless, the approval goes. |
| `in_flight` at claim | none | a duplicate is told to wait instead of "tell me again what you'd like sent" — which invited a re-propose of a write mid-dispatch, i.e. a **double send**. It is a WAIT outcome, so it burns no attempt and leaves `confirm_terminal` false; the claim is released in a `finally`, and a wedged marker would itself be a silent loop (tested, including on a raising runner). |

## Await ceiling (#5)

`ceiling` was snapshotted before the ≤2.5s await and widened only by `found`. A denial the owner **begins** during the await has a `speech_started` above the snapshot and no transcript, so `after` (filters on `complete`) can't see it and `unheard_between` excluded it — the write executed with a take-back in transcription. Now the mark is re-read after the await: still bounded, still strictly before the verdict.

The `wait_s=0` fixture provably cannot construct this shape (no await, no window). The new test uses real threads and **forces** the ordering rather than racing it — the denial's `speech_started` is emitted *before* the approval's transcript, so the await is still blocked when the sequence advances. It also asserts the fixture actually straddles, and ran 5× clean.

## Atomic claim (#6)

`_claim` now marks the token in-flight under the lock. Two tests: a re-entrant runner (a second confirm arriving strictly *during* dispatch) and a second confirm arriving while the first is inside its bounded await. Not "not reproduced in 250 trials" — guaranteed by construction, which is this module's own standard.

## Verification

`uv run --extra dev pytest -q -m "not requires_tmux"` (CI's own selection): **5580 passed, 36 skipped, 1 failed**.

The one failure is **pre-existing on `voice-confirm-spine` and not mine**: `test_session_metadata_ssot::test_no_module_hand_builds_the_metadata_path`, flagging `voice_layer/delivery.py:55` and `voice_layer/identity.py:171` — files another worker owns this wave. Confirmed by stashing my two files and re-running: still red.

Draft on purpose. Do not merge.

Built by [dotdev.dev](https://dotdev.dev)