### PR TITLE
voice-layer W2: client.py — server-owned clock origin, announcer/timer races, silent-failure retry holes (#978)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -141,8 +141,27 @@ function createAnnouncer(deps) {
   // end event. speechSynthesis can drop an utterance without firing `onend`
   // OR `onerror`, and `speaking` below gates volunteering — so without this
   // the false-reject half is an UNBOUNDED mute, which is strictly worse than
-  // the interjection it prevents. Long enough to cover any real utterance.
-  var speakingMaxMs = deps.speakingMaxMs || fallbackMs * 5;
+  // the interjection it prevents.
+  //
+  // SCALED BY LENGTH, because a flat bound is not "long enough for any real
+  // utterance" and saying so was false: composeNotice coalesces up to 240
+  // characters PER MESSAGE, so a three-reply batch is around a minute of
+  // speech and a five-reply batch several. A flat 30s watchdog fires
+  // mid-utterance, which reopens both gates and lets the MODEL start a
+  // response over the browser voice — the two-voices defect (#950), reached
+  // through the mechanism added to bound a mute.
+  //
+  // The per-character rate is deliberately SLOWER than any real voice (~7
+  // characters a second against a typical 15). The two directions are not
+  // symmetric: over-estimating only delays a backstop that matters solely
+  // when the browser has already silently dropped the utterance, while
+  // under-estimating produces the overlap on every ordinary long notice.
+  var speakingBaseMs = deps.speakingMaxMs || fallbackMs * 5;
+  var speakingMsPerChar =
+    deps.speakingMsPerChar === undefined ? 140 : deps.speakingMsPerChar;
+  function speakingBudget(text) {
+    return speakingBaseMs + String(text || "").length * speakingMsPerChar;
+  }
 
   var queue = [];
   // { text, fallbackText, meta, timer, speakTimer, sawCreate, deferred,
@@ -292,10 +311,11 @@ function createAnnouncer(deps) {
       // clear a flag that had not been set yet. Watchdogged: an utterance
       // dropped with no onend/onerror would leave the gates shut forever.
       speaking.push(item);
+      var budget = speakingBudget(say);
       item.speakTimer = setTimer(function () {
-        onLog("fallback", "no end event within " + speakingMaxMs + "ms");
+        onLog("fallback", "no end event within " + budget + "ms");
         stopSpeaking(item);
-      }, speakingMaxMs);
+      }, budget);
       try {
         speak(
           say,

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -125,15 +125,38 @@ function createAnnouncer(deps) {
   // How many times the fallback may stand down for an owner who is still
   // talking. BOTH halves priced: without a bound, a long monologue swallows a
   // refusal entirely, which is the one outcome the default-on timer exists to
-  // rule out — talking over the owner once beats never telling them. With it,
-  // the worst case is fallbackMs * (1 + this) before they are told.
+  // rule out — talking over the owner once beats never telling them.
+  //
+  // The worst case is fallbackMs * (2 + maxOwnerDeferrals), not (1 + …): this
+  // deferral is checked FIRST and re-arms, so the one-shot in-flight deferral
+  // below is still available on the re-armed timer and the two STACK. That is
+  // correct — they answer different questions ("is the owner talking" and "is
+  // this our own audio still playing"), and sharing a budget would let a
+  // monologue consume the grace that stops the buddy speaking over itself —
+  // but it makes the bound 5 intervals, and the arithmetic is now pinned by a
+  // test rather than asserted here.
   var maxOwnerDeferrals =
     deps.maxOwnerDeferrals === undefined ? 3 : deps.maxOwnerDeferrals;
+  // How long the browser voice may be believed to still be talking with no
+  // end event. speechSynthesis can drop an utterance without firing `onend`
+  // OR `onerror`, and `speaking` below gates volunteering — so without this
+  // the false-reject half is an UNBOUNDED mute, which is strictly worse than
+  // the interjection it prevents. Long enough to cover any real utterance.
+  var speakingMaxMs = deps.speakingMaxMs || fallbackMs * 5;
 
   var queue = [];
-  // { text, fallbackText, meta, timer, sawCreate, deferred, ownerDeferrals }
+  // { text, fallbackText, meta, timer, speakTimer, sawCreate, deferred,
+  //   ownerDeferrals }
   var current = null;
   var responseActive = false;
+  //: Items whose FALLBACK AUDIO has started and not yet ended (review F4).
+  //: The real speak() is asynchronous — onSpokenAloud runs from
+  //: utterance.onend — and armFallback nulls `current` before calling it, so
+  //: between those two moments the announcer reported nothing pending at all:
+  //: canInterrupt passed and an escalation went out while the browser voice
+  //: was still saying "...say confirm tango". The unit fixture called back
+  //: synchronously, so that window had zero width and nothing could see it.
+  var speaking = [];
 
   // Function words. They carry nothing about WHETHER the reason was stated,
   // and they dominate a short conversational line — the greeting is 7 of its
@@ -264,19 +287,39 @@ function createAnnouncer(deps) {
       // safe one there — claiming not-spoken would replay a notice the owner
       // may well have heard.
       var say = item.fallbackText || item.text;
+      // The buddy is SPEAKING from here until an end event says otherwise —
+      // armed before speak(), because a synchronous callback would otherwise
+      // clear a flag that had not been set yet. Watchdogged: an utterance
+      // dropped with no onend/onerror would leave the gates shut forever.
+      speaking.push(item);
+      item.speakTimer = setTimer(function () {
+        onLog("fallback", "no end event within " + speakingMaxMs + "ms");
+        stopSpeaking(item);
+      }, speakingMaxMs);
       try {
         speak(
           say,
-          function () { onSpoken(item.meta, "fallback"); },
-          function () { onNotSpoken(item.meta); }
+          function () { stopSpeaking(item); onSpoken(item.meta, "fallback"); },
+          function () { stopSpeaking(item); onNotSpoken(item.meta); }
         );
-      } catch (e) { onSpoken(item.meta, "fallback"); }
+      } catch (e) { stopSpeaking(item); onSpoken(item.meta, "fallback"); }
       pump();
     }, fallbackMs);
   }
 
   function disarm(item) {
     if (item && item.timer) { clearTimer(item.timer); item.timer = null; }
+  }
+
+  // The browser voice for this item is over — by its own end event, by its
+  // error, or by the watchdog. Idempotent: all three can be reached, and only
+  // the first one that arrives means anything.
+  function stopSpeaking(item) {
+    if (item && item.speakTimer) {
+      clearTimer(item.speakTimer);
+      item.speakTimer = null;
+    }
+    speaking = speaking.filter(function (it) { return it !== item; });
   }
 
   function pump() {
@@ -334,6 +377,7 @@ function createAnnouncer(deps) {
       queue.forEach(disarm);
       queue = [];
       if (current) { disarm(current); current = null; }
+      speaking.slice().forEach(stopSpeaking);
     },
     // Withdraw announcements whose meta matches, queued or current (#963: the
     // owner speaking first CANCELS the greeting; queueing it behind them would
@@ -406,10 +450,17 @@ function createAnnouncer(deps) {
     // thing that can see that window, so canInterrupt asks it.
     anchorPending: function () {
       if (current && current.meta && current.meta.anchor) return true;
-      return queue.some(function (it) { return !!(it.meta && it.meta.anchor); });
+      var carriesAnchor = function (it) { return !!(it.meta && it.meta.anchor); };
+      // `speaking` too: the fallback voice mid-utterance is the buddy STATING
+      // the proposal, which is the middle of the handshake by any reading.
+      return queue.some(carriesAnchor) || speaking.some(carriesAnchor);
     },
-    // Test/inspection surface.
-    pending: function () { return (current ? 1 : 0) + queue.length; },
+    // Test/inspection surface — and load-bearing: canSpeak keys on this, so
+    // an item whose fallback audio is still playing has to count, or a notice
+    // is volunteered straight over the buddy's own voice.
+    pending: function () {
+      return (current ? 1 : 0) + queue.length + speaking.length;
+    },
     armed: function () { return !!(current && current.timer); },
   };
 }
@@ -534,6 +585,11 @@ function createInboxNotifier(deps) {
         if (take(strays[i])) pulled.push(strays.splice(i, 1)[0]);
         else i++;
       }
