### PR TITLE
voice-layer: ack the spool by id, and delete the strays workaround (#970)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -524,7 +524,13 @@ INBOX_NOTIFIER_JS = """
 //
 // Injected dependencies:
 //   fetchInbox() -> Promise<{success, messages}>  PEEK — never advances the cursor
-//   ackInbox()   -> Promise<{success, messages}>  read + advance the cursor
+//   ackInbox(id) -> Promise<{success, acked}>  advance the cursor to EXACTLY id
+//              (#970). The old bool ack advanced to the spool TAIL as it stood
+//              at ack time, and the buddy acks only after SPEAKING — so mail
+//              landing in that window was cursor-advanced past unread, with no
+//              dead-letter and no screen to notice it on. #969 caught those in
+//              a page-lifetime array and a page unload dropped them silently;
+//              acking by id means there is nothing to catch.
 //   announce(text, meta)   the page's announce() — no other voice exists here
 //   canSpeak() -> bool     owner not speaking, no active response, nothing queued
 //   canInterrupt() -> bool the RELAXED gate for escalation-kind messages
@@ -545,12 +551,6 @@ INBOX_NOTIFIER_JS = """
 //              builds a fresh notifier over the same map and cannot replay a
 //              spoken notice — while a notice announced but never SPOKEN is
 //              not in it, and is correctly said again.
-//   strays: [] page-lifetime array of acked-but-never-spoken replies (the
-//              peek/ack race — see noticeSpoken). The cursor is already past
-//              them, so the spool will NEVER return them again: this array is
-//              their only way back to the owner's ear, and giving it to the
-//              notifier to own meant a stop() before the next gated tick took
-//              it to the grave. Passed in for the same reason `seen` is.
 function createInboxNotifier(deps) {
   var fetchInbox = deps.fetchInbox;
   var ackInbox = deps.ackInbox;
@@ -561,7 +561,6 @@ function createInboxNotifier(deps) {
   var onLog = deps.onLog || function () {};
   var pollMs = deps.pollMs;
   var seen = deps.seen;
-  var strays = deps.strays;
   var canInterrupt = deps.canInterrupt || function () { return false; };
   var reRaise = deps.reRaise || null;
 
@@ -602,9 +601,9 @@ function createInboxNotifier(deps) {
       // STOPPED MID-FLIGHT. This promise is not cancellable, so a poll begun
       // before stop() resolves after it — and the interrupt tier could still
       // pass, handing an escalation to a null announcer for a bare
-      // speechSynthesis.speak with no meta: never acked, never seen, and
-      // cursor-past, so the spool will never return it (#978 item 6). Checked
-      // BEFORE the strays are pulled, so nothing leaves the array either.
+      // speechSynthesis.speak with no meta: never acked, never seen (#978
+      // item 6). Since #970 it is at least not cursor-past — only a SPOKEN
+      // notice acks — so the next session re-reads it.
       if (stopped) return;
       if (!res || !res.success) {
         onLog("inbox", "poll failed: " + ((res && res.error) || "no response"));
@@ -621,20 +620,9 @@ function createInboxNotifier(deps) {
       var full = canSpeak();
       if (!full && !canInterrupt()) return;
       var take = function (m) { return full || isUrgent(m); };
-      // Strays: pull only what this tick may speak; the rest STAY in the
-      // array — a stray is cursor-past, so dropping one here loses it.
-      var pulled = [];
-      for (var i = 0; i < strays.length; ) {
-        if (take(strays[i])) pulled.push(strays.splice(i, 1)[0]);
-        else i++;
-      }
-      // Which of the announced ids came OUT of the strays array. A stray is
-      // cursor-past, so releasing it on failure is not enough — it has to go
-      // back in, and only the poll that took it knows which ones those were.
-      var wasStray = {};
-      pulled.forEach(function (m) { if (m && m.id) wasStray[m.id] = true; });
+      var unread = res.messages || [];
       var claimed = {};
-      var fresh = pulled.concat((res.messages || []).filter(take)).filter(function (m) {
+      var fresh = unread.filter(take).filter(function (m) {
         if (!m || !m.id || seen[m.id] || inFlight[m.id] || claimed[m.id]) return false;
         claimed[m.id] = true;
         return true;
@@ -655,6 +643,24 @@ function createInboxNotifier(deps) {
       }
       var ids = fresh.map(function (m) { return m.id; });
       ids.forEach(function (id) { inFlight[id] = true; });
+      // HOW FAR THIS NOTICE MAY ACK (#970). The cursor is ONE id, so acking
+      // through id X marks everything before X read too. The only safe target
+      // is the end of the longest UNBROKEN run of unread messages that are
+      // either being said now or were already heard — walked over the peek's
+      // own list, so nothing the spool grows afterwards can widen it.
+      //
+      // Stopping at the first message this tick skipped is what keeps the
+      // interrupt tier honest: it speaks an escalation and leaves an ordinary
+      // report unread AHEAD of it, and there is no ack that covers the alarm
+      // without also burying the report. So that tick acks nothing, and the
+      // full tick that finally speaks the report clears both — the skipped
+      // message is announced late, never lost.
+      var ackThrough = "";
+      for (var i = 0; i < unread.length; i++) {
+        var m = unread[i];
+        if (!m || !m.id || !(seen[m.id] || claimed[m.id])) break;
+        ackThrough = m.id;
+      }
       onLog("inbox", "volunteering " + fresh.length + " message(s)");
       // inboxMsgs rides along so the page can register request/escalation
       // notices in the re-raise ledger AT THE MOMENT THEY ARE HEARD (its
@@ -662,7 +668,7 @@ function createInboxNotifier(deps) {
       // actually told.
       announce(composeNotice(fresh), {
         inboxIds: ids,
-        strayIds: ids.filter(function (id) { return wasStray[id]; }),
+        ackThrough: ackThrough,
         inboxMsgs: fresh.map(function (m) {
           return { id: m.id, from: m.from, kind: m.kind, text: m.text };
         }),
@@ -679,23 +685,22 @@ function createInboxNotifier(deps) {
   function noticeSpoken(meta) {
     if (!meta || !meta.inboxIds) return Promise.resolve();
     meta.inboxIds.forEach(function (id) { seen[id] = true; });
-    return ackInbox().then(function (res) {
-      if (!res || !res.success) {
+    // Nothing contiguous to ack — this tick spoke past an unread message and
+    // the cursor cannot express that. Marking `seen` is the whole receipt; the
+    // ack rides the later tick that says the skipped one.
+    if (!meta.ackThrough) return Promise.resolve();
+    return ackInbox(meta.ackThrough).then(function (res) {
+      if (!res || !res.success || res.acked === false) {
         // Cursor not advanced: a page reload will re-read these. `seen`
         // suppresses a replay for THIS page's lifetime, which is the right
         // half to keep — re-reading is an annoyance, losing one is the bug.
-        onLog("inbox", "ack failed: " + ((res && res.error) || "no response"));
-        return;
+        // Said out loud on screen: a refused ack that reads as success
+        // re-announces every session with nothing to explain why.
+        onLog("inbox", "ack through " + meta.ackThrough + " failed: "
+          + ((res && res.error) || "cursor not advanced"));
       }
-      // The ack read everything unread — including anything that landed
-      // between our peek and now. Those were acked but never spoken; queue
-      // them for the next tick's gate check rather than announcing here
-      // (announcing outside the gate is barging in by another door).
-      (res.messages || []).forEach(function (m) {
-        if (m && m.id && !seen[m.id] && !inFlight[m.id]) strays.push(m);
-      });
     }).catch(function (err) {
-      onLog("inbox", "ack failed: " + err);
+      onLog("inbox", "ack through " + meta.ackThrough + " failed: " + err);
     });
   }
 
@@ -706,31 +711,26 @@ function createInboxNotifier(deps) {
   // notice is retried", but ids entered the map at ANNOUNCE time and never
   // left it: speechSynthesis fails silently, `utterance.onerror` only logged,
   // and so a notice that was neither heard nor acked was suppressed for the
-  // rest of the session (#978 item 5). `seen` still outranks this — releasing
-  // an id the owner HAS heard would replay it.
+  // rest of the session (#978 item 5).
+  //
+  // Releasing the id is now the WHOLE job (#970). It was not, while the ack
+  // swept to the tail: a message pulled from the strays array was already
+  // cursor-past, so releasing its id dropped it from both places and "the next
+  // tick says it again" was false for exactly the class that became strays.
+  // Since only a SPOKEN notice acks, and only through what it spoke, a failed
+  // announcement leaves the message untouched in the spool — the next peek
+  // returns it, and so does the next page.
+  //
+  // `seen` still outranks a release, but structurally rather than by a guard
+  // here: pollOnce drops a `seen` message BEFORE it consults `inFlight`, so a
+  // heard notice cannot be re-announced by a late failure whatever this map
+  // says. The guard that used to stand here was load-bearing only while a
+  // release could push a body back into the strays array; with the array gone
+  // it could be cut with the whole suite green, which makes it a line claiming
+  // a guarantee it no longer holds.
   function noticeFailed(meta) {
     if (!meta || !meta.inboxIds) return;
-    var body = {};
-    (meta.inboxMsgs || []).forEach(function (m) { if (m && m.id) body[m.id] = m; });
-    var cameFromStrays = {};
-    (meta.strayIds || []).forEach(function (id) { cameFromStrays[id] = true; });
-    var alreadyBack = {};
-    strays.forEach(function (m) { if (m && m.id) alreadyBack[m.id] = true; });
-    meta.inboxIds.forEach(function (id) {
-      if (seen[id]) return;
-      delete inFlight[id];
-      // A SPOOL message needs nothing more: the cursor never advanced (only
-      // noticeSpoken moves it), so the next peek returns it. A STRAY was
-      // spliced out of the array to be announced and the cursor is already
-      // past it, so releasing the id alone dropped it from BOTH places —
-      // "the next tick says it again" was false for exactly the class that
-      // becomes strays, which is escalations. Putting it back is the whole
-      // reason the array exists.
-      if (cameFromStrays[id] && !alreadyBack[id] && body[id]) {
-        alreadyBack[id] = true;   // idempotent: a second call must not double it
-        strays.push(body[id]);
-      }
-    });
+    meta.inboxIds.forEach(function (id) { delete inFlight[id]; });
   }
 
   function schedule() {
@@ -1038,13 +1038,6 @@ const INBOX_POLL_MS = 5000;
 // Page-lifetime: ids the owner has actually HEARD. Never reset by stop() — a
 // reconnect must not replay every notice.
 const heardReplies = {};
-// Page-lifetime, like heardReplies: acked-but-never-spoken replies (the
-// peek/ack race). The cursor is already past them and the spool has no
-// ack-by-id, so this array is their only way back to the owner's ear — a
-// stop() or reconnect must not take it down with the notifier. A full page
-// unload still loses whatever is here; closing that residual needs an
-// ack-by-id the inbox does not offer.
-const strayReplies = [];
 let inboxNotifier = null;
 let ownerSpeaking = false;
 
@@ -1445,7 +1438,7 @@ async function start() {
     // flight, nothing already queued to be said.
     inboxNotifier = createInboxNotifier({
       fetchInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: false } }),
-      ackInbox: () => post("/tool", { name: "buddy_inbox", arguments: { ack: true } }),
+      ackInbox: (through) => post("/tool", { name: "buddy_inbox", arguments: { ack_through: through } }),
       announce: announce,
       canSpeak: () => !ownerSpeaking && !responseActive && !!announcer && announcer.pending() === 0 && !confirmGate.outstanding(),
       // The interrupt tier (#967): an escalation need not wait for the buddy's
@@ -1469,7 +1462,6 @@ async function start() {
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
       pollMs: INBOX_POLL_MS,
       seen: heardReplies,
-      strays: strayReplies,
     });
     dc.addEventListener("open", () => { setStatus("listening"); $stop.disabled = false; });
     dc.addEventListener("close", () => setStatus("closed"));
@@ -1638,9 +1630,10 @@ function stop() {
   // TORN DOWN, not merely dropped (#978 item 4). Nulling the reference left
   // the current item's armed setTimeout closure alive: 6s into "idle" the
   // browser voice spoke and anchored a proposal on the bridge, closing the
-  // next session's volunteering gate for up to 120s. d45601b covered
-  // page-lifetime strays; `disarm` was reachable only from onResponseDone and
-  // cancel, neither of which stop() calls.
+  // next session's volunteering gate for up to 120s. d45601b covered the
+  // page-lifetime strays array (itself deleted in #970); `disarm` was
+  // reachable only from onResponseDone and cancel, neither of which stop()
+  // calls.
   if (announcer) announcer.teardown();
   announcer = null;
   // Session-scoped readiness resets; `greeted` deliberately does NOT — a
@@ -1648,11 +1641,9 @@ function stop() {
   sessionReady = false;
   audioAttached = false;
   ownerSpeaking = false;
-  // The clock dies with the session; `heardReplies` and `strayReplies`
-  // deliberately survive (a stray is cursor-past — losing the array loses the
-  // message for good), and `confirmGate` survives too: the spine lives in the
-  // bridge, so a proposal outlasts a stop() and its TTL is what reopens the
-  // gate. `heardReplies` survives so
+  // The clock dies with the session; `confirmGate` deliberately survives — the
+  // spine lives in the bridge, so a proposal outlasts a stop() and its TTL is
+  // what reopens the gate. `heardReplies` survives so
   // the fresh notifier after a reconnect cannot replay a spoken notice (#962),
   // and the re-raise ledger survives with it (#967): what the owner was told
   // is page-lifetime state, or a reconnect wipes the peer's memory of its own

--- a/agentwire/voice_layer/delivery.py
+++ b/agentwire/voice_layer/delivery.py
@@ -134,17 +134,8 @@ def _write_cursor(session: str, last_id: str) -> None:
         json.dump({"last_id": last_id}, fh)
 
 
-def read_spool(session: str, unread_only: bool = True, ack: bool = False) -> list[dict]:
-    """Read spooled messages. ``ack=True`` advances the read cursor past them.
-
-    The cursor stores the last-acked message ID, not a line count. A count looks
-    simpler and is wrong: rotating or truncating the spool leaves the count
-    pointing into a file that no longer has that shape, and the failure is
-    silent — new mail reads as already-seen and is never spoken. Message ids are
-    unique (``{epoch_ns}-{uuid6}``), so an id that is no longer present means
-    the spool was rotated, and the safe answer is "treat everything as unread".
-    Re-reading a message is a small annoyance; losing one is the bug.
-    """
+def _entries(session: str) -> list[dict]:
+    """Every message in the spool, in append order. Unparseable lines skipped."""
     path = spool_path(session)
     if not path.exists():
         return []
@@ -162,18 +153,99 @@ def read_spool(session: str, unread_only: bool = True, ack: bool = False) -> lis
             entries.append(json.loads(line))
         except json.JSONDecodeError:
             continue
+    return entries
+
+
+def _index_of(entries: list[dict], message_id: str) -> int:
+    """Position of *message_id*, or -1 when it isn't in the spool at all.
+
+    -1 also stands for "nothing acked yet", which is what makes the comparison
+    in :func:`advance_cursor` work without a special case: an absent cursor and
+    a rotated-away cursor are the same thing — everything is unread.
+    """
+    if not message_id:
+        return -1
+    for index, entry in enumerate(entries):
+        if entry.get("id") == message_id:
+            return index
+    return -1
+
+
+def _advance(entries: list[dict], session: str, message_id: str) -> bool:
+    target = _index_of(entries, message_id)
+    if target < 0:
+        # Rotated away (or never ours). Writing it would strand the cursor on an
+        # id no read can ever match; sweeping to the tail would lose mail. Refuse
+        # and say so — the caller re-reads, which is the cheap failure.
+        return False
+    if target <= _index_of(entries, _read_cursor(session)):
+        return True  # already at or past it: idempotent, and NEVER a rewind
+    _write_cursor(session, message_id)
+    return True
+
+
+def advance_cursor(session: str, message_id: "str | None") -> bool:
+    """Ack EXACTLY through *message_id* — the fix for the read/ack race (#970).
+
+    ``read_spool(ack=True)`` advances to the spool tail *as it stands at ack
+    time*, which is not what the caller read. Every consumer of this spool reads,
+    then processes, then acks — the voice notifier deliberately acks only after
+    speaking — so mail lands in that window and is cursor-advanced past without
+    ever having been read. The cursor was already id-based; this is the missing
+    parameter, not a missing mechanism.
+
+    Returns whether the cursor is now at or past *message_id*. The one False is
+    an id the spool no longer holds, and it is returned rather than swallowed:
+    a silently-refused ack is indistinguishable from a successful one, and the
+    caller re-announces forever with nothing on screen to say why.
+
+    Both halves are priced. Acking too little re-reads a message the owner
+    already heard (an annoyance). Acking too much loses one silently — no
+    dead-letter, no email, and in a voice channel no screen to notice on. So
+    every refusal here fails toward re-reading, and the cursor never moves
+    backwards either: a rewind un-reads mail that WAS heard.
+    """
+    if not message_id:
+        return False
+    return _advance(_entries(session), session, str(message_id))
+
+
+def read_spool(
+    session: str,
+    unread_only: bool = True,
+    ack: bool = False,
+    ack_through: "str | None" = None,
+) -> list[dict]:
+    """Read spooled messages, optionally advancing the read cursor.
+
+    ``ack_through=<id>`` acks exactly through that message (see
+    :func:`advance_cursor`) and OUTRANKS ``ack``: honouring both would sweep the
+    tail, which is the behaviour ``ack_through`` exists to avoid. ``ack=True``
+    keeps its old meaning — advance past everything unread — for callers that
+    genuinely consume the whole spool in one breath.
+
+    The cursor stores the last-acked message ID, not a line count. A count looks
+    simpler and is wrong: rotating or truncating the spool leaves the count
+    pointing into a file that no longer has that shape, and the failure is
+    silent — new mail reads as already-seen and is never spoken. Message ids are
+    unique (``{epoch_ns}-{uuid6}``), so an id that is no longer present means
+    the spool was rotated, and the safe answer is "treat everything as unread".
+    Re-reading a message is a small annoyance; losing one is the bug.
+    """
+    entries = _entries(session)
+    if not entries:
+        return []
 
     start = 0
     if unread_only:
-        last_id = _read_cursor(session)
-        if last_id:
-            for index, entry in enumerate(entries):
-                if entry.get("id") == last_id:
-                    start = index + 1
-                    break
+        found = _index_of(entries, _read_cursor(session))
+        if found >= 0:
+            start = found + 1
 
     selected = entries[start:] if unread_only else entries
-    if ack and entries:
+    if ack_through:
+        _advance(entries, session, str(ack_through))
+    elif ack:
         _write_cursor(session, str(entries[-1].get("id") or ""))
     return selected
 

--- a/agentwire/voice_layer/delivery.py
+++ b/agentwire/voice_layer/delivery.py
@@ -194,10 +194,12 @@ def advance_cursor(session: str, message_id: "str | None") -> bool:
     ever having been read. The cursor was already id-based; this is the missing
     parameter, not a missing mechanism.
 
-    Returns whether the cursor is now at or past *message_id*. The one False is
-    an id the spool no longer holds, and it is returned rather than swallowed:
-    a silently-refused ack is indistinguishable from a successful one, and the
-    caller re-announces forever with nothing on screen to say why.
+    Returns whether the cursor is now at or past *message_id*. False means it is
+    not, and there are exactly two ways to get one: an id the spool no longer
+    holds, and an empty/None id (a caller asking to ack through nothing). Both
+    are returned rather than swallowed — a silently-refused ack is
+    indistinguishable from a successful one, and the caller re-announces forever
+    with nothing on screen to say why.
 
     Both halves are priced. Acking too little re-reads a message the owner
     already heard (an annoyance). Acking too much loses one silently — no
@@ -243,8 +245,14 @@ def read_spool(
             start = found + 1
 
     selected = entries[start:] if unread_only else entries
-    if ack_through:
-        _advance(entries, session, str(ack_through))
+    if ack_through is not None:
+        # NOT `if ack_through:` — an empty string is a caller asking to ack
+        # through nothing, which acks nothing. Falling through to the bool path
+        # there would sweep the tail from inside the guard against sweeping it.
+        # None is the default and means "absent", the closest Python has to the
+        # tool layer's presence check.
+        if ack_through:
+            _advance(entries, session, str(ack_through))
     elif ack:
         _write_cursor(session, str(entries[-1].get("id") or ""))
     return selected

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -298,7 +298,8 @@ VOICE_NATIVE: dict[str, dict] = {
     "buddy_inbox": {
         "grade": "write_light",
         "ruling": (
-            "Reads the buddy's own spool, and with ack=true advances its read "
+            "Reads the buddy's own spool, and with ack_through=<id> (or the "
+            "blunter ack=true) advances its read "
             "cursor — a mutation, from the read-only allowlist. Light, not "
             "gated: the message is untouched, `unread_only=false` reads it "
             "straight back, and the worst wrong execution loses a read marker "

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -361,19 +361,31 @@ def _buddy_inbox(args: dict) -> dict:
     name = args.get("_buddy") or ""
     if not name:
         raise ToolError("buddy identity missing from tool context")
+    # PRESENCE, not truth. Keying the precedence on the stripped value collapses
+    # "no ack_through" with "an ack_through that stripped to nothing", so
+    # {ack: true, ack_through: ""} — or null, or whitespace — fell through to the
+    # bool path and swept the tail: the exact loss this parameter exists to
+    # close, reachable from inside its own guard. Asking to ack through nothing
+    # acks nothing and says so; re-reading is the cheap failure, and a sweep is
+    # the one that has no screen to surface it.
+    asked_through = "ack_through" in args
     through = args.get("ack_through")
     if through is not None and not isinstance(through, str):
         raise ToolError("ack_through must be a message id")
-    through = (through or "").strip()
+    # Not stripped: an id comes from a prior read of this same spool, never a
+    # human's fingers, so " m1 " is a caller that has already lost track of what
+    # it read. Refusing is the loud failure; trimming it into a match is a guess
+    # on the one operation where guessing generously loses mail.
+    through = through or ""
     ack = bool(args.get("ack", False))
     unread_only = bool(args.get("unread_only", True))
-    # ack_through OUTRANKS ack: honouring both would sweep the tail, which is
-    # exactly what the specific ack exists to avoid.
     messages = delivery.read_spool(
-        name, unread_only=unread_only, ack=ack and not through
+        name, unread_only=unread_only, ack=ack and not asked_through
     )
     acked = (
-        delivery.advance_cursor(name, through) if through else bool(ack and messages)
+        delivery.advance_cursor(name, through)
+        if asked_through
+        else bool(ack and messages)
     )
     return {
         "success": True,

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -348,18 +348,37 @@ def _fleet_voice_health(args: dict) -> dict:
 def _buddy_inbox(args: dict) -> dict:
     """The buddy's OWN mail — what other sessions have reported to it.
 
-    Reads the spool the delivery adapter writes. ``ack`` advances the read
-    cursor, so the buddy only marks mail read once it has actually said it out
-    loud — an unacked read after a dropped call is re-read, not lost.
+    Reads the spool the delivery adapter writes. The cursor advances only on an
+    ack, so the buddy marks mail read once it has actually said it out loud — an
+    unacked read after a dropped call is re-read, not lost.
+
+    ``ack_through`` is the one to reach for (#970): it acks EXACTLY the message
+    named, so anything that landed between the read and the ack is still pending
+    by construction. ``ack`` sweeps to the tail as it stands at ack time, which
+    is not what the caller read. ``acked`` reports whether the cursor actually
+    moved — a refused ack that reads as success re-announces forever.
     """
     name = args.get("_buddy") or ""
     if not name:
         raise ToolError("buddy identity missing from tool context")
+    through = args.get("ack_through")
+    if through is not None and not isinstance(through, str):
+        raise ToolError("ack_through must be a message id")
+    through = (through or "").strip()
     ack = bool(args.get("ack", False))
     unread_only = bool(args.get("unread_only", True))
-    messages = delivery.read_spool(name, unread_only=unread_only, ack=ack)
+    # ack_through OUTRANKS ack: honouring both would sweep the tail, which is
+    # exactly what the specific ack exists to avoid.
+    messages = delivery.read_spool(
+        name, unread_only=unread_only, ack=ack and not through
+    )
+    acked = (
+        delivery.advance_cursor(name, through) if through else bool(ack and messages)
+    )
     return {
         "success": True,
+        "acked": acked,
+        "acked_through": through,
         "count": len(messages),
         "messages": [
             {k: m.get(k) for k in ("id", "from", "kind", "text", "ts", "ref")}
@@ -504,16 +523,29 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
         name="buddy_inbox",
         description=(
             "Your own mail — reports and requests other sessions have sent YOU. Read "
-            "this when asked what needs attention. Set ack to true only once you have "
-            "actually told the owner what it says."
+            "this when asked what needs attention. Mark mail read only once you have "
+            "actually told the owner what it says, and mark it with ack_through set to "
+            "the id of the last message you said out loud — ack sweeps past anything "
+            "that arrived while you were speaking, and that mail is then never read "
+            "by anyone."
         ),
         run=_buddy_inbox,
         parameters={
             "type": "object",
             "properties": {
+                "ack_through": {
+                    "type": "string",
+                    "description": (
+                        "Id of the last message you actually said out loud. Marks "
+                        "everything up to and including it read, and nothing after."
+                    ),
+                },
                 "ack": {
                     "type": "boolean",
-                    "description": "Mark the returned messages as read. Default false.",
+                    "description": (
+                        "Mark ALL unread messages read, including any that arrived "
+                        "since you read. Prefer ack_through. Default false."
+                    ),
                 },
                 "unread_only": {
                     "type": "boolean",

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -297,9 +297,14 @@ whose stated residual was that a page unload dropped them silently; that array
 is gone, and the property it was defending now rests on the cursor rather than
 on client state surviving a page.
 
-Two refusals, both failing toward re-reading: an id the spool no longer holds
-moves nothing (and reports so — a silently-refused ack is indistinguishable
-from a successful one, and re-announces forever), and the cursor never rewinds.
+Refusals fail toward re-reading, never toward sweeping: an id the spool no
+longer holds moves nothing (and reports so — a silently-refused ack is
+indistinguishable from a successful one, and re-announces forever), ids are
+matched exactly rather than trimmed into a match, and the cursor never rewinds.
+**The precedence keys on PRESENCE, not on the value** — collapsing "no
+`ack_through`" with "an `ack_through` that is blank" sends `{ack: true,
+ack_through: ""}` down the bool path and sweeps the tail from inside the guard
+against sweeping it.
 The notifier acks only through an unbroken run of messages it is speaking now
 or has already been heard: the interrupt tier speaks an escalation while an
 ordinary report sits *ahead* of it, and one id cannot cover the alarm without

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -285,6 +285,27 @@ as already-seen and is never spoken. An id that is no longer present means the
 spool rotated, and the safe answer is "treat everything as unread". Re-reading a
 message is an annoyance; losing one is the bug.
 
+**The ack names an id, not "everything" (#970).** `ack=true` advances to the
+spool TAIL as it stands *at ack time* — and every consumer here reads, then
+processes, then acks (the notifier deliberately acks only after SPEAKING), so
+mail lands in that window and is cursor-advanced past having been read by
+nobody. In a screenless channel that loss surfaces nowhere: no dead-letter, no
+email, no screen. `ack_through=<id>` acks exactly through what the caller
+consumed, so a later arrival is still pending **by construction**. PR #969
+narrowed the window instead, catching swept messages in a page-lifetime array
+whose stated residual was that a page unload dropped them silently; that array
+is gone, and the property it was defending now rests on the cursor rather than
+on client state surviving a page.
+
+Two refusals, both failing toward re-reading: an id the spool no longer holds
+moves nothing (and reports so — a silently-refused ack is indistinguishable
+from a successful one, and re-announces forever), and the cursor never rewinds.
+The notifier acks only through an unbroken run of messages it is speaking now
+or has already been heard: the interrupt tier speaks an escalation while an
+ordinary report sits *ahead* of it, and one id cannot cover the alarm without
+burying the report — so that tick acks nothing, and the full tick that finally
+speaks the report clears both.
+
 ### The tool surface is an allowlist, not a passthrough
 
 The model chooses *which* tool. It never chooses *what runs*. Every tool builds

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -635,7 +635,7 @@ _NOTIFIER_HARNESS = """
 const announcedCalls = [];
 const logs = [];
 const seen = {};
-const strays = [];
+const ackCalls = [];
 let spool = [];
 let cursor = 0;
 let speakable = true;
@@ -647,10 +647,16 @@ let nextHandle = 1;
 function fetchInbox() {
   return Promise.resolve({ success: true, messages: spool.slice(cursor) });
 }
-function ackInbox() {
-  const msgs = spool.slice(cursor);
-  cursor = spool.length;
-  return Promise.resolve({ success: true, messages: msgs });
+// Mirrors delivery.advance_cursor exactly, including both refusals: an id the
+// spool no longer holds moves nothing, and the cursor never rewinds. A harness
+// that acked more freely than the real bridge would prove the wrong thing.
+function ackInbox(through) {
+  ackCalls.push(through === undefined ? "<undefined>" : String(through));
+  if (!through) return Promise.resolve({ success: true, acked: false });
+  const idx = spool.findIndex((m) => m.id === through);
+  if (idx < 0) return Promise.resolve({ success: true, acked: false });
+  if (idx + 1 > cursor) cursor = idx + 1;
+  return Promise.resolve({ success: true, acked: true, acked_through: through });
 }
 function makeNotifier(overrides) {
   return createInboxNotifier(Object.assign({
@@ -664,14 +670,13 @@ function makeNotifier(overrides) {
     onLog: (kind, detail) => logs.push(kind + ": " + detail),
     pollMs: 5000,
     seen,
-    strays,
   }, overrides || {}));
 }
 let notifier = makeNotifier();
 function report() {
   return JSON.stringify({
-    announced: announcedCalls, logs, cursor, seen, armedTimers: timers.length,
-    strays: strays.length,
+    announced: announcedCalls, logs, cursor, seen, ackCalls,
+    armedTimers: timers.length,
   });
 }
 """
@@ -746,6 +751,8 @@ class TestTheBuddyClock:
         assert "cursor after announce: 0" in report["logs"]
         assert report["cursor"] == 1
         assert report["seen"] == {"m1": True}
+        # …and the ack named the message, rather than sweeping to the tail.
+        assert report["ackCalls"] == ["m1"]
 
     def test_a_pending_notice_is_not_reannounced_by_the_next_tick(self):
         report = run_notifier("""
@@ -779,38 +786,96 @@ class TestTheBuddyClock:
         assert len(report["announced"]) == 2
 
     def test_a_reply_landing_between_speak_and_ack_is_not_silently_acked(self):
-        """ack advances the cursor past EVERYTHING unread, including a message
-        that arrived after the peek. That message was never spoken — it must
-        surface on a later tick, not vanish behind the cursor."""
+        """#970's acceptance case. The ack names the last message actually
+        SPOKEN, so a reply that arrived after the peek is behind no cursor at
+        all — it is still unread in the spool, by construction, with no
+        client-side bookkeeping between it and the owner's ear."""
         report = run_notifier("""
             spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
             await notifier.pollOnce();
             spool.push({ id: "m2", from: "billing", kind: "note", text: "late arrival" });
             await notifier.noticeSpoken(announcedCalls[0].meta);
+            logs.push("cursor after acking m1: " + cursor);
             await notifier.pollOnce();
         """)
+        assert "cursor after acking m1: 1" in report["logs"]
         assert len(report["announced"]) == 2
         assert "billing" in report["announced"][1]["text"]
         assert report["announced"][1]["meta"]["inboxIds"] == ["m2"]
 
-    def test_a_stray_reply_survives_stop_before_the_next_tick(self):
-        """The wave-2 D1 construction: a reply lands between the peek and the
-        ack, the cursor advances past it, and the owner clicks Stop before the
-        next gated tick. The stray's home must outlive the notifier — the
-        spool will never return that message again (there is no ack-by-id),
-        so a per-notifier array is its grave."""
+    def test_the_ack_names_the_last_message_announced(self):
+        """The mutation this class exists to forbid: an ack that walks past
+        what was announced. The id on the meta is decided at ANNOUNCE time,
+        from the peek's own list — nothing the spool grows afterwards can widen
+        it."""
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "docs", kind: "done", text: "one" },
+              { id: "m2", from: "billing", kind: "note", text: "two" },
+            ];
+            await notifier.pollOnce();
+            spool.push({ id: "m3", from: "late", kind: "note", text: "three" });
+            logs.push("ackThrough: " + announcedCalls[0].meta.ackThrough);
+        """)
+        assert "ackThrough: m2" in report["logs"]
+
+    def test_a_notice_with_nothing_to_ack_does_not_call_the_bridge(self):
+        """The empty ``ackThrough`` is a decision, not a missing value, so it
+        must not be posted. Acking through nothing is a no-op the bridge
+        correctly refuses — and that refusal is now a LOUD one, so posting it
+        would log a failure on the one path that has nothing wrong with it,
+        training the owner to ignore the line that means real loss.
+
+        Its own control is ``test_ack_happens_only_after_it_was_spoken``: the
+        ordinary path DOES call the bridge, with the id.
+        """
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "minecraft", kind: "done", text: "done" },
+              { id: "m2", from: "watchdog", kind: "escalation", text: "auth expired" },
+            ];
+            speakable = false;
+            interruptable = true;
+            await notifier.pollOnce();
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+        """)
+        assert report["ackCalls"] == []
+        assert not [line for line in report["logs"] if "failed" in line]
+
+    def test_the_race_survives_stop_before_the_next_tick(self):
+        """The wave-2 D1 construction, which is what #969 built the
+        page-lifetime strays array for: a reply lands between the peek and the
+        ack, and the owner clicks Stop before the next gated tick. With the ack
+        scoped to what was spoken there is nothing to carry across the
+        reconnect — the message never left the spool, so a page UNLOAD (which
+        the array could not survive at all) is covered by the same fact."""
         report = run_notifier("""
             spool = [{ id: "m1", from: "minecraft", kind: "done", text: "done" }];
             await notifier.pollOnce();
             spool.push({ id: "m2", from: "billing", kind: "note", text: "late arrival" });
             await notifier.noticeSpoken(announcedCalls[0].meta);
-            notifier.stop();             // owner clicks Stop with the stray pending
+            notifier.stop();             // owner clicks Stop with the reply pending
             notifier = makeNotifier();   // the reconnect
             await notifier.pollOnce();
         """)
         assert len(report["announced"]) == 2
         assert "billing" in report["announced"][1]["text"]
         assert report["announced"][1]["meta"]["inboxIds"] == ["m2"]
+
+    def test_a_refused_ack_is_logged_not_swallowed(self):
+        """The bridge can refuse (a rotated spool). Treating that as success
+        leaves the cursor where it was with nothing said about it — the notice
+        then re-announces every session, and the owner has no screen to see
+        why."""
+        report = run_notifier("""
+            notifier = makeNotifier({
+              ackInbox: () => Promise.resolve({ success: true, acked: false }),
+            });
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "done" }];
+            await notifier.pollOnce();
+            await notifier.noticeSpoken(announcedCalls[0].meta);
+        """)
+        assert any("ack" in line and "m1" in line for line in report["logs"])
 
     def test_an_empty_inbox_is_silence(self):
         """The recipient never replying produces silence — no follow-up, no
@@ -872,9 +937,12 @@ class TestTheBuddyClock:
             " arguments: { ack: false } })," in page
         )
         assert (
-            'ackInbox: () => post("/tool", { name: "buddy_inbox",'
-            " arguments: { ack: true } })," in page
+            'ackInbox: (through) => post("/tool", { name: "buddy_inbox",'
+            " arguments: { ack_through: through } })," in page
         )
+        # The wire that matters: the id travels, so the bridge acks exactly
+        # what was spoken. `ack: true` would sweep the tail (#970).
+        assert '{ name: "buddy_inbox", arguments: { ack: true } }' not in page
         # onSpoken routes a spoken notice back to the notifier for the ack.
         onspoken_body = page.split("function onSpoken(meta, how)", 1)[1]
         assert "meta.inboxIds" in onspoken_body.split("function send", 1)[0]
@@ -886,19 +954,26 @@ class TestTheBuddyClock:
         assert "heardReplies =" not in stop_body
         assert "heardReplies[" not in stop_body
 
-    def test_strays_get_the_same_page_lifetime_home_as_heard_replies(self):
-        """D1: the page owns the strays array and passes it in like `seen`;
-        stop() must not touch it — a stray is cursor-past, so this array is
-        the only route left to the owner's ear."""
+    def test_the_page_carries_no_strays_array_at_all(self):
+        """#970 deletes #969's workaround rather than relocating it. The array
+        existed for one reason — the ack was all-or-nothing to the tail, so a
+        message swept past it had no route left but page-lifetime client state,
+        and a page unload lost it silently. With the ack scoped to what was
+        spoken, nothing is ever swept past unread: the spool IS the store.
+
+        Pinned as an absence because that is the claim. A surviving array would
+        mean the invariant still rests on client bookkeeping surviving a page.
+        """
         page = client.page("buddy", "tok")
-        assert "const strayReplies = [];" in page
-        wiring = page.split("createInboxNotifier({", 1)[1].split("});", 1)[0]
-        assert "strays: strayReplies," in wiring
-        # Pin the operations, not the mentions: stop() must not reassign or
-        # mutate the array (a comment naming it is fine).
-        stop_body = page.split("function stop() {", 1)[1].split("\n}", 1)[0]
-        assert "strayReplies =" not in stop_body
-        assert "strayReplies." not in stop_body
+        assert "strayReplies" not in page
+        assert "strayIds" not in page
+        # Pin the operations, not the mentions — the comments still explain
+        # what the array was for and why it is gone, which is the record.
+        code = "\n".join(
+            line for line in client.notifier_source().splitlines()
+            if not line.strip().startswith("//")
+        )
+        assert "stray" not in code.lower()
 
 
 _CONFIRM_GATE_HARNESS = """
@@ -1248,10 +1323,18 @@ class TestTheInterruptTier:
             assert len(report["announced"]) == 1, f"kind {kind} was lost by waiting"
 
     def test_a_mixed_batch_under_interrupt_takes_only_the_escalation(self):
-        """And the skipped ordinary message is NOT buried by the ack: acking
-        the spoken escalation advances the cursor past everything, so the
-        done-report must come back through the strays path on the next full
-        tick — the same never-lose-one property the peek/ack race has."""
+        """And the skipped ordinary message is NOT buried by the ack. The
+        interrupt tier speaks m2 while m1 sits AHEAD of it in the spool, and
+        the cursor is a single id: there is no ack that covers m2 without also
+        covering m1. So this tick acks NOTHING (``ackThrough`` is empty), m1
+        stays unread, and the next full tick says it — after which the ack
+        walks over both, because m2 is `seen` by then.
+
+        This is the false-reject half priced in the loud direction: the
+        escalation stays unacked in the spool for a while, which costs a repeat
+        after a page reload. Acking m2 alone would cursor-advance past a report
+        no one ever read, with nothing on screen to notice it by.
+        """
         report = run_notifier("""
             spool = [
               { id: "m1", from: "minecraft", kind: "done", text: "done" },
@@ -1261,14 +1344,23 @@ class TestTheInterruptTier:
             interruptable = true;
             await notifier.pollOnce();
             logs.push("interrupt took: " + announcedCalls.length);
+            logs.push("ackThrough: '" + announcedCalls[0].meta.ackThrough + "'");
             await notifier.noticeSpoken(announcedCalls[0].meta);
+            logs.push("cursor after the escalation was spoken: " + cursor);
             speakable = true;
             await notifier.pollOnce();
+            await notifier.noticeSpoken(announcedCalls[1].meta);
+            logs.push("cursor once the skipped report was spoken too: " + cursor);
         """)
         assert "interrupt took: 1" in report["logs"]
+        assert "ackThrough: ''" in report["logs"]
+        assert "cursor after the escalation was spoken: 0" in report["logs"]
         assert len(report["announced"]) == 2
         assert report["announced"][0]["meta"]["inboxIds"] == ["m2"]
         assert report["announced"][1]["meta"]["inboxIds"] == ["m1"]
+        # It converges: the cursor clears BOTH once each has been heard, so a
+        # skipped message never wedges the spool open forever.
+        assert "cursor once the skipped report was spoken too: 2" in report["logs"]
 
     def test_the_owner_speaking_blocks_even_an_escalation(self):
         """The unconditional leg. Nothing — including the alarm — speaks over
@@ -1283,24 +1375,26 @@ class TestTheInterruptTier:
         """)
         assert len(report["announced"]) == 1
 
-    def test_an_escalation_stray_is_taken_and_an_ordinary_stray_stays(self):
-        """Strays are cursor-past — the array is their only route back. The
-        interrupt tick must pull only what it may speak and leave the rest
-        IN the array, not drop them on the floor."""
+    def test_an_escalation_behind_an_ordinary_message_is_still_taken(self):
+        """The interrupt tier reads the spool, not a side array: an escalation
+        sitting BEHIND an ordinary message is spoken while the owner is busy,
+        and the ordinary one waits for the full gate. Order of arrival does not
+        decide which alarms."""
         report = run_notifier("""
-            strays.push({ id: "s1", from: "minecraft", kind: "note", text: "fyi" });
-            strays.push({ id: "s2", from: "watchdog", kind: "escalation", text: "blocked pane" });
+            spool = [
+              { id: "m1", from: "minecraft", kind: "note", text: "fyi" },
+              { id: "m2", from: "watchdog", kind: "escalation", text: "blocked pane" },
+            ];
             speakable = false;
             interruptable = true;
             await notifier.pollOnce();
-            logs.push("strays left: " + strays.length);
+            await notifier.noticeSpoken(announcedCalls[0].meta);
             speakable = true;
             await notifier.pollOnce();
         """)
-        assert "strays left: 1" in report["logs"]
         assert len(report["announced"]) == 2
-        assert report["announced"][0]["meta"]["inboxIds"] == ["s2"]
-        assert report["announced"][1]["meta"]["inboxIds"] == ["s1"]
+        assert report["announced"][0]["meta"]["inboxIds"] == ["m2"]
+        assert report["announced"][1]["meta"]["inboxIds"] == ["m1"]
 
     def test_an_escalation_notice_names_itself_as_one(self):
         report = run_notifier("""
@@ -2043,7 +2137,14 @@ class TestASilentlyFailedAnnouncementIsRetried:
 
     def test_a_heard_notice_is_never_released_by_a_later_failure(self):
         """``seen`` is what settles a notice, and it outranks this: releasing
-        an id the owner HAS heard would replay it."""
+        an id the owner HAS heard would replay it.
+
+        Where that holds moved in #970. It was a guard inside ``noticeFailed``
+        while a release could push a body back into the strays array; with the
+        array gone the guarantee is structural — ``pollOnce`` drops a ``seen``
+        message before it ever consults ``inFlight``. This test passes either
+        way, which is the point: it pins the property, not the line.
+        """
         report = run_notifier("""
             spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
             await notifier.pollOnce();
@@ -2063,13 +2164,17 @@ class TestASilentlyFailedAnnouncementIsRetried:
         assert "noticeFailed" in handler
 
 
-class TestTheStopTimeRaceCannotStrandAStray:
+class TestTheStopTimeRaceAnnouncesNothing:
     """#978 item 6. ``pollOnce`` is not cancellable mid-flight. After
     ``stop()`` the full gate fails but ``canInterrupt`` could still pass, and
     ``announce`` with a null announcer did a bare ``speechSynthesis.speak`` —
-    no meta, no ``onSpoken``, never acked, never seen. Being cursor-past, the
-    spool will never return those replies: the ``strays`` array is their only
-    way back to the owner's ear, and this path emptied it into nothing.
+    no meta, no ``onSpoken``, never acked, never seen.
+
+    #970 downgrades the consequence without removing the defect: the reply is
+    no longer cursor-past when this happens (only a spoken notice acks now), so
+    the next session re-reads it. Speaking into a dead announcer is still an
+    utterance the owner may hear and the layer cannot account for, which is why
+    both guards stay.
     """
 
     def test_a_poll_resolving_after_stop_announces_nothing(self):
@@ -2081,26 +2186,11 @@ class TestTheStopTimeRaceCannotStrandAStray:
         """)
         assert report["announced"] == []
 
-    def test_it_never_takes_a_stray_out_of_the_array(self):
-        """The invariant the array exists for. A stray dropped here is lost
-        for good — the cursor is already past it, so the spool will never
-        return it. The stopped check therefore runs BEFORE the pull, not after
-        it: putting them back would work too, but only if every later return
-        path remembered to."""
+    def test_the_message_is_still_there_for_the_next_session(self):
+        """Whole-loop: nothing was acked, so the notifier built after a
+        reconnect finds it in the spool and says it."""
         report = run_notifier("""
-            strays.push({ id: "s1", from: "docs", kind: "escalation", text: "still open" });
-            const inFlight = notifier.pollOnce();
-            notifier.stop();
-            await inFlight;
-        """)
-        assert report["announced"] == []
-        assert report["strays"] == 1
-
-    def test_a_stray_survives_to_the_next_session(self):
-        """Whole-loop: the array is page-lifetime, so the notifier built after
-        a reconnect finds it and says it."""
-        report = run_notifier("""
-            strays.push({ id: "s1", from: "docs", kind: "done", text: "still open" });
+            spool = [{ id: "m1", from: "docs", kind: "done", text: "still open" }];
             const inFlight = notifier.pollOnce();
             notifier.stop();
             await inFlight;
@@ -2295,23 +2385,23 @@ class TestTheBrowserVoiceErrorIsActuallyWired:
         assert "onSpokenAloud()" in handler
 
 
-class TestAFailedStrayIsPutBack:
-    """Review F3. ``pollOnce`` SPLICES a stray out of the array when it pulls
-    one, and a stray is cursor-past: the spool will never return it. Releasing
-    only the id from ``inFlight`` therefore leaves the message gone from both
-    places, so "the next gated tick says it again" was FALSE for exactly the
-    class that becomes strays — escalations, the one kind that emails the
-    owner on dead-letter.
+class TestAFailedNoticeComesBackFromTheSpool:
+    """Review F3, re-based on #970. The old shape: ``pollOnce`` SPLICED a
+    stray out of the page-lifetime array, and a stray was cursor-past — so
+    releasing only the id from ``inFlight`` left the message gone from BOTH
+    places, and "the next gated tick says it again" was false for exactly the
+    class that became strays (escalations).
 
-    ``test_it_never_takes_a_stray_out_of_the_array`` forbids this loss, and
-    its own docstring named the trap: putting them back works "only if every
-    later return path remembered to". This is the return path that did not.
+    With the ack scoped to what was spoken, nothing announced is ever
+    cursor-past before it is heard. ``noticeFailed`` therefore has one job left
+    — release the ids — and the spool itself is what says the message again.
+    The class that was hardest to keep is now the one with no special case.
     """
 
-    def test_a_failed_stray_is_volunteered_again(self):
+    def test_a_failed_notice_is_volunteered_again(self):
         report = run_notifier("""
-            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
-                          text: "a done report dead-lettered" });
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation",
+                       text: "a done report dead-lettered" }];
             await notifier.pollOnce();
             notifier.noticeFailed(announcedCalls[0].meta);
             await notifier.pollOnce();
