### PR TITLE
fleet-alerts: detectors can address a session, not just the owner (part of #982)

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -183,7 +183,7 @@ Command Categories:
     #   - diff:   structured git diff for the mobile Review window
     #   - prompts: prompt routing (rides the limits watchdog)
     #   - msg:    polite agent-to-agent inbox (rides the watchdog)
-    from . import diff_cli, limits_cli, msg_cli, pane_cli, prompts_cli, send_cli  # noqa: I001  # session_cli kept on its own line below to minimize Phase 1 #495 merge conflicts
+    from . import alerts_cli, diff_cli, limits_cli, msg_cli, pane_cli, prompts_cli, send_cli  # noqa: I001  # session_cli kept on its own line below to minimize Phase 1 #495 merge conflicts
     from . import session_cli
     from . import channels_cli, config_cli, portal_cli, tts_cli
     from . import scheduler_cli, ensure_cli, tasks_cli
@@ -197,6 +197,7 @@ Command Categories:
         diff_cli.register_diff_parser,
         prompts_cli.register_prompts_parser,
         msg_cli.register_msg_parser,
+        alerts_cli.register_alerts_parser,
         limits_cli.register_limits_parser,
         pane_cli.register_pane_parser,
         send_cli.register_send_parser,

--- a/agentwire/alerts_cli.py
+++ b/agentwire/alerts_cli.py
@@ -64,16 +64,43 @@ def cmd_alerts_unsubscribe(args) -> int:
 
 
 def cmd_alerts_list(args) -> int:
+    """Who is subscribed — and whether this answer can be trusted.
+
+    ``list`` reads the same candidate index the emit path does, so a lost index
+    makes both of them say "nobody". That would be the worst property this
+    command could have: the one surface built to make a silent stop VISIBLE
+    would agree with the silent stop. So the index's presence is reported
+    alongside the answer, and its absence is not rendered as a confident zero.
+    """
     json_mode = getattr(args, "json", False)
     names = fleet_alerts.subscribers()
+    index_present = fleet_alerts.subscribers_index_path().exists()
     rows = [{"session": n, "lease": fleet_alerts.subscription(n)} for n in names]
-    lines = ["No session is subscribed to fleet alerts."] if not names else [
-        "Sessions receiving fleet alerts:",
-        *(f"  {r['session']}  (lease expires {(r['lease'] or {}).get('expires_at')})"
-          for r in rows),
-    ]
+    if names:
+        lines = [
+            "Sessions receiving fleet alerts:",
+            *(f"  {r['session']}  (lease expires {(r['lease'] or {}).get('expires_at')})"
+              for r in rows),
+        ]
+    elif index_present:
+        lines = ["No session is subscribed to fleet alerts."]
+    else:
+        lines = [
+            "No subscriber index — so this is NOT a confident 'nobody subscribed'.",
+            "Either nobody ever subscribed, or the index was lost; from here those "
+            "look identical, and while it is missing every alert reaches nobody.",
+            "Settle it (cheap, and it rebuilds the index either way):",
+            "  agentwire alerts reindex",
+        ]
     return _emit(
-        {"success": True, "subscribers": names, "leases": rows}, json_mode, lines
+        {
+            "success": True,
+            "subscribers": names,
+            "leases": rows,
+            "index_present": index_present,
+        },
+        json_mode,
+        lines,
     )
 
 

--- a/agentwire/alerts_cli.py
+++ b/agentwire/alerts_cli.py
@@ -1,0 +1,126 @@
+"""``agentwire alerts`` — who hears the machine's own detectors (#982).
+
+Fleet detectors (expired login, usage-limit park, dead-lettered report-backs, a
+root pane blocked with nowhere to route) have always been able to email the
+OWNER. ``fleet_alerts`` lets them address a SESSION as typed mail instead, and
+this is the surface that turns that on: without a CLI verb the subscription API
+would be reachable only from inside the tree that calls it, which is precisely
+the shape "CLI is the single source of truth" exists to prevent.
+
+Subscription is a renewable **lease**, so ``list`` reports the expiry rather
+than a boolean: a subscriber that stopped renewing has silently stopped
+hearing anything, and that is a state an operator has to be able to see.
+"""
+
+from __future__ import annotations
+
+import json
+
+from . import fleet_alerts
+
+
+def _emit(payload: dict, json_mode: bool, lines: "list[str] | None" = None) -> int:
+    if json_mode:
+        print(json.dumps(payload, indent=2))
+    else:
+        for line in lines or []:
+            print(line)
+    return 0 if payload.get("success", True) else 1
+
+
+def cmd_alerts_subscribe(args) -> int:
+    json_mode = getattr(args, "json", False)
+    try:
+        lease = fleet_alerts.subscribe(args.session)
+    except Exception as exc:
+        return _emit(
+            {"success": False, "error": str(exc)}, json_mode, [f"error: {exc}"]
+        )
+    return _emit(
+        {"success": True, "session": args.session, "lease": lease},
+        json_mode,
+        [
+            f"'{args.session}' now receives fleet alerts.",
+            f"  lease expires: {lease['expires_at']}",
+            "  Renew before then — an expired lease goes quiet, it does not warn.",
+        ],
+    )
+
+
+def cmd_alerts_unsubscribe(args) -> int:
+    json_mode = getattr(args, "json", False)
+    dropped = fleet_alerts.unsubscribe(args.session)
+    if not dropped:
+        return _emit(
+            {"success": False, "error": f"'{args.session}' was not subscribed"},
+            json_mode,
+            [f"'{args.session}' was not subscribed."],
+        )
+    return _emit(
+        {"success": True, "session": args.session},
+        json_mode,
+        [f"'{args.session}' no longer receives fleet alerts."],
+    )
+
+
+def cmd_alerts_list(args) -> int:
+    json_mode = getattr(args, "json", False)
+    names = fleet_alerts.subscribers()
+    rows = [{"session": n, "lease": fleet_alerts.subscription(n)} for n in names]
+    lines = ["No session is subscribed to fleet alerts."] if not names else [
+        "Sessions receiving fleet alerts:",
+        *(f"  {r['session']}  (lease expires {(r['lease'] or {}).get('expires_at')})"
+          for r in rows),
+    ]
+    return _emit(
+        {"success": True, "subscribers": names, "leases": rows}, json_mode, lines
+    )
+
+
+def cmd_alerts_reindex(args) -> int:
+    """Rebuild the candidate index from the session records.
+
+    The alert path never walks the record store — that cost sits on the
+    synchronous permission-hook path — so a lost index means fewer alerts until
+    somebody rebuilds it. This is that somebody.
+    """
+    json_mode = getattr(args, "json", False)
+    names = fleet_alerts.reindex()
+    return _emit(
+        {"success": True, "subscribers": names},
+        json_mode,
+        [f"Reindexed: {len(names)} live subscriber(s)." , *(f"  {n}" for n in names)],
+    )
+
+
+def register_alerts_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "alerts",
+        help="Who hears the machine's own detectors (fleet alerts)",
+        description=(
+            "Fleet detectors — expired login, usage-limit park, dead-lettered "
+            "report-backs, a root pane blocked with nowhere to route — email the "
+            "owner. They can also address a SESSION as typed mail: an escalation "
+            "for the two conditions only a human can clear, a note or a request "
+            "for the rest. A session subscribes here, on a renewable lease."
+        ),
+    )
+    sub = parser.add_subparsers(dest="alerts_command", required=True)
+
+    p = sub.add_parser("subscribe", help="Lease fleet alerts for a session")
+    p.add_argument("session", help="Session name (must have a session record)")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.set_defaults(func=cmd_alerts_subscribe)
+
+    p = sub.add_parser("unsubscribe", help="Drop a session's fleet-alert lease")
+    p.add_argument("session")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.set_defaults(func=cmd_alerts_unsubscribe)
+
+    p = sub.add_parser("list", help="Sessions with a live lease, and its expiry")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.set_defaults(func=cmd_alerts_list)
+
+    p = sub.add_parser("reindex", help="Rebuild the subscriber index from records")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.set_defaults(func=cmd_alerts_reindex)

--- a/agentwire/auth_expired.py
+++ b/agentwire/auth_expired.py
@@ -360,8 +360,10 @@ def record_outage(detail: dict, source: str = "ensure") -> dict:
         "source": source,
         "host": socket.gethostname(),
         "escalated_at": prior.get("escalated_at"),
+        "alerted_at": prior.get("alerted_at"),
     }
     state["escalated_at"] = _escalate(state, prior)
+    state["alerted_at"] = _alert_fleet(state, prior)
     write_state(state)
     log_event("outage_detected", session=detail.get("session"),
               transcript=detail.get("transcript"), source=source)
@@ -419,6 +421,50 @@ def _escalate(state: dict, prior: dict) -> str | None:
     except Exception as exc:  # never break the caller
         log_event("escalate_failed", error=str(exc))
     return previous