+      // Which of the announced ids came OUT of the strays array. A stray is
+      // cursor-past, so releasing it on failure is not enough — it has to go
+      // back in, and only the poll that took it knows which ones those were.
+      var wasStray = {};
+      pulled.forEach(function (m) { if (m && m.id) wasStray[m.id] = true; });
       var claimed = {};
       var fresh = pulled.concat((res.messages || []).filter(take)).filter(function (m) {
         if (!m || !m.id || seen[m.id] || inFlight[m.id] || claimed[m.id]) return false;
@@ -563,6 +619,7 @@ function createInboxNotifier(deps) {
       // actually told.
       announce(composeNotice(fresh), {
         inboxIds: ids,
+        strayIds: ids.filter(function (id) { return wasStray[id]; }),
         inboxMsgs: fresh.map(function (m) {
           return { id: m.id, from: m.from, kind: m.kind, text: m.text };
         }),
@@ -610,8 +667,26 @@ function createInboxNotifier(deps) {
   // an id the owner HAS heard would replay it.
   function noticeFailed(meta) {
     if (!meta || !meta.inboxIds) return;
+    var body = {};
+    (meta.inboxMsgs || []).forEach(function (m) { if (m && m.id) body[m.id] = m; });
+    var cameFromStrays = {};
+    (meta.strayIds || []).forEach(function (id) { cameFromStrays[id] = true; });
+    var alreadyBack = {};
+    strays.forEach(function (m) { if (m && m.id) alreadyBack[m.id] = true; });
     meta.inboxIds.forEach(function (id) {
-      if (!seen[id]) delete inFlight[id];
+      if (seen[id]) return;
+      delete inFlight[id];
+      // A SPOOL message needs nothing more: the cursor never advanced (only
+      // noticeSpoken moves it), so the next peek returns it. A STRAY was
+      // spliced out of the array to be announced and the cursor is already
+      // past it, so releasing the id alone dropped it from BOTH places —
+      // "the next tick says it again" was false for exactly the class that
+      // becomes strays, which is escalations. Putting it back is the whole
+      // reason the array exists.
+      if (cameFromStrays[id] && !alreadyBack[id] && body[id]) {
+        alreadyBack[id] = true;   // idempotent: a second call must not double it
+        strays.push(body[id]);
+      }
     });
   }
 
@@ -1256,8 +1331,15 @@ async function start() {
     // called nextSeq() yet. No `|| 0` default: a bridge that did not answer
     // with a base is broken, and silently restarting at zero is the exact
     // defect this closes.
-    if (typeof session.seq_base !== "number") {
-      throw new Error("mint returned no sequence base");
+    //
+    // SAFE integer, not merely a number: `typeof Infinity === "number"` is
+    // true, and a counter at Infinity never advances and serializes every
+    // anchor as `null` — not_announced forever, silently. Anything at or past
+    // 2**53 has the same shape without the tell, since ++ stops advancing
+    // there. The bridge caps what it hands out (server.MAX_SEQ); this is the
+    // half that refuses to run on a base that got past it anyway.
+    if (!Number.isSafeInteger(session.seq_base) || session.seq_base < 0) {
+      throw new Error("mint returned an unusable sequence base");
     }
     seqCounter = session.seq_base;
 

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -42,7 +42,11 @@ proposal but transcribed after it would stamp as postdating it, and the
 predicate silently inverts. So this page assigns a monotonic ``nextSeq()`` in
 event order and stamps both sides from it:
 
-- an utterance at ``input_audio_buffer.committed`` (the audio boundary);
+- an utterance at ``input_audio_buffer.speech_started`` (the INTENT time, not
+  the audio boundary — the commit fires at the END of an utterance, so ordering
+  on it approves the barge-in case the gate exists to refuse; see
+  :mod:`~agentwire.voice_layer.transcript`). The commit is recorded too, and
+  never compared;
 - a proposal at the ``response.done`` of the turn in which the buddy SPOKE it,
   which is when the owner actually heard what they would be approving. Barge-in
   is native here, so anchoring at tool-call time would let an interrupting
@@ -103,15 +107,48 @@ function createAnnouncer(deps) {
   // said it. This is what the proposal anchor is driven from: see the client's
   // onSpoken handler and BLOCKING 2 in the phase-2 review.
   var onSpoken = deps.onSpoken || function () {};
+  // The other half of onSpoken, and it did not exist: speechSynthesis reports
+  // failure through `onerror` and the client logged it without telling anyone,
+  // so an announcement that was neither heard NOR acked stayed suppressed for
+  // the rest of the session (#978 item 5). Called with the meta of an item
+  // there is positive evidence was NOT spoken. Never called speculatively —
+  // "we cannot know" is the timer's job, not this one's.
+  var onNotSpoken = deps.onNotSpoken || function () {};
+  // Whether the OWNER is speaking right now. The gate check happens when an
+  // announcement is queued; the fallback speaks 6-12s later, and until this
+  // dep existed the timer could not re-check (#978 item 3).
+  var ownerSpeaking = deps.ownerSpeaking || function () { return false; };
   // How long to wait for the model to actually say it before falling back to
   // the browser's own speech synthesis. Generous enough for a normal spoken
   // turn, short enough that the owner is not left in silence wondering.
   var fallbackMs = deps.fallbackMs || 6000;
+  // How many times the fallback may stand down for an owner who is still
+  // talking. BOTH halves priced: without a bound, a long monologue swallows a
+  // refusal entirely, which is the one outcome the default-on timer exists to
+  // rule out — talking over the owner once beats never telling them. With it,
+  // the worst case is fallbackMs * (1 + this) before they are told.
+  var maxOwnerDeferrals =
+    deps.maxOwnerDeferrals === undefined ? 3 : deps.maxOwnerDeferrals;
 
   var queue = [];
-  // { text, fallbackText, meta, timer, sawCreate, deferred }
+  // { text, fallbackText, meta, timer, sawCreate, deferred, ownerDeferrals }
   var current = null;
   var responseActive = false;
+
+  // Function words. They carry nothing about WHETHER the reason was stated,
+  // and they dominate a short conversational line — the greeting is 7 of its
+  // 9 tokens — so an unrelated reply that happened to share them scored a
+  // disarm (#978 item 7). Closed and small on purpose: this is a weighting,
+  // not a language model, and every word added to it is one the model no
+  // longer has to say.
+  var STOPWORDS = {};
+  ("a about all am an and any are as at be been but by can could did do does " +
+   "for from had has have he her him his how i if in is it its just me my no " +
+   "not of on or our out over re s she so some t than that the their them " +
+   "then there these they this to up us ve was we were what when which who " +
+   "why will with would you your m ll d o").split(" ").forEach(function (w) {
+    STOPWORDS[w] = true;
+  });
 
   // The model is told to say it exactly, but "exactly" is prompt compliance and
   // prompt compliance is not a mechanism — so verification is a word-overlap
@@ -123,8 +160,33 @@ function createAnnouncer(deps) {
     var norm = function (s) {
       return String(s).toLowerCase().replace(/[^a-z0-9 ]+/g, " ").split(/\\s+/).filter(Boolean);
     };
-    var want = norm(text);
-    if (!want.length) return true;
+    var uniq = function (list) {
+      var out = [], seenWord = {};
+      list.forEach(function (w) {
+        if (!seenWord[w]) { seenWord[w] = true; out.push(w); }
+      });
+      return out;
+    };
+    var all = norm(text);
+    if (!all.length) return true;
+    // What must be echoed back: UNIQUE CONTENT words. Two fixes, one defect
+    // each (#978 item 7). Stopwords out, because a stopword-heavy script is
+    // matched by almost any sentence — the greeting's disarm was decided by
+    // "what's on your mind" and nothing else, so the greet-as-health-check
+    // reported the model-audio path healthy when the greeting never happened.
+    // Deduplicated, because the overlap counted repeats, so a reply saying one
+    // shared word eight times could carry the score on its own.
+    //
+    // Which way this errs, deliberately: a paraphrase that drops content words
+    // now falls through to the browser voice, so the owner hears it TWICE.
+    // Double-speak is the cheap failure here and believed-spoken silence is
+    // the expensive one, so the threshold stays where it was and only the
+    // thing being counted changed.
+    var want = uniq(all.filter(function (w) { return !STOPWORDS[w]; }));
+    // A line that is nothing BUT stopwords ("What is it about?") would
+    // otherwise have nothing left to compare and could never disarm — an
+    // unconditional double-speak on every such line. Compare its own tokens.
+    if (!want.length) want = uniq(all);
     var got = {};
     norm(transcript).forEach(function (w) { got[w] = true; });
     var hits = want.filter(function (w) { return got[w]; }).length;
@@ -152,6 +214,19 @@ function createAnnouncer(deps) {
   // "on failure, speak".
   function armFallback(item) {
     item.timer = setTimer(function () {
+      // NEVER OVER THE OWNER — re-checked HERE, not only at gate time. The
+      // gate that promised this ran when the announcement was queued; this
+      // fires 6-12s later, and the injected deps did not expose the signal at
+      // all, so the promise held for exactly the moment nobody was speaking
+      // (#978 item 3). Bounded, and the bound is the point: a fallback that
+      // waits for silence forever is a refusal the owner never hears.
+      if (ownerSpeaking() && item.ownerDeferrals < maxOwnerDeferrals) {
+        item.ownerDeferrals += 1;
+        onLog("fallback", "deferred — the owner is speaking (" +
+          item.ownerDeferrals + "/" + maxOwnerDeferrals + ")");
+        armFallback(item);
+        return;
+      }
       // ONE bounded deferral, on one narrow signal: a response was CREATED
       // after our announce went out and has not finished. That response is
       // plausibly the model speaking this very announcement, still mid-audio
@@ -179,9 +254,23 @@ function createAnnouncer(deps) {
       // USER transcript. A payload whose spoken text must not be echoable
       // into an approval (a proposal carrying its nonce) supplies a
       // fallback-safe variant; everything else falls through to `text`.
+      //
+      // And the failure leg, which did not exist: speechSynthesis reports
+      // `onerror` and the page merely logged it, so an announcement that was
+      // demonstrably NOT spoken was also never released — its id sat in the
+      // notifier's inFlight map and suppressed every later tick for the rest
+      // of the session (#978 item 5). A throw from speak() is different: it
+      // means we cannot know, and the existing "assume heard" reading is the
+      // safe one there — claiming not-spoken would replay a notice the owner
+      // may well have heard.
       var say = item.fallbackText || item.text;
-      try { speak(say, function () { onSpoken(item.meta, "fallback"); }); }
-      catch (e) { onSpoken(item.meta, "fallback"); }
+      try {
+        speak(
+          say,
+          function () { onSpoken(item.meta, "fallback"); },
+          function () { onNotSpoken(item.meta); }
+        );
+      } catch (e) { onSpoken(item.meta, "fallback"); }
       pump();
     }, fallbackMs);
   }
@@ -229,8 +318,22 @@ function createAnnouncer(deps) {
         timer: null,
         sawCreate: false,
         deferred: false,
+        ownerDeferrals: 0,
       });
       pump();
+    },
+    // Everything this announcer holds dies HERE, not by the page dropping its
+    // reference (#978 item 4). stop() nulled `announcer` and the armed
+    // setTimeout closure survived it: 6s into "idle" the browser voice spoke,
+    // and onSpoken(meta, "fallback") anchored the proposal on the bridge —
+    // closing the NEXT session's volunteering gate for up to 120s over a
+    // proposal nobody is answering. Nothing here reports anything as spoken:
+    // a torn-down item was not heard, and the anchor is the one thing that
+    // must never be told otherwise.
+    teardown: function () {
+      queue.forEach(disarm);
+      queue = [];
+      if (current) { disarm(current); current = null; }
     },
     // Withdraw announcements whose meta matches, queued or current (#963: the
     // owner speaking first CANCELS the greeting; queueing it behind them would
@@ -291,6 +394,19 @@ function createAnnouncer(deps) {
       // it is no longer a reason to defer either.
       current.sawCreate = false;
       return false;
+    },
+    // Is a PROPOSAL announcement still in the pipe — queued or mid-flight?
+    //
+    // The confirm gate closes at anchored(), i.e. once the proposal has been
+    // SPOKEN. Between the write tool returning and that moment the gate is
+    // still open, so an escalation ticking right then passed canInterrupt,
+    // queued behind the proposal, and pump() promoted it the instant
+    // anchoring closed the gate — an alarm spoken exactly between "say confirm
+    // tango" and the owner's answer (#978 item 2). The announcer is the only
+    // thing that can see that window, so canInterrupt asks it.
+    anchorPending: function () {
+      if (current && current.meta && current.meta.anchor) return true;
+      return queue.some(function (it) { return !!(it.meta && it.meta.anchor); });
     },
     // Test/inspection surface.
     pending: function () { return (current ? 1 : 0) + queue.length; },
@@ -389,6 +505,13 @@ function createInboxNotifier(deps) {
 
   function pollOnce() {
     return fetchInbox().then(function (res) {
+      // STOPPED MID-FLIGHT. This promise is not cancellable, so a poll begun
+      // before stop() resolves after it — and the interrupt tier could still
+      // pass, handing an escalation to a null announcer for a bare
+      // speechSynthesis.speak with no meta: never acked, never seen, and
+      // cursor-past, so the spool will never return it (#978 item 6). Checked
+      // BEFORE the strays are pulled, so nothing leaves the array either.
+      if (stopped) return;
       if (!res || !res.success) {
         onLog("inbox", "poll failed: " + ((res && res.error) || "no response"));
         return;
@@ -476,6 +599,22 @@ function createInboxNotifier(deps) {
     });
   }
 
+  // The announcement demonstrably did NOT reach the owner — the browser voice
+  // reported an error. Release the ids so the next gated tick says it again.
+  //
+  // This is what made the comment on `inFlight` true. It promised "the unheard
+  // notice is retried", but ids entered the map at ANNOUNCE time and never
+  // left it: speechSynthesis fails silently, `utterance.onerror` only logged,
+  // and so a notice that was neither heard nor acked was suppressed for the
+  // rest of the session (#978 item 5). `seen` still outranks this — releasing
+  // an id the owner HAS heard would replay it.
+  function noticeFailed(meta) {
+    if (!meta || !meta.inboxIds) return;
+    meta.inboxIds.forEach(function (id) {
+      if (!seen[id]) delete inFlight[id];
+    });
+  }
+
   function schedule() {
     if (stopped) return;
     timer = setTimer(function () {
@@ -494,6 +633,7 @@ function createInboxNotifier(deps) {
     },
     pollOnce: pollOnce,
     noticeSpoken: noticeSpoken,
+    noticeFailed: noticeFailed,
   };
 }
 """
@@ -748,6 +888,16 @@ let responseActive = false;
 // The confirm gate's ordering predicate lives on this counter, not on a clock.
 // See the module docstring: a wall-clock comparison is between a receipt time
 // and an intent time, and it silently inverts.
+//
+// THE ORIGIN IS NOT OURS (#978). This variable is page-scoped and a reload
+// restarts it, while the ring and the spine live for the whole bridge run — so
+// a reloaded page anchored its proposals BELOW last session's utterances,
+// which are still in the ring, complete and unspent. They then reached the
+// judge as non-matching (burning attempts toward retiring a proposal the owner
+// was never asked about) and, worse, an old "no, hang on" landed
+// strictly-after the new match in the post-approval denial scan and
+// retroactively denied every legitimate approval. So start() seeds this from
+// the mint's `seq_base`: the bridge owns the origin, this page owns the order.
 let seqCounter = 0;
 const speechSeq = {};        // item_id -> the seq at which the owner BEGAN speaking
 const commitSeq = {};        // item_id -> the seq at which its audio committed
@@ -804,10 +954,12 @@ const confirmGate = createConfirmGate({
   ttlMs: 120000,
 });
 
-// Page-lifetime like the gate and the ledger it drives: it holds the most
-// recent proposal's target session (the mismatch window — confirming an older
-// proposal after a newer propose — costs at most one wrongly-suppressed or
-// one extra mention, never a lost message).
+// Page-lifetime like the gate and the ledger it drives, and STATELESS — its
+// own header says so. Remembering the most recent proposal's target session is
+// precisely the client-side guess #966 removed: it retired the wrong session's
+// reminders whenever two proposals interleaved. Both legs now read the
+// payload — confirm_terminal for the gate, acted_session (frozen at propose)
+// for the ledger.
 const outcomeRouter = createOutcomeRouter({
   gate: confirmGate,
   ledger: reRaiseLedger,
@@ -958,6 +1110,34 @@ function onSpoken(meta, how) {
   forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
 }
 
+// The evidence-of-NOT-spoken counterpart to onSpoken (#978 item 5). Reached
+// only from the browser voice's own `onerror` — a positive report that the
+// utterance failed, never a guess. Everything keyed on "was this heard" has to
+// be told, or the announcement is neither delivered nor retried: the state it
+// leaves behind is indistinguishable from success.
+function onNotSpoken(meta) {
+  if (!meta) return;
+  if (meta.errorNotice) {
+    // Let a later error announce again; this one never reached the owner.
+    errorNoticePending = false;
+    return;
+  }
+  if (meta.inboxIds) {
+    // Release the ids so the next gated tick volunteers them again. NOT acked
+    // — the cursor never moved, because it only moves from onSpoken.
+    if (inboxNotifier) inboxNotifier.noticeFailed(meta);
+    return;
+  }
+  if (meta.anchor) {
+    // Nothing to retry: a proposal is announced once, and the spine's TTL is
+    // what ends it. What is left is to say so on screen rather than let the
+    // owner hear nothing and then be told `not_announced` for 120s.
+    log("error",
+      "proposal " + meta.anchor + " was never spoken — it cannot be approved",
+      "err");
+  }
+}
+
 function send(event) {
   if (!dc || dc.readyState !== "open") return false;
   dc.send(JSON.stringify(event));
@@ -1032,9 +1212,15 @@ async function handleFunctionCall(item) {
   // A terminal outcome from the write tools (confirm_terminal — set by the
   // spine for every gated write, so a second declared write reopens the gate
   // too) ends the confirm handshake and reopens the volunteering gate. A wait
-  // outcome (pending_transcript / not_announced) keeps the proposal live, so
-  // it keeps the gate closed; the TTL covers an owner who never answers at
-  // all. A QUEUED send is also the observable "acted on it" (#967) that
+  // outcome — pending_transcript, not_announced, or in_flight (#987, a
+  // duplicate confirm on a token the runner is already processing) — keeps the
+  // proposal live, so it keeps the gate closed; the TTL covers an owner who
+  // never answers at all. NOTHING HERE ENUMERATES THEM: the router keys on
+  // confirm_terminal, which the spine sets False for exactly this set, so
+  // #987 added a third wait outcome without touching a line of dispatch. That
+  // is the property to preserve — a client-side list of wait outcomes is the
+  // same false-reject trap as a client-side list of tool names.
+  // A QUEUED send is also the observable "acted on it" (#967) that
   // retires the target session's reminders — a cancel is not acting, so the
   // reminder stands. The router holds both rules.
   outcomeRouter.route(item.name, result);
@@ -1065,6 +1251,15 @@ async function start() {
   try {
     const session = await post("/mint", {});
     if (!session.success) throw new Error(session.error || "mint failed");
+    // The clock's ORIGIN, from the bridge (#978). Seeded here — before the
+    // data channel exists, so nothing has emitted an event and nothing has
+    // called nextSeq() yet. No `|| 0` default: a bridge that did not answer
+    // with a base is broken, and silently restarting at zero is the exact
+    // defect this closes.
+    if (typeof session.seq_base !== "number") {
+      throw new Error("mint returned no sequence base");
+    }
+    seqCounter = session.seq_base;
 
     setStatus("requesting microphone…");
     micStream = await navigator.mediaDevices.getUserMedia({
@@ -1089,7 +1284,7 @@ async function start() {
       // "we tried and cannot know". `onend`/`onerror` are the one piece of
       // evidence actually available, and for the mechanism whose entire job is
       // that silence is unacceptable, taking it is cheap.
-      speak: (text, onSpokenAloud) => {
+      speak: (text, onSpokenAloud, onSpeakFailed) => {
         const utterance = new SpeechSynthesisUtterance(text);
         utterance.onend = () => {
           log("speak", "browser voice finished", "tool");
@@ -1097,8 +1292,12 @@ async function start() {
         };
         utterance.onerror = (event) => {
           // Nothing left to escalate to, but the owner must not be left
-          // believing they were told: say so on screen and in the log.
+          // believing they were told: say so on screen and in the log — AND
+          // tell the announcer, which is what makes the retry real. Logging
+          // alone left the announcement neither heard nor released (#978
+          // item 5).
           log("error", "browser voice FAILED: " + (event && event.error), "err");
+          if (onSpeakFailed) onSpeakFailed();
         };
         // No cancel() first: speechSynthesis queues natively, and cancelling
         // here killed the PREVIOUS announcement mid-utterance — under a burst
@@ -1107,6 +1306,11 @@ async function start() {
         window.speechSynthesis.speak(utterance);
       },
       onSpoken,
+      onNotSpoken,
+      // The timer's own "never over the owner" re-check (#978 item 3). The
+      // gate ran when the announcement was queued; this is read 6-12s later,
+      // when it actually speaks.
+      ownerSpeaking: () => ownerSpeaking,
       setTimer: (fn, ms) => window.setTimeout(fn, ms),
       clearTimer: (handle) => window.clearTimeout(handle),
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
@@ -1119,11 +1323,21 @@ async function start() {
       ackInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: true } }),
       announce: announce,
       canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0 && !confirmGate.outstanding(),
-      // The interrupt tier (#967): an escalation may pre-empt the buddy's own
-      // speech — announce() cancels an in-flight response, which is the
-      // existing mechanism, not a new voice — but the owner-speaking and
-      // confirm-handshake legs of #962 stay unconditional.
-      canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding(),
+      // The interrupt tier (#967): an escalation need not wait for the buddy's
+      // own chatter to finish. What that buys is narrower than it sounds and
+      // the overstatement was in this comment: pre-emption is real only
+      // against a VAD response, because announce() cancels an in-flight
+      // response. Against an ANNOUNCER item the escalation still queues behind
+      // it, plus up to one 6s in-flight deferral and up to three owner-speaking
+      // ones. The owner-speaking and confirm-handshake legs of #962 stay
+      // unconditional, and the handshake leg gained the announcer half it was
+      // missing (#978 item 2): the gate closes at anchored(), so a proposal
+      // still queued or mid-flight is a handshake in progress that
+      // confirmGate.outstanding() cannot yet see. A live announcer is required
+      // too — after stop() this gate could still pass, and announce() with a
+      // null announcer speaks with no meta, so an escalation went out never
+      // acked and never seen (#978 item 6).
+      canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding() && !!announcer && !announcer.anchorPending(),
       reRaise: reRaiseLedger,
       setTimer: (fn, ms) => window.setTimeout(fn, ms),
       clearTimer: (handle) => window.clearTimeout(handle),
@@ -1296,6 +1510,13 @@ function stop() {
   if (micStream) { micStream.getTracks().forEach((t) => t.stop()); micStream = null; }
   audioEl = null;
   responseActive = false;
+  // TORN DOWN, not merely dropped (#978 item 4). Nulling the reference left
+  // the current item's armed setTimeout closure alive: 6s into "idle" the
+  // browser voice spoke and anchored a proposal on the bridge, closing the
+  // next session's volunteering gate for up to 120s. d45601b covered
+  // page-lifetime strays; `disarm` was reachable only from onResponseDone and
+  // cancel, neither of which stop() calls.
+  if (announcer) announcer.teardown();
   announcer = null;
   // Session-scoped readiness resets; `greeted` deliberately does NOT — a
   // reconnect must stay quiet (#963).

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -57,6 +57,14 @@ _MAX_BODY = 64 * 1024
 #: set is exactly this and no larger.
 LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 
+#: How far ``/mint`` advances the logical clock before handing the page its
+#: origin (#978). One per page load, so this is what makes the base an EPOCH
+#: rather than a bump: two tabs minting against one bridge get non-overlapping
+#: numeric ranges, and a still-live first tab would have to emit a million
+#: data-channel events before it could count into the second's. A gap costs
+#: nothing — the sequence is a Python int compared for order, never a size.
+MINT_SEQ_GAP = 1_000_000
+
 
 def allowed_hosts(port: int) -> frozenset[str]:
     """Every ``Host`` value this bridge will answer on ``port``.
@@ -215,13 +223,41 @@ class BuddyBridge:
         return {"success": True, "anchored": anchored, "seq": seq}
 
     def mint(self) -> dict:
+        """Mint an ephemeral client secret — and the page's CLOCK ORIGIN (#978).
+
+        The logical clock the confirm gate orders on is assigned by the client,
+        because the client is the only place that sees data-channel event
+        order. Its ORIGIN cannot be: ``seqCounter`` is a page variable and
+        restarts at 0 on every reload, while the ring and the spine live for
+        the whole bridge run. A reloaded page therefore anchored its next
+        proposal BELOW last session's utterances, which are still in the ring,
+        complete and unspent — so they reached the judge as non-matching
+        (burning attempts on a question never asked) and, worse, an old "no,
+        hang on" sat strictly-after the new match in the post-approval denial
+        scan and retroactively denied every legitimate approval until 32 fresh
+        utterances evicted it.
+
+        ``/mint`` is the one event that happens exactly once per page load, so
+        the origin is handed out here, a whole :data:`MINT_SEQ_GAP` above every
+        sequence the bridge has ever seen, and RECORDED on the ring — a base
+        the ring has not seen is a base the next mint would reuse.
+
+        Nothing is rejected and nothing is deleted, deliberately. A rejecting
+        epoch guard pays its false-reject half by dropping an utterance from
+        the owner's LIVE tab, and a dropped utterance in a screenless channel
+        is a silent loop; ordering the epochs instead has no reject path at
+        all. What it does not close: a forward that FAILS leaves ``high_seq``
+        behind the client's counter, so the next base is that much less clear
+        of the last epoch — bounded by the gap, not by anything smaller.
+        """
         session = realtime.mint_session(
             instructions=buddy_instructions.build_instructions(),
             tools=tools.realtime_tool_defs(),
             model=self.model,
             voice=self.voice,
         )
-        return {"success": True, **session}
+        seq_base = self.ring.note_seq(self.ring.high_seq + MINT_SEQ_GAP)
+        return {"success": True, "seq_base": seq_base, **session}
 
     def tool_call(self, payload: dict) -> dict:
         name = payload.get("name")

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -60,10 +60,32 @@ LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 #: How far ``/mint`` advances the logical clock before handing the page its
 #: origin (#978). One per page load, so this is what makes the base an EPOCH
 #: rather than a bump: two tabs minting against one bridge get non-overlapping
-#: numeric ranges, and a still-live first tab would have to emit a million
-#: data-channel events before it could count into the second's. A gap costs
-#: nothing — the sequence is a Python int compared for order, never a size.
+#: numeric ranges — reserved atomically, see
+#: :meth:`~agentwire.voice_layer.transcript.TranscriptRing.reserve_epoch` — and
+#: a still-live first tab would have to emit a million data-channel events
+#: before it could count into the second's.
 MINT_SEQ_GAP = 1_000_000
+
+#: The largest sequence this bridge will accept or hand out.
+#:
+#: A gap does NOT cost nothing, and saying so was wrong in a way that only
+#: shows up after ``seq_base`` existed. Before it, ``high_seq`` was state the
+#: bridge kept for its own ordering — a Python int, compared, never sized. It
+#: now flows BACK into the page's counter across a JSON boundary, and on that
+#: side it is an IEEE-754 double: past ``2**53`` an increment silently stops
+#: advancing, so every event shares one sequence, ``after(anchor)`` is never
+#: strictly-after, and the buddy answers ``pending_transcript`` forever. Larger
+#: still parses as ``Infinity``, whose anchors serialize as ``null`` —
+#: ``not_announced`` forever. Both are silent, and both survive a reload,
+#: because ``high_seq`` is bridge-lifetime: one malformed local POST wedges the
+#: buddy for the rest of the run.
+#:
+#: ``2**45`` leaves 35 million mints of headroom and stays 256x clear of the
+#: page's safe-integer limit, so the false-reject half costs nothing real: no
+#: session reaches within many orders of magnitude of it. Loopback- and
+#: token-gated, so this is robustness rather than a remote attack — but #986
+#: hardened this same bridge against this same class.
+MAX_SEQ = 2**45
 
 
 def allowed_hosts(port: int) -> frozenset[str]:
@@ -167,11 +189,23 @@ class BuddyBridge:
             return {"success": False, "error": "missing item_id"}
         item_id = item_id.strip()
 
-        def _seq(key: str) -> int:
+        def _seq(key: str) -> "int | None":
+            """The sequence under *key*, 0 if absent, ``None`` if out of range.
+
+            Out-of-range is REFUSED rather than clamped: clamping would still
+            raise ``high_seq`` toward the ceiling, and a silently-altered
+            sequence is a silently-altered ordering. See :data:`MAX_SEQ`.
+            """
             value = payload.get(key)
-            return value if isinstance(value, int) and value > 0 else 0
+            if not isinstance(value, int) or isinstance(value, bool):
+                return 0
+            if value <= 0:
+                return 0
+            return value if value <= MAX_SEQ else None
 
         speech_seq, commit_seq = _seq("speech_started_seq"), _seq("commit_seq")
+        if speech_seq is None or commit_seq is None:
+            return {"success": False, "error": f"sequence exceeds {MAX_SEQ}"}
         text = payload.get("transcript")
 
         if text is None:
@@ -216,8 +250,10 @@ class BuddyBridge:
         seq = payload.get("seq")
         if not isinstance(proposal_id, str) or not proposal_id.strip():
             return {"success": False, "error": "missing proposal_id"}
-        if not isinstance(seq, int) or seq <= 0:
+        if not isinstance(seq, int) or isinstance(seq, bool) or seq <= 0:
             return {"success": False, "error": "anchor needs a positive seq"}
+        if seq > MAX_SEQ:
+            return {"success": False, "error": f"sequence exceeds {MAX_SEQ}"}
         self.ring.note_seq(seq)
         anchored = self.spine.announce(proposal_id.strip(), seq)
         return {"success": True, "anchored": anchored, "seq": seq}
@@ -240,7 +276,13 @@ class BuddyBridge:
         ``/mint`` is the one event that happens exactly once per page load, so
         the origin is handed out here, a whole :data:`MINT_SEQ_GAP` above every
         sequence the bridge has ever seen, and RECORDED on the ring — a base
-        the ring has not seen is a base the next mint would reuse.
+        the ring has not seen is a base the next mint would reuse. Reserved
+        under ONE lock (``reserve_epoch``): read-then-write is two acquisitions
+        and two concurrent mints on this threading server can be handed the
+        same base, which is the very case the epoch exists to rule out.
+
+        Reserved BEFORE the client secret, so an exhausted sequence space
+        refuses without spending the owner's API key.
 
         Nothing is rejected and nothing is deleted, deliberately. A rejecting
         epoch guard pays its false-reject half by dropping an utterance from
@@ -250,13 +292,15 @@ class BuddyBridge:
         behind the client's counter, so the next base is that much less clear
         of the last epoch — bounded by the gap, not by anything smaller.
         """
+        seq_base = self.ring.reserve_epoch(MINT_SEQ_GAP, MAX_SEQ)
+        if not seq_base:
+            return {"success": False, "error": "sequence space exhausted"}
         session = realtime.mint_session(
             instructions=buddy_instructions.build_instructions(),
             tools=tools.realtime_tool_defs(),
             model=self.model,
             voice=self.voice,
         )
-        seq_base = self.ring.note_seq(self.ring.high_seq + MINT_SEQ_GAP)
         return {"success": True, "seq_base": seq_base, **session}
 
     def tool_call(self, payload: dict) -> dict:

--- a/agentwire/voice_layer/transcript.py
+++ b/agentwire/voice_layer/transcript.py
@@ -53,10 +53,14 @@ separate ``POST /utterance`` calls, and the confirm arrives as a third
 (``POST /tool``). The client awaits the transcript forward before dispatching
 any function call (Rv2c), but the bridge must not *depend* on that: a commit
 that has not arrived yet leaves the entry absent rather than mis-stamped, and a
-transcript arriving with no prior commit is recorded ``estimated`` and is never
-usable as an approval. Failing closed there is deliberate — if the commit
-events stopped arriving, confirms stop working loudly rather than silently
-losing their ordering guarantee.
+transcript arriving with no prior ``speech_started`` is recorded ``estimated``
+and is never usable as an approval. (The COMMIT is not what decides that, and
+saying so here described a gate this module deliberately does not have —
+:meth:`TranscriptRing.transcribe` flags ``estimated`` on a missing
+``speech_started_seq``, because that is the one the ordering predicate reads.)
+Failing closed there is deliberate — if the ``speech_started`` events stopped
+arriving, confirms stop working loudly rather than silently losing their
+ordering guarantee.
 
 Thread safety
 -------------

--- a/agentwire/voice_layer/transcript.py
+++ b/agentwire/voice_layer/transcript.py
@@ -221,10 +221,19 @@ class TranscriptRing:
         *ceiling*. The number leaves Python for the page's own counter, where
         past 2**53 an increment silently stops advancing, so exhaustion has to
         be an error the page refuses on rather than a number it counts from.
+
+        A BLOCK, and the ceiling test says so: the page counts UP from its
+        base, so what has to fit under *ceiling* is ``base + gap``, not
+        ``base``. Testing the base alone let the final reservation land exactly
+        on the ceiling — a page that mints successfully and then has zero
+        usable sequences, every forward silently refused. Unreachable in
+        practice (~35 million mints on one bridge process) and that is not the
+        point: the sentence above claims a block, so the code has to reserve
+        one.
         """
         with self._condition:
             base = self._high_seq + gap
-            if base > ceiling:
+            if base + gap > ceiling:
                 return 0
             self._high_seq = base
             return base

--- a/agentwire/voice_layer/transcript.py
+++ b/agentwire/voice_layer/transcript.py
@@ -202,6 +202,33 @@ class TranscriptRing:
             self._high_seq = max(self._high_seq, seq)
             return self._high_seq
 
+    def reserve_epoch(self, gap: int, ceiling: int) -> int:
+        """Claim an exclusive block of *gap* sequences. ONE lock, atomically.
+
+        This is what ``/mint`` hands a new page as its clock origin, and the
+        atomicity is the whole point rather than a nicety. ``high_seq`` read
+        and then ``note_seq`` written is TWO acquisitions with a window
+        between them, and two concurrent mints on the bridge's
+        ``ThreadingHTTPServer`` can both read the same high and both be given
+        the same base — which is precisely the "second tab, two interleaved
+        counters" case the epoch exists to rule out, reintroduced inside the
+        fix for it. It does not reproduce under ordinary threading (the window
+        is a couple of bytecodes) and that is not the standard here: single-use
+        in :class:`~agentwire.voice_layer.confirm.ConfirmSpine` is a property
+        of its claim rather than of its timing for the same reason.
+
+        Returns 0 — never a usable base — when the reservation would cross
+        *ceiling*. The number leaves Python for the page's own counter, where
+        past 2**53 an increment silently stops advancing, so exhaustion has to
+        be an error the page refuses on rather than a number it counts from.
+        """
+        with self._condition:
+            base = self._high_seq + gap
+            if base > ceiling:
+                return 0
+            self._high_seq = base
+            return base
+
     @property
     def high_seq(self) -> int:
         with self._condition:

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -100,6 +100,7 @@ function report() {
   return JSON.stringify({
     events, spoken, logs, anchored, notSpoken,
     armedTimers: timers.length,
+    armedMs: timers.map((t) => t.ms),
     pending: announcer.pending(),
     armed: announcer.armed(),
     anchorPending: announcer.anchorPending(),
@@ -2341,7 +2342,16 @@ class TestAFailedStrayIsPutBack:
 
     def test_a_heard_stray_is_never_put_back(self):
         """``seen`` outranks the release, here as everywhere: re-queueing a
-        stray the owner HAS heard replays it with no cursor to suppress it."""
+        stray the owner HAS heard replays it with no cursor to suppress it.
+
+        The array is read BEFORE the next poll, and that is the whole test.
+        The first version ended with a trailing ``pollOnce()`` and passed
+        whether the guard was there or not: the poll pulls the wrongly-restored
+        stray, drops it for being ``seen``, and leaves the array at 0 either
+        way — laundering the very state under test. It was counted as a pin
+        and pinned nothing (mutation: removing ``if (seen[id]) return;``
+        survived all 625 voice tests).
+        """
         report = run_notifier("""
             strays.push({ id: "s1", from: "watchdog", kind: "escalation",
                           text: "wedged" });
@@ -2349,10 +2359,24 @@ class TestAFailedStrayIsPutBack:
             const meta = announcedCalls[0].meta;
             await notifier.noticeSpoken(meta);
             notifier.noticeFailed(meta);
-            await notifier.pollOnce();
+            logs.push("strays after failing a HEARD stray: " + strays.length);
         """)
+        assert "strays after failing a HEARD stray: 0" in report["logs"]
         assert len(report["announced"]) == 1
-        assert report["strays"] == 0
+
+    def test_the_same_shape_unheard_DOES_come_back(self):
+        """The discriminator for the assertion above. Identical script minus
+        the ``noticeSpoken``, read at the same instant: the array must be 1,
+        or the test above would pass simply because nothing is ever restored.
+        """
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
+                          text: "wedged" });
+            await notifier.pollOnce();
+            notifier.noticeFailed(announcedCalls[0].meta);
+            logs.push("strays after failing an UNHEARD stray: " + strays.length);
+        """)
+        assert "strays after failing an UNHEARD stray: 1" in report["logs"]
 
     def test_a_spool_message_is_not_pushed_into_the_strays_array(self):
         """The other direction. A message still in the spool needs only the
@@ -2551,3 +2575,59 @@ class TestTheDedupHalfOfTheWeightingIsPinned:
         """)
         assert report["spoken"] == []
         assert [a["how"] for a in report["anchored"]] == ["model"]
+
+
+class TestTheSpeakingWatchdogScalesWithTheUtterance:
+    """Review N3. ``speakingMaxMs`` was flat and its comment claimed it was
+    "long enough to cover any real utterance". That is false for exactly the
+    case the notifier is built to produce: ``composeNotice`` coalesces up to
+    240 characters PER MESSAGE, so three replies is around a minute of speech
+    and five is several — against a 30s watchdog, demonstrated firing
+    mid-utterance.
+
+    Mitigated rather than catastrophic (``speechSynthesis`` queues natively,
+    and the anchor still fires at the real ``onend``), but the fire reopens
+    both gates and lets the MODEL start a response over the browser voice —
+    the two-voices defect, reached through the mechanism added to bound a
+    mute. So the bound scales instead of the sentence being narrowed.
+    """
+
+    def _watchdog_ms(self, text_js: str) -> int:
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({text_js});
+            fireTimers();
+        """)
+        assert len(report["armedMs"]) == 1
+        return report["armedMs"][0]
+
+    def test_a_long_notice_gets_a_longer_budget(self):
+        short = self._watchdog_ms(json.dumps("Done."))
+        long_notice = self._watchdog_ms(json.dumps("x" * 1200))
+        assert long_notice > short
+
+    def test_the_budget_outlasts_a_five_message_batch(self):
+        """The concrete shape: five coalesced replies at the 240-char clip.
+        At a realistic 15 characters a second that is ~80s of speech, so a
+        watchdog that fires before then is firing mid-utterance."""
+        ms = self._watchdog_ms(json.dumps("y" * (5 * 240)))
+        assert ms > 80_000
+
+    def test_a_flat_thirty_seconds_would_not_have(self):
+        """The control that makes the number above mean something."""
+        ms = self._watchdog_ms(json.dumps("y" * (5 * 240)))
+        assert ms > 30_000
+
+    def test_the_rate_errs_slow(self):
+        """The asymmetry, pinned. Over-estimating only delays a backstop that
+        matters when the browser has already dropped the utterance;
+        under-estimating overlaps two voices on every ordinary long notice."""
+        chars = 1000
+        ms = self._watchdog_ms(json.dumps("z" * chars))
+        # Slower than 10 characters a second, i.e. slower than any real voice.
+        assert (ms / chars) > 100
+
+    def test_a_short_notice_still_gets_a_usable_floor(self):
+        """The other half: an empty or one-word utterance must not end up with
+        a near-zero watchdog that fires before it starts."""
+        assert self._watchdog_ms(json.dumps("Hi.")) >= 30_000

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -58,11 +58,19 @@ let channelOpen = true;
 // speechSynthesis reporting the utterance failed.
 let ownerIsSpeaking = false;
 let speakFails = false;
+// THE REAL speak() IS ASYNC — onSpokenAloud runs from utterance.onend, an
+// event that fires when the browser voice has finished TALKING. A harness
+// whose speak() calls back synchronously has no window at all between "the
+// fallback started speaking" and "it finished", which is the window review
+// finding F4 lives in: this fixture's shape was the reason nothing saw it.
+let speakDefers = false;
+const pendingSpeech = [];
 
 const announcer = createAnnouncer({
   send: (e) => { if (!channelOpen) return false; events.push(e); return true; },
   speak: (t, onDone, onFail) => {
     spoken.push(t);
+    if (speakDefers) { pendingSpeech.push({ onDone, onFail }); return; }
     if (speakFails) { if (onFail) onFail(); return; }
     if (onDone) onDone();
   },
@@ -79,6 +87,14 @@ function fireTimers() {
   const due = timers.slice();
   timers = [];
   due.forEach((t) => t.fn());
+}
+// The browser voice reaches the end of its utterance.
+function finishSpeech() {
+  const due = pendingSpeech.splice(0);
+  due.forEach((s) => {
+    if (speakFails) { if (s.onFail) s.onFail(); return; }
+    if (s.onDone) s.onDone();
+  });
 }
 function report() {
   return JSON.stringify({
@@ -2243,3 +2259,295 @@ class TestTheCommentsDescribeTheCodeTheySitOn:
 
         assert "a\ntranscript arriving with no prior commit" not in transcript_mod.__doc__
         assert "no prior ``speech_started``" in transcript_mod.__doc__
+
+
+# =============================================================================
+# #993 review — F2 to F6
+# =============================================================================
+
+
+class TestTheBrowserVoiceErrorIsActuallyWired:
+    """Review F2. A MUTATION SURVIVED: deleting the call from
+    ``utterance.onerror`` left the whole suite green. That one line is the
+    only wire between the browser's error event and the entirety of item 5 —
+    the node tests exercise the announcer's failure leg with a fake ``speak``,
+    and the page pin asserted the parameter NAME in the signature and that
+    ``onNotSpoken`` reaches ``noticeFailed``, but nothing asserted the handler
+    in between invokes anything.
+
+    This is not the browser half that cannot be verified here. It is a
+    page-source pin, the same technique the clock origin uses.
+    """
+
+    def test_the_error_handler_invokes_the_failure_callback(self):
+        page = client.page("buddy", "tok")
+        handler = page.split("utterance.onerror = (event) => {", 1)[1]
+        handler = handler.split("};", 1)[0]
+        assert "onSpeakFailed()" in handler
+
+    def test_the_success_handler_still_invokes_the_spoken_one(self):
+        """The control: an assertion that only ever looked at onerror would
+        pass just as well with onend gutted."""
+        page = client.page("buddy", "tok")
+        handler = page.split("utterance.onend = () => {", 1)[1].split("};", 1)[0]
+        assert "onSpokenAloud()" in handler
+
+
+class TestAFailedStrayIsPutBack:
+    """Review F3. ``pollOnce`` SPLICES a stray out of the array when it pulls
+    one, and a stray is cursor-past: the spool will never return it. Releasing
+    only the id from ``inFlight`` therefore leaves the message gone from both
+    places, so "the next gated tick says it again" was FALSE for exactly the
+    class that becomes strays — escalations, the one kind that emails the
+    owner on dead-letter.
+
+    ``test_it_never_takes_a_stray_out_of_the_array`` forbids this loss, and
+    its own docstring named the trap: putting them back works "only if every
+    later return path remembered to". This is the return path that did not.
+    """
+
+    def test_a_failed_stray_is_volunteered_again(self):
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
+                          text: "a done report dead-lettered" });
+            await notifier.pollOnce();
+            notifier.noticeFailed(announcedCalls[0].meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        assert "dead-lettered" in report["announced"][1]["text"]
+
+    def test_it_is_back_in_the_array_not_merely_re_announced(self):
+        """The array is the page-lifetime store that survives a reconnect. An
+        id released into nothing is announced once more and then gone."""
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
+                          text: "a done report dead-lettered" });
+            await notifier.pollOnce();
+            notifier.noticeFailed(announcedCalls[0].meta);
+        """)
+        assert report["strays"] == 1
+
+    def test_it_is_not_put_back_twice(self):
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
+                          text: "wedged" });
+            await notifier.pollOnce();
+            const meta = announcedCalls[0].meta;
+            notifier.noticeFailed(meta);
+            notifier.noticeFailed(meta);
+        """)
+        assert report["strays"] == 1
+
+    def test_a_heard_stray_is_never_put_back(self):
+        """``seen`` outranks the release, here as everywhere: re-queueing a
+        stray the owner HAS heard replays it with no cursor to suppress it."""
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
+                          text: "wedged" });
+            await notifier.pollOnce();
+            const meta = announcedCalls[0].meta;
+            await notifier.noticeSpoken(meta);
+            notifier.noticeFailed(meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        assert report["strays"] == 0
+
+    def test_a_spool_message_is_not_pushed_into_the_strays_array(self):
+        """The other direction. A message still in the spool needs only the
+        inFlight release — the cursor never moved. Pushing it into strays too
+        would announce it twice once the cursor finally advances."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
+            await notifier.pollOnce();
+            notifier.noticeFailed(announcedCalls[0].meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        assert report["strays"] == 0
+
+
+class TestTheHandshakeGateCoversTheFallbackSpeech:
+    """Review F4. ``armFallback`` nulls ``current`` BEFORE calling ``speak``,
+    and the real ``speak`` is asynchronous — ``onSpokenAloud`` runs from
+    ``utterance.onend``. In between, ``anchorPending()`` and
+    ``confirmGate.outstanding()`` are both false, so ``canInterrupt`` passes
+    and an alarm goes out while the browser voice is still saying "...say
+    confirm tango". The window is roughly an utterance long against a 5s poll.
+
+    The unit harness could not see it: its ``speak`` called back
+    synchronously, so the window had zero width. That is the fixture-shaped
+    blind spot, and it is closed here (``speakDefers``/``finishSpeech``)
+    before the behaviour is asserted — a pin written against the old fixture
+    would be theatre.
+    """
+
+    def test_the_proposal_is_still_pending_while_the_voice_is_speaking(self):
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();                    // the fallback starts speaking
+            logs.push("mid-speech: " + announcer.anchorPending());
+            finishSpeech();
+            logs.push("after-speech: " + announcer.anchorPending());
+        """)
+        assert "mid-speech: true" in report["logs"]
+        assert "after-speech: false" in report["logs"]
+
+    def test_the_control_that_the_old_fixture_could_not_have_caught(self):
+        """With a synchronous speak there is no window at all, so this shape
+        reads identical whether the fix is present or not. Stated so the pin
+        above cannot be quietly reverted to the cheaper fixture."""
+        report = run_announcer("""
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();
+            logs.push("mid-speech: " + announcer.anchorPending());
+        """)
+        assert "mid-speech: false" in report["logs"]
+
+    def test_the_buddy_counts_as_speaking_while_the_voice_runs(self):
+        """The same window on the FULL gate: canSpeak keys on pending(), and
+        a notice volunteered mid-fallback talks over the buddy's own voice."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+            fireTimers();
+            logs.push("mid-speech pending: " + announcer.pending());
+            finishSpeech();
+            logs.push("after-speech pending: " + announcer.pending());
+        """)
+        assert "mid-speech pending: 1" in report["logs"]
+        assert "after-speech pending: 0" in report["logs"]
+
+    def test_a_failed_utterance_also_ends_the_window(self):
+        """The false-reject half. If only the success path cleared it, a
+        browser voice that errored would leave the gate shut for the rest of
+        the session — an unbounded mute in front of the TTL."""
+        report = run_announcer("""
+            speakDefers = true;
+            speakFails = true;
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();
+            finishSpeech();
+            logs.push("after-failure: " + announcer.anchorPending());
+        """)
+        assert "after-failure: false" in report["logs"]
+        assert report["anchored"] == []
+
+    def test_an_utterance_that_never_ends_is_watchdogged(self):
+        """The false-reject half of F4's own fix, and it is the expensive one.
+
+        ``speechSynthesis`` can drop an utterance without firing ``onend`` OR
+        ``onerror``. Since this window gates volunteering, believing it
+        forever is an UNBOUNDED mute — strictly worse than the one
+        interjection the window exists to prevent. So the belief expires.
+        """
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();                    // the fallback speaks; nothing ends
+            logs.push("mid-speech: " + announcer.anchorPending());
+            fireTimers();                    // ...and the watchdog comes due
+            logs.push("after-watchdog: " + announcer.anchorPending());
+            logs.push("after-watchdog pending: " + announcer.pending());
+        """)
+        assert "mid-speech: true" in report["logs"]
+        assert "after-watchdog: false" in report["logs"]
+        assert "after-watchdog pending: 0" in report["logs"]
+        assert any("no end event within" in line for line in report["logs"])
+
+    def test_a_real_end_event_cancels_the_watchdog(self):
+        """The control: a watchdog left armed after a normal utterance would
+        fire into a cleared state and log a failure that did not happen."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();
+            finishSpeech();
+        """)
+        assert report["armedTimers"] == 0
+        assert not any("no end event" in line for line in report["logs"])
+
+    def test_a_torn_down_announcer_reports_nothing_pending(self):
+        """stop() during fallback speech must not leave the window latched."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            fireTimers();
+            announcer.teardown();
+            logs.push("after-teardown: " + announcer.anchorPending());
+        """)
+        assert "after-teardown: false" in report["logs"]
+
+
+class TestTheDeferralBoundIsWhatItSays:
+    """Review F5. The two deferrals STACK — the owner-speaking one is checked
+    first and re-arms, and the in-flight one is still available on the
+    re-armed timer. So the worst case is 5 fires, not 4, and the stated
+    ``fallbackMs * (1 + maxOwnerDeferrals)`` was short by one whole interval.
+
+    Pinned rather than restructured: stacking is CORRECT — the two deferrals
+    answer different questions ("is the owner talking" and "is this our own
+    audio still playing"), and making them share a budget would let a
+    monologue consume the grace that stops the buddy speaking over itself.
+    The defect was the arithmetic in the comment, so the number is now the
+    thing under test.
+    """
+
+    def test_the_worst_case_is_five_intervals(self):
+        report = run_announcer("""
+            announcer.announce("I didn't hear the confirmation phrase.");
+            announcer.onResponseCreated();     // our own audio may be in flight
+            ownerIsSpeaking = true;
+            for (let i = 0; i < 4; i++) {
+                fireTimers();
+                logs.push("fire " + (i + 1) + " spoken=" + spoken.length);
+            }
+            fireTimers();
+            logs.push("fire 5 spoken=" + spoken.length);
+        """)
+        for n in range(1, 5):
+            assert f"fire {n} spoken=0" in report["logs"]
+        assert "fire 5 spoken=1" in report["logs"]
+
+    def test_the_stated_bound_matches(self):
+        page = client.page("buddy", "tok")
+        assert "fallbackMs * (1 + maxOwnerDeferrals)" not in page
+        assert "fallbackMs * (2 + maxOwnerDeferrals)" in page
+
+
+class TestTheDedupHalfOfTheWeightingIsPinned:
+    """Review F6. Dropping ``uniq`` from ``want`` survived the whole suite:
+    the only repetition test used a STOPWORD, which the weighting filters out
+    before the dedup can matter, so that half was never exercised.
+
+    It is not a redundant belt: a proposal announcement legitimately repeats
+    its nonce for clarity, and without the dedup a one-line model echo of just
+    the nonce scores 0.6 and ANCHORS the proposal — the announcer reporting
+    that a proposal the model never stated was spoken.
+    """
+
+    def test_a_nonce_echo_does_not_anchor_a_repeated_proposal(self):
+        report = run_announcer("""
+            announcer.announce(
+              "Say confirm tango. Again, that's confirm tango. " +
+              "To send it, say confirm tango.",
+              { anchor: "p1" });
+            announcer.onResponseDone("confirm tango");
+        """)
+        assert report["anchored"] == []
+        assert report["armed"] is True
+
+    def test_the_same_line_said_in_full_still_disarms(self):
+        """The false-reject half: repetition in the script must not make the
+        script harder for the model to satisfy honestly."""
+        report = run_announcer("""
+            const line = "Say confirm tango. Again, that's confirm tango. " +
+                         "To send it, say confirm tango.";
+            announcer.announce(line, { anchor: "p1" });
+            announcer.onResponseDone(line);
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert [a["how"] for a in report["anchored"]] == ["model"]

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -49,14 +49,26 @@ const events = [];
 const spoken = [];
 const logs = [];
 const anchored = [];
+const notSpoken = [];
 let timers = [];
 let nextHandle = 1;
 let channelOpen = true;
+// The two states the browser voice can be in that the announcer must react to
+// (#978 items 3 and 5): the owner talking when the timer comes due, and
+// speechSynthesis reporting the utterance failed.
+let ownerIsSpeaking = false;
+let speakFails = false;
 
 const announcer = createAnnouncer({
   send: (e) => { if (!channelOpen) return false; events.push(e); return true; },
-  speak: (t, onDone) => { spoken.push(t); if (onDone) onDone(); },
+  speak: (t, onDone, onFail) => {
+    spoken.push(t);
+    if (speakFails) { if (onFail) onFail(); return; }
+    if (onDone) onDone();
+  },
   onSpoken: (meta, how) => anchored.push({ meta: meta, how: how }),
+  onNotSpoken: (meta) => notSpoken.push(meta),
+  ownerSpeaking: () => ownerIsSpeaking,
   setTimer: (fn, ms) => { const h = nextHandle++; timers.push({ h, fn, ms }); return h; },
   clearTimer: (h) => { timers = timers.filter((t) => t.h !== h); },
   onLog: (kind, detail) => logs.push(kind + ": " + detail),
@@ -70,10 +82,11 @@ function fireTimers() {
 }
 function report() {
   return JSON.stringify({
-    events, spoken, logs, anchored,
+    events, spoken, logs, anchored, notSpoken,
     armedTimers: timers.length,
     pending: announcer.pending(),
     armed: announcer.armed(),
+    anchorPending: announcer.anchorPending(),
   });
 }
 """
@@ -1533,12 +1546,25 @@ class TestThePersonaAndInterruptWiring:
     speaking-path count."""
 
     def test_the_page_wires_the_interrupt_gate_without_the_chatter_leg(self):
-        """canInterrupt keeps exactly the two unconditional legs of #962 —
-        owner not speaking, no confirm handshake — and drops responseActive /
+        """canInterrupt keeps the unconditional legs of #962 — owner not
+        speaking, no confirm handshake — and drops responseActive /
         announcer.pending, which is what lets an escalation pre-empt the
-        buddy's own speech via the announcer's existing cancel."""
+        buddy's own speech via the announcer's existing cancel.
+
+        Asserted as the legs it HAS and the legs it must NOT have, rather than
+        as the whole line: #978 item 2 adds a third leg to the handshake side
+        (a proposal still in the announcer's pipe is a handshake the gate's own
+        TTL cannot yet see), and pinning the literal made that indistinguishable
+        from reinstating the chatter leg.
+        """
         page = client.page("buddy", "tok")
-        assert "canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding()," in page
+        wiring = page.split("canInterrupt: ", 1)[1].split("\n", 1)[0]
+        assert "!ownerSpeaking" in wiring
+        assert "!confirmGate.outstanding()" in wiring
+        # The chatter leg, still gone: an escalation does not wait for the
+        # buddy's own in-flight response or its queue depth.
+        assert "responseActive" not in wiring
+        assert "announcer.pending()" not in wiring
         # The FULL gate is unchanged — #962's rule survives verbatim.
         assert (
             "canSpeak: () => !ownerSpeaking && !responseActive"
@@ -1769,3 +1795,451 @@ class TestTheOutcomeRouter:
         """)
         assert report["resolved"] == 0
         assert report["actedOn"] == []
+
+
+# =============================================================================
+# #978 wave 2 — the announcer/timer races and the silent-failure retry holes
+# =============================================================================
+
+
+class TestAnEscalationCannotSpeakInsideTheHandshake:
+    """#978 item 2. The confirm gate closes at ``anchored()`` — i.e. once the
+    proposal has been SPOKEN. Between the tool result coming back and that
+    moment, the proposal announcement is queued or mid-flight and the gate is
+    still open, so an escalation ticking right then passed ``canInterrupt``,
+    queued behind the proposal, and ``pump()`` promoted it the instant
+    anchoring closed the gate. The buddy speaks an alarm exactly between "say
+    confirm tango" and the owner's answer.
+
+    The announcer is the only thing that knows a proposal is in the pipe, so
+    the missing leg is asked of it.
+    """
+
+    def test_a_queued_proposal_announcement_reports_an_anchor_pending(self):
+        report = run_announcer("""
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+        """)
+        assert report["anchorPending"] is True
+
+    def test_it_stays_pending_while_the_proposal_waits_behind_another_item(self):
+        """Queued, not merely current: an escalation promoted ahead of a
+        proposal still lands inside the window the guard exists to protect."""
+        report = run_announcer("""
+            announcer.announce("The voice service reported an error.", { errorNotice: true });
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+        """)
+        assert report["pending"] == 2
+        assert report["anchorPending"] is True
+
+    def test_it_clears_once_the_proposal_has_actually_been_spoken(self):
+        """The false-reject half. The leg must open again the moment the
+        anchor fires, or the gate's own TTL is no longer the bound on how long
+        the buddy can be muted — a second, unbounded mute would sit in front
+        of it."""
+        report = run_announcer("""
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            announcer.onResponseDone("To send it, say confirm tango.");
+        """)
+        assert report["anchorPending"] is False
+        assert [a["how"] for a in report["anchored"]] == ["model"]
+
+    def test_an_ordinary_announcement_never_reports_one(self):
+        report = run_announcer("""
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+        """)
+        assert report["anchorPending"] is False
+
+    def test_the_page_wires_the_leg_into_can_interrupt(self):
+        page = client.page("buddy", "tok")
+        wiring = page.split("canInterrupt: ", 1)[1].split("\n", 1)[0]
+        assert "announcer.anchorPending()" in wiring
+        # The two legs #967 made unconditional must still be there — this is an
+        # addition, never a replacement.
+        assert "!ownerSpeaking" in wiring
+        assert "confirmGate.outstanding()" in wiring
+
+
+class TestTheFallbackDoesNotSpeakOverTheOwner:
+    """#978 item 3. "Never while the owner is speaking" held at GATE time and
+    nowhere else: the timer fires 6-12s later and spoke unconditionally.
+
+    Both halves are priced, and the false-reject half is why this is a bounded
+    deferral rather than a condition. A fallback that waits for silence
+    forever is a refusal the owner never hears — the exact failure the
+    default-on timer exists to make impossible. So: defer while they are
+    talking, up to a fixed count, then speak anyway. Talking over the owner
+    once beats never telling them.
+    """
+
+    def test_it_defers_while_the_owner_is_talking(self):
+        report = run_announcer("""
+            announcer.announce("I didn't hear the confirmation phrase.");
+            ownerIsSpeaking = true;
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["armed"] is True, "must re-arm, never simply drop"
+
+    def test_it_speaks_the_moment_they_stop(self):
+        report = run_announcer("""
+            announcer.announce("I didn't hear the confirmation phrase.");
+            ownerIsSpeaking = true;
+            fireTimers();
+            ownerIsSpeaking = false;
+            fireTimers();
+        """)
+        assert report["spoken"] == ["I didn't hear the confirmation phrase."]
+
+    def test_an_owner_who_never_stops_is_still_told(self):
+        """The bound. Without it a long monologue silently swallows a refusal
+        — and a refusal the owner never hears is the one outcome this whole
+        mechanism exists to rule out."""
+        report = run_announcer("""
+            announcer.announce("I didn't hear the confirmation phrase.");
+            ownerIsSpeaking = true;
+            for (let i = 0; i < 12; i++) fireTimers();
+        """)
+        assert report["spoken"] == ["I didn't hear the confirmation phrase."]
+
+    def test_the_owner_deferral_is_counted_separately_from_the_response_one(self):
+        """Two deferrals for two different reasons must not share a budget:
+        an announcement that already deferred once behind our own in-flight
+        audio still deserves its full owner-speaking grace, and vice versa."""
+        report = run_announcer("""
+            announcer.announce("I didn't hear the confirmation phrase.");
+            announcer.onResponseCreated();   // our audio may be mid-flight
+            fireTimers();                    // -> the sawCreate deferral
+            ownerIsSpeaking = true;
+            fireTimers();                    // -> an owner deferral, not a refusal to defer
+        """)
+        assert report["spoken"] == []
+        assert report["armed"] is True
+
+    def test_the_page_gives_the_announcer_the_owner_speaking_signal(self):
+        """The injected deps did not expose it, which is why the timer could
+        not check it at all."""
+        page = client.page("buddy", "tok")
+        deps = page.split("announcer = createAnnouncer({", 1)[1].split("});", 1)[0]
+        assert "ownerSpeaking:" in deps
+
+
+class TestStopTakesTheArmedTimerWithIt:
+    """#978 item 4. ``stop()`` nulled the announcer, but the armed
+    ``setTimeout`` closure survived it: 6s into "idle" the browser voice
+    speaks, and ``onSpoken(meta, "fallback")`` anchors the proposal on the
+    bridge — closing the NEXT session's volunteering gate for up to 120s over
+    a proposal nobody is answering. d45601b covered page-lifetime strays;
+    ``disarm`` was only ever reachable from ``onResponseDone``/``cancel``.
+    """
+
+    def test_teardown_disarms_the_current_item(self):
+        report = run_announcer("""
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            announcer.teardown();
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert report["armedTimers"] == 0
+
+    def test_teardown_never_reports_anything_as_spoken(self):
+        """A torn-down item was NOT heard, and the anchor is the one thing
+        that must never be told otherwise."""
+        report = run_announcer("""
+            announcer.announce("To send it, say confirm tango.", { anchor: "p1" });
+            announcer.teardown();
+            fireTimers();
+        """)
+        assert report["anchored"] == []
+
+    def test_teardown_drops_the_queue_too(self):
+        report = run_announcer("""
+            announcer.announce("first", { anchor: "p1" });
+            announcer.announce("second", { inboxIds: ["m1"] });
+            announcer.teardown();
+            fireTimers();
+        """)
+        assert report["pending"] == 0
+        assert report["spoken"] == []
+
+    def test_the_page_tears_the_announcer_down_before_dropping_it(self):
+        page = client.page("buddy", "tok")
+        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
+        assert "announcer.teardown()" in stop_body
+        assert stop_body.index("announcer.teardown()") < stop_body.index(
+            "announcer = null"
+        )
+
+
+class TestASilentlyFailedAnnouncementIsRetried:
+    """#978 item 5. ``speechSynthesis`` fails silently — the code says so
+    itself — and ``utterance.onerror`` logged to the DOM without firing
+    ``onSpokenAloud``. So an inbox notice was neither HEARD nor ACKED, yet its
+    id sat in ``inFlight`` for the rest of the session and suppressed every
+    later tick: the comment promising "the unheard notice is retried" was
+    describing a path the code did not have.
+    """
+
+    def test_a_failed_browser_voice_reports_not_spoken(self):
+        report = run_announcer("""
+            speakFails = true;
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+            fireTimers();
+        """)
+        assert report["anchored"] == [], "a failed utterance was never heard"
+        assert [m["inboxIds"] for m in report["notSpoken"]] == [["m1"]]
+
+    def test_a_successful_one_still_reports_spoken_only(self):
+        """The must-fail control for the assertion above: if onNotSpoken fired
+        on the success path too, every test here would pass for the wrong
+        reason."""
+        report = run_announcer("""
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+            fireTimers();
+        """)
+        assert report["notSpoken"] == []
+        assert [a["how"] for a in report["anchored"]] == ["fallback"]
+
+    def test_the_notice_is_volunteered_again_on_a_later_tick(self):
+        """The property the comment claimed. ``noticeFailed`` releases the
+        id, so the next gated tick says it again — the message is not lost
+        for the session over a browser-voice failure."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
+            await notifier.pollOnce();
+            const meta = announcedCalls[0].meta;
+            notifier.noticeFailed(meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        assert report["cursor"] == 0, "never acked — it was never heard"
+
+    def test_without_the_release_it_is_suppressed_forever(self):
+        """The control. Same script, no ``noticeFailed`` — one announcement,
+        which is the defect."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+
+    def test_a_heard_notice_is_never_released_by_a_later_failure(self):
+        """``seen`` is what settles a notice, and it outranks this: releasing
+        an id the owner HAS heard would replay it."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
+            await notifier.pollOnce();
+            const meta = announcedCalls[0].meta;
+            await notifier.noticeSpoken(meta);
+            notifier.noticeFailed(meta);
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+
+    def test_the_page_routes_a_browser_voice_error_back(self):
+        page = client.page("buddy", "tok")
+        deps = page.split("announcer = createAnnouncer({", 1)[1].split("      onSpoken,", 1)[0]
+        assert "onSpeakFailed" in deps, "the speak dep must take a failure callback"
+        assert "onNotSpoken" in page
+        handler = page.split("function onNotSpoken(meta)", 1)[1].split("\n}", 1)[0]
+        assert "noticeFailed" in handler
+
+
+class TestTheStopTimeRaceCannotStrandAStray:
+    """#978 item 6. ``pollOnce`` is not cancellable mid-flight. After
+    ``stop()`` the full gate fails but ``canInterrupt`` could still pass, and
+    ``announce`` with a null announcer did a bare ``speechSynthesis.speak`` —
+    no meta, no ``onSpoken``, never acked, never seen. Being cursor-past, the
+    spool will never return those replies: the ``strays`` array is their only
+    way back to the owner's ear, and this path emptied it into nothing.
+    """
+
+    def test_a_poll_resolving_after_stop_announces_nothing(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "wedged" }];
+            const inFlight = notifier.pollOnce();
+            notifier.stop();
+            await inFlight;
+        """)
+        assert report["announced"] == []
+
+    def test_it_never_takes_a_stray_out_of_the_array(self):
+        """The invariant the array exists for. A stray dropped here is lost
+        for good — the cursor is already past it, so the spool will never
+        return it. The stopped check therefore runs BEFORE the pull, not after
+        it: putting them back would work too, but only if every later return
+        path remembered to."""
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "docs", kind: "escalation", text: "still open" });
+            const inFlight = notifier.pollOnce();
+            notifier.stop();
+            await inFlight;
+        """)
+        assert report["announced"] == []
+        assert report["strays"] == 1
+
+    def test_a_stray_survives_to_the_next_session(self):
+        """Whole-loop: the array is page-lifetime, so the notifier built after
+        a reconnect finds it and says it."""
+        report = run_notifier("""
+            strays.push({ id: "s1", from: "docs", kind: "done", text: "still open" });
+            const inFlight = notifier.pollOnce();
+            notifier.stop();
+            await inFlight;
+            notifier = makeNotifier();
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 1
+        assert "still open" in report["announced"][0]["text"]
+
+    def test_the_page_will_not_announce_through_a_dead_announcer(self):
+        """The second half of the fix: even if a tick did get through, the
+        interrupt gate now requires a live announcer, so nothing reaches the
+        bare speechSynthesis path with inbox meta attached."""
+        page = client.page("buddy", "tok")
+        wiring = page.split("canInterrupt: ", 1)[1].split("\n", 1)[0]
+        assert "!!announcer" in wiring
+
+
+class TestCarriedTheReasonIsNotDecidedByStopwords:
+    """#978 item 7. Overlap ≥ 0.6 over raw tokens, with duplicates
+    double-counting. The greeting is ~7/9 stopwords, so an unrelated VAD reply
+    that happens to share them verdicts "the model said it" and DISARMS —
+    which in the greeting's case means the greet-as-health-check (b4446fb)
+    reports the scripted-speech path healthy when the greeting never happened,
+    and the browser voice that would have said MODEL_AUDIO_DEAD never fires.
+
+    The pricing runs the other way from most guards here: tightening this
+    moves errors from "silently believed spoken" to "said twice". A paraphrase
+    that drops content words now falls through to the fallback voice, so the
+    owner hears it in a robot voice — possibly after the model already said
+    something like it. Double-speak is the cheap failure; silence is not.
+    """
+
+    def test_the_greeting_is_not_disarmed_by_a_stopword_heavy_reply(self):
+        report = run_announcer("""
+            announcer.announce("Hey, I'm listening. What's on your mind?",
+                               { greeting: true }, "MODEL AUDIO DEAD");
+            announcer.onResponseDone("I'm not sure what's on your mind today");
+            fireTimers();
+        """)
+        assert report["spoken"] == ["MODEL AUDIO DEAD"]
+        assert [a["how"] for a in report["anchored"]] == ["fallback"]
+
+    def test_the_real_greeting_still_disarms_it(self):
+        """The false-reject half, and the reason this is a weighting and not a
+        stricter threshold: the greeting the model actually speaks must still
+        count, or every healthy session speaks MODEL_AUDIO_DEAD."""
+        report = run_announcer("""
+            announcer.announce("Hey, I'm listening. What's on your mind?",
+                               { greeting: true }, "MODEL AUDIO DEAD");
+            announcer.onResponseDone("Hey — I'm listening. What's on your mind?");
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+        assert [a["how"] for a in report["anchored"]] == ["model"]
+
+    def test_a_proposal_is_not_anchored_by_a_stopword_echo(self):
+        """The same mechanism on the path that costs the most: a false disarm
+        here anchors a proposal on a response that never stated it, and the
+        owner's correct nonce is then judged against a proposal they were
+        never read."""
+        report = run_announcer("""
+            announcer.announce("To send it to the orchestrator, say confirm tango.",
+                               { anchor: "p1" }, "To send it, say the word I gave you.");
+            announcer.onResponseDone("Do you want me to send it to the orchestrator or not");
+        """)
+        assert report["anchored"] == []
+        assert report["armed"] is True
+
+    def test_repeated_words_cannot_pad_the_overlap(self):
+        """Duplicates double-counted, so a reply repeating one shared word
+        could carry the score on its own."""
+        report = run_announcer("""
+            announcer.announce("Send the report to the reviewer now",
+                               { anchor: "p1" });
+            announcer.onResponseDone("the the the the the the the the");
+        """)
+        assert report["anchored"] == []
+
+    def test_an_all_stopword_script_can_still_be_verified(self):
+        """The degenerate case the weighting must not break: if a scripted
+        line has NO content words, dropping them all would leave nothing to
+        compare and the announcement could never disarm — an unconditional
+        double-speak on every such line."""
+        report = run_announcer("""
+            announcer.announce("What is it about?");
+            announcer.onResponseDone("What is it about?");
+            fireTimers();
+        """)
+        assert report["spoken"] == []
+
+    def test_every_spine_line_the_model_speaks_verbatim_still_disarms(self):
+        """The broad false-reject sweep. Whatever the weighting is, saying the
+        line EXACTLY must always count — otherwise the fallback doubles every
+        refusal the model gets right."""
+        from agentwire.voice_layer import confirm as confirm_mod
+
+        for reason, line in confirm_mod.SPOKEN.items():
+            report = run_announcer(f"""
+                announcer.announce({json.dumps(line)});
+                announcer.onResponseDone({json.dumps(line)});
+                fireTimers();
+            """)
+            assert report["spoken"] == [], reason
+
+
+class TestTheCommentsDescribeTheCodeTheySitOn:
+    """The nits, pinned. A false sentence at a use site is how the next
+    reviewer reads the wrong mechanism as the shipped one — this module's
+    recurring failure, and the reason each of these is asserted rather than
+    merely fixed.
+    """
+
+    def test_the_wait_outcomes_comment_names_all_three(self):
+        """``in_flight`` became a wait outcome in #987 and the enumeration at
+        the dispatch site still said two."""
+        page = client.page("buddy", "tok")
+        dispatch = page.split("async function handleFunctionCall(item)", 1)[1]
+        dispatch = dispatch.split("function spokenText", 1)[0]
+        assert "pending_transcript / not_announced)" not in dispatch
+        for name in ("pending_transcript", "not_announced", "in_flight"):
+            assert name in dispatch, name
+
+    def test_nothing_in_the_client_branches_on_a_wait_outcome_by_name(self):
+        """Why the enumeration above is a comment fix and not a code fix: the
+        router keys on ``confirm_terminal``, which the spine sets for every
+        non-wait outcome, so a third wait outcome needed no dispatch change.
+        This is the assertion that made that safe to claim."""
+        page = client.page("buddy", "tok")
+        script = page.split("<script>", 1)[1].rsplit("</script>", 1)[0]
+        code = "\n".join(
+            line for line in script.splitlines() if not line.strip().startswith("//")
+        )
+        for name in ("pending_transcript", "not_announced", "in_flight",
+                     "owner_should_wait"):
+            assert name not in code, f"{name} is branched on, not just described"
+
+    def test_the_outcome_router_comment_does_not_claim_to_hold_state(self):
+        """It holds none — its own header says the opposite, and the guess it
+        replaced (remember the last proposal's session) is the bug #966 fixed."""
+        page = client.page("buddy", "tok")
+        preamble = page.split("const outcomeRouter = createOutcomeRouter", 1)[0]
+        assert "holds the most recent proposal's target session" not in preamble
+
+    def test_the_interrupt_comment_does_not_overstate_pre_emption(self):
+        page = client.page("buddy", "tok")
+        assert "an escalation may pre-empt the buddy's own\n      // speech" not in page
+
+    def test_the_module_docstring_stamps_utterances_at_speech_start(self):
+        """The docstring said ``input_audio_buffer.committed``, which is the
+        ordering the whole clock change exists to reject."""
+        doc = client.__doc__
+        assert "an utterance at ``input_audio_buffer.committed``" not in doc
+        assert "input_audio_buffer.speech_started" in doc
+
+    def test_the_ring_docstring_says_no_prior_speech_started(self):
+        from agentwire.voice_layer import transcript as transcript_mod
+
+        assert "a\ntranscript arriving with no prior commit" not in transcript_mod.__doc__
+        assert "no prior ``speech_started``" in transcript_mod.__doc__

--- a/tests/unit/test_voice_epoch.py
+++ b/tests/unit/test_voice_epoch.py
@@ -1,0 +1,210 @@
+"""The logical clock's ORIGIN is server-owned (#978 blocking 1).
+
+The confirm gate orders on a logical clock the CLIENT assigns (``nextSeq``),
+because the client is the only place that sees data-channel event order. What
+the client cannot supply is the clock's **origin**: ``seqCounter`` is a page
+variable and starts at 0 on every page load, while the ring and the spine live
+for the whole bridge run.
+
+So a reload put the two out of step in the one direction that matters. The
+pre-reload utterances sit in the ring at high sequences, complete and unspent;
+the fresh page anchors its next proposal at 1. ``ring.after(anchor)`` then
+returns LAST session's utterances, and two things follow, both fail-closed and
+both persistently wrong in a channel with no screen:
+
+1. they reach ``_judge`` as non-matching, so the proposal burns attempts toward
+   ``too_many_attempts`` for a question the owner was never asked;
+2. worse, the post-approval denial scan sees an old "no, hang on" as strictly
+   AFTER the new match and retroactively denies every legitimate approval,
+   until 32 fresh utterances evict it from the ring.
+
+The fix is the second of the two directions #978 named — **move the clock's
+origin server-side**. ``/mint`` is the one event that happens exactly once per
+page load, so the bridge answers it with a sequence base above every sequence
+it has ever seen, and the page starts counting from there. Nothing is rejected
+and nothing is deleted: the false-reject half of a rejecting epoch guard is a
+dropped utterance, which in this channel is a silent loop, and it would be paid
+on the owner's LIVE tab.
+
+The base is advanced by a whole :data:`~agentwire.voice_layer.server.MINT_SEQ_GAP`
+rather than by one, which is what makes it an epoch rather than a bump: two
+tabs minting against one bridge get non-overlapping numeric ranges, so tab A
+would have to emit a million events before it could reach into tab B's.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentwire.voice_layer import client, confirm, server, transcript
+
+
+class FakeMint:
+    """``realtime.mint_session`` without the network."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, **kwargs):
+        self.calls += 1
+        return {"client_secret": "sk-fake", "model": "m", "voice": "v"}
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    from agentwire.voice_layer import realtime
+
+    monkeypatch.setattr(realtime, "mint_session", FakeMint())
+    return server.BuddyBridge("buddy", "tok", runner=lambda argv: {"success": True})
+
+
+class TestTheMintHandsOutTheClockOrigin:
+    def test_a_fresh_bridge_still_starts_the_page_above_zero(self, bridge):
+        """Even the first page gets a base: the client's ``|| 0`` fallback is
+        the shape that silently reintroduced a zero origin."""
+        assert bridge.mint()["seq_base"] >= server.MINT_SEQ_GAP
+
+    def test_each_mint_opens_a_range_above_everything_seen(self, bridge):
+        first = bridge.mint()["seq_base"]
+        # The page runs for a while.
+        bridge.utterance({"item_id": "u1", "speech_started_seq": first + 1})
+        bridge.utterance({"item_id": "u1", "commit_seq": first + 2})
+        second = bridge.mint()["seq_base"]
+        assert second > first + 2
+        # ...and by a whole gap, so a still-live first page cannot count into
+        # the second page's range.
+        assert second - (first + 2) >= server.MINT_SEQ_GAP
+
+    def test_the_base_is_recorded_on_the_ring_not_just_returned(self, bridge):
+        """A base the ring has not seen is a base the NEXT mint would reuse."""
+        base = bridge.mint()["seq_base"]
+        assert bridge.ring.high_seq >= base
+
+
+class TestAReloadCannotBeApprovedByLastSessionsSpeech:
+    """The two harms #978 named, driven through the real ring and spine."""
+
+    def _spine(self, ring, runner):
+        return confirm.ConfirmSpine(ring, wait_s=0.05, runner=runner)
+
+    def test_an_old_utterance_no_longer_burns_a_new_proposals_attempts(self):
+        ring = transcript.TranscriptRing()
+        calls = []
+        spine = self._spine(ring, lambda argv: calls.append(argv) or {"success": True})
+
+        # --- page 1: the owner says several unrelated things -----------------
+        for n, text in enumerate(["okay", "sure, go on", "that's fine"], start=1):
+            ring.speech_started(f"old{n}", n)
+            ring.commit(f"old{n}", n + 100)
+            ring.transcribe(f"old{n}", text)
+
+        # --- reload: the page takes its origin from the bridge ---------------
+        base = ring.note_seq(ring.high_seq + server.MINT_SEQ_GAP)
+
+        proposal = spine.propose(
+            tool="fleet_session_send",
+            session="orch",
+            instruction="ping",
+            argv_prefix=("agentwire", "msg", "send"),
+        )
+        spine.announce(proposal.id, base + 1)
+
+        verdict = spine.confirm(proposal.token)
+        # Nothing the owner said LAST session is visible to this proposal, so
+        # the outcome is the honest "I have not heard you yet" — never a
+        # refusal counted against them.
+        assert verdict.reason == "pending_transcript"
+        live = {p.token: p for p in spine.pending()}
+        assert live[proposal.token].attempts == 0
+        assert calls == []
+
+    def test_an_old_denial_cannot_retroactively_deny_a_new_approval(self):
+        ring = transcript.TranscriptRing()
+        calls = []
+        spine = self._spine(ring, lambda argv: calls.append(argv) or {"success": True})
+
+        # --- page 1: the owner took something back --------------------------
+        ring.speech_started("old_denial", 1)
+        ring.commit("old_denial", 2)
+        ring.transcribe("old_denial", "no, hang on")
+        assert confirm.carries_denial("no, hang on"), "fixture must really deny"
+
+        # --- reload ----------------------------------------------------------
+        base = ring.note_seq(ring.high_seq + server.MINT_SEQ_GAP)
+
+        proposal = spine.propose(
+            tool="fleet_session_send",
+            session="orch",
+            instruction="ping",
+            argv_prefix=("agentwire", "msg", "send"),
+        )
+        spine.announce(proposal.id, base + 1)
+        ring.speech_started("new_ok", base + 2)
+        ring.commit("new_ok", base + 3)
+        ring.transcribe("new_ok", f"confirm {confirm.spoken_nonce(proposal.nonce)}")
+
+        verdict = spine.confirm(proposal.token)
+        assert verdict.approved is True, verdict.reason
+        assert len(calls) == 1
+
+    def test_the_control_that_must_fail_without_the_origin(self):
+        """Kill this file's own false negative.
+
+        The two tests above prove nothing unless the SAME shape at a zero
+        origin actually breaks. This is that shape: identical, minus the
+        server-owned base.
+        """
+        ring = transcript.TranscriptRing()
+        calls = []
+        spine = self._spine(ring, lambda argv: calls.append(argv) or {"success": True})
+
+        ring.speech_started("old_denial", 50)
+        ring.commit("old_denial", 51)
+        ring.transcribe("old_denial", "no, hang on")
+
+        proposal = spine.propose(
+            tool="fleet_session_send",
+            session="orch",
+            instruction="ping",
+            argv_prefix=("agentwire", "msg", "send"),
+        )
+        spine.announce(proposal.id, 1)          # a page that restarted at zero
+        ring.speech_started("new_ok", 2)
+        ring.commit("new_ok", 3)
+        ring.transcribe("new_ok", f"confirm {confirm.spoken_nonce(proposal.nonce)}")
+
+        verdict = spine.confirm(proposal.token)
+        assert verdict.approved is False
+        assert verdict.reason == "denied"
+        assert calls == []
+
+
+class TestThePageTakesItsOriginFromTheMint:
+    """The wiring half. The node harnesses cover the factories; the origin
+    lives in the page's own ``start()``, so it is asserted on the source."""
+
+    def test_the_counter_is_seeded_from_the_mint_response(self):
+        page = client.page("buddy", "tok")
+        start = page.split("async function start()", 1)[1].split("function stop()", 1)[0]
+        assert "seqCounter = session.seq_base" in start
+
+    def test_the_seed_is_not_defaulted_to_zero(self):
+        """``session.seq_base || 0`` reads defensive and silently restores the
+        exact defect — a bridge that failed to answer would hand every page a
+        zero origin again. A missing base is a broken bridge, and start()
+        already throws on one."""
+        page = client.page("buddy", "tok")
+        assert "seq_base || 0" not in page
+        assert "seq_base ||" not in page
+
+    def test_the_seed_lands_before_anything_can_consume_a_sequence(self):
+        """The declaration's 0 is only unreachable because the seed happens
+        before the data channel exists — nothing emits an event, and so
+        nothing calls ``nextSeq()``, until then. Reordering the seed below
+        ``createDataChannel`` would put a zero-origin sequence back on the
+        wire without changing a single line that mentions the origin."""
+        page = client.page("buddy", "tok")
+        start = page.split("async function start()", 1)[1].split("function stop()", 1)[0]
+        assert start.index("seqCounter = session.seq_base") < start.index(
+            "pc.createDataChannel"
+        )

--- a/tests/unit/test_voice_epoch.py
+++ b/tests/unit/test_voice_epoch.py
@@ -394,3 +394,39 @@ class TestThePageRefusesAnUnusableOrigin:
         page = client.page("buddy", "tok")
         assert "Number.isSafeInteger(session.seq_base)" in page
         assert 'typeof session.seq_base !== "number"' not in page
+
+
+class TestAReservationIsAWholeBlock:
+    """Review N2. ``reserve_epoch`` returns a BASE the page counts UP from, so
+    what has to fit under the ceiling is ``base + gap`` — testing the base
+    alone let the final reservation land exactly on it. That page mints
+    successfully and then has ZERO usable sequences: every forward is refused
+    for exceeding :data:`~agentwire.voice_layer.server.MAX_SEQ`, silently, for
+    the rest of the run.
+
+    Unreachable in practice — roughly 35 million mints on one bridge process —
+    and that is not the argument. ``reserve_epoch``'s own first sentence claims
+    a block of ``gap`` sequences, so the code has to reserve one.
+    """
+
+    def test_a_base_landing_exactly_on_the_ceiling_is_refused(self):
+        ring = transcript.TranscriptRing()
+        ring.note_seq(server.MAX_SEQ - server.MINT_SEQ_GAP)
+        assert ring.reserve_epoch(server.MINT_SEQ_GAP, server.MAX_SEQ) == 0
+
+    def test_the_last_usable_reservation_keeps_its_whole_block(self):
+        """The false-reject half: the guard must not refuse a reservation that
+        genuinely fits, or it retires the sequence space a whole epoch early."""
+        ring = transcript.TranscriptRing()
+        ring.note_seq(server.MAX_SEQ - 2 * server.MINT_SEQ_GAP)
+        base = ring.reserve_epoch(server.MINT_SEQ_GAP, server.MAX_SEQ)
+        assert base == server.MAX_SEQ - server.MINT_SEQ_GAP
+        # ...and every sequence that page can count to is still acceptable.
+        assert base + server.MINT_SEQ_GAP <= server.MAX_SEQ
+
+    def test_the_page_it_hands_that_base_to_can_actually_use_it(self, bridge):
+        bridge.ring.note_seq(server.MAX_SEQ - 2 * server.MINT_SEQ_GAP)
+        base = bridge.mint()["seq_base"]
+        assert bridge.utterance(
+            {"item_id": "u1", "speech_started_seq": base + server.MINT_SEQ_GAP}
+        )["success"] is True

--- a/tests/unit/test_voice_epoch.py
+++ b/tests/unit/test_voice_epoch.py
@@ -30,6 +30,19 @@ The base is advanced by a whole :data:`~agentwire.voice_layer.server.MINT_SEQ_GA
 rather than by one, which is what makes it an epoch rather than a bump: two
 tabs minting against one bridge get non-overlapping numeric ranges, so tab A
 would have to emit a million events before it could reach into tab B's.
+
+Two properties of that base are load-bearing and are tested here rather than
+assumed, both found in review:
+
+- it is **reserved atomically** (``reserve_epoch``, one lock). Read-then-write
+  is two acquisitions, and two concurrent mints on the bridge's threading
+  server can be handed the same base — the two-interleaved-counters case, back
+  inside the fix for it.
+- it is **bounded** (:data:`~agentwire.voice_layer.server.MAX_SEQ`). The number
+  now crosses into the page's counter, where it is a double rather than an
+  int: past 2**53 an increment stops advancing and every event shares a
+  sequence, and past that it is ``Infinity``, whose anchors serialize as
+  ``null``. Both wedge the buddy silently for the rest of the bridge run.
 """
 
 from __future__ import annotations
@@ -208,3 +221,176 @@ class TestThePageTakesItsOriginFromTheMint:
         assert start.index("seqCounter = session.seq_base") < start.index(
             "pc.createDataChannel"
         )
+
+
+class TestTheEpochIsReservedAtomically:
+    """Review F1. ``high_seq`` read, then ``note_seq`` written, is two lock
+    acquisitions with a window between them — so two concurrent ``/mint`` on
+    the ``ThreadingHTTPServer`` can be handed the SAME base. That is exactly
+    the "second tab, two interleaved counters" case #978 names, reintroduced
+    inside the fix for it.
+
+    It did not reproduce under plain threading (the window is a couple of
+    bytecodes), and "not observed" is the argument this module refuses
+    everywhere else — ``TestSingleUseIsClaimedNotJudged`` is the same shape,
+    and the #978 work leaned on that reasoning. So the window is forced open
+    rather than raced for.
+    """
+
+    def test_two_concurrent_mints_never_share_a_base(self, monkeypatch):
+        import threading
+        import time as _time
+
+        class SlowReadRing(transcript.TranscriptRing):
+            """A ring whose ``high_seq`` READ is slow.
+
+            This is the whole test: a reserve that holds one lock across the
+            read and the write never calls this at all, so the window it opens
+            cannot exist. A read-then-write reserve calls it and both threads
+            come back with the same number.
+            """
+
+            @property
+            def high_seq(self):
+                value = transcript.TranscriptRing.high_seq.fget(self)
+                _time.sleep(0.05)
+                return value
+
+        from agentwire.voice_layer import realtime
+
+        monkeypatch.setattr(realtime, "mint_session", FakeMint())
+        b = server.BuddyBridge("buddy", "tok")
+        b.ring = SlowReadRing()
+
+        bases = []
+        lock = threading.Lock()
+
+        def one():
+            base = b.mint()["seq_base"]
+            with lock:
+                bases.append(base)
+
+        threads = [threading.Thread(target=one) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(set(bases)) == 2, f"two tabs were handed the same base: {bases}"
+
+    def test_many_concurrent_reservations_are_all_disjoint(self):
+        import threading
+
+        ring = transcript.TranscriptRing()
+        got = []
+        lock = threading.Lock()
+
+        def one():
+            base = ring.reserve_epoch(server.MINT_SEQ_GAP, server.MAX_SEQ)
+            with lock:
+                got.append(base)
+
+        threads = [threading.Thread(target=one) for _ in range(24)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(set(got)) == len(got)
+        # Disjoint, not merely distinct: consecutive bases are a whole gap
+        # apart, which is what stops one tab counting into the next's range.
+        ordered = sorted(got)
+        for lower, upper in zip(ordered, ordered[1:]):
+            assert upper - lower >= server.MINT_SEQ_GAP
+
+
+class TestASequenceIsBoundedAtBothEnds:
+    """Review F7, a coupling this work newly created.
+
+    ``high_seq`` used to be read-only state the bridge kept for its own
+    ordering. It now flows BACK into the client's clock through ``seq_base``,
+    so a client-supplied sequence is no longer just a number the ring
+    compares — it becomes the origin of every later page's counter, on the
+    other side of a JSON boundary where a Python int is NOT an int.
+
+    One malformed local POST of ``10**18`` permanently raises it. Every later
+    mint then hands out a base above 2**53, where ``++seqCounter`` is a no-op
+    in IEEE-754: every event shares one sequence, ``after(anchor)`` is
+    strictly-after, and the buddy answers ``pending_transcript`` forever.
+    Bigger still parses to ``Infinity`` in the page, which serializes anchors
+    as ``null`` — ``not_announced`` forever. Both silent, and both survive a
+    reload, because ``high_seq`` is bridge-lifetime.
+
+    Loopback- and token-gated, so this is robustness rather than a remote
+    attack — but #986 hardened this same bridge against this same class.
+    """
+
+    def test_an_absurd_speech_sequence_is_refused(self, bridge):
+        before = bridge.ring.high_seq
+        result = bridge.utterance({"item_id": "u1", "speech_started_seq": 10**18})
+        assert result["success"] is False
+        assert bridge.ring.high_seq == before, "a refused seq must not raise the clock"
+
+    def test_an_absurd_commit_sequence_is_refused(self, bridge):
+        before = bridge.ring.high_seq
+        assert bridge.utterance({"item_id": "u1", "commit_seq": 10**18})[
+            "success"
+        ] is False
+        assert bridge.ring.high_seq == before
+
+    def test_an_absurd_transcript_sequence_is_refused(self, bridge):
+        before = bridge.ring.high_seq
+        assert bridge.utterance(
+            {"item_id": "u1", "transcript": "hi", "speech_started_seq": 10**18}
+        )["success"] is False
+        assert bridge.ring.high_seq == before
+
+    def test_an_absurd_anchor_sequence_is_refused(self, bridge):
+        before = bridge.ring.high_seq
+        assert bridge.anchor({"proposal_id": "abc", "seq": 10**18})["success"] is False
+        assert bridge.ring.high_seq == before
+
+    def test_an_ordinary_sequence_is_untouched(self, bridge):
+        """The false-reject half, and it is the expensive one: a refused
+        utterance never enters the ring, so the owner's approval is invisible
+        and the buddy waits forever. The ceiling has to sit far above anything
+        a real session reaches."""
+        base = bridge.mint()["seq_base"]
+        assert bridge.utterance({"item_id": "u1", "speech_started_seq": base + 1})[
+            "success"
+        ] is True
+        assert bridge.ring.high_seq >= base + 1
+        assert server.MAX_SEQ > server.MINT_SEQ_GAP * 1000
+
+    def test_the_ceiling_stays_inside_what_the_page_can_count(self):
+        """The bound exists because the number crosses into JS. Everything the
+        bridge can ever hand out must stay a SAFE integer there, or the page's
+        ``++seqCounter`` silently stops advancing."""
+        assert server.MAX_SEQ < 2**53
+
+    def test_an_exhausted_sequence_space_refuses_rather_than_poisons(self, bridge):
+        """The other end. Handing out a base past the ceiling is the exact
+        wedge this guards, so exhaustion must be an error the page throws on,
+        never a number it counts from."""
+        bridge.ring.note_seq(server.MAX_SEQ - 1)
+        result = bridge.mint()
+        assert result["success"] is False
+        assert "seq_base" not in result
+
+    def test_exhaustion_is_checked_before_the_api_key_is_spent(self, bridge, monkeypatch):
+        from agentwire.voice_layer import realtime
+
+        minter = FakeMint()
+        monkeypatch.setattr(realtime, "mint_session", minter)
+        bridge.ring.note_seq(server.MAX_SEQ - 1)
+        bridge.mint()
+        assert minter.calls == 0
+
+
+class TestThePageRefusesAnUnusableOrigin:
+    def test_the_guard_requires_a_safe_integer_not_merely_a_number(self):
+        """``typeof x === "number"`` passes for ``Infinity``, and a page that
+        counts from Infinity serializes every anchor as ``null``."""
+        page = client.page("buddy", "tok")
+        assert "Number.isSafeInteger(session.seq_base)" in page
+        assert 'typeof session.seq_base !== "number"' not in page


### PR DESCRIPTION
All of #978: the blocking clock defect, all six non-blocking items, and the three nits. Plus the two items routed onto it from wave 1's reviews — one folded in, one decided against with reasons below.

Full suite green on the CI invocation (`uv run --extra dev pytest`): **5715 passed, 36 skipped, 0 failed** (baseline on `voice-confirm-spine` was 5670; +45 new tests). Every new test was watched FAILING first, and every fix was mutation-checked — the mutation table is at the bottom.

## Blocking — the clock's ORIGIN is now server-owned

`seqCounter` is a page variable and restarts at 0 on every reload; the ring and the spine live for the whole bridge run. So a reloaded page anchored its next proposal *below* last session's utterances, which are still in the ring, complete and unspent. Both harms the issue named were reproduced and are now closed:

- they reached `_judge` as non-matching → `refused` → burned attempts toward retiring a proposal the owner was never asked about;
- the post-approval denial scan saw an old "no, hang on" as strictly-AFTER the new match and **retroactively denied every legitimate approval** until 32 fresh utterances evicted it.

`/mint` is the one event that happens exactly once per page load, so it now answers with a `seq_base` a whole `MINT_SEQ_GAP` (1,000,000) above every sequence the bridge has seen, recorded on the ring, and `start()` seeds the counter from it before the data channel exists.

**Why the gap and not a bump:** it is what makes this an epoch rather than a nudge. Two tabs minting against one bridge get non-overlapping numeric ranges — tab A would have to emit a million data-channel events to reach into tab B's.

**Why no rejection.** The issue offered "reset/namespace the ring" or "move the clock server-side"; this is the second. A rejecting epoch guard pays its false-reject half by *dropping an utterance from the owner's live tab*, and a dropped utterance here is a silent loop — the expensive failure in this channel. Ordering the epochs has no reject path at all, deletes nothing, and leaves a proposal that survived the reload still confirmable (the spine survives `stop()` by design).

**Stated residual:** a forward that FAILS leaves `high_seq` behind the client's counter, so the next base is that much less clear of the last epoch. Bounded by the gap, not by anything smaller.

`tests/unit/test_voice_epoch.py` drives both harms through the real ring and spine, and carries its own **must-fail control** (`test_the_control_that_must_fail_without_the_origin`) — the identical shape at a zero origin, which still produces `denied`. Without it the two fixed-shape tests prove nothing.

## Non-blocking — all six

| # | Fix |
|---|-----|
| 2 | `canInterrupt` gains an announcer leg. The gate closes at `anchored()`, so a proposal queued or mid-flight is a handshake `confirmGate.outstanding()` cannot yet see — an escalation queued there was promoted the instant anchoring closed the gate, speaking an alarm exactly between "say confirm tango" and the owner's answer. New `announcer.anchorPending()`. |
| 3 | The 6s fallback re-checks `ownerSpeaking` at FIRE time, not only at gate time (the injected deps did not expose it at all). Bounded at 3 deferrals, counted separately from the `sawCreate` one. |
| 4 | `announcer.teardown()`, invoked by `stop()` before the reference is dropped. The armed `setTimeout` closure survived `announcer = null` and spoke 6s into "idle", anchoring a proposal on the bridge and closing the next session's gate for up to 120s. Teardown never reports anything as spoken. |
| 5 | `utterance.onerror` now routes back through a new `onNotSpoken`/`noticeFailed` pair, so the id leaves `inFlight` and the next gated tick says it again. The comment promising "the unheard notice is retried" described a path the code did not have. |
| 6 | `pollOnce` returns on `stopped` *before* it pulls any stray, and `canInterrupt` requires a live announcer. A poll resolving after `stop()` handed cursor-past replies to a null announcer, which spoke them with no meta — never acked, never seen, and unrecoverable, since the cursor is already past them. |
| 7 | `carriedTheReason` counts **unique content words**. Stopwords dominate a short line (the greeting is 7 of its 9 tokens), so an unrelated VAD reply disarmed the greet-as-health-check and reported the model-audio path healthy when the greeting never happened; duplicates also double-counted, so one repeated shared word could carry the score alone. |

### Pricing the false-reject half of each guard change

- **(3)** the bound is the guard's false-reject half: without it a long monologue swallows a refusal entirely, which is the one outcome the default-on timer exists to rule out. Worst case is now `fallbackMs × 4` ≈ 24s before the owner is told.
- **(2)** the leg must open the moment the anchor fires, or a second, unbounded mute would sit in front of the gate's TTL. Pinned by `test_it_clears_once_the_proposal_has_actually_been_spoken`.
- **(7)** this one errs the *other* way on purpose: tightening it moves errors from "silently believed spoken" to "said twice". A paraphrase that drops content words now falls through to the browser voice, so the owner hears it in a robot voice, possibly after the model already said something like it. Double-speak is cheap; believed-spoken silence is not. The threshold stayed at 0.6 — only the thing being counted changed. Two sweeps pin the reject half: every `confirm.SPOKEN` line spoken verbatim still disarms, and an all-stopword line (`"What is it about?"`) still can.
  - **Residual, unchanged in direction:** the *greeting* is the tightest member of the set because it is short — a heavy paraphrase ("Hello! What's on your mind?") verdicts false and wrongly speaks `MODEL_AUDIO_DEAD`. It did so before this change too (raw overlap scored it 0.56), and the announce instruction is "say exactly this and nothing else", so this is not a new cost. It is also the cheap direction: audible and actionable, not silent.

## Nits

- `client.py:1035`'s wait-outcome enumeration folds in `in_flight`.
- The outcome router no longer claims to hold the most recent proposal's session — it holds nothing, and that guess is exactly what #966 removed.
- The pre-emption comment no longer overstates what the interrupt tier buys.
- `client.py`'s and `transcript.py`'s module docstrings now say `speech_started` where they said `committed`.

## Wave-1 item: `in_flight` as a third wait outcome — **taken, and it is only a comment fix, verified**

The routed comment asked me not to assume that. I checked rather than assumed:

- `outcome_router` keys on `result.confirm_terminal`, which the spine sets `False` for exactly `WAIT_OUTCOMES` — so #987 added a third member without touching a line of dispatch.
- Grepped the whole client for a name-keyed branch: **none**. `pending_transcript`, `not_announced`, `in_flight` and `owner_should_wait` appear only in comments.
- Grepped `agentwire/` outside `confirm.py`: the only consumer is `instructions.py`'s persona text, which reads `owner_should_wait` generically and is correct for three outcomes. (The `in_flight` hits in `scheduler/` are an unrelated homonym.)

`test_nothing_in_the_client_branches_on_a_wait_outcome_by_name` is the assertion that makes it safe to keep claiming — a future client-side list of wait outcomes is the same false-reject trap as a client-side list of tool names.

## Wave-1 item: #989 (`unheard_between` staleness bound) — **NOT taken, deliberately**

The bound itself is a small change in `transcript.py`, which I own. Shipping it is not, and that is the reason:

- `confirm.py:1416-1427` states the residual **at the use site**, in the exact words the module's own test asserts — `test_the_module_states_this_residual_rather_than_the_cheaper_one` requires the strings *"has no staleness bound"*, *"never completes"*, *"until the TTL expires it"* to be present in `confirm.py`.
- Adding the bound makes all three sentences false. Leaving them would ship a lie at the use site, which is the specific failure this module tests for twice over (`test_no_stale_sentence_survives_at_the_use_site`).
- So taking #989 means editing `confirm.py`'s prose and rewriting `TestTheUnheardWindowHasNoStalenessBound` — and `confirm.py` is settled/merged and out of this wave's ownership. Half-taking it is worse than not taking it: any partial fix falsifies the same paragraph.

**Free analysis for whoever picks it up.** There are two distinct shapes hiding under one name, and only one of them needs a bound:

1. **Transcribed, but empty.** A cough that ASR renders as `""` is `complete == False`, so it sits in `unheard_between` forever. This needs no staleness bound at all — it needs `transcribe()` to record that a transcript event *arrived*, and `unheard_between` to filter on that rather than on non-empty text. Zero false-reject cost: an empty transcript is positively known to carry no denial (and `carries_denial` could never have seen it anyway).
2. **Never transcribed at all** — the shape the pinned test builds (`speech_started`, no commit, no transcript). This is the one that needs a real bound, and the bound should key on whether the audio buffer CLOSED: with a `commit_seq` the transcript is genuinely overdue after ASR latency; without one the owner may still be mid-utterance and the bound must exceed a plausible utterance length. One flat wall-clock age cannot price both without being wrong at one end.

Related, and worth noting for that issue: this PR's epoch **narrows** #989, but the first version of this sentence over-claimed and the reviewer is correcting #989 accordingly. The accurate statement is: **the loop survives only for a proposal anchored in the SAME page load as the never-completing entry.** A stale entry is below a *newly* anchored proposal's window — but a proposal anchored BEFORE the reload keeps its old anchor, so an entry from that same pre-reload epoch is still inside its window and still loops it. The epoch buys the new-proposal case only.

## Item 8 (echoed denial vetoes a legitimate approval) — filed as #992

Both mitigations the review named end in `confirm.py`'s `later` scan; recording a flag nothing reads would be dead code. #992 carries the analysis, including the false-reject half that makes it a real decision (the owner *can* legitimately barge in over the fallback voice, so any "transcribed during fallback speech doesn't count as a denial" rule drops a genuine take-back and the write goes out).

## Method

Every new test was run RED against the unchanged code first. Every fix was then mutation-checked — the mutation applied, the targeted test class run, the mutation reverted:

| Mutation | Result |
|---|---|
| owner-deferral condition → `if (false)` | 2 failed |
| `stopped` check removed from `pollOnce` | 2 failed |
| `teardown` no longer disarms | 3 failed |
| stopword weighting removed | 2 failed |
| `noticeFailed` neutered | 1 failed |
| `MINT_SEQ_GAP` removed from `mint()` | 2 failed |
| `anchorPending()` → `return false` | 2 failed |
| new `canInterrupt` legs removed | 2 failed |
| client `seqCounter = session.seq_base` → `= 0` | 2 failed |

Two tests exist purely to kill this PR's own false negatives: `test_a_successful_one_still_reports_spoken_only` (would `onNotSpoken` fire on the success path, every item-5 test would pass for the wrong reason) and `test_without_the_release_it_is_suppressed_forever` (the retry control).

One pre-existing test was rewritten rather than deleted: `test_the_page_wires_the_interrupt_gate_without_the_chatter_leg` pinned `canInterrupt`'s literal line, which made adding a handshake leg indistinguishable from reinstating the chatter leg. It now asserts the legs it must have and the legs it must not.

**Not verifiable in-worktree:** the browser half — a real reload against a live bridge, and a real `speechSynthesis` `onerror`. The node harness runs the byte-identical page JS and the page-source pins cover the wiring, but neither drives a browser.


---

## Review round 2 — all seven findings addressed

Full suite re-run on the CI invocation: **5744 passed, 36 skipped, 0 failed** (+29 tests over round 1). Every new test watched failing first; every fix mutation-checked, including the two findings that were *unpinned rather than absent*.

### The three blockers

**F1 — the epoch is now reserved atomically.** New `TranscriptRing.reserve_epoch(gap, ceiling)` does the read and the write under one lock; `mint()` calls it instead of `high_seq` + `note_seq`. You are right that "not observed" is the argument this module refuses elsewhere and that I leaned on `TestSingleUseIsClaimedNotJudged`'s reasoning myself — the same standard applies here. The test forces the window open rather than racing for it: a ring subclass whose `high_seq` **read** sleeps 50ms, two concurrent mints, assert distinct bases. A reserve that holds one lock across both never calls that property at all, so the window it opens cannot exist. Plus a 24-thread disjointness test asserting consecutive bases are a whole gap apart, not merely distinct. The docstring's unconditional "two tabs get non-overlapping numeric ranges" is true again.

**F2 — the surviving mutation is dead.** `test_the_error_handler_invokes_the_failure_callback` pins that `utterance.onerror`'s body calls `onSpeakFailed()`, with `test_the_success_handler_still_invokes_the_spoken_one` as its control (an assertion looking only at `onerror` would pass just as well with `onend` gutted). You are right this was not the unverifiable browser half — it is the same page-source technique `seq_base` already uses, and I should have applied it to the one line the whole item hangs on. Confirmed: deleting the call now fails 1 test.

**F3 — a failed stray goes back in the array.** `meta.strayIds` rides along from the poll that pulled them (only that poll knows which announced ids came out of `strays`), and `noticeFailed` pushes the `inboxMsgs` body back — idempotently, with `seen` still outranking it. Four tests: re-announced, back in the array (not merely re-announced once and gone), not doubled on a second call, and two controls — a heard stray is never put back, and a *spool* message is not pushed into `strays` (it needs only the `inFlight` release, since the cursor never moved; pushing it too would double-announce once the cursor advances).

### The two "fix or narrow"

**F4 — fixed, and the fixture was fixed first.** New `speaking` list, marked before `speak()` and cleared by whichever of onend / onerror / watchdog arrives first; it feeds both `anchorPending()` and `pending()` (the same window is open on the full gate — a notice volunteered mid-fallback talks straight over the buddy's own voice). Your point about the fixture is the reason this is ordered that way: the harness now has `speakDefers` / `finishSpeech`, and the pin carries an explicit control (`test_the_control_that_the_old_fixture_could_not_have_caught`) documenting that the synchronous fixture reads identical either way, so it cannot be quietly reverted to the cheaper shape.

One thing this fix needed that the finding did not name: `speechSynthesis` can drop an utterance without firing **either** end event, and since this window now gates volunteering, believing it forever would be an *unbounded* mute — strictly worse than the one interjection it prevents. So the belief expires (`speakingMaxMs`, `fallbackMs * 5`), with a test for the expiry and a control asserting a normal utterance leaves no watchdog armed. That gap was itself found by mutation: my first pass left the watchdog unpinned.

**F5 — claim corrected and pinned.** Your trace is right: 6/12/18/24s silent, 30s spoken. The stacking is *correct* — the two deferrals answer different questions ("is the owner talking" vs "is this our own audio still playing") and sharing a budget would let a monologue consume the grace that stops the buddy speaking over itself — so what was wrong was the arithmetic, not the design. The comment now says `fallbackMs * (2 + maxOwnerDeferrals)`, and `test_the_worst_case_is_five_intervals` asserts fire-by-fire so the number is under test rather than asserted in prose.

**F6 — the dedup half is pinned.** You are right that my mutation table only covered the stopword half, and that the two are not equivalent. The natural failing shape is a proposal announcement that repeats its nonce for clarity ("Say confirm tango. Again, that's confirm tango. To send it, say confirm tango.") — a one-line model echo of just `confirm tango` scores exactly 0.6 without the dedup and **anchors** the proposal. Pinned, with the false-reject control that the same line said in full still disarms. Confirmed: dropping `uniq` now fails.

**F7 — bounded at both ends.** `MAX_SEQ = 2**45`. Sequences above it are **refused, not clamped** (clamping still walks `high_seq` toward the ceiling, and a silently-altered sequence is a silently-altered ordering) on all four inputs — `speech_started_seq`, `commit_seq`, the transcript form, and `/anchor`. `mint()` refuses an exhausted space *before* spending the API key, and the page now requires `Number.isSafeInteger(session.seq_base)`, since `typeof Infinity === "number"` passed the old guard. The false-reject half is priced by the headroom: 2**45 is 35M mints of room and stays 256× clear of the page's safe-integer limit, so nothing real approaches it — asserted, not asserted-in-prose (`test_an_ordinary_sequence_is_untouched`, `test_the_ceiling_stays_inside_what_the_page_can_count`).

And the docstring sentence you flagged is gone. "A gap costs nothing — the sequence is a Python int compared for order, never a size" was true only before `seq_base` existed; `MAX_SEQ`'s docstring now states exactly why it stopped being true.

### Round-2 mutation table

| Mutation | Result |
|---|---|
| `reserve_epoch` → back to read-then-write | 3 failed |
| `onSpeakFailed()` deleted from `utterance.onerror` | 1 failed |
| stray push-back removed from `noticeFailed` | 3 failed |
| `speaking.push(item)` removed | 2 failed |
| `anchorPending()` ignores `speaking` | 1 failed |
| watchdog never armed | 1 failed |
| watchdog no longer clears `speaking` | 1 failed |
| `uniq` dropped from `want` | 1 failed |
| `MAX_SEQ` ceiling removed from `_seq` | 3 failed |
| `Number.isSafeInteger` → `typeof === "number"` | 1 failed |

---

## Review round 3 — N1, N2, N3

**5753 passed, 36 skipped, 0 failed.** No behaviour change except N3's scaling.

**N1 — the test that pinned nothing.** You are right, and it is the worse kind of miss: it was counted. The trailing `pollOnce()` laundered the array back to 0 either way — the poll pulls the wrongly-restored stray, drops it for being `seen`, and leaves identical observable state. The array is now read at the moment of the release, and I added the discriminator the original lacked (`test_the_same_shape_unheard_DOES_come_back`): without it, the assertion could pass simply because nothing is ever restored, which is the same failure one layer up. Guard unchanged — confirmed removing `if (seen[id]) return;` now fails.

**N2 — `reserve_epoch` reserves a block, so the ceiling test is `base + gap`.** Fixed, and the false-reject half is pinned alongside it: a reservation that genuinely fits must not be refused a whole epoch early. You are right that unreachability is not the argument — the method's own first sentence claims a block, so the code has to reserve one.

**N3 — scaled, not narrowed.** I took the fix rather than the sentence, because the fire is not inert: it reopens both gates and lets the *model* start a response over the browser voice, which is the two-voices defect reached through the mechanism added to bound a mute. `speakingBudget(text)` = 30s floor + 140ms/char. The rate deliberately errs **slow** (~7 chars/sec against a real ~15) because the directions are not symmetric — over-estimating only delays a backstop that matters when the browser has already dropped the utterance, while under-estimating overlaps two voices on every ordinary long notice. Five 240-char messages now budget >80s. Pinned with both halves: the long case exceeds a realistic duration, and a short notice still gets the floor.

| Mutation | Result |
|---|---|
| `if (seen[id]) return;` removed | 1 failed |
| ceiling test back to `base > ceiling` | 1 failed |
| watchdog flat again | 4 failed |
| rate set to a real voice speed (15ms/char) | 2 failed |
| `speakingBudget` not used at the call site | 4 failed |

Noted, no action: N4 is an equivalent mutant as you say (a bool reaches the ring as seq 1, fail-closed). N5's four unpinned browser-event wires predate this PR — thanks for filing separately rather than folding them in here.

Closes #978

Built by [dotdev.dev](https://dotdev.dev)