@@ -2319,78 +2409,50 @@ class TestAFailedStrayIsPutBack:
         assert len(report["announced"]) == 2
         assert "dead-lettered" in report["announced"][1]["text"]
 
-    def test_it_is_back_in_the_array_not_merely_re_announced(self):
-        """The array is the page-lifetime store that survives a reconnect. An
-        id released into nothing is announced once more and then gone."""
+    def test_a_failed_notice_was_never_acked_in_the_first_place(self):
+        """The property that replaces the array. The cursor only moves from
+        ``noticeSpoken``, so a failed announcement leaves the message exactly
+        where it was — including across a page unload, which the array could
+        never survive (#970's stated residual on #969)."""
         report = run_notifier("""
-            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
-                          text: "a done report dead-lettered" });
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "wedged" }];
             await notifier.pollOnce();
             notifier.noticeFailed(announcedCalls[0].meta);
+            logs.push("cursor after a failed notice: " + cursor);
+            notifier = makeNotifier();   // the reload: no client state carried
+            await notifier.pollOnce();
         """)
-        assert report["strays"] == 1
+        assert "cursor after a failed notice: 0" in report["logs"]
+        assert len(report["announced"]) == 2
 
-    def test_it_is_not_put_back_twice(self):
+    def test_releasing_twice_announces_once(self):
+        """Idempotent, and the discriminator for the test above: a double
+        release must not double the notice on the next tick."""
         report = run_notifier("""
-            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
-                          text: "wedged" });
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "wedged" }];
             await notifier.pollOnce();
             const meta = announcedCalls[0].meta;
             notifier.noticeFailed(meta);
             notifier.noticeFailed(meta);
+            await notifier.pollOnce();
         """)
