### PR TITLE
voice-layer: route session paths through the metadata SSOT

### DIFF
--- a/agentwire/voice_layer/delivery.py
+++ b/agentwire/voice_layer/delivery.py
@@ -51,8 +51,14 @@ ADAPTERS = (VOICE_ADAPTER,)
 
 
 def session_state_dir(session: str) -> Path:
-    """The session's metadata directory (``~/.agentwire/sessions/<name>/``)."""
-    return core.CONFIG_DIR / "sessions" / session.split("@")[0]
+    """The session's metadata directory (``~/.agentwire/sessions/<name>/``).
+
+    Derived from the record path rather than rebuilt (#899): the ``@machine``
+    strip and the containment check both live in
+    :func:`core.session_metadata_path`, so a name that escapes the store raises
+    here instead of addressing a spool outside it.
+    """
+    return core.session_metadata_path(session).parent
 
 
 def spool_path(session: str) -> Path:

--- a/agentwire/voice_layer/identity.py
+++ b/agentwire/voice_layer/identity.py
@@ -124,7 +124,7 @@ def unregister(name: str = DEFAULT_NAME, *, purge: bool = False) -> dict:
 
     removed = {"metadata": False, "spool": False, "cursor": False, "pending": 0}
 
-    meta_file = delivery.session_state_dir(name) / "metadata.json"
+    meta_file = core.session_metadata_path(name)
     if meta_file.exists():
         meta_file.unlink()
         removed["metadata"] = True
@@ -168,7 +168,7 @@ def status(name: str = DEFAULT_NAME) -> dict:
 
 def list_buddies() -> list[dict]:
     """Every voice-layer record in the session store."""
-    root = core.CONFIG_DIR / "sessions"
+    root = core.sessions_dir()
     if not root.exists():
         return []
     found = []


### PR DESCRIPTION
Fixes the red `tests/unit/test_session_metadata_ssot.py::test_no_module_hand_builds_the_metadata_path` on `voice-confirm-spine`. The guard arrived from main via #904; the two offending lines predate it.

- `delivery.session_state_dir` → `core.session_metadata_path(session).parent`
- `identity.list_buddies` root → `core.sessions_dir()`

No third path-builder — both route through the helpers that already exist.

**`@machine` preserved exactly.** The strip moves from `delivery.py`'s inline `session.split("@")[0]` to `core.session_metadata_path`, which does the same split and is documented as the one place it happens. Removing `@machine` support is #979's call, not this change's.

Also routed `identity.unregister`'s `meta_file` through `session_metadata_path` — same defect class, and it is an **unlink**, which is the case the SSOT docstring cites by name. Callers now inherit the containment check, so a name that escapes the store raises rather than addressing (and deleting) a file outside it.

Verification: guard green; full suite `5606 passed, 36 skipped` in 5m25s.

Scope: only `voice_layer/delivery.py` and `voice_layer/identity.py` touched — sibling workers own the rest of the package.