### PR TITLE
voice-layer W2: instructions.py — reconcile three prose guarantees with the code (#980)

### DIFF
--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -79,11 +79,17 @@ to review or merge it. It is the most common thing that actually needs the owner
 #:   by OWNERSHIP — an opinion is yours and said as yours; a fact belongs to a
 #:   tool or to the owner, and is looked up, not remembered.
 #: - "Insisting" is deliberately NOT a licence to interrupt. The prose here
-#:   describes re-raising — say it once, and if it is visibly still true later,
-#:   say it once more at a gap. The interrupt decision itself is made in CODE
-#:   (the notifier's two-tier gate in client.py, keyed on message kind), for
-#:   the same reason the confirm judgment is: prompt compliance is not a
-#:   mechanism, and "how urgent does the model feel this is" is not a gate.
+#:   describes re-raising — say it once, and say it once more when the second
+#:   mention is handed back to you. **The ledger decides when** (#980):
+#:   ``createReRaiseLedger`` in client.py holds the open item and offers it
+#:   again on a quiet full-gate tick, so the model speaks the second mention
+#:   rather than choosing it. This comment described the choosing for one
+#:   round after the paragraph stopped granting it, which is how a deleted
+#:   sentence gets restored by a reader trusting the comment above it. The
+#:   interrupt decision is in CODE for the same reason (the notifier's
+#:   two-tier gate, keyed on message kind), and so is the confirm judgment:
+#:   prompt compliance is not a mechanism, and "how urgent does the model feel
+#:   this is" is not a gate.
 PERSONA = """\
 <persona>
 You are a peer, not an assistant. Think of the register of a pair-programming \
@@ -157,11 +163,17 @@ gate, out loud.
 #:   write (:mod:`~agentwire.voice_layer.surface`); a kill spec would have
 #:   shipped with the prompt still denying it, and nothing re-labels prose.
 #:   What survives as an absolute is only what
-#:   :data:`~agentwire.voice_layer.surface.TIER_EXCLUDED` makes permanent. The
-#:   confirm-gate sentence is deliberately phrased as what a gated tool DOES
-#:   (hands back a phrase instead of acting) rather than as "every write is
-#:   gated" — the light grade is confirm-free by design, and none are wired
-#:   only because none has a CLI verb yet.
+#:   :data:`~agentwire.voice_layer.surface.TIER_EXCLUDED` makes permanent.
+#:   The confirm sentence says "SOME of them ask first", and the quantifier is
+#:   the point: the first repair of this paragraph shipped "a tool that
+#:   changes something hands back a confirm phrase", which quantifies over
+#:   every mutating tool and is true only while no
+#:   :data:`~agentwire.voice_layer.surface.TIER_WRITE_LIGHT` write is wired —
+#:   they are confirm-free BY DESIGN, and unwired only because none has a CLI
+#:   verb yet. Same defect as the sentence it replaced, one round later. Nor
+#:   can the prose be rescued by naming the grade: "gated" is a word this
+#:   prompt never defines to the model, so a sentence that turns on it says
+#:   nothing to its actual reader. Describe what the model observes.
 #: - **The reply nudge is conditional**, because ``confirm.render_body`` drops
 #:   it whole whenever the body would exceed ``MAX_BODY_CHARS``. Stated
 #:   unconditionally, the buddy could tell the owner a recipient was told how
@@ -197,9 +209,9 @@ closest match. Read back what you heard and ask, or list the candidates. Acting 
 the wrong session is worse than asking twice.
 
 LIMITS. Your tools are the whole of what you can do, and the list you were \
-given is the list. Most of them only observe. A tool that changes something \
-tells you so by handing back a confirm phrase instead of doing it; the owner \
-saying that phrase out loud is what runs it. Before you \
+given is the list. Most of them only observe. Some of them ask first: they \
+hand back a confirm phrase instead of doing it, and the owner saying that \
+phrase out loud is what runs them. Before you \
 say you can do something, ask which tool does it: if none does, you cannot, \
 and saying so is the answer — not a workaround. A few things stay out of your \
 hands however the tool list grows: you never start, restart or drive a session, \

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -121,11 +121,12 @@ missed wit costs nothing, waited-out wit costs the owner's time.
 
 PUSH BACK, THEN INSIST. If the owner is about to do something you think is a \
 mistake, say so plainly, once, with the reason. If you told them something \
-needed attention and you can see it is still true the next time there's a \
-natural gap, raise it again — briefly, noting it is the second mention — and \
-then leave it with them. Twice is a peer; a third time is a nag. And none of \
-this ever speaks over them: insistence is about the second attempt, not about \
-volume.
+needed attention and it is still open a while later, it will be handed to you \
+again at a quiet moment; when that happens, raise it briefly, say it is \
+the second mention, and leave it with them. Twice is a peer; a third time is a \
+nag — which is why the second mention is scheduled for you rather than left to \
+your judgment, and why there is no third. And none of this ever speaks over \
+them: insistence is about the second attempt, not about volume.
 
 A SUPPORT LAYER, NOT A WORK SURFACE. The real work happens in Claude Code sessions; you \
 are the layer the owner talks to ABOUT the work. You never write code, never \
@@ -134,6 +135,41 @@ doing, a session does it, and your part is to ask one — through the confirm \
 gate, out loud.
 </persona>"""
 
+#: The spoken-channel addendum. Three of its paragraphs are STATEMENTS ABOUT
+#: CODE and were repaired in #980, each having been correct when written and
+#: falsified by a later change nothing re-read them against:
+#:
+#: - **VOLUNTEERING** names the unprompted set, and that set lives in
+#:   ``client.py``: an inbox notice on a quiet full-gate tick, a re-raise
+#:   reminder on a quiet full-gate tick (``createReRaiseLedger``, request and
+#:   escalation kinds only), and an escalation through the relaxed interrupt
+#:   gate. It used to say "exactly one thing" — a session replying to
+#:   something you sent — written before the ledger existed and before the
+#:   inbox carried anything a session cared to send. The prompt shipped both
+#:   halves of a contradiction: PERSONA told the model to re-raise, VOICE_MODE
+#:   told it not to volunteer. **Add a fourth unprompted path in client.py and
+#:   this paragraph is stale**, because the model is told the list is closed.
+#: - **LIMITS** must derive from what is wired —
+#:   :data:`~agentwire.voice_layer.write_tools.WRITE_SPECS` for writes,
+#:   ``tools.READ_ONLY_TOOLS`` for reads — not enumerate what the buddy cannot
+#:   do. It used to say "you cannot stop one", true of today's wiring and
+#:   false of the tier ruling that grades ``session_kill`` as a wireable gated
+#:   write (:mod:`~agentwire.voice_layer.surface`); a kill spec would have
+#:   shipped with the prompt still denying it, and nothing re-labels prose.
+#:   What survives as an absolute is only what
+#:   :data:`~agentwire.voice_layer.surface.TIER_EXCLUDED` makes permanent. The
+#:   confirm-gate sentence is deliberately phrased as what a gated tool DOES
+#:   (hands back a phrase instead of acting) rather than as "every write is
+#:   gated" — the light grade is confirm-free by design, and none are wired
+#:   only because none has a CLI verb yet.
+#: - **The reply nudge is conditional**, because ``confirm.render_body`` drops
+#:   it whole whenever the body would exceed ``MAX_BODY_CHARS``. Stated
+#:   unconditionally, the buddy could tell the owner a recipient was told how
+#:   to answer when the slot was dropped.
+#:
+#: The shared shape: a sentence here is a guarantee the buddy speaks and acts
+#: on, so one stated broader than the code gets rounded back up by the next
+#: reader. Narrow the sentence; do not bolt a qualifier onto it.
 VOICE_MODE = """\
 <voice_mode>
 This is a live spoken conversation. Speak the way a person speaks: no markdown, \
@@ -160,10 +196,18 @@ single word. If you are not certain you heard a name correctly, do not pick the 
 closest match. Read back what you heard and ask, or list the candidates. Acting on \
 the wrong session is worse than asking twice.
 
-LIMITS. You can look, and you can pass a message to a session that is already \
-running. You cannot start a session, stop one, merge anything, or change a file. \
-If nothing suitable is running, say so plainly — "nothing is listening" is a real \
-answer — and do not offer a workaround. Never claim you did something you did not do.
+LIMITS. Your tools are the whole of what you can do, and the list you were \
+given is the list. Most of them only observe. A tool that changes something \
+tells you so by handing back a confirm phrase instead of doing it; the owner \
+saying that phrase out loud is what runs it. Before you \
+say you can do something, ask which tool does it: if none does, you cannot, \
+and saying so is the answer — not a workaround. A few things stay out of your \
+hands however the tool list grows: you never start, restart or drive a session, \
+you never write code or produce work of your own, you never reach the owner \
+through another channel than this one, and you never send anything outside the \
+fleet. A session does those; your part is to ask one. If nothing suitable is \
+running, say so plainly — "nothing is listening" is a real answer. Never claim \
+you did something you did not do.
 
 PASSING A MESSAGE. Two steps, with the owner's spoken confirmation in between. \
 First call propose_session_message. It sends nothing and gives you back a confirm \
@@ -192,9 +236,12 @@ session simply has not received it yet. Your messages go out with a leading \
 Delivery can defer while the recipient stays busy, and after too many failures \
 a message is dead-lettered — dropped, with the owner emailed. Both outcomes are \
 observable: buddy_sent shows each message you have sent and its current state. \
-Your messages also carry the reply path — the recipient is asked to answer you \
-by message, and when it does, that reply lands in buddy_inbox. A recipient may \
-still never reply; never promise the owner one.
+When there is room for it, your message also carries the reply path — the \
+recipient is told, in so many words, to answer you by message, and when it \
+does, that reply lands in buddy_inbox. It is the first thing dropped when a \
+message runs long, so it is not a guarantee: if the owner asks whether the \
+recipient knows how to reach you, read the body back from buddy_sent rather \
+than assuming it. A recipient may still never reply; never promise the owner one.
 
 WHAT YOU SENT. Any question about a message you sent — what it said, whether \
 some word or detail ended up in it, what happened to it — is answered by \
@@ -223,27 +270,36 @@ silently retry, and do not reword a message to get past a refusal. If the result
 says "owner_should_wait", tell them to hold on rather than to say it again — those \
 are opposite instructions and giving the wrong one makes it worse.
 
-VOLUNTEERING. Exactly one thing is worth raising unprompted: a session replying \
-to something you sent. When a reply comes in, open by naming who finished and \
-what it was about — "minecraft finished responding about the server crash" — \
-then give the shape of the answer, not a recital: "looks like there are four \
-main options to consider". A sentence or two, then hand the conversation back; \
-the owner will ask for the detail they want. A volunteered report that becomes \
-a monologue is worse than silence — the owner did not ask, cannot skim speech, \
-and cannot predict when you will stop.
+VOLUNTEERING. Everything you say unprompted is handed to you by code, and the \
+list is closed. There are three kinds: mail arriving for you — a session \
+reporting back or asking you something, whether or not it is answering \
+anything you sent; the second mention of something that asked for action and \
+is still open, which comes back to you at a quiet moment once it has sat a \
+while; and an escalation, the one kind urgent enough to cut across your own \
+talking. You do not add to that list. Wanting to mention something is not one \
+of the three: if the owner did not ask and nothing was put in front of you, it \
+waits.
 
-Ground every volunteered claim in output you actually read — the reply's \
+When one of them does arrive, open by naming who and what it is about — \
+"minecraft finished responding about the server crash" — then give the shape \
+of the answer, not a recital: "looks like there are four main options to \
+consider". A sentence or two, then hand the conversation back; the owner will \
+ask for the detail they want. A volunteered report that becomes a monologue is \
+worse than silence — the owner did not ask, cannot skim speech, and cannot \
+predict when you will stop.
+
+Ground every volunteered claim in output you actually read — the message's \
 recorded text in buddy_inbox, or the session's own terminal via \
 fleet_session_output — never what you expect the answer to be. A plausible \
 summary of output you did not read sounds exactly like one you did, and in a \
 volunteered report the owner has no way to tell them apart, because they did \
-not ask. If you have not read it, say only that a reply arrived and offer to \
+not ask. If you have not read it, say only that something arrived and offer to \
 look. \
-Beyond that one case, do not volunteer status the owner did not ask for. And \
-never interrupt the owner: nothing you have to report is worth speaking over a \
-human mid-sentence. When something urgent arrives — an escalation from the \
-fleet — the timing of saying it is decided in code, not by you; your job is \
-only to say what it is, specifically, when it is put in front of you.
+And never interrupt the owner: nothing you have to report is worth speaking \
+over a human mid-sentence. That leg holds for an escalation too — what an \
+escalation may cut across is your own talking, never theirs — and the timing \
+of all of it is decided in code, not by you; your job is only to say what it \
+is, specifically, when it is put in front of you.
 </voice_mode>"""
 
 

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -361,11 +361,16 @@ class TestInstructions:
 
     def test_states_its_limits_truthfully_and_the_freshness_rule(self):
         """Slice 1 gave the buddy one write, so "you can only look" became a
-        lie. The persona must state the NEW boundary, not the old one."""
+        lie. The persona must state the NEW boundary, not the old one — and
+        since #980 it states it by DERIVATION from the tool list rather than
+        by enumerating negatives, because the enumeration went stale the same
+        way (``session_kill`` is a wireable gated write, so "you cannot stop
+        one" was one spec away from being false with nothing to catch it)."""
         text = instructions.build_instructions()
         assert "LIMITS." in text
         assert "only look" not in text, "stale claim: the buddy can write now"
-        assert "cannot start a session" in text
+        assert "if none does, you cannot" in text
+        assert "never start, restart or drive a session" in text
         assert "FRESHNESS." in text
         assert "IDENTITY." in text
 
@@ -380,19 +385,26 @@ class TestInstructions:
         assert "must_speak" in text
         assert "owner_should_wait" in text
 
-    def test_volunteers_replies_only_and_still_never_interrupts(self):
-        """#962: the one thing raised unprompted is a reply to something the
-        buddy sent. The old absolute ("you speak when spoken to") is now false
-        — the announcer's clock speaks replies — but general unprompted status
-        and interruption stay banned."""
+    def test_volunteers_only_what_code_hands_it_and_still_never_interrupts(self):
+        """#962 wrote this as "replies only", which was the whole unprompted
+        set at the time. #967 then shipped two more paths (the re-raise ledger
+        and the escalation interrupt tier) and #980 reconciled the prose: the
+        set is whatever the client hands the model, and the model may not
+        extend it. The old absolute ("you speak when spoken to") stays false,
+        and interruption of the OWNER stays banned on every tier."""
         text = instructions.build_instructions()
         flowed = " ".join(text.split())
         assert "VOLUNTEERING." in text
         assert "You speak when spoken to." not in flowed, (
             "stale absolute: contradicts the reply announcer"
         )
-        assert "do not volunteer status the owner did not ask for" in flowed
-        assert "never interrupt" in flowed
+        assert "do not volunteer status the owner did not ask for" not in flowed, (
+            "stale absolute: contradicts the re-raise ledger and the "
+            "escalation tier, both of which volunteer unasked"
+        )
+        assert "Everything you say unprompted is handed to you by code" in flowed
+        assert "You do not add to that list" in flowed
+        assert "never interrupt the owner" in flowed
 
     def test_a_volunteered_report_is_shape_not_recital(self):
         """The owner's example is 'looks like there are four main options', not
@@ -413,7 +425,9 @@ class TestInstructions:
         assert "never what you expect the answer to be" in flowed
         assert "buddy_inbox" in flowed
         assert "fleet_session_output" in flowed
-        assert "say only that a reply arrived" in flowed
+        # "something", not "a reply": the unprompted set is wider than replies
+        # (#980) — a request or an escalation is grounded the same way.
+        assert "say only that something arrived" in flowed
 
 
 # =============================================================================

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -25,7 +25,29 @@ what is wired, not assert a negative the next wiring falsifies), and the reply
 nudge (which ``render_body`` drops whole whenever the body runs long).
 """
 
+import inspect
+
 from agentwire.voice_layer import confirm, instructions, surface, write_tools
+
+
+def source() -> str:
+    """The module's own text, comments included.
+
+    The comments above PERSONA and VOICE_MODE describe what the prompt
+    strings say. They are prose about prose, and they drift the same way the
+    prompt does — twice already: one described the re-raise sentence it had
+    just been rewritten past, the other claimed a phrasing the shipped
+    sentence did not have. Nothing reads a comment at runtime, so pinning
+    them needs the source.
+    """
+    return inspect.getsource(instructions)
+
+
+def flowed_comments() -> str:
+    """:func:`source` with the ``#:`` markers and line wrapping flowed away,
+    so an assertion about what a comment SAYS does not also pin where the
+    72-column wrap happens to fall."""
+    return " ".join(source().replace("#:", " ").split())
 
 
 def full() -> str:
@@ -178,6 +200,15 @@ class TestVolunteeringMatchesTheCodeDrivenSet:
         assert "handed to you" in persona
         assert "scheduled for you rather than left to" in persona
 
+    def test_the_comment_above_persona_agrees_with_the_paragraph(self):
+        """#991 review. The comment still described the deleted sentence —
+        "say it once more at a gap" if "it is visibly still true later", which
+        is the model judgment the ledger took over. A comment that documents
+        the previous draft is how the next reader restores it."""
+        src = source()
+        assert "visibly still true later" not in src
+        assert "The ledger decides when" in flowed_comments()
+
 
 class TestLimitsDeriveFromWhatIsWired:
     """#980 defect 2: "you cannot … stop one" is true of today's wiring and
@@ -208,6 +239,39 @@ class TestLimitsDeriveFromWhatIsWired:
         assert "never write code" in text
         assert "another channel" in text
         assert "outside the fleet" in text
+
+
+class TestTheConfirmSentenceDoesNotQuantifyOverEveryWrite:
+    """#991 review. The repair for defect 2 shipped its own copy of the
+    defect: "A tool that changes something tells you so by handing back a
+    confirm phrase" quantifies over ALL mutating tools, and the light grade is
+    confirm-free BY DESIGN. True only while no light write is wired — which is
+    a wiring accident, exactly the thing this paragraph stopped relying on."""
+
+    def test_the_light_grade_is_confirm_free_and_unwired_by_accident(self):
+        """The premise. Light writes are graded, disjoint from gated, and
+        absent from WRITE_SPECS only because none has a CLI verb yet."""
+        assert surface.TIER_WRITE_LIGHT
+        assert not (surface.TIER_WRITE_LIGHT & surface.TIER_WRITE_GATED)
+        wired = {spec.name for spec in write_tools.WRITE_SPECS}
+        assert not (surface.TIER_WRITE_LIGHT & wired)
+
+    def test_the_prose_says_some_not_all(self):
+        text = instructions.VOICE_MODE
+        assert "A tool that changes something tells you so" not in text
+        assert "Some of them ask first" in text
+
+    def test_the_comment_describes_the_sentence_that_shipped(self):
+        """The second half of the same finding: the comment claimed a
+        phrasing ("what a gated tool DOES") the string did not have, and
+        "gated" is a word the prompt never defines to the model."""
+        src = source()
+        assert "deliberately phrased as what a gated tool DOES" not in src
+        comments = flowed_comments()
+        assert "the quantifier is the point" in comments
+        assert "confirm-free BY DESIGN" in comments
+        # And the reason naming the grade would not have rescued it.
+        assert "a word this prompt never defines to the model" in comments
 
 
 class TestTheReplyPathIsConditional:

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -15,9 +15,17 @@ as prose someone can soften in passing:
   explicitly located in code — prompt compliance is not a gate;
 - the support-layer boundary survives verbatim in spirit: never writes code,
   never owns a worktree, never creates a session.
+
+#980 adds the other half of that job: a sentence in this prompt is a guarantee
+the buddy speaks and acts on, so where the prose states something broader than
+the code enforces, the prose is wrong. Three of those are pinned below AGAINST
+THE CODE rather than against their own wording — the volunteering set (which
+the client drives, not the model), the limits sentence (which must derive from
+what is wired, not assert a negative the next wiring falsifies), and the reply
+nudge (which ``render_body`` drops whole whenever the body runs long).
 """
 
-from agentwire.voice_layer import instructions
+from agentwire.voice_layer import confirm, instructions, surface, write_tools
 
 
 def full() -> str:
@@ -121,6 +129,131 @@ class TestInsistenceAndTheBoundary:
         assert "never write code" in persona
         assert "never own a worktree" in persona
         assert "never create a session" in persona
+
+
+class TestVolunteeringMatchesTheCodeDrivenSet:
+    """#980 defect 1. VOICE_MODE said "exactly one thing is worth raising
+    unprompted … beyond that one case, do not volunteer" while the client
+    ships three unprompted paths and PERSONA instructs a second mention. Each
+    text was correct when written; the composition was not."""
+
+    def test_it_no_longer_claims_a_single_sanctioned_case(self):
+        text = full()
+        assert "Exactly one thing is worth raising unprompted" not in text
+        assert "Beyond that one case" not in text
+
+    def test_all_three_code_driven_paths_are_named(self):
+        """The client's unprompted speech: an inbox notice on a quiet
+        full-gate tick, a re-raise reminder on a quiet full-gate tick, and an
+        escalation through the relaxed interrupt gate."""
+        text = full()
+        # 1. mail arriving — and NOT narrowed to replies to what you sent:
+        #    buddy_inbox is "reports and requests other sessions have sent
+        #    YOU", whoever started the exchange.
+        assert "mail arriving" in text
+        # 2. the code-scheduled second mention.
+        assert "second mention" in instructions.VOICE_MODE
+        # 3. the one kind that may pre-empt the buddy's own speech.
+        assert "escalation" in instructions.VOICE_MODE
+
+    def test_the_set_is_closed_and_owned_by_code(self):
+        """The model must not read the list as examples it may extend."""
+        text = instructions.VOICE_MODE
+        assert "the list is closed" in text
+        assert "You do not add to that list" in text
+
+    def test_the_re_raise_leg_is_the_one_the_ledger_actually_schedules(self):
+        """The ledger registers ONLY request/escalation kinds (a done or a
+        note is news, and re-raising news is chatter), and it fires after the
+        item has stayed open — not on the model noticing."""
+        text = instructions.VOICE_MODE
+        assert "asked for action" in text
+        assert "still open" in text
+
+    def test_the_persona_does_not_put_the_second_mention_in_the_models_hands(self):
+        """PERSONA and VOICE_MODE must agree on WHO decides the re-raise; the
+        ledger does, the model only speaks it."""
+        persona = instructions.PERSONA
+        assert "you can see it is still true" not in persona
+        assert "handed to you" in persona
+        assert "scheduled for you rather than left to" in persona
+
+
+class TestLimitsDeriveFromWhatIsWired:
+    """#980 defect 2: "you cannot … stop one" is true of today's wiring and
+    false of the tier ruling, and nothing re-labels prose when a spec ships."""
+
+    def test_kill_is_wireable_so_the_prose_must_not_deny_it_categorically(self):
+        """The premise, asserted rather than assumed: session_kill is a graded
+        gated write, not an exclusion, so a sentence saying the buddy cannot
+        stop a session is a claim the next spec silently falsifies."""
+        assert "session_kill" in surface.TIER_WRITE_GATED
+        assert "session_kill" not in surface.TIER_EXCLUDED
+        assert "session_kill" not in {spec.name for spec in write_tools.WRITE_SPECS}
+        assert "stop one" not in instructions.VOICE_MODE
+
+    def test_capability_is_stated_positively_against_the_tool_list(self):
+        text = instructions.VOICE_MODE
+        assert "Your tools are the whole of what you can do" in text
+        assert "if none does, you cannot" in text
+
+    def test_the_permanent_exclusions_it_still_states_really_are_excluded(self):
+        """What survives as an absolute must be absolute IN THE TIER TABLE —
+        a design decision, not a wiring accident."""
+        for name in ("session_create", "worktree_create", "say", "email_send",
+                     "desktop_write_artifact"):
+            assert name in surface.TIER_EXCLUDED
+        text = instructions.VOICE_MODE
+        assert "never start" in text
+        assert "never write code" in text
+        assert "another channel" in text
+        assert "outside the fleet" in text
+
+
+class TestTheReplyPathIsConditional:
+    """#980 defect 3: the nudge is droppable, the sentence was not."""
+
+    def test_the_code_really_does_drop_the_nudge_on_a_long_body(self):
+        """The premise, demonstrated rather than cited — if render_body ever
+        makes the nudge unconditional, this test says so and the prose below
+        becomes the thing that needs changing."""
+        short = confirm.render_body("ship it", "", "abc123", reply_to="worker")
+        assert "reply: agentwire msg send" in short
+        long = confirm.render_body(
+            "x" * confirm.MAX_RENDERED_INSTRUCTION_CHARS,
+            "y" * confirm.MAX_UTTERANCE_CHARS,
+            "abc123",
+            reply_to="a-rather-long-worktree-session-name-here",
+        )
+        assert len(long) <= confirm.MAX_BODY_CHARS
+        assert "reply: agentwire msg send" not in long
+
+    def test_the_sentence_is_narrowed_not_qualified(self):
+        text = instructions.VOICE_MODE
+        assert "Your messages also carry the reply path" not in text
+        assert "When there is room for it" in text
+        assert "not a guarantee" in text
+
+    def test_it_points_at_the_record_that_can_settle_it(self):
+        """buddy_sent records the exact body that went out, so "was the
+        recipient told how to answer" is a lookup, not a belief."""
+        text = instructions.VOICE_MODE
+        nudge = text.split("When there is room for it")[1].split("\n\n")[0]
+        assert "buddy_sent" in nudge
+
+
+class TestTheWaitInstructionKeysOnTheFlagNotTheOutcomeNames:
+    """W1 added a THIRD wait outcome (in_flight). This prompt survived that
+    change unedited because it consumes the FLAG; the test pins the reason so
+    a future edit cannot quietly reintroduce an enumeration that goes stale."""
+
+    def test_the_flag_is_what_the_prose_names(self):
+        assert "owner_should_wait" in instructions.VOICE_MODE
+
+    def test_no_wait_outcome_is_named_in_the_prose(self):
+        for outcome in confirm.WAIT_OUTCOMES:
+            assert outcome not in instructions.VOICE_MODE
+        assert len(confirm.WAIT_OUTCOMES) == 3  # in_flight arrived in W1
 
 
 class TestSpeakability:


### PR DESCRIPTION
`instructions.py` only. Siblings' files (client.py/server.py/transcript.py, tools.py/write_tools.py/surface.py/outbox.py) untouched; confirm.py read, not edited.

## The contradiction (issue §1)

VOICE_MODE said *"Exactly one thing is worth raising unprompted … Beyond that one case, do not volunteer status the owner did not ask for"* while PERSONA instructed a re-raise and `client.py` ships **three** unprompted paths. Reconciled against the ledger in code, not the issue's summary of it:

| path | code | scheduled how |
|---|---|---|
| mail arriving | `createInboxNotifier.pollOnce` | quiet **full**-gate tick |
| second mention | `createReRaiseLedger.dueText` | quiet full-gate tick, `RERAISE_DUE_MS`, **request/escalation kinds only** (`onSpoken` registers) |
| escalation | `canInterrupt` | relaxed gate — may pre-empt the buddy's own speech, never the owner |

Two corrections the issue's phrasing did not carry: the ledger registers only kinds that *ask* (a `done`/`note` is news), and `buddy_inbox` is *"reports and requests other sessions have sent YOU"* — so "a session replying to something you sent" was **narrower** than the code in one direction while "beyond that one case, do not volunteer" was **broader** in the other. Both fixed. The set is now stated as code-driven and closed.

## §2 LIMITS

`session_kill` is `TIER_WRITE_GATED` — wireable, not excluded — so *"you cannot … stop one"* was one spec away from false with nothing to re-label it. Now derives from the tool list (*"ask which tool does it: if none does, you cannot"*), keeping as absolutes only what `TIER_EXCLUDED` makes permanent (session creation/driving, authoring work, another owner channel, outward publishing). A comment above `VOICE_MODE` binds the paragraph to `WRITE_SPECS`/`surface`. The confirm-gate sentence is phrased as what a gated tool *does* rather than "every write is gated" — the light grade is confirm-free by design.

## §3 reply nudge

`render_body` drops it whole when the body would exceed `MAX_BODY_CHARS`. Narrowed to "when there is room for it", stated as not a guarantee, and pointed at `buddy_sent` — the record that can settle it.

## Wave-1 checks, verified rather than assumed

- **Third wait outcome (`in_flight`)** — no change needed. The prose consumes `owner_should_wait`, the flag `Verdict` computes from `WAIT_OUTCOMES`, and never names an outcome. Now pinned: a test iterates `confirm.WAIT_OUTCOMES` and fails if any member appears in the prose, plus asserts the set is size 3 so a fourth arrival is announced.
- **Gapped never-confirm pair + `("cant","wait")` exception** — no change needed. This file never enumerates what the owner may say to deny (only *"if they decline, call cancel_session_message"*), and must not: the module docstring's standing rule is that restating the confirm judgment in prose invites the next reader to believe the prose is the mechanism.

## Method

Every new test watched failing first (10 RED on the prose, then GREEN). The two premise tests pass from the start by design — they assert the *code*: `session_kill`'s tier, and `render_body` driven with a max-length instruction to demonstrate the nudge is genuinely dropped while the id survives. Three tests in `test_voice_layer.py` asserted the removed sentences verbatim; updated with the reason recorded, since they encoded the defect.

CI's own invocation, full suite: **5683 passed, 36 skipped, 0 failed** (base 5670).

Closes #980

Built by [dotdev.dev](https://dotdev.dev)