-        assert report["strays"] == 1
+        assert len(report["announced"]) == 2
 
-    def test_a_heard_stray_is_never_put_back(self):
-        """``seen`` outranks the release, here as everywhere: re-queueing a
-        stray the owner HAS heard replays it with no cursor to suppress it.
-
-        The array is read BEFORE the next poll, and that is the whole test.
-        The first version ended with a trailing ``pollOnce()`` and passed
-        whether the guard was there or not: the poll pulls the wrongly-restored
-        stray, drops it for being ``seen``, and leaves the array at 0 either
-        way — laundering the very state under test. It was counted as a pin
-        and pinned nothing (mutation: removing ``if (seen[id]) return;``
-        survived all 625 voice tests).
-        """
+    def test_a_heard_notice_is_never_re_announced_by_a_late_failure(self):
+        """``seen`` outranks the release — structurally, since ``pollOnce``
+        drops a seen message before consulting ``inFlight``. A notice that was
+        HEARD and acked stays settled even if a failure callback arrives after
+        it, and even against a re-read of the whole spool."""
         report = run_notifier("""
-            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
-                          text: "wedged" });
+            spool = [{ id: "m1", from: "watchdog", kind: "escalation", text: "wedged" }];
             await notifier.pollOnce();
             const meta = announcedCalls[0].meta;
             await notifier.noticeSpoken(meta);
             notifier.noticeFailed(meta);
-            logs.push("strays after failing a HEARD stray: " + strays.length);
+            cursor = 0;                  // even against a re-read of the spool
+            await notifier.pollOnce();
         """)
