### PR TITLE
voice-layer W2: three guarantees stated broader than the code

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -147,9 +147,21 @@ function createAnnouncer(deps) {
   // utterance" and saying so was false: composeNotice coalesces up to 240
   // characters PER MESSAGE, so a three-reply batch is around a minute of
   // speech and a five-reply batch several. A flat 30s watchdog fires
-  // mid-utterance, which reopens both gates and lets the MODEL start a
-  // response over the browser voice — the two-voices defect (#950), reached
-  // through the mechanism added to bound a mute.
+  // mid-utterance, and what that costs names exactly what this budget rules
+  // out: `speaking` is what pending() and anchorPending() count, so an early
+  // fire empties it and reopens the NOTIFIER's gates — canSpeak and
+  // canInterrupt — letting a volunteered notice or an escalation be announced
+  // over the browser voice.
+  //
+  // What it does NOT rule out, stated because the previous version of this
+  // comment claimed the whole of #950: the budget never gates the announcer's
+  // own FIFO. armFallback nulls `current`, starts speak(), and calls pump() in
+  // the SAME tick, and pump() consults `current` and `queue` only — never
+  // `speaking`. So a second must_speak item queued behind a long notice is
+  // promoted and its response.create goes out while the browser voice is
+  // starting the first one's audio: two voices, at any watchdog length,
+  // reached without the watchdog firing at all. That path is a live residual
+  // and a separate decision, not something the scaling closes.
   //
   // The per-character rate is deliberately SLOWER than any real voice (~7
   // characters a second against a typical 15). The two directions are not

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1096,11 +1096,29 @@ SPOKEN = {
     # owner hears nothing, waits, and the conversation deadlocks on two parties
     # each waiting for the other. The announcer must not special-case it, must
     # not skip the cancel for it (the cancel is gated on the in-flight mirror,
-    # which is TRUE in exactly this state), and a response already in flight
-    # BEFORE the announce must never defer its fallback — see client.py's
-    # createAnnouncer: the timer is armed before anything that can fail, and
-    # the one bounded deferral keys only on a response created AFTER the
-    # announce, which can delay speech but never suppress it.
+    # which is TRUE in exactly this state), and its fallback must stay
+    # reachable — see client.py's createAnnouncer: the timer is armed before
+    # anything that can fail, and TWO bounded deferrals may POSTPONE it,
+    # neither of which can cancel it. They differ on whether this outcome's own
+    # state can take them. The in-flight one keys on a response created AFTER the
+    # announce (`sawCreate` is only set while the item is current), so the
+    # response already in flight HERE never defers; the owner-speaking one
+    # (`maxOwnerDeferrals`, 3) does not care which response is running and can
+    # fire in any state. At `fallbackMs` 6000 that makes the worst case in this
+    # outcome 4 intervals — 24s — rising to the announcer's general worst case
+    # of 5 intervals, 30s, only if a NEW response also starts after the
+    # announce. The deadlock sentence above was written against 2 intervals, 12s.
+    #
+    # The deadlock argument survives the bigger number, and not by calling 30s
+    # tolerable. It survives because a deferral is not a suppression: each is
+    # counted per item and the re-armed timer eventually speaks with no
+    # condition left to fail. And the leg that grew is the one that costs the
+    # owner nothing — the owner-speaking deferral is taken only when the owner
+    # IS speaking at the moment of the check, so it extends the buddy's wait,
+    # not the owner's silence. An owner who stops talking is spoken to at the
+    # next fire, which bounds the silence anyone can be left in waiting for
+    # THIS refusal at 12s (6s in this outcome's own state, where the in-flight
+    # leg is unavailable). A deadlock needs both parties waiting; only one is.
     "not_announced": (
         "Hang on — I haven't finished telling you what I'd send yet."
     ),

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1099,15 +1099,18 @@ SPOKEN = {
     # which is TRUE in exactly this state), and its fallback must stay
     # reachable — see client.py's createAnnouncer: the timer is armed before
     # anything that can fail, and TWO bounded deferrals may POSTPONE it,
-    # neither of which can cancel it. They differ on whether this outcome's own
-    # state can take them. The in-flight one keys on a response created AFTER the
-    # announce (`sawCreate` is only set while the item is current), so the
-    # response already in flight HERE never defers; the owner-speaking one
-    # (`maxOwnerDeferrals`, 3) does not care which response is running and can
-    # fire in any state. At `fallbackMs` 6000 that makes the worst case in this
-    # outcome 4 intervals — 24s — rising to the announcer's general worst case
-    # of 5 intervals, 30s, only if a NEW response also starts after the
-    # announce. The deadlock sentence above was written against 2 intervals, 12s.
+    # neither of which can cancel it. BOTH are live in this state, which is not
+    # obvious and was got wrong once. The in-flight leg keys on a response
+    # created AFTER the announce (`sawCreate` is only set while the item is
+    # current), so the response already in flight HERE cannot take it — but
+    # that is not the only response in play: this outcome fires with
+    # `responseActive` TRUE, so pump() cancels that one and creates OURS, and
+    # the server's ack of our create sets `sawCreate` while the item is still
+    # current. The owner-speaking leg (`maxOwnerDeferrals`, 3) never cared which
+    # response is running. So at `fallbackMs` 6000 the bound here is the
+    # announcer's general worst case, 5 intervals — 30s — dropping to 4 (24s)
+    # only in the sub-case where our own create is never acked at all. The
+    # deadlock sentence above was written against 2 intervals, 12s.
     #
     # The deadlock argument survives the bigger number, and not by calling 30s
     # tolerable. It survives because a deferral is not a suppression: each is
@@ -1115,10 +1118,12 @@ SPOKEN = {
     # condition left to fail. And the leg that grew is the one that costs the
     # owner nothing — the owner-speaking deferral is taken only when the owner
     # IS speaking at the moment of the check, so it extends the buddy's wait,
-    # not the owner's silence. An owner who stops talking is spoken to at the
-    # next fire, which bounds the silence anyone can be left in waiting for
-    # THIS refusal at 12s (6s in this outcome's own state, where the in-flight
-    # leg is unavailable). A deadlock needs both parties waiting; only one is.
+    # not the owner's silence. An owner who stops talking stops that leg
+    # deferring at once; the in-flight leg does not key on them at all, so at
+    # most one unspent deferral still lands between their silence and the
+    # speech. That bounds the silence anyone can be left in waiting for THIS
+    # refusal at 12s, whatever the 30s above does to the buddy's own patience.
+    # A deadlock needs both parties waiting; only one of them ever is.
     "not_announced": (
         "Hang on — I haven't finished telling you what I'd send yet."
     ),

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -78,9 +78,17 @@ def _require_live(session: str, cannot: str) -> None:
     remote name was checked against LOCAL tmux, so a remote session got either
     a false "nothing is listening" or — worse — a pass, on the strength of a
     local session that happens to share its name. Remote targets are out of
-    scope (owner ruling, 2026-08-09) and ``_session_arg`` now refuses the
-    syntax outright, so by the time a name reaches here it is local by
-    construction and splitting it could only re-open that gap.
+    scope (owner ruling, 2026-08-09), but nothing refuses the ``@`` SYNTAX —
+    that was the first attempt at the ruling and it was itself a false
+    statement, since ``ops@edge`` is a creatable, addressable LOCAL session
+    (see surface.py, "Remote ``name@machine`` targets are out of scope"). What
+    ships is a LIVENESS gate: ``tools._session_arg`` checks the shape, then
+    refuses any whole name containing ``@`` that local tmux does not report
+    live. So a name reaching here is local by DEMONSTRATION — and the bare half
+    before the ``@`` is exactly the string that was never the thing
+    demonstrated, which is why splitting it could only re-open that gap. The
+    one case that demonstrates nothing is an unreachable tmux, where both that
+    gate and this one refuse nothing (spec §5) rather than either guessing.
     """
     from .. import inbox
 

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -2685,14 +2685,27 @@ class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
         assert "TWO bounded deferrals" in note
 
     def test_the_note_states_the_bound_the_constants_produce(self):
-        """24s here, 30s in general — derived, so bumping either constant in
-        ``client.py`` fails this sentence in ``confirm.py``."""
+        """Every number in the paragraph, DERIVED — bumping either constant in
+        ``client.py`` fails the sentence in ``confirm.py`` that quotes it.
+        Transcription across two files with nothing connecting them is how the
+        first number went stale, and the second one after it."""
         fallback, owner = self._constants()
-        here = fallback * (1 + owner) // 1000
-        general = fallback * (2 + owner) // 1000
+        both_legs = fallback * (2 + owner) // 1000       # the bound: 30s
+        unacked = fallback * (1 + owner) // 1000         # the sub-case: 24s
+        silence = fallback * 2 // 1000                   # the owner's: 12s
         note = _source_prose(confirm.__file__)
-        assert f"{1 + owner} intervals — {here}s" in note
-        assert f"{2 + owner} intervals, {general}s" in note
+        assert f"{2 + owner} intervals — {both_legs}s" in note
+        assert f"{1 + owner} ({unacked}s)" in note
+        assert f"at {silence}s" in note
+
+    def test_the_note_does_not_present_the_sub_case_as_the_bound(self):
+        """The corrected error, pinned in the direction it actually went: 24s
+        was stated as this outcome's bound when it is the unacked sub-case, and
+        6s as the owner's silence when the in-flight leg is available here."""
+        note = _source_prose(confirm.__file__)
+        assert "the worst case in this outcome 4 intervals" not in note
+        assert "where the in-flight leg is unavailable" not in note
+        assert "BOTH are live in this state" in note
 
     def test_the_reason_the_deadlock_argument_survives_is_stated(self):
         """Not "30s is fine" — the argument has to name WHY, or the next bump
@@ -2702,10 +2715,40 @@ class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
         assert "a deferral is not a suppression" in note
         assert "not the owner's silence" in note
 
-    def test_this_outcomes_own_state_cannot_take_the_in_flight_deferral(self):
-        """The behavioural half of the claim: a response created BEFORE the
-        announce never sets ``sawCreate``, so the only deferrals available here
-        are the owner-speaking ones — the fallback speaks on fire 4, not 5."""
+    def test_the_ordinary_path_here_takes_BOTH_legs_and_speaks_on_fire_five(self):
+        """The behavioural half of the claim, and the correction to a first
+        version of this test that could not see it.
+
+        The response already in flight cannot defer — ``sawCreate`` is only set
+        while the item is current, and that one predates the announce. But it
+        is not the only response in play: this outcome fires with
+        ``responseActive`` true, so pump() CANCELS that response and creates
+        ours, and the server's ack of OUR create lands while the item is still
+        current (client.py ``onResponseCreated``). Both legs are therefore live
+        in this state on the ordinary path, and the fallback speaks on fire 5.
+
+        The fixture omitting that ack is what made "4 intervals" look pinned.
+        """
+        fallback, owner = self._constants()
+        report = run_announcer(f"""
+            announcer.onResponseCreated();     // in flight BEFORE the announce
+            announcer.announce("Hang on — I haven't finished telling you.");
+            announcer.onResponseCreated();     // the server ACKS our own create
+            ownerIsSpeaking = true;
+            for (let i = 0; i < {owner + 2}; i++) {{
+                fireTimers();
+                logs.push("fire " + (i + 1) + " spoken=" + spoken.length);
+            }}
+        """)
+        for n in range(1, owner + 2):
+            assert f"fire {n} spoken=0" in report["logs"]
+        assert f"fire {owner + 2} spoken=1" in report["logs"]
+
+    def test_only_an_unacked_create_leaves_the_in_flight_leg_untaken(self):
+        """The sub-case, named as one. With no ack for our own create nothing
+        ever sets ``sawCreate``, so the owner-speaking deferrals are the only
+        ones available and speech lands one interval earlier. This is the state
+        the paragraph calls out as the exception — not the bound."""
         fallback, owner = self._constants()
         report = run_announcer(f"""
             announcer.onResponseCreated();     // in flight BEFORE the announce
@@ -2720,16 +2763,23 @@ class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
             assert f"fire {n} spoken=0" in report["logs"]
         assert f"fire {owner + 1} spoken=1" in report["logs"]
 
-    def test_an_owner_who_stops_talking_is_spoken_to_at_the_next_fire(self):
-        """What bounds the owner's SILENCE rather than the buddy's wait, and
-        the sentence the rewritten paragraph rests on."""
+    def test_an_owner_who_stops_talking_waits_at_most_one_more_deferral(self):
+        """What bounds the owner's SILENCE rather than the buddy's wait — two
+        intervals, not one. The owner-speaking leg stops deferring the moment
+        they go quiet, but the in-flight leg does not key on the owner at all,
+        so a single unspent in-flight deferral still lands between their
+        silence and the speech. That is the 12s the paragraph states."""
         report = run_announcer("""
             announcer.announce("Hang on — I haven't finished telling you.");
+            announcer.onResponseCreated();     // the server ACKS our own create
             ownerIsSpeaking = true;
-            fireTimers();
+            fireTimers();                      // owner-speaking deferral
             ownerIsSpeaking = false;
+            fireTimers();                      // in-flight deferral, owner silent
+            logs.push("after one silent fire: spoken=" + spoken.length);
             fireTimers();
         """)
+        assert "after one silent fire: spoken=0" in report["logs"]
         assert len(report["spoken"]) == 1
 
 

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -30,6 +30,7 @@ observe:
 """
 
 import json
+import re
 import shutil
 import subprocess
 import textwrap
@@ -2631,3 +2632,169 @@ class TestTheSpeakingWatchdogScalesWithTheUtterance:
         """The other half: an empty or one-word utterance must not end up with
         a near-zero watchdog that fires before it starts."""
         assert self._watchdog_ms(json.dumps("Hi.")) >= 30_000
+
+
+# =============================================================================
+# Wave-2 prose: two guarantees stated broader than the code
+# =============================================================================
+
+
+def _source_prose(path: str) -> str:
+    """A module's source, comment markers stripped and whitespace-normalized.
+
+    A sentence written across several ``#`` lines is one sentence, and the
+    comment beside the code is exactly where the stale claim lived. Normalizing
+    lets an assertion survive a re-wrap of the prose.
+    """
+    from pathlib import Path
+
+    lines = [
+        line.lstrip().removeprefix("#:").removeprefix("#").strip()
+        for line in Path(path).read_text(encoding="utf-8").splitlines()
+    ]
+    return " ".join(" ".join(lines).split())
+
+
+class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
+    """``confirm.py``'s ``not_announced`` note promised "the ONE bounded
+    deferral", and reasoned its deadlock argument against the ~12s that
+    implied. #993 added a SECOND deferral (``ownerSpeaking``,
+    ``maxOwnerDeferrals`` 3) which STACKS with the first, so the announcer's
+    worst case is 5 intervals — 30s — and 4 (24s) in this outcome's own state,
+    where the in-flight leg cannot be taken at all.
+
+    The count and the arithmetic are pinned against the CODE rather than
+    transcribed, because transcription is how the first number went stale: the
+    constants live in ``client.py`` and the sentence lives in ``confirm.py``,
+    and nothing connected them.
+    """
+
+    def _constants(self) -> tuple[int, int]:
+        src = client.ANNOUNCER_JS
+        fallback = int(
+            re.search(r"deps\.fallbackMs \|\| (\d+)", src).group(1)
+        )
+        owner = int(
+            re.search(r"deps\.maxOwnerDeferrals === undefined \? (\d+)", src).group(1)
+        )
+        return fallback, owner
+
+    def test_the_single_deferral_claim_is_gone(self):
+        note = _source_prose(confirm.__file__)
+        assert "the one bounded deferral keys only on a response created AFTER" not in note
+        assert "TWO bounded deferrals" in note
+
+    def test_the_note_states_the_bound_the_constants_produce(self):
+        """24s here, 30s in general — derived, so bumping either constant in
+        ``client.py`` fails this sentence in ``confirm.py``."""
+        fallback, owner = self._constants()
+        here = fallback * (1 + owner) // 1000
+        general = fallback * (2 + owner) // 1000
+        note = _source_prose(confirm.__file__)
+        assert f"{1 + owner} intervals — {here}s" in note
+        assert f"{2 + owner} intervals, {general}s" in note
+
+    def test_the_reason_the_deadlock_argument_survives_is_stated(self):
+        """Not "30s is fine" — the argument has to name WHY, or the next bump
+        re-opens it. Both legs: a deferral is not a suppression, and the leg
+        that grew is bought by the owner's own voice."""
+        note = _source_prose(confirm.__file__)
+        assert "a deferral is not a suppression" in note
+        assert "not the owner's silence" in note
+
+    def test_this_outcomes_own_state_cannot_take_the_in_flight_deferral(self):
+        """The behavioural half of the claim: a response created BEFORE the
+        announce never sets ``sawCreate``, so the only deferrals available here
+        are the owner-speaking ones — the fallback speaks on fire 4, not 5."""
+        fallback, owner = self._constants()
+        report = run_announcer(f"""
+            announcer.onResponseCreated();     // in flight BEFORE the announce
+            announcer.announce("Hang on — I haven't finished telling you.");
+            ownerIsSpeaking = true;
+            for (let i = 0; i < {owner + 1}; i++) {{
+                fireTimers();
+                logs.push("fire " + (i + 1) + " spoken=" + spoken.length);
+            }}
+        """)
+        for n in range(1, owner + 1):
+            assert f"fire {n} spoken=0" in report["logs"]
+        assert f"fire {owner + 1} spoken=1" in report["logs"]
+
+    def test_an_owner_who_stops_talking_is_spoken_to_at_the_next_fire(self):
+        """What bounds the owner's SILENCE rather than the buddy's wait, and
+        the sentence the rewritten paragraph rests on."""
+        report = run_announcer("""
+            announcer.announce("Hang on — I haven't finished telling you.");
+            ownerIsSpeaking = true;
+            fireTimers();
+            ownerIsSpeaking = false;
+            fireTimers();
+        """)
+        assert len(report["spoken"]) == 1
+
+
+class TestTheSpeakingBudgetCommentDoesNotClaimThePumpPath:
+    """``speakingBaseMs`` claimed the scaled budget kept the MODEL from
+    starting a response over the browser voice — the whole of #950. It does
+    not. The budget gates ``pending()``/``anchorPending()``, which are the
+    NOTIFIER's gates; the announcer's own FIFO never consults ``speaking``.
+
+    Behaviour deliberately unchanged (a separate decision). This class pins the
+    COMMENT: the residual is reproduced, so if the pump path is ever fixed this
+    fails and whoever fixes it has to come back and delete the paragraph that
+    calls it live.
+    """
+
+    def _prose(self) -> str:
+        """The page's JS comments as flat prose, so an assertion survives a
+        re-wrap — these sentences are 80 columns wide and every one of them
+        spans a line break."""
+        lines = [
+            line.strip().removeprefix("//").strip()
+            for line in client.page("buddy", "tok").splitlines()
+        ]
+        return " ".join(" ".join(lines).split())
+
+    def test_the_comment_no_longer_claims_the_defect_is_ruled_out(self):
+        prose = self._prose()
+        assert "which reopens both gates and lets the MODEL start a response" not in prose
+        assert "`current` and `queue` only — never `speaking`" in prose
+        assert "live residual" in prose
+
+    def test_the_comment_names_the_gates_the_budget_actually_covers(self):
+        prose = self._prose()
+        assert "reopens the NOTIFIER's gates — canSpeak and canInterrupt" in prose
+
+    def test_a_queued_item_is_pumped_into_the_starting_browser_voice(self):
+        """The reproduction. A long notice falls back to the browser voice; a
+        second must_speak item is queued behind it. armFallback nulls
+        `current`, starts speak(), and calls pump() in the same tick — so the
+        second item's response.create goes out while the first is still only
+        STARTING to be spoken aloud."""
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+            logs.push("speaking=" + spoken.length + " pending=" + announcer.pending());
+        """)
+        # The browser voice has started and has NOT ended.
+        assert len(report["spoken"]) == 1
+        # ...and the queued item was promoted onto the channel anyway.
+        assert len(creates(report)) == 2
+        assert "speaking=1 pending=2" in report["logs"]
+
+    def test_the_watchdog_did_not_have_to_fire_for_that(self):
+        """The part that makes it a residual rather than a symptom of the flat
+        bound: the overlap above happens at the fallback fire, with the
+        speaking watchdog freshly armed and nowhere near due."""
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+        """)
+        # Two timers are armed: the promoted item's own 6s fallback, and the
+        # speaking watchdog for the utterance now being started. The watchdog
+        # is the one this claim is about, and it is nowhere near due.
+        assert max(report["armedMs"]) > 30_000

--- a/tests/unit/test_voice_surface.py
+++ b/tests/unit/test_voice_surface.py
@@ -1097,3 +1097,59 @@ class TestExpandedReads:
         assert result["success"] is False
         assert result["must_speak"] is True
         assert seen == []
+
+
+# =============================================================================
+# Wave-2 prose: the premise a repair would argue from
+# =============================================================================
+
+
+def _flat(text: str) -> str:
+    """Whitespace-normalized, so an assertion survives a re-wrap of the prose."""
+    return " ".join((text or "").split())
+
+
+class TestRequireLiveNamesTheMechanismItActuallyHas:
+    """``_require_live``'s docstring justified its whole-name comparison from a
+    premise the shipped code does not have: that ``_session_arg`` "refuses the
+    syntax outright", making a name "local by construction".
+
+    #994's final shape refuses no syntax — surface.py records that the first
+    attempt did and that doing so was itself a false statement, because
+    ``ops@edge`` is a creatable local session. The gate is LIVENESS. The
+    conclusion survives; the premise did not, and a premise is what the next
+    person repairing this reasons from — they would look for a syntax refusal,
+    fail to find one, and "restore" it.
+
+    Pinned in both directions: the dead mechanism must not come back into the
+    prose, and the live one must be named.
+    """
+
+    def test_the_docstring_does_not_claim_a_syntax_refusal(self):
+        doc = _flat(write_tools._require_live.__doc__)
+        assert "refuses the syntax outright" not in doc
+        assert "local by construction" not in doc
+
+    def test_the_docstring_names_liveness_and_session_arg(self):
+        doc = _flat(write_tools._require_live.__doc__)
+        assert "LIVENESS" in doc
+        assert "_session_arg" in doc
+        assert "local by DEMONSTRATION" in doc
+
+    def test_the_named_mechanism_is_the_one_that_runs(self, monkeypatch):
+        """The control that keeps the sentence honest rather than merely
+        rewritten: ``_session_arg`` admits an ``@`` name local tmux reports
+        live and refuses one it does not — a liveness gate, not a syntax one.
+        If that ever becomes a syntax refusal again, this fails alongside the
+        prose that describes it."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: {"ops@edge"})
+        assert tools._session_arg({"session": "ops@edge"}) == "ops@edge"
+        with pytest.raises(tools.ToolError, match="no live session"):
+            tools._session_arg({"session": "web@laptop"})
+
+    def test_an_unreachable_tmux_makes_neither_layer_guess(self, monkeypatch):
+        """The one case the rewritten sentence carves out (spec §5): nothing is
+        demonstrated, so nothing is refused."""
+        monkeypatch.setattr("agentwire.inbox.live_sessions", lambda: None)
+        assert tools._session_arg({"session": "web@laptop"}) == "web@laptop"
+        write_tools._require_live("web@laptop", cannot="")


### PR DESCRIPTION
Prose only — **no behaviour changes anywhere**. Three sentences that other wave-2 PRs made false, each rewritten (not qualified) and each now pinned.

**[A] `confirm.py` `not_announced`** — #993 added a second deferral (`ownerSpeaking`, `maxOwnerDeferrals=3`) that STACKS with the in-flight one, so "the ONE bounded deferral" was false and the paragraph's deadlock argument was reasoned against ~12s. Restated: TWO deferrals; the in-flight one keys on a response created AFTER the announce, so the response already in flight in *this* state can never take it — bound here is 4 intervals / 24s, rising to the announcer's general 5 / 30s only if a new response starts after the announce. The deadlock argument holds, and now says why at the new number: a deferral is not a suppression, and the leg that grew is taken only while the owner IS speaking, so it extends the buddy's wait rather than the owner's silence (still ≤ one interval).

**[B] `write_tools._require_live`** — #994's final shape refuses no `@` syntax; `surface.py:80-93` records that the first attempt did and that doing so was itself a false statement. Conclusion kept, premise replaced: local by *demonstration* via the liveness gate in `tools._session_arg`, and the bare half before the `@` is exactly the string that was never demonstrated.

**[C] `client.py` `speakingBaseMs`** — the budget gates `pending()`/`anchorPending()`, the notifier's gates; it never gates the announcer's own FIFO. `armFallback` nulls `current`, starts `speak()`, and calls `pump()` in the same tick, and `pump()` consults `current`/`queue` only. Comment narrowed to what the budget actually rules out, with the `pump()` path named as a live residual. **Behaviour deliberately unchanged** — separate decision.

## Pins

13 tests, every prose assertion watched to fail against the old wording first (7 fail, 6 behavioural controls pass — they are prose-independent by design).

- The deferral arithmetic is **derived** from `client.py`'s constants, not transcribed — transcription across two files with nothing connecting them is how the first number went stale. Bump `fallbackMs` or `maxOwnerDeferrals` and the sentence in `confirm.py` fails.
- The `pump()` overlap is **reproduced**, so fixing that behaviour later fails the test and forces whoever fixes it to delete the paragraph calling it live.
- Prose assertions run against whitespace-normalized source, so a re-wrap doesn't false-fail.

## Verification

`uv run --extra dev pytest` — **5828 passed, 36 skipped, 0 failed** (base 5815 + 13 new).

Built by [dotdev.dev](https://dotdev.dev)