### PR TITLE
voice-layer T4: the buddy as a supervised service (#983)

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -363,9 +363,20 @@ class CustomServiceConfig:
 
     Custom services show up in the portal's Services column, are booted by
     `agentwire up` AND on portal launch, and are watched by the portal's
-    service watchdog. A service is just an agentwire session created in a
-    project directory; `roles`/`posture` override the project's .agentwire.yml
-    when set.
+    service watchdog.
+
+    Two kinds, distinguished by whether `command` is set:
+
+    - **agent** (no `command`) — an agentwire session created in a project
+      directory; `roles`/`posture`/`context_policy` override the project's
+      .agentwire.yml when set.
+    - **command** (`command` set) — an arbitrary long-running process, run in
+      a detached tmux session of the same name. `roles`/`posture`/
+      `context_policy` are meaningless here (there is no agent) and are
+      rejected at parse time rather than silently ignored.
+
+    The command kind is deliberately generic: agentwire supervises a process,
+    it does not know or care what the process is.
 
     restart: never | on-failure | always — what the watchdog does when the
     healthcheck fails ("always" behaves like "on-failure" for tmux services;
@@ -378,6 +389,9 @@ class CustomServiceConfig:
     roles: Optional[str] = None  # comma-separated; overrides project .agentwire.yml
     posture: Optional[str] = None   # posture override (e.g. bypass, auto)
     restart: str = "on-failure"  # never | on-failure | always
+    # Shell command to supervise. When set this service is a plain process, not
+    # an agent session — see the class docstring.
+    command: Optional[str] = None
     healthcheck: HealthcheckConfig = field(default_factory=HealthcheckConfig)
     # Context auto-management policy (issue #442): clear | compact | none.
     # Default "none" — a service is only auto-managed when it opts in. Stateless
@@ -740,15 +754,39 @@ def _dict_to_config(data: dict) -> Config:
             context_policy = entry.get("context_policy", "none")
             if context_policy not in ("clear", "compact", "none"):
                 context_policy = "none"
+            command = entry.get("command") or None
+            roles = entry.get("roles")
+            posture = entry.get("posture")
+            if command:
+                # A command service supervises a PROCESS — there is no agent to
+                # carry a role, a posture or a context policy. Dropping these
+                # silently is how a service ends up looking guarded when nothing
+                # is reading the field, so say so.
+                stale = [
+                    k for k, v in (
+                        ("roles", roles), ("posture", posture),
+                        ("context_policy", context_policy if context_policy != "none" else None),
+                    ) if v
+                ]
+                if stale:
+                    print(
+                        f"Warning: service '{entry['name']}' sets command: — "
+                        f"{', '.join(stale)} {'have' if len(stale) > 1 else 'has'} no effect "
+                        "on a process service and will be ignored.",
+                        file=sys.stderr,
+                    )
+                roles = posture = None
+                context_policy = "none"
             custom_services.append(CustomServiceConfig(
                 name=entry["name"],
                 project=entry.get("project"),
                 autostart=entry.get("autostart", True),
-                roles=entry.get("roles"),
-                posture=entry.get("posture"),
+                roles=roles,
+                posture=posture,
                 restart=entry.get("restart", "on-failure"),
                 healthcheck=healthcheck,
                 context_policy=context_policy,
+                command=command,
             ))
     services = ServicesConfig(
         portal=portal_service,

--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -1204,6 +1204,64 @@ def _render_secrets_permissions_section(
     return len(issues), fixed
 
 
+def _render_custom_services_section() -> int:
+    """Doctor section: every registry service, agent and process alike (#983).
+
+    Registry-driven, so a new ``services.custom`` entry is reported here the
+    moment it is registered — including a ``command`` service such as the voice
+    buddy's bridge, whose state was previously visible nowhere because it was
+    hand-launched and therefore in no registry at all.
+
+    Two things are reported that a bare healthcheck does not carry:
+
+    - the service's KIND, because "session not found" means a dead agent for
+      one kind and a dead process for the other, and the fix differs;
+    - an inline secret in a process service's ``command``, which is the one
+      leak the tmux supervisor does not close — argv is world-readable in the
+      process table. Same standard as #887's owner-only files, one surface
+      over.
+    """
+    from . import services as services_mod
+    from .config import load_config as _load_config_typed
+
+    issues = 0
+    try:
+        cfg = _load_config_typed()
+        disabled = services_mod.load_disabled()
+        registry = services_mod.registry(cfg)
+    except Exception as e:
+        print(f"  [..] Could not check custom services: {e}")
+        return 0
+
+    for svc in registry:
+        kind = services_mod.service_kind(svc)
+        try:
+            healthy, detail = services_mod.run_healthcheck(svc)
+        except Exception as e:  # a broken healthcheck must not hide the rest
+            print(f"  [..] Service {svc.name} ({kind}): healthcheck error — {e}")
+            continue
+        label = f"Service {svc.name} ({kind})"
+        if healthy:
+            print(f"  [ok] {label}: {detail}")
+        elif svc.name in disabled:
+            print(f"  [..] {label}: stopped via 'services down' ({detail})")
+        elif not svc.autostart:
+            print(f"  [..] {label}: not running (autostart off, {detail})")
+        else:
+            print(f"  [!!] {label}: unhealthy — {detail}")
+            print(f"     Run: agentwire services up {svc.name}")
+            issues += 1
+
+        risk = services_mod.command_secret_risk(svc)
+        if risk:
+            print(f"  [!!] Service {svc.name}: command carries '{risk}' — argv is "
+                  "world-readable in the process table")
+            print("     Fix: move the secret to ~/.agentwire/.env and read it "
+                  "from the environment")
+            issues += 1
+    return issues
+
+
 def cmd_doctor(args) -> int:
     """Auto-diagnose and fix common issues."""
     from .hooks_cli import _managed_file_state, _managed_hook_files, get_hooks_source
@@ -1398,25 +1456,7 @@ def cmd_doctor(args) -> int:
     # Check custom services (registry-driven: built-in notifications bridge
     # + user-defined services from services.custom)
     print("\nChecking custom services...")
-    from . import services as services_mod
-    from .config import load_config as _load_config_typed
-    try:
-        _svc_cfg = _load_config_typed()
-        _svc_disabled = services_mod.load_disabled()
-        for svc in services_mod.registry(_svc_cfg):
-            healthy, detail = services_mod.run_healthcheck(svc)
-            if healthy:
-                print(f"  [ok] Service {svc.name}: {detail}")
-            elif svc.name in _svc_disabled:
-                print(f"  [..] Service {svc.name}: stopped via 'services down' ({detail})")
-            elif not svc.autostart:
-                print(f"  [..] Service {svc.name}: not running (autostart off, {detail})")
-            else:
-                print(f"  [!!] Service {svc.name}: unhealthy — {detail}")
-                print(f"     Run: agentwire services up {svc.name}")
-                issues_found += 1
-    except Exception as e:
-        print(f"  [..] Could not check custom services: {e}")
+    issues_found += _render_custom_services_section()
 
     # 5. Validate config
     print("\nChecking configuration...")

--- a/agentwire/mcp_services.py
+++ b/agentwire/mcp_services.py
@@ -32,8 +32,10 @@ def services_list() -> str:
             flags.append("disabled")
         suffix = f" [{', '.join(flags)}]" if flags else ""
         hc = s.get("healthcheck", {})
-        lines.append(f"- {s['name']}: restart={s.get('restart')}, "
+        lines.append(f"- {s['name']} ({s.get('kind')}): restart={s.get('restart')}, "
                      f"healthcheck={hc.get('kind')}/{hc.get('interval')}s{suffix}")
+        if s.get("command"):
+            lines.append(f"  command: {s['command']}")
         if s.get("project"):
             lines.append(f"  project: {s['project']}")
     return "\n".join(lines)
@@ -63,7 +65,7 @@ def services_status() -> str:
             mark = "!!"
         extra = " (disabled)" if s.get("disabled") else (
             "" if s.get("autostart") else " (autostart off)")
-        lines.append(f"[{mark}] {s['name']}: {s.get('detail')}{extra}")
+        lines.append(f"[{mark}] {s['name']} ({s.get('kind')}): {s.get('detail')}{extra}")
     all_healthy = data.get("all_healthy")
     lines.append(f"\nAll healthy: {'yes' if all_healthy else 'NO'}")
     return "\n".join(lines)

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -12,6 +12,7 @@ the watchdog resurrects them.
 """
 
 import json
+import re
 import subprocess
 import sys
 import time
@@ -167,16 +168,35 @@ def registry(cfg: Config) -> list[CustomServiceConfig]:
 STARTUP_GRACE_S = 0.6
 
 #: Lines of a dead pane's output carried into the failure message. Bounded on
-#: purpose: this is the process's OWN stderr being surfaced to the operator, so
-#: a process that prints a secret on the way down surfaces it exactly where its
-#: log would have. The trade is deliberate — a refusal that cannot say why is a
-#: fix-loop, and in a channel with no screen that is the expensive failure.
+#: purpose: this is the process's OWN stderr being surfaced to the operator,
+#: and not only on a terminal — the detail built from it is toasted and SPOKEN
+#: by the portal watchdog. The trade is deliberate (a refusal that cannot say
+#: why is a fix-loop, and in a channel with no screen that is the expensive
+#: failure), which is why the content is redacted, not just clipped.
 _TAIL_LINES = 3
+
+#: ...and a separate cap, because ``_TAIL_LINES`` bounds LINES, not characters:
+#: three lines of a 5000-column traceback is one utterance nobody can listen to.
+_TAIL_CHARS = 300
+
+
+def _tmux_name(name: str) -> str:
+    """The name tmux will actually have chosen for *name*.
+
+    tmux rewrites its own address separators — ``.`` and ``:`` → ``_`` — so a
+    service called ``rev.dot:2`` becomes ``rev_dot_2`` the moment it is
+    created, and every later target built from the raw name misses. That is
+    #868/#878, and the mapping has exactly ONE implementation by rule: never
+    inline the substitution, call the helper.
+    """
+    from .worktree import tmux_safe_name
+
+    return tmux_safe_name(name)
 
 
 def _tmux_session_exists(name: str) -> bool:
     result = subprocess.run(
-        ["tmux", "has-session", "-t", f"={name}"],
+        ["tmux", "has-session", "-t", f"={_tmux_name(name)}"],
         capture_output=True,
     )
     return result.returncode == 0
@@ -192,27 +212,43 @@ def _tmux_pane_dead(name: str) -> bool:
     the moment anything kept a corpse around.
     """
     result = subprocess.run(
-        ["tmux", "display-message", "-p", "-t", f"={name}:.0", "#{pane_dead}"],
+        ["tmux", "display-message", "-p", "-t", f"={_tmux_name(name)}:.0",
+         "#{pane_dead}"],
         capture_output=True, text=True,
     )
     return result.returncode == 0 and result.stdout.strip() == "1"
 
 
 def _tmux_pane_tail(name: str) -> str:
-    """The last few non-empty lines of *name*'s pane, or "".
+    """The last few non-empty lines of *name*'s pane, redacted, or "".
 
     Read from tmux's in-memory scrollback — no file is created, so the command
     kind's secret property is unchanged. tmux's own "Pane is dead (status N)"
     line is kept: the exit status is often the most actionable part.
+
+    Redacted HERE because this is the one choke point every consumer reads
+    through, and the consumers are not all a terminal: the healthcheck detail
+    built from this reaches the portal watchdog's ``_notify_service_event``,
+    which toasts it AND speaks it via ``agentwire say``. A crash line is
+    exactly where a secret shows up, and "it only goes where its own log would
+    have" was not true of a spoken utterance.
     """
     result = subprocess.run(
-        ["tmux", "capture-pane", "-p", "-S", "-", "-t", f"={name}:.0"],
+        ["tmux", "capture-pane", "-p", "-S", "-", "-t", f"={_tmux_name(name)}:.0"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
         return ""
     lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
-    return " | ".join(lines[-_TAIL_LINES:])
+    # Redact BEFORE clipping, and the reason is legibility, not safety: clipping
+    # first is equally SAFE (a cut can only remove trailing material, and the
+    # key stays in front of whatever value survives, so the pattern still
+    # matches) — but a 400-character token would then eat the whole budget and
+    # push the actionable part of the message off the end. Redaction shortens
+    # `--token=<400 chars>` to `--token=***`, so doing it first spends the cap
+    # on the words the operator needs.
+    tail = redact_secrets(" | ".join(lines[-_TAIL_LINES:]))
+    return tail if len(tail) <= _TAIL_CHARS else tail[:_TAIL_CHARS] + "…"
 
 
 def run_healthcheck(svc: CustomServiceConfig) -> tuple[bool, str]:
@@ -306,8 +342,21 @@ def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
     The ordering is the point and is why a placeholder exists at all: setting
     the option AFTER launching the real command is a race a fast-dying process
     wins, and it is exactly the fast-dying processes whose reason we need.
+
+    **The placeholder must never outlive the spawn.** Steps 2 and 3 run against
+    a session step 1 just created, so a failure there is not the benign
+    "someone else got there first" the old handler assumed — it is our own
+    placeholder, alive and running ``sleep 3600``. ``pane_dead`` cannot tell
+    that from a healthy process, so leaving it would report a sleep loop as a
+    running service: the same false all-clear one costume over. ``already
+    running`` is therefore reachable only when the session genuinely
+    PRE-EXISTED this call.
     """
     cwd = svc.project or str(Path.home())
+    # Every -s and -t goes through the one mapping. tmux rewrites `.` and `:`
+    # at creation, so a target built from the raw name misses the session that
+    # was actually made — and a teardown that misses reports success (#868).
+    name = _tmux_name(svc.name)
     prior = ""
     if _tmux_session_exists(svc.name):
         if not _tmux_pane_dead(svc.name):
@@ -318,32 +367,40 @@ def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
         tail = _tmux_pane_tail(svc.name)
         prior = f" (previous run exited: {tail})" if tail else " (previous run exited)"
         subprocess.run(
-            ["tmux", "kill-session", "-t", f"={svc.name}"],
+            ["tmux", "kill-session", "-t", f"={name}"],
             capture_output=True, timeout=30,
         )
 
+    created_here = False
     try:
         subprocess.run(
-            ["tmux", "new-session", "-d", "-s", svc.name, "-c", cwd,
+            ["tmux", "new-session", "-d", "-s", name, "-c", cwd,
              "sh -c 'while :; do sleep 3600; done'"],
             check=True, capture_output=True, timeout=30,
         )
+        created_here = True
         subprocess.run(
-            ["tmux", "set-option", "-w", "-t", f"={svc.name}:", "remain-on-exit", "on"],
+            ["tmux", "set-option", "-w", "-t", f"={name}:", "remain-on-exit", "on"],
             check=True, capture_output=True, timeout=30,
         )
         subprocess.run(
-            ["tmux", "respawn-pane", "-k", "-c", cwd, "-t", f"={svc.name}:.0",
+            ["tmux", "respawn-pane", "-k", "-c", cwd, "-t", f"={name}:.0",
              svc.command],
             check=True, capture_output=True, timeout=30,
         )
-    except subprocess.CalledProcessError as e:
-        if _tmux_session_exists(svc.name) and not _tmux_pane_dead(svc.name):
-            return True, "already running"  # lost a benign spawn race
-        stderr = (e.stderr or b"").decode(errors="replace").strip()
-        return False, (stderr or str(e)) + prior
     except Exception as e:
-        return False, str(e) + prior
+        if created_here:
+            # Ours, and it is only running the placeholder. Take it with us.
+            subprocess.run(
+                ["tmux", "kill-session", "-t", f"={name}"],
+                capture_output=True, timeout=30,
+            )
+        elif _tmux_session_exists(svc.name) and not _tmux_pane_dead(svc.name):
+            return True, "already running"  # genuinely lost a benign spawn race
+        stderr = ""
+        if isinstance(e, subprocess.CalledProcessError):
+            stderr = (e.stderr or b"").decode(errors="replace").strip()
+        return False, (stderr or str(e)) + prior
 
     time.sleep(STARTUP_GRACE_S)
     if _tmux_pane_dead(svc.name):
@@ -369,6 +426,25 @@ _SECRET_ARGV_PATTERNS = tuple(
     for name in _SECRET_NAMES
     for pattern in (f"--{name}=", f"--{name} ", f"{name}=")
 ) + ("bearer ",)
+
+
+#: Built from the same tuple as the argv check, deliberately: a second list
+#: would drift from it the moment either is extended, which is exactly what
+#: happened to the argv one.
+_SECRET_VALUE_RE = re.compile(
+    "(" + "|".join(re.escape(p) for p in _SECRET_ARGV_PATTERNS) + r")(\S+)",
+    re.IGNORECASE,
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Mask values that follow a secret-shaped key in *text*.
+
+    Masks the VALUE and keeps everything else — a redaction that ate the
+    message would re-create the failure it is guarding, which is a refusal that
+    cannot say why.
+    """
+    return _SECRET_VALUE_RE.sub(lambda m: m.group(1) + "***", text)
 
 
 def command_secret_risk(svc: CustomServiceConfig) -> str | None:
@@ -436,7 +512,7 @@ def stop_service(svc: CustomServiceConfig) -> tuple[bool, str]:
     try:
         if svc.command:
             subprocess.run(
-                ["tmux", "kill-session", "-t", f"={svc.name}"],
+                ["tmux", "kill-session", "-t", f"={_tmux_name(svc.name)}"],
                 check=True, capture_output=True, timeout=30,
             )
         else:

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -219,6 +219,29 @@ def _tmux_pane_dead(name: str) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "1"
 
 
+#: What step 1 runs while step 2 sets ``remain-on-exit`` — see
+#: ``_start_command_service``. A module constant because it is also the
+#: discriminator: a session running THIS is a half-built spawn, never a service.
+_PLACEHOLDER_CMD = "sh -c 'while :; do sleep 3600; done'"
+
+
+def _tmux_pane_is_placeholder(name: str) -> bool:
+    """Is *name*'s pane still running the spawn placeholder?
+
+    ``respawn-pane`` REPLACES ``pane_start_command`` (measured, tmux 3.5a), so
+    a service that finished starting reports its own command here and can never
+    be mistaken for a placeholder. That direction is the one that matters: this
+    predicate gates a kill, and a false positive would tear down a live
+    service.
+    """
+    result = subprocess.run(
+        ["tmux", "display-message", "-p", "-t", f"={_tmux_name(name)}:.0",
+         "#{pane_start_command}"],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == _PLACEHOLDER_CMD
+
+
 def _tmux_pane_tail(name: str) -> str:
     """The last few non-empty lines of *name*'s pane, redacted, or "".
 
@@ -374,8 +397,7 @@ def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
     created_here = False
     try:
         subprocess.run(
-            ["tmux", "new-session", "-d", "-s", name, "-c", cwd,
-             "sh -c 'while :; do sleep 3600; done'"],
+            ["tmux", "new-session", "-d", "-s", name, "-c", cwd, _PLACEHOLDER_CMD],
             check=True, capture_output=True, timeout=30,
         )
         created_here = True
@@ -389,13 +411,30 @@ def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
             check=True, capture_output=True, timeout=30,
         )
     except Exception as e:
-        if created_here:
+        # `created_here` covers the ordinary route; the placeholder check covers
+        # the rest. `new-session` raising CalledProcessError means tmux refused
+        # and made nothing — but TimeoutExpired does NOT: the server can have
+        # created the session and simply not answered in time, leaving
+        # `created_here` False with a live placeholder sitting there. Asking
+        # what the pane is actually running closes that without having to
+        # enumerate the ways it can happen.
+        #
+        # Probing to decide that must not itself throw: this runs while an
+        # error is already in hand, and a second failure here would replace the
+        # real reason with a traceback about the probe.
+        try:
+            ours = created_here or _tmux_pane_is_placeholder(svc.name)
+            foreign = (not ours and _tmux_session_exists(svc.name)
+                       and not _tmux_pane_dead(svc.name))
+        except Exception:
+            ours, foreign = created_here, False
+        if ours:
             # Ours, and it is only running the placeholder. Take it with us.
             subprocess.run(
                 ["tmux", "kill-session", "-t", f"={name}"],
                 capture_output=True, timeout=30,
             )
-        elif _tmux_session_exists(svc.name) and not _tmux_pane_dead(svc.name):
+        elif foreign:
             return True, "already running"  # genuinely lost a benign spawn race
         stderr = ""
         if isinstance(e, subprocess.CalledProcessError):

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -196,11 +196,17 @@ def run_healthcheck(svc: CustomServiceConfig) -> tuple[bool, str]:
     return False, "session not found"
 
 
+def service_kind(svc: CustomServiceConfig) -> str:
+    """"command" (a supervised process) or "agent" (an agentwire session)."""
+    return "command" if svc.command else "agent"
+
+
 def service_status(svc: CustomServiceConfig) -> dict:
     """Full status for one service (runs its healthcheck now)."""
     healthy, detail = run_healthcheck(svc)
     return {
         "name": svc.name,
+        "kind": service_kind(svc),
         "running": _tmux_session_exists(svc.name),
         "healthy": healthy,
         "detail": detail,
@@ -217,8 +223,74 @@ def service_status(svc: CustomServiceConfig) -> dict:
 # ─────────────────────────────────────────────────────────────
 
 
+def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
+    """Run a plain process under tmux, detached. Idempotent.
+
+    tmux IS the supervisor here, and that choice is what keeps a process
+    service's output off any world-readable surface: tmux captures stdout and
+    stderr into the pane's scrollback, which lives in the tmux server's memory
+    and is reachable only through the per-user socket dir ``/tmp/tmux-<uid>``
+    (mode 0700). Nothing is redirected to a file — deliberately. A wrapper that
+    is careful in its own code and then tees stdout into a log has not solved
+    the problem, and the same standard #887 holds ``~/.agentwire`` and
+    ``portal.token`` to applies here: owner-only or not at all.
+
+    What this does NOT hide is ``command`` itself: it lands in the process
+    table, where every local user can read it. Secrets belong in
+    ``~/.agentwire/.env``, never in a service's argv — see
+    ``command_secret_risk``.
+    """
+    if _tmux_session_exists(svc.name):
+        return True, "already running"
+    cwd = svc.project or str(Path.home())
+    try:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", svc.name, "-c", cwd, svc.command],
+            check=True, capture_output=True, timeout=30,
+        )
+        return True, "started"
+    except subprocess.CalledProcessError as e:
+        if _tmux_session_exists(svc.name):
+            return True, "already running"  # lost a benign spawn race
+        stderr = (e.stderr or b"").decode(errors="replace").strip()
+        return False, stderr or str(e)
+    except Exception as e:
+        return False, str(e)
+
+
+# Argv patterns that read as an inline secret. The process table is world-
+# readable, so a service command carrying one hands it to every local user —
+# the one leak a tmux-supervised process service still has.
+_SECRET_ARGV_PATTERNS = (
+    "--token=", "--api-key=", "--apikey=", "--secret=", "--password=",
+    "token=", "api_key=", "apikey=", "secret=", "password=", "bearer ",
+)
+
+
+def command_secret_risk(svc: CustomServiceConfig) -> str | None:
+    """The inline-secret pattern *svc*'s command carries, or None.
+
+    Detection only, and named rather than guessed at: the caller decides what
+    to do about it. A false positive here costs a doctor line; a miss costs a
+    credential.
+    """
+    if not svc.command:
+        return None
+    lowered = svc.command.lower()
+    for pattern in _SECRET_ARGV_PATTERNS:
+        if pattern in lowered:
+            return pattern
+    return None
+
+
 def start_service(svc: CustomServiceConfig) -> tuple[bool, str]:
-    """Start a service session (detached) if not already running. Idempotent."""
+    """Start a service (detached) if not already running. Idempotent.
+
+    A `command` service is a supervised process; everything else is an
+    agentwire agent session.
+    """
+    if svc.command:
+        return _start_command_service(svc)
     if _tmux_session_exists(svc.name):
         return True, "already running"
 
@@ -247,15 +319,27 @@ def start_service(svc: CustomServiceConfig) -> tuple[bool, str]:
         return False, str(e)
 
 
-def stop_service(name: str) -> tuple[bool, str]:
-    """Kill a service's tmux session."""
-    if not _tmux_session_exists(name):
+def stop_service(svc: CustomServiceConfig) -> tuple[bool, str]:
+    """Kill a service's tmux session.
+
+    A command service is killed through tmux directly: `agentwire kill`'s
+    graceful leg sends `/exit` to an *agent*, and there is no agent here — a
+    process would just be handed two characters it never asked for before the
+    kill landed anyway.
+    """
+    if not _tmux_session_exists(svc.name):
         return True, "not running"
     try:
-        subprocess.run(
-            [sys.executable, "-m", "agentwire", "kill", "-s", name, "--json"],
-            check=True, capture_output=True, timeout=30,
-        )
+        if svc.command:
+            subprocess.run(
+                ["tmux", "kill-session", "-t", f"={svc.name}"],
+                check=True, capture_output=True, timeout=30,
+            )
+        else:
+            subprocess.run(
+                [sys.executable, "-m", "agentwire", "kill", "-s", svc.name, "--json"],
+                check=True, capture_output=True, timeout=30,
+            )
         return True, "stopped"
     except Exception as e:
         return False, str(e)

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -14,6 +14,7 @@ the watchdog resurrects them.
 import json
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -159,12 +160,59 @@ def registry(cfg: Config) -> list[CustomServiceConfig]:
 # ─────────────────────────────────────────────────────────────
 
 
+#: How long a freshly spawned process gets to prove it survived exec. Short
+#: enough that `services up` stays interactive, long enough to catch the class
+#: this exists for: a missing key, an unregistered name, a bad flag — failures
+#: that happen at startup, not later.
+STARTUP_GRACE_S = 0.6
+
+#: Lines of a dead pane's output carried into the failure message. Bounded on
+#: purpose: this is the process's OWN stderr being surfaced to the operator, so
+#: a process that prints a secret on the way down surfaces it exactly where its
+#: log would have. The trade is deliberate — a refusal that cannot say why is a
+#: fix-loop, and in a channel with no screen that is the expensive failure.
+_TAIL_LINES = 3
+
+
 def _tmux_session_exists(name: str) -> bool:
     result = subprocess.run(
         ["tmux", "has-session", "-t", f"={name}"],
         capture_output=True,
     )
     return result.returncode == 0
+
+
+def _tmux_pane_dead(name: str) -> bool:
+    """Is *name*'s pane a corpse tmux is holding open?
+
+    Only ever true under ``remain-on-exit`` — which command services now set,
+    and which a user may have set globally for anything else. Measured, and the
+    reason this predicate has to exist: ``tmux has-session`` returns 0 for a
+    session whose pane is dead, so "the session exists" stopped being liveness
+    the moment anything kept a corpse around.
+    """
+    result = subprocess.run(
+        ["tmux", "display-message", "-p", "-t", f"={name}:.0", "#{pane_dead}"],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "1"
+
+
+def _tmux_pane_tail(name: str) -> str:
+    """The last few non-empty lines of *name*'s pane, or "".
+
+    Read from tmux's in-memory scrollback — no file is created, so the command
+    kind's secret property is unchanged. tmux's own "Pane is dead (status N)"
+    line is kept: the exit status is often the most actionable part.
+    """
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-S", "-", "-t", f"={name}:.0"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    return " | ".join(lines[-_TAIL_LINES:])
 
 
 def run_healthcheck(svc: CustomServiceConfig) -> tuple[bool, str]:
@@ -190,10 +238,16 @@ def run_healthcheck(svc: CustomServiceConfig) -> tuple[bool, str]:
             return False, "healthcheck timed out (10s)"
         except Exception as e:
             return False, str(e)
-    # Default: tmux_session
-    if _tmux_session_exists(svc.name):
-        return True, "session exists"
-    return False, "session not found"
+    # Default: tmux_session — "the session exists AND its pane is not a corpse".
+    # The second clause is not belt-and-braces: `has-session` returns 0 for a
+    # dead pane, so without it a crashed service reads healthy forever, which
+    # is a worse failure than the one at start it would be masking.
+    if not _tmux_session_exists(svc.name):
+        return False, "session not found"
+    if _tmux_pane_dead(svc.name):
+        tail = _tmux_pane_tail(svc.name)
+        return False, f"process exited: {tail}" if tail else "process exited"
+    return True, "session exists"
 
 
 def service_kind(svc: CustomServiceConfig) -> str:
@@ -207,7 +261,7 @@ def service_status(svc: CustomServiceConfig) -> dict:
     return {
         "name": svc.name,
         "kind": service_kind(svc),
-        "running": _tmux_session_exists(svc.name),
+        "running": _tmux_session_exists(svc.name) and not _tmux_pane_dead(svc.name),
         "healthy": healthy,
         "detail": detail,
         "disabled": svc.name in load_disabled(),
@@ -239,32 +293,82 @@ def _start_command_service(svc: CustomServiceConfig) -> tuple[bool, str]:
     table, where every local user can read it. Secrets belong in
     ``~/.agentwire/.env``, never in a service's argv — see
     ``command_secret_risk``.
+
+    **A created pane is not a surviving process.** ``tmux new-session``
+    returning 0 says a pane was made; the command inside it may already have
+    exited. Reporting that as "started" produced the worst shape available: a
+    success line, a ``[!!] unhealthy`` from doctor one second later prescribing
+    the command that had just claimed success, and the process's own stderr
+    gone with the pane. So the spawn is three steps rather than one — a
+    placeholder, ``remain-on-exit on``, then the real command via
+    ``respawn-pane`` — and then the pane is re-read after a grace period.
+
+    The ordering is the point and is why a placeholder exists at all: setting
+    the option AFTER launching the real command is a race a fast-dying process
+    wins, and it is exactly the fast-dying processes whose reason we need.
     """
-    if _tmux_session_exists(svc.name):
-        return True, "already running"
     cwd = svc.project or str(Path.home())
+    prior = ""
+    if _tmux_session_exists(svc.name):
+        if not _tmux_pane_dead(svc.name):
+            return True, "already running"
+        # A corpse from a previous run. Read WHY before clearing it — the
+        # respawn destroys the only copy of that output, and this is the moment
+        # the operator is asking about it.
+        tail = _tmux_pane_tail(svc.name)
+        prior = f" (previous run exited: {tail})" if tail else " (previous run exited)"
+        subprocess.run(
+            ["tmux", "kill-session", "-t", f"={svc.name}"],
+            capture_output=True, timeout=30,
+        )
+
     try:
         subprocess.run(
-            ["tmux", "new-session", "-d", "-s", svc.name, "-c", cwd, svc.command],
+            ["tmux", "new-session", "-d", "-s", svc.name, "-c", cwd,
+             "sh -c 'while :; do sleep 3600; done'"],
             check=True, capture_output=True, timeout=30,
         )
-        return True, "started"
+        subprocess.run(
+            ["tmux", "set-option", "-w", "-t", f"={svc.name}:", "remain-on-exit", "on"],
+            check=True, capture_output=True, timeout=30,
+        )
+        subprocess.run(
+            ["tmux", "respawn-pane", "-k", "-c", cwd, "-t", f"={svc.name}:.0",
+             svc.command],
+            check=True, capture_output=True, timeout=30,
+        )
     except subprocess.CalledProcessError as e:
-        if _tmux_session_exists(svc.name):
+        if _tmux_session_exists(svc.name) and not _tmux_pane_dead(svc.name):
             return True, "already running"  # lost a benign spawn race
         stderr = (e.stderr or b"").decode(errors="replace").strip()
-        return False, stderr or str(e)
+        return False, (stderr or str(e)) + prior
     except Exception as e:
-        return False, str(e)
+        return False, str(e) + prior
+
+    time.sleep(STARTUP_GRACE_S)
+    if _tmux_pane_dead(svc.name):
+        tail = _tmux_pane_tail(svc.name)
+        # The pane is deliberately LEFT dead: it is the only place that output
+        # exists, and the next start reads it before clearing it.
+        return False, f"process exited immediately: {tail}" if tail else (
+            "process exited immediately")
+    return True, "started" + prior
 
 
 # Argv patterns that read as an inline secret. The process table is world-
 # readable, so a service command carrying one hands it to every local user —
 # the one leak a tmux-supervised process service still has.
-_SECRET_ARGV_PATTERNS = (
-    "--token=", "--api-key=", "--apikey=", "--secret=", "--password=",
-    "token=", "api_key=", "apikey=", "secret=", "password=", "bearer ",
-)
+#
+# Both joinings, because a flag and its value are the same secret either way:
+# `--token=abc` and `--token abc` reach `ps` identically, and matching only the
+# first would select for whoever writes it the other way — the same class of
+# spelling-shaped rule this repo has been bitten by before (#913/#915).
+_SECRET_NAMES = ("token", "api-key", "apikey", "api_key", "secret", "password", "passwd")
+_SECRET_ARGV_PATTERNS = tuple(
+    pattern
+    for name in _SECRET_NAMES
+    for pattern in (f"--{name}=", f"--{name} ", f"{name}=")
+) + ("bearer ",)
 
 
 def command_secret_risk(svc: CustomServiceConfig) -> str | None:

--- a/agentwire/system_cli.py
+++ b/agentwire/system_cli.py
@@ -226,6 +226,8 @@ def cmd_services_list(args) -> int:
 
     entries = [{
         "name": svc.name,
+        "kind": services_mod.service_kind(svc),
+        "command": svc.command,
         "project": svc.project,
         "autostart": svc.autostart,
         "restart": svc.restart,
@@ -249,8 +251,10 @@ def cmd_services_list(args) -> int:
         if e["disabled"]:
             flags.append("disabled")
         suffix = f" [{', '.join(flags)}]" if flags else ""
-        print(f"  {e['name']}  restart={e['restart']}  "
+        print(f"  {e['name']}  kind={e['kind']}  restart={e['restart']}  "
               f"healthcheck={e['healthcheck']['kind']}/{e['healthcheck']['interval']}s{suffix}")
+        if e["command"]:
+            print(f"    command: {e['command']}")
         if e["project"]:
             print(f"    project: {e['project']}")
     return 0
@@ -331,12 +335,13 @@ def cmd_services_down(args) -> int:
     json_mode = getattr(args, "json", False)
     name = args.name
     services_mod, reg = _load_services_registry()
-    if _find_service(services_mod, reg, name) is None:
+    svc = _find_service(services_mod, reg, name)
+    if svc is None:
         return _output_result(False, json_mode, f"Unknown service: {name}")
 
     # Disable BEFORE killing so the watchdog can't race a respawn
     services_mod.set_disabled(name, True)
-    ok, msg = services_mod.stop_service(name)
+    ok, msg = services_mod.stop_service(svc)
     return _output_result(ok, json_mode, f"{name}: {msg} (disabled until 'services up {name}')",
                           name=name, result=msg, disabled=True)
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -30,8 +30,18 @@ Two consequences worth stating plainly:
 
 - **`remain-on-exit` means `has-session` is no longer liveness.** Measured: `tmux has-session` returns 0 for a session whose pane is dead. So the `tmux_session` healthcheck asks `#{pane_dead}` too, for *both* kinds — `remain-on-exit` is a user tmux setting, so an agent session could always have been in this state and was reported healthy.
 - **A dead pane is not "already running".** A start that found a corpse clears it and respawns, or the watchdog would loop forever: healthcheck says unhealthy, watchdog starts, start says "already running".
+- **Neither is a placeholder.** Steps 2 and 3 run against a session step 1 just created, so a failure there is *our* placeholder — alive, running `sleep 3600`, and indistinguishable from a healthy process to `pane_dead`. It is killed and the start fails; `already running` is reachable only when the session genuinely pre-existed the call.
+- **Every `-s` and `-t` goes through `worktree.tmux_safe_name`.** tmux rewrites `.` and `:` to `_` at creation, so a target built from the raw name misses the session that was actually made — the spawn has five targets, and a teardown that misses reports success while the session survives (#868/#878). That mapping has one implementation by rule; never inline it.
 
-The process's last lines are surfaced to the operator (in the start message and the healthcheck detail), so a process that prints a secret on the way down surfaces it where its own log would have. Bounded to the last few lines, written to no file, and a deliberate trade: a refusal that cannot say why is the failure this exists to remove.
+### Where a crash line actually goes, and why it is redacted
+
+The process's last lines end up in the start message and in the healthcheck `detail` — and `detail` does not stay on a terminal. The portal watchdog passes it to `_notify_service_event`, which **toasts it in the browser and speaks it via `agentwire say`**. So a process printing `bearer eyJ…` as it died would have put that verbatim into a spoken utterance.
+
+Everything the pane yields is therefore run through `redact_secrets` at the single point every consumer reads through (`_tmux_pane_tail`), using the *same* pattern set as the argv check — one source of truth, because a second list drifts from the first the moment either is extended. The value is masked and the rest of the line kept: a redaction that ate the message would re-create the failure it guards.
+
+Two bounds, and they are different: `_TAIL_LINES` (3) bounds **lines**, `_TAIL_CHARS` (300) bounds **characters** — three lines of a 5000-column traceback is one utterance nobody can listen to. Redaction runs *before* the clip for legibility, not safety: clipping first is equally safe (a cut only removes trailing material, and the key stays in front of whatever value survives, so the pattern still matches), but a 400-character token would eat the whole budget and push the actionable part of the message off the end.
+
+Still: no file is written, and the channels are owner-facing. Surfacing the reason at all is a deliberate trade — a refusal that cannot say why is the failure this whole mechanism exists to remove.
 
 ## Registering a service
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -2,9 +2,22 @@
 
 > Living document. Update this, don't create new versions.
 
-A **custom service** is a long-running agentwire session you register once and never babysit again: it boots when the portal boots (including after a reboot), the portal watchdog health-checks it, and a dead service gets a toast + TTS alert and an automatic respawn with backoff. Examples: a work-tracker session that receives `/log-work` pushes, a monitoring agent, a cron-companion session.
+A **custom service** is something long-running you register once and never babysit again: it boots when the portal boots (including after a reboot), the portal watchdog health-checks it, and a dead service gets a toast + TTS alert and an automatic respawn with backoff. Examples: a work-tracker session that receives `/log-work` pushes, a monitoring agent, a cron-companion session, a local bridge process.
 
 The notifications bridge (`agentwire-notifications`, the idle-nag TTS session) is a **built-in registry entry** — it gets the same lifecycle, with no bespoke code path.
+
+## Two kinds
+
+A service is an **agent** or a **command**, and the only thing that decides is whether the entry sets `command:`.
+
+| | agent (no `command`) | command (`command:` set) |
+|---|---|---|
+| What runs | an agentwire session (`agentwire new`) | your process, in a detached tmux session |
+| `roles` / `posture` / `context_policy` | apply | **rejected** — there is no agent to carry them |
+| Stopped by | `agentwire kill` (graceful `/exit` first) | `tmux kill-session` |
+| Default healthcheck | the tmux session exists | the tmux session exists (it ends when the process does) |
+
+The command kind is deliberately generic. agentwire supervises a process; it does not know or care what the process is. The voice buddy's bridge is one caller (see [voice-layer §6](voice-layer.md#6-lifecycle-host)), and nothing in the mechanism mentions it.
 
 ## Registering a service
 
@@ -22,8 +35,14 @@ services:
       healthcheck:
         kind: tmux_session           # tmux_session (default) | http | command
         interval: 60                 # seconds between watchdog checks
+    - name: some-bridge              # a COMMAND service — a plain process
+      command: some-bridge --port 9999
+      project: ~/projects/bridge     # working directory (default: $HOME)
+      autostart: false
     - "simple-service"               # string shorthand: name only, all defaults
 ```
+
+Setting `roles`, `posture` or `context_policy` alongside `command:` prints a warning and drops them. They are not silently ignored on purpose — a field that reads as a guard while nothing consumes it is worse than no field at all.
 
 Healthcheck kinds:
 
@@ -63,11 +82,23 @@ agentwire services down NAME     # stop and keep stopped
 
 MCP (read-only introspection for agents): `services_list()`, `services_status()`.
 
-`agentwire doctor` includes a registry-driven services section: `[ok]` healthy, `[!!]` should-be-running-but-isn't (with the fix command), `[..]` downed or autostart-off.
+`agentwire doctor` includes a registry-driven services section: `[ok]` healthy, `[!!]` should-be-running-but-isn't (with the fix command), `[..]` downed or autostart-off. Every line names the service's **kind**, because "session not found" means a dead agent for one and a dead process for the other, and the fix differs. A broken healthcheck on one entry is reported and the loop carries on — one bad service must not abandon the rest of the report.
+
+## Where a command service's output goes — and where it must not
+
+Nowhere on disk. tmux is the supervisor, and that choice **is** the secret-handling answer: stdout and stderr land in the pane's scrollback, which lives in the tmux server's memory behind the per-user socket dir `/tmp/tmux-<uid>` (mode 0700). agentwire adds no redirection — no `>`, no `tee`, no `pipe-pane`. A wrapper that is careful in its own code and then tees stdout into a log has not solved the problem, and the standard #887 holds `~/.agentwire`, `.env` and `portal.token` to applies here too: owner-only or not at all.
+
+One thing that is **not** hidden, and cannot be: `command` itself lands in the process table, which every local user can read. Secrets belong in `~/.agentwire/.env`, read from the environment by the process — never in a service's argv. `agentwire doctor` flags a `command` that looks like it carries one (`--token=`, `--api-key=`, `password=`, `Bearer …`) and names the pattern it matched.
+
+## Restart semantics
+
+The watchdog kills and respawns; it does not resume. A command service is therefore responsible for landing in a sane state on a cold start, and the useful question to ask of any candidate is *what does a restart mid-operation leave behind?* — with in-memory-only per-run state, the answer is "nothing", and that is worth a test rather than an assumption. The buddy bridge's is [`tests/unit/test_buddy_restart.py`](../../tests/unit/test_buddy_restart.py).
 
 ## Internals
 
 Single source of truth: `agentwire/services.py` — registry synthesis (built-ins + config), healthcheck runners, start/stop, disabled-state file, and the pure `WatchdogState` policy class (unit-tested backoff/notify matrix). The CLI commands wrap it; `agentwire up` and the portal's autostart + watchdog call the CLI (`services up --all`, `services status`), never duplicate the logic.
+
+`start_service` / `stop_service` branch on `svc.command`; `service_kind(svc)` is the one place that answers "agent or command", and `command_secret_risk(svc)` is detection-only (it names the pattern; the caller decides). `stop_service` takes the registry **entry**, not a bare name — the kill path branches on `command`, and a name alone would send `/exit` to a process.
 
 Portal Services column: the sidebar fetches `/api/services/custom` and groups those session names under Services automatically.
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -15,9 +15,23 @@ A service is an **agent** or a **command**, and the only thing that decides is w
 | What runs | an agentwire session (`agentwire new`) | your process, in a detached tmux session |
 | `roles` / `posture` / `context_policy` | apply | **rejected** — there is no agent to carry them |
 | Stopped by | `agentwire kill` (graceful `/exit` first) | `tmux kill-session` |
-| Default healthcheck | the tmux session exists | the tmux session exists (it ends when the process does) |
+| Default healthcheck | session exists **and** its pane is not dead | same |
+| A failed start | `agentwire new` exits non-zero | the pane is re-read after a grace period |
 
-The command kind is deliberately generic. agentwire supervises a process; it does not know or care what the process is. The voice buddy's bridge is one caller (see [voice-layer §6](voice-layer.md#6-lifecycle-host)), and nothing in the mechanism mentions it.
+The command kind is deliberately generic. agentwire supervises a process; it does not know or care what the process is.
+
+## A created pane is not a surviving process
+
+`tmux new-session` returning 0 says a pane was made. The command inside it may already have exited — a missing key, a bad flag, a name that isn't registered — and reporting that as `started` produces the worst shape available: a success line, then `[!!] unhealthy` from doctor one second later prescribing the command that just claimed success, with the process's own stderr gone along with the pane. Screenless, that is a fix-loop behind an all-clear.
+
+So a command service is spawned in three steps — a placeholder, `remain-on-exit on`, then the real command via `respawn-pane` — and the pane is re-read after `STARTUP_GRACE_S`. The ordering is why the placeholder exists at all: setting the option *after* launching the real command is a race that a fast-dying process wins, and fast-dying processes are exactly the ones whose reason is needed. A process that died reports `process exited immediately: <its last lines>`, and the corpse is deliberately left in place — tmux's memory is the only copy of that output, and the next start reads it before clearing it.
+
+Two consequences worth stating plainly:
+
+- **`remain-on-exit` means `has-session` is no longer liveness.** Measured: `tmux has-session` returns 0 for a session whose pane is dead. So the `tmux_session` healthcheck asks `#{pane_dead}` too, for *both* kinds — `remain-on-exit` is a user tmux setting, so an agent session could always have been in this state and was reported healthy.
+- **A dead pane is not "already running".** A start that found a corpse clears it and respawns, or the watchdog would loop forever: healthcheck says unhealthy, watchdog starts, start says "already running".
+
+The process's last lines are surfaced to the operator (in the start message and the healthcheck detail), so a process that prints a secret on the way down surfaces it where its own log would have. Bounded to the last few lines, written to no file, and a deliberate trade: a refusal that cannot say why is the failure this exists to remove.
 
 ## Registering a service
 
@@ -92,7 +106,7 @@ One thing that is **not** hidden, and cannot be: `command` itself lands in the p
 
 ## Restart semantics
 
-The watchdog kills and respawns; it does not resume. A command service is therefore responsible for landing in a sane state on a cold start, and the useful question to ask of any candidate is *what does a restart mid-operation leave behind?* — with in-memory-only per-run state, the answer is "nothing", and that is worth a test rather than an assumption. The buddy bridge's is [`tests/unit/test_buddy_restart.py`](../../tests/unit/test_buddy_restart.py).
+The watchdog kills and respawns; it does not resume. A command service is therefore responsible for landing in a sane state on a cold start, and the useful question to ask of any candidate is *what does a restart mid-operation leave behind?* — if the answer is "nothing, the state is per-run and in memory", that is worth a test rather than an assumption, because it is one refactor away from being false and nothing fails when it becomes false.
 
 ## Internals
 

--- a/docs/wiki/services.md
+++ b/docs/wiki/services.md
@@ -39,6 +39,17 @@ The process's last lines end up in the start message and in the healthcheck `det
 
 Everything the pane yields is therefore run through `redact_secrets` at the single point every consumer reads through (`_tmux_pane_tail`), using the *same* pattern set as the argv check — one source of truth, because a second list drifts from the first the moment either is extended. The value is masked and the rest of the line kept: a redaction that ate the message would re-create the failure it guards.
 
+**It masks a value that follows a key it recognises. That is all it does**, and the boundary is worth stating rather than leaving a reader to infer "secrets are redacted":
+
+| Caught | Not caught |
+|---|---|
+| `--token=x`, `--token x` (and `--api-key`, `--apikey`, `--api_key`, `--secret`, `--password`, `--passwd`) | `Authorization: Basic dXNlcjpwdw==` |
+| bare `token=`, `secret=`, `password=`, `passwd=`, `apikey=`, `api-key=`, `api_key=` | colon-separated headers — `X-Api-Key: 6f1e…` |
+| the same forms inside a URL — `?token=…` | `password: hunter2` (colon, not equals) |
+| `bearer x` / `Authorization: Bearer x`, case-insensitively | bare high-entropy strings with no key in front — a 40-char hex digest, a lone JWT, `sk-proj-…` |
+
+The right-hand column is a deliberate stopping point, not an oversight: a keyless-entropy detector run over crash output would eat stack addresses, hashes and commit SHAs, and the cost of that lands on the one thing this mechanism exists to deliver — a crash line the operator can act on. A process that prints its own credentials in a shape with no key in front of them will have them toasted and spoken.
+
 Two bounds, and they are different: `_TAIL_LINES` (3) bounds **lines**, `_TAIL_CHARS` (300) bounds **characters** — three lines of a 5000-column traceback is one utterance nobody can listen to. Redaction runs *before* the clip for legibility, not safety: clipping first is equally safe (a cut only removes trailing material, and the key stays in front of whatever value survives, so the pattern still matches), but a 400-character token would eat the whole budget and push the actionable part of the message off the end.
 
 Still: no file is written, and the channels are owner-facing. Surfacing the reason at all is a deliberate trade — a refusal that cannot say why is the failure this whole mechanism exists to remove.

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1622,7 +1622,10 @@ Those last lines are **redacted before they leave the pane**, because they do
 not stay on a terminal: the healthcheck detail built from them is toasted by
 the portal watchdog and spoken through `agentwire say`, so a bridge printing
 `bearer eyJ…` on the way down would otherwise have had that read aloud. Same
-pattern set as the argv check, value masked and the message kept.
+pattern set as the argv check, value masked and the message kept — and it masks
+a value that follows a key it recognises, nothing more; the exact boundary
+(what it does not catch, and why that is a stopping point rather than a gap) is
+tabulated in [services.md](services.md).
 
 ### Restart semantics: what a supervisor kill mid-handshake leaves behind
 

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1547,22 +1547,86 @@ changing underneath the conversation.**
 
 ## 6. Lifecycle host
 
-The buddy is not a tmux session, so it needs somewhere to live. The
+The buddy is not an agent session, so it needs somewhere to live. The
 [custom-services registry](services.md) is the natural home — autostart on
-portal launch, watchdog health checks, restart with backoff:
+portal launch, watchdog health checks, restart with backoff. What that registry
+had, until #983, was only *agent* services: every entry was an
+`agentwire new` session, and there was nowhere to declare a process. So the
+registry grew a second kind, `command`, which is entirely generic — it
+supervises a process and has no idea the voice layer exists. The buddy is one
+caller of it.
+
+The entry, ready to paste. It is **not** written into the owner's
+`config.yaml` by anything on this branch (that file is protected control plane,
+and a spike must not add itself to a startup path); wiring it up is one edit:
 
 ```yaml
-# ~/.agentwire/config.yaml  (NOT added by this branch — the owner's call)
+# ~/.agentwire/config.yaml
 services:
   custom:
     - name: buddy
       command: agentwire buddy serve buddy --port 8788
-      autostart: false
-      healthcheck: "curl -sf http://127.0.0.1:8788/ >/dev/null"
+      autostart: false        # flip to true when you want it on the startup path
+      restart: on-failure
+      healthcheck:
+        kind: tmux_session
+        interval: 60
 ```
 
-Not wired up by this branch on purpose: a spike must not add itself to the
-owner's startup path.
+Three details in that block are rulings, not defaults that happened to land:
+
+**`kind: tmux_session`, not the `curl http://127.0.0.1:8788/` this page used to
+suggest.** `/` is the route that hands over the run token — it is served with
+no auth at all, which is the whole reason the `Host` allowlist runs first on
+every route. A healthcheck polling it would pull a fresh copy of the token into
+the watchdog's process once a minute, forever, to learn something the tmux
+session already answers: the command service's session ENDS when its process
+does, so "the session exists" is the liveness signal. A probe should not fetch
+a secret to find out whether a port is open.
+
+**`autostart: false`.** The buddy needs `OPENAI_API_KEY` and a browser tab to
+be useful; a machine that boots it and never opens the page has spent nothing
+but a port. Still, opting in is the owner's call and doctor does not nag about
+a service nobody asked to run — an `autostart: false` entry reports `[..]`, not
+`[!!]`.
+
+**Nothing is redirected to a log.** tmux captures the process's stdout into the
+pane's scrollback, which lives in the tmux server's memory behind a 0700
+per-user socket dir. Measured, not assumed: the pane holds exactly the two
+lines `serve` prints, the token appears in neither, the HTTP server's request
+log is a no-op, and the token is absent from the process table. What the
+process table DOES expose is `command` itself, so a secret must never ride in a
+service's argv — doctor flags one that looks like it does.
+
+### Restart semantics: what a supervisor kill mid-handshake leaves behind
+
+Nothing pending, and this is now pinned rather than asserted. The confirm spine
+and the utterance ring are built per `BuddyBridge`, one bridge per `serve()`,
+and neither `confirm.py` nor `transcript.py` touches disk — so a watchdog kill
+between a proposal being anchored and its spoken nonce arriving leaves a
+proposal that exists nowhere. `tests/unit/test_buddy_restart.py` asserts both
+halves: the second run's spine and ring are empty and the dead run's token is
+refused, AND nothing under `~/.agentwire` gained the proposal's token, nonce or
+instruction. The second assertion is the one that survives someone deciding
+proposals should be durable; the first alone would still pass if a restart
+merely *reloaded* them.
+
+One thing a restart does not undo, and it is worth being exact rather than
+reassuring: a kill that lands *after* the write dispatched but *before* the
+announcement is confirmed spoken leaves the write **sent and unannounced**. The
+restart is clean; the fleet still got the message. That is a narrower guarantee
+than "mid-handshake work is rolled back", and nothing here rolls anything back.
+
+**The greet is the liveness probe.** Because the token is minted per run, a
+restart invalidates the open tab — its POSTs 401 rather than half-working — so
+the acceptance path is *reload, then Start talking*, and the greeting is what
+says the whole approval path came back up (a heard greeting proves model audio,
+which #950 made the write path fail-closed on). #995 records that the wires
+arming that greet have no pin at all: cutting `maybeGreet()` out of
+`pc.ontrack` leaves the entire suite green — **measured, 5736 unit tests, zero
+failures**. `tests/unit/test_buddy_restart.py` executes both arming legs,
+extracted from the page the server actually serves, and each cut now turns it
+red.
 
 ---
 
@@ -1728,9 +1792,15 @@ undecided. A next session that picks an answer silently is the failure mode.
       and wiring fleet detectors to actually SEND `--kind escalation` to the
       buddy — today the tier fires only for what other sessions choose to
       escalate.
-- [ ] **T4 — Lifecycle host.** Wire §6's `services.custom` entry, if and when
-      the owner wants the buddy on the startup path. Independent of Q1–Q3; safe
-      to do first.
+- [x] **T4 — Lifecycle host.** Shipped (#983). The registry grew a generic
+      `command` service kind — a supervised process rather than an agent
+      session — and §6 carries the paste-ready entry, the reasons the
+      healthcheck is `tmux_session` rather than a poll of the token-bearing
+      `/`, and the restart ruling with its pins. The one step deliberately NOT
+      taken: the entry is not written into the owner's `config.yaml`. Residual,
+      named rather than closed: a kill landing after the write dispatched but
+      before the announcement is confirmed spoken leaves the write sent and
+      unannounced.
 - [x] **T5 — Confirm the confirm.** Satisfied by construction, not by a separate
       step: the approval surface IS speech (a spoken nonce), so there is no card
       to tap and nothing to reach for. DocumentScribe shipped a click-gated

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1579,10 +1579,15 @@ Three details in that block are rulings, not defaults that happened to land:
 suggest.** `/` is the route that hands over the run token — it is served with
 no auth at all, which is the whole reason the `Host` allowlist runs first on
 every route. A healthcheck polling it would pull a fresh copy of the token into
-the watchdog's process once a minute, forever, to learn something the tmux
-session already answers: the command service's session ENDS when its process
-does, so "the session exists" is the liveness signal. A probe should not fetch
-a secret to find out whether a port is open.
+the watchdog's process once a minute, forever, to learn something tmux already
+answers. A probe should not fetch a secret to find out whether a port is open.
+
+What "the tmux session answers" is **not** simply "the session exists" — that
+sentence was true only while nothing kept a dead pane around, and the buddy's
+own spawn now deliberately does. `tmux has-session` returns 0 for a session
+whose pane is a corpse, so the `tmux_session` healthcheck asks `#{pane_dead}`
+as well. Without that second clause, retaining the crash reason would have
+traded a false success at start for a permanent one.
 
 **`autostart: false`.** The buddy needs `OPENAI_API_KEY` and a browser tab to
 be useful; a machine that boots it and never opens the page has spent nothing
@@ -1596,7 +1601,22 @@ per-user socket dir. Measured, not assumed: the pane holds exactly the two
 lines `serve` prints, the token appears in neither, the HTTP server's request
 log is a no-op, and the token is absent from the process table. What the
 process table DOES expose is `command` itself, so a secret must never ride in a
-service's argv — doctor flags one that looks like it does.
+service's argv — doctor flags one that looks like it does, in both the
+`--token=x` and `--token x` joinings, since they reach `ps` identically.
+
+### The failure the buddy hits first
+
+`agentwire buddy serve <name>` with an unregistered name refuses and exits at
+once — and with `autostart: false` shipped above, opting in is precisely when
+the owner meets it. A supervisor that reported that as a successful start would
+hand them a success line, a `[!!] unhealthy` from doctor a second later
+prescribing the command that just claimed success, and no copy anywhere of the
+process's own explanation. That is the shape this whole branch exists to
+remove, so the command kind spawns with `remain-on-exit on`, re-reads the pane
+after a grace period, and fails with the process's last lines attached:
+`process exited immediately: No voice buddy named 'nope'.` The corpse is left
+in place — tmux's memory is the only copy — and the next start reads it before
+clearing it. Still no file, still 0700.
 
 ### Restart semantics: what a supervisor kill mid-handshake leaves behind
 

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1618,6 +1618,12 @@ after a grace period, and fails with the process's last lines attached:
 in place — tmux's memory is the only copy — and the next start reads it before
 clearing it. Still no file, still 0700.
 
+Those last lines are **redacted before they leave the pane**, because they do
+not stay on a terminal: the healthcheck detail built from them is toasted by
+the portal watchdog and spoken through `agentwire say`, so a bridge printing
+`bearer eyJ…` on the way down would otherwise have had that read aloud. Same
+pattern set as the argv check, value masked and the message kept.
+
 ### Restart semantics: what a supervisor kill mid-handshake leaves behind
 
 Nothing pending, and this is now pinned rather than asserted. The confirm spine

--- a/tests/unit/test_buddy_restart.py
+++ b/tests/unit/test_buddy_restart.py
@@ -1,0 +1,314 @@
+"""Restart semantics for the supervised buddy bridge (#983).
+
+The lifecycle-host wave puts the bridge under a supervisor, which means the
+question "what does a restart mid-handshake land in?" stops being hypothetical:
+the watchdog can kill and respawn the process at any point, including between a
+proposal being anchored and its spoken nonce arriving.
+
+The issue said this is clean "by construction". It is — the confirm spine and
+the utterance ring are per-``BuddyBridge`` and nothing in ``confirm.py`` or
+``transcript.py`` touches disk — but *by construction* is a claim about code
+that is one refactor away from being false, and nothing failed when it became
+false. So it is pinned two ways here: the objects a second ``serve()`` hands
+out are empty, AND nothing the first run proposed exists anywhere under
+``~/.agentwire`` afterwards. The second assertion is the one that survives
+someone deciding proposals should be durable.
+
+The acceptance test the issue names is the greet: after a supervised restart,
+the next "Start talking" must greet, because a heard greeting is what proves
+the write path can approve anything at all (#950/#963). #995 records that the
+wires arming that greet — ``pc.ontrack`` among them — have no pin at all and
+can be cut with the whole suite staying green. They are executed here, as
+themselves, extracted from the page the server actually serves.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import urllib.request
+
+import pytest
+
+from agentwire.voice_layer import client, server
+
+# ─────────────────────────────────────────────────────────────
+# A real serve() → kill → serve() cycle
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def runs(monkeypatch):
+    """Record every BuddyBridge a serve() builds, and clean up the servers.
+
+    Recording the bridge is itself a pin: ``serve()`` constructing a bridge per
+    call is the whole mechanism, and a module-level bridge would show up here as
+    one object across two runs.
+    """
+    built = []
+    real = server.BuddyBridge
+
+    def recording(*args, **kwargs):
+        bridge = real(*args, **kwargs)
+        built.append(bridge)
+        return bridge
+
+    monkeypatch.setattr(server, "BuddyBridge", recording)
+    started = []
+
+    def start():
+        httpd, url = server.serve("buddy", port=0)
+        started.append(httpd)
+        return httpd, url, built[-1]
+
+    def kill(httpd):
+        """What the supervisor does: the process goes away. No teardown hook
+        runs on the spine, deliberately — that is the case under test."""
+        httpd.shutdown()
+        httpd.server_close()
+
+    yield start, kill, built
+    for httpd in started:
+        try:
+            httpd.shutdown()
+            httpd.server_close()
+        except Exception:
+            pass
+
+
+def _mid_handshake(bridge):
+    """Put *bridge* where a restart is worst: a proposal announced and anchored,
+    waiting on a spoken nonce that will never come."""
+    bridge.ring.speech_started("item-1", 1)
+    bridge.ring.commit("item-1", 2)
+    bridge.ring.transcribe("item-1", "send them a note", 2)
+    proposal = bridge.spine.propose(
+        tool="fleet_msg_send",
+        session="agentwire",
+        instruction="tell them the PR is up",
+        argv_prefix=("agentwire", "msg", "send"),
+    )
+    bridge.spine.announce(proposal.id, 3)
+    assert bridge.spine.pending(), "fixture built no handshake to interrupt"
+    return proposal
+
+
+class TestASupervisedRestartLandsNothingPending:
+    def test_the_second_run_gets_a_fresh_spine_and_ring(self, runs):
+        start, kill, built = runs
+        httpd1, _url1, bridge1 = start()
+        proposal = _mid_handshake(bridge1)
+        kill(httpd1)
+
+        httpd2, _url2, bridge2 = start()
+        assert bridge2 is not bridge1
+        assert bridge2.spine is not bridge1.spine
+        assert bridge2.ring is not bridge1.ring
+        assert bridge2.spine.pending() == []
+        assert bridge2.ring.snapshot() == []
+        # And the dead run's proposal is not merely invisible — it is unusable.
+        verdict = bridge2.spine.confirm(proposal.token)
+        assert verdict.approved is False
+
+    def test_the_run_token_is_fresh_so_the_old_page_cannot_keep_talking(self, runs):
+        """A restart invalidates the browser tab: the token was minted per run.
+        This is why the acceptance path is *reload, then Start talking* — the
+        old page's POSTs 401 rather than half-working."""
+        start, kill, _built = runs
+        httpd1, url1, bridge1 = start()
+        kill(httpd1)
+        httpd2, url2, bridge2 = start()
+        assert bridge2.token != bridge1.token
+        assert url1.startswith("http://127.0.0.1:") and url2.startswith("http://127.0.0.1:")
+
+    def test_nothing_from_the_handshake_is_written_to_disk(self, runs, tmp_path):
+        """The construction argument, asserted as a fact about the filesystem.
+
+        A spine that started persisting proposals would still pass the
+        fresh-object test above (a new run would just LOAD them), so the pin
+        that actually holds the guarantee is this one.
+        """
+        from pathlib import Path
+
+        start, kill, _built = runs
+        home = Path.home() / ".agentwire"
+        before = _snapshot(home)
+        httpd1, _url, bridge1 = start()
+        proposal = _mid_handshake(bridge1)
+        kill(httpd1)
+
+        after = _snapshot(home)
+        new_or_changed = {p: c for p, c in after.items() if before.get(p) != c}
+        for path, content in new_or_changed.items():
+            assert proposal.token not in content, f"proposal token persisted in {path}"
+            assert proposal.nonce not in content, f"nonce persisted in {path}"
+            assert "tell them the PR is up" not in content, f"instruction persisted in {path}"
+
+
+def _snapshot(root) -> dict:
+    """Text content of every file under *root* (binary files skipped)."""
+    out = {}
+    if not root.exists():
+        return out
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            out[str(path)] = path.read_text(errors="replace")
+        except OSError:
+            continue
+    return out
+
+
+class TestTheRestartedRunServesAGreetArmedPage:
+    """The liveness probe end of it, at the HTTP boundary."""
+
+    def test_the_page_served_after_a_restart_carries_the_new_token(self, runs):
+        start, kill, _built = runs
+        httpd1, _url1, bridge1 = start()
+        kill(httpd1)
+        _httpd2, url2, bridge2 = start()
+
+        with urllib.request.urlopen(url2, timeout=5) as resp:
+            page = resp.read().decode("utf-8")
+        assert json.dumps(bridge2.token) in page
+        assert bridge1.token not in page
+
+    def test_the_greet_latch_is_page_lifetime_so_a_restart_re_arms_it(self, runs):
+        """``greeted`` is never reset by ``stop()`` on purpose — a reconnect must
+        not re-greet. A supervisor restart is not a reconnect: it serves a new
+        page, and that page starts unlatched. If the latch ever moved server-side
+        the buddy would come back from a restart silent, and silence is exactly
+        what the greet exists to distinguish from health."""
+        start, kill, _built = runs
+        httpd1, _url1, _b1 = start()
+        kill(httpd1)
+        _httpd2, url2, _b2 = start()
+
+        with urllib.request.urlopen(url2, timeout=5) as resp:
+            page = resp.read().decode("utf-8")
+        assert re.search(r"let\s+greeted\s*=\s*false\s*;", page)
+        assert re.search(r"let\s+sessionReady\s*=\s*false\s*;", page)
+        assert re.search(r"let\s+audioAttached\s*=\s*false\s*;", page)
+
+
+# ─────────────────────────────────────────────────────────────
+# The greet wires, executed (#995 — these have no other pin)
+# ─────────────────────────────────────────────────────────────
+
+pytestmark_node = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is needed to run the client's own JS"
+)
+
+
+def _page() -> str:
+    return client.page("buddy", "tok")
+
+
+def _slice(page: str, start_pat: str, end_pat: str, what: str) -> str:
+    """Cut a region out of the served page, failing loudly if the anchor moved.
+
+    Extraction rather than a copy, for the reason ``announcer_source`` gives:
+    a test that re-derives its subject proves something about the copy. And a
+    silent miss here would be the worst outcome — the wire could be gone and
+    this file would still be green, which is the #995 failure repeated by the
+    test written to close it.
+    """
+    start = re.search(start_pat, page)
+    assert start, f"anchor for {what} not found — the page moved, this test is stale"
+    end = re.search(end_pat, page[start.start():])
+    assert end, f"end anchor for {what} not found"
+    return page[start.start():start.start() + end.end()]
+
+
+def _greet_program(*, fire: str) -> str:
+    page = _page()
+    greet_block = _slice(
+        page, r"const GREETING\s*=", r"function maybeGreet\(\)\s*\{[\s\S]*?\n\}",
+        "the greeting block",
+    )
+    ontrack = _slice(page, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire")
+    session_created = _slice(
+        page, r'case "session\.created":', r"break;", "the session.created wire",
+    )
+    # `case`/`break` are only legal inside a switch; the body is what is under
+    # test, so it is lifted into a function verbatim.
+    body = session_created[len('case "session.created":'):-len("break;")]
+
+    return "\n".join([
+        "const announced = [];",
+        "function announce(text, meta, fallback) { announced.push({ text, meta, fallback }); }",
+        "let inboxNotifier = { starts: 0, start() { this.starts++; } };",
+        "let audioEl = {};",
+        "let pc = {};",
+        greet_block,
+        ontrack,
+        "function fireOntrack() { pc.ontrack({ streams: [{}] }); }",
+        f"function fireSessionCreated() {{ {body} }}",
+        fire,
+        "console.log(JSON.stringify({ announced, greeted, "
+        "sessionReady, audioAttached, notifierStarts: inboxNotifier.starts }));",
+    ])
+
+
+def _run_greet(fire: str) -> dict:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", _greet_program(fire=fire)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+@pytestmark_node
+class TestBothGreetWiresAreLoadBearing:
+    """Cut either wire and the buddy comes back from a restart silent.
+
+    Before this file, cutting either one left the entire suite green (#995).
+    """
+
+    def test_ontrack_alone_does_not_greet(self):
+        report = _run_greet("fireOntrack();")
+        assert report["audioAttached"] is True
+        assert report["announced"] == []
+        assert report["greeted"] is False
+
+    def test_session_created_alone_does_not_greet(self):
+        report = _run_greet("fireSessionCreated();")
+        assert report["sessionReady"] is True
+        assert report["announced"] == []
+        assert report["greeted"] is False
+
+    def test_both_wires_greet_exactly_once(self):
+        report = _run_greet("fireOntrack(); fireSessionCreated();")
+        assert report["greeted"] is True
+        assert len(report["announced"]) == 1
+        item = report["announced"][0]
+        assert item["text"] == "Hey, I'm listening. What's on your mind?"
+        assert item["meta"] == {"greeting": True}
+        # The fallback text is NOT the greeting: a fallback-spoken greeting
+        # would confirm the browser voice while model audio is dead, and
+        # nothing could be approved (#950).
+        assert "isn't working" in item["fallback"]
+
+    def test_the_other_order_greets_too(self):
+        """Whichever lands last fires it — the wires are symmetric, and a
+        greeting that depended on arrival order would be a race the owner hears
+        as intermittent silence."""
+        report = _run_greet("fireSessionCreated(); fireOntrack();")
+        assert len(report["announced"]) == 1
+
+    def test_a_second_pass_does_not_re_greet(self):
+        report = _run_greet(
+            "fireOntrack(); fireSessionCreated(); fireOntrack(); fireSessionCreated();"
+        )
+        assert len(report["announced"]) == 1
+        assert report["notifierStarts"] == 2  # the notifier wire ran both times
+
+    def test_the_session_created_wire_also_starts_the_inbox_notifier(self):
+        """Ordering that the wire encodes: the notifier starts AFTER the greeting
+        is queued, so the first inbox tick defers behind it."""
+        report = _run_greet("fireOntrack(); fireSessionCreated();")
+        assert report["notifierStarts"] == 1
+        assert len(report["announced"]) == 1

--- a/tests/unit/test_buddy_restart.py
+++ b/tests/unit/test_buddy_restart.py
@@ -205,7 +205,7 @@ def _page() -> str:
     return client.page("buddy", "tok")
 
 
-def _slice(page: str, start_pat: str, end_pat: str, what: str) -> str:
+def _slice(page: str, start_pat: str, end_pat: str, what: str, *, shape: str) -> str:
     """Cut a region out of the served page, failing loudly if the anchor moved.
 
     Extraction rather than a copy, for the reason ``announcer_source`` gives:
@@ -213,12 +213,24 @@ def _slice(page: str, start_pat: str, end_pat: str, what: str) -> str:
     silent miss here would be the worst outcome — the wire could be gone and
     this file would still be green, which is the #995 failure repeated by the
     test written to close it.
+
+    "Loudly" has to cover the PARTIAL match too. A start anchor that still hits
+    while the end anchor has drifted yields a syntactically broken fragment,
+    and what the reader then sees is an opaque node ``SyntaxError`` rather than
+    "the anchor moved". So each slice declares the *shape* it must still have —
+    chosen to be invariant under the mutations these tests exist to catch, so a
+    cut wire fails as a behaviour failure and never as a stale-anchor one.
     """
     start = re.search(start_pat, page)
     assert start, f"anchor for {what} not found — the page moved, this test is stale"
     end = re.search(end_pat, page[start.start():])
-    assert end, f"end anchor for {what} not found"
-    return page[start.start():start.start() + end.end()]
+    assert end, f"end anchor for {what} not found — the page moved, this test is stale"
+    region = page[start.start():start.start() + end.end()]
+    assert re.search(shape, region), (
+        f"extracted {what} does not have the shape this test assumes — the page "
+        f"moved and the extraction is stale, NOT a behaviour failure. Got:\n{region}"
+    )
+    return region
 
 
 def _greet_program(*, fire: str) -> str:
@@ -226,10 +238,19 @@ def _greet_program(*, fire: str) -> str:
     greet_block = _slice(
         page, r"const GREETING\s*=", r"function maybeGreet\(\)\s*\{[\s\S]*?\n\}",
         "the greeting block",
+        # Shape, not behaviour: the declarations and the function's existence.
+        # Whether maybeGreet's BODY still greets is what the tests decide.
+        shape=r"let greeted[\s\S]*function maybeGreet\(\)\s*\{[\s\S]*\}\s*$",
     )
-    ontrack = _slice(page, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire")
+    ontrack = _slice(
+        page, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire",
+        # An assignment of an arrow function, ending in a statement. True with
+        # or without the maybeGreet() call inside it.
+        shape=r"^pc\.ontrack\s*=\s*\([\s\S]*=>[\s\S]*;\s*$",
+    )
     session_created = _slice(
         page, r'case "session\.created":', r"break;", "the session.created wire",
+        shape=r'^case "session\.created":[\s\S]*break;$',
     )
     # `case`/`break` are only legal inside a switch; the body is what is under
     # test, so it is lifted into a function verbatim.
@@ -280,6 +301,25 @@ class TestBothGreetWiresAreLoadBearing:
         assert report["announced"] == []
         assert report["greeted"] is False
 
+    def test_the_ontrack_wire_greets_when_it_lands_last(self):
+        """THE pin for #995's worst wire, and the ordering is load-bearing.
+
+        ``pc.ontrack``'s ``maybeGreet()`` call only decides anything when
+        ontrack arrives SECOND — with the other order, session.created's call
+        fires the greeting and the cut is masked. A single "both wires" test in
+        the convenient order would have left the wire unpinned while looking
+        like it covered it.
+        """
+        report = _run_greet("fireSessionCreated(); fireOntrack();")
+        assert len(report["announced"]) == 1
+        assert report["greeted"] is True
+
+    def test_the_session_created_wire_greets_when_it_lands_last(self):
+        """The mirror, pinning the other wire's call for the same reason."""
+        report = _run_greet("fireOntrack(); fireSessionCreated();")
+        assert len(report["announced"]) == 1
+        assert report["greeted"] is True
+
     def test_both_wires_greet_exactly_once(self):
         report = _run_greet("fireOntrack(); fireSessionCreated();")
         assert report["greeted"] is True
@@ -291,13 +331,6 @@ class TestBothGreetWiresAreLoadBearing:
         # would confirm the browser voice while model audio is dead, and
         # nothing could be approved (#950).
         assert "isn't working" in item["fallback"]
-
-    def test_the_other_order_greets_too(self):
-        """Whichever lands last fires it — the wires are symmetric, and a
-        greeting that depended on arrival order would be a race the owner hears
-        as intermittent silence."""
-        report = _run_greet("fireSessionCreated(); fireOntrack();")
-        assert len(report["announced"]) == 1
 
     def test_a_second_pass_does_not_re_greet(self):
         report = _run_greet(

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -284,7 +284,7 @@ class TestServicesCLI:
     def test_down_disables_then_stops(self, cli, capsys, monkeypatch):
         calls = []
         monkeypatch.setattr(services, "stop_service",
-                            lambda name: (calls.append(("stop", name, "tracker" in services.load_disabled())) or True, "stopped"))
+                            lambda svc: (calls.append(("stop", svc.name, "tracker" in services.load_disabled())) or True, "stopped"))
         assert cli.cmd_services_down(self._args(name="tracker")) == 0
         # Disabled flag was already set when stop ran (no watchdog race)
         assert calls == [("stop", "tracker", True)]

--- a/tests/unit/test_services_command.py
+++ b/tests/unit/test_services_command.py
@@ -343,6 +343,215 @@ class TestTheHealthcheckMustSeeADeadPane:
             CustomServiceConfig(name="buddy", command="x"))["running"] is False
 
 
+class TestThePlaceholderMustNeverOutliveTheSpawn:
+    """A spawn that fails partway must leave nothing behind claiming to be the
+    service.
+
+    The three-step spawn introduced a window the one-shot version did not have:
+    steps 2 and 3 run against a session step 1 just created, and the old
+    "lost a benign spawn race" handler treated ANY failure in the try block as
+    "someone else's session is already up". It isn't — it is the placeholder,
+    genuinely alive, running `sleep 3600`. `pane_dead` cannot see that (the
+    sleep loop is not a corpse), so the healthcheck calls it healthy: a sleep
+    loop reported as a running service, which is F1's false all-clear wearing a
+    different costume.
+
+    So `already running` must be reachable ONLY when the session genuinely
+    pre-existed this call.
+    """
+
+    def _svc(self):
+        return CustomServiceConfig(name="buddy", command="real-command --port 1")
+
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self, monkeypatch):
+        monkeypatch.setattr(services.time, "sleep", lambda s: None)
+
+    def _failing_at(self, monkeypatch, failing: str, calls: list):
+        """Let every tmux call succeed except the one whose argv contains
+        *failing*."""
+        import subprocess as sp
+
+        def run(cmd, **kw):
+            calls.append(cmd)
+            if failing in cmd:
+                raise sp.CalledProcessError(1, "tmux", stderr=b"tmux said no")
+            return _ok()
+        monkeypatch.setattr(services.subprocess, "run", run)
+
+    @pytest.mark.parametrize("failing", ["set-option", "respawn-pane"])
+    def test_a_failure_after_the_placeholder_exists_is_a_failed_start(
+        self, monkeypatch, failing,
+    ):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        calls = []
+        self._failing_at(monkeypatch, failing, calls)
+        ok, msg = services.start_service(self._svc())
+        assert ok is False, msg
+        assert "already running" not in msg
+
+    @pytest.mark.parametrize("failing", ["set-option", "respawn-pane"])
+    def test_the_placeholder_is_killed_rather_than_left_running(
+        self, monkeypatch, failing,
+    ):
+        """Otherwise the orphan sits there running a sleep loop, the healthcheck
+        reports it healthy, and the real service never starts again."""
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        calls = []
+        self._failing_at(monkeypatch, failing, calls)
+        services.start_service(self._svc())
+        assert any("kill-session" in c for c in calls), calls
+
+    def test_a_genuinely_pre_existing_session_is_still_already_running(
+        self, monkeypatch,
+    ):
+        """The case the handler was written for, which must keep working: two
+        starts race, new-session loses on a duplicate, and the loser reports
+        the winner rather than a failure."""
+        import subprocess as sp
+        exists = iter([False, True])
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: next(exists))
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        killed = []
+
+        def run(cmd, **kw):
+            if "new-session" in cmd:
+                raise sp.CalledProcessError(1, "tmux", stderr=b"duplicate session")
+            if "kill-session" in cmd:
+                killed.append(cmd)
+            return _ok()
+        monkeypatch.setattr(services.subprocess, "run", run)
+        assert services.start_service(self._svc()) == (True, "already running")
+        # and it must NOT kill the winner's session on its way out
+        assert killed == []
+
+
+class TestNamesGoThroughTheOneMapping:
+    """tmux rewrites `.` and `:` in a session name; `worktree.tmux_safe_name`
+    is the single implementation of that mapping (#868/#878).
+
+    Building `-s` from the raw name and then targeting `-t` with the raw name
+    is the documented failure: tmux creates `a_b`, every subsequent target
+    misses, and teardown reports success while the session survives. That is
+    live here because the spawn now has FIVE targets, not one.
+    """
+
+    def test_every_tmux_target_uses_the_sanitized_name(self, monkeypatch):
+        from agentwire.worktree import tmux_safe_name
+        raw = "rev.dot:2"
+        safe = tmux_safe_name(raw)
+        assert safe == "rev_dot_2"  # the mapping, stated so a change is visible
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.time, "sleep", lambda s: None)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        services.start_service(CustomServiceConfig(name=raw, command="x"))
+        targets = [part for call in calls for part in call if part.startswith("=")]
+        assert targets, calls
+        for target in targets:
+            assert safe in target, target
+            assert raw not in target, target
+        assert ["-s", safe] == [p for call in calls for i, p in enumerate(call)
+                                if p == "-s" or (i and call[i - 1] == "-s")]
+
+    @pytest.mark.parametrize("helper", ["_tmux_session_exists", "_tmux_pane_dead",
+                                        "_tmux_pane_tail"])
+    def test_the_probes_ask_about_the_name_tmux_actually_chose(
+        self, monkeypatch, helper,
+    ):
+        calls = []
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok_text())
+        getattr(services, helper)("rev.dot:2")
+        flat = " ".join(calls[0])
+        assert "rev_dot_2" in flat
+        assert "rev.dot:2" not in flat
+
+
+def _ok_text():
+    class R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+    return R()
+
+
+class TestACrashLineIsRedactedBeforeItIsSpoken:
+    """A captured crash line is exactly where a secret shows up, and `detail`
+    does not stay on the terminal.
+
+    It reaches the portal watchdog's `_notify_service_event`, which TOASTS it
+    and SPEAKS it through `agentwire say`. Owner-facing, so surfacing it at all
+    is a deliberate trade — but a process printing `bearer eyJ…` while dying
+    would have put that verbatim into a spoken utterance. Redaction happens at
+    the single choke point every consumer reads through, and uses the SAME
+    pattern set as the argv check rather than a second list that can drift.
+    """
+
+    def _tail(self, monkeypatch, text):
+        class R:
+            returncode = 0
+            stdout = text
+            stderr = ""
+        monkeypatch.setattr(services.subprocess, "run", lambda *a, **k: R())
+        return services._tmux_pane_tail("x")
+
+    @pytest.mark.parametrize("line,secret", [
+        ("FATAL: bad creds: bearer eyJLEAKED", "eyJLEAKED"),
+        ("usage: bridge --token=SUPERSECRET123", "SUPERSECRET123"),
+        ("usage: bridge --token SUPERSECRET123", "SUPERSECRET123"),
+        ("usage: bridge --api-key sk-live-abc", "sk-live-abc"),
+        ("env PASSWORD=hunter2 not found", "hunter2"),
+    ])
+    def test_the_secret_is_masked(self, monkeypatch, line, secret):
+        tail = self._tail(monkeypatch, line)
+        assert secret not in tail, tail
+        assert "***" in tail
+
+    def test_the_rest_of_the_line_survives(self, monkeypatch):
+        """Redaction that ate the message would re-create the failure it is
+        guarding: a refusal that cannot say why."""
+        tail = self._tail(monkeypatch, "FATAL: bad creds: bearer eyJLEAKED")
+        assert "FATAL: bad creds" in tail
+
+    def test_an_ordinary_crash_line_is_untouched(self, monkeypatch):
+        assert self._tail(monkeypatch, "No voice buddy named 'nope'.") == (
+            "No voice buddy named 'nope'.")
+
+    def test_a_very_long_line_is_clipped(self, monkeypatch):
+        """`_TAIL_LINES` bounds LINES. Three lines of a 5000-column traceback is
+        one spoken utterance nobody can listen to."""
+        tail = self._tail(monkeypatch, "x" * 5000)
+        assert len(tail) <= services._TAIL_CHARS + 1
+        assert tail.endswith("…")
+
+    def test_redacting_before_the_clip_keeps_the_actionable_part(self, monkeypatch):
+        """Ordering, and the reason is legibility rather than safety.
+
+        Clipping first would be equally safe — a cut only removes trailing
+        material, and the key stays in front of whatever value survives, so the
+        pattern still matches. But a 400-character token would eat the whole
+        character budget and push the words the operator needs off the end.
+        Redaction shortens the value, so doing it first spends the cap on the
+        message.
+        """
+        secret = "SUPERSECRET" + "9" * 400
+        tail = self._tail(monkeypatch, f"bridge --token={secret} FATAL-boom")
+        assert "SUPERSECRET" not in tail, tail
+        assert "***" in tail
+        assert "FATAL-boom" in tail, tail
+
+    def test_redaction_uses_the_argv_pattern_set(self):
+        """One source of truth. A second list would drift from the argv check
+        the moment either is extended — which just happened to the argv one."""
+        for pattern in services._SECRET_ARGV_PATTERNS:
+            assert services.redact_secrets(f"x {pattern}VALUE") .endswith("***"), pattern
+
+
 @pytest.mark.requires_tmux
 class TestAgainstRealTmux:
     """The same claims against the real binary.
@@ -396,6 +605,85 @@ class TestAgainstRealTmux:
         assert ok is True, msg
         assert "FATAL: boom" in msg  # the previous run's reason, read before clearing
         assert services.run_healthcheck(self._svc("sleep 30"))[0] is True
+
+    def test_a_crash_line_carrying_a_secret_is_redacted(self):
+        """Against the real capture path, since that is where it would leak:
+        `detail` is toasted AND spoken by the portal watchdog."""
+        svc = self._svc('sh -c "echo bearer eyJLEAKED >&2; exit 1"')
+        ok, msg = services.start_service(svc)
+        assert ok is False
+        assert "eyJLEAKED" not in msg, msg
+        assert "***" in msg
+        assert "eyJLEAKED" not in services.run_healthcheck(svc)[1]
+
+
+@pytest.mark.requires_tmux
+class TestARewrittenNameAgainstRealTmux:
+    """Leg 1 of the placeholder finding, with zero mocks.
+
+    A service name containing `.` or `:` is rewritten by tmux itself, so a
+    spawn that creates with the raw name and then targets with the raw name
+    fails at step 2 — and used to leave the placeholder running while
+    `stop_service` reported "not running". A false all-clear plus an orphan,
+    and the service never runs again.
+    """
+
+    RAW = "zz983.dot:probe"
+
+    @pytest.fixture(autouse=True)
+    def _cleanup(self):
+        import subprocess as sp
+
+        from agentwire.worktree import tmux_safe_name
+        for name in (self.RAW, tmux_safe_name(self.RAW)):
+            sp.run(["tmux", "kill-session", "-t", f"={name}"], capture_output=True)
+        yield
+        for name in (self.RAW, tmux_safe_name(self.RAW)):
+            sp.run(["tmux", "kill-session", "-t", f"={name}"], capture_output=True)
+
+    def _svc(self, command):
+        return CustomServiceConfig(name=self.RAW, command=command)
+
+    def test_a_rewritten_name_starts_and_is_seen_and_stops(self):
+        svc = self._svc("sleep 30")
+        ok, msg = services.start_service(svc)
+        assert ok is True, msg
+        assert services.run_healthcheck(svc) == (True, "session exists")
+        ok, msg = services.stop_service(svc)
+        assert ok is True, msg
+        # The claim `stop_service` makes must be TRUE of the session tmux
+        # actually created, not of a name that never existed.
+        assert services._tmux_session_exists(self.RAW) is False
+
+    def test_no_orphan_placeholder_is_left_behind(self):
+        import subprocess as sp
+
+        from agentwire.worktree import tmux_safe_name
+        services.start_service(self._svc("sleep 30"))
+        services.stop_service(self._svc("sleep 30"))
+        live = sp.run(["tmux", "list-sessions", "-F", "#{session_name}"],
+                      capture_output=True, text=True).stdout
+        assert tmux_safe_name(self.RAW) not in live.split(), live
+
+    def test_a_partial_spawn_leaves_nothing_running(self, monkeypatch):
+        """Leg 2, against real tmux: only step 3 fails. Nothing may survive
+        claiming to be the service — least of all the sleep loop, which
+        `pane_dead` cannot distinguish from a healthy process."""
+        import subprocess as sp
+        real_run = sp.run
+
+        def run(cmd, **kw):
+            if isinstance(cmd, list) and "respawn-pane" in cmd:
+                raise sp.CalledProcessError(1, "tmux", stderr=b"injected")
+            return real_run(cmd, **kw)
+        monkeypatch.setattr(services.subprocess, "run", run)
+
+        ok, msg = services.start_service(self._svc("sleep 30"))
+        assert ok is False, msg
+        monkeypatch.undo()
+        assert services._tmux_session_exists(self.RAW) is False
+        # and nothing reports the corpse-free placeholder as healthy
+        assert services.run_healthcheck(self._svc("sleep 30"))[0] is False
 
 
 class TestInlineSecretsInArgv:

--- a/tests/unit/test_services_command.py
+++ b/tests/unit/test_services_command.py
@@ -1,0 +1,327 @@
+"""Process ("command") custom services, and doctor's reporting leg (#983).
+
+A custom service used to be one thing: an agentwire agent session. The voice
+buddy's bridge is not that — it is a plain long-running process — and until it
+had somewhere to live it was hand-launched, which means it survived no reboot
+and appeared in no diagnostic.
+
+These pin the generic half of that: what a `command:` entry parses to, that it
+is supervised by tmux rather than by `agentwire new`, that its output lands on
+no world-readable surface, and that doctor reports it beside the agent
+services. Nothing here knows what the process is — the buddy is one caller of a
+mechanism that has no idea it exists.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from agentwire import doctor_cli, services
+from agentwire.config import (
+    Config,
+    CustomServiceConfig,
+    HealthcheckConfig,
+    ServicesConfig,
+    _dict_to_config,
+)
+
+
+@pytest.fixture
+def state_file(tmp_path, monkeypatch):
+    f = tmp_path / "services-state.json"
+    monkeypatch.setattr(services, "STATE_FILE", f)
+    return f
+
+
+class TestCommandServiceParsing:
+    def test_command_entry_parses(self):
+        cfg = _dict_to_config({"services": {"custom": [{
+            "name": "buddy",
+            "command": "agentwire buddy serve buddy --port 8788",
+            "autostart": False,
+        }]}})
+        svc = cfg.services.custom[0]
+        assert svc.command == "agentwire buddy serve buddy --port 8788"
+        assert svc.autostart is False
+        assert services.service_kind(svc) == "command"
+
+    def test_an_agent_service_is_unchanged(self):
+        cfg = _dict_to_config({"services": {"custom": [{"name": "tracker"}]}})
+        svc = cfg.services.custom[0]
+        assert svc.command is None
+        assert services.service_kind(svc) == "agent"
+
+    def test_empty_command_is_not_a_command_service(self):
+        """`command: ""` must not silently become a process service that runs
+        the empty string — tmux would open an idle shell and the healthcheck
+        would call it healthy forever."""
+        cfg = _dict_to_config({"services": {"custom": [
+            {"name": "x", "command": ""},
+        ]}})
+        assert cfg.services.custom[0].command is None
+        assert services.service_kind(cfg.services.custom[0]) == "agent"
+
+    def test_agent_only_fields_are_dropped_and_announced(self, capsys):
+        """roles/posture/context_policy describe an agent. On a process service
+        they describe nothing, and a field that reads as a guard while nothing
+        consumes it is worse than no field at all."""
+        cfg = _dict_to_config({"services": {"custom": [{
+            "name": "buddy",
+            "command": "sleep 1",
+            "roles": "worker",
+            "posture": "bypass",
+            "context_policy": "clear",
+        }]}})
+        svc = cfg.services.custom[0]
+        assert svc.roles is None
+        assert svc.posture is None
+        assert svc.context_policy == "none"
+        warned = capsys.readouterr().err
+        assert "buddy" in warned
+        assert "roles" in warned and "posture" in warned and "context_policy" in warned
+
+    def test_agent_service_keeps_its_roles(self, capsys):
+        cfg = _dict_to_config({"services": {"custom": [
+            {"name": "tracker", "roles": "worker", "posture": "bypass"},
+        ]}})
+        svc = cfg.services.custom[0]
+        assert svc.roles == "worker" and svc.posture == "bypass"
+        assert capsys.readouterr().err == ""
+
+
+class TestCommandServiceSupervision:
+    """tmux is the supervisor, and that is the secret-handling answer."""
+
+    def _svc(self, **kw):
+        kw.setdefault("name", "buddy")
+        kw.setdefault("command", "agentwire buddy serve buddy --port 8788")
+        return CustomServiceConfig(**kw)
+
+    def test_start_runs_the_command_under_tmux_not_agentwire_new(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        svc = self._svc(project="/tmp/proj")
+        ok, msg = services.start_service(svc)
+        assert (ok, msg) == (True, "started")
+        assert calls == [[
+            "tmux", "new-session", "-d", "-s", "buddy", "-c", svc.project,
+            "agentwire buddy serve buddy --port 8788",
+        ]]
+        assert "agentwire" not in calls[0][:6]  # not `agentwire new`
+
+    def test_start_redirects_nothing_to_a_file(self, monkeypatch):
+        """The whole secret-handling argument. tmux captures stdout/stderr into
+        the pane's scrollback, which lives in the tmux server's memory behind a
+        0700 per-user socket dir; a shell redirect into a log file would put the
+        same bytes somewhere with a mode nobody set. If a `>`, a `tee` or a
+        `pipe-pane` ever appears here, that argument is void."""
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        services.start_service(self._svc())
+        flat = " ".join(calls[0])
+        # The service's OWN command is the operator's business; agentwire must
+        # not add redirection around it.
+        wrapper = [part for part in calls[0] if part != self._svc().command]
+        assert ">" not in " ".join(wrapper)
+        assert "tee" not in " ".join(wrapper)
+        assert "pipe-pane" not in flat
+
+    def test_start_is_idempotent(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda *a, **k: pytest.fail("must not respawn"))
+        assert services.start_service(self._svc()) == (True, "already running")
+
+    def test_a_lost_spawn_race_is_benign(self, monkeypatch):
+        """Autostart, watchdog and a manual `services up` can collide. The loser
+        must report the winner's session, never a failure."""
+        import subprocess as sp
+        exists = iter([False, True])
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: next(exists))
+
+        def boom(*a, **k):
+            raise sp.CalledProcessError(1, "tmux", stderr=b"duplicate session")
+        monkeypatch.setattr(services.subprocess, "run", boom)
+        assert services.start_service(self._svc()) == (True, "already running")
+
+    def test_start_failure_reports_tmux_stderr(self, monkeypatch):
+        import subprocess as sp
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+
+        def boom(*a, **k):
+            raise sp.CalledProcessError(1, "tmux", stderr=b"no server running")
+        monkeypatch.setattr(services.subprocess, "run", boom)
+        ok, msg = services.start_service(self._svc())
+        assert ok is False and "no server running" in msg
+
+    def test_stop_kills_the_session_without_sending_exit(self, monkeypatch):
+        """`agentwire kill`'s graceful leg types `/exit` at an agent. There is
+        no agent in a process service — those two characters would go to the
+        process's stdin."""
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        assert services.stop_service(self._svc()) == (True, "stopped")
+        assert calls == [["tmux", "kill-session", "-t", "=buddy"]]
+
+    def test_stop_of_an_agent_service_still_goes_through_agentwire_kill(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        services.stop_service(CustomServiceConfig(name="tracker"))
+        assert calls[0][1:] == ["-m", "agentwire", "kill", "-s", "tracker", "--json"]
+
+    def test_status_carries_the_kind(self, state_file, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        assert services.service_status(self._svc())["kind"] == "command"
+        assert services.service_status(CustomServiceConfig(name="t"))["kind"] == "agent"
+
+
+def _ok():
+    class R:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+    return R()
+
+
+class TestInlineSecretsInArgv:
+    """The one leak tmux does NOT close: argv is world-readable in `ps`."""
+
+    @pytest.mark.parametrize("command,expected", [
+        ("agentwire buddy serve buddy --port 8788", None),
+        ("some-bridge --token=hunter2", "--token="),
+        ("some-bridge --api-key=sk-live", "--api-key="),
+        ("env PASSWORD=hunter2 some-bridge", "password="),
+        ("curl -H 'Authorization: Bearer abc' x", "bearer "),
+    ])
+    def test_detection(self, command, expected):
+        svc = CustomServiceConfig(name="x", command=command)
+        assert services.command_secret_risk(svc) == expected
+
+    def test_an_agent_service_has_no_argv_to_leak(self):
+        assert services.command_secret_risk(CustomServiceConfig(name="x")) is None
+
+
+class TestDoctorSection:
+    """`agentwire doctor` reports a process service beside the agent ones."""
+
+    def _patch(self, monkeypatch, custom, *, healthy=True, disabled=()):
+        cfg = Config(services=ServicesConfig(custom=custom))
+        monkeypatch.setattr("agentwire.config.load_config", lambda *a, **k: cfg)
+        monkeypatch.setattr(services, "notifications_session_name", lambda: "notif")
+        monkeypatch.setattr(services, "_source_dir", lambda: "/tmp/src")
+        monkeypatch.setattr(services, "load_disabled", lambda: set(disabled))
+        monkeypatch.setattr(services, "run_healthcheck",
+                            lambda svc: (healthy, "session exists" if healthy
+                                         else "session not found"))
+
+    def test_a_healthy_command_service_is_reported_with_its_kind(self, monkeypatch, capsys):
+        self._patch(monkeypatch, [CustomServiceConfig(
+            name="buddy", command="agentwire buddy serve buddy --port 8788")])
+        assert doctor_cli._render_custom_services_section() == 0
+        out = capsys.readouterr().out
+        assert "[ok] Service buddy (command): session exists" in out
+        assert "[ok] Service notif (agent)" in out
+
+    def test_a_dead_command_service_is_an_issue_with_a_fix(self, monkeypatch, capsys):
+        self._patch(monkeypatch, [CustomServiceConfig(
+            name="buddy", command="agentwire buddy serve buddy")], healthy=False)
+        found = doctor_cli._render_custom_services_section()
+        out = capsys.readouterr().out
+        assert "[!!] Service buddy (command): unhealthy" in out
+        assert "Run: agentwire services up buddy" in out
+        assert found == 2  # the buddy and the built-in notifications bridge
+
+    def test_a_downed_service_is_not_scored(self, monkeypatch, capsys):
+        self._patch(monkeypatch, [CustomServiceConfig(name="buddy", command="x")],
+                    healthy=False, disabled={"buddy", "notif"})
+        assert doctor_cli._render_custom_services_section() == 0
+        assert "stopped via 'services down'" in capsys.readouterr().out
+
+    def test_autostart_off_is_not_scored(self, monkeypatch, capsys):
+        """The buddy's own entry ships `autostart: false` until the owner opts
+        in, and doctor must not nag about a service nobody asked to run."""
+        self._patch(monkeypatch, [CustomServiceConfig(
+            name="buddy", command="x", autostart=False)], healthy=False)
+        found = doctor_cli._render_custom_services_section()
+        out = capsys.readouterr().out
+        assert "[..] Service buddy (command): not running (autostart off" in out
+        assert found == 1  # notif only
+
+    def test_an_inline_secret_is_flagged(self, monkeypatch, capsys):
+        self._patch(monkeypatch, [CustomServiceConfig(
+            name="bridge", command="some-bridge --token=hunter2")])
+        found = doctor_cli._render_custom_services_section()
+        out = capsys.readouterr().out
+        assert "world-readable in the process table" in out
+        assert "~/.agentwire/.env" in out
+        assert found == 1
+
+    def test_a_broken_healthcheck_does_not_hide_the_other_services(
+        self, monkeypatch, capsys,
+    ):
+        """One bad entry must not abandon the rest of the report — the #905
+        shape, one subsystem over."""
+        self._patch(monkeypatch, [CustomServiceConfig(name="buddy", command="x")])
+
+        def selective(svc):
+            if svc.name == "notif":
+                raise RuntimeError("tmux exploded")
+            return True, "session exists"
+        monkeypatch.setattr(services, "run_healthcheck", selective)
+        doctor_cli._render_custom_services_section()
+        out = capsys.readouterr().out
+        assert "healthcheck error — tmux exploded" in out
+        assert "[ok] Service buddy (command)" in out
+
+    def test_unloadable_config_degrades_to_a_note(self, monkeypatch, capsys):
+        def boom(*a, **k):
+            raise RuntimeError("bad yaml")
+        monkeypatch.setattr("agentwire.config.load_config", boom)
+        assert doctor_cli._render_custom_services_section() == 0
+        assert "Could not check custom services: bad yaml" in capsys.readouterr().out
+
+
+class TestServicesCLIExposesTheKind:
+    @pytest.fixture
+    def cli(self, state_file, monkeypatch):
+        from agentwire import system_cli as main_mod
+        monkeypatch.setattr(services, "notifications_session_name", lambda: "notif")
+        monkeypatch.setattr(services, "_source_dir", lambda: "/tmp/src")
+        cfg = Config(services=ServicesConfig(custom=[CustomServiceConfig(
+            name="buddy", command="agentwire buddy serve buddy --port 8788",
+            autostart=False, healthcheck=HealthcheckConfig(interval=30),
+        )]))
+        monkeypatch.setattr("agentwire.config.load_config", lambda *a, **k: cfg)
+        return main_mod
+
+    def _args(self, **kw):
+        defaults = {"json": True, "name": None, "all": False}
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_list_json_carries_kind_and_command(self, cli, capsys):
+        assert cli.cmd_services_list(self._args()) == 0
+        data = json.loads(capsys.readouterr().out)
+        by_name = {s["name"]: s for s in data["services"]}
+        assert by_name["buddy"]["kind"] == "command"
+        assert by_name["buddy"]["command"] == "agentwire buddy serve buddy --port 8788"
+        assert by_name["notif"]["kind"] == "agent"
+        assert by_name["notif"]["command"] is None
+
+    def test_down_passes_the_service_not_a_bare_name(self, cli, monkeypatch, capsys):
+        """The kill path branches on `command`, so it needs the entry. Passing a
+        name would send `/exit` to a process."""
+        seen = []
+        monkeypatch.setattr(services, "stop_service",
+                            lambda svc: (seen.append(svc) or True, "stopped"))
+        assert cli.cmd_services_down(self._args(name="buddy")) == 0
+        assert seen[0].command == "agentwire buddy serve buddy --port 8788"

--- a/tests/unit/test_services_command.py
+++ b/tests/unit/test_services_command.py
@@ -101,16 +101,22 @@ class TestCommandServiceSupervision:
     def test_start_runs_the_command_under_tmux_not_agentwire_new(self, monkeypatch):
         calls = []
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.time, "sleep", lambda s: None)
         monkeypatch.setattr(services.subprocess, "run",
                             lambda cmd, **kw: calls.append(cmd) or _ok())
         svc = self._svc(project="/tmp/proj")
         ok, msg = services.start_service(svc)
         assert (ok, msg) == (True, "started")
-        assert calls == [[
-            "tmux", "new-session", "-d", "-s", "buddy", "-c", svc.project,
-            "agentwire buddy serve buddy --port 8788",
-        ]]
-        assert "agentwire" not in calls[0][:6]  # not `agentwire new`
+        assert calls == [
+            ["tmux", "new-session", "-d", "-s", "buddy", "-c", svc.project,
+             "sh -c 'while :; do sleep 3600; done'"],
+            ["tmux", "set-option", "-w", "-t", "=buddy:", "remain-on-exit", "on"],
+            ["tmux", "respawn-pane", "-k", "-c", svc.project, "-t", "=buddy:.0",
+             "agentwire buddy serve buddy --port 8788"],
+        ]
+        # not `agentwire new` — the agent path is a different mechanism
+        assert not any("new-session" in c and "agentwire" in c for c in calls)
 
     def test_start_redirects_nothing_to_a_file(self, monkeypatch):
         """The whole secret-handling argument. tmux captures stdout/stderr into
@@ -120,29 +126,35 @@ class TestCommandServiceSupervision:
         `pipe-pane` ever appears here, that argument is void."""
         calls = []
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.time, "sleep", lambda s: None)
         monkeypatch.setattr(services.subprocess, "run",
                             lambda cmd, **kw: calls.append(cmd) or _ok())
         services.start_service(self._svc())
-        flat = " ".join(calls[0])
         # The service's OWN command is the operator's business; agentwire must
-        # not add redirection around it.
-        wrapper = [part for part in calls[0] if part != self._svc().command]
-        assert ">" not in " ".join(wrapper)
-        assert "tee" not in " ".join(wrapper)
-        assert "pipe-pane" not in flat
+        # not add redirection around it, in ANY of the spawn's steps.
+        wrapper = " ".join(
+            part for call in calls for part in call if part != self._svc().command
+        )
+        assert ">" not in wrapper
+        assert "tee" not in wrapper
+        assert "pipe-pane" not in wrapper
 
     def test_start_is_idempotent(self, monkeypatch):
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
         monkeypatch.setattr(services.subprocess, "run",
                             lambda *a, **k: pytest.fail("must not respawn"))
         assert services.start_service(self._svc()) == (True, "already running")
 
     def test_a_lost_spawn_race_is_benign(self, monkeypatch):
         """Autostart, watchdog and a manual `services up` can collide. The loser
-        must report the winner's session, never a failure."""
+        must report the winner's LIVE session — and only a live one, or a corpse
+        would be reported as the winner."""
         import subprocess as sp
         exists = iter([False, True])
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: next(exists))
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
 
         def boom(*a, **k):
             raise sp.CalledProcessError(1, "tmux", stderr=b"duplicate session")
@@ -152,6 +164,7 @@ class TestCommandServiceSupervision:
     def test_start_failure_reports_tmux_stderr(self, monkeypatch):
         import subprocess as sp
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
 
         def boom(*a, **k):
             raise sp.CalledProcessError(1, "tmux", stderr=b"no server running")
@@ -192,6 +205,199 @@ def _ok():
     return R()
 
 
+class TestADyingProcessIsNotASuccessfulStart:
+    """`tmux new-session` succeeding says a PANE was created, not that the
+    process in it survived.
+
+    The shape that shipped: `services up` printed "started" while the process
+    had already exited, doctor immediately printed "[!!] unhealthy — session
+    not found" and prescribed the command that had just claimed success, and
+    the process's own stderr died with the pane and existed nowhere. Screenless,
+    that is a fix-loop behind a misleading all-clear — the exact failure this
+    branch exists to remove. And it was specific to the command kind: the agent
+    kind runs `agentwire new` in the FOREGROUND, so a failure there is already
+    an exit code.
+
+    Two halves, and the second is not decoration: a refusal that cannot say WHY
+    still leaves the owner with nothing to act on.
+    """
+
+    def _svc(self):
+        return CustomServiceConfig(name="buddy", command="agentwire buddy serve nope")
+
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self, monkeypatch):
+        monkeypatch.setattr(services.time, "sleep", lambda s: None)
+
+    def test_an_immediate_exit_is_reported_as_a_failed_start(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail",
+                            lambda n: "FATAL: no OPENAI_API_KEY")
+        monkeypatch.setattr(services.subprocess, "run", lambda *a, **k: _ok())
+        ok, msg = services.start_service(self._svc())
+        assert ok is False
+        assert "exited immediately" in msg
+
+    def test_the_refusal_carries_the_process_s_own_last_words(self, monkeypatch):
+        """The half that makes the refusal actionable. tmux holds the dead
+        pane's output in memory; without it the owner gets 'it failed' and no
+        way to learn that the buddy name is unregistered."""
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail",
+                            lambda n: "No voice buddy named 'nope'.")
+        monkeypatch.setattr(services.subprocess, "run", lambda *a, **k: _ok())
+        _ok_, msg = services.start_service(self._svc())
+        assert "No voice buddy named 'nope'." in msg
+
+    def test_a_survivor_still_reports_started(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.subprocess, "run", lambda *a, **k: _ok())
+        assert services.start_service(self._svc()) == (True, "started")
+
+    def test_the_pane_is_kept_alive_so_the_reason_survives(self, monkeypatch):
+        """`remain-on-exit on` is what retains the dead pane's output — in tmux
+        memory, behind the 0700 socket dir. No file is created, so the secret
+        property of the command kind is unchanged."""
+        calls = []
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        services.start_service(self._svc())
+        joined = [" ".join(c) for c in calls]
+        assert any("remain-on-exit on" in j for j in joined), joined
+        # The option must be set BEFORE the real command runs, or a process that
+        # dies fast beats it and the reason is lost anyway.
+        opt = next(i for i, j in enumerate(joined) if "remain-on-exit" in j)
+        real = next(i for i, j in enumerate(joined) if "respawn-pane" in j)
+        assert opt < real, joined
+        assert "agentwire buddy serve nope" not in joined[opt]
+
+    def test_a_dead_pane_is_cleared_on_respawn_not_called_already_running(
+        self, monkeypatch,
+    ):
+        """The interaction that would wedge the watchdog: healthcheck says
+        unhealthy, watchdog calls start, start sees a session and says 'already
+        running' — forever. A dead pane is not a running service."""
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        dead = iter([True, False])
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: next(dead))
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda n: "FATAL: boom")
+        calls = []
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda cmd, **kw: calls.append(cmd) or _ok())
+        ok, msg = services.start_service(self._svc())
+        assert ok is True
+        # and the reason the previous run died is read BEFORE it is destroyed
+        assert "FATAL: boom" in msg
+        assert any("kill-session" in " ".join(c) for c in calls)
+
+    def test_a_live_pane_is_still_left_alone(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services.subprocess, "run",
+                            lambda *a, **k: pytest.fail("must not respawn a live service"))
+        assert services.start_service(self._svc()) == (True, "already running")
+
+
+class TestTheHealthcheckMustSeeADeadPane:
+    """Taking `remain-on-exit` means `has-session` alone stops being liveness.
+
+    Measured: `tmux has-session` returns 0 for a session whose pane is DEAD. A
+    healthcheck left on that predicate would report a crashed service healthy
+    forever — trading a false success at start for a permanent one, which is
+    strictly worse. And it is not only the command kind: `remain-on-exit` is a
+    user tmux setting, so an agent session could always have been in this state.
+    """
+
+    def test_a_dead_pane_is_unhealthy(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda n: "FATAL: boom")
+        healthy, detail = services.run_healthcheck(
+            CustomServiceConfig(name="buddy", command="x"))
+        assert healthy is False
+        assert "exited" in detail and "FATAL: boom" in detail
+
+    def test_an_agent_session_with_a_dead_pane_is_unhealthy_too(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda n: "")
+        healthy, _detail = services.run_healthcheck(CustomServiceConfig(name="t"))
+        assert healthy is False
+
+    def test_a_live_pane_is_healthy(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        assert services.run_healthcheck(CustomServiceConfig(name="t")) == (
+            True, "session exists")
+
+    def test_status_running_is_false_for_a_dead_pane(self, state_file, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda n: "")
+        assert services.service_status(
+            CustomServiceConfig(name="buddy", command="x"))["running"] is False
+
+
+@pytest.mark.requires_tmux
+class TestAgainstRealTmux:
+    """The same claims against the real binary.
+
+    Everything above monkeypatches the tmux helpers, which is what makes it run
+    in the hermetic CI gate — and is also exactly the fixture shape that let F1
+    ship. `#{pane_dead}`, `remain-on-exit` and capture-pane-after-death are
+    tmux behaviours, not ours, and a mock agrees with whatever it was told.
+    """
+
+    NAME = "zz983-realtmux-probe"
+
+    @pytest.fixture(autouse=True)
+    def _cleanup(self):
+        import subprocess as sp
+        sp.run(["tmux", "kill-session", "-t", f"={self.NAME}"], capture_output=True)
+        yield
+        sp.run(["tmux", "kill-session", "-t", f"={self.NAME}"], capture_output=True)
+
+    def _svc(self, command):
+        return CustomServiceConfig(name=self.NAME, command=command)
+
+    def test_a_dying_process_fails_the_start_and_says_why(self):
+        svc = self._svc('sh -c "echo FATAL: no OPENAI_API_KEY >&2; exit 1"')
+        ok, msg = services.start_service(svc)
+        assert ok is False, msg
+        assert "FATAL: no OPENAI_API_KEY" in msg
+
+    def test_the_healthcheck_agrees_rather_than_reporting_healthy(self):
+        svc = self._svc('sh -c "exit 1"')
+        services.start_service(svc)
+        # has-session alone would say yes here — that is the whole finding.
+        assert services._tmux_session_exists(self.NAME) is True
+        healthy, detail = services.run_healthcheck(svc)
+        assert healthy is False, detail
+
+    def test_a_survivor_starts_and_is_healthy_and_stops(self):
+        svc = self._svc("sleep 30")
+        ok, msg = services.start_service(svc)
+        assert ok is True, msg
+        assert services.run_healthcheck(svc)[0] is True
+        assert services.start_service(svc) == (True, "already running")
+        assert services.stop_service(svc)[0] is True
+        assert services._tmux_session_exists(self.NAME) is False
+
+    def test_a_crashed_service_can_be_respawned(self):
+        """The watchdog's recovery path, end to end."""
+        services.start_service(self._svc('sh -c "echo FATAL: boom >&2; exit 1"'))
+        assert services.run_healthcheck(self._svc("x"))[0] is False
+        ok, msg = services.start_service(self._svc("sleep 30"))
+        assert ok is True, msg
+        assert "FATAL: boom" in msg  # the previous run's reason, read before clearing
+        assert services.run_healthcheck(self._svc("sleep 30"))[0] is True
+
+
 class TestInlineSecretsInArgv:
     """The one leak tmux does NOT close: argv is world-readable in `ps`."""
 
@@ -201,6 +407,11 @@ class TestInlineSecretsInArgv:
         ("some-bridge --api-key=sk-live", "--api-key="),
         ("env PASSWORD=hunter2 some-bridge", "password="),
         ("curl -H 'Authorization: Bearer abc' x", "bearer "),
+        # Space-joined reaches `ps` identically. Matching only the `=` form
+        # would select for whoever writes it the other way.
+        ("some-bridge --token hunter2", "--token "),
+        ("some-bridge --api-key sk-live", "--api-key "),
+        ("some-bridge --password hunter2", "--password "),
     ])
     def test_detection(self, command, expected):
         svc = CustomServiceConfig(name="x", command=command)

--- a/tests/unit/test_services_command.py
+++ b/tests/unit/test_services_command.py
@@ -155,6 +155,8 @@ class TestCommandServiceSupervision:
         exists = iter([False, True])
         monkeypatch.setattr(services, "_tmux_session_exists", lambda n: next(exists))
         monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        # The winner is running the real command, not our placeholder.
+        monkeypatch.setattr(services, "_tmux_pane_is_placeholder", lambda n: False)
 
         def boom(*a, **k):
             raise sp.CalledProcessError(1, "tmux", stderr=b"duplicate session")
@@ -404,6 +406,38 @@ class TestThePlaceholderMustNeverOutliveTheSpawn:
         services.start_service(self._svc())
         assert any("kill-session" in c for c in calls), calls
 
+    def test_a_timeout_after_the_server_created_the_session_is_not_already_running(
+        self, monkeypatch,
+    ):
+        """The residual door into the same failure.
+
+        `CalledProcessError` from new-session means tmux refused and created
+        nothing. `TimeoutExpired` does not: the server can have made the session
+        and simply not answered inside 30s. `created_here` is still False there,
+        so the pre-existing-session branch would report a LIVE PLACEHOLDER as
+        `already running` — the exact state this class exists to make
+        unreachable. Unrealistic (new-session taking 30s), but the guard is one
+        condition and the failure mode is proven.
+        """
+        import subprocess as sp
+        exists = iter([False, True])
+        monkeypatch.setattr(services, "_tmux_session_exists", lambda n: next(exists))
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda n: False)
+        monkeypatch.setattr(services, "_tmux_pane_is_placeholder", lambda n: True)
+        killed = []
+
+        def run(cmd, **kw):
+            if "new-session" in cmd:
+                raise sp.TimeoutExpired("tmux", 30)
+            if "kill-session" in cmd:
+                killed.append(cmd)
+            return _ok()
+        monkeypatch.setattr(services.subprocess, "run", run)
+        ok, msg = services.start_service(self._svc())
+        assert ok is False, msg
+        assert "already running" not in msg
+        assert killed, "the live placeholder was left behind"
+
     def test_a_genuinely_pre_existing_session_is_still_already_running(
         self, monkeypatch,
     ):
@@ -422,10 +456,30 @@ class TestThePlaceholderMustNeverOutliveTheSpawn:
             if "kill-session" in cmd:
                 killed.append(cmd)
             return _ok()
+        monkeypatch.setattr(services, "_tmux_pane_is_placeholder", lambda n: False)
         monkeypatch.setattr(services.subprocess, "run", run)
         assert services.start_service(self._svc()) == (True, "already running")
         # and it must NOT kill the winner's session on its way out
         assert killed == []
+
+    def test_the_placeholder_check_reads_the_pane_s_own_start_command(self, monkeypatch):
+        """The discriminator, and the direction that matters is the false
+        reject: `respawn-pane` REPLACES `pane_start_command`, so a healthy
+        service reports its real command and is never mistaken for a
+        placeholder. If it did not, this guard would kill live services."""
+        seen = {}
+
+        def run(cmd, **kw):
+            class R:
+                returncode = 0
+                stderr = ""
+                stdout = seen["reply"]
+            return R()
+        monkeypatch.setattr(services.subprocess, "run", run)
+        seen["reply"] = services._PLACEHOLDER_CMD + "\n"
+        assert services._tmux_pane_is_placeholder("x") is True
+        seen["reply"] = "agentwire buddy serve buddy --port 8788\n"
+        assert services._tmux_pane_is_placeholder("x") is False
 
 
 class TestNamesGoThroughTheOneMapping:
@@ -545,6 +599,25 @@ class TestACrashLineIsRedactedBeforeItIsSpoken:
         assert "***" in tail
         assert "FATAL-boom" in tail, tail
 
+    @pytest.mark.parametrize("line", [
+        "Authorization: Basic dXNlcjpwdw==",
+        "X-Api-Key: 6f1e2d3c4b5a",
+        "password: hunter2",                       # colon, not equals
+        "unauthorized: 7f3a9c1e5b2d4088aa11bb22cc33dd44ee55ff66",  # bare hex
+        "using key sk-proj-abcdef123456",          # no key in front
+    ])
+    def test_the_limit_is_where_the_wiki_says_it_is(self, line):
+        """The boundary, pinned so it cannot drift away from the doc.
+
+        These are NOT redacted, and that is a deliberate stopping point: a
+        keyless-entropy detector over crash output would eat stack addresses,
+        hashes and commit SHAs, and that cost lands on the one thing this
+        mechanism exists to deliver — a line the operator can act on. If
+        someone widens the detector, this test fails and the wiki table gets
+        updated with it.
+        """
+        assert services.redact_secrets(line) == line
+
     def test_redaction_uses_the_argv_pattern_set(self):
         """One source of truth. A second list would drift from the argv check
         the moment either is extended — which just happened to the argv one."""
@@ -605,6 +678,26 @@ class TestAgainstRealTmux:
         assert ok is True, msg
         assert "FATAL: boom" in msg  # the previous run's reason, read before clearing
         assert services.run_healthcheck(self._svc("sleep 30"))[0] is True
+
+    def test_a_repeated_start_does_not_disturb_a_live_service(self):
+        """The false-reject half of the placeholder guard, which is the
+        expensive direction: a live service must survive a redundant start
+        untouched. Same pane, same PID — not merely 'still healthy'."""
+        svc = self._svc("sleep 30")
+        assert services.start_service(svc)[0] is True
+        import subprocess as sp
+
+        def pid():
+            return sp.run(
+                ["tmux", "display-message", "-p", "-t", f"={self.NAME}:.0",
+                 "#{pane_pid}"],
+                capture_output=True, text=True,
+            ).stdout.strip()
+
+        before = pid()
+        assert before
+        assert services.start_service(svc) == (True, "already running")
+        assert pid() == before, "a redundant start replaced a live service"
 
     def test_a_crash_line_carrying_a_secret_is_redacted(self):
         """Against the real capture path, since that is where it would leak:


### PR DESCRIPTION
T4 from the voice-layer plan. The buddy was hand-launched; the services registry had exactly one kind of entry — an `agentwire new` agent session — so a process had nowhere to live.

**Base is `voice-confirm-spine`, not `main`. Draft, do not merge.**

## What ships

**A generic `command` service kind.** agentwire supervises a process and has no idea what the process is — the buddy is one caller, and nothing in the mechanism mentions it. `start_service`/`stop_service` branch on `svc.command`; the kill path uses `tmux kill-session` rather than `agentwire kill` (whose graceful leg types `/exit` at an agent that isn't there). Agent-only fields (`roles`/`posture`/`context_policy`) are **rejected with a warning**, not dropped silently — a field that reads as a guard while nothing consumes it is worse than no field.

**The entry itself** is documented paste-ready in wiki §6 and deliberately NOT written into the owner's `config.yaml`: that file is protected control plane, and a spike must not add itself to a startup path.

**Doctor.** The services block was inline in `cmd_doctor` and therefore untestable; it is now `_render_custom_services_section()`. Every line names the service's kind — "session not found" means a dead agent for one and a dead process for the other, and the fix differs. A broken healthcheck on one entry no longer abandons the rest of the report.

## The three things the issue called out

**1. Secrets.** tmux IS the supervisor, and that is the answer rather than a wrapper being careful in its own code. Output goes to the pane's scrollback — tmux server memory, behind the 0700 per-user socket dir — and agentwire adds no redirection at all; a test fails if a `>`, a `tee` or a `pipe-pane` ever appears in the wrapper. Verified live, not argued: the pane holds exactly the two lines `serve` prints, the token is in neither, the bridge's HTTP request log is already a no-op, and the token is absent from the process table.

Two rulings follow:
- The healthcheck is `tmux_session`, **not** the `curl http://127.0.0.1:8788/` §6 used to suggest. `/` is the route that hands over the run token; a probe should not fetch a secret once a minute to learn whether a port is open, and a command service's tmux session ends when its process does.
- What the process table *does* expose is `command` itself. Doctor flags an inline secret in a service's argv (`--token=`, `--api-key=`, `password=`, `Bearer …`) and names the pattern it matched — same standard as #887, one surface over.

**2. Branch-only caveat respected.** No voice-specific code anywhere in the mechanism. `services.py`, `config.py`, `doctor_cli.py` and `mcp_services.py` know only "agent or command".

**3. Restart semantics — verified, then pinned.** `tests/unit/test_buddy_restart.py` drives a real `serve()` → kill → `serve()` with a proposal *anchored mid-handshake*, and asserts both halves: the second run's spine and ring are empty and the dead run's token is refused, AND nothing under `~/.agentwire` gained the proposal's token, nonce or instruction. The second is the one that survives someone deciding proposals should be durable — the first alone would still pass if a restart merely reloaded them.

**Named rather than closed:** a kill landing *after* the write dispatched but *before* the announcement is confirmed spoken leaves the write **sent and unannounced**. The restart is clean; the fleet still got the message. That is narrower than "mid-handshake work is rolled back", and nothing here rolls anything back.

## The acceptance test — the greet

Not treated as covered by the existing suite. #995 says the wires arming the greet have no pin; **measured**: cutting `maybeGreet()` out of `pc.ontrack` leaves the full unit suite at **5736 passed, 0 failed**.

Now both arming legs are executed under node, extracted from the page the server actually serves (extraction fails loudly if the anchor moves — a silent miss would repeat #995 inside the test written to close it). Either leg alone does not greet; both do, exactly once, in either order, with `{greeting: true}` meta and the MODEL_AUDIO_DEAD fallback.

And end to end besides — the real bridge supervised through `start_service` on port **18788** (never the owner's 8788), killed the way the watchdog would, respawned: serves a greet-armed page carrying a **fresh** token, the http healthcheck flips down and back, the bind is 127.0.0.1-only, and the dead run's token **401s** (which is why the acceptance path is *reload, then Start talking*).

## Method

Every new test watched failing first (source stashed, tests kept: 25 failed + 2 errors). Every guarantee proved by mutation — 7 mutations, each landing as expected:

| | mutation | result |
|---|---|---|
| M1 | cut `maybeGreet()` from `pc.ontrack` | RED |
| M2 | cut `audioAttached = true` | RED |
| M3 | cut `maybeGreet()` from `session.created` | RED |
| M4 | make the spine's proposal store module-global | RED |
| M5 | persist proposals to `~/.agentwire` | RED |
| M6 | make `serve()` reuse one module-level bridge | RED |
| M7 | untouched control | GREEN |

Full suite, CI's own invocation (`uv run --extra dev pytest`): **5930 passed, 36 skipped, 0 failed** — base 5891 + the 39 added here.

Closes #983

Built by [dotdev.dev](https://dotdev.dev)