-        assert "strays after failing a HEARD stray: 0" in report["logs"]
         assert len(report["announced"]) == 1
-
-    def test_the_same_shape_unheard_DOES_come_back(self):
-        """The discriminator for the assertion above. Identical script minus
-        the ``noticeSpoken``, read at the same instant: the array must be 1,
-        or the test above would pass simply because nothing is ever restored.
-        """
-        report = run_notifier("""
-            strays.push({ id: "s1", from: "watchdog", kind: "escalation",
-                          text: "wedged" });
-            await notifier.pollOnce();
-            notifier.noticeFailed(announcedCalls[0].meta);
-            logs.push("strays after failing an UNHEARD stray: " + strays.length);
-        """)
-        assert "strays after failing an UNHEARD stray: 1" in report["logs"]
-
-    def test_a_spool_message_is_not_pushed_into_the_strays_array(self):
-        """The other direction. A message still in the spool needs only the
-        inFlight release — the cursor never moved. Pushing it into strays too
-        would announce it twice once the cursor finally advances."""
-        report = run_notifier("""
-            spool = [{ id: "m1", from: "docs", kind: "done", text: "draft ready" }];
-            await notifier.pollOnce();
-            notifier.noticeFailed(announcedCalls[0].meta);
-            await notifier.pollOnce();
-        """)
-        assert len(report["announced"]) == 2
-        assert report["strays"] == 0
 
 
 class TestTheHandshakeGateCoversTheFallbackSpeech:

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -285,6 +285,37 @@ class TestAckThrough:
         assert delivery.advance_cursor("buddy", ids[0]) is True  # idempotent, not a move
         assert delivery.read_spool("buddy") == []
 
