### PR TITLE
voice-layer W2: tool surface & outbox — record the spec's shape, stop over-claiming delivery, drop @machine (#979)

### DIFF
--- a/agentwire/voice_layer/outbox.py
+++ b/agentwire/voice_layer/outbox.py
@@ -8,21 +8,41 @@ is the instrument.
 
 **Recorded, not reconstructed.** :func:`record_write` is called from the one
 place a buddy write executes — ``ConfirmSpine.confirm``, right after the
-runner returns — and what it records is the executed argv itself. The body is
-``argv[-1]``, the exact rendered string the CLI received, never a re-render
-from the proposal: ``render_body`` is under active change (#953), and a
-reconstruction would quietly diverge from what actually went out, which is the
-precise failure this exists to end. Where the argv and the proposal disagree,
-the record sides with the argv.
+runner returns — and what it records is the executed argv itself. For a write
+that carries a body, the body is ``argv[-1]``: the exact rendered string the
+CLI received, never a re-render from the proposal, because ``render_body`` is
+under active change (#953) and a reconstruction would quietly diverge from
+what actually went out. Where the argv and the proposal disagree, the record
+sides with the argv.
+
+**Which writes have a body is the SPEC's answer, not the argv's** (#979).
+``argv[-1]`` is the body of a ``msg send``; for an ``append_body=False``
+write it is a session name or a flag value, and recording that as "the body"
+would be a confident, specific lie — the instructions tell the model to quote
+this field verbatim as the authoritative answer to "what did I send". So
+:func:`record_write` reads ``proposal.append_body`` and records no body at all
+where there is none, plus the flag itself so a reader can tell "no body" from
+"body not recorded".
 
 **Delivery state is computed at read time, never stored.** A message's state
 changes after the write returns — queued now, delivered or dead-lettered
 later — so a stored state is a lie with a timestamp. :func:`delivery_state`
 asks the recipient's real inbox (the same store ``agentwire msg inbox`` and
 ``msg dead`` read): still pending → ``queued``; in the graveyard →
-``dead_lettered`` with the drop reason; neither → ``delivered``, because the
-drain removes a message from pending only by delivering it or dead-lettering
-it. A write whose dispatch failed short-circuits to ``dispatch_failed``.
+``dead_lettered`` with the drop reason.
+
+**Neither store matching is NOT proof of delivery** (#979). This module used
+to answer ``delivered`` there, reasoning that the drain removes a message from
+pending only by delivering or dead-lettering it. That is false: ``msg purge``
+drops the pending queue outright and ``msg dead --purge`` clears the
+graveyard — both documented escape hatches, both leaving exactly this trace.
+A purged message and a delivered one are indistinguishable from here, so the
+state is ``no_longer_queued`` and its detail says both halves. The narrower
+claim is not a hedge on the same sentence: the two stores establish that it
+left the queue, and nothing about who read it. Nothing in the inbox records
+per-message delivery (the ``delivered`` event carries a count and kinds, no
+ids), so a positive answer would need a new mechanism, not a bolder reading of
+this one. A write whose dispatch failed short-circuits to ``dispatch_failed``.
 
 **Recording never raises.** It runs after the write has executed. An exception
 here would propagate to the dispatcher's catch-all, which tells the owner
@@ -57,6 +77,10 @@ def record_write(proposal, argv: list, result: dict) -> None:
     try:
         argv = [str(a) for a in argv]
         dispatched = bool((result or {}).get("success", False))
+        # The spec decides, not the argv shape. Absent (a caller with no such
+        # attribute) means the body-carrying default, which is what every
+        # shipped spec is and what ``Proposal`` itself defaults to.
+        append_body = bool(getattr(proposal, "append_body", True))
         entry = {
             "proposal_id": getattr(proposal, "id", "") or "",
             "session": _flag_value(argv, "--to") or getattr(proposal, "session", ""),
@@ -64,7 +88,8 @@ def record_write(proposal, argv: list, result: dict) -> None:
             or str(getattr(proposal, "params", {}).get("_buddy") or ""),
             "kind": _flag_value(argv, "--kind"),
             "instruction": getattr(proposal, "instruction", "") or "",
-            "body": argv[-1] if argv else "",
+            "append_body": append_body,
+            "body": (argv[-1] if argv else "") if append_body else "",
             "argv": argv,
             "ts": time.time(),
             "dispatched": dispatched,
@@ -110,20 +135,27 @@ def delivery_state(entry: dict) -> dict:
     Matches by exact body first, then by the ``#<proposal-id>`` tag — the tag
     survives a change in body shape (#953), so a divergence between the
     recorded body and the enqueued text degrades to a looser match rather than
-    silently reading as ``delivered``.
+    silently reading as having left the queue.
     """
     if not entry.get("dispatched", False):
         return {"state": "dispatch_failed", "detail": str(entry.get("error", ""))}
 
-    if not str(entry.get("kind") or ""):
-        # Not a message handoff (no --kind in the argv): the write completed
-        # when the CLI returned, so there is no queue to interrogate and
-        # "delivered" would be a category error. "executed" is the whole truth.
+    # No body means no message, and therefore no queue to interrogate: the
+    # write completed when the CLI returned. ``append_body`` is the property
+    # that decides it; the empty-``kind`` test is the older proxy for the same
+    # thing, kept for records written before the flag existed and for a
+    # body-carrying argv that never named a kind.
+    if entry.get("append_body") is False or not str(entry.get("kind") or ""):
         return {"state": "executed"}
 
     from .. import inbox  # deferred, matching write_tools — keeps import light
 
-    session = str(entry.get("session") or "").split("@")[0]
+    # The WHOLE name. Stripping `@machine` here read a different session's
+    # local inbox and reported its state as this message's; `inbox` keys on
+    # the whole string, so this is the only question that can answer about
+    # this message. Remote targets are refused upstream now (#979) — this
+    # matters for records written before that ruling.
+    session = str(entry.get("session") or "")
     body = str(entry.get("body") or "")
     proposal_id = str(entry.get("proposal_id") or "")
     tag = f"#{proposal_id}" if proposal_id else ""
@@ -143,6 +175,14 @@ def delivery_state(entry: dict) -> dict:
                 }
     except Exception as exc:
         # An unreadable inbox is not knowledge. "unknown" is the honest state;
-        # guessing "delivered" here would be the confabulation with extra steps.
+        # guessing here would be the confabulation with extra steps.
         return {"state": "unknown", "detail": f"could not check the inbox: {exc}"}
-    return {"state": "delivered"}
+    return {
+        "state": "no_longer_queued",
+        "detail": (
+            f"not waiting in {session}'s inbox and not in its dead-letter store. "
+            "That is what a delivered message looks like, and also what one looks "
+            "like after a purge — so it is no longer queued, and whether it was "
+            "read is not something this can tell you."
+        ),
+    }

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -68,18 +68,34 @@ with no reason is re-argued at the next reading:
   this entry is the only guard, and a nonce is the wrong guard: the harness
   boundary is not a thing the owner should be able to approve their way past.
 
-**Remote targets are out of scope (owner ruling, 2026-08-09).** A ``@machine``
-suffix is not accepted anywhere on the voice surface: ``tools._SESSION_RE`` no
-longer matches it and ``tools._session_arg`` refuses it in its own words, out
-loud (``REMOTE_REFUSAL``). The syntax was half-supported and wrong in
-three directions at once: ``inbox.enqueue`` keyed an inbox dir on the raw
-string, ``outbox.delivery_state`` stripped the suffix and interrogated the
+**Remote ``name@machine`` targets are out of scope (owner ruling, 2026-08-09),
+and the gate is LIVENESS, not the ``@`` character.** The syntax was
+half-supported and
+wrong in three directions at once: ``inbox.enqueue`` keyed an inbox dir on the
+raw string, ``outbox.delivery_state`` stripped the suffix and interrogated the
 LOCAL inbox, and ``write_tools._require_live`` checked the bare half against
-LOCAL tmux and so refused a live remote session with a confidently false
-"nothing is listening". ``core.session_metadata_path`` still strips ``@`` —
-that is the store's own keying rule (#899/#988) and is unrelated to what this
-layer admits. Re-adding remotes is its own reviewed slice: a remote liveness
-probe, remote inbox interrogation, and tests for both.
+LOCAL tmux — refusing a live remote session with a confidently false "nothing
+is listening". Every layer now asks about the WHOLE name.
+
+The first attempt at enforcing the ruling refused any name containing ``@``,
+and that was itself a false statement: ``@`` does not mean remote. tmux accepts
+it verbatim (only ``.`` and ``:`` are rewritten, #878) and ``inbox._SESSION_RE``
+admits it, so ``ops@edge`` is a creatable, addressable LOCAL session that the
+buddy told the owner was unreachable — a confident falsehood with no move from
+it, which is the expensive failure in a channel with no screen. So
+``tools._session_arg`` validates the SHAPE first (a garbled name containing an
+``@`` is a mis-transcription and gets the mis-transcription answer), then
+consults ``inbox.live_sessions()``: a whole name local tmux reports live is
+local by demonstration and is allowed. What that refuses is exactly a name
+nothing local answers to — every genuinely remote target — stated as the one
+thing measured ("no live session called X on this machine") rather than as a
+diagnosis of where it lives. An unreachable tmux proves nothing and so refuses
+nothing (spec §5).
+
+``core.session_metadata_path`` still strips ``@`` — that is the store's own
+keying rule (#899/#988) and is unrelated to what this layer admits. Reaching a
+remote session remains its own reviewed slice: a remote liveness probe, remote
+inbox interrogation, and tests for both.
 
 **Reads (tier 1)** — anything that only observes. Expand freely: a read the
 buddy lacks is just a question it has to deflect.
@@ -117,6 +133,18 @@ tool appears in exactly one tier" was true of tools nobody had graded.
 :data:`VOICE_NATIVE` carries a written grade for the ones that map to none;
 :func:`unruled_tools` is what the audit calls, so a new voice-native tool is
 red until someone rules on it.
+
+**That map is checked against reality, not just against itself.** Every leg
+that reads :data:`TOOL_CAPABILITY` believes it, so a wrong entry —
+``fleet_session_output`` pointed at ``sessions_list`` — left the whole suite
+green and made "a wired tool's tier is derivable" mean "a hand-written map
+nothing checks", which is the same over-claim this module polices one level
+up. The audit now runs each read tool with the CLI stubbed and compares the
+argv it really builds against the argv the mapped MCP capability builds. One
+entry cannot be corroborated that way: ``wiki_query`` builds no extractable
+argv, so ``fleet_wiki_search``'s mapping rests on reading it. That exemption is
+allowed only for capabilities the analyzer already records as unanalyzable, and
+it is stated here rather than left as a silent pass.
 
 One light write IS wired: ``buddy_inbox(ack=true)`` advances the buddy's own
 read cursor. Light because the message itself is untouched — the same tool with

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -140,11 +140,25 @@ that reads :data:`TOOL_CAPABILITY` believes it, so a wrong entry —
 green and made "a wired tool's tier is derivable" mean "a hand-written map
 nothing checks", which is the same over-claim this module polices one level
 up. The audit now runs each read tool with the CLI stubbed and compares the
-argv it really builds against the argv the mapped MCP capability builds. One
-entry cannot be corroborated that way: ``wiki_query`` builds no extractable
-argv, so ``fleet_wiki_search``'s mapping rests on reading it. That exemption is
-allowed only for capabilities the analyzer already records as unanalyzable, and
-it is stated here rather than left as a silent pass.
+argv it really builds against the argv the mapped MCP capability builds.
+
+**Where that check has no purchase, stated at its real size.** Fifteen
+capabilities build no argv the analyzer can extract — nine ``desktop_*``,
+``desktop_write_artifact``, ``notify_user``, ``transcribe``, and ``wiki_lint``
+/ ``wiki_query`` / ``wiki_status`` — and a mapping onto any of them is
+unfalsifiable, not verified. Three of the fifteen are tier READ, so the
+exemption is granted per (tool, capability) PAIR and asserted set-equal
+(``_UNCORROBORATED`` in the audit), never per capability name: name-scoped, one
+recorded exemption silently covered all fifteen, and any future tool mapped to
+``wiki_lint`` or ``wiki_status`` would have been graded read with nothing able
+to contradict it. Exactly one wired mapping needs it today —
+``fleet_wiki_search`` → ``wiki_query`` — and that one rests on a human having
+read it.
+
+A weaker residual, unfixed and named: the comparison is a prefix match, so a
+capability whose extracted argv is a single token (``panes_list`` builds
+``["info"]``) corroborates any voice argv starting with that token. It
+discriminates less than the others; it is not nothing.
 
 One light write IS wired: ``buddy_inbox(ack=true)`` advances the buddy's own
 read cursor. Light because the message itself is untouched — the same tool with

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -48,6 +48,39 @@ omission. A capability is excluded when it:
     artifacts; producing work makes it a place work happens.
 (e) **mutates infrastructure identity** — ``machine_add``/``remove``.
 
+Two rulings from the wave-2 review (#979), recorded here because a tier move
+with no reason is re-argued at the next reading:
+
+- **``scheduler_report`` is EXCLUDED, not a read** — clauses (d) and (b).
+  The name says report and the return value says summary, but the call writes
+  an HTML artifact into ``~/.agentwire/artifacts/`` and, with ``artifact=True``,
+  pushes a click-to-open portal notification at the owner. That is authored
+  work product plus a second output channel. Nothing about it is undone by one
+  action of the same kind, and "expand reads freely" would have wired it
+  confirm-free on the strength of the verb. The buddy answers scheduler
+  questions from ``scheduler_history``/``board``, which observe and no more.
+- **``pane_detach`` is EXCLUDED, not gated** — clause (a). Its own docstring
+  says the target session is "created if doesn't exist", so a mis-heard target
+  name does not misfire a move: it INSTANTIATES a session, one with no #871
+  metadata record behind it and therefore no conversation identity, no
+  recorded role, and nothing for ``restart`` to regenerate. The dispatch-path
+  analyzer cannot see this one (no ``build_agent_command`` on that path), so
+  this entry is the only guard, and a nonce is the wrong guard: the harness
+  boundary is not a thing the owner should be able to approve their way past.
+
+**Remote targets are out of scope (owner ruling, 2026-08-09).** A ``@machine``
+suffix is not accepted anywhere on the voice surface: ``tools._SESSION_RE`` no
+longer matches it and ``tools._session_arg`` refuses it in its own words, out
+loud (``REMOTE_REFUSAL``). The syntax was half-supported and wrong in
+three directions at once: ``inbox.enqueue`` keyed an inbox dir on the raw
+string, ``outbox.delivery_state`` stripped the suffix and interrogated the
+LOCAL inbox, and ``write_tools._require_live`` checked the bare half against
+LOCAL tmux and so refused a live remote session with a confidently false
+"nothing is listening". ``core.session_metadata_path`` still strips ``@`` —
+that is the store's own keying rule (#899/#988) and is unrelated to what this
+layer admits. Re-adding remotes is its own reviewed slice: a remote liveness
+probe, remote inbox interrogation, and tests for both.
+
 **Reads (tier 1)** — anything that only observes. Expand freely: a read the
 buddy lacks is just a question it has to deflect.
 
@@ -73,10 +106,25 @@ target or wrong verb costs, not on how scary the verb sounds:
 Tiering is capability classification; WIRING is a separate, smaller set.
 ``tools.READ_ONLY_TOOLS`` and ``write_tools.WRITE_SPECS`` hold what is live;
 everything live must map into tier 1 or 2, and a test asserts the excluded
-names are absent from the realtime surface BY NAME. Light writes are graded
-but currently none are wired: the candidates (desktop arrangement, tab
-tracking) have no CLI verb, and the voice layer dispatches only through the
-CLI (see ``tools.py``'s module docstring for why).
+names are absent from the realtime surface BY NAME.
+
+**Voice-native tools are ruled here too** (#979). The tier sets above are keyed
+on MCP capability names, and for a while the audit swept exactly those — a
+namespace that is not the exposed surface. ``buddy_inbox``, ``buddy_sent`` and
+``fleet_pull_requests`` have no MCP capability behind them at all, so "every
+tool appears in exactly one tier" was true of tools nobody had graded.
+:data:`TOOL_CAPABILITY` maps each wired tool to the capability it exposes and
+:data:`VOICE_NATIVE` carries a written grade for the ones that map to none;
+:func:`unruled_tools` is what the audit calls, so a new voice-native tool is
+red until someone rules on it.
+
+One light write IS wired: ``buddy_inbox(ack=true)`` advances the buddy's own
+read cursor. Light because the message itself is untouched — the same tool with
+``unread_only=false`` reads it straight back — so the worst wrong execution
+loses a read marker, not mail, and a nonce on "what's in my inbox" is the
+reflex-training a light grade exists to avoid. The other candidates (desktop
+arrangement, tab tracking) remain unwired: they have no CLI verb, and the voice
+layer dispatches only through the CLI (see ``tools.py``'s module docstring).
 """
 
 from __future__ import annotations
@@ -87,7 +135,7 @@ TIER_READ = frozenset({
     "diff", "panes_list", "pane_output",
     "worktree_list", "worktree_status",
     "scheduler_status", "scheduler_board", "scheduler_live",
-    "scheduler_events", "scheduler_history", "scheduler_report",
+    "scheduler_events", "scheduler_history",
     "task_list", "task_show", "task_validate",
     "machines_list", "services_list", "services_status",
     "history_list", "history_show",
@@ -116,7 +164,7 @@ TIER_WRITE_LIGHT = frozenset({
 #: or destroys something. Only ever reachable through the confirm spine.
 TIER_WRITE_GATED = frozenset({
     "msg_send",
-    "session_kill", "pane_kill", "pane_detach",
+    "session_kill", "pane_kill",
     "worktree_remove", "worktree_prune",
     "lock_clean", "lock_remove",
     # msg_pull reads AND REMOVES another session's ingest messages (it takes
@@ -139,6 +187,9 @@ TIER_EXCLUDED = frozenset({
     "session_create", "session_recreate", "session_fork",
     "session_send", "session_send_keys",
     "pane_spawn", "pane_send", "pane_split",
+    # pane_detach's target session is "created if doesn't exist" — clause (a)
+    # under a name that reads like a move (#979).
+    "pane_detach",
     "worktree_create", "history_resume", "wait_children",
     "task_run", "scheduler_run",
     "council_start", "council_stop", "council_ask",
@@ -150,11 +201,102 @@ TIER_EXCLUDED = frozenset({
     "email_send", "quo_send",
     # (d) authors work product
     "handoff_init", "handoff_render", "desktop_write_artifact",
+    # scheduler_report writes an HTML artifact and can push a portal
+    # notification — (d) plus (b), whatever the verb sounds like (#979).
+    "scheduler_report",
     # (e) mutates infrastructure identity
     "machine_add", "machine_remove",
 })
 
 ALL_TIERS = (TIER_READ, TIER_WRITE_LIGHT, TIER_WRITE_GATED, TIER_EXCLUDED)
+
+#: Wired voice tool → the MCP capabilities it exposes, so a WIRED tool's tier
+#: is derivable rather than assumed from its ``fleet_`` prefix. Writes are
+#: keyed by their ``send_<spec>`` name — the step that executes.
+TOOL_CAPABILITY: dict[str, tuple[str, ...]] = {
+    "fleet_sessions": ("sessions_list",),
+    "fleet_worktrees": ("worktree_list",),
+    "fleet_dangling": ("worktree_list",),
+    "fleet_scheduler": ("scheduler_board",),
+    "fleet_projects": ("projects_list",),
+    "fleet_dead_letters": ("msg_dead",),
+    "fleet_session_output": ("session_output",),
+    "fleet_session_info": ("session_info",),
+    "fleet_scheduler_status": ("scheduler_status",),
+    "fleet_scheduler_history": ("scheduler_history",),
+    "fleet_scheduler_live": ("scheduler_live",),
+    "fleet_tasks": ("task_list",),
+    "fleet_machines": ("machines_list",),
+    "fleet_services": ("services_status",),
+    "fleet_history": ("history_list",),
+    "fleet_locks": ("lock_list",),
+    "fleet_portal": ("portal_status",),
+    "fleet_councils": ("council_list",),
+    "fleet_wiki_search": ("wiki_query",),
+    "fleet_session_inbox": ("msg_inbox",),
+    "fleet_roles": ("roles_list",),
+    "fleet_network": ("network_status",),
+    "fleet_voice_health": ("tts_status", "stt_status"),
+    "send_session_message": ("msg_send",),
+}
+
+#: Wired tools with NO MCP capability behind them. The tier sets cannot grade
+#: these — nothing to look up — so the grade is written out here, with its
+#: reason, and :func:`unruled_tools` makes an ungraded one fail the audit.
+VOICE_NATIVE: dict[str, dict] = {
+    "fleet_pull_requests": {
+        "grade": "read",
+        "ruling": (
+            "Runs `gh pr list --json` in a subprocess: no agentwire capability "
+            "exists for it, and it only observes. Read by the tier-1 rule. The "
+            "repo is validated to `owner/name` and never defaulted from a cwd, "
+            "because the buddy has no checkout to be wrong about."
+        ),
+    },
+    "buddy_inbox": {
+        "grade": "write_light",
+        "ruling": (
+            "Reads the buddy's own spool, and with ack=true advances its read "
+            "cursor — a mutation, from the read-only allowlist. Light, not "
+            "gated: the message is untouched, `unread_only=false` reads it "
+            "straight back, and the worst wrong execution loses a read marker "
+            "rather than mail. A nonce on 'what's in my inbox' would train the "
+            "reflex that makes the gated nonce worthless."
+        ),
+    },
+    "buddy_sent": {
+        "grade": "read",
+        "ruling": (
+            "Reads the buddy's own outbox and computes delivery state from the "
+            "recipient's inbox. Observes only; writes nothing (#958)."
+        ),
+    },
+}
+
+
+def unruled_tools(names) -> dict[str, str]:
+    """Wired tool names with neither a tier nor a voice-native ruling.
+
+    The audit's entry point (#979/5). Sweeping ``@mcp.tool`` names proves
+    things about a namespace that is not the exposed surface; this sweeps what
+    is actually WIRED and demands each name resolve to a written grade.
+    """
+    unruled: dict[str, str] = {}
+    for name in names:
+        native = VOICE_NATIVE.get(name)
+        if native is not None:
+            if native.get("grade") and native.get("ruling"):
+                continue
+            unruled[name] = "voice-native entry with no grade or no ruling"
+            continue
+        capabilities = TOOL_CAPABILITY.get(name)
+        if not capabilities:
+            unruled[name] = "no capability mapping and no voice-native ruling"
+            continue
+        untiered = [c for c in capabilities if tier_of(c) == "untiered"]
+        if untiered:
+            unruled[name] = f"maps to untiered capabilities: {untiered}"
+    return unruled
 
 
 def tier_of(name: str) -> str:

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -40,9 +40,8 @@ from ..mcp_core import run_agentwire_cmd
 from . import delivery, outbox
 from .confirm import strip_controls
 
-# Session names as the inbox defines them, plus the optional `@machine` suffix
-# a remote session carries. Anchored: a partial match is how a fuzzy
-# transcription would slip through.
+# Session names as the inbox defines them — LOCAL names only. Anchored: a
+# partial match is how a fuzzy transcription would slip through.
 #
 # Every segment must START alphanumeric, which is doing two jobs the obvious
 # character class misses (both caught by tests, both real):
@@ -51,13 +50,23 @@ from .confirm import strip_controls
 #   - `.` is a legal name character, so it accepts `../etc/passwd`.
 # A leading separator is never a real session name, so requiring alphanumeric
 # first closes both without narrowing anything legitimate.
-_SESSION_RE = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*"
-    r"(?:@[A-Za-z0-9][A-Za-z0-9._-]*)?$"
-)
+#
+# The `@machine` suffix a remote session carries used to be admitted here, and
+# the owner ruled it out of scope on 2026-08-09 (see `surface`'s docstring for
+# the ruling and the three wrong answers half-support produced). Removing it
+# from the pattern is what makes the refusal complete: no path in this layer
+# accepts the syntax, so nothing downstream has to decide what a suffix it
+# cannot honor means. `REMOTE_REFUSAL` gives that refusal its own words —
+# "not a valid session name" would send the owner round the loop
+# re-pronouncing a name that was transcribed perfectly.
+_SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$")
 
 #: `owner/name`, the only form `gh --repo` should ever receive from a model.
-_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+#: Both segments start alphanumeric, for the same reason `_SESSION_RE`'s do —
+#: `-x/y` is not a repository, and a pattern that admits a leading dash while
+#: the file two paragraphs up calls that rule load-bearing is the kind of
+#: inconsistency the next copy of the pattern inherits (#979).
+_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 _MAX_OUTPUT_LINES = 200
 _MAX_PR_LIMIT = 50
@@ -76,8 +85,20 @@ class ToolError(Exception):
     """
 
 
+#: Spoken when the owner names a remote target. Its own message, not the
+#: generic one: the transcription was RIGHT and repeating it cannot help, so a
+#: refusal that says "invalid name" is a silent loop with extra steps.
+REMOTE_REFUSAL = (
+    "I can only reach sessions on this machine — remote sessions like '{value}' "
+    "aren't reachable by voice yet. Name a local session, or ask a session on "
+    "this machine to do it."
+)
+
+
 def _session_arg(args: dict, key: str = "session") -> str:
     value = args.get(key)
+    if isinstance(value, str) and "@" in value:
+        raise ToolError(REMOTE_REFUSAL.format(value=strip_controls(value)[:60]))
     if (
         not isinstance(value, str)
         or not _SESSION_RE.match(value.strip())
@@ -475,11 +496,18 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
         name="buddy_sent",
         description=(
             "Messages YOU have sent, newest first: the exact body that went out, "
-            "who it went to, and its current delivery state (queued, delivered, "
-            "dead_lettered, or dispatch_failed). This is the answer to any "
-            "question about a message you sent — what it said, whether something "
-            "was in it, what happened to it. Quote the body from here; never "
-            "answer from memory or by reading the recipient's terminal."
+            "who it went to, and its current delivery state. Quote the body from "
+            "here; never answer from memory or by reading the recipient's "
+            "terminal. The states, and exactly what each one licenses you to "
+            "say: 'queued' — still waiting in their inbox, not read yet; "
+            "'dead_lettered' — it failed and was dropped, say so and say why "
+            "(the reason is in detail); 'dispatch_failed' — it never went out "
+            "at all; 'executed' — the command ran and carried no message body; "
+            "'no_longer_queued' — it has left their queue, which is what "
+            "delivery looks like AND what a purge looks like, so say it is no "
+            "longer waiting and that you cannot confirm they read it; "
+            "'unknown' — you could not check. Never upgrade one of these to "
+            "'delivered'; that word claims more than anything here establishes."
         ),
         run=_buddy_sent,
         parameters={

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -40,8 +40,8 @@ from ..mcp_core import run_agentwire_cmd
 from . import delivery, outbox
 from .confirm import strip_controls
 
-# Session names as the inbox defines them — LOCAL names only. Anchored: a
-# partial match is how a fuzzy transcription would slip through.
+# Session names as the inbox defines them. Anchored: a partial match is how a
+# fuzzy transcription would slip through.
 #
 # Every segment must START alphanumeric, which is doing two jobs the obvious
 # character class misses (both caught by tests, both real):
@@ -51,22 +51,30 @@ from .confirm import strip_controls
 # A leading separator is never a real session name, so requiring alphanumeric
 # first closes both without narrowing anything legitimate.
 #
-# The `@machine` suffix a remote session carries used to be admitted here, and
-# the owner ruled it out of scope on 2026-08-09 (see `surface`'s docstring for
-# the ruling and the three wrong answers half-support produced). Removing it
-# from the pattern is what makes the refusal complete: no path in this layer
-# accepts the syntax, so nothing downstream has to decide what a suffix it
-# cannot honor means. `REMOTE_REFUSAL` gives that refusal its own words —
-# "not a valid session name" would send the owner round the loop
-# re-pronouncing a name that was transcribed perfectly.
-_SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$")
+# `@` is admitted inside a segment. Remote `name@machine` targets are out of
+# scope (owner ruling, 2026-08-09) — but `@` does NOT mean
+# remote, and a gate keyed on the character told the owner a true local name
+# was unreachable. tmux accepts `@` verbatim (only `.` and `:` are rewritten,
+# #878) and `inbox._SESSION_RE` admits it, so `ops@edge` is a creatable,
+# addressable LOCAL session, and refusing it as "remote" is a confident
+# falsehood the owner has no move from — the expensive failure with no screen.
+#
+# So the SHAPE is validated here and the RULING is enforced by liveness in
+# `_session_arg`: a whole name tmux reports live is local by demonstration.
+# What that refuses is precisely a name nothing local answers to, which is
+# every genuinely remote target, said without claiming to know why.
+_SESSION_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._@-]*(?:/[A-Za-z0-9][A-Za-z0-9._@-]*)*$"
+)
 
 #: `owner/name`, the only form `gh --repo` should ever receive from a model.
-#: Both segments start alphanumeric, for the same reason `_SESSION_RE`'s do —
-#: `-x/y` is not a repository, and a pattern that admits a leading dash while
-#: the file two paragraphs up calls that rule load-bearing is the kind of
-#: inconsistency the next copy of the pattern inherits (#979).
-_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+#: The leading-alphanumeric rule binds the OWNER only, which is where GitHub
+#: actually constrains it (logins are alphanumeric-and-hyphen). REPOSITORY
+#: names may begin with `.`, `_` or `-` — `github/.github` is real — so
+#: extending the rule across the slash for symmetry would refuse real
+#: repositories to close a value-position flag the owner segment already
+#: closes (#979, wave-2 review).
+_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+$")
 
 _MAX_OUTPUT_LINES = 200
 _MAX_PR_LIMIT = 50
@@ -85,30 +93,53 @@ class ToolError(Exception):
     """
 
 
-#: Spoken when the owner names a remote target. Its own message, not the
-#: generic one: the transcription was RIGHT and repeating it cannot help, so a
-#: refusal that says "invalid name" is a silent loop with extra steps.
-REMOTE_REFUSAL = (
-    "I can only reach sessions on this machine — remote sessions like '{value}' "
-    "aren't reachable by voice yet. Name a local session, or ask a session on "
-    "this machine to do it."
+#: Spoken when a well-formed `@` name is not live locally. It states the one
+#: thing that was measured — nothing here answers to that name — and offers the
+#: remote case as a possibility, never as a diagnosis. Asserting "that's remote"
+#: about a name this layer cannot classify is how a correct transcription of a
+#: real local session became an unanswerable refusal.
+UNREACHABLE_AT_REFUSAL = (
+    "There's no live session called '{value}' on this machine. If it's running "
+    "somewhere else, I can't reach other machines yet. If it's local, check "
+    "fleet_sessions and say the name again."
 )
 
 
 def _session_arg(args: dict, key: str = "session") -> str:
     value = args.get(key)
-    if isinstance(value, str) and "@" in value:
-        raise ToolError(REMOTE_REFUSAL.format(value=strip_controls(value)[:60]))
     if (
         not isinstance(value, str)
         or not _SESSION_RE.match(value.strip())
         or ".." in value.split("/")  # belt-and-braces; the pattern already refuses it
     ):
+        # SHAPE first, always. A garbled name that happens to contain an `@`
+        # ("we b at x") is a mis-transcription, not a remote target, and
+        # answering it with the reachability message diagnoses the wrong
+        # problem — the owner is told to check another machine when what they
+        # need is to say the name again.
         raise ToolError(
             f"'{value}' is not a valid session name. Ask which session was meant, "
             "then use the exact name from fleet_sessions."
         )
-    return value.strip()
+    session = value.strip()
+    if "@" in session and not _is_live_locally(session):
+        raise ToolError(UNREACHABLE_AT_REFUSAL.format(value=strip_controls(session)[:60]))
+    return session
+
+
+def _is_live_locally(session: str) -> bool:
+    """Does local tmux report *session*, by its WHOLE name?
+
+    Only POSITIVE knowledge decides, matching ``write_tools._require_live``
+    (spec §5): ``live_sessions()`` returns None when tmux itself is
+    unreachable, which is an outage rather than a verdict, and refusing there
+    would ground every local ``@`` name during a tmux blip. The CLI reports
+    what it finds instead.
+    """
+    from .. import inbox
+
+    live = inbox.live_sessions()
+    return True if live is None else session in live
 
 
 def _int_arg(args: dict, key: str, default: int, lo: int, hi: int) -> int:

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -72,13 +72,22 @@ def _require_live(session: str, cannot: str) -> None:
     POSITIVE knowledge (tmux answered, the target is not in the list) refuses.
 
     *cannot* names what the buddy cannot do instead, spoken verbatim.
+
+    The name is compared WHOLE. It used to be compared as ``split("@")[0]``,
+    from when the voice pattern admitted ``name@machine``: the bare half of a
+    remote name was checked against LOCAL tmux, so a remote session got either
+    a false "nothing is listening" or — worse — a pass, on the strength of a
+    local session that happens to share its name. Remote targets are out of
+    scope (owner ruling, 2026-08-09) and ``_session_arg`` now refuses the
+    syntax outright, so by the time a name reaches here it is local by
+    construction and splitting it could only re-open that gap.
     """
     from .. import inbox
 
     live = inbox.live_sessions()
     if live is None:
         return
-    if session.split("@")[0] not in live:
+    if session not in live:
         raise ToolError(
             f"Nothing is listening — there's no live session called '{session}'. "
             f"Check what's actually running and say the name again. {cannot}"
@@ -176,7 +185,17 @@ def gated_triple(spec: WriteSpec) -> tuple:
             session=frozen.session,
             instruction=frozen.instruction,
             argv_prefix=list(frozen.argv_prefix),
-            params={"session": frozen.session, **frozen.params},
+            # ``_buddy`` rides on EVERY proposal, not just the specs whose argv
+            # happens to carry ``--from``. It is how the outbox attributes an
+            # executed write (#979): a write filed under "unknown" is one the
+            # buddy's own ``buddy_sent`` cannot see, which is the instrument
+            # failing at exactly the question it was built for. A spec's own
+            # params win — freeze is the authority on what it validated.
+            params={
+                "session": frozen.session,
+                "_buddy": args.get("_buddy") or "",
+                **frozen.params,
+            },
             append_body=frozen.append_body,
             success_say=_spec.success_say,
         )

--- a/tests/unit/test_voice_outbox.py
+++ b/tests/unit/test_voice_outbox.py
@@ -46,8 +46,12 @@ def _argv(session="orchestrator", buddy="buddy", body="<voice> hello ┃ #abc123
     ]
 
 
-def _proposal(id="abc123", session="orchestrator", instruction="hello"):
-    return SimpleNamespace(id=id, session=session, instruction=instruction)
+def _proposal(id="abc123", session="orchestrator", instruction="hello",
+              append_body=True, buddy="buddy"):
+    return SimpleNamespace(
+        id=id, session=session, instruction=instruction, append_body=append_body,
+        params={"_buddy": buddy},
+    )
 
 
 # =============================================================================
@@ -107,6 +111,31 @@ class TestRecordWrite:
         entries = outbox.read_outbox("buddy", limit=2)
         assert [e["proposal_id"] for e in entries] == ["id0004", "id0003"]
 
+    def test_an_argv_only_write_records_no_body(self, isolate):
+        """#979/1: `body = argv[-1]` is the msg shape, not the write shape. For
+        an ``append_body=False`` spec the last argv element is a session name
+        or a flag value — and the instructions order the model to quote the
+        recorded body word for word as the authoritative answer to 'what did I
+        send'. The instrument built to end confabulation would have handed it a
+        confidently wrong exact body. There IS no body here, and the record
+        must say so rather than name one."""
+        proposal = _proposal(append_body=False)
+        outbox.record_write(proposal, ["info", "-s", "orchestrator"], {"success": True})
+        (entry,) = outbox.read_outbox("buddy")
+        assert entry["body"] == ""
+        assert entry["append_body"] is False
+        assert entry["argv"] == ["info", "-s", "orchestrator"]
+        assert entry["session"] == "orchestrator"
+
+    def test_a_body_carrying_write_still_records_the_executed_string(self, isolate):
+        """The other half: the fix must not cost the msg shape its verbatim
+        body, which is the whole point of the outbox."""
+        argv = _argv(body="<voice> hello ┃ #abc123")
+        outbox.record_write(_proposal(), argv, {"success": True})
+        (entry,) = outbox.read_outbox("buddy")
+        assert entry["body"] == argv[-1]
+        assert entry["append_body"] is True
+
     def test_corrupt_lines_are_skipped_not_fatal(self, isolate):
         outbox.record_write(_proposal(), _argv(), {"success": True})
         with open(outbox.outbox_path("buddy"), "a", encoding="utf-8") as fh:
@@ -151,8 +180,55 @@ class TestDeliveryState:
         assert state["state"] == "dead_lettered"
         assert "target_gone" in state.get("detail", "")
 
-    def test_neither_pending_nor_dead_reads_as_delivered(self, isolate):
-        assert outbox.delivery_state(self._entry())["state"] == "delivered"
+    def test_neither_store_matches_does_not_assert_delivery(self, isolate):
+        """#979/2. The old claim: 'neither → delivered, because the drain
+        removes a message from pending only by delivering or dead-lettering
+        it.' False — ``msg purge`` drops pending and ``msg dead --purge``
+        clears the graveyard, both documented escape hatches, and both leave
+        exactly this trace. The state now names what the two stores actually
+        establish, and nothing past it."""
+        state = outbox.delivery_state(self._entry())
+        assert state["state"] == "no_longer_queued"
+        assert "delivered" != state["state"]
+        assert state.get("detail", "")
+
+    def test_a_purged_queue_does_not_read_as_delivered(self, isolate):
+        """The concrete failure: the owner purges a wedged queue, asks 'did it
+        get my message?', and hears 'delivered' about a message that was
+        dropped. Same trace as delivery, so the honest answer is the one that
+        does not pick between them."""
+        inbox.enqueue(
+            "orchestrator", "<voice> hello ┃ #abc123", kind="request", sender="buddy"
+        )
+        assert outbox.delivery_state(self._entry())["state"] == "queued"
+        assert inbox.purge_pending("orchestrator") == 1
+        assert outbox.delivery_state(self._entry())["state"] == "no_longer_queued"
+
+    def test_a_recorded_remote_name_interrogates_the_inbox_that_holds_it(self, isolate):
+        """#979/2. The voice surface no longer accepts `name@machine`, but an
+        outbox line written before that ruling still carries one. This used to
+        strip the suffix and read a DIFFERENT session's local inbox — the same
+        recipient name minus the machine — and report its state as this
+        message's. `inbox` keys on the whole string (its own pattern admits
+        `@`), so asking for the whole string is the only question that can
+        return an answer about this message."""
+        inbox.enqueue(
+            "orchestrator@laptop", "<voice> hello ┃ #abc123",
+            kind="request", sender="buddy",
+        )
+        # The local same-named session holds nothing; a strip would read it and
+        # report "left the queue" about a message still sitting in the remote's.
+        assert inbox.list_messages("orchestrator") == []
+        state = outbox.delivery_state(self._entry(session="orchestrator@laptop"))
+        assert state["state"] == "queued"
+
+    def test_an_argv_only_write_reads_as_executed_whatever_its_kind(self, isolate):
+        """``append_body`` is the property that decides whether there is a
+        queue to interrogate; an empty --kind was only a proxy for it. An
+        argv-only write that happens to carry --kind must not be looked up in
+        an inbox it never enqueued into."""
+        entry = self._entry(kind="request", append_body=False)
+        assert outbox.delivery_state(entry)["state"] == "executed"
 
     def test_failed_dispatch_short_circuits(self, isolate):
         state = outbox.delivery_state(self._entry(dispatched=False))

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -21,6 +21,7 @@ import ast
 import itertools
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -121,6 +122,29 @@ class TestTierAudit:
         assert surface.tier_of("session_create") == "excluded"
         assert surface.tier_of("no_such_capability") == "untiered"
 
+    def test_a_report_that_authors_an_artifact_is_not_a_read(self):
+        """#979/3: scheduler_report sat in TIER_READ while it writes an HTML
+        artifact into ~/.agentwire/artifacts/ and can push a click-to-open
+        portal notification — clause (d) and clause (b). 'Expand reads freely'
+        would have wired it confirm-free on the strength of the word report."""
+        assert surface.tier_of("scheduler_report") == "excluded"
+
+    def test_a_detach_that_creates_a_session_is_excluded_not_gated(self):
+        """#979/3: pane_detach's own docstring says the target session is
+        'created if doesn't exist' — clause (a), and the created session has
+        no #871 metadata record. The dispatch-path analyzer cannot see it
+        (no build_agent_command on that path), so the tier entry is the only
+        guard and a nonce is not the right one."""
+        assert surface.tier_of("pane_detach") == "excluded"
+
+    def test_each_reclassification_carries_a_written_ruling(self):
+        """A bare tier move is not a ruling. surface.py is the precedent
+        store, so the reason must be readable in the module that holds the
+        decision — a future reader hits the docstring, not this test."""
+        doc = surface.__doc__ or ""
+        for name in ("scheduler_report", "pane_detach"):
+            assert name in doc, f"{name} moved tier with no written ruling"
+
 
 class TestTierThreeIsUnreachableByName:
     """The design decision, asserted — not inferred from an absence."""
@@ -144,14 +168,14 @@ class TestTierThreeIsUnreachableByName:
 
     def test_every_wired_write_is_tiered_gated(self):
         """A shipped WriteSpec must correspond to a TIER_WRITE_GATED capability."""
-        capability_of = {"session_message": "msg_send"}
         for spec in write_tools.WRITE_SPECS:
-            capability = capability_of.get(spec.name)
-            assert capability is not None, (
+            capabilities = surface.TOOL_CAPABILITY.get(f"send_{spec.name}")
+            assert capabilities, (
                 f"WriteSpec {spec.name} has no declared capability mapping — "
-                "add it here so its tier is auditable"
+                "add it to surface.TOOL_CAPABILITY so its tier is auditable"
             )
-            assert capability in surface.TIER_WRITE_GATED
+            for capability in capabilities:
+                assert capability in surface.TIER_WRITE_GATED
 
     def test_every_wired_read_observes_a_tiered_read(self):
         """No read tool may be named after a write or excluded capability."""
@@ -163,6 +187,62 @@ class TestTierThreeIsUnreachableByName:
                 assert not tool.name.endswith(capability), (
                     f"read tool {tool.name} shadows non-read capability {capability}"
                 )
+
+
+class TestEveryWiredToolIsRuled:
+    """#979/5: the tier audit swept ``@mcp.tool`` names — a namespace that is
+    not the exposed surface. ``buddy_inbox``, ``buddy_sent`` and
+    ``fleet_pull_requests`` have no MCP capability behind them, so 'EVERY tool
+    appears in exactly one tier' was true and beside the point: the next
+    voice-native tool could ship with nothing forcing a grade out of anyone.
+    Concretely ``buddy_inbox(ack=true)`` mutates state from the read-only
+    allowlist."""
+
+    def test_every_wired_tool_maps_to_a_capability_or_a_native_ruling(self):
+        unruled = surface.unruled_tools(
+            [t.name for t in tools.READ_ONLY_TOOLS]
+            + [f"send_{s.name}" for s in write_tools.WRITE_SPECS]
+        )
+        assert unruled == {}, (
+            f"wired tools with no tier and no voice-native ruling: {unruled} — "
+            "rule them in voice_layer/surface.py"
+        )
+
+    def test_no_wired_tool_maps_to_an_excluded_capability(self):
+        """The by-name check catches `propose_worktree_create`; it cannot catch
+        a wired read whose CAPABILITY is excluded under an unrelated name —
+        which is precisely the scheduler_report shape (#979/3)."""
+        wired = {t.name for t in tools.READ_ONLY_TOOLS} | {
+            f"send_{s.name}" for s in write_tools.WRITE_SPECS
+        }
+        for name in wired:
+            for capability in surface.TOOL_CAPABILITY.get(name, ()):
+                assert capability not in surface.TIER_EXCLUDED, (
+                    f"{name} wires excluded capability {capability}"
+                )
+
+    def test_a_new_unruled_tool_turns_this_red(self):
+        """Mutation check: the leg above is worthless if it passes for a name
+        nobody ever ruled on."""
+        unruled = surface.unruled_tools(["fleet_sessions", "buddy_telepathy"])
+        assert set(unruled) == {"buddy_telepathy"}
+
+    def test_a_native_tool_that_mutates_is_ruled_as_a_write(self):
+        """buddy_inbox(ack=true) advances the read cursor. It sits in the
+        read-only allowlist because the WIRING has one shape; its GRADE is a
+        separate question and gets a separate answer."""
+        assert surface.VOICE_NATIVE["buddy_inbox"]["grade"] == "write_light"
+        assert surface.VOICE_NATIVE["buddy_sent"]["grade"] == "read"
+        for ruling in surface.VOICE_NATIVE.values():
+            assert ruling["ruling"].strip(), "a grade with no reason is not a ruling"
+
+    def test_the_docstring_no_longer_claims_no_light_writes_are_wired(self):
+        """The sentence was true when written and false the moment buddy_inbox
+        shipped. Rewritten, not qualified — a stale guarantee gets rounded back
+        up by the next reader."""
+        doc = " ".join((surface.__doc__ or "").split())
+        assert "currently none are wired" not in doc
+        assert "buddy_inbox" in doc
 
 
 # =============================================================================
@@ -285,27 +365,80 @@ def cli_verb_tree() -> dict:
     return tree
 
 
-def mcp_tool_argvs() -> dict[str, list[list]]:
-    """tool name -> the constant-string argv literals its body builds."""
-    package_root = Path(tools.__file__).resolve().parents[1]
-    out: dict[str, list[list]] = {}
-    for path in package_root.glob("mcp_*.py"):
-        for node in ast.parse(path.read_text()).body:
+def mcp_tool_defs(sources: "list[str] | None" = None) -> dict[str, ast.AST]:
+    """tool name -> its ``@mcp.tool``-decorated function node.
+
+    *sources* replaces the packaged ``mcp_*.py`` modules with literal source
+    strings, which is how the must-fail controls below exercise shapes the
+    real package does not currently contain.
+    """
+    if sources is None:
+        package_root = Path(tools.__file__).resolve().parents[1]
+        sources = [p.read_text() for p in package_root.glob("mcp_*.py")]
+    out: dict[str, ast.AST] = {}
+    for source in sources:
+        for node in ast.parse(source).body:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             if not any((isinstance(d, ast.Call) and _call_name(d) == "tool")
                        or (isinstance(d, ast.Attribute) and d.attr == "tool")
                        for d in node.decorator_list):
                 continue
-            argvs = []
-            for sub in ast.walk(node):
-                if (isinstance(sub, ast.List) and sub.elts
-                        and isinstance(sub.elts[0], ast.Constant)
-                        and isinstance(sub.elts[0].value, str)):
-                    argvs.append([e.value if isinstance(e, ast.Constant) else None
-                                  for e in sub.elts])
-            out[node.name] = argvs
+            out[node.name] = node
     return out
+
+
+def mcp_tool_argvs(sources: "list[str] | None" = None) -> dict[str, list[list]]:
+    """tool name -> the constant-string argv literals its body builds.
+
+    **The covered shape, stated** (#979/4): a LIST LITERAL whose first element
+    is a string constant, appearing anywhere in the tool's body. That is the
+    shape ``run_agentwire_cmd(["worktree", ...])`` takes and nothing else. An
+    argv assembled dynamically — built by a helper, extended from a variable,
+    chosen by a branch that stores the verb in a name — contributes NOTHING
+    here, and a tool with no extracted argv is therefore UNCHECKED by the
+    dispatch-path analyzer rather than cleared by it. Those tools are flagged
+    for manual placement by
+    ``TestNoTieredInToolCanCreateASession`` (the manual-placement leg)
+    instead of passing silently, which is the direction this whole check
+    claims to fail in.
+    """
+    out: dict[str, list[list]] = {}
+    for name, node in mcp_tool_defs(sources).items():
+        argvs = []
+        for sub in ast.walk(node):
+            if (isinstance(sub, ast.List) and sub.elts
+                    and isinstance(sub.elts[0], ast.Constant)
+                    and isinstance(sub.elts[0].value, str)):
+                argvs.append([e.value if isinstance(e, ast.Constant) else None
+                              for e in sub.elts])
+        out[name] = argvs
+    return out
+
+
+def in_process_creating_tools(sources: "list[str] | None" = None) -> dict[str, str]:
+    """MCP tool -> the session-creating function it calls IN PROCESS.
+
+    The second blind spot (#979/4): ``session_creating_functions`` deliberately
+    skips ``mcp_*.py`` when building its map, so an MCP tool that reaches a
+    creation helper directly — no CLI dispatch, no argv to walk — was invisible
+    to the whole check. No shipped tool has that shape today; the control below
+    proves the detector would see one, because a check that is silently green
+    and a check that is green because the codebase is clean are the same
+    observation until you force the difference.
+    """
+    # The markers themselves count: they are the creation, so a tool calling
+    # ``build_agent_command`` directly is the shortest possible version of
+    # this path and must not need an intermediary to register.
+    creating = session_creating_functions() | _CREATION_MARKER_CALLS
+    flagged: dict[str, str] = {}
+    for name, node in mcp_tool_defs(sources).items():
+        calls = {n for sub in ast.walk(node)
+                 if isinstance(sub, ast.Call) and (n := _call_name(sub))}
+        hit = sorted(calls & creating)
+        if hit or _spawns_ensure(node):
+            flagged[name] = hit[0] if hit else "agentwire ensure"
+    return flagged
 
 
 #: Dispatches that reach a creating HANDLER in a mode that cannot create:
@@ -315,6 +448,23 @@ def mcp_tool_argvs() -> dict[str, list[list]]:
 _NON_CREATING_MODES = {
     "cmd_worktree": {"--list", "--status", "--remove", "--prune", "--dangling"},
 }
+
+#: MCP tools the dispatch-path analyzer extracts NO argv from, and therefore
+#: never checked — each one placed in its tier by hand, by reading it. They
+#: reach their work through a Python API rather than a CLI argv: the desktop
+#: family writes the portal's window state, the wiki family calls
+#: ``agentwire.wiki`` directly, ``notify_user``/``transcribe`` go through the
+#: portal and the STT backend, ``desktop_write_artifact`` writes a file.
+#: Adding to this set is a claim that a human looked; the leg that asserts it
+#: is the thing stopping a new tool from being unchecked AND unnoticed.
+UNANALYZABLE_TOOLS = frozenset({
+    "desktop_close_window", "desktop_collage", "desktop_focus_window",
+    "desktop_layout", "desktop_minimize_all", "desktop_open_artifact",
+    "desktop_open_panel", "desktop_open_session", "desktop_tile_window",
+    "desktop_write_artifact",
+    "notify_user", "transcribe",
+    "wiki_lint", "wiki_query", "wiki_status",
+})
 
 
 def session_creating_tools() -> dict[str, str]:
@@ -351,6 +501,55 @@ class TestNoTieredInToolCanCreateASession:
         # The two wave-3 escapees, caught by path — not by their names.
         assert flagged.get("task_run") == "cmd_ensure"
         assert flagged.get("scheduler_run") == "cmd_scheduler_run"
+
+    def test_a_tool_with_no_extractable_argv_is_flagged_for_manual_placement(self):
+        """#979/4: the analyzer's covered shape is narrower than 'every MCP
+        tool'. A tool it extracts no argv from is UNCHECKED, and an unchecked
+        tool passing the main assertion is silent green — the exact direction
+        the docstring claims this check avoids. Recorded here so a NEW one
+        fails until a human places it by hand."""
+        unanalyzable = {t for t, argvs in mcp_tool_argvs().items() if not argvs}
+        assert unanalyzable == UNANALYZABLE_TOOLS, (
+            "the set of MCP tools the dispatch-path analyzer cannot see has "
+            "changed — place each new one by hand, then record it here: "
+            f"new={sorted(unanalyzable - UNANALYZABLE_TOOLS)} "
+            f"gone={sorted(UNANALYZABLE_TOOLS - unanalyzable)}"
+        )
+
+    def test_the_analyzer_admits_what_it_cannot_see(self):
+        """Must-fail control for the leg above: a dynamically-built argv must
+        register as unanalyzable, not as 'no argv, therefore harmless'."""
+        source = (
+            "@mcp.tool()\n"
+            "def sneaky_verb(name: str) -> str:\n"
+            "    argv = build_the_argv(name)\n"
+            "    return run_agentwire_cmd(argv)\n"
+        )
+        assert mcp_tool_argvs([source]) == {"sneaky_verb": []}
+
+    def test_an_in_process_creator_would_be_seen(self):
+        """Must-fail control for the in-process leg: the fixture-shaped trap is
+        a detector exercised only on the shape it already handles."""
+        source = (
+            "@mcp.tool()\n"
+            "def helpful_verb(name: str) -> str:\n"
+            "    cmd = build_agent_command(name)\n"
+            "    return run(cmd)\n"
+        )
+        assert in_process_creating_tools([source]) == {
+            "helpful_verb": "build_agent_command"
+        }
+
+    def test_no_tiered_in_tool_creates_a_session_in_process(self):
+        """Clause (a) again, for the path with no argv at all."""
+        offenders = {
+            tool: fn for tool, fn in in_process_creating_tools().items()
+            if tool not in surface.TIER_EXCLUDED
+        }
+        assert offenders == {}, (
+            f"MCP tools calling session creation in process while tiered in: "
+            f"{offenders}"
+        )
 
     def test_every_session_creating_dispatch_path_is_excluded(self):
         """Clause (a) by dispatch path: any MCP tool whose argv reaches a
@@ -477,6 +676,43 @@ class TestDeclaredWriteMechanism:
         nonce_word = result["confirm_phrase"].split()[1]
         assert nonce_word not in result["fallback_say"]
 
+    def test_a_proposal_carries_the_buddy_identity_whatever_its_argv(self):
+        """#979/1, the same assumption one field over: the outbox reads the
+        writer from ``--from``, which only the msg shape has. An argv-only
+        write recorded under 'unknown' is invisible to the buddy's own
+        buddy_sent — the instrument cannot answer about a write it filed under
+        someone else. propose carries the identity in params, so attribution
+        does not depend on the argv having a --from."""
+        convo, _runner = _spine()
+        propose = gated_triple(probe_spec())[0][3]
+        propose({"_buddy": "buddy"}, convo.spine)
+        (proposal,) = list(convo.spine._proposals.values())
+        assert proposal.params.get("_buddy") == "buddy"
+
+    def test_a_write_to_a_remote_target_is_refused_at_the_pattern(self, monkeypatch):
+        """The write side of the same ruling. `_require_live` used to compare
+        `session.split("@")[0]` against LOCAL tmux, so a remote name that was
+        genuinely live locally under its bare half could pass liveness and then
+        address the wrong machine. With `@` gone from the pattern the refusal
+        happens before liveness is ever consulted — asserted with tmux SAYING
+        the bare half is live, which is the shape that used to slip."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"web"})
+        # The liveness check itself, called directly — the pattern refuses
+        # before it is ever reached, so nothing else in the suite can tell a
+        # whole-name comparison from a split one, and an unpinned split grows
+        # back the moment remotes are revisited.
+        with pytest.raises(tools.ToolError, match="Nothing is listening"):
+            write_tools._require_live("web@laptop", cannot="")
+
+        propose = write_tools.WRITE_TOOL_FNS["propose_session_message"]
+        convo, runner = _spine()
+        with pytest.raises(tools.ToolError, match="(?i)remote"):
+            propose(
+                {"session": "web@laptop", "message": "ship it", "_buddy": "buddy"},
+                convo.spine,
+            )
+        assert runner.calls == []
+
     def test_shipped_specs_pass_the_same_declaration_guards(self):
         for spec in write_tools.WRITE_SPECS:
             assert "{phrase}" not in spec.fallback_template
@@ -576,6 +812,80 @@ class TestExpandedReads:
         value = seen[0][2]
         assert "\x1b" not in value
         assert len(value) <= tools._MAX_QUERY_CHARS
+
+    @pytest.mark.parametrize(
+        "name", ["fleet_session_info", "fleet_session_inbox", "fleet_session_output"]
+    )
+    def test_a_remote_target_is_refused_and_says_why(self, seen, name):
+        """#979/2, owner ruling 2026-08-09: remote `name@machine` targets are
+        out of scope. The voice layer no longer ACCEPTS the syntax at all —
+        half-accepting it is what produced three wrong answers at once (the
+        wrong inbox interrogated, a live remote session called dead, an inbox
+        dir keyed on the raw string).
+
+        The false-reject half is priced by the wording, not by admitting the
+        name: a refusal that just says 'not a valid session name' sends the
+        owner round the loop re-pronouncing a name that was heard correctly.
+        This one names the actual limit, so the owner can stop asking."""
+        result = tools.dispatch(name, {"session": "web@laptop"}, "buddy")
+        assert result["success"] is False
+        assert result["must_speak"] is True
+        assert "remote" in result["error"].lower()
+        assert seen == []
+
+    def test_the_pattern_itself_no_longer_admits_the_syntax(self):
+        """Both layers, asserted separately. The spoken refusal fires first, so
+        every behavioural test above passes with `@` still in the pattern —
+        which is how the pattern quietly stays permissive and the next reader,
+        seeing it accept `name@machine`, decides the message check is
+        redundant. The ruling is that NO layer here accepts the syntax."""
+        assert tools._SESSION_RE.match("web@laptop") is None
+        assert tools._SESSION_RE.match("web") is not None
+
+    def test_a_bare_local_name_is_still_accepted(self, seen):
+        """The other half of the same gate: dropping @ must not narrow the
+        ordinary local name, which is every name the buddy can reach."""
+        result = tools.dispatch(
+            "fleet_session_info", {"session": "agentwire-dev"}, "buddy"
+        )
+        assert result.get("success") is not False, result
+        assert seen == [["info", "-s", "agentwire-dev"]]
+
+    @pytest.mark.parametrize("bad", ["-x/y", "x/-y", "-/-"])
+    def test_a_leading_dash_repo_is_refused_by_the_pattern(self, monkeypatch, bad):
+        """#979/6: `_REPO_RE` admitted `-x/y`, which violates the
+        leading-alphanumeric rule `_SESSION_RE` states two paragraphs earlier.
+        A value-position flag is not exploitable today; an inconsistent stated
+        discipline is how the next copy of the pattern gets it wrong.
+
+        Asserted at the pattern, with `gh` monkeypatched out — letting the real
+        subprocess run makes 'gh said no' indistinguishable from 'the pattern
+        said no', which is exactly how this test passes without the fix."""
+        ran: list = []
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.subprocess.run",
+            lambda *a, **kw: ran.append(a) or (_ for _ in ()).throw(AssertionError),
+        )
+        result = tools.dispatch("fleet_pull_requests", {"repo": bad}, "buddy")
+        assert result["success"] is False
+        assert "owner/name" in result["error"]
+        assert ran == []
+
+    def test_an_ordinary_repo_still_reaches_gh(self, monkeypatch):
+        """The false-reject half of the same tightening."""
+        seen_cmd: list = []
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.subprocess.run",
+            lambda cmd, **kw: seen_cmd.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="[]", stderr=""),
+        )
+        result = tools.dispatch(
+            "fleet_pull_requests", {"repo": "dotdevdotdev/agentwire-dev"}, "buddy"
+        )
+        assert result["success"] is True
+        assert seen_cmd[0][:5] == [
+            "gh", "pr", "list", "--repo", "dotdevdotdev/agentwire-dev",
+        ]
 
     def test_an_empty_query_is_refused_with_speech(self, seen):
         result = tools.dispatch("fleet_wiki_search", {"query": "  ---  "}, "b")

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -211,37 +211,69 @@ def _argv_compatible(voice_argv: list, mcp_argv: list) -> bool:
     )
 
 
+#: The ONE wired mapping the argv cross-check cannot corroborate, recorded as
+#: a (tool, capability) PAIR and asserted set-equal. Scoping the exemption to
+#: the capability NAME instead covered all 15 capabilities that build no
+#: extractable argv — including `wiki_lint` and `wiki_status`, both tier READ,
+#: so a future tool mapped to either would have been graded read with nothing
+#: able to contradict it. An exemption that widens by itself is the failure
+#: mode this whole file exists to make impossible.
+_UNCORROBORATED = frozenset({("fleet_wiki_search", "wiki_query")})
+
+
+def _dispatched_argvs(tool_name: str) -> list[list]:
+    """What *tool_name* actually sends to the CLI, with the CLI stubbed out."""
+    from unittest import mock
+
+    seen: list[list] = []
+    with mock.patch(
+        "agentwire.voice_layer.tools.run_agentwire_cmd",
+        lambda argv, **kw: seen.append(list(argv)) or {"success": True},
+    ):
+        tools.dispatch(tool_name, dict(_SWEEP_ARGS), "buddy")
+    return seen
+
+
+def uncorroborated_pairs(mapping: dict) -> set:
+    """(tool, capability) pairs the argv cross-check cannot corroborate.
+
+    Reported separately from the mismatches so the exemption can be asserted
+    set-equal — a new uncheckable mapping is red, and so is a stale entry here
+    once the capability grows an extractable argv.
+    """
+    mcp_argvs = mcp_tool_argvs()
+    pairs = set()
+    for tool in tools.READ_ONLY_TOOLS:
+        for capability in mapping.get(tool.name, ()):
+            if _dispatched_argvs(tool.name) and not mcp_argvs.get(capability):
+                pairs.add((tool.name, capability))
+    return pairs
+
+
 def capability_argv_mismatches(mapping: dict) -> dict[str, str]:
     """Wired read tools whose dispatched argv contradicts their mapped capability.
 
-    A capability with no extractable argv cannot corroborate anything; that is
-    tolerated ONLY for capabilities already recorded in ``UNANALYZABLE_TOOLS``,
-    so the exemption is a named one rather than a silent pass.
+    A capability with no extractable argv corroborates nothing. That is
+    tolerated only for the exact pairs in :data:`_UNCORROBORATED` — never for a
+    capability name, which would exempt every tool that ever maps to it.
     """
-    from unittest import mock
-
     mcp_argvs = mcp_tool_argvs()
     mismatches: dict[str, str] = {}
     for tool in tools.READ_ONLY_TOOLS:
         capabilities = mapping.get(tool.name)
         if not capabilities:
             continue
-        seen: list[list] = []
-        with mock.patch(
-            "agentwire.voice_layer.tools.run_agentwire_cmd",
-            lambda argv, **kw: seen.append(list(argv)) or {"success": True},
-        ):
-            tools.dispatch(tool.name, dict(_SWEEP_ARGS), "buddy")
+        seen = _dispatched_argvs(tool.name)
         if not seen:
             continue  # voice-native (gh, spool) — ruled in VOICE_NATIVE
         for capability in capabilities:
             candidates = mcp_argvs.get(capability, [])
             if not candidates:
-                if capability in UNANALYZABLE_TOOLS:
+                if (tool.name, capability) in _UNCORROBORATED:
                     continue
                 mismatches[tool.name] = (
-                    f"{capability} builds no extractable argv and is not "
-                    "recorded as unanalyzable"
+                    f"{capability} builds no extractable argv, so this mapping "
+                    "is unfalsifiable and is not a recorded exemption"
                 )
                 continue
             if not any(
@@ -308,12 +340,34 @@ class TestEveryWiredToolIsRuled:
         mutated["fleet_session_output"] = ("sessions_list",)
         assert "fleet_session_output" in capability_argv_mismatches(mutated)
 
+    def test_the_uncorroborable_exemption_is_scoped_to_named_pairs(self):
+        """The exemption is one MAPPING, not a capability name.
+
+        Scoped to the name, it covered every capability that builds no
+        extractable argv — 15 of them, three of which (`wiki_lint`,
+        `wiki_query`, `wiki_status`) are tier READ, so any future tool mapped
+        to one would be graded read and be structurally unfalsifiable. That is
+        the exemption widening in silence, which is the thing
+        ``UNANALYZABLE_TOOLS`` is asserted set-equal to prevent."""
+        assert uncorroborated_pairs(surface.TOOL_CAPABILITY) == _UNCORROBORATED
+        # The pair exists because of the analyzer's blind spot, and the two
+        # records must agree about which capability that is.
+        for _tool, capability in _UNCORROBORATED:
+            assert capability in UNANALYZABLE_TOOLS
+
+    def test_a_second_uncheckable_mapping_is_not_covered_by_the_first(self):
+        """Watched failing before the scoping: `wiki_status` is uncheckable and
+        tier READ, so under a name-scoped exemption this mapping passed with
+        nothing corroborating it."""
+        mutated = dict(surface.TOOL_CAPABILITY)
+        mutated["fleet_locks"] = ("wiki_status",)
+        assert "fleet_locks" in capability_argv_mismatches(mutated)
+        assert ("fleet_locks", "wiki_status") in uncorroborated_pairs(mutated)
+
     def test_an_uncheckable_mapping_is_named_not_waved_through(self):
-        """`wiki_query` builds no extractable argv, so the cross-check cannot
-        corroborate it. That exemption is allowed only for a capability already
-        recorded as unanalyzable — otherwise 'no argv to compare' becomes a
-        silent pass, which is the shape being fixed."""
-        assert "wiki_query" in UNANALYZABLE_TOOLS
+        """The exempted mapping is still held to the rest of the check: point
+        `fleet_wiki_search` somewhere that DOES build an argv and it must be
+        compared against it like any other."""
         mutated = dict(surface.TOOL_CAPABILITY)
         mutated["fleet_wiki_search"] = ("council_list",)
         assert "fleet_wiki_search" in capability_argv_mismatches(mutated)

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -189,6 +189,71 @@ class TestTierThreeIsUnreachableByName:
                 )
 
 
+#: Arguments that satisfy every read tool's schema, so one sweep can capture
+#: what each one actually dispatches. Extra keys are ignored by tools that do
+#: not take them.
+_SWEEP_ARGS = {"session": "sess", "repo": "owner/name", "query": "q"}
+
+
+def _argv_compatible(voice_argv: list, mcp_argv: list) -> bool:
+    """Does *mcp_argv* describe the same CLI call as *voice_argv*?
+
+    Compared as a prefix with ``None`` (a non-constant element in the MCP
+    source) as a wildcard: the MCP tool interpolates its parameters where the
+    voice tool interpolates validated ones, and the leading verbs are what
+    identify the capability.
+    """
+    if not mcp_argv or not voice_argv:
+        return False
+    width = min(len(mcp_argv), len(voice_argv))
+    return all(
+        mcp_argv[i] is None or mcp_argv[i] == voice_argv[i] for i in range(width)
+    )
+
+
+def capability_argv_mismatches(mapping: dict) -> dict[str, str]:
+    """Wired read tools whose dispatched argv contradicts their mapped capability.
+
+    A capability with no extractable argv cannot corroborate anything; that is
+    tolerated ONLY for capabilities already recorded in ``UNANALYZABLE_TOOLS``,
+    so the exemption is a named one rather than a silent pass.
+    """
+    from unittest import mock
+
+    mcp_argvs = mcp_tool_argvs()
+    mismatches: dict[str, str] = {}
+    for tool in tools.READ_ONLY_TOOLS:
+        capabilities = mapping.get(tool.name)
+        if not capabilities:
+            continue
+        seen: list[list] = []
+        with mock.patch(
+            "agentwire.voice_layer.tools.run_agentwire_cmd",
+            lambda argv, **kw: seen.append(list(argv)) or {"success": True},
+        ):
+            tools.dispatch(tool.name, dict(_SWEEP_ARGS), "buddy")
+        if not seen:
+            continue  # voice-native (gh, spool) — ruled in VOICE_NATIVE
+        for capability in capabilities:
+            candidates = mcp_argvs.get(capability, [])
+            if not candidates:
+                if capability in UNANALYZABLE_TOOLS:
+                    continue
+                mismatches[tool.name] = (
+                    f"{capability} builds no extractable argv and is not "
+                    "recorded as unanalyzable"
+                )
+                continue
+            if not any(
+                _argv_compatible(voice, mcp)
+                for voice in seen for mcp in candidates
+            ):
+                mismatches[tool.name] = (
+                    f"dispatches {seen} but {capability} builds {candidates}"
+                )
+    return mismatches
+
+
 class TestEveryWiredToolIsRuled:
     """#979/5: the tier audit swept ``@mcp.tool`` names — a namespace that is
     not the exposed surface. ``buddy_inbox``, ``buddy_sent`` and
@@ -220,6 +285,48 @@ class TestEveryWiredToolIsRuled:
                 assert capability not in surface.TIER_EXCLUDED, (
                     f"{name} wires excluded capability {capability}"
                 )
+
+    def test_each_mapping_matches_the_argv_the_tool_actually_dispatches(self):
+        """The map is asserted CORRECT, not merely consistent.
+
+        Every other leg here reads `TOOL_CAPABILITY` and believes it, so
+        `fleet_session_output: ('sessions_list',)` — simply wrong — kept the
+        whole suite green, and "a wired tool's tier is derivable" meant "a
+        hand-written map nothing checks": the same over-claim this PR fixes,
+        one level up. This runs each read tool with the CLI stubbed, captures
+        the argv it really builds, and demands the mapped MCP capability build
+        a compatible one."""
+        mismatches = capability_argv_mismatches(surface.TOOL_CAPABILITY)
+        assert mismatches == {}, (
+            f"TOOL_CAPABILITY entries whose argv does not match the capability "
+            f"they name: {mismatches}"
+        )
+
+    def test_a_wrong_mapping_turns_that_red(self):
+        """Must-fail control, using the reviewer's own mutation."""
+        mutated = dict(surface.TOOL_CAPABILITY)
+        mutated["fleet_session_output"] = ("sessions_list",)
+        assert "fleet_session_output" in capability_argv_mismatches(mutated)
+
+    def test_an_uncheckable_mapping_is_named_not_waved_through(self):
+        """`wiki_query` builds no extractable argv, so the cross-check cannot
+        corroborate it. That exemption is allowed only for a capability already
+        recorded as unanalyzable — otherwise 'no argv to compare' becomes a
+        silent pass, which is the shape being fixed."""
+        assert "wiki_query" in UNANALYZABLE_TOOLS
+        mutated = dict(surface.TOOL_CAPABILITY)
+        mutated["fleet_wiki_search"] = ("council_list",)
+        assert "fleet_wiki_search" in capability_argv_mismatches(mutated)
+
+    def test_the_remote_ruling_is_pinned_like_the_other_two(self):
+        """The constraint was that EVERY reclassification lands as a written
+        ruling. The `@machine` paragraph could be deleted whole with nothing
+        going red, while the other two rulings were pinned by name."""
+        doc = " ".join((surface.__doc__ or "").split())
+        assert "@machine" in doc
+        assert "2026-08-09" in doc
+        # The ruling as it now stands: LIVENESS decides, not the character.
+        assert "LIVENESS" in doc
 
     def test_a_new_unruled_tool_turns_this_red(self):
         """Mutation check: the leg above is worthless if it passes for a name
@@ -689,29 +796,42 @@ class TestDeclaredWriteMechanism:
         (proposal,) = list(convo.spine._proposals.values())
         assert proposal.params.get("_buddy") == "buddy"
 
-    def test_a_write_to_a_remote_target_is_refused_at_the_pattern(self, monkeypatch):
-        """The write side of the same ruling. `_require_live` used to compare
-        `session.split("@")[0]` against LOCAL tmux, so a remote name that was
-        genuinely live locally under its bare half could pass liveness and then
-        address the wrong machine. With `@` gone from the pattern the refusal
-        happens before liveness is ever consulted — asserted with tmux SAYING
-        the bare half is live, which is the shape that used to slip."""
+    def test_a_write_to_an_unreachable_at_name_is_refused_whole(self, monkeypatch):
+        """`_require_live` used to compare `session.split("@")[0]` against LOCAL
+        tmux, so `web@laptop` passed liveness on the strength of a local `web`
+        and then addressed something else. It compares the WHOLE name now — and
+        that is also what makes accepting a local `ops@edge` safe, since every
+        layer asks about the name it was given."""
         monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"web"})
-        # The liveness check itself, called directly — the pattern refuses
-        # before it is ever reached, so nothing else in the suite can tell a
-        # whole-name comparison from a split one, and an unpinned split grows
-        # back the moment remotes are revisited.
+        # Called directly: `_session_arg` refuses this name first, so nothing
+        # else in the suite can tell a whole-name comparison from a split one,
+        # and an unpinned split grows back the moment remotes are revisited.
         with pytest.raises(tools.ToolError, match="Nothing is listening"):
             write_tools._require_live("web@laptop", cannot="")
 
         propose = write_tools.WRITE_TOOL_FNS["propose_session_message"]
         convo, runner = _spine()
-        with pytest.raises(tools.ToolError, match="(?i)remote"):
+        with pytest.raises(tools.ToolError, match="(?i)no live session"):
             propose(
                 {"session": "web@laptop", "message": "ship it", "_buddy": "buddy"},
                 convo.spine,
             )
         assert runner.calls == []
+
+    def test_a_write_to_a_live_local_at_name_is_allowed(self, monkeypatch):
+        """The false-reject half on the write path: `ops@edge` is a creatable,
+        addressable LOCAL tmux session, and refusing to message one is the
+        buddy declining work it can do."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"ops@edge"})
+        propose = write_tools.WRITE_TOOL_FNS["propose_session_message"]
+        convo, _runner = _spine()
+        result = propose(
+            {"session": "ops@edge", "message": "ship it", "_buddy": "buddy"},
+            convo.spine,
+        )
+        assert result["session"] == "ops@edge"
+        (proposal,) = list(convo.spine._proposals.values())
+        assert "ops@edge" in proposal.argv_prefix
 
     def test_shipped_specs_pass_the_same_declaration_guards(self):
         for spec in write_tools.WRITE_SPECS:
@@ -816,47 +936,75 @@ class TestExpandedReads:
     @pytest.mark.parametrize(
         "name", ["fleet_session_info", "fleet_session_inbox", "fleet_session_output"]
     )
-    def test_a_remote_target_is_refused_and_says_why(self, seen, name):
-        """#979/2, owner ruling 2026-08-09: remote `name@machine` targets are
-        out of scope. The voice layer no longer ACCEPTS the syntax at all —
-        half-accepting it is what produced three wrong answers at once (the
-        wrong inbox interrogated, a live remote session called dead, an inbox
-        dir keyed on the raw string).
-
-        The false-reject half is priced by the wording, not by admitting the
-        name: a refusal that just says 'not a valid session name' sends the
-        owner round the loop re-pronouncing a name that was heard correctly.
-        This one names the actual limit, so the owner can stop asking."""
+    def test_an_at_name_tmux_does_not_know_is_refused(self, seen, monkeypatch, name):
+        """Owner ruling 2026-08-09: remote `name@machine` targets are out of
+        scope. Enforced by LIVENESS, not by the shape of the name — because the
+        shape does not say remote. tmux accepts `@` verbatim, so `ops@edge` is
+        a creatable local session, and a refusal keyed on the character alone
+        told the owner a true local name was remote: a confident falsehood with
+        no move from it, in a channel with no screen."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"ops@edge"})
         result = tools.dispatch(name, {"session": "web@laptop"}, "buddy")
         assert result["success"] is False
         assert result["must_speak"] is True
-        assert "remote" in result["error"].lower()
+        assert seen == []
+        # It must NOT assert remoteness — that is the claim it cannot make.
+        assert "web@laptop" in result["error"]
+        assert "no live session" in result["error"].lower()
+        assert "aren't reachable" not in result["error"]
+
+    def test_a_live_local_at_name_is_reachable(self, seen, monkeypatch):
+        """The false-reject half, measured against the base branch's behaviour:
+        base dispatched `['info', '-s', 'ops@edge']` and the first fix refused
+        it. `@` is legal in tmux (only `.` and `:` are rewritten, #878) and in
+        `inbox._SESSION_RE`, so this name is ordinary local work."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"ops@edge"})
+        result = tools.dispatch(
+            "fleet_session_info", {"session": "ops@edge"}, "buddy"
+        )
+        assert result.get("success") is not False, result
+        assert seen == [["info", "-s", "ops@edge"]]
+
+    def test_an_unprovable_liveness_does_not_refuse(self, seen, monkeypatch):
+        """`live_sessions()` returns None when tmux itself is unreachable. That
+        is an outage, not a verdict — refusing there would ground the buddy on
+        every local `@` name during a tmux blip, and the CLI reports what it
+        finds. Same doctrine as `_require_live` (spec §5): only POSITIVE
+        knowledge refuses."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: None)
+        result = tools.dispatch(
+            "fleet_session_info", {"session": "ops@edge"}, "buddy"
+        )
+        assert result.get("success") is not False, result
+        assert seen == [["info", "-s", "ops@edge"]]
+
+    @pytest.mark.parametrize("bad", ["we b@x", "@a", "--help@x", "../etc@passwd"])
+    def test_a_malformed_at_name_gets_the_shape_refusal(self, seen, monkeypatch, bad):
+        """Ordering, pinned. The `@` check used to run BEFORE shape validation,
+        so a garbled name that happened to contain one was told it was remote —
+        a wrong diagnosis of a mis-transcription, and nothing in the suite
+        noticed if the two moved past each other."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: set())
+        result = tools.dispatch("fleet_session_info", {"session": bad}, "buddy")
+        assert result["success"] is False
+        assert "valid session name" in result["error"]
+        assert "no live session" not in result["error"].lower()
         assert seen == []
 
-    def test_the_pattern_itself_no_longer_admits_the_syntax(self):
-        """Both layers, asserted separately. The spoken refusal fires first, so
-        every behavioural test above passes with `@` still in the pattern —
-        which is how the pattern quietly stays permissive and the next reader,
-        seeing it accept `name@machine`, decides the message check is
-        redundant. The ruling is that NO layer here accepts the syntax."""
-        assert tools._SESSION_RE.match("web@laptop") is None
-        assert tools._SESSION_RE.match("web") is not None
-
     def test_a_bare_local_name_is_still_accepted(self, seen):
-        """The other half of the same gate: dropping @ must not narrow the
-        ordinary local name, which is every name the buddy can reach."""
+        """A name with no `@` never consults liveness at all — reads must keep
+        working for a session that has since exited."""
         result = tools.dispatch(
             "fleet_session_info", {"session": "agentwire-dev"}, "buddy"
         )
         assert result.get("success") is not False, result
         assert seen == [["info", "-s", "agentwire-dev"]]
 
-    @pytest.mark.parametrize("bad", ["-x/y", "x/-y", "-/-"])
-    def test_a_leading_dash_repo_is_refused_by_the_pattern(self, monkeypatch, bad):
-        """#979/6: `_REPO_RE` admitted `-x/y`, which violates the
-        leading-alphanumeric rule `_SESSION_RE` states two paragraphs earlier.
-        A value-position flag is not exploitable today; an inconsistent stated
-        discipline is how the next copy of the pattern gets it wrong.
+    @pytest.mark.parametrize("bad", ["-x/y", "-/-", "own er/x", "a/b/c", "o.x/n"])
+    def test_a_bad_owner_segment_is_refused_by_the_pattern(self, monkeypatch, bad):
+        """#979/6: `_REPO_RE` admitted `-x/y`, a value-position flag. GitHub
+        constrains OWNERS to alphanumeric-and-hyphen starting alphanumeric, so
+        that is where the rule belongs.
 
         Asserted at the pattern, with `gh` monkeypatched out — letting the real
         subprocess run makes 'gh said no' indistinguishable from 'the pattern
@@ -871,21 +1019,24 @@ class TestExpandedReads:
         assert "owner/name" in result["error"]
         assert ran == []
 
-    def test_an_ordinary_repo_still_reaches_gh(self, monkeypatch):
-        """The false-reject half of the same tightening."""
+    @pytest.mark.parametrize(
+        "repo", ["dotdevdotdev/agentwire-dev", "github/.github", "owner/_name",
+                 "owner/-name"],
+    )
+    def test_real_repository_names_still_reach_gh(self, monkeypatch, repo):
+        """The false-reject half, and the reason the rule is owner-only:
+        `github/.github` is a real repository, and GitHub lets a REPO name
+        begin with `.`, `_` or `-`. Buying pattern symmetry with a refusal of
+        real repositories is a worse trade than the inconsistency it fixes."""
         seen_cmd: list = []
         monkeypatch.setattr(
             "agentwire.voice_layer.tools.subprocess.run",
             lambda cmd, **kw: seen_cmd.append(cmd)
             or SimpleNamespace(returncode=0, stdout="[]", stderr=""),
         )
-        result = tools.dispatch(
-            "fleet_pull_requests", {"repo": "dotdevdotdev/agentwire-dev"}, "buddy"
-        )
+        result = tools.dispatch("fleet_pull_requests", {"repo": repo}, "buddy")
         assert result["success"] is True
-        assert seen_cmd[0][:5] == [
-            "gh", "pr", "list", "--repo", "dotdevdotdev/agentwire-dev",
-        ]
+        assert seen_cmd[0][:5] == ["gh", "pr", "list", "--repo", repo]
 
     def test_an_empty_query_is_refused_with_speech(self, seen):
         result = tools.dispatch("fleet_wiki_search", {"query": "  ---  "}, "b")


### PR DESCRIPTION
Wave 2 of the voice-layer review. Branches off `voice-confirm-spine` and targets it — never `main`.

## What changed

**1. `record_write` no longer assumes the msg shape.** `body = argv[-1]` is the body of a `msg send`; for an `append_body=False` spec it is a session name or a flag value, and `instructions.py` orders the model to quote that field word for word as the authoritative answer to "what did I send". The instrument built to end confabulation would have handed it a confidently wrong exact body. It now reads `proposal.append_body`, records no body where there is none, and records the flag so a reader can distinguish "no body" from "body not recorded".

Same assumption one field over, found while fixing it: the writer was read from `--from`, which only the msg shape has, so an argv-only write filed itself under `unknown` — invisible to the buddy's own `buddy_sent`. `gated_triple` now puts `_buddy` on every proposal (a spec's own params still win).

**2. `delivery_state` no longer over-claims.** The old sentence: *neither store matches → `delivered`, because the drain removes a message from pending only by delivering it or dead-lettering it.* False — `msg purge` drops pending, `msg dead --purge` clears the graveyard, both documented escape hatches, both leaving exactly that trace. The claim is **rewritten, not qualified**: the state is `no_longer_queued` and its detail says both halves ("that is what a delivered message looks like, and also what one looks like after a purge"). Nothing in the inbox records per-message delivery — the `delivered` event carries a count and kinds, no ids — so a positive answer needs a new mechanism, not a bolder reading of this one. The `buddy_sent` tool description now enumerates every state and what each one licenses the buddy to say, ending with *never upgrade one of these to "delivered"*.

**3. Two tier reclassifications, each as a written ruling in `surface.py`:**
- `scheduler_report`: READ → **EXCLUDED**. Writes an HTML artifact to `~/.agentwire/artifacts/` and with `artifact=True` pushes a click-to-open portal notification — clause (d) plus clause (b). "Expand reads freely" would have wired it confirm-free on the strength of the verb.
- `pane_detach`: GATED → **EXCLUDED**. Its own docstring says the target session is "created if doesn't exist" — clause (a), and the created session has no #871 metadata record. The dispatch-path analyzer cannot see it, so the tier entry is the only guard; a nonce is the wrong guard, because the harness boundary isn't something the owner should be able to approve past.

**4. The analyzer's covered shape is stated, and both silent-green blind spots are closed.** `mcp_tool_argvs` documents exactly what it extracts (a list literal with a string-constant head) and what it therefore cannot see. Tools it extracts nothing from are recorded in `UNANALYZABLE_TOOLS` and asserted set-equal, so a new unanalyzable tool is red until a human places it. A second leg detects an MCP tool reaching session creation **in process** (no CLI dispatch) — the map used to skip `mcp_*.py` entirely. Neither shape exists in the package today, so both legs carry must-fail controls driving synthetic sources; without them a blind detector and a clean codebase are the same observation.

**5. Voice-native tools are inside the audit now.** `surface.TOOL_CAPABILITY` maps every wired tool to the capability it exposes; `surface.VOICE_NATIVE` carries a written grade + reason for the three that map to none (`fleet_pull_requests`, `buddy_inbox`, `buddy_sent`); `surface.unruled_tools` is what the audit calls, so a new voice-native tool fails until someone rules on it. `buddy_inbox(ack=true)` is ruled a **wired light write** (it advances the read cursor; the message itself is untouched and `unread_only=false` reads it straight back — and a nonce on "what's in my inbox" is the reflex-training a light grade exists to prevent). The "Light writes are graded but currently none are wired" sentence is corrected. A new leg also asserts no wired tool maps to an EXCLUDED capability — the by-name check catches `propose_worktree_create`, not the `scheduler_report` shape.

**6.** `_REPO_RE` no longer admits a leading dash.

## Dropping `@machine` — which layer does what now

Per the owner's 2026-08-09 ruling, remote `name@machine` targets are out of scope for the voice layer. The syntax was half-accepted, which produced three wrong answers at once: `inbox.enqueue` keyed the inbox dir on the raw string, `outbox.delivery_state` stripped the suffix and interrogated the **local** inbox, and `_require_live` checked the bare half against **local** tmux — refusing a live remote session with a confidently false "nothing is listening".

| Layer | Before | Now |
|---|---|---|
| `tools._SESSION_RE` | matched `name@machine` | **no longer matches it** |
| `tools._session_arg` | passed it through | **refuses it**, in its own words (`REMOTE_REFUSAL`) — "I can only reach sessions on this machine…" |
| `write_tools._require_live` | compared `session.split("@")[0]` against local tmux | compares the **whole name** |
| `outbox.delivery_state` | stripped `@machine`, read a different session's inbox | asks for the **whole name** (which is how `inbox` keys), so a pre-ruling outbox record still resolves to the inbox that holds it |
| `core.session_metadata_path` (→ `delivery.session_state_dir`, #988) | strips `@machine` | **unchanged, and still strips it** — that is the metadata store's own keying rule (#899/#988): `web@remote` and `web` are one record. It is not this layer accepting the syntax, and I did not touch it. |

Nothing half-accepts the syntax: the pattern refuses it, and the two layers that used to strip it now ask about the name they were given. Re-adding remotes is its own reviewed slice (remote liveness probe + remote inbox interrogation + tests).

The false-reject half is priced in the wording, not by admitting the name: the transcription was *right*, so "not a valid session name" would send the owner round the loop re-pronouncing a name that was heard correctly. The refusal names the actual limit so they can stop asking.

## Method

Every test was watched failing first (13 red in the first behavioural batch, for the right reasons — one that passed vacuously against real `gh` was rewritten to assert at the pattern with the subprocess stubbed out).

Every fix is pinned by mutation — reverting any one turns a named test red:

| mutation | result |
|---|---|
| `delivery_state` re-strips `@machine` | 1 failed |
| `body` back to unconditional `argv[-1]` | 1 failed |
| final state back to `delivered` | 2 failed |
| `append_body` gate removed from `delivery_state` | 1 failed |
| `@` re-admitted to `_SESSION_RE` | 1 failed |
| the spoken remote refusal removed | 4 failed |
| `_REPO_RE` back to leading-dash-permissive | 3 failed |
| `_require_live` re-splits on `@` | 1 failed |
| `_buddy` dropped from propose params | 1 failed |
| `scheduler_report` moved back to READ | 1 failed |
| `pane_detach` moved back to GATED | 1 failed |

(Corrected after review: the last two rows originally read "2 failed" — that was a mutation that DELETED the tier entry, which also trips the untiered-drift leg. Moving each entry to the tier its old placement had is the mutation that belongs here, and it gives 1 each.)

The `_SESSION_RE` one is worth calling out: with `@` back in the pattern every *behavioural* test still passed, because the spoken refusal fires first — which is exactly how a pattern quietly stays permissive and the next reader deletes the "redundant" check. There is now a test asserting the pattern itself. **Superseded by the review**: the `@` gate is liveness-based now, so `_SESSION_RE` admits `@` again and the ruling is enforced by asking tmux — see the review-fix comment below.

Full CI invocation (`uv run --extra dev pytest`): **5698 passed, 36 skipped** — spine baseline was 5670, and the delta is this branch's new tests.

## Not done, deliberately

- `delivery.py` was read, not edited (its `session_state_dir` change is #988's, and the `@` strip lives correctly downstream in `core`). `instructions.py`, `client.py`, `server.py`, `transcript.py` are sibling-owned this wave — `instructions.py` refers to "its current delivery state" generically and never names a state string, so it needs no change from this, but its owner may want the new vocabulary.
- No positive delivery confirmation. `no_longer_queued` is honest, not complete; establishing delivery per message would need the inbox to log message ids on drain, which is a separate change to a shared subsystem.

Closes #979