+
+
+def _alert_fleet(state: dict, prior: dict) -> "str | None":
+    """Tell subscribed sessions, on the same clock the owner email rides (#982).
+
+    Escalation kind, and this is the clearest case for it in the fleet: the
+    outage is machine-wide, every subsequent turn is refused, and nothing but a
+    human running ``/login`` can clear it. It is bounded to once per
+    :data:`ESCALATE_TTL` per outage — machine-wide, not per session and not per
+    dispatch — which is what makes an interrupt affordable here.
+
+    Stamped separately from ``escalated_at`` while sharing that field's state
+    record and its TTL. Not a parallel throttle store — the same file, the same
+    window — but a separate stamp, because the two channels fail differently:
+    the email deliberately retries per detection when the provider is down
+    (only a successful send stamps), and an alert inheriting that retry would
+    turn a broken Resend key into one interrupt per dispatch. Enqueueing is a
+    local write, so this stamp lands whenever the alert actually did.
+    """
+    previous = prior.get("alerted_at")
+    if previous:
+        try:
+            if _now() - datetime.fromisoformat(previous) < ESCALATE_TTL:
+                return previous
+        except (TypeError, ValueError):
+            pass
+    try:
+        from . import fleet_alerts
+
+        sessions = ", ".join(state.get("sessions") or []) or "(none recorded)"
+        reached = fleet_alerts.emit_for(
+            "auth_expired",
+            f"Claude login expired on {state.get('host')} — every turn is being "
+            f"refused ({RENDERED}). Sessions hit so far: {sessions}. Scheduled "
+            f"dispatch is gated until someone runs /login; nothing recovers on "
+            f"its own. First seen {state.get('detected_at')}.",
+        )
+    except Exception as exc:  # alerting is best-effort; never break the gate
+        log_event("alert_failed", error=str(exc))
+        return previous
+    if not reached:
+        return previous
+    log_event("alerted", sessions=state.get("sessions"), to=reached)
+    return _now().isoformat()
 
 
 def check_and_flag(

--- a/agentwire/fleet_alerts.py
+++ b/agentwire/fleet_alerts.py
@@ -1,0 +1,262 @@
+"""Fleet detectors, addressed as typed mail — the producer side of the kind axis (#982).
+
+Every detector in this repo already knows how to tell the OWNER something: the
+shared Resend wiring, best-effort, throttled by whatever state the detector
+already keeps. What none of them could do is tell a *session*. This module is
+that half, and it is deliberately the same shape as the email one: one call,
+never raises, and inert when nobody is listening.
+
+**The kind IS the policy.** ``inbox`` already types mail — ``note`` / ``done`` /
+``request`` / ``escalation`` — and consumers key on the type rather than
+re-deriving urgency for themselves. So the only real decision this module makes
+is which kind each detector gets, and that decision lives in one place as data:
+:data:`DETECTOR_KINDS`. The rulings, and what each one costs, are in
+``docs/wiki/sessions/messaging.md``.
+
+**Why the ruling is the hard part.** ``escalation`` is the one kind a consumer
+may act on out of turn. A producer that over-fires does not add noise, it
+retires the tier — a recipient that learns escalations are usually ignorable
+will ignore the one that wasn't. So the bar is not "is this true?" (all five
+candidate detectors are true when they fire) but "can this clear without a
+human, and is something burning while it waits?" Two detectors pass. One is
+demoted to ``note`` because it self-heals, one has a floor of ``request`` with
+an inherit rule, and one is not wired at all. That is the whole design.
+
+**Subscription is a LEASE, not a flag.** A subscriber records
+:data:`SUBSCRIBE_KEY` in its ``metadata.json`` (the #871 SSOT store, so there
+is no second registry to drift) carrying an expiry it must renew. The reason is
+the dormancy failure: a recipient whose mail is spooled rather than pasted does
+not "go gone" the way a dead tmux session does, so a permanent flag would keep
+producing into a spool that nobody reads and then replay hours of stale
+escalations the next time it starts. An expired lease fails QUIET, which is the
+correct direction for a producer whose expensive failure is over-production.
+
+Nothing here knows what a subscriber is. A voice buddy, a durable orchestrator,
+a future dashboard process — anything with a session record and an inbox can
+lease one, and no detector below gains a dependency on any of them.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+#: Session-record key holding the subscription lease.
+SUBSCRIBE_KEY = "fleet_alerts"
+
+#: Sender stamped on every alert. Load-bearing, not cosmetic: it is how the
+#: dead-letter detector recognizes its own undelivered mail and declines to
+#: alert about the alert (see ``inbox._escalate_dead_letters``).
+SENDER = "fleet-alerts"
+
+#: How long a lease is good for without renewal. Long enough that a working
+#: session renewed at startup keeps hearing about the fleet for a full day of
+#: use; short enough that a subscriber which ran once last week is not still
+#: accumulating interrupts. A long-running subscriber past this simply goes
+#: quiet until it renews — see the module docstring on failing quiet.
+DEFAULT_LEASE = timedelta(hours=12)
+
+#: THE RULING. Which detector's event earns which kind — pinned as data so that
+#: changing what may interrupt is an edit somebody has to justify, not a literal
+#: buried at a call site. Rationale per entry:
+#:
+#: ``auth_expired`` → **escalation**. Machine-wide: every subsequent turn on the
+#:   host is refused, and nothing clears it but a human running ``/login``.
+#:   Bounded to once per ``auth_expired.ESCALATE_TTL`` per outage, machine-wide,
+#:   by the outage record itself.
+#:
+#: ``blocked_pane_no_parent`` → **escalation**. A ROOT session blocked on an
+#:   interactive prompt has, by design, nobody to route to; it is stalled until
+#:   a human answers, and some of those prompts have deadlines. Bounded to once
+#:   per ``prompt_router.NO_PARENT_ESCALATE_TTL`` per distinct prompt.
+#:
+#: ``usage_limit_park`` → **note**. Demoted deliberately. The park is
+#:   self-healing — the reset time is parsed, the resume nudge is armed, and the
+#:   owner's own email says "no action needed". Worth hearing at a gap; it
+#:   cannot earn an interrupt when there is nothing to interrupt anyone FOR.
+#:
+#: ``dead_letter`` → **request**, with one inherit rule: if what was lost was
+#:   itself an ``escalation``, the alert is an escalation, because the fleet
+#:   already made that judgment and losing it is the failure. The floor is
+#:   ``request`` because the realistic bad case is a permanently-stuck
+#:   recipient — 147 dead letters in ~2s, once — and that shape must not be
+#:   able to buy 147 interrupts. Bounded to one alert per dead-letter BATCH,
+#:   the same coalescing the digest email already does.
+#:
+#: Not here, and on purpose: ``worktree --dangling``. It has no autonomous
+#: trigger (only ``doctor`` and the explicit flag, both run by a human already
+#: looking at the output) and no per-finding throttle state to reuse, so a
+#: producer would re-announce the same durable, passive condition on every
+#: invocation. A dangling PR is not burning anything while it waits.
+DETECTOR_KINDS: dict[str, str] = {
+    "auth_expired": "escalation",
+    "blocked_pane_no_parent": "escalation",
+    "usage_limit_park": "note",
+    "dead_letter": "request",
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _config_dir() -> Path:
+    """Read through the MODULE, never a from-import (#902).
+
+    ``from .core import CONFIG_DIR`` freezes the value at import time, so a test
+    patching ``core.CONFIG_DIR`` is silently ignored and this writes into the
+    operator's real store.
+    """
+    from . import core
+
+    return Path(core.CONFIG_DIR)
+
+
+def events_path() -> Path:
+    return _config_dir() / "fleet-alerts-events.jsonl"
+
+
+def log_event(event: str, **fields) -> None:
+    """Append telemetry. Best-effort — never break a detector."""
+    try:
+        path = events_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(json.dumps({"ts": _now().isoformat(), "event": event, **fields}) + "\n")
+    except (OSError, TypeError, ValueError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Subscription
+# ---------------------------------------------------------------------------
+
+
+def subscribe(session: str, lease: timedelta = DEFAULT_LEASE) -> dict:
+    """Lease fleet alerts for *session*, or renew an existing lease.
+
+    Writes into the session's existing record rather than replacing it — the
+    store holds conversation identity (#871), and clobbering that to register
+    for mail would be a data-destruction bug wearing a feature's clothes.
+    """
+    from . import core
+
+    meta = core.load_session_metadata(session)
+    now = _now()
+    meta[SUBSCRIBE_KEY] = {
+        "since": now.isoformat(),
+        "expires_at": (now + lease).isoformat(),
+    }
+    core.store_session_metadata(session, meta)
+    log_event("subscribed", session=session, expires_at=meta[SUBSCRIBE_KEY]["expires_at"])
+    return meta[SUBSCRIBE_KEY]
+
+
+def unsubscribe(session: str) -> bool:
+    """Drop *session*'s lease. True iff there was one."""
+    from . import core
+
+    meta = core.load_session_metadata(session)
+    if SUBSCRIBE_KEY not in meta:
+        return False
+    meta.pop(SUBSCRIBE_KEY)
+    core.store_session_metadata(session, meta)
+    log_event("unsubscribed", session=session)
+    return True
+
+
+def subscription(session: str, now: "datetime | None" = None) -> "dict | None":
+    """*session*'s live lease, or None (absent, malformed, or expired).
+
+    A malformed value reads as "not subscribed" rather than "subscribed
+    forever": a typo must not become a permanent interrupt licence.
+    """
+    from . import core
+
+    try:
+        record = core.load_session_metadata(session).get(SUBSCRIBE_KEY)
+    except Exception:
+        return None
+    if not isinstance(record, dict):
+        return None
+    try:
+        expires = datetime.fromisoformat(str(record.get("expires_at")))
+    except (TypeError, ValueError):
+        return None
+    return record if expires > (now or _now()) else None
+
+
+def subscribers(now: "datetime | None" = None) -> list[str]:
+    """Every session holding a live lease, sorted. ``[]`` on any failure.
+
+    Walks the session-record store (``core.recorded_sessions``) rather than
+    keeping an index, so there is nothing to fall out of sync with a record
+    that was deleted by ``agentwire kill``. That costs one small read per
+    record; alerts are throttled to a handful an hour, so it is not on any hot
+    path.
+    """
+    from . import core
+
+    try:
+        names = core.recorded_sessions()
+    except Exception:
+        return []
+    at = now or _now()
+    return sorted(name for name in names if subscription(name, at) is not None)
+
+
+# ---------------------------------------------------------------------------
+# Emit
+# ---------------------------------------------------------------------------
+
+
+def emit(
+    text: str,
+    *,
+    kind: str,
+    ref: str = "",
+    exclude: Iterable[str] = (),
+    detector: str = "",
+) -> list[str]:
+    """Enqueue one typed alert per live subscriber. Returns who was reached.
+
+    Never raises on anything environmental: a detector's job is to detect, and
+    a full disk or an unwritable inbox must not turn "we caught the outage" into
+    an exception thrown from the catch. One failing target does not abandon the
+    others, and a failure is logged rather than swallowed — a producer that
+    cannot be distinguished from a quiet fleet is the #885 shape again.
+
+    An unknown *kind* DOES raise: it can only be a coding bug at a call site,
+    and silently dropping it would leave a detector that looks wired and is not.
+    """
+    from . import inbox
+
+    if kind not in inbox.KINDS:
+        raise ValueError(f"invalid alert kind: {kind!r} (expected one of {inbox.KINDS})")
+
+    skip = set(exclude)
+    targets = [name for name in subscribers() if name not in skip]
+    reached: list[str] = []
+    for target in targets:
+        try:
+            inbox.enqueue(target, text, kind=kind, sender=SENDER, ref=ref)
+        except Exception as exc:
+            log_event("emit_failed", to=target, kind=kind, detector=detector, error=str(exc))
+            continue
+        reached.append(target)
+    if reached:
+        log_event("emitted", to=reached, kind=kind, detector=detector)
+    return reached
+
+
+def emit_for(detector: str, text: str, **kwargs) -> list[str]:
+    """:func:`emit` with the kind taken from the ruling in :data:`DETECTOR_KINDS`.
+
+    The call sites use this so that "what may interrupt" is answered in one
+    place. ``kind=`` may still be passed explicitly for the one detector with an
+    inherit rule (dead letters), which is why that override exists at all.
+    """
+    kind = kwargs.pop("kind", None) or DETECTOR_KINDS[detector]
+    return emit(text, kind=kind, detector=detector, **kwargs)

--- a/agentwire/fleet_alerts.py
+++ b/agentwire/fleet_alerts.py
@@ -25,20 +25,23 @@ an inherit rule, and one is not wired at all. That is the whole design.
 **Subscription is a LEASE, not a flag.** A subscriber records
 :data:`SUBSCRIBE_KEY` in its ``metadata.json`` (the #871 SSOT store, so there
 is no second registry to drift) carrying an expiry it must renew. The reason is
-the dormancy failure: a recipient whose mail is spooled rather than pasted does
-not "go gone" the way a dead tmux session does, so a permanent flag would keep
-producing into a spool that nobody reads and then replay hours of stale
-escalations the next time it starts. An expired lease fails QUIET, which is the
-correct direction for a producer whose expensive failure is over-production.
+the dormancy failure: the inbox's own liveness gates are about *pasting into a
+pane*, so a recipient that reads its mail some other way never reads as gone
+the way a dead tmux session does. A permanent flag would keep producing into a
+queue nobody is draining, and hand the whole backlog over at once whenever that
+recipient next came up — every message arriving with the priority it was sent
+with, long after any of it was actionable. An expired lease fails QUIET, which
+is the correct direction for a producer whose expensive failure is
+over-production.
 
-Nothing here knows what a subscriber is. A voice buddy, a durable orchestrator,
-a future dashboard process — anything with a session record and an inbox can
-lease one, and no detector below gains a dependency on any of them.
+Nothing here knows what a subscriber is. Anything with a session record and an
+inbox can lease one, and no detector below gains a dependency on any of them.
 """
 
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
@@ -150,6 +153,7 @@ def subscribe(session: str, lease: timedelta = DEFAULT_LEASE) -> dict:
         "expires_at": (now + lease).isoformat(),
     }
     core.store_session_metadata(session, meta)
+    _write_index([*_read_index(), session])
     log_event("subscribed", session=session, expires_at=meta[SUBSCRIBE_KEY]["expires_at"])
     return meta[SUBSCRIBE_KEY]
 
@@ -163,6 +167,7 @@ def unsubscribe(session: str) -> bool:
         return False
     meta.pop(SUBSCRIBE_KEY)
     core.store_session_metadata(session, meta)
+    _write_index([n for n in _read_index() if n != session])
     log_event("unsubscribed", session=session)
     return True
 
@@ -188,14 +193,56 @@ def subscription(session: str, now: "datetime | None" = None) -> "dict | None":
     return record if expires > (now or _now()) else None
 
 
+def subscribers_index_path() -> Path:
+    """Candidate list of subscribers — who to ASK, never who IS subscribed."""
+    return _config_dir() / "fleet-alerts" / "subscribers.json"
+
+
+def _read_index() -> list[str]:
+    try:
+        names = json.loads(subscribers_index_path().read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    return [n for n in names if isinstance(n, str)] if isinstance(names, list) else []
+
+
+def _write_index(names: list[str]) -> None:
+    path = subscribers_index_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(sorted(set(names)), indent=2))
+    os.replace(tmp, path)
+
+
 def subscribers(now: "datetime | None" = None) -> list[str]:
     """Every session holding a live lease, sorted. ``[]`` on any failure.
 
-    Walks the session-record store (``core.recorded_sessions``) rather than
-    keeping an index, so there is nothing to fall out of sync with a record
-    that was deleted by ``agentwire kill``. That costs one small read per
-    record; alerts are throttled to a handful an hour, so it is not on any hot
-    path.
+    **Two-level, and the levels are not equal.** The index names CANDIDATES;
+    each candidate's own record decides. That ordering is what keeps a cache
+    from becoming a second source of truth — a stale index entry (unregistered,
+    killed, expired) is verified away on read, so the index can only ever cause
+    us to ask a question, never to answer one.
+
+    The reason it exists is cost, measured rather than assumed: walking the
+    record store took ~326ms against 1155 records on this machine, and one
+    caller of this function sits on the SYNCHRONOUS permission-hook path. A
+    feature that taxes the product's hot path to discover nobody is listening
+    is not "inert". With no index file the answer is one failed ``stat``.
+
+    The failure direction is the same one the lease chose: a lost or truncated
+    index means fewer alerts, never more, and ``agentwire alerts reindex``
+    rebuilds it from the records that are authoritative anyway.
+    """
+    at = now or _now()
+    return sorted(name for name in _read_index() if subscription(name, at) is not None)
+
+
+def reindex() -> list[str]:
+    """Rebuild the index by walking the record store. Returns live subscribers.
+
+    The expensive path, on purpose and on demand only: this is what
+    ``agentwire alerts reindex`` runs after a lost index, not something an
+    alert path ever reaches.
     """
     from . import core
 
@@ -203,8 +250,12 @@ def subscribers(now: "datetime | None" = None) -> list[str]:
         names = core.recorded_sessions()
     except Exception:
         return []
-    at = now or _now()
-    return sorted(name for name in names if subscription(name, at) is not None)
+    live = sorted(name for name in names if subscription(name) is not None)
+    try:
+        _write_index(live)
+    except OSError as exc:
+        log_event("reindex_write_failed", error=str(exc))
+    return live
 
 
 # ---------------------------------------------------------------------------

--- a/agentwire/fleet_alerts.py
+++ b/agentwire/fleet_alerts.py
@@ -143,9 +143,23 @@ def subscribe(session: str, lease: timedelta = DEFAULT_LEASE) -> dict:
     Writes into the session's existing record rather than replacing it — the
     store holds conversation identity (#871), and clobbering that to register
     for mail would be a data-destruction bug wearing a feature's clothes.
+
+    **Requires a record to already exist**, and that is about the store rather
+    than about typos. ``load_session_metadata`` returns ``{}`` for a name it has
+    never seen, so writing the lease back created a record for a session that
+    does not exist — a ``{}`` entry that ``core.recorded_sessions()`` counts and
+    nothing distinguishes from a real one. A verb that can mint junk into the
+    SSOT for conversation identity is the wrong shape however it is reached; a
+    subscription is a property OF a session, so a session it can invent is not
+    a subscription at all.
     """
     from . import core
 
+    if not core.session_metadata_path(session).exists():
+        raise ValueError(
+            f"no session record for {session!r} — subscribe an existing session "
+            f"(see `agentwire list`), or register it first"
+        )
     meta = core.load_session_metadata(session)
     now = _now()
     meta[SUBSCRIBE_KEY] = {

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -684,6 +684,51 @@ def _fmt_ts(ms: int) -> str:
 _ESCALATE_DIGEST_DETAIL_CAP = 10
 
 
+def _alert_dead_letters(batch: list[Message], reason: str) -> None:
+    """Mirror a dead-letter digest to subscribed sessions (#982).
+
+    ``request`` by default: a permanently lost report-back needs somebody to go
+    look at ``agentwire msg dead``, but it is not worth cutting across a
+    sentence — and the realistic bad case here is a single stuck recipient that
+    dead-lettered 147 messages in ~2s (2026-07-19). One alert per BATCH, the
+    same coalescing the digest email already does, so that shape buys one
+    message rather than 147.
+
+    The one promotion: if what was lost was itself an ``escalation``, the alert
+    is an escalation. That is not this module re-deriving urgency — the sender
+    already made the judgment, and a *lost interrupt* is precisely the failure
+    the tier exists for.
+
+    Two recursion guards, because an alert is ordinary mail and can dead-letter
+    like any other. The recipient guard alone is not enough once more than one
+    session subscribes: an alert stranded on the way to subscriber A would
+    otherwise be reported to subscriber B, whose own copy is stuck for the same
+    reason, once per drain forever. So our own undelivered alerts are dropped
+    by SENDER, and every subscriber named as a recipient is excluded.
+    """
+    from . import fleet_alerts
+
+    try:
+        mirrored = [m for m in batch if m.sender != fleet_alerts.SENDER]
+        if not mirrored:
+            return
+        recipients = sorted({m.to for m in mirrored})
+        kind = "escalation" if any(m.kind == "escalation" for m in mirrored) else None
+        noun = "message" if len(mirrored) == 1 else "messages"
+        kinds = ", ".join(sorted({m.kind for m in mirrored}))
+        fleet_alerts.emit_for(
+            "dead_letter",
+            f"{len(mirrored)} load-bearing {noun} ({kinds}) to "
+            f"{', '.join(recipients)} were never delivered and have been "
+            f"dead-lettered (last defer reason: {reason}). They are recoverable "
+            f"with `agentwire msg dead`, but nobody has seen them.",
+            kind=kind,
+            exclude=recipients,
+        )
+    except Exception as exc:  # best-effort; never break the drain
+        _log_event("dead_letter_alert_failed", count=len(batch), error=str(exc))
+
+
 def _escalate_dead_letters(messages: list[Message], reason: str) -> None:
     """Email the owner once per batch when load-bearing report-backs dead-letter.
 
@@ -704,6 +749,7 @@ def _escalate_dead_letters(messages: list[Message], reason: str) -> None:
     batch = [m for m in messages if m.kind in ESCALATE_KINDS]
     if not batch:
         return
+    _alert_dead_letters(batch, reason)
     try:
         import socket
 

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -672,7 +672,7 @@ def _alert_no_parent(
     the previous (absent) stamp. So the marker was rewritten every 60s sweep
     with ``escalated_at=None`` and the alert re-fired every tick — measured at
     5 escalations for 5 sweeps of ONE prompt, which over a 12h lease is ~720.
-    That is precisely the failure mode the interrupt tier cannot survive: the
+    That is precisely the failure mode this tier cannot survive: the
     over-production does not merely annoy, it retires the tier.
 
     ``alerted_at`` therefore stamps on successful ENQUEUE, which is a local

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -655,8 +655,8 @@ def build_message(session: str, pane_index: int, info: PromptInfo) -> str:
 
 
 def _alert_no_parent(
-    session: str, pane_index: int, info: PromptInfo, waiting
-) -> None:
+    session: str, pane_index: int, info: PromptInfo, prior: "dict | None"
+) -> "str | None":
     """Mirror a no-parent prompt to subscribed sessions (#982). Escalation kind.
 
     Earns the interrupt on both halves of the test: nothing but a human can
@@ -664,25 +664,42 @@ def _alert_no_parent(
     burning wall-clock, and in the plan/permission cases holding a tool call
     open — for as long as it waits.
 
-    Throttling is inherited rather than added: the only caller is
-    :func:`_escalate_no_parent`, past its ``escalated_at`` gate, so this rides
-    the same once-per-:data:`NO_PARENT_ESCALATE_TTL`-per-prompt window as the
-    email. The prompt HASH is what that marker keys on, so a redraw of the same
-    dialog does not re-alert while a genuinely new question does.
+    **Its own stamp, and this is the whole bug.** The first version rode
+    ``escalated_at``, described as "inheriting" the email's throttle. It does
+    not inherit it, because that gate never closes on a machine without
+    ``RESEND_API_KEY``: ``send_email`` RAISES ``EmailConfigError`` rather than
+    returning a failed result, and :func:`_escalate_no_parent`'s handler returns
+    the previous (absent) stamp. So the marker was rewritten every 60s sweep
+    with ``escalated_at=None`` and the alert re-fired every tick — measured at
+    5 escalations for 5 sweeps of ONE prompt, which over a 12h lease is ~720.
+    That is precisely the failure mode the interrupt tier cannot survive: the
+    over-production does not merely annoy, it retires the tier.
 
-    Deliberately sent before the email: the local enqueue cannot fail for the
-    reason the email usually does (no provider key), and a fleet with a live
-    subscriber is a fleet where somebody may answer this in seconds rather than
-    whenever the owner next reads mail.
+    ``alerted_at`` therefore stamps on successful ENQUEUE, which is a local
+    write and cannot fail for the reason the email does. Same marker, same
+    ``NO_PARENT_ESCALATE_TTL`` window, keyed on the same prompt hash (the
+    caller only passes a *prior* whose hash matches), so a redraw is suppressed
+    while a genuinely different question still alerts.
+
+    Sent before the email for the same reason it needed its own stamp: on the
+    common keyless machine the email is not a channel at all.
     """
+    previous = (prior or {}).get("alerted_at")
+    if previous:
+        try:
+            if _now() - datetime.fromisoformat(previous) < NO_PARENT_ESCALATE_TTL:
+                return previous
+        except (TypeError, ValueError):
+            pass
     try:
         from . import fleet_alerts
 
+        waiting = _marker_age(prior, "detected_at") if prior else None
         waited = (
             f" It has been waiting {int(waiting.total_seconds() // 60)} minutes."
             if waiting else ""
         )
-        fleet_alerts.emit_for(
+        reached = fleet_alerts.emit_for(
             "blocked_pane_no_parent",
             f"{session} (pane {pane_index}) is blocked on a {info.kind} prompt "
             f"and is a root session — there is no parent to route it to, so "
@@ -694,6 +711,11 @@ def _alert_no_parent(
         _log_event(
             "no_parent_alert_failed", session=session, pane=pane_index, error=str(exc)
         )
+        return previous
+    if not reached:
+        return previous
+    _log_event("no_parent_alerted", session=session, pane=pane_index, to=reached)
+    return _now().isoformat()
 
 
 def _escalate_no_parent(
@@ -723,7 +745,6 @@ def _escalate_no_parent(
             pass
 
     waiting = _marker_age(prior, "detected_at") if prior else None
-    _alert_no_parent(session, pane_index, info, waiting)
     try:
         import socket
 
@@ -794,6 +815,11 @@ def route_prompt(
             if not prior or prior.get("hash") != content_hash:
                 prior = None
             escalated_at = _escalate_no_parent(session, pane_index, info, prior)
+            # Two channels, two stamps, deliberately (#982). They cannot share
+            # one: the email's gate only closes on a SUCCESSFUL send, and on a
+            # machine with no RESEND_API_KEY there is never one — which left the
+            # fleet alert re-firing every 60s sweep when it rode that stamp.
+            alerted_at = _alert_no_parent(session, pane_index, info, prior)
             write_marker(
                 session, pane_index,
                 kind=info.kind, question=info.question,
@@ -802,6 +828,7 @@ def route_prompt(
                 detected_at=(prior or {}).get("detected_at") or _now().isoformat(),
                 notified_at=None,
                 escalated_at=escalated_at,
+                alerted_at=alerted_at,
             )
             _log_event("no_parent", session=session, pane=pane_index, kind=info.kind)
             return None

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -654,6 +654,48 @@ def build_message(session: str, pane_index: int, info: PromptInfo) -> str:
     )
 
 
+def _alert_no_parent(
+    session: str, pane_index: int, info: PromptInfo, waiting
+) -> None:
+    """Mirror a no-parent prompt to subscribed sessions (#982). Escalation kind.
+
+    Earns the interrupt on both halves of the test: nothing but a human can
+    answer a prompt with no parent to route to, and the session is stalled —
+    burning wall-clock, and in the plan/permission cases holding a tool call
+    open — for as long as it waits.
+
+    Throttling is inherited rather than added: the only caller is
+    :func:`_escalate_no_parent`, past its ``escalated_at`` gate, so this rides
+    the same once-per-:data:`NO_PARENT_ESCALATE_TTL`-per-prompt window as the
+    email. The prompt HASH is what that marker keys on, so a redraw of the same
+    dialog does not re-alert while a genuinely new question does.
+
+    Deliberately sent before the email: the local enqueue cannot fail for the
+    reason the email usually does (no provider key), and a fleet with a live
+    subscriber is a fleet where somebody may answer this in seconds rather than
+    whenever the owner next reads mail.
+    """
+    try:
+        from . import fleet_alerts
+
+        waited = (
+            f" It has been waiting {int(waiting.total_seconds() // 60)} minutes."
+            if waiting else ""
+        )
+        fleet_alerts.emit_for(
+            "blocked_pane_no_parent",
+            f"{session} (pane {pane_index}) is blocked on a {info.kind} prompt "
+            f"and is a root session — there is no parent to route it to, so "
+            f"nothing will answer it automatically.{waited} Question: "
+            f"{info.question} Answer with: agentwire prompts answer -s "
+            f"'{session}' --pane {pane_index} --expect {info.content_hash()} <key>",
+        )
+    except Exception as exc:  # best-effort; never break the sweep
+        _log_event(
+            "no_parent_alert_failed", session=session, pane=pane_index, error=str(exc)
+        )
+
+
 def _escalate_no_parent(
     session: str, pane_index: int, info: PromptInfo, prior: "dict | None"
 ) -> "str | None":
@@ -681,6 +723,7 @@ def _escalate_no_parent(
             pass
 
     waiting = _marker_age(prior, "detected_at") if prior else None
+    _alert_no_parent(session, pane_index, info, waiting)
     try:
         import socket
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -432,12 +432,41 @@ def _notify_parked(state: dict) -> bool:
         state.get("excerpt", ""),
         "```",
     ]
+    _alert_fleet(state)
     return _send_notification(
         state,
         subject=f"[agentwire] usage limit: {session} parked until {_fmt_local(state['reset_at'])}",
         body="\n".join(lines),
         mark_notified=True,
     )
+
+
+def _alert_fleet(state: dict) -> None:
+    """Tell subscribed sessions a session parked (#982). A NOTE, deliberately.
+
+    A park is self-healing: the reset time is parsed, the resume nudge is armed,
+    and the owner's own email ends "no action needed". There is nothing for
+    anyone to do with it in the next thirty seconds, so it does not earn the
+    interrupt tier — it is exactly the kind of fleet news that should wait for
+    a gap. Demoting it is what keeps `escalation` worth acting on.
+
+    Throttling is inherited, not added: the only caller is
+    :func:`_notify_parked`, which ``park`` reaches once per park thanks to its
+    ``is_parked`` guard. Sent BEFORE the email so a dead Resend key (the
+    common local case) cannot silently take the fleet channel with it.
+    """
+    try:
+        from . import fleet_alerts
+
+        fleet_alerts.emit_for(
+            "usage_limit_park",
+            f"Session {state['session']} hit a usage limit and was parked"
+            f"{' on task ' + state['task'] if state.get('task') else ''}. "
+            f"Limit resets {_fmt_local(state['reset_at'])}; it will be nudged to "
+            f"continue at {_fmt_local(state['resume_at'])}. No action needed.",
+        )
+    except Exception as e:  # best-effort; the park is what matters
+        log_event("fleet_alert_failed", session=state.get("session"), error=str(e))
 
 
 def _notify_resumed(state: dict) -> None:

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -413,7 +413,12 @@ def _fmt_local(iso: str) -> str:
 
 
 def _notify_parked(state: dict) -> bool:
-    """Email the owner that a session is parked. Plain Resend call, no agent."""
+    """Email the owner that a session is parked. Plain Resend call, no agent.
+
+    Called from ``park`` AND from :func:`resume_due` — the latter on every tick
+    until ``notified`` sticks, which on a keyless machine is never. Anything
+    added here must carry its own idempotence rather than assuming one call.
+    """
     session = state["session"]
     lines = [
         f"Session **{session}** on `{socket.gethostname()}` hit a usage limit "
@@ -450,21 +455,35 @@ def _alert_fleet(state: dict) -> None:
     interrupt tier — it is exactly the kind of fleet news that should wait for
     a gap. Demoting it is what keeps `escalation` worth acting on.
 
-    Throttling is inherited, not added: the only caller is
-    :func:`_notify_parked`, which ``park`` reaches once per park thanks to its
-    ``is_parked`` guard. Sent BEFORE the email so a dead Resend key (the
-    common local case) cannot silently take the fleet channel with it.
+    **Its own stamp, on the park record.** This originally claimed to inherit
+    ``park``'s once-per-park ``is_parked`` guard on the strength of
+    :func:`_notify_parked` having one caller. It has TWO: ``park`` and
+    :func:`resume_due`, which re-calls it on every watchdog tick for as long as
+    ``notified`` is False — and ``notified`` is only set on a SUCCESSFUL send,
+    so on a machine without ``RESEND_API_KEY`` (``send_email`` raises rather
+    than returning a failure) it is False for the entire park. Measured: 1 park
+    + 10 ticks produced 11 notes.
+
+    ``fleet_alerted`` is stamped on successful ENQUEUE — a local write, which
+    cannot fail the way the email does — and lives on the park state, so it
+    clears with the park: a session that parks again genuinely is new news.
     """
+    if state.get("fleet_alerted"):
+        return
     try:
         from . import fleet_alerts
 
-        fleet_alerts.emit_for(
+        reached = fleet_alerts.emit_for(
             "usage_limit_park",
             f"Session {state['session']} hit a usage limit and was parked"
             f"{' on task ' + state['task'] if state.get('task') else ''}. "
             f"Limit resets {_fmt_local(state['reset_at'])}; it will be nudged to "
             f"continue at {_fmt_local(state['resume_at'])}. No action needed.",
         )
+        if reached:
+            state["fleet_alerted"] = True
+            if is_parked(state["session"]):
+                write_park_state(state)
     except Exception as e:  # best-effort; the park is what matters
         log_event("fleet_alert_failed", session=state.get("session"), error=str(e))
 

--- a/agentwire/usage_limit.py
+++ b/agentwire/usage_limit.py
@@ -452,7 +452,7 @@ def _alert_fleet(state: dict) -> None:
     A park is self-healing: the reset time is parsed, the resume nudge is armed,
     and the owner's own email ends "no action needed". There is nothing for
     anyone to do with it in the next thirty seconds, so it does not earn the
-    interrupt tier — it is exactly the kind of fleet news that should wait for
+    kind that may be acted on out of turn — it is exactly the fleet news that
     a gap. Demoting it is what keeps `escalation` worth acting on.
 
     **Its own stamp, on the park record.** This originally claimed to inherit

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -276,18 +276,21 @@ it. Nothing about the email path changed; this rides alongside it.
 **Subscription is a lease, not a flag.** A session opts in with
 `fleet_alerts.subscribe(name)`, which records an expiry in that session's
 `metadata.json` (the #871 store — no second registry to drift) and must be
-renewed. That is not ceremony: a recipient whose mail is *spooled* rather than
-pasted never reads as "gone" the way a dead tmux session does, so a permanent
-flag would keep producing into a spool nobody reads and then replay hours of
-stale alerts at its next start. An expired lease fails **quiet**, which is the
-correct direction for a producer whose expensive failure is over-production.
+renewed. That is not ceremony: the drain's liveness gates are about *pasting
+into a pane*, so a recipient that collects its mail some other way never reads
+as "gone" the way a dead tmux session does. A permanent flag would keep
+producing into a queue nobody is draining and then hand over the whole backlog
+at once whenever that recipient came back — every message still carrying the
+priority it was sent with, long after any of it was actionable. An expired lease
+fails **quiet**, the correct direction for a producer whose expensive failure is
+over-production.
 With no subscriber, `emit` walks the store, finds nothing, and returns — every
 detector behaves exactly as it did before.
 
 ### The ruling: which detector earns which kind
 
-`escalation` is the only kind a consumer may act on out of turn (the voice
-buddy's interrupt tier is the first consumer). So the bar is **not** "is this
+`escalation` is the only kind a consumer may act on out of turn — every other
+kind waits for the recipient to be free. So the bar is **not** "is this
 event real?" — all five candidates are real when they fire. It is: *can this
 clear without a human, and is something burning while it waits?*
 
@@ -305,19 +308,44 @@ named as a *recipient* of the lost batch is excluded. Either alone is
 insufficient — with two subscribers, an alert stranded en route to one would
 otherwise be reported to the other, once per drain, forever.
 
-### What an escalation actually buys
+### What an escalation does NOT buy: speed
 
-Less than the word suggests, and the wiring was designed against the measured
-number rather than the intuition. For the voice buddy, pre-emption is real only
-against a VAD response; against an announcer item an escalation **queues behind
-it**, plus up to one 6s in-flight deferral and up to three owner-speaking ones —
-roughly 30s worst case. So `escalation` means "worth cutting the buddy off
-within about half a minute", never "immediately". A detector whose event does
-not clear the *30-second* bar has no business in the tier.
+`escalation` is a **priority** statement, not a latency one, and the difference
+is worth stating because the word invites the other reading. An alert is
+ordinary inbox mail: it is written to the recipient's inbox immediately and then
+waits for the drain, which rides the watchdog at `TICK_INTERVAL = 60`s. So
+**up to ~60s passes before a subscriber sees an escalation at all**, before that
+consumer applies whatever gating of its own it has. What the kind buys is what
+happens *after* it arrives — a consumer may act on an escalation out of turn,
+where it would make anything else wait for a gap.
+
+The practical bar for the table above is therefore: *would this still be worth
+someone's interruption a minute or two after it fired?* An event that is only
+urgent in its first few seconds is not served by this channel at all, and an
+event that will still matter in an hour belongs in `note`.
 
 Rulings live as data in `fleet_alerts.DETECTOR_KINDS` and are pinned by
 `tests/unit/test_fleet_alerts.py`, so changing what may interrupt is a
 deliberate edit to a test that says why.
+
+### CLI
+
+```bash
+agentwire alerts subscribe <session>     # lease alerts for a session
+agentwire alerts unsubscribe <session>
+agentwire alerts list [--json]           # live leases, with their expiry
+agentwire alerts reindex [--json]        # rebuild the candidate index
+```
+
+`list` reports the **expiry**, not a boolean, because a lease that stopped being
+renewed stops delivering silently — that is the designed failure direction, and
+it is one an operator has to be able to see.
+
+`reindex` exists because the emit path deliberately never walks the session
+record store: that walk measured ~326ms against 1155 records, and one caller
+sits on the synchronous permission-hook path. The index names *candidates* and
+each candidate's own record decides, so a stale entry is verified away and a
+lost index costs alerts (never spurious ones) until this rebuilds it.
 
 ## Broadcast
 

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -302,6 +302,24 @@ clear without a human, and is something burning while it waits?*
 | dead-lettered load-bearing mail | `request`, promoted to `escalation` iff the lost message *was* an escalation | Someone must go look at `agentwire msg dead`. The floor is `request` because the realistic bad case is one stuck recipient — 147 dead letters in ~2s, observed — and that shape must not buy 147 interrupts. One alert per **batch**, matching the digest email's coalescing. |
 | dangling PR (`worktree --dangling`) | **not wired** | No autonomous trigger (only `doctor` and the explicit flag, both run by a human already reading the output) and no per-finding throttle state to reuse, so a producer would re-announce the same durable, passive condition every invocation. Nothing is burning while a dangling PR waits. |
 
+**No alert rides an email-shaped throttle.** Each producer stamps its own state
+on a successful *enqueue* — a local write — rather than reusing the stamp that
+gates its owner email. That distinction is load-bearing rather than fussy:
+`channels/email.py` **raises** `EmailConfigError` when `RESEND_API_KEY` is
+absent, so on a keyless machine (the ordinary state of a fresh install) the
+email-shaped gates never close at all, and anything riding one re-fires on every
+60s watchdog tick. Note what this claim does *not* say: three email callers
+(`auth_expired._escalate`, `prompt_router._escalate_no_parent`,
+`usage_limit._send_notification`) still gate persistent state on a successful
+send. That is untouched and out of scope here — but it is why a future producer
+must not be wired to `notified`, `escalated_at` or their siblings.
+
+A stamp also records that somebody **was told**, never that we tried: when an
+alert reaches no subscriber, no stamp is written. Otherwise an operator who
+subscribes during a live incident would hear nothing until the TTL expired,
+which is the failure that is hardest to notice — it looks exactly like a quiet
+fleet.
+
 Two guards keep the dead-letter mirror from feeding itself: alerts carry a
 distinct sender (`fleet-alerts`) and are never mirrored, and any subscriber
 named as a *recipient* of the lost batch is excluded. Either alone is
@@ -346,6 +364,20 @@ record store: that walk measured ~326ms against 1155 records, and one caller
 sits on the synchronous permission-hook path. The index names *candidates* and
 each candidate's own record decides, so a stale entry is verified away and a
 lost index costs alerts (never spurious ones) until this rebuilds it.
+
+**The residual, stated because it is the one silent stop left:** a lost index
+zeroes alerts quietly, and `list` reads that same index — so the surface meant
+to reveal the stop would otherwise agree with it. `list` therefore reports
+`index_present` and refuses to render a missing index as a confident zero. It
+cannot do better than that: a machine where nobody ever subscribed also has no
+index, and from the outside those two states are identical. `reindex` settles
+it, cheaply, in both directions.
+
+`subscribe` requires the session to already have a record. It used to create one
+— a `{}` entry in the store that is the SSOT for conversation identity (#871),
+counted by `core.recorded_sessions()` and indistinguishable from a real session.
+A subscription is a property *of* a session, so one it can invent is not a
+subscription.
 
 ## Broadcast
 

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -264,6 +264,61 @@ pointers and reads the files. The durable content lives in the referenced file,
 not the message — so `pull` (consume-on-read) is the only way these leave the
 inbox; they are never dead-lettered.
 
+## Fleet alerts — detectors as senders (#982)
+
+Until #982 every kind above had exactly one class of sender: an agent typing
+`msg send`. The machine's own detectors — expired login, usage-limit park,
+dead-lettered report-backs, a root session blocked with nowhere to route — could
+only reach the **owner**, by email. `agentwire/fleet_alerts.py` is the other
+half: the same detectors, addressed as typed mail to any session that asks for
+it. Nothing about the email path changed; this rides alongside it.
+
+**Subscription is a lease, not a flag.** A session opts in with
+`fleet_alerts.subscribe(name)`, which records an expiry in that session's
+`metadata.json` (the #871 store — no second registry to drift) and must be
+renewed. That is not ceremony: a recipient whose mail is *spooled* rather than
+pasted never reads as "gone" the way a dead tmux session does, so a permanent
+flag would keep producing into a spool nobody reads and then replay hours of
+stale alerts at its next start. An expired lease fails **quiet**, which is the
+correct direction for a producer whose expensive failure is over-production.
+With no subscriber, `emit` walks the store, finds nothing, and returns — every
+detector behaves exactly as it did before.
+
+### The ruling: which detector earns which kind
+
+`escalation` is the only kind a consumer may act on out of turn (the voice
+buddy's interrupt tier is the first consumer). So the bar is **not** "is this
+event real?" — all five candidates are real when they fire. It is: *can this
+clear without a human, and is something burning while it waits?*
+
+| Detector | Kind | Why, and what bounds it |
+|---|---|---|
+| expired login (`auth_expired`) | `escalation` | Machine-wide; every subsequent turn is refused and only `/login` clears it. Once per `ESCALATE_TTL` (1h) **per outage, per machine** — not per session, not per dispatch — stamped in the outage record next to the email's own stamp. |
+| root session blocked, no parent (`prompt_router`) | `escalation` | By design nothing can route it; the session is stalled until a human answers. Once per hour **per distinct prompt** (keyed on the prompt hash, so a redraw doesn't re-fire). |
+| usage-limit park | `note` | **Demoted on purpose.** Self-healing: reset time parsed, resume nudge armed, the owner's email literally ends "no action needed". Real news, nothing to act on inside thirty seconds. One per park (`is_parked` is the throttle). |
+| dead-lettered load-bearing mail | `request`, promoted to `escalation` iff the lost message *was* an escalation | Someone must go look at `agentwire msg dead`. The floor is `request` because the realistic bad case is one stuck recipient — 147 dead letters in ~2s, observed — and that shape must not buy 147 interrupts. One alert per **batch**, matching the digest email's coalescing. |
+| dangling PR (`worktree --dangling`) | **not wired** | No autonomous trigger (only `doctor` and the explicit flag, both run by a human already reading the output) and no per-finding throttle state to reuse, so a producer would re-announce the same durable, passive condition every invocation. Nothing is burning while a dangling PR waits. |
+
+Two guards keep the dead-letter mirror from feeding itself: alerts carry a
+distinct sender (`fleet-alerts`) and are never mirrored, and any subscriber
+named as a *recipient* of the lost batch is excluded. Either alone is
+insufficient — with two subscribers, an alert stranded en route to one would
+otherwise be reported to the other, once per drain, forever.
+
+### What an escalation actually buys
+
+Less than the word suggests, and the wiring was designed against the measured
+number rather than the intuition. For the voice buddy, pre-emption is real only
+against a VAD response; against an announcer item an escalation **queues behind
+it**, plus up to one 6s in-flight deferral and up to three owner-speaking ones —
+roughly 30s worst case. So `escalation` means "worth cutting the buddy off
+within about half a minute", never "immediately". A detector whose event does
+not clear the *30-second* bar has no business in the tier.
+
+Rulings live as data in `fleet_alerts.DETECTOR_KINDS` and are pinned by
+`tests/unit/test_fleet_alerts.py`, so changing what may interrupt is a
+deliberate edit to a test that says why.
+
 ## Broadcast
 
 `--to @all` fans out to every **live agent session except the sender** — useful
@@ -355,6 +410,8 @@ session right now.
 | `~/.agentwire/inbox/<session>/.lock/` | mkdir-based per-session drain lock |
 | `~/.agentwire/inbox/.tick.lock` | global flock guarding `tick()` |
 | `~/.agentwire/inbox-events.jsonl` | audit log (enqueued/delivered/deferred/dead_letter) |
+| `~/.agentwire/sessions/<session>/metadata.json` → `fleet_alerts` | the subscription lease (see Fleet alerts) |
+| `~/.agentwire/fleet-alerts-events.jsonl` | audit log (subscribed/emitted/emit_failed) |
 
 ## Scope (v1)
 

--- a/tests/unit/test_fleet_alerts.py
+++ b/tests/unit/test_fleet_alerts.py
@@ -1,0 +1,424 @@
+"""Fleet detectors produce typed-kind mail; the interrupt tier gets a producer (#982).
+
+Two halves are tested here and they fail in opposite directions:
+
+* **The false-REJECT half** — a detector that fires and reaches nobody. That is
+  the state before this module existed: `kind: escalation` rode `canInterrupt`
+  and no fleet detector ever sent one, so the alarm bell was wired to nothing.
+* **The false-ACCEPT half, which is the expensive one.** `escalation` is the
+  only kind allowed to cut across the buddy's own speech. A detector that
+  over-produces escalations does not merely add noise — it destroys the tier,
+  because the owner learns to ignore it. So the rulings in
+  :data:`fleet_alerts.DETECTOR_KINDS` are pinned here as DATA: changing what
+  earns an interrupt has to be a deliberate edit to a test that says why.
+
+Nothing here asserts anything about *speed*. Against an announcer item an
+escalation still queues behind it plus up to one 6s in-flight deferral and up
+to three owner-speaking ones (~30s worst case); pre-emption is real only
+against a VAD response. "Escalation" means "worth cutting the buddy off within
+half a minute", never "immediately".
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import auth_expired, core, fleet_alerts, inbox, prompt_router, usage_limit
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    """A throwaway config dir: session records, inboxes and event logs."""
+    root = tmp_path / "agentwire"
+    (root / "sessions").mkdir(parents=True)
+    monkeypatch.setattr(core, "CONFIG_DIR", root)
+    monkeypatch.setattr(inbox, "INBOX_ROOT", root / "inbox")
+    monkeypatch.setattr(inbox, "EVENTS_FILE", root / "inbox-events.jsonl")
+    monkeypatch.setattr(inbox, "live_sessions", lambda: None)
+    return root
+
+
+def _subscribe(name: str = "buddy") -> str:
+    fleet_alerts.subscribe(name)
+    return name
+
+
+def _inbox_messages(session: str) -> list:
+    return inbox.list_messages(session) + inbox.list_ingest(session)
+
+
+# =============================================================================
+# The ruling — which detector earns which kind
+# =============================================================================
+
+
+class TestRuling:
+    def test_only_two_detectors_may_interrupt(self):
+        """Escalation is the interrupt tier; exactly two producers hold it.
+
+        Both share one property: the condition cannot clear without a human,
+        and it is burning something while it waits. auth-expired refuses every
+        turn on the machine until `/login`; a root session blocked on a prompt
+        with no parent is stalled with nobody able to answer it.
+        """
+        interrupting = {
+            name for name, kind in fleet_alerts.DETECTOR_KINDS.items()
+            if kind == "escalation"
+        }
+        assert interrupting == {"auth_expired", "blocked_pane_no_parent"}
+
+    def test_usage_limit_park_is_a_note(self):
+        """A parked session is self-healing — reset parsed, auto-resume armed.
+
+        Nothing is asked of the owner ("no action needed" is literally in the
+        email), so it fails the interrupt test even though it is a real fleet
+        event worth hearing about at a gap.
+        """
+        assert fleet_alerts.DETECTOR_KINDS["usage_limit_park"] == "note"
+
+    def test_dead_letter_floor_is_request_not_escalation(self):
+        """A lost report-back needs owner attention, not the owner's sentence.
+
+        The batch can inherit `escalation` when what was LOST was itself an
+        escalation (tested below) — but the floor is `request`, because the
+        stuck-recipient case dead-lettered 147 messages in ~2s once and that
+        shape must not be able to buy 147 interrupts.
+        """
+        assert fleet_alerts.DETECTOR_KINDS["dead_letter"] == "request"
+
+    def test_dangling_pr_is_deliberately_unwired(self):
+        """Not an oversight — a ruling.
+
+        `worktree --dangling` has no autonomous trigger (only `doctor` and the
+        explicit flag, both run by a human who is already looking) and no
+        per-finding throttle state to reuse, so a producer there would re-alert
+        the same durable, passive condition every invocation. Wiring it means
+        revisiting this test.
+        """
+        assert "dangling_pr" not in fleet_alerts.DETECTOR_KINDS
+
+    def test_every_ruling_names_a_real_kind(self):
+        for name, kind in fleet_alerts.DETECTOR_KINDS.items():
+            assert kind in inbox.KINDS, name
+
+
+# =============================================================================
+# Subscription — a lease, not a permanent flag
+# =============================================================================
+
+
+class TestSubscription:
+    def test_no_subscriber_means_no_behavior_change(self, isolate):
+        assert fleet_alerts.subscribers() == []
+        assert fleet_alerts.emit("anything", kind="escalation") == []
+        assert not (isolate / "inbox").exists()
+
+    def test_subscribe_records_a_lease_and_is_listed(self, isolate):
+        _subscribe("buddy")
+        assert fleet_alerts.subscribers() == ["buddy"]
+        record = core.load_session_metadata("buddy")[fleet_alerts.SUBSCRIBE_KEY]
+        assert record["expires_at"] > record["since"]
+
+    def test_subscribe_preserves_the_rest_of_the_record(self, isolate):
+        core.store_session_metadata("buddy", {"role": "buddy", "delivery": "voice"})
+        _subscribe("buddy")
+        meta = core.load_session_metadata("buddy")
+        assert meta["role"] == "buddy" and meta["delivery"] == "voice"
+
+    def test_an_expired_lease_stops_producing(self, isolate):
+        """The dormancy bound. A buddy that ran once in July must not collect
+        August's escalations in a spool it will replay at next start."""
+        _subscribe("buddy")
+        stale = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        meta = core.load_session_metadata("buddy")
+        meta[fleet_alerts.SUBSCRIBE_KEY]["expires_at"] = stale
+        core.store_session_metadata("buddy", meta)
+
+        assert fleet_alerts.subscribers() == []
+        assert fleet_alerts.emit("x", kind="escalation") == []
+
+    def test_a_malformed_subscription_is_ignored_not_honored(self, isolate):
+        core.store_session_metadata("buddy", {fleet_alerts.SUBSCRIBE_KEY: True})
+        assert fleet_alerts.subscribers() == []
+
+    def test_unsubscribe(self, isolate):
+        _subscribe("buddy")
+        assert fleet_alerts.unsubscribe("buddy") is True
+        assert fleet_alerts.subscribers() == []
+        assert fleet_alerts.unsubscribe("buddy") is False
+
+
+# =============================================================================
+# emit — best-effort, never the detector's problem
+# =============================================================================
+
+
+class TestEmit:
+    def test_enqueues_to_every_subscriber(self, isolate):
+        _subscribe("buddy")
+        _subscribe("second")
+        assert sorted(fleet_alerts.emit("hi", kind="note")) == ["buddy", "second"]
+        msg = _inbox_messages("buddy")[0]
+        assert msg.kind == "note" and msg.sender == fleet_alerts.SENDER
+        assert msg.text == "hi"
+
+    def test_exclude_skips_a_target(self, isolate):
+        _subscribe("buddy")
+        assert fleet_alerts.emit("hi", kind="note", exclude=["buddy"]) == []
+
+    def test_never_raises_when_the_inbox_fails(self, isolate, monkeypatch):
+        _subscribe("buddy")
+
+        def boom(*a, **k):
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(inbox, "enqueue", boom)
+        assert fleet_alerts.emit("hi", kind="note") == []
+
+    def test_one_bad_target_does_not_abandon_the_rest(self, isolate, monkeypatch):
+        _subscribe("aaa")
+        _subscribe("zzz")
+        real = inbox.enqueue
+
+        def selective(to, *a, **k):
+            if to == "aaa":
+                raise OSError("nope")
+            return real(to, *a, **k)
+
+        monkeypatch.setattr(inbox, "enqueue", selective)
+        assert fleet_alerts.emit("hi", kind="note") == ["zzz"]
+
+    def test_a_bogus_kind_is_a_coding_bug_not_a_silent_drop(self, isolate):
+        _subscribe("buddy")
+        with pytest.raises(ValueError):
+            fleet_alerts.emit("hi", kind="urgent")
+
+
+# =============================================================================
+# Detector: expired login (#906) — escalation, once per outage hour
+# =============================================================================
+
+
+class TestAuthExpired:
+    def test_records_outage_and_escalates_to_the_buddy(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=False, error="no key"),
+        )
+        auth_expired.record_outage({"session": "task-a", "transcript": "/t.jsonl"})
+
+        msgs = _inbox_messages("buddy")
+        assert len(msgs) == 1
+        assert msgs[0].kind == "escalation"
+        assert "login" in msgs[0].text.lower()
+
+    def test_throttled_by_the_same_state_record(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=False, error="no key"),
+        )
+        auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
+        auth_expired.record_outage({"session": "b", "transcript": "/t.jsonl"})
+        assert len(_inbox_messages("buddy")) == 1
+
+        state = json.loads(auth_expired.state_path().read_text())
+        assert state["alerted_at"]
+
+        # ...and it fires again once the window is over.
+        state["alerted_at"] = (
+            datetime.now(timezone.utc) - auth_expired.ESCALATE_TTL - timedelta(minutes=1)
+        ).isoformat()
+        auth_expired.write_state(state)
+        auth_expired.record_outage({"session": "c", "transcript": "/t.jsonl"})
+        assert len(_inbox_messages("buddy")) == 2
+
+    def test_a_broken_alert_never_breaks_the_gate(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=False, error="no key"),
+        )
+        monkeypatch.setattr(
+            fleet_alerts, "emit", lambda *a, **k: (_ for _ in ()).throw(RuntimeError())
+        )
+        state = auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
+        assert state["last_seen"] and auth_expired.outage_active()
+
+
+# =============================================================================
+# Detector: usage-limit park — a note, once per park
+# =============================================================================
+
+
+class TestUsageLimitPark:
+    def _state(self) -> dict:
+        now = datetime.now(timezone.utc)
+        return {
+            "session": "worker-1",
+            "task": "nightly",
+            "detected_at": now.isoformat(),
+            "parked_at": now.isoformat(),
+            "reset_at": (now + timedelta(hours=2)).isoformat(),
+            "resume_at": (now + timedelta(hours=2, minutes=5)).isoformat(),
+            "excerpt": "",
+            "notified": False,
+        }
+
+    def test_park_notice_reaches_the_buddy_as_a_note(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        usage_limit._notify_parked(self._state())
+
+        msgs = _inbox_messages("buddy")
+        assert len(msgs) == 1
+        assert msgs[0].kind == "note"
+        assert "worker-1" in msgs[0].text
+
+    def test_the_notice_survives_a_dead_email_channel(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: (_ for _ in ()).throw(RuntimeError("no provider")),
+        )
+        usage_limit._notify_parked(self._state())
+        assert len(_inbox_messages("buddy")) == 1
+
+
+# =============================================================================
+# Detector: dead-lettered load-bearing mail — inherits the lost kind
+# =============================================================================
+
+
+def _dead(kind: str, to: str = "someone", sender: str = "worker") -> inbox.Message:
+    return inbox.Message(
+        id="1-abc", sender=sender, to=to, kind=kind, text="report", ts=1, attempts=40
+    )
+
+
+class TestDeadLetters:
+    def test_a_lost_done_is_a_request(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters([_dead("done")], "target_gone")
+        msgs = _inbox_messages("buddy")
+        assert len(msgs) == 1 and msgs[0].kind == "request"
+
+    def test_a_lost_escalation_stays_an_escalation(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters([_dead("done"), _dead("escalation")], "target_gone")
+        assert _inbox_messages("buddy")[0].kind == "escalation"
+
+    def test_the_buddys_own_undelivered_mail_does_not_loop(self, isolate, monkeypatch):
+        """The recursion guard, in both directions.
+
+        Alerts addressed TO the buddy that dead-letter would otherwise alert
+        the buddy about the alert failing to reach the buddy — forever.
+        """
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters(
+            [_dead("escalation", to="buddy", sender=fleet_alerts.SENDER)], "target_gone"
+        )
+        assert _inbox_messages("buddy") == []
+
+    def test_a_stranded_alert_is_not_reported_to_a_second_subscriber(
+        self, isolate, monkeypatch
+    ):
+        """The half the recipient guard cannot cover.
+
+        With two subscribers, an alert stranded on the way to `buddy` is not
+        addressed to `second` — so excluding recipients alone would let it be
+        reported there, once per drain, about a delivery that is stuck for the
+        same reason `second`'s own copy is. Only the SENDER guard stops it.
+        """
+        _subscribe("buddy")
+        _subscribe("second")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters(
+            [_dead("escalation", to="buddy", sender=fleet_alerts.SENDER)], "target_gone"
+        )
+        assert _inbox_messages("second") == []
+
+    def test_mail_lost_on_the_way_to_the_buddy_still_excludes_it(
+        self, isolate, monkeypatch
+    ):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters([_dead("done", to="buddy")], "target_gone")
+        assert _inbox_messages("buddy") == []
+
+    def test_one_alert_per_batch_not_per_message(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        inbox._escalate_dead_letters([_dead("done") for _ in range(147)], "target_gone")
+        msgs = _inbox_messages("buddy")
+        assert len(msgs) == 1
+        assert "147" in msgs[0].text
+
+
+# =============================================================================
+# Detector: a root session blocked with nowhere to route (#905) — escalation
+# =============================================================================
+
+
+def _prompt_info() -> prompt_router.PromptInfo:
+    return prompt_router.PromptInfo(
+        kind="permission",
+        question="Allow Bash(rm -rf build)?",
+        options=[{"number": "1", "label": "Yes"}, {"number": "2", "label": "No"}],
+        summary="",
+    )
+
+
+class TestBlockedRootPane:
+    def test_no_parent_escalation_reaches_the_buddy(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        prompt_router._escalate_no_parent("root-1", 0, _prompt_info(), None)
+
+        msgs = _inbox_messages("buddy")
+        assert len(msgs) == 1
+        assert msgs[0].kind == "escalation"
+        assert "root-1" in msgs[0].text
+
+    def test_throttled_by_the_markers_own_stamp(self, isolate, monkeypatch):
+        _subscribe("buddy")
+        monkeypatch.setattr(
+            "agentwire.channels.email.send_email",
+            lambda **k: SimpleNamespace(success=True, error=None),
+        )
+        info = _prompt_info()
+        stamp = prompt_router._escalate_no_parent("root-1", 0, info, None)
+        prompt_router._escalate_no_parent("root-1", 0, info, {"escalated_at": stamp})
+        assert len(_inbox_messages("buddy")) == 1

--- a/tests/unit/test_fleet_alerts.py
+++ b/tests/unit/test_fleet_alerts.py
@@ -1,22 +1,20 @@
-"""Fleet detectors produce typed-kind mail; the interrupt tier gets a producer (#982).
+"""Fleet detectors produce typed-kind mail; `escalation` gets a producer (#982).
 
 Two halves are tested here and they fail in opposite directions:
 
 * **The false-REJECT half** — a detector that fires and reaches nobody. That is
-  the state before this module existed: `kind: escalation` rode `canInterrupt`
-  and no fleet detector ever sent one, so the alarm bell was wired to nothing.
-* **The false-ACCEPT half, which is the expensive one.** `escalation` is the
-  only kind allowed to cut across the buddy's own speech. A detector that
+  the state before this module existed: the one kind a recipient may act on out
+  of turn had no fleet detector sending it, so the bell was wired to nothing.
+* **The false-ACCEPT half, which is the expensive one.** A detector that
   over-produces escalations does not merely add noise — it destroys the tier,
-  because the owner learns to ignore it. So the rulings in
-  :data:`fleet_alerts.DETECTOR_KINDS` are pinned here as DATA: changing what
-  earns an interrupt has to be a deliberate edit to a test that says why.
+  because a recipient who learns escalations are usually ignorable will ignore
+  the one that wasn't. So the rulings in :data:`fleet_alerts.DETECTOR_KINDS`
+  are pinned here as DATA: changing what may interrupt has to be a deliberate
+  edit to a test that says why.
 
-Nothing here asserts anything about *speed*. Against an announcer item an
-escalation still queues behind it plus up to one 6s in-flight deferral and up
-to three owner-speaking ones (~30s worst case); pre-emption is real only
-against a VAD response. "Escalation" means "worth cutting the buddy off within
-half a minute", never "immediately".
+Nothing here asserts anything about *speed*, and nothing should. An alert is
+ordinary inbox mail, so it waits for the drain (a 60s watchdog tick) before any
+recipient sees it: `escalation` is a statement of priority, not of latency.
 """
 
 from __future__ import annotations
@@ -42,7 +40,7 @@ def isolate(tmp_path, monkeypatch):
     return root
 
 
-def _subscribe(name: str = "buddy") -> str:
+def _subscribe(name: str = "listener") -> str:
     fleet_alerts.subscribe(name)
     return name
 
@@ -58,7 +56,7 @@ def _inbox_messages(session: str) -> list:
 
 class TestRuling:
     def test_only_two_detectors_may_interrupt(self):
-        """Escalation is the interrupt tier; exactly two producers hold it.
+        """Escalation is the act-out-of-turn kind; exactly two producers hold it.
 
         Both share one property: the condition cannot clear without a human,
         and it is burning something while it waits. auth-expired refuses every
@@ -118,38 +116,39 @@ class TestSubscription:
         assert not (isolate / "inbox").exists()
 
     def test_subscribe_records_a_lease_and_is_listed(self, isolate):
-        _subscribe("buddy")
-        assert fleet_alerts.subscribers() == ["buddy"]
-        record = core.load_session_metadata("buddy")[fleet_alerts.SUBSCRIBE_KEY]
+        _subscribe("listener")
+        assert fleet_alerts.subscribers() == ["listener"]
+        record = core.load_session_metadata("listener")[fleet_alerts.SUBSCRIBE_KEY]
         assert record["expires_at"] > record["since"]
 
     def test_subscribe_preserves_the_rest_of_the_record(self, isolate):
-        core.store_session_metadata("buddy", {"role": "buddy", "delivery": "voice"})
-        _subscribe("buddy")
-        meta = core.load_session_metadata("buddy")
-        assert meta["role"] == "buddy" and meta["delivery"] == "voice"
+        core.store_session_metadata("listener", {"role": "worker", "created_at": "x"})
+        _subscribe("listener")
+        meta = core.load_session_metadata("listener")
+        assert meta["role"] == "worker" and meta["created_at"] == "x"
 
     def test_an_expired_lease_stops_producing(self, isolate):
-        """The dormancy bound. A buddy that ran once in July must not collect
-        August's escalations in a spool it will replay at next start."""
-        _subscribe("buddy")
+        """The dormancy bound. A listener that ran once in July must not collect
+        August's escalations in a queue it hands over all at once at next
+        start."""
+        _subscribe("listener")
         stale = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
-        meta = core.load_session_metadata("buddy")
+        meta = core.load_session_metadata("listener")
         meta[fleet_alerts.SUBSCRIBE_KEY]["expires_at"] = stale
-        core.store_session_metadata("buddy", meta)
+        core.store_session_metadata("listener", meta)
 
         assert fleet_alerts.subscribers() == []
         assert fleet_alerts.emit("x", kind="escalation") == []
 
     def test_a_malformed_subscription_is_ignored_not_honored(self, isolate):
-        core.store_session_metadata("buddy", {fleet_alerts.SUBSCRIBE_KEY: True})
+        core.store_session_metadata("listener", {fleet_alerts.SUBSCRIBE_KEY: True})
         assert fleet_alerts.subscribers() == []
 
     def test_unsubscribe(self, isolate):
-        _subscribe("buddy")
-        assert fleet_alerts.unsubscribe("buddy") is True
+        _subscribe("listener")
+        assert fleet_alerts.unsubscribe("listener") is True
         assert fleet_alerts.subscribers() == []
-        assert fleet_alerts.unsubscribe("buddy") is False
+        assert fleet_alerts.unsubscribe("listener") is False
 
 
 # =============================================================================
@@ -159,19 +158,19 @@ class TestSubscription:
 
 class TestEmit:
     def test_enqueues_to_every_subscriber(self, isolate):
-        _subscribe("buddy")
+        _subscribe("listener")
         _subscribe("second")
-        assert sorted(fleet_alerts.emit("hi", kind="note")) == ["buddy", "second"]
-        msg = _inbox_messages("buddy")[0]
+        assert sorted(fleet_alerts.emit("hi", kind="note")) == ["listener", "second"]
+        msg = _inbox_messages("listener")[0]
         assert msg.kind == "note" and msg.sender == fleet_alerts.SENDER
         assert msg.text == "hi"
 
     def test_exclude_skips_a_target(self, isolate):
-        _subscribe("buddy")
-        assert fleet_alerts.emit("hi", kind="note", exclude=["buddy"]) == []
+        _subscribe("listener")
+        assert fleet_alerts.emit("hi", kind="note", exclude=["listener"]) == []
 
     def test_never_raises_when_the_inbox_fails(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
 
         def boom(*a, **k):
             raise OSError("disk gone")
@@ -193,7 +192,7 @@ class TestEmit:
         assert fleet_alerts.emit("hi", kind="note") == ["zzz"]
 
     def test_a_bogus_kind_is_a_coding_bug_not_a_silent_drop(self, isolate):
-        _subscribe("buddy")
+        _subscribe("listener")
         with pytest.raises(ValueError):
             fleet_alerts.emit("hi", kind="urgent")
 
@@ -204,28 +203,28 @@ class TestEmit:
 
 
 class TestAuthExpired:
-    def test_records_outage_and_escalates_to_the_buddy(self, isolate, monkeypatch):
-        _subscribe("buddy")
+    def test_records_outage_and_escalates_to_the_listener(self, isolate, monkeypatch):
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=False, error="no key"),
         )
         auth_expired.record_outage({"session": "task-a", "transcript": "/t.jsonl"})
 
-        msgs = _inbox_messages("buddy")
+        msgs = _inbox_messages("listener")
         assert len(msgs) == 1
         assert msgs[0].kind == "escalation"
         assert "login" in msgs[0].text.lower()
 
     def test_throttled_by_the_same_state_record(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=False, error="no key"),
         )
         auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
         auth_expired.record_outage({"session": "b", "transcript": "/t.jsonl"})
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
 
         state = json.loads(auth_expired.state_path().read_text())
         assert state["alerted_at"]
@@ -236,10 +235,10 @@ class TestAuthExpired:
         ).isoformat()
         auth_expired.write_state(state)
         auth_expired.record_outage({"session": "c", "transcript": "/t.jsonl"})
-        assert len(_inbox_messages("buddy")) == 2
+        assert len(_inbox_messages("listener")) == 2
 
     def test_a_broken_alert_never_breaks_the_gate(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=False, error="no key"),
@@ -270,27 +269,27 @@ class TestUsageLimitPark:
             "notified": False,
         }
 
-    def test_park_notice_reaches_the_buddy_as_a_note(self, isolate, monkeypatch):
-        _subscribe("buddy")
+    def test_park_notice_reaches_the_listener_as_a_note(self, isolate, monkeypatch):
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         usage_limit._notify_parked(self._state())
 
-        msgs = _inbox_messages("buddy")
+        msgs = _inbox_messages("listener")
         assert len(msgs) == 1
         assert msgs[0].kind == "note"
         assert "worker-1" in msgs[0].text
 
     def test_the_notice_survives_a_dead_email_channel(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: (_ for _ in ()).throw(RuntimeError("no provider")),
         )
         usage_limit._notify_parked(self._state())
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
 
 
 # =============================================================================
@@ -306,80 +305,80 @@ def _dead(kind: str, to: str = "someone", sender: str = "worker") -> inbox.Messa
 
 class TestDeadLetters:
     def test_a_lost_done_is_a_request(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         inbox._escalate_dead_letters([_dead("done")], "target_gone")
-        msgs = _inbox_messages("buddy")
+        msgs = _inbox_messages("listener")
         assert len(msgs) == 1 and msgs[0].kind == "request"
 
     def test_a_lost_escalation_stays_an_escalation(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         inbox._escalate_dead_letters([_dead("done"), _dead("escalation")], "target_gone")
-        assert _inbox_messages("buddy")[0].kind == "escalation"
+        assert _inbox_messages("listener")[0].kind == "escalation"
 
-    def test_the_buddys_own_undelivered_mail_does_not_loop(self, isolate, monkeypatch):
+    def test_the_listeners_own_undelivered_mail_does_not_loop(self, isolate, monkeypatch):
         """The recursion guard, in both directions.
 
-        Alerts addressed TO the buddy that dead-letter would otherwise alert
-        the buddy about the alert failing to reach the buddy — forever.
+        Alerts addressed TO the listener that dead-letter would otherwise alert
+        the listener about the alert failing to reach the listener — forever.
         """
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         inbox._escalate_dead_letters(
-            [_dead("escalation", to="buddy", sender=fleet_alerts.SENDER)], "target_gone"
+            [_dead("escalation", to="listener", sender=fleet_alerts.SENDER)], "target_gone"
         )
-        assert _inbox_messages("buddy") == []
+        assert _inbox_messages("listener") == []
 
     def test_a_stranded_alert_is_not_reported_to_a_second_subscriber(
         self, isolate, monkeypatch
     ):
         """The half the recipient guard cannot cover.
 
-        With two subscribers, an alert stranded on the way to `buddy` is not
+        With two subscribers, an alert stranded on the way to `listener` is not
         addressed to `second` — so excluding recipients alone would let it be
         reported there, once per drain, about a delivery that is stuck for the
         same reason `second`'s own copy is. Only the SENDER guard stops it.
         """
-        _subscribe("buddy")
+        _subscribe("listener")
         _subscribe("second")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         inbox._escalate_dead_letters(
-            [_dead("escalation", to="buddy", sender=fleet_alerts.SENDER)], "target_gone"
+            [_dead("escalation", to="listener", sender=fleet_alerts.SENDER)], "target_gone"
         )
         assert _inbox_messages("second") == []
 
-    def test_mail_lost_on_the_way_to_the_buddy_still_excludes_it(
+    def test_mail_lost_on_the_way_to_the_listener_still_excludes_it(
         self, isolate, monkeypatch
     ):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
-        inbox._escalate_dead_letters([_dead("done", to="buddy")], "target_gone")
-        assert _inbox_messages("buddy") == []
+        inbox._escalate_dead_letters([_dead("done", to="listener")], "target_gone")
+        assert _inbox_messages("listener") == []
 
     def test_one_alert_per_batch_not_per_message(self, isolate, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
         inbox._escalate_dead_letters([_dead("done") for _ in range(147)], "target_gone")
-        msgs = _inbox_messages("buddy")
+        msgs = _inbox_messages("listener")
         assert len(msgs) == 1
         assert "147" in msgs[0].text
 
@@ -426,7 +425,7 @@ class TestKeylessMachine:
         self, isolate, monkeypatch, tmp_path
     ):
         """The reproduction: 5 sweeps of ONE prompt must be 1 escalation."""
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
         monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
         monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
@@ -434,7 +433,7 @@ class TestKeylessMachine:
         for _ in range(5):
             prompt_router.route_prompt("root-1", 0, _prompt_info(), source="sweep")
 
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
 
     def test_a_genuinely_new_prompt_still_alerts(self, isolate, monkeypatch, tmp_path):
         """The false-reject half: the throttle is per PROMPT, not per pane.
@@ -443,7 +442,7 @@ class TestKeylessMachine:
         different one is still stalled, and the second question is new
         information. Only a redraw of the SAME prompt is suppressed.
         """
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
         monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
         monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
@@ -454,13 +453,13 @@ class TestKeylessMachine:
         )
         prompt_router.route_prompt("root-1", 0, other, source="sweep")
 
-        assert len(_inbox_messages("buddy")) == 2
+        assert len(_inbox_messages("listener")) == 2
 
     def test_auth_outage_alerts_once_across_repeated_detections(self, isolate):
-        _subscribe("buddy")
+        _subscribe("listener")
         for _ in range(5):
             auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
 
     def test_park_note_fires_once_across_the_whole_park(
         self, isolate, monkeypatch, tmp_path
@@ -471,7 +470,7 @@ class TestKeylessMachine:
         as ``notified`` stays False, which on a keyless machine is forever —
         ``resume_due``, on every tick.
         """
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(usage_limit, "STATE_DIR", tmp_path / "usage-limit")
         now = datetime.now(timezone.utc)
         state = {
@@ -490,13 +489,13 @@ class TestKeylessMachine:
         for _ in range(10):  # resume_due(), once per tick, notified still False
             usage_limit._notify_parked(usage_limit.read_park_state("worker-1"))
 
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
 
     def test_a_new_park_of_the_same_session_alerts_again(
         self, isolate, monkeypatch, tmp_path
     ):
         """The false-reject half: the stamp lives on the PARK, not the session."""
-        _subscribe("buddy")
+        _subscribe("listener")
         monkeypatch.setattr(usage_limit, "STATE_DIR", tmp_path / "usage-limit")
         now = datetime.now(timezone.utc)
 
@@ -514,7 +513,7 @@ class TestKeylessMachine:
             usage_limit._notify_parked(state)
             usage_limit.state_path("worker-1").unlink()  # the park cleared
 
-        assert len(_inbox_messages("buddy")) == 2
+        assert len(_inbox_messages("listener")) == 2
 
 
 class TestCostWhenNobodyListens:
@@ -550,12 +549,12 @@ class TestCostWhenNobodyListens:
     def test_one_subscriber_reads_only_that_subscribers_record(
         self, isolate, monkeypatch
     ):
-        _subscribe("buddy")
+        _subscribe("listener")
         for name in ("other-1", "other-2", "other-3"):
             core.store_session_metadata(name, {"role": "worker"})
 
         calls = self._count_walks(monkeypatch)
-        assert fleet_alerts.subscribers() == ["buddy"]
+        assert fleet_alerts.subscribers() == ["listener"]
         assert calls == []
 
     def test_the_index_is_a_candidate_list_not_the_truth(self, isolate):
@@ -564,16 +563,16 @@ class TestCostWhenNobodyListens:
         The record is authoritative; the index only says who to ask. A name
         whose lease is gone (unregistered, killed, expired) is verified away.
         """
-        _subscribe("buddy")
-        core.session_metadata_path("buddy").unlink()
+        _subscribe("listener")
+        core.session_metadata_path("listener").unlink()
         assert fleet_alerts.subscribers() == []
 
     def test_reindex_rebuilds_a_lost_index_from_the_records(self, isolate):
-        _subscribe("buddy")
+        _subscribe("listener")
         fleet_alerts.subscribers_index_path().unlink()
         assert fleet_alerts.subscribers() == []  # fails quiet, as designed
-        assert fleet_alerts.reindex() == ["buddy"]
-        assert fleet_alerts.subscribers() == ["buddy"]
+        assert fleet_alerts.reindex() == ["listener"]
+        assert fleet_alerts.subscribers() == ["listener"]
 
 
 class TestCliSurface:
@@ -586,11 +585,11 @@ class TestCliSurface:
         return args.func(args)
 
     def test_subscribe_list_unsubscribe_round_trip(self, isolate, capsys):
-        assert self._run(["alerts", "subscribe", "buddy"]) == 0
+        assert self._run(["alerts", "subscribe", "listener"]) == 0
         capsys.readouterr()
         assert self._run(["alerts", "list", "--json"]) == 0
-        assert json.loads(capsys.readouterr().out)["subscribers"] == ["buddy"]
-        assert self._run(["alerts", "unsubscribe", "buddy"]) == 0
+        assert json.loads(capsys.readouterr().out)["subscribers"] == ["listener"]
+        assert self._run(["alerts", "unsubscribe", "listener"]) == 0
         capsys.readouterr()
         self._run(["alerts", "list", "--json"])
         assert json.loads(capsys.readouterr().out)["subscribers"] == []
@@ -601,11 +600,11 @@ class TestCliSurface:
         assert self._run(["alerts", "unsubscribe", "nobody"]) == 1
 
     def test_reindex_is_reachable_from_the_cli(self, isolate, capsys):
-        self._run(["alerts", "subscribe", "buddy"])
+        self._run(["alerts", "subscribe", "listener"])
         fleet_alerts.subscribers_index_path().unlink()
         capsys.readouterr()
         assert self._run(["alerts", "reindex", "--json"]) == 0
-        assert json.loads(capsys.readouterr().out)["subscribers"] == ["buddy"]
+        assert json.loads(capsys.readouterr().out)["subscribers"] == ["listener"]
 
 
 class TestBlockedRootPane:
@@ -625,24 +624,24 @@ class TestBlockedRootPane:
             "root-1", 0, info or _prompt_info(), source="sweep"
         )
 
-    def test_no_parent_escalation_reaches_the_buddy(self, isolate, sweep):
-        _subscribe("buddy")
+    def test_no_parent_escalation_reaches_the_listener(self, isolate, sweep):
+        _subscribe("listener")
         sweep()
-        msgs = _inbox_messages("buddy")
+        msgs = _inbox_messages("listener")
         assert len(msgs) == 1
         assert msgs[0].kind == "escalation"
         assert "root-1" in msgs[0].text
 
     def test_throttled_by_its_own_stamp_on_the_marker(self, isolate, sweep):
-        _subscribe("buddy")
+        _subscribe("listener")
         sweep()
         sweep()
-        assert len(_inbox_messages("buddy")) == 1
+        assert len(_inbox_messages("listener")) == 1
         marker = prompt_router.read_marker("root-1", 0)
         assert marker["alerted_at"]
 
     def test_the_stamp_expires_with_its_own_ttl(self, isolate, sweep, monkeypatch):
-        _subscribe("buddy")
+        _subscribe("listener")
         sweep()
         marker = prompt_router.read_marker("root-1", 0)
         marker["alerted_at"] = (
@@ -654,4 +653,4 @@ class TestBlockedRootPane:
             k: v for k, v in marker.items() if k not in ("session", "pane")
         })
         sweep()
-        assert len(_inbox_messages("buddy")) == 2
+        assert len(_inbox_messages("listener")) == 2

--- a/tests/unit/test_fleet_alerts.py
+++ b/tests/unit/test_fleet_alerts.py
@@ -398,27 +398,260 @@ def _prompt_info() -> prompt_router.PromptInfo:
     )
 
 
-class TestBlockedRootPane:
-    def test_no_parent_escalation_reaches_the_buddy(self, isolate, monkeypatch):
+class TestKeylessMachine:
+    """The shape the first round of throttle tests could not build.
+
+    Every throttle test above patches ``send_email`` to RETURN a result — and a
+    machine with no ``RESEND_API_KEY`` does not return, it RAISES
+    ``EmailConfigError`` before any send is attempted. That is the ordinary
+    state of a fresh install and of every machine in this fleet without the key.
+    The email-shaped throttles (``escalated_at`` on an exception path,
+    ``notified`` on a successful send) never close there, so anything riding
+    them re-fires every 60s watchdog tick — 720 escalations over a 12h lease.
+
+    The alert therefore may NEVER ride an email-shaped throttle. Each producer
+    stamps its own state on successful ENQUEUE, which is a local write.
+    """
+
+    @pytest.fixture(autouse=True)
+    def keyless(self, monkeypatch):
+        from agentwire.channels.email import EmailConfigError
+
+        def raises(**kwargs):
+            raise EmailConfigError("Email API key not configured.")
+
+        monkeypatch.setattr("agentwire.channels.email.send_email", raises)
+
+    def test_no_parent_sweep_alerts_once_not_once_per_tick(
+        self, isolate, monkeypatch, tmp_path
+    ):
+        """The reproduction: 5 sweeps of ONE prompt must be 1 escalation."""
         _subscribe("buddy")
+        monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
+        monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
+
+        for _ in range(5):
+            prompt_router.route_prompt("root-1", 0, _prompt_info(), source="sweep")
+
+        assert len(_inbox_messages("buddy")) == 1
+
+    def test_a_genuinely_new_prompt_still_alerts(self, isolate, monkeypatch, tmp_path):
+        """The false-reject half: the throttle is per PROMPT, not per pane.
+
+        A session that answers one blocking question and immediately hits a
+        different one is still stalled, and the second question is new
+        information. Only a redraw of the SAME prompt is suppressed.
+        """
+        _subscribe("buddy")
+        monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
+        monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
+
+        prompt_router.route_prompt("root-1", 0, _prompt_info(), source="sweep")
+        other = prompt_router.PromptInfo(
+            kind="plan", question="Proceed with the migration plan?", options=[]
+        )
+        prompt_router.route_prompt("root-1", 0, other, source="sweep")
+
+        assert len(_inbox_messages("buddy")) == 2
+
+    def test_auth_outage_alerts_once_across_repeated_detections(self, isolate):
+        _subscribe("buddy")
+        for _ in range(5):
+            auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
+        assert len(_inbox_messages("buddy")) == 1
+
+    def test_park_note_fires_once_across_the_whole_park(
+        self, isolate, monkeypatch, tmp_path
+    ):
+        """The multi-caller reproduction: 1 park + 10 watchdog ticks = 1 note.
+
+        ``_notify_parked`` has TWO callers, not one: ``park`` and — for as long
+        as ``notified`` stays False, which on a keyless machine is forever —
+        ``resume_due``, on every tick.
+        """
+        _subscribe("buddy")
+        monkeypatch.setattr(usage_limit, "STATE_DIR", tmp_path / "usage-limit")
+        now = datetime.now(timezone.utc)
+        state = {
+            "session": "worker-1",
+            "task": "nightly",
+            "detected_at": now.isoformat(),
+            "parked_at": now.isoformat(),
+            "reset_at": (now + timedelta(hours=2)).isoformat(),
+            "resume_at": (now + timedelta(hours=2, minutes=5)).isoformat(),
+            "excerpt": "",
+            "notified": False,
+        }
+        usage_limit.write_park_state(state)
+
+        usage_limit._notify_parked(state)  # park()
+        for _ in range(10):  # resume_due(), once per tick, notified still False
+            usage_limit._notify_parked(usage_limit.read_park_state("worker-1"))
+
+        assert len(_inbox_messages("buddy")) == 1
+
+    def test_a_new_park_of_the_same_session_alerts_again(
+        self, isolate, monkeypatch, tmp_path
+    ):
+        """The false-reject half: the stamp lives on the PARK, not the session."""
+        _subscribe("buddy")
+        monkeypatch.setattr(usage_limit, "STATE_DIR", tmp_path / "usage-limit")
+        now = datetime.now(timezone.utc)
+
+        for _ in range(2):
+            state = {
+                "session": "worker-1",
+                "detected_at": now.isoformat(),
+                "parked_at": now.isoformat(),
+                "reset_at": (now + timedelta(hours=2)).isoformat(),
+                "resume_at": (now + timedelta(hours=2)).isoformat(),
+                "excerpt": "",
+                "notified": False,
+            }
+            usage_limit.write_park_state(state)
+            usage_limit._notify_parked(state)
+            usage_limit.state_path("worker-1").unlink()  # the park cleared
+
+        assert len(_inbox_messages("buddy")) == 2
+
+
+class TestCostWhenNobodyListens:
+    """"Zero behavior change with no subscriber" has to mean zero WORK, too.
+
+    ``subscribers()`` originally walked every session record — 1155 of them on
+    this machine, ~326ms — and one of its callers sits on the SYNCHRONOUS
+    permission-hook path. A detector that taxes the product's hot path to
+    discover that nobody is listening is a regression, not an inert feature.
+    """
+
+    @staticmethod
+    def _count_walks(monkeypatch) -> list:
+        """Count store walks. A RAISING stub cannot be used here: ``subscribers``
+        swallows exceptions by design, so a raise would be caught and the test
+        would pass whether or not the walk happened — a pin that cannot fail."""
+        calls: list = []
+        real = core.recorded_sessions
+
+        def counted():
+            calls.append(1)
+            return real()
+
+        monkeypatch.setattr(core, "recorded_sessions", counted)
+        return calls
+
+    def test_no_index_means_the_record_store_is_never_walked(self, isolate, monkeypatch):
+        calls = self._count_walks(monkeypatch)
+        assert fleet_alerts.subscribers() == []
+        assert fleet_alerts.emit("x", kind="escalation") == []
+        assert calls == []
+
+    def test_one_subscriber_reads_only_that_subscribers_record(
+        self, isolate, monkeypatch
+    ):
+        _subscribe("buddy")
+        for name in ("other-1", "other-2", "other-3"):
+            core.store_session_metadata(name, {"role": "worker"})
+
+        calls = self._count_walks(monkeypatch)
+        assert fleet_alerts.subscribers() == ["buddy"]
+        assert calls == []
+
+    def test_the_index_is_a_candidate_list_not_the_truth(self, isolate):
+        """A stale index entry must not resurrect a dropped subscription.
+
+        The record is authoritative; the index only says who to ask. A name
+        whose lease is gone (unregistered, killed, expired) is verified away.
+        """
+        _subscribe("buddy")
+        core.session_metadata_path("buddy").unlink()
+        assert fleet_alerts.subscribers() == []
+
+    def test_reindex_rebuilds_a_lost_index_from_the_records(self, isolate):
+        _subscribe("buddy")
+        fleet_alerts.subscribers_index_path().unlink()
+        assert fleet_alerts.subscribers() == []  # fails quiet, as designed
+        assert fleet_alerts.reindex() == ["buddy"]
+        assert fleet_alerts.subscribers() == ["buddy"]
+
+
+class TestCliSurface:
+    """CLI is the SSOT: an API only a branch can reach is not shipped."""
+
+    def _run(self, argv: list[str]) -> int:
+        from agentwire.__main__ import build_parser
+
+        args = build_parser().parse_args(argv)
+        return args.func(args)
+
+    def test_subscribe_list_unsubscribe_round_trip(self, isolate, capsys):
+        assert self._run(["alerts", "subscribe", "buddy"]) == 0
+        capsys.readouterr()
+        assert self._run(["alerts", "list", "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["subscribers"] == ["buddy"]
+        assert self._run(["alerts", "unsubscribe", "buddy"]) == 0
+        capsys.readouterr()
+        self._run(["alerts", "list", "--json"])
+        assert json.loads(capsys.readouterr().out)["subscribers"] == []
+
+    def test_unsubscribing_something_that_never_subscribed_fails_loudly(
+        self, isolate, capsys
+    ):
+        assert self._run(["alerts", "unsubscribe", "nobody"]) == 1
+
+    def test_reindex_is_reachable_from_the_cli(self, isolate, capsys):
+        self._run(["alerts", "subscribe", "buddy"])
+        fleet_alerts.subscribers_index_path().unlink()
+        capsys.readouterr()
+        assert self._run(["alerts", "reindex", "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["subscribers"] == ["buddy"]
+
+
+class TestBlockedRootPane:
+    @pytest.fixture
+    def sweep(self, monkeypatch, tmp_path):
+        """The REAL entry point. The alert is throttled by a stamp the caller
+        persists, so exercising the inner function alone cannot see the loop
+        that shipped — the marker round-trip is where the throttle lives."""
+        monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
+        monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
         monkeypatch.setattr(
             "agentwire.channels.email.send_email",
             lambda **k: SimpleNamespace(success=True, error=None),
         )
-        prompt_router._escalate_no_parent("root-1", 0, _prompt_info(), None)
+        return lambda info=None: prompt_router.route_prompt(
+            "root-1", 0, info or _prompt_info(), source="sweep"
+        )
 
+    def test_no_parent_escalation_reaches_the_buddy(self, isolate, sweep):
+        _subscribe("buddy")
+        sweep()
         msgs = _inbox_messages("buddy")
         assert len(msgs) == 1
         assert msgs[0].kind == "escalation"
         assert "root-1" in msgs[0].text
 
-    def test_throttled_by_the_markers_own_stamp(self, isolate, monkeypatch):
+    def test_throttled_by_its_own_stamp_on_the_marker(self, isolate, sweep):
         _subscribe("buddy")
-        monkeypatch.setattr(
-            "agentwire.channels.email.send_email",
-            lambda **k: SimpleNamespace(success=True, error=None),
-        )
-        info = _prompt_info()
-        stamp = prompt_router._escalate_no_parent("root-1", 0, info, None)
-        prompt_router._escalate_no_parent("root-1", 0, info, {"escalated_at": stamp})
+        sweep()
+        sweep()
         assert len(_inbox_messages("buddy")) == 1
+        marker = prompt_router.read_marker("root-1", 0)
+        assert marker["alerted_at"]
+
+    def test_the_stamp_expires_with_its_own_ttl(self, isolate, sweep, monkeypatch):
+        _subscribe("buddy")
+        sweep()
+        marker = prompt_router.read_marker("root-1", 0)
+        marker["alerted_at"] = (
+            datetime.now(timezone.utc)
+            - prompt_router.NO_PARENT_ESCALATE_TTL
+            - timedelta(minutes=1)
+        ).isoformat()
+        prompt_router.write_marker("root-1", 0, **{
+            k: v for k, v in marker.items() if k not in ("session", "pane")
+        })
+        sweep()
+        assert len(_inbox_messages("buddy")) == 2

--- a/tests/unit/test_fleet_alerts.py
+++ b/tests/unit/test_fleet_alerts.py
@@ -41,6 +41,14 @@ def isolate(tmp_path, monkeypatch):
 
 
 def _subscribe(name: str = "listener") -> str:
+    """A subscriber is a session that EXISTS — the record comes first.
+
+    Not fixture ceremony: a subscription is a property of a session, and
+    ``subscribe`` refuses a name with no record precisely so it can never mint
+    one into the #871 store.
+    """
+    if not core.session_metadata_path(name).exists():
+        core.store_session_metadata(name, {"role": "worker", "created_at": "x"})
     fleet_alerts.subscribe(name)
     return name
 
@@ -143,6 +151,30 @@ class TestSubscription:
     def test_a_malformed_subscription_is_ignored_not_honored(self, isolate):
         core.store_session_metadata("listener", {fleet_alerts.SUBSCRIBE_KEY: True})
         assert fleet_alerts.subscribers() == []
+
+    def test_subscribing_an_unknown_session_refuses_and_writes_nothing(self, isolate):
+        """The session-record store is the #871 SSOT for conversation identity.
+
+        A verb that mints ``{}`` into it on a typo is the wrong shape whatever
+        the typo case: the empty record is indistinguishable from a real one to
+        ``core.recorded_sessions()``, which sweeps and doctor surfaces count.
+        The help text already promised a record must exist; now the code does.
+        """
+        with pytest.raises(ValueError):
+            fleet_alerts.subscribe("typoo")
+        assert core.recorded_sessions() == []
+        assert not core.session_metadata_path("typoo").exists()
+        assert fleet_alerts.subscribers() == []
+
+    def test_a_refused_subscription_leaves_no_index_entry(self, isolate):
+        _subscribe("listener")
+        with pytest.raises(ValueError):
+            fleet_alerts.subscribe("typoo")
+        assert fleet_alerts.subscribers() == ["listener"]
+
+    def test_unsubscribing_an_unknown_session_creates_no_record(self, isolate):
+        assert fleet_alerts.unsubscribe("typoo") is False
+        assert core.recorded_sessions() == []
 
     def test_unsubscribe(self, isolate):
         _subscribe("listener")
@@ -516,6 +548,77 @@ class TestKeylessMachine:
         assert len(_inbox_messages("listener")) == 2
 
 
+class TestNoStampWhenNobodyHeard:
+    """A stamp records that somebody WAS TOLD, never that we tried.
+
+    The expensive direction: an operator who subscribes during a live incident
+    must still hear about it. If a throttle stamp were burned while nobody was
+    listening, the alert would be suppressed for the rest of its TTL and the
+    subscriber would sit through the incident in silence — the failure that is
+    hardest to notice, because the system looks exactly like a quiet fleet.
+
+    ``if not reached: return previous`` is what makes that work. It was correct
+    but unasserted, which for behaviour in this direction is the same as
+    undefended.
+    """
+
+    @pytest.fixture(autouse=True)
+    def keyless(self, monkeypatch):
+        from agentwire.channels.email import EmailConfigError
+
+        def raises(**kwargs):
+            raise EmailConfigError("Email API key not configured.")
+
+        monkeypatch.setattr("agentwire.channels.email.send_email", raises)
+
+    def test_auth_outage_alerts_a_subscriber_that_arrives_mid_incident(self, isolate):
+        for _ in range(3):
+            auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
+        assert json.loads(auth_expired.state_path().read_text())["alerted_at"] is None
+
+        _subscribe("listener")  # a listener comes up mid-outage
+        auth_expired.record_outage({"session": "a", "transcript": "/t.jsonl"})
+        assert len(_inbox_messages("listener")) == 1
+
+    def test_no_parent_sweep_alerts_a_subscriber_that_arrives_mid_incident(
+        self, isolate, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(prompt_router, "STATE_DIR", tmp_path / "prompt-router")
+        monkeypatch.setattr(prompt_router, "EVENTS_FILE", tmp_path / "pr-events.jsonl")
+        monkeypatch.setattr(prompt_router, "resolve_parent", lambda *a, **k: None)
+
+        for _ in range(3):
+            prompt_router.route_prompt("root-1", 0, _prompt_info(), source="sweep")
+        assert prompt_router.read_marker("root-1", 0)["alerted_at"] is None
+
+        _subscribe("listener")
+        prompt_router.route_prompt("root-1", 0, _prompt_info(), source="sweep")
+        assert len(_inbox_messages("listener")) == 1
+
+    def test_park_notes_a_subscriber_that_arrives_mid_park(
+        self, isolate, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(usage_limit, "STATE_DIR", tmp_path / "usage-limit")
+        now = datetime.now(timezone.utc)
+        state = {
+            "session": "worker-1",
+            "detected_at": now.isoformat(),
+            "parked_at": now.isoformat(),
+            "reset_at": (now + timedelta(hours=2)).isoformat(),
+            "resume_at": (now + timedelta(hours=2)).isoformat(),
+            "excerpt": "",
+            "notified": False,
+        }
+        usage_limit.write_park_state(state)
+        for _ in range(3):
+            usage_limit._notify_parked(usage_limit.read_park_state("worker-1"))
+        assert not usage_limit.read_park_state("worker-1").get("fleet_alerted")
+
+        _subscribe("listener")
+        usage_limit._notify_parked(usage_limit.read_park_state("worker-1"))
+        assert len(_inbox_messages("listener")) == 1
+
+
 class TestCostWhenNobodyListens:
     """"Zero behavior change with no subscriber" has to mean zero WORK, too.
 
@@ -584,6 +687,11 @@ class TestCliSurface:
         args = build_parser().parse_args(argv)
         return args.func(args)
 
+    @pytest.fixture(autouse=True)
+    def a_real_session(self, isolate):
+        """`listener` is an existing session here — the CLI refuses to invent one."""
+        core.store_session_metadata("listener", {"role": "worker", "created_at": "x"})
+
     def test_subscribe_list_unsubscribe_round_trip(self, isolate, capsys):
         assert self._run(["alerts", "subscribe", "listener"]) == 0
         capsys.readouterr()
@@ -598,6 +706,46 @@ class TestCliSurface:
         self, isolate, capsys
     ):
         assert self._run(["alerts", "unsubscribe", "nobody"]) == 1
+
+    def test_subscribe_typo_fails_and_mints_no_record(self, isolate, capsys):
+        assert self._run(["alerts", "subscribe", "typoo"]) == 1
+        assert "typoo" not in core.recorded_sessions()
+
+    def test_list_never_reports_a_missing_index_as_a_confident_zero(
+        self, isolate, capsys
+    ):
+        """The one surface built to make a silent stop visible must not agree
+        with it. `list` reads the same index the emit path does, so a lost index
+        would otherwise render as "nobody is subscribed" — while a live lease
+        sits right there in the record store, hearing nothing.
+
+        What it can honestly say is narrower than I first wrote: a machine where
+        nobody ever subscribed ALSO has no index, and from here those two are
+        identical. So the answer is flagged as unconfident either way, and
+        `reindex` is what settles it.
+        """
+        self._run(["alerts", "subscribe", "listener"])
+        capsys.readouterr()
+        self._run(["alerts", "list", "--json"])
+        assert json.loads(capsys.readouterr().out)["index_present"] is True
+
+        fleet_alerts.subscribers_index_path().unlink()
+        self._run(["alerts", "list", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out["subscribers"] == [] and out["index_present"] is False
+
+        # ...and the lease was never gone — reindex proves the zero was false.
+        self._run(["alerts", "reindex", "--json"])
+        capsys.readouterr()
+        self._run(["alerts", "list", "--json"])
+        assert json.loads(capsys.readouterr().out)["subscribers"] == ["listener"]
+
+    def test_list_says_so_in_prose_too(self, isolate, capsys):
+        self._run(["alerts", "subscribe", "listener"])
+        fleet_alerts.subscribers_index_path().unlink()
+        capsys.readouterr()
+        self._run(["alerts", "list"])
+        assert "reindex" in capsys.readouterr().out
 
     def test_reindex_is_reachable_from_the_cli(self, isolate, capsys):
         self._run(["alerts", "subscribe", "listener"])


### PR DESCRIPTION
Part of #982 — the main-bound half of that issue's split. Generic typed-kind messaging with no consumer named anywhere in it; the branch-only consumer that motivated it lives in #1003 and never comes here.

## What was missing

Every fleet detector in this repo could tell the **owner** something — the shared Resend wiring, throttled by whatever state that detector already keeps. None of them could tell a **session**. `agentwire/fleet_alerts.py` is that half: one call, never raises, and inert until some session leases a subscription.

## The design is the ruling

`escalation` is the only kind a recipient may act on out of turn; everything else waits until the recipient is free. A producer that over-fires doesn't add noise, it *retires the tier* — a recipient who learns escalations are usually ignorable will ignore the one that wasn't. So the bar is not "is this event real?" (all five candidates are real when they fire) but **"can this clear without a human, and is something burning while it waits?"**

| Detector | Kind | Why, and what bounds it |
|---|---|---|
| expired login | `escalation` | machine-wide, every turn refused, only `/login` clears it — **1/hour per outage, per machine** |
| root pane blocked, no parent | `escalation` | by design nothing can route it; stalled until a human answers — **1/hour per distinct prompt**, keyed on the prompt hash |
| usage-limit park | `note` | **demoted** — self-healing; the reset time is parsed, the resume nudge is armed, and its own owner email ends "no action needed" |
| dead-lettered load-bearing mail | `request`, promoted to `escalation` iff what was *lost* was an escalation | one alert per **batch** — the observed bad case is 147 dead letters in ~2s, and that shape must not buy 147 interrupts |
| dangling PR | **not wired** | no autonomous trigger (only `doctor` and the explicit flag, both run by a human already reading the output), no per-finding throttle state to reuse, and nothing is burning while it waits |

Rulings live as data in `DETECTOR_KINDS`, pinned by tests, so changing what may interrupt is a deliberate edit to a test that says why.

## Each alert stamps its own state, on enqueue

This is the load-bearing mechanic and it is not obvious. `channels/email.py` **raises** `EmailConfigError` when `RESEND_API_KEY` is absent — it does not return `success=False`. So on a keyless machine (the ordinary state of a fresh install) every email-shaped throttle in the tree is permanently open, and anything riding one re-fires on each 60s watchdog tick. Two review-caught bugs came from exactly that: the no-parent alert produced 5 escalations for 5 sweeps of one prompt, and the park note produced 11 for 1 park + 10 ticks.

So no alert rides an email-shaped throttle. Each producer stamps its own state on a successful **enqueue**, a local write that cannot fail the way the email does:

- `alerted_at` on the prompt-router marker, persisted by `route_prompt`, same TTL and same prompt hash as the email's gate;
- `alerted_at` in the auth-expired outage record, beside `escalated_at`;
- `fleet_alerted` on the park record, so it clears when the park does.

Note precisely what that claim does **not** say. Three email callers — `auth_expired._escalate`, `prompt_router._escalate_no_parent`, `usage_limit._send_notification` — still gate persistent state on a successful send. That is untouched and out of scope here, and it is exactly why a future producer must not be wired to `notified`, `escalated_at` or their siblings. The docs say so too.

A stamp records that somebody **was told**, never that we tried: when an alert reaches no subscriber, no stamp is written, so an operator who subscribes *during* a live incident still hears about it.

Two recursion guards on the dead-letter mirror, because an alert is ordinary mail and can dead-letter like any other: our own undelivered alerts are dropped by sender, and any subscriber named as a recipient of the lost batch is excluded. Either alone is insufficient — with two subscribers, an alert stranded en route to one would otherwise be reported to the other, once per drain, forever.

## Subscription is a lease, and only for sessions that exist

Recorded in the session's `metadata.json` (the #871 SSOT — no second registry to drift) with an expiry the subscriber renews. The inbox's liveness gates are about *pasting into a pane*, so a recipient that collects its mail another way never reads as "gone"; a permanent flag would keep producing into a queue nobody drains and hand the whole backlog over at once whenever that recipient came back, every message still carrying the priority it was sent with. An expired lease fails **quiet**, the right direction for a producer whose expensive failure is over-production.

`subscribe` requires the session to already have a record. It used to create one — a `{}` entry in the store that is the SSOT for conversation identity, counted by `core.recorded_sessions()` and indistinguishable from a real session. A subscription is a property *of* a session, so one it can invent is not a subscription.

## CLI

```
agentwire alerts subscribe <session>     # lease alerts (session must exist)
agentwire alerts unsubscribe <session>
agentwire alerts list [--json]           # live leases + their expiry
agentwire alerts reindex [--json]        # rebuild the candidate index
```

`list` reports lease **expiry** rather than a boolean, because a lapsed lease stops delivering silently. It also reports `index_present` and refuses to render a missing index as a confident zero — it reads the same index the emit path does, so without that flag the one surface built to reveal a silent stop would agree with it. It cannot claim more: a machine where nobody ever subscribed also has no index. `reindex` settles it either way.

## Cost

The emit path never walks the session record store — that walk measured ~326ms against 1155 records, and one caller sits on the **synchronous permission-hook path**. A candidate index gates it; each candidate's own record still decides, so a stale entry is verified away and a lost index costs alerts, never spurious ones.

| | before | after |
|---|---|---|
| emit, no subscriber | ~326 ms | **0.017 ms** |
| emit, one subscriber | ~326 ms | **0.358 ms** |
| reindex (on demand only) | — | ~92 ms |

Measured on a synthetic 1155-record store; review measured the hook path independently at 0.0076ms.

## What this does not claim: speed

`escalation` is a statement of **priority, not latency**. An alert is ordinary inbox mail, so it waits for the drain (60s watchdog tick) before any recipient sees it, and a consumer then applies its own gating on top. The practical bar for the table above is "would this still be worth someone's interruption a minute or two after it fired?" — an event that is only urgent in its first few seconds is not served by this channel at all, whatever kind it carries.

## Verification

- `uv run --extra dev pytest` on `59c5c9e` against `main` at `635829e`: **5197 passed, 36 skipped, 0 failed** (base 5141, +56). `ruff check agentwire/ tests/` clean.
- 51 tests in `tests/unit/test_fleet_alerts.py`, each watched failing before the code existed — except the three "no stamp when the alert reached nobody" pins, which guard behaviour that was already correct and were proved by mutation instead.
- 25 mutations across three review rounds, every one confirmed red: each kind ruling, both dead-letter recursion guards, the escalation-inherit rule, all three enqueue stamps and their persistence paths, the index (both directions — trusting it as truth *and* reverting to the store walk), the record-existence guard, `exclude`, the CLI registration, and each of the four detector call sites removed.

Docs: `docs/wiki/sessions/messaging.md` gains a "Fleet alerts" section with the ruling table, the throttle bounds, the CLI, and the residual above.