+    def test_read_spool_ack_through_outranks_the_bool(self, isolate):
+        """The precedence the docstring promises, at the FUNCTION layer.
+
+        Pinned separately from the tool layer on purpose: the tool never
+        forwards both, so a test there cannot see this rule, and making `ack`
+        win inside ``read_spool`` survived the entire voice suite. A documented
+        precedence nothing can falsify is the shape this PR names as its own
+        standard.
+        """
+        identity.register("buddy")
+        ids = self._spool(["one", "two"])
+        delivery.read_spool("buddy", ack=True, ack_through=ids[0])
+        assert [m["text"] for m in delivery.read_spool("buddy")] == ["two"]
+
+    def test_read_spool_never_sweeps_on_an_ack_through_that_acks_nothing(self, isolate):
+        """Same collapse as the tool layer, one floor down: an explicit empty
+        ack_through must not fall through to the bool path. Python cannot see
+        presence, so "not None" is what stands in for it."""
+        identity.register("buddy")
+        self._spool(["one", "two"])
+        delivery.read_spool("buddy", ack=True, ack_through="")
+        assert len(delivery.read_spool("buddy")) == 2
+
+    def test_read_spool_bool_ack_still_sweeps_when_ack_through_is_none(self, isolate):
+        """The discriminator: None (the default, meaning absent) leaves the
+        bool path exactly as it was."""
+        identity.register("buddy")
+        self._spool(["one", "two"])
+        delivery.read_spool("buddy", ack=True, ack_through=None)
+        assert delivery.read_spool("buddy") == []
+
     def test_acking_through_the_current_cursor_is_idempotent(self, isolate):
         identity.register("buddy")
         first = self._spool(["one"])[0]
@@ -338,6 +369,65 @@ class TestBuddyInboxAckThrough:
         assert [m["text"] for m in tools.dispatch("buddy_inbox", {}, "buddy")["messages"]] == [
             "second"
         ]
+
+    @pytest.mark.parametrize("blank", ["", "   ", None])
+    def test_a_blank_ack_through_never_falls_back_to_sweeping(self, isolate, blank):
+        """The precedence guard keys on PRESENCE, not on the stripped value.
+
+        Keying on the value collapses "no ack_through" and "ack_through that
+        stripped to nothing" into the same falsy thing, so ``{ack: true,
+        ack_through: ""}`` fell through to the bool path and swept the tail —
+        the exact loss this whole change exists to close, reachable from
+        inside its own guard. It is the only place here that could err toward
+        SILENT loss, which is the half that has no screen to surface it.
+        """
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        tools.dispatch("buddy_inbox", {}, "buddy")
+        inbox.enqueue("buddy", "second", kind="note", sender="w")
+        inbox.flush_session("buddy")
+
+        result = tools.dispatch(
+            "buddy_inbox", {"ack": True, "ack_through": blank}, "buddy"
+        )
+        assert result["acked"] is False
+        # Neither message was acked — asking to ack through nothing acks
+        # nothing, and re-reading is the cheap failure.
+        assert [
+            m["text"] for m in tools.dispatch("buddy_inbox", {}, "buddy")["messages"]
+        ] == ["first", "second"]
+
+    def test_an_id_is_matched_exactly_never_trimmed_into_a_match(self, isolate):
+        """Ids are matched EXACTLY. A `.strip()` used to stand here, and once
+        presence became the precedence gate it had exactly one effect left:
+        turning `" m1 "` into an ack of m1 — guessing which message the caller
+        meant, on the one operation where guessing too generously loses mail.
+        Every other unrecognised id refuses; this one now refuses too.
+
+        Also the reviewer's surviving mutation M13, closed in the direction
+        that leaves nothing unfalsifiable: the leniency is gone rather than
+        pinned, and this test is what a re-added strip would fail.
+        """
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        read = tools.dispatch("buddy_inbox", {}, "buddy")
+        padded = " " + read["messages"][0]["id"] + " "
+
+        result = tools.dispatch("buddy_inbox", {"ack_through": padded}, "buddy")
+        assert result["acked"] is False
+        assert len(tools.dispatch("buddy_inbox", {}, "buddy")["messages"]) == 1
+
+    def test_the_bool_path_still_works_when_ack_through_is_absent(self, isolate):
+        """The discriminator for the parametrized test above: presence is what
+        switches modes, so an ABSENT ack_through must leave `ack` alone."""
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        result = tools.dispatch("buddy_inbox", {"ack": True}, "buddy")
+        assert result["acked"] is True
+        assert tools.dispatch("buddy_inbox", {}, "buddy")["messages"] == []
 
     def test_a_non_string_id_fails_loudly(self, isolate):
         identity.register("buddy")

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -216,6 +216,142 @@ class TestSpoolCursor:
         assert [m["text"] for m in delivery.read_spool("buddy")] == ["after rotation"]
 
 
+class TestAckThrough:
+    """#970. ``ack=True`` advances to the spool TAIL — whatever the tail is at
+    ack time, which is not what the caller read. Every consumer here reads,
+    then processes, then acks (the voice notifier acks only after speaking),
+    so the window between the read and the ack is real and mail lands in it.
+
+    Both halves are priced, and they are not symmetric. Acking too LITTLE
+    re-announces a message the owner already heard — an annoyance. Acking too
+    MUCH cursor-advances past a message nobody ever read, and in a screenless
+    channel nothing surfaces that loss: no dead-letter, no email, no screen.
+    So every refusal below fails toward re-reading.
+    """
+
+    def _spool(self, texts):
+        for text in texts:
+            inbox.enqueue("buddy", text, kind="note", sender="w")
+            inbox.flush_session("buddy")
+        return [m["id"] for m in delivery.read_spool("buddy", unread_only=False)]
+
+    def test_acking_through_an_id_leaves_later_arrivals_pending(self, isolate):
+        """The acceptance case: mail that arrived between the read and the ack
+        is still unread BY CONSTRUCTION — no client-side bookkeeping needed."""
+        identity.register("buddy")
+        first = self._spool(["first"])[0]
+        # …the caller reads "first", and "second" lands before it acks.
+        self._spool(["second"])
+
+        assert delivery.advance_cursor("buddy", first) is True
+        assert [m["text"] for m in delivery.read_spool("buddy")] == ["second"]
+
+    def test_the_bool_path_still_sweeps_to_the_tail(self, isolate):
+        """The discriminator for the test above: same construction, bool ack,
+        and the late arrival IS swept — which is the defect, still there for
+        any caller that asks for it."""
+        identity.register("buddy")
+        self._spool(["first"])
+        self._spool(["second"])
+
+        delivery.read_spool("buddy", ack=True)
+        assert delivery.read_spool("buddy") == []
+
+    def test_an_id_the_spool_no_longer_has_moves_nothing(self, isolate):
+        """Rotation, and the only case that reports False. Writing an unknown
+        id would strand the cursor; sweeping to the tail would lose mail. The
+        cursor stays put, so the mail is re-read."""
+        identity.register("buddy")
+        self._spool(["one"])
+
+        assert delivery.advance_cursor("buddy", "no-such-id") is False
+        assert [m["text"] for m in delivery.read_spool("buddy")] == ["one"]
+
+    def test_an_empty_id_moves_nothing(self, isolate):
+        identity.register("buddy")
+        self._spool(["one"])
+        assert delivery.advance_cursor("buddy", "") is False
+        assert delivery.advance_cursor("buddy", None) is False
+        assert len(delivery.read_spool("buddy")) == 1
+
+    def test_it_never_rewinds_the_cursor(self, isolate):
+        """A late/duplicate ack naming an older id must not un-read the mail
+        between it and the cursor — that replays messages the owner heard, and
+        `seen` only suppresses that for one page's lifetime."""
+        identity.register("buddy")
+        ids = self._spool(["one", "two"])
+        delivery.advance_cursor("buddy", ids[1])
+
+        assert delivery.advance_cursor("buddy", ids[0]) is True  # idempotent, not a move
+        assert delivery.read_spool("buddy") == []
+
+    def test_acking_through_the_current_cursor_is_idempotent(self, isolate):
+        identity.register("buddy")
+        first = self._spool(["one"])[0]
+        assert delivery.advance_cursor("buddy", first) is True
+        assert delivery.advance_cursor("buddy", first) is True
+        assert delivery.read_spool("buddy") == []
+
+
+class TestBuddyInboxAckThrough:
+    def test_it_acks_exactly_what_the_caller_read(self, isolate):
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        read = tools.dispatch("buddy_inbox", {}, "buddy")
+        inbox.enqueue("buddy", "second", kind="note", sender="w")
+        inbox.flush_session("buddy")
+
+        acked = tools.dispatch(
+            "buddy_inbox", {"ack_through": read["messages"][0]["id"]}, "buddy"
+        )
+        assert acked["acked"] is True
+        assert [m["text"] for m in tools.dispatch("buddy_inbox", {}, "buddy")["messages"]] == [
+            "second"
+        ]
+
+    def test_a_refused_ack_is_reported_not_swallowed(self, isolate):
+        """The caller has to be able to tell. A silently-refused ack looks
+        exactly like a successful one and re-announces forever."""
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        result = tools.dispatch("buddy_inbox", {"ack_through": "gone"}, "buddy")
+        assert result["acked"] is False
+        assert len(tools.dispatch("buddy_inbox", {}, "buddy")["messages"]) == 1
+
+    def test_ack_through_outranks_the_bool(self, isolate):
+        """Both given: the specific one wins. Honouring `ack` as well would
+        sweep the tail, which is the whole defect."""
+        identity.register("buddy")
+        inbox.enqueue("buddy", "first", kind="note", sender="w")
+        inbox.flush_session("buddy")
+        read = tools.dispatch("buddy_inbox", {}, "buddy")
+        inbox.enqueue("buddy", "second", kind="note", sender="w")
+        inbox.flush_session("buddy")
+
+        tools.dispatch(
+            "buddy_inbox",
+            {"ack": True, "ack_through": read["messages"][0]["id"]},
+            "buddy",
+        )
+        assert [m["text"] for m in tools.dispatch("buddy_inbox", {}, "buddy")["messages"]] == [
+            "second"
+        ]
+
+    def test_a_non_string_id_fails_loudly(self, isolate):
+        identity.register("buddy")
+        result = tools.dispatch("buddy_inbox", {"ack_through": ["m1"]}, "buddy")
+        assert result["success"] is False
+
+    def test_the_model_is_told_the_parameter_exists(self):
+        entry = next(
+            e for e in tools.realtime_tool_defs() if e["name"] == "buddy_inbox"
+        )
+        assert "ack_through" in entry["parameters"]["properties"]
+        assert "ack_through" in entry["description"]
+
+
 class TestSendTimeWarning:
     def test_no_false_gone_warning_for_a_buddy(self, isolate, capsys):
         """``msg send`` must not predict a dead-letter that cannot happen."""


### PR DESCRIPTION
## The defect

`buddy_inbox(ack=true)` → `read_spool(ack=True)` advances the cursor to the spool **tail as it stands at ack time**, not to what the caller read. Every consumer here reads → processes → acks, and the notifier deliberately acks only after **speaking**. Mail landing in that window is cursor-advanced past having been read by nobody, and screenless there is no dead-letter, no email and no screen to notice it on.

## What landed

**`delivery.advance_cursor(session, id) -> bool`** — ack exactly through one message. `read_spool(ack_through=…)` takes it too, outranking `ack` (honouring both would sweep the tail, which is the whole defect). Two refusals, both failing toward re-reading:

- an id the spool no longer holds moves nothing, and **says so** — a silently-refused ack is indistinguishable from a successful one and re-announces forever;
- the cursor never rewinds — a rewind un-reads mail that *was* heard.

**`buddy_inbox`** gains `ack_through` and returns `acked` / `acked_through`. The tool description now steers the model to it: `ack` is described as the one that sweeps past anything that arrived while you were speaking.

**The notifier** acks through the longest **unbroken run** of unread messages it is speaking now or has already heard, walked over the peek's own list — so nothing the spool grows afterwards can widen it. The interesting case is the interrupt tier: it speaks an escalation while an ordinary report sits *ahead* of it in the spool, and one cursor id cannot cover the alarm without burying the report. So that tick acks **nothing** (`ackThrough` empty, and the bridge is not called at all), and the full tick that finally speaks the report clears both — announced late, never lost. Pinned, including that it converges.

## The workaround, deleted

Read against what #993 actually left there, not against #969's original:

| gone | why |
|---|---|
| `strayReplies` array + `strays` dep + the pull/splice in `pollOnce` | existed only because a swept message had no route back but client state |
| `strayIds` on the meta (#993) | its one consumer was the stray restore |
| the restore-on-failure branch in `noticeFailed` (#993) | ditto |
| the `seen` guard in `noticeFailed` | see below |

**Kept, because #993 needs them for something else:**

- `noticeFailed` itself — #978 item 5's release path, unrelated to strays.
- `inboxMsgs` on the meta — the page's `onSpoken` registers request/escalation notices in the **re-raise ledger** (#967) from it. `noticeFailed` no longer reads it; the ledger does.
- Both stop-time guards (#978 item 6). #970 downgrades that defect's consequence (the reply is no longer cursor-past) without removing it, and the tests say so rather than quietly weakening.

The `seen` guard in `noticeFailed` went because after the array it is **unfalsifiable**: `pollOnce` drops a `seen` message before it ever consults `inFlight`, so cutting the guard leaves the whole suite green — a line claiming a guarantee it no longer holds, which is the #995 shape. Both tests that named it still pass; their docstrings now say the property moved, not the test.

## Method

Every test watched **failing first** (the Python set: 10 red, 1 green — the bool-path discriminator, which asserts today's behaviour and must stay green). Every guard mutation-checked:

| mutation | caught by |
|---|---|
| drop the contiguity walk (ack the tail) | mixed-batch + escalation-behind-a-message |
| ack when nothing is contiguous | `…does_not_call_the_bridge` (added — this one **survived** the first pass and is why the ack-call spy exists) |
| swallow a refused ack | `…refused_ack_is_logged_not_swallowed` |
| `noticeFailed` releases nothing | 3 tests |
| unknown id writes anyway / no rewind guard / `ack_through` doesn't outrank `ack` / `acked` hardcoded True | 1–2 tests each |

The harness `ackInbox` mirrors `advance_cursor` exactly, both refusals included — a harness acking more freely than the bridge proves the wrong thing.

**`uv run --extra dev pytest`: 5902 passed, 36 skipped, 0 failed.**

## False-reject pricing

Acking too little re-announces something the owner already heard (annoyance). Acking too much loses a report silently, and in a voice channel nothing surfaces that. Every refusal above fails toward re-reading. The cost taken deliberately: a message the interrupt tier skipped stays unacked until a later tick speaks it, so a page reload in that window repeats the escalation.

## Residuals

- **#996** — the recovery story **improves**, and in a way worth stating because a future reader will otherwise meet the symptom and file it as a bug. The watchdog still never releases the notice (unfixed here), but nothing announced is cursor-past any more, so *"a page reload recovers it"* is now true of **every** dropped-utterance case rather than only spool-resident ones. The cost, in the safe direction: a permanently-`inFlight` id wedges the contiguity walk for the page's lifetime, so everything behind it is spoken and never acked — a reload **repeats** those notices instead of losing them. Strictly better than the old sweep, which lost them. When #996 is wired, `noticeFailed` is a simpler target than it was: release the ids, and the spool re-announces — no array to put bodies back into.
- **#995** — untouched; the four unpinned browser-event wires are unchanged. This PR adds no new unpinned wire: `ackInbox`'s new signature is page-source-pinned in both directions (the new form present, `arguments: { ack: true }` absent).
- *(Correction to an earlier version of this body: it claimed `strayIds` was named in #995. It is not — it appears in **#996**'s Direction section. The reviewer is correcting #996 itself.)*

## Review round 2 (REQUEST-CHANGES → addressed)

**F1 BLOCKING — fixed.** `{ack: true, ack_through: ""}` — also null, also whitespace — collapsed with an absent `ack_through`, fell through to the bool path and swept the tail. The one place in this change that erred toward *silent* loss, sitting inside the PR's central guard and contradicting its own stated bias. Now keyed on `"ack_through" in args`, with the same fix one floor down in `read_spool` (`is not None`). Pinned parametrized over `""` / `"   "` / `None`, plus a discriminator that an *absent* `ack_through` still leaves `ack` alone.

The reviewer's **M13** (dropping `.strip()`) survived — so the strip is **deleted**, not pinned. Once presence gates the precedence, its only remaining effect was trimming `" m1 "` into an ack of m1: guessing which message the caller meant, on the operation where a generous guess loses mail. Ids come from a prior read of the same spool, so a padded one is a caller that has lost track of what it read; every other unrecognised id refuses, and now this one does too. Pinned in the other direction — re-adding the strip turns the test red.

**F2 — fixed.** `read_spool`'s documented `ack_through` precedence had no test: the tool layer never forwards both, so nothing there could see it, and making `ack` win inside the function survived the whole voice suite (the reviewer's M3). Now pinned at the function layer in both directions, plus the blank-value case one floor down.

**F3 — fixed.** `advance_cursor` said "the one False"; there are two (unknown id, and empty/None).

**F4 — corrected in this body**, above.

Every fix watched failing first (4 red, then 1 more for the strip deletion). All new pins mutation-checked: M13/M13b/M13c, M3, M3b. **5910 passed / 0 failed.**

## Not touched

`buddy_cli.py` (the `--ack` bool path is unchanged and still correct for a human draining the whole spool). Sibling files left alone.

Closes #970

Built by [dotdev.dev](https://dotdev.dev)
