### PR TITLE
voice-layer: close the three beta-gate residuals in the confirm spine (#989, #990, #992)

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1247,7 +1247,7 @@ SPOKEN = {
         "Hang on — I'm already working on that one. "
         "I'll tell you how it went in a moment; don't repeat it yet."
     ),
-    # A CANCEL that lost the race to a confirm already inside the runner
+    # A CANCEL that lost the race to a confirm already INSIDE THE RUNNER
     # (#990). It must not say "I haven't sent it" — that is the over-claim
     # `in_flight` is worded to avoid, and here it would be worse, because the
     # owner asked for exactly that outcome and would hear it granted.
@@ -1256,9 +1256,25 @@ SPOKEN = {
     # tried to do is the one thing that is no longer available, so the line
     # names the uncertainty AND the move that is still open (undo it after the
     # fact, from the recipient's side), which is what "wait" alone would hide.
+    #
+    # The condition is `_dispatching`, NOT `_in_flight`, and the difference is
+    # this line's whole truth value: the claim is held across the ≤2.5s await,
+    # where nothing has been sent and this sentence would be false. See
+    # ConfirmSpine.cancel.
     "cancel_in_flight": (
         "Too late to stop that one — it's already going out. Don't repeat it; "
         "I'll tell you how it went in a moment and we can undo it from there."
+    ),
+    # A cancel with nothing of ours to retract — never proposed, already
+    # retired, or expired. It collapses `no_proposal` and `expired` for the
+    # cancel caller ONLY, and the reason is that both of their confirm-shaped
+    # lines argue for the write: "Tell me again what you'd like sent" and "Ask
+    # me again and I'll set it up fresh". Answering a retraction by pressing
+    # for the thing retracted is the taxonomy defect §3.4 names, reached
+    # through a reused line rather than a wrong one.
+    "nothing_to_cancel": (
+        "There's nothing waiting on my side, so there's nothing to take back — "
+        "I haven't sent anything."
     ),
     "too_many_attempts": (
         "I've got that wrong too many times, so I've dropped it. Ask me again from the top."
@@ -1390,7 +1406,7 @@ REASONS = frozenset(
         "no_proposal", "expired", "not_announced", "replayed", "refused",
         "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
         "too_many_attempts", "dispatch_failed", "in_flight",
-        "cancel_in_flight",
+        "cancel_in_flight", "nothing_to_cancel",
     }
 )
 
@@ -1513,7 +1529,20 @@ class ConfirmSpine:
         #: _succeeded so a retry is told the truth rather than "already sent".
         self._failed: set[str] = set()
         #: Tokens claimed by a confirm that has not returned yet. See _claim.
+        #: **Claimed is not dispatching.** The claim is taken at the TOP of
+        #: :meth:`confirm`, before the ≤2.5s await and before the judge, so for
+        #: most of its life this set means "a confirm is deciding", not "a write
+        #: is going out". Anything that speaks about the WRITE must read
+        #: ``_dispatching`` instead — see :meth:`cancel`.
         self._in_flight: set[str] = set()
+        #: Tokens whose argv has been handed to the runner and has not come
+        #: back. The ONLY state in which "it's already going out" is true.
+        self._dispatching: set[str] = set()
+        #: Tokens the owner retracted while a confirm held the claim. The
+        #: confirm re-reads this under the lock immediately before dispatch, so
+        #: a cancel that arrives during the await genuinely WINS rather than
+        #: being told it was too late (#990, review round 2).
+        self._cancelled: set[str] = set()
 
     # -- propose ------------------------------------------------------------
 
@@ -1661,6 +1690,34 @@ class ConfirmSpine:
                 return Verdict(approved=False, reason="too_many_attempts")
             return verdict
 
+        # THE CANCEL BARRIER (#990, review round 2). The claim is taken at the
+        # top of `confirm`, so it has been held across the ≤2.5s await and the
+        # judge — during which nothing has been sent. A cancel arriving in that
+        # window is therefore not "too late": it WINS, and this is where the
+        # confirm finds out.
+        #
+        # Under the lock together with the `_dispatching` mark, because the two
+        # are one decision: reading `_cancelled` and then marking would leave a
+        # window in which a cancel lands after the check and is told, truthfully
+        # by then but wrongly at the time it spoke, that the write was going
+        # out. The approving utterance is deliberately NOT spent on this path —
+        # nothing was acted on, so nothing was consumed.
+        with self._lock:
+            if token in self._cancelled:
+                self._proposals.pop(token, None)
+                return Verdict(
+                    approved=False, reason="denied", utterance=verdict.utterance
+                )
+            self._dispatching.add(token)
+
+        try:
+            return self._dispatch(proposal, token, verdict)
+        finally:
+            with self._lock:
+                self._dispatching.discard(token)
+
+    def _dispatch(self, proposal: Proposal, token: str, verdict: Verdict) -> Verdict:
+        """Run the frozen argv. Reached only past the cancel barrier."""
         self._ring.spend(verdict.utterance_item_id)
         with self._lock:
             self._proposals.pop(token, None)
@@ -1724,35 +1781,75 @@ class ConfirmSpine:
         by construction and stopped there; cancel-vs-in-flight-confirm is the
         same shape.
 
-        So the claim is taken here too, and the outcomes it produces are all
-        honest ones: ``cancel_in_flight`` while a confirm owns the token,
-        ``replayed`` / ``dispatch_failed`` once the write has actually been
-        attempted, ``expired`` / ``no_proposal`` when there is nothing to drop.
+        **"A confirm holds the claim" is NOT "the write is going out", and
+        conflating them re-committed the defect this issue is about** (review
+        round 2). :meth:`_claim` is taken at the TOP of :meth:`confirm`, before
+        the ≤2.5s await and before the judge, so the dominant occupant of
+        ``_in_flight`` is a confirm still DECIDING. Refusing a cancel there with
+        "it's already going out" is the same false statement, inverted: the
+        measured shape is a cancel during the await, a confirm that then returns
+        ``pending_transcript``, a runner never called, and a proposal the owner
+        asked to drop still sitting pending.
 
-        **The false-reject half, priced.** A cancel refused for the wrong reason
-        is a proposal the owner believes is dead and the buddy still holds, so:
+        So the race is split on the thing the sentence is about:
+
+        - ``_dispatching`` — the argv is inside the runner. This, and only this,
+          is when ``cancel_in_flight`` is true.
+        - ``_cancelled`` — a cancel that arrives while a confirm merely holds the
+          claim WINS. It pops the proposal and answers ``denied``, honestly:
+          nothing has been sent. The confirm re-reads the marker under the same
+          lock immediately before dispatch and returns ``denied`` too, so the
+          write does not go out behind the retraction.
+
+        **The false-reject half, priced across all of it.** A cancel refused for
+        the wrong reason leaves a proposal the owner believes is dead:
 
         - the announcement requirement is DROPPED (``require_announced=False``).
           A cancel of a proposal the buddy has not finished speaking must
           succeed — refusing it with ``not_announced`` would leave the proposal
           live for its full TTL over a technicality about who was talking.
+        - **no cancel outcome leaves a live proposal behind.** The measured
+          failure was "refused cancel, then refused confirm, wedged to TTL with
+          no second word", and it came from refusing during the await; the split
+          above removes it at the source, because that cancel now wins. The
+          remaining refusals reach the owner only when the proposal is already
+          gone (dispatched, replayed, failed, expired). Pinned as a property
+          over every reachable cancel outcome rather than asserted here.
         - ``cancel_in_flight`` is a WAIT outcome with its own spoken line, and
           that line has to say what happens next, because the one thing the
           owner cannot do is take it back: the write is already going out and
           its real outcome is seconds away.
+        - the shared claim's other refusals are TRANSLATED, not passed through
+          (:meth:`_cancel_refusal`) — a cancel must never be answered with
+          confirm-shaped advice to re-propose the write just retracted.
         """
+        with self._lock:
+            if token in self._dispatching:
+                # The ONE true "too late": the argv is inside the runner.
+                #
+                # Nothing is popped or marked here, and that is deliberate
+                # rather than an omission: `_dispatch` popped the proposal
+                # before calling the runner, and the cancel barrier is already
+                # behind us, so both would be writes nothing can read. A line
+                # whose effect is unreachable reads as a guarantee on the next
+                # pass — the same objection this module makes to a property
+                # that documents a rule nothing enforces. The property they
+                # looked like they were buying — no cancel outcome leaves a
+                # live proposal — is real, and is pinned as a property.
+                return Verdict(approved=False, reason="cancel_in_flight")
+            if token in self._in_flight:
+                # A confirm holds the claim but has not reached the runner.
+                # Nothing has been sent, so the cancel is simply honoured.
+                self._cancelled.add(token)
+                self._proposals.pop(token, None)
+                return Verdict(approved=False, reason="denied")
+
         proposal, refusal = self._claim(token, require_announced=False)
         if refusal is not None:
-            if refusal.reason == "in_flight":
-                # Same race, different question. `in_flight` answers "should I
-                # confirm again?" (no, wait); this answers "did you stop it?"
-                # (no, and here is why), and collapsing them would tell the
-                # owner to wait for an outcome they asked to prevent without
-                # ever saying it could not be prevented.
-                return Verdict(approved=False, reason="cancel_in_flight")
-            return refusal
+            return self._cancel_refusal(refusal)
         try:
             with self._lock:
+                self._cancelled.add(token)
                 self._proposals.pop(token, None)
             return Verdict(approved=False, reason="denied")
         finally:
@@ -1761,6 +1858,31 @@ class ConfirmSpine:
             # on that one" — a silent loop.
             with self._lock:
                 self._in_flight.discard(token)
+
+    @staticmethod
+    def _cancel_refusal(refusal: Verdict) -> Verdict:
+        """Re-key a shared-claim refusal for the CANCEL caller.
+
+        The claim is shared so the two paths cannot drift, but its spoken lines
+        are written for a confirm, and two of them argue for exactly the thing
+        the owner just retracted: ``no_proposal`` says *"Tell me again what
+        you'd like sent"* and ``expired`` says *"Ask me again and I'll set it up
+        fresh"*. Answering a cancel with either is the system pressing for the
+        write — in a screenless channel, with no way to see that it is
+        answering the wrong question.
+
+        The two COLLAPSE into one outcome deliberately, and that is consistent
+        with the taxonomy rule rather than an exception to it: outcomes are kept
+        apart when the owner's next move differs, and here both mean "there is
+        nothing of mine to take back", whose next move is the same — none.
+
+        ``replayed`` and ``dispatch_failed`` pass through unchanged: both are
+        true of a cancel, and neither invites a re-propose ("I already did that
+        one" / "check that session before asking me again").
+        """
+        if refusal.reason in ("no_proposal", "expired"):
+            return Verdict(approved=False, reason="nothing_to_cancel")
+        return refusal
 
     # -- internals ----------------------------------------------------------
 
@@ -1853,10 +1975,11 @@ class ConfirmSpine:
             )
             if entry.speech_started_seq <= ceiling
         ]
-        # `_denies`, not `carries_denial`: the buddy's own spoken line echoing
-        # back through the un-echo-cancelled fallback channel is not the owner
-        # changing their mind (#992). See :func:`is_buddy_echo` for why the
-        # discriminator is content rather than "was the robot talking".
+        # The echo guard, not `carries_denial` alone: the buddy's own spoken
+        # line echoing back through the un-echo-cancelled fallback channel is
+        # not the owner changing their mind (#992). See :func:`is_buddy_echo`
+        # for why the discriminator is content rather than "was the robot
+        # talking", and the judge loop above for the second site it needs.
         if any(
             carries_denial(entry.text) and not is_buddy_echo(entry.text)
             for entry in later

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1854,8 +1854,32 @@ class ConfirmSpine:
           confirm-shaped advice to re-propose the write just retracted.
         """
         with self._lock:
+            # THE RECORDED OUTCOME OUTRANKS EVERY IN-PROGRESS MARKER, and the
+            # order of these three tests is the whole of it.
+            #
+            # `_succeeded`/`_failed` are facts about the WRITE; `_dispatching`
+            # and `_in_flight` are facts about the ATTEMPT, and only the first
+            # kind can contradict a spoken claim about sending. That rule was
+            # stated one round ago and applied against `_in_flight` alone,
+            # which left the identical hole on the other marker: a confirm adds
+            # `_failed` and only THEN clears `_dispatching`, so in between, a
+            # cancel testing the marker first was told "Too late to stop that
+            # one — it's already going out … we can undo it from there" about a
+            # dispatch already recorded as FAILED. Two definite claims, about
+            # the one outcome the system has established it CANNOT characterise
+            # (see `dispatch_failed`'s line: "I can't tell whether it took
+            # effect"). A rule enforced against one of two markers is not a
+            # rule; it is a fix at the site that happened to break.
+            #
+            # Hoisting costs nothing where `cancel_in_flight` is right: mid-
+            # runner NEITHER terminal fact is set, so it still wins there.
+            if token in self._succeeded:
+                return Verdict(approved=False, reason="replayed")
+            if token in self._failed:
+                return Verdict(approved=False, reason="dispatch_failed")
             if token in self._dispatching:
-                # The ONE true "too late": the argv is inside the runner.
+                # The ONE true "too late": the argv is inside the runner, and
+                # no outcome has been recorded for it yet.
                 #
                 # Nothing is popped or marked here, and that is deliberate
                 # rather than an omission: `_dispatch` popped the proposal
@@ -1867,22 +1891,6 @@ class ConfirmSpine:
                 # looked like they were buying — no cancel outcome leaves a
                 # live proposal — is real, and is pinned as a property.
                 return Verdict(approved=False, reason="cancel_in_flight")
-            # THE TERMINAL FACTS OUTRANK THE CLAIM, and getting that order
-            # wrong was the same over-claim in a third window — found by the
-            # lock-hold sweep rather than by reading.
-            #
-            # A confirm records its result and only THEN unwinds the claim, so
-            # between `_succeeded.add` and `_in_flight.discard` a token is both
-            # "written" and "claimed". Testing `_in_flight` first answered a
-            # cancel there with `cancelled` — "I haven't sent anything" — about
-            # a write that had already gone out. These two sets answer
-            # different questions: `_succeeded`/`_failed` are facts about the
-            # WRITE, `_in_flight` is a fact about the ATTEMPT, and only the
-            # first kind can contradict a spoken claim about sending.
-            if token in self._succeeded:
-                return Verdict(approved=False, reason="replayed")
-            if token in self._failed:
-                return Verdict(approved=False, reason="dispatch_failed")
             if token in self._in_flight:
                 # A confirm holds the claim, has not reached the runner, and
                 # has not recorded a result. Nothing has been sent, so the

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1247,6 +1247,19 @@ SPOKEN = {
         "Hang on — I'm already working on that one. "
         "I'll tell you how it went in a moment; don't repeat it yet."
     ),
+    # A CANCEL that lost the race to a confirm already inside the runner
+    # (#990). It must not say "I haven't sent it" — that is the over-claim
+    # `in_flight` is worded to avoid, and here it would be worse, because the
+    # owner asked for exactly that outcome and would hear it granted.
+    #
+    # It must also not tell them to wait and stop there: the one thing they
+    # tried to do is the one thing that is no longer available, so the line
+    # names the uncertainty AND the move that is still open (undo it after the
+    # fact, from the recipient's side), which is what "wait" alone would hide.
+    "cancel_in_flight": (
+        "Too late to stop that one — it's already going out. Don't repeat it; "
+        "I'll tell you how it went in a moment and we can undo it from there."
+    ),
     "too_many_attempts": (
         "I've got that wrong too many times, so I've dropped it. Ask me again from the top."
     ),
@@ -1269,13 +1282,99 @@ SPOKEN = {
     ),
 }
 
+#: How many tokens of the buddy's own line an utterance must reproduce, VERBATIM
+#: and CONTIGUOUSLY, before :func:`is_buddy_echo` will call it an echo.
+#:
+#: This number is the entire false-reject budget of that rule, so it is chosen
+#: against the collision rather than for tidiness. The denial triggers that
+#: appear in :data:`SPOKEN` are short and ordinary — ``hold off``, ``hang on``,
+#: ``dont`` — and they are exactly what a real owner says to retract. At two or
+#: three tokens the rule would suppress a genuine "hold off" spoken over the
+#: browser voice, and a suppressed retraction WRITES.
+#:
+#: Six tokens is past the point where a human utters a machine's sentence word
+#: for word by coincidence: it takes ``hang on im already working on`` rather
+#: than ``hang on``.
+_ECHO_MIN_TOKENS = 6
+
+
+def is_buddy_echo(text: str) -> bool:
+    """Is *text* the buddy's own voice coming back through the microphone?
+
+    ``speechSynthesis`` is outside the WebRTC path, so ``echoCancellation`` does
+    not cover the fallback voice: what it says re-enters the mic and lands in
+    the USER transcript. Approval is safe from that by construction — the
+    fallback channel never carries a nonce (#953) — but :func:`carries_denial`
+    is not nonce-gated, and several :data:`SPOKEN` lines CONTAIN denial
+    triggers ("I heard you hold off…", "Hang on — I'm already working on that
+    one", "I don't have anything pending…"). Echoed inside the approval→confirm
+    window, one of those retroactively denies the owner's own approval and
+    reports a take-back they never spoke (#992).
+
+    **The discriminator is content, not timing, and that choice is the whole
+    decision.** The obvious rule — "utterances transcribed while the fallback
+    voice is speaking do not count as denials" — is unusable here: barge-in over
+    the robot voice is the NORMAL way to retract in this channel, so that rule
+    drops genuine take-backs and the write goes out. That is the acting-twice
+    direction, which is strictly worse than the wrongful refusal it fixes (one
+    utterance to recover, via the newest-first binding in
+    :meth:`ConfirmSpine._judge`). A content rule has no such cost: it cannot
+    fire on words the buddy never said.
+
+    Two properties keep it on the safe side:
+
+    - **The WHOLE utterance must be the echo.** A barge-in captured together
+      with the tail of the buddy's line ("hang on im already working on that one
+      no stop") is not a contiguous run of that line, so it denies. Only a clean
+      capture of the machine's own words is suppressed.
+    - **The enumeration fails CLOSED.** A short or garbled echo — the
+      transcriber catching three words of it — misses :data:`_ECHO_MIN_TOKENS`
+      and denies, costing one re-spoken approval. Nothing about being
+      incomplete here can make a write happen.
+
+    **What it does NOT cover, stated rather than implied.** :data:`SPOKEN` is
+    the buddy's own taxonomy, so this covers only what THIS module makes it
+    say. Attacker-influenceable text (a delivered message body, spoken verbatim
+    by ``composeNotice``) is not in it. That text cannot reach this window
+    today for a separate reason — ``client.py``'s ``canSpeak``/``canInterrupt``
+    both require ``!confirmGate.outstanding()``, and the gate is closed from the
+    moment a proposal is spoken until its terminal outcome or TTL, which is
+    exactly the approval→confirm window. If that gate is ever relaxed, this
+    function needs the spoken text fed to it rather than read from
+    :data:`SPOKEN`, and the ``said-during-fallback`` mark stays the wrong
+    instrument for the reason above.
+    """
+    tokens = normalize(text).split()
+    if len(tokens) < _ECHO_MIN_TOKENS:
+        return False
+    return any(_contains_run(normalize(line).split(), tokens) for line in SPOKEN.values())
+
+
+def _contains_run(haystack: "list[str]", needle: "list[str]") -> bool:
+    """Does *needle* appear in *haystack* as a contiguous run?"""
+    if not needle or len(needle) > len(haystack):
+        return False
+    first = needle[0]
+    span = len(needle)
+    for index, token in enumerate(haystack):
+        if token == first and haystack[index:index + span] == needle:
+            return True
+    return False
+
+
 #: Outcomes whose correct owner response is to WAIT rather than to speak again.
 #: Named so the persona and the tests can both reason about it.
 #: ``in_flight`` belongs here on both counts the flag drives: the owner's
 #: correct move is to wait, and ``confirm_terminal`` must stay False — closing
 #: the gate on a duplicate would close it out from under the confirm that is
 #: actually running.
-WAIT_OUTCOMES = frozenset({"pending_transcript", "not_announced", "in_flight"})
+#: ``cancel_in_flight`` belongs here for the same two reasons ``in_flight``
+#: does: the owner's correct move is to wait for the real outcome, and
+#: ``confirm_terminal`` must stay False — a cancel that lost the race must not
+#: close the handshake out from under the confirm that is still running.
+WAIT_OUTCOMES = frozenset(
+    {"pending_transcript", "not_announced", "in_flight", "cancel_in_flight"}
+)
 
 #: Every reason :class:`ConfirmSpine` can return. The SSOT for the taxonomy.
 #:
@@ -1291,6 +1390,7 @@ REASONS = frozenset(
         "no_proposal", "expired", "not_announced", "replayed", "refused",
         "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
         "too_many_attempts", "dispatch_failed", "in_flight",
+        "cancel_in_flight",
     }
 )
 
@@ -1524,18 +1624,23 @@ class ConfirmSpine:
         # verdict. The widened `found` seqs are subsumed, since high_seq
         # advances on every ring event.
         #
-        # THE PRICE, stated at its true size. It is not "one pending_transcript
-        # wait": `unheard_between` has no staleness bound, so an utterance that
-        # never completes — a cough, a VAD blip, TTS bleed, any speech_started
-        # with no transcript to follow — sits in this window and refuses every
-        # confirm until the TTL expires it. And it refuses as a WAIT outcome,
-        # so no attempt is burned, `too_many_attempts` never fires, and the
-        # owner hears "give me a second" for up to 120s and then "that one
-        # expired" — a spoken loop, which in a screenless channel is the
-        # expensive failure. The bound belongs in TranscriptRing (age the
-        # entry, or cap the wait), NOT here: this function cannot tell a
-        # never-completing entry from a slow one without reading the ring's
-        # own clock. Pinned in the tests as a residual, not as a design.
+        # THE PRICE, and it is now bounded rather than open-ended (#989). The
+        # widened window used to cost more than "one pending_transcript wait":
+        # any speech_started with no transcript to follow — a cough, a VAD blip,
+        # TTS bleed — sat here refusing every confirm as a WAIT outcome, so no
+        # attempt was burned, `too_many_attempts` never fired, and the owner
+        # heard "give me a second" for up to the whole TTL and then "that one
+        # expired". A spoken loop, which in a screenless channel is the
+        # expensive failure.
+        #
+        # The bound lives in TranscriptRing, not here, and that division is the
+        # same one as before: this function cannot tell a never-completing entry
+        # from a slow one without the ring's clock. What the ring adds is two
+        # bounds rather than one — `transcribed` retires the cough (an EMPTY
+        # transcript is an answer, not a wait) and the commit splits the rest
+        # into "the audio closed, so ASR is overdue" and "the owner may still be
+        # speaking". See transcript.unheard_between; the two-shape argument is
+        # in that module's docstring rather than duplicated here.
         ceiling = max(self._ring.high_seq, anchor)
         found = self._ring.await_utterance_after(anchor, self._wait_s)
         ceiling = max(ceiling, self._ring.high_seq)
@@ -1607,10 +1712,55 @@ class ConfirmSpine:
         return verdict
 
     def cancel(self, token: str) -> Verdict:
-        """Retire a proposal without writing. Never gated — refusing is free."""
-        with self._lock:
-            self._proposals.pop(token, None)
-        return Verdict(approved=False, reason="denied")
+        """Retire a proposal without writing — through the SAME claim (#990).
+
+        "Never gated, because refusing is free" was true of the refusal and
+        false of the SENTENCE. This used to pop whatever it found and say *"I
+        heard you hold off, so I haven't sent it"* — including while a confirm
+        holding the same token was inside the runner. That is the over-claim
+        :data:`SPOKEN`'s ``in_flight`` line is deliberately worded to avoid, on
+        the sibling path: the owner hears an affirmative "nothing was sent",
+        with no screen to discover otherwise. #987 made confirm-vs-confirm safe
+        by construction and stopped there; cancel-vs-in-flight-confirm is the
+        same shape.
+
+        So the claim is taken here too, and the outcomes it produces are all
+        honest ones: ``cancel_in_flight`` while a confirm owns the token,
+        ``replayed`` / ``dispatch_failed`` once the write has actually been
+        attempted, ``expired`` / ``no_proposal`` when there is nothing to drop.
+
+        **The false-reject half, priced.** A cancel refused for the wrong reason
+        is a proposal the owner believes is dead and the buddy still holds, so:
+
+        - the announcement requirement is DROPPED (``require_announced=False``).
+          A cancel of a proposal the buddy has not finished speaking must
+          succeed — refusing it with ``not_announced`` would leave the proposal
+          live for its full TTL over a technicality about who was talking.
+        - ``cancel_in_flight`` is a WAIT outcome with its own spoken line, and
+          that line has to say what happens next, because the one thing the
+          owner cannot do is take it back: the write is already going out and
+          its real outcome is seconds away.
+        """
+        proposal, refusal = self._claim(token, require_announced=False)
+        if refusal is not None:
+            if refusal.reason == "in_flight":
+                # Same race, different question. `in_flight` answers "should I
+                # confirm again?" (no, wait); this answers "did you stop it?"
+                # (no, and here is why), and collapsing them would tell the
+                # owner to wait for an outcome they asked to prevent without
+                # ever saying it could not be prevented.
+                return Verdict(approved=False, reason="cancel_in_flight")
+            return refusal
+        try:
+            with self._lock:
+                self._proposals.pop(token, None)
+            return Verdict(approved=False, reason="denied")
+        finally:
+            # Same discipline as confirm: released on every exit, or the token
+            # is wedged for its TTL answering every retry with "still working
+            # on that one" — a silent loop.
+            with self._lock:
+                self._in_flight.discard(token)
 
     # -- internals ----------------------------------------------------------
 
@@ -1644,6 +1794,13 @@ class ConfirmSpine:
         quoted = None
         for entry in reversed(usable):
             outcome = classify(entry.text, proposal.nonce)
+            if outcome == DENIED and is_buddy_echo(entry.text):
+                # Our own refusal line, back through the mic (#992). Skipped
+                # rather than treated as a denial — and skipped HERE as well as
+                # in the post-approval scan below, because an echo landing after
+                # the approval is the newest entry, so this loop would return
+                # `denied` before the scan was ever reached.
+                continue
             if outcome == DENIED:
                 # An explicit take-back wins immediately, and is a DIFFERENT
                 # refusal from "that wasn't the phrase" — the owner should stop,
@@ -1696,7 +1853,14 @@ class ConfirmSpine:
             )
             if entry.speech_started_seq <= ceiling
         ]
-        if any(carries_denial(entry.text) for entry in later):
+        # `_denies`, not `carries_denial`: the buddy's own spoken line echoing
+        # back through the un-echo-cancelled fallback channel is not the owner
+        # changing their mind (#992). See :func:`is_buddy_echo` for why the
+        # discriminator is content rather than "was the robot talking".
+        if any(
+            carries_denial(entry.text) and not is_buddy_echo(entry.text)
+            for entry in later
+        ):
             return Verdict(approved=False, reason="denied", utterance=match.text)
 
         # And the same window may hold an utterance the owner has SPOKEN whose
@@ -1721,8 +1885,17 @@ class ConfirmSpine:
             acted_session=proposal.session,
         )
 
-    def _claim(self, token: str) -> "tuple[Proposal | None, Verdict | None]":
+    def _claim(
+        self, token: str, *, require_announced: bool = True
+    ) -> "tuple[Proposal | None, Verdict | None]":
         """Take exclusive ownership of *token*, or say why not.
+
+        ``require_announced=False`` is :meth:`cancel`'s (#990). Every other
+        check applies to both callers — one claim, so the cancel path cannot
+        drift away from the confirm path — but "the buddy has not finished
+        saying it yet" is a reason to refuse a CONFIRM (the owner cannot have
+        approved what they have not heard) and not a reason to refuse a
+        RETRACTION, which needs no announcement to be meant.
 
         **Single use is a property of this method, not of the timing.** The
         proposal used to be consumed at the far side of the await and the
@@ -1760,7 +1933,7 @@ class ConfirmSpine:
             self._expire_locked()
             if proposal is None:
                 return None, Verdict(approved=False, reason="no_proposal")
-            if not proposal.announced:
+            if require_announced and not proposal.announced:
                 return None, Verdict(approved=False, reason="not_announced")
             self._in_flight.add(token)
             return proposal, None
@@ -1804,6 +1977,7 @@ __all__ = [
     "WRONG_NONCE",
     "carries_denial",
     "classify",
+    "is_buddy_echo",
     "matches_nonce",
     "mint_nonce",
     "normalize",

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1232,10 +1232,29 @@ SPOKEN = {
     ),
     # Covers "no" AND "wait"/"hold on", so it must not assert the owner said
     # the word "no" — a reason that misinforms is the defect §3.4 is about.
+    #
+    # "Say the phrase again" is TRUE HERE and only here: an in-band denial
+    # leaves the proposal LIVE, so the nonce still works. It is false on the
+    # retraction paths, which pop — hence `cancelled` below rather than one
+    # line stretched over two different next moves.
     "denied": (
         "I heard you hold off, so I haven't sent it. "
         "Say the phrase again when you're ready."
     ),
+    # An explicit retraction that RETIRED the proposal: `cancel`, and the
+    # confirm barrier that finds a cancel already recorded.
+    #
+    # Split from `denied` for the reason the taxonomy exists — the owner's next
+    # move differs. `denied`'s advice is "say the phrase again", and following
+    # it here lands on `no_proposal` ("Tell me again what you'd like sent") one
+    # turn later: advice that cannot work, pointing at the exact line
+    # `_cancel_refusal` was built to keep off this path.
+    #
+    # A pure stand-down, and that is the whole content: the owner asked for
+    # this, so nothing further is required of them. It deliberately does NOT
+    # offer to set it up again — pressing for the write just retracted is the
+    # same defect from the other side.
+    "cancelled": "Okay — I've dropped that one, so I haven't sent anything.",
     "pending_transcript": (
         "Give me a second — I'm still catching up on what you said. Don't repeat it yet."
     ),
@@ -1311,6 +1330,13 @@ SPOKEN = {
 #: Six tokens is past the point where a human utters a machine's sentence word
 #: for word by coincidence: it takes ``hang on im already working on`` rather
 #: than ``hang on``.
+#:
+#: **Guarded from BELOW only, and that asymmetry is deliberate.** Lowering this
+#: is what the tests forbid, because it suppresses a real retraction and a
+#: suppressed retraction WRITES. Raising it is the fail-closed direction — a
+#: genuine echo stops being recognised, denies, and costs one re-spoken
+#: approval — so nothing pins it from above. Do not read the pins as saying 6
+#: is optimal in both directions; they say it is a FLOOR.
 _ECHO_MIN_TOKENS = 6
 
 
@@ -1406,7 +1432,7 @@ REASONS = frozenset(
         "no_proposal", "expired", "not_announced", "replayed", "refused",
         "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
         "too_many_attempts", "dispatch_failed", "in_flight",
-        "cancel_in_flight", "nothing_to_cancel",
+        "cancel_in_flight", "nothing_to_cancel", "cancelled",
     }
 )
 
@@ -1704,9 +1730,13 @@ class ConfirmSpine:
         # nothing was acted on, so nothing was consumed.
         with self._lock:
             if token in self._cancelled:
-                self._proposals.pop(token, None)
+                # No pop here, deliberately: every writer of `_cancelled` pops
+                # in the same lock hold, so this could never be the removing
+                # one — an unreachable write that reads as a guarantee on the
+                # next pass, which is what this module objects to two branches
+                # away in `cancel`.
                 return Verdict(
-                    approved=False, reason="denied", utterance=verdict.utterance
+                    approved=False, reason="cancelled", utterance=verdict.utterance
                 )
             self._dispatching.add(token)
 
@@ -1837,12 +1867,29 @@ class ConfirmSpine:
                 # looked like they were buying — no cancel outcome leaves a
                 # live proposal — is real, and is pinned as a property.
                 return Verdict(approved=False, reason="cancel_in_flight")
+            # THE TERMINAL FACTS OUTRANK THE CLAIM, and getting that order
+            # wrong was the same over-claim in a third window — found by the
+            # lock-hold sweep rather than by reading.
+            #
+            # A confirm records its result and only THEN unwinds the claim, so
+            # between `_succeeded.add` and `_in_flight.discard` a token is both
+            # "written" and "claimed". Testing `_in_flight` first answered a
+            # cancel there with `cancelled` — "I haven't sent anything" — about
+            # a write that had already gone out. These two sets answer
+            # different questions: `_succeeded`/`_failed` are facts about the
+            # WRITE, `_in_flight` is a fact about the ATTEMPT, and only the
+            # first kind can contradict a spoken claim about sending.
+            if token in self._succeeded:
+                return Verdict(approved=False, reason="replayed")
+            if token in self._failed:
+                return Verdict(approved=False, reason="dispatch_failed")
             if token in self._in_flight:
-                # A confirm holds the claim but has not reached the runner.
-                # Nothing has been sent, so the cancel is simply honoured.
+                # A confirm holds the claim, has not reached the runner, and
+                # has not recorded a result. Nothing has been sent, so the
+                # cancel is simply honoured.
                 self._cancelled.add(token)
                 self._proposals.pop(token, None)
-                return Verdict(approved=False, reason="denied")
+                return Verdict(approved=False, reason="cancelled")
 
         proposal, refusal = self._claim(token, require_announced=False)
         if refusal is not None:
@@ -1851,7 +1898,7 @@ class ConfirmSpine:
             with self._lock:
                 self._cancelled.add(token)
                 self._proposals.pop(token, None)
-            return Verdict(approved=False, reason="denied")
+            return Verdict(approved=False, reason="cancelled")
         finally:
             # Same discipline as confirm: released on every exit, or the token
             # is wedged for its TTL answering every retry with "still working

--- a/agentwire/voice_layer/transcript.py
+++ b/agentwire/voice_layer/transcript.py
@@ -65,6 +65,40 @@ Failing closed there is deliberate — if the ``speech_started`` events stopped
 arriving, confirms stop working loudly rather than silently losing their
 ordering guarantee.
 
+Two shapes hide under "the transcript never came", and only one needs a clock
+---------------------------------------------------------------------------
+
+:meth:`TranscriptRing.unheard_between` is the denial half of the timing
+asymmetry: an utterance whose ``speech_started`` was recorded but whose
+transcript has not landed holds the gate at ``pending_transcript``. Left
+unbounded, one such entry refuses every confirm for a proposal's whole TTL
+(#989). The obvious repair — a flat wall-clock age — is wrong, because the name
+covers two failures with opposite prices:
+
+**1. Transcribed, but empty.** A cough that the transcription model renders as
+``""`` produced a transcript EVENT; ``complete`` is False only because the text
+is blank. This needs no clock at all. The gate's question is "did the owner say
+something we cannot yet read", and an empty transcript positively answers it:
+they said nothing readable, so there is no denial hiding in it. Hence
+:attr:`Utterance.transcribed` — a transcript ARRIVED — which is what this method
+filters on. ``complete`` still gates :meth:`TranscriptRing.after`, where the
+question is different (can this text approve), and an empty utterance answers
+that one no.
+
+**2. Never transcribed at all.** Here there genuinely is an unread utterance and
+only time can retire it — and the bound must key on whether the audio buffer
+CLOSED, not on age alone. With a ``commit_seq`` the utterance is over and the
+transcript is simply overdue: a few seconds of ASR latency is the whole budget
+(:data:`UNHEARD_COMMITTED_GRACE_S`). Without one the owner may still be
+speaking, and the bound has to exceed a plausible utterance
+(:data:`UNHEARD_OPEN_UTTERANCE_S`) or the gate stops waiting for a take-back the
+owner is in the middle of saying — the acting-twice direction, not a wait.
+
+**One flat age cannot price both.** Set to the committed grace it truncates a
+long spoken denial; set to the open bound it leaves a cough holding the gate for
+a minute. That is why there are two constants and why the split is on the commit
+rather than on the age.
+
 Thread safety
 -------------
 
@@ -87,6 +121,35 @@ from dataclasses import dataclass
 #: persisted, deliberately.
 DEFAULT_CAPACITY = 32
 
+#: How long a COMMITTED utterance with no transcript keeps holding the gate.
+#:
+#: The audio buffer closed, so the utterance is over and the only thing missing
+#: is the transcription pass. :data:`~agentwire.voice_layer.confirm.APPROVAL_WAIT_S`
+#: (2.5s) is what an ordinary short-utterance transcript costs, so this is that
+#: with room for a slow one — past it, the transcript is not late, it is not
+#: coming.
+#:
+#: **Both halves, and they are not symmetric.** Too tight: a genuinely slow
+#: transcriber's denial is dropped from the window and the write goes out with a
+#: take-back mid-transcription — acting twice. Too loose: the confirm loops on
+#: "give me a second" for that long, recoverable by waiting. So the false-accept
+#: half is the expensive one here and the number leans generous.
+UNHEARD_COMMITTED_GRACE_S = 10.0
+
+#: How long an OPEN utterance — ``speech_started`` with no commit — keeps
+#: holding the gate.
+#:
+#: No commit means the owner may still be talking, so this bound is not an ASR
+#: latency at all: it has to exceed a plausible spoken utterance, or the gate
+#: stops waiting for a retraction the owner is halfway through. It also covers
+#: the case where the commit event itself was lost.
+#:
+#: Deliberately well under
+#: :data:`~agentwire.voice_layer.confirm.PROPOSAL_TTL_S` (120s): the failure
+#: being closed is a proposal that loops for its whole TTL, so a bound that
+#: approaches the TTL closes nothing.
+UNHEARD_OPEN_UTTERANCE_S = 60.0
+
 
 @dataclass
 class Utterance:
@@ -102,6 +165,12 @@ class Utterance:
 
     ``spent`` marks an entry already used to approve something, so one approval
     cannot satisfy a second proposal — the "acting twice" failure §4 names.
+
+    ``transcribed`` and ``complete`` answer DIFFERENT questions and the
+    difference is the whole of #989's first shape: ``transcribed`` is "a
+    transcript event arrived", ``complete`` is "there are words in it". A cough
+    the model renders as ``""`` is transcribed and not complete, and treating
+    those as one thing is what left it holding the gate forever.
     """
 
     item_id: str
@@ -111,6 +180,14 @@ class Utterance:
     estimated: bool = False
     spent: bool = False
     received_at: float = 0.0
+    #: A transcript event ARRIVED for this item — even an empty one. Never
+    #: derived from ``text``: the empty rendering is exactly the case that has
+    #: to be distinguishable from "nothing came back yet".
+    transcribed: bool = False
+    #: When the audio buffer closed, on the ring's clock. 0 means it has not.
+    #: Read only by the staleness bound; the ORDERING still never touches the
+    #: commit (see the module docstring).
+    committed_at: float = 0.0
 
     @property
     def complete(self) -> bool:
@@ -172,6 +249,7 @@ class TranscriptRing:
                 self._append(entry)
             if not entry.commit_seq:
                 entry.commit_seq = seq
+                entry.committed_at = self._clock()
             return entry
 
     def transcribe(self, item_id: str, text: str, seq: int = 0) -> Utterance:
@@ -194,6 +272,11 @@ class TranscriptRing:
             if not entry.speech_started_seq:
                 entry.estimated = True
             entry.text = text
+            # Recorded even for ``""``. The transcription model rendering an
+            # utterance as empty is an ANSWER — "nothing readable was said" —
+            # and the gate's unheard window has to be able to tell it from
+            # silence on the wire (#989). See :attr:`Utterance.transcribed`.
+            entry.transcribed = True
             self._condition.notify_all()
             return entry
 
@@ -286,7 +369,7 @@ class TranscriptRing:
                 self._condition.wait(remaining)
 
     def unheard_between(self, after: int, ceiling: int) -> list[Utterance]:
-        """Ordered utterances in ``(after, ceiling]`` with NO transcript yet.
+        """Ordered utterances in ``(after, ceiling]`` still awaiting a transcript.
 
         The denial half of the timing asymmetry the bounded await fixes for
         approvals. An utterance whose ``speech_started`` was recorded but whose
@@ -295,15 +378,39 @@ class TranscriptRing:
         transcribed did not block the write. The system already KNOWS the owner
         spoke again (the sequence advanced); it just cannot yet say what they
         said. That is ``pending_transcript``, never approval.
+
+        **Bounded on two axes, because "no transcript" is two failures** — see
+        the module docstring. An entry whose transcript ARRIVED is out of this
+        window whatever it says, including ``""``; an entry whose transcript
+        never arrives ages out on :data:`UNHEARD_COMMITTED_GRACE_S` once the
+        audio buffer closed, and on :data:`UNHEARD_OPEN_UTTERANCE_S` while it
+        has not. Ageing out is not a ruling that nothing was said — it is this
+        method ceasing to be able to say otherwise, which is why the bounds sit
+        where a real utterance cannot plausibly still be arriving.
         """
         with self._condition:
+            now = self._clock()
             return [
                 u
                 for u in self._items
-                if not u.complete
+                if not u.transcribed
                 and u.speech_started_seq > after
                 and u.speech_started_seq <= ceiling
+                and not self._aged_out(u, now)
             ]
+
+    def _aged_out(self, entry: Utterance, now: float) -> bool:
+        """Has *entry*'s missing transcript stopped being worth waiting for?
+
+        The commit is what splits the two bounds, and it is the one read of
+        ``commit_seq`` in this module that is not purely for inspection — it
+        says the utterance is OVER, which is what makes a missing transcript
+        overdue rather than merely pending. It still never orders anything.
+        """
+        if entry.commit_seq:
+            started = entry.committed_at or entry.received_at
+            return now - started >= UNHEARD_COMMITTED_GRACE_S
+        return now - entry.received_at >= UNHEARD_OPEN_UTTERANCE_S
 
     def snapshot(self) -> list[Utterance]:
         with self._condition:

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -565,13 +565,22 @@ Three things make the shared claim correct rather than merely shared:
   refactor. Pinned by sweeping *every* observable lock boundary rather than the
   one that happens to be the barrier today, so moving it does not silence the
   test.
-- **The terminal facts outrank the claim.** A confirm records its result and
-  only *then* unwinds, so between `_succeeded.add` and `_in_flight.discard` a
-  token is both written and claimed. Testing `_in_flight` first answered a cancel
-  there with "I haven't sent anything" about a write that had gone out — a third
-  window, found by the lock sweep rather than by reading. `_succeeded`/`_failed`
-  are facts about the WRITE; `_in_flight` is a fact about the ATTEMPT, and only
-  the first kind can contradict a spoken claim about sending.
+- **The recorded outcome outranks EVERY in-progress marker**, and it took two
+  goes to get that right. A confirm records its result and only *then* unwinds,
+  so a token sits in `_succeeded`/`_failed` while still marked. Testing
+  `_in_flight` first answered a cancel there with "I haven't sent anything"
+  about a write that had gone out — the third window. The rule that fixed it —
+  `_succeeded`/`_failed` are facts about the WRITE, `_in_flight` and
+  `_dispatching` are facts about the ATTEMPT, and only the first kind can
+  contradict a spoken claim about sending — was then applied against
+  `_in_flight` **and not against `_dispatching`**, leaving the identical hole on
+  the other marker: between `_failed.add` and `_dispatching.discard`, a cancel
+  was told *"Too late to stop that one — it's already going out … we can undo it
+  from there"* about a dispatch already recorded as FAILED. Two definite claims,
+  about the one outcome `dispatch_failed` exists to say cannot be characterised.
+  Both terminal checks now sit above both markers, and the property is pinned as
+  the cross-product rather than at either site. **A rule enforced against one of
+  two markers is not a rule.**
 - **A cancel is never answered with confirm-shaped advice.** The claim is
   shared so the two paths cannot drift, but two of its lines argue for the very
   write just retracted — `no_proposal` says *"Tell me again what you'd like

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -542,11 +542,34 @@ an affirmative "nothing was sent" the owner has no way to check.
 
 Three things make the shared claim correct rather than merely shared:
 
+- **"A confirm holds the claim" is not "the write is going out",** and the
+  first fix for this re-committed the original defect by conflating them. The
+  claim is taken at the TOP of `confirm()`, *before* the ≤2.5s await and the
+  judge, so its dominant occupant is a confirm still DECIDING — and telling a
+  cancel there "it's already going out" is false, while leaving the proposal
+  the owner asked to drop still pending. The race is therefore split on the
+  thing the sentence is about: `_dispatching` (inside the runner — the only
+  state in which the claim is true) versus `_cancelled` (a cancel during the
+  await WINS; it answers `denied`, and the confirm re-reads the marker under
+  the same lock immediately before dispatch, so the write does not go out
+  behind the retraction).
 - The losing cancel gets its **own** outcome, `cancel_in_flight`, not
   `in_flight`. They answer different questions — "should I confirm again?"
   (no, wait) versus "did you stop it?" (no, and here is why) — and its spoken
   line names the move that is still open, because the one thing the owner asked
   for is the one thing no longer available.
+- **A cancel is never answered with confirm-shaped advice.** The claim is
+  shared so the two paths cannot drift, but two of its lines argue for the very
+  write just retracted — `no_proposal` says *"Tell me again what you'd like
+  sent"* and `expired` says *"Ask me again and I'll set it up fresh"*. On the
+  cancel path both become `nothing_to_cancel`. Collapsing them is consistent
+  with the taxonomy rule rather than an exception to it: outcomes stay apart
+  when the owner's next move differs, and here both mean "there is nothing of
+  mine to take back", whose next move is none. `replayed` and `dispatch_failed`
+  pass through unchanged — both are true of a cancel and neither invites a
+  re-propose.
+- **No cancel outcome leaves a live proposal behind**, pinned as a property
+  over every reachable one rather than at the site that used to break it.
 - It is a **wait** outcome, so `confirm_terminal` stays False: closing the
   handshake here would close it out from under the confirm still running.
 - The announcement requirement is **dropped** (`require_announced=False`). "The
@@ -806,7 +829,8 @@ the set `SPOKEN` is checked against **both ways**:
 | `denied` | say the phrase again when you're ready |
 | `pending_transcript` | **wait** |
 | `in_flight` | **wait** — that confirm is already running |
-| `cancel_in_flight` | **wait** — the cancel lost the race; it is already going out |
+| `cancel_in_flight` | **wait** — the cancel lost the race *to the runner*; it is already going out |
+| `nothing_to_cancel` | nothing — there was nothing of ours left to take back |
 | `too_many_attempts` | ask again from the top; that proposal is gone |
 | `dispatch_failed` | check that session, *then* decide — it may have gone out |
 
@@ -868,18 +892,23 @@ nonce in it — an echo of the fallback cannot carry an approval, structurally.
 `WriteSpec.__post_init__` raises at import on a `fallback_template` containing
 `{phrase}` or `{nonce}`, so the property is enforced rather than remembered.
 
-**That closes the approval direction only, and the denial direction is open
-(#992).** `carries_denial` is not nonce-gated, and the fallback voice also speaks
-inbox notices, re-raises and error notices — whose text is a message BODY any
-session can send. So a delivered body containing "no, stop, don't", echoed during
-the approval→confirm window, lands in the post-approval scan and retroactively
-denies the owner's legitimate approval: remotely triggerable, and invisible to
-the owner, who hears "I heard you hold off" about a take-back they never spoke.
-The obvious fixes (mark ring entries transcribed during fallback speech, or
-suppress the scan window) both end in `_judge`, and both have an expensive
-false-reject half — barge-in over the robot voice is the normal case here, so
-"utterances during fallback speech do not count as denials" drops a genuine
-take-back and the write goes out. Open, and priced rather than assumed.
+**That closes the approval direction structurally. The denial direction needed
+its own answer, and it is now CLOSED (#992)** — see [The buddy's own voice
+cannot deny](#the-buddys-own-voice-cannot-deny-992) for the rule and its price.
+The failure: `carries_denial` is not nonce-gated, and several `SPOKEN` lines
+carry denial triggers, so one echoed into the approval→confirm window
+retroactively denied the owner's legitimate approval — invisible to them, who
+heard "I heard you hold off" about a take-back they never spoke.
+
+**Both mitigations originally proposed were REJECTED, and the reason is the
+transferable part.** Marking ring entries transcribed during fallback speech,
+and suppressing the scan window, are both TIMING rules — and barge-in over the
+robot voice is the normal way to retract in this channel, so "utterances during
+fallback speech do not count as denials" drops a genuine take-back and the write
+goes out. That is the acting-twice direction, strictly worse than the wrongful
+refusal being fixed. The shipped rule is CONTENT (`confirm.is_buddy_echo`): it
+cannot fire on words the buddy never said, so it has no such half. Do not
+reintroduce a timing rule here without pricing that.
 
 **The `speechSynthesis` fallback is armed by a timer, not triggered by a
 detected failure**, and that is the part that decides whether this property is

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -533,11 +533,29 @@ each `response.done` spawns its own async IIFE and the bridge is a
 `ThreadingHTTPServer`, so the sequencing that made it safe was nowhere in the
 code.
 
-**`cancel()` does not go through `_claim()`, and that is an open residual**
-(#990): a cancel racing a dispatching confirm pops the proposal and says *"I
-heard you hold off, so I haven't sent it"* while the runner is sending. It is the
-same race `in_flight` was written to avoid making a false claim about, left
-uncovered on the sibling path.
+**`cancel()` takes the SAME claim** (#990). It used to bypass `_claim()`
+entirely, so a cancel racing a dispatching confirm popped the proposal and said
+*"I heard you hold off, so I haven't sent it"* while the runner was sending —
+the same race `in_flight`'s wording exists to avoid making a false claim about,
+left uncovered on the sibling path. Screenless, that is not a lost cancel: it is
+an affirmative "nothing was sent" the owner has no way to check.
+
+Three things make the shared claim correct rather than merely shared:
+
+- The losing cancel gets its **own** outcome, `cancel_in_flight`, not
+  `in_flight`. They answer different questions — "should I confirm again?"
+  (no, wait) versus "did you stop it?" (no, and here is why) — and its spoken
+  line names the move that is still open, because the one thing the owner asked
+  for is the one thing no longer available.
+- It is a **wait** outcome, so `confirm_terminal` stays False: closing the
+  handshake here would close it out from under the confirm still running.
+- The announcement requirement is **dropped** (`require_announced=False`). "The
+  buddy hasn't finished saying it" is a reason to refuse a confirm — the owner
+  cannot have approved what they have not heard — and not a reason to refuse a
+  RETRACTION, which needs no announcement to be meant. Refusing one would leave
+  the proposal live for its full TTL over who was talking. Everything else in
+  the claim applies to both callers, so a cancel after the write really went out
+  now says `replayed` instead of asserting it did not.
 
 ### (b) The approval judgment: a spoken nonce
 
@@ -733,26 +751,44 @@ before the verdict. The denial half of the same asymmetry is covered too:
 transcript has not landed, and "cannot yet say what they said" is
 `pending_transcript`, never approval.
 
-**The price is stated at its true size, and it is an open residual (#989).**
-`unheard_between` has no staleness bound, so an utterance that never completes —
-a cough, a VAD blip, TTS bleed, any `speech_started` with no transcript to
-follow — sits in that window and refuses every confirm until the TTL. It refuses
-as a WAIT outcome, so no attempt is burned and `too_many_attempts` never fires:
-the owner hears "give me a second" for up to 120s and then "that one expired". A
-spoken loop, which in a screenless channel is the expensive failure. The bound
-belongs in `transcript.py` — `_judge` cannot tell a never-completing entry from a
-slow one — so it is **pinned in the tests as behaviour, not as a design**.
+**The price used to be open-ended, and closing it (#989) took TWO bounds rather
+than one.** `unheard_between` had no staleness bound at all, so any
+`speech_started` with no transcript to follow — a cough, a VAD blip, TTS bleed —
+sat in that window refusing every confirm as a WAIT outcome: no attempt burned,
+`too_many_attempts` never fired, and the owner heard "give me a second" for up
+to 120s and then "that one expired". A spoken loop, which in a screenless
+channel is the expensive failure.
 
-**Scope it precisely, because the epoch section two above will mislead you into
-scoping it wrongly.** The blocking entry has to be one whose sequence lands
-inside `(match.speech_started_seq, ceiling]`, so what it takes is a proposal
-anchored **in the SAME PAGE LOAD as the entry** — not "only within one page
-load". Having just read that `/mint` hands each load a base a whole
-`MINT_SEQ_GAP` above everything before it, a reader is primed to derive the
-narrower claim and conclude a reload clears it. It does not: the ring is
-bridge-lifetime and outlives the page, so a stale never-completing entry from an
-earlier epoch is simply below the new window rather than gone, and a fresh load
-starts blocking again the moment it produces one of its own.
+The obvious repair — one flat wall-clock age — is wrong, because two failures
+hide under "the transcript never came" and they price oppositely:
+
+- **Transcribed but empty.** A cough the model renders as `""` is
+  `complete == False`, which is what put it in the window; it needs *no clock at
+  all*. `Utterance.transcribed` records that a transcript EVENT arrived, and
+  `unheard_between` filters on that instead. An empty transcript positively
+  carries no denial, so the false-reject cost is zero. `complete` still gates
+  `after()`, where the question is "can this text approve" and the answer is no.
+- **Never transcribed.** Here a real bound is needed, and it keys on whether the
+  audio buffer **CLOSED**. With a `commit_seq` the utterance is over and the
+  transcript is merely overdue — `UNHEARD_COMMITTED_GRACE_S` (10s, comfortably
+  past the ~2.5s an ordinary short-utterance transcript costs). Without one the
+  owner may still be mid-utterance, so the bound has to exceed a plausible
+  utterance — `UNHEARD_OPEN_UTTERANCE_S` (60s), well under the 120s TTL or it
+  would close nothing. Ageing out on the committed grace instead would stop
+  waiting for a retraction that is halfway spoken: the acting-twice direction,
+  not a wait.
+
+The division of labour is unchanged: `_judge` still cannot tell a
+never-completing entry from a slow one without the ring's clock, so the bound
+lives in `transcript.py` and the caller says so.
+
+**Scope the residual precisely if you are reading an older account of it,
+because the epoch section two above misleads.** The blocking entry has to be one
+whose sequence lands inside `(match.speech_started_seq, ceiling]`, so what it
+took was a proposal anchored **in the SAME PAGE LOAD as the entry** — not "only
+within one page load". `/mint` hands each load a base a whole `MINT_SEQ_GAP`
+above everything before it, which primes a reader to conclude a reload cleared
+it. It did not: the ring is bridge-lifetime and outlives the page.
 
 Outcomes are keyed on **what the owner should do next**, and are never
 collapsed. This is `confirm.REASONS` in full — the SSOT for the taxonomy, and
@@ -770,18 +806,21 @@ the set `SPOKEN` is checked against **both ways**:
 | `denied` | say the phrase again when you're ready |
 | `pending_transcript` | **wait** |
 | `in_flight` | **wait** — that confirm is already running |
+| `cancel_in_flight` | **wait** — the cancel lost the race; it is already going out |
 | `too_many_attempts` | ask again from the top; that proposal is gone |
 | `dispatch_failed` | check that session, *then* decide — it may have gone out |
 
 `refused` and `pending_transcript` demand *opposite* behaviour. Collapsing them
-trains the owner to repeat into a system that needed them to hold still. Three
+trains the owner to repeat into a system that needed them to hold still. Four
 outcomes carry that "hold still" property, and they are named once rather than
 inferred from the table: `WAIT_OUTCOMES = {pending_transcript, not_announced,
-in_flight}` drives two flags on the payload — `owner_should_wait`, which the
-persona consumes as a FLAG and never by outcome name, and `confirm_terminal`,
-which is the name-independent signal that this outcome ENDS the handshake.
-`in_flight` belongs there on both counts: the owner should wait, and closing the
-gate on a duplicate would close it out from under the confirm that is running.
+in_flight, cancel_in_flight}` drives two flags on the payload —
+`owner_should_wait`, which the persona consumes as a FLAG and never by outcome
+name, and `confirm_terminal`, which is the name-independent signal that this
+outcome ENDS the handshake. `in_flight` belongs there on both counts: the owner
+should wait, and closing the gate on a duplicate would close it out from under
+the confirm that is running. `cancel_in_flight` is the same two counts reached
+from the cancel side (#990).
 
 **`denied` does not say "you said no".** It covers "wait"/"hold on" as well, and
 those are not a refusal of the write — the spoken line is *"I heard you hold off,
@@ -1098,6 +1137,60 @@ So the check runs in both directions: **after changing a spoken line, re-check
 its properties; after changing behaviour, re-read every line that describes
 it.** Neither edit looks like it touches the other, which is exactly why both
 need saying.
+
+### The buddy's own voice cannot deny (#992)
+
+`speechSynthesis` is outside the WebRTC path, so `echoCancellation` does not
+cover the fallback voice: what it says re-enters the microphone and lands in the
+**USER** transcript. Approval by echo is closed structurally — the fallback
+channel never carries a nonce (#953). `carries_denial` has no such gate, and
+several `SPOKEN` lines contain denial triggers: *"I heard you **hold off**…"*,
+*"**Hang on** — I'm already working on that one"*, *"I **don't** have anything
+pending…"*. Echoed inside the approval→confirm window, one of those retroactively
+denies the owner's own approval and reports a take-back they never spoke.
+
+**The rule is CONTENT, not timing, and that choice is the whole decision.** The
+obvious rule — "utterances transcribed while the fallback voice is speaking do
+not count as denials" — is unusable here: barge-in over the robot voice is the
+NORMAL way to retract in this channel, so that rule drops genuine take-backs and
+the write goes out. That is the acting-twice direction, strictly worse than the
+wrongful refusal it fixes, which costs one re-spoken approval (the newest-first
+binding in `_judge` makes recovery cheap). A content rule has no such half: it
+cannot fire on words the buddy never said.
+
+`confirm.is_buddy_echo` therefore asks whether the WHOLE normalized utterance is
+a contiguous run of tokens inside some `SPOKEN` line, at least
+`_ECHO_MIN_TOKENS` (6) long. Both properties are load-bearing:
+
+- **Whole-utterance.** A barge-in captured together with the tail of the buddy's
+  line (*"hang on im already working on that one no stop"*) is not a contiguous
+  run of any line, so it denies. Only a clean capture of the machine's own words
+  is suppressed.
+- **Six tokens.** That is the entire false-reject budget, chosen against the
+  collision rather than for tidiness: the triggers in those lines are exactly
+  what a real owner says (*"hold off"*, *"hang on"*), so a two- or three-token
+  floor would suppress a genuine retraction — and a suppressed retraction
+  WRITES. A short or garbled echo misses the floor and denies: the enumeration
+  **fails closed**, and nothing about being incomplete here can make a write
+  happen.
+
+It is applied at **two** sites, and the second is easy to miss: `_judge`'s own
+newest-first loop reaches an echo that landed after the approval *before* the
+post-approval scan does, so guarding only the scan leaves the loop returning
+`denied` first. (Only echoes containing a confirm word reach that branch —
+`classify` returns `NO_MATCH` before consulting the denial grammar otherwise —
+which is why a test built on the wrong line passes with the loop guard deleted.)
+
+**What it does not cover, stated rather than implied.** `SPOKEN` is this
+module's own taxonomy, so the rule covers only what the confirm spine makes the
+buddy say. Attacker-influenceable text — a delivered message body, spoken
+verbatim by `composeNotice` — is not in it. That text cannot reach this window
+today for a separate reason: `client.py`'s `canSpeak` **and** `canInterrupt`
+both require `!confirmGate.outstanding()`, and the gate is closed from the moment
+a proposal is spoken until its terminal outcome or TTL — which is exactly the
+approval→confirm window. **If that gate is ever relaxed, this rule needs the
+spoken text fed to it** rather than read from `SPOKEN`; the
+"said-during-fallback" mark stays the wrong instrument for the reason above.
 
 ### Denial words and denial EXCEPTIONS have opposite bars
 
@@ -2012,37 +2105,49 @@ exist**, so these are listed here as well as inline.
 
 | # | Where | The hole |
 |---|---|---|
-| #989 | `transcript.unheard_between` | no staleness bound: one never-completing `speech_started` (a cough, a VAD blip, TTS bleed) refuses every confirm as a WAIT outcome — no attempt burned, so the proposal loops on "give me a second" for the whole 120s TTL and then expires |
-| #990 | `confirm.cancel()` | bypasses `_claim()`, so a cancel racing a dispatching confirm says "I haven't sent it" while the runner is sending — the exact over-claim `in_flight`'s wording exists to avoid, on the sibling path |
-| #992 | `_judge`'s post-approval scan | `carries_denial` is not nonce-gated, and the fallback voice speaks message BODIES any session can send — so an echoed "no, stop, don't" retroactively denies a legitimate approval. Remotely triggerable; invisible to the owner |
 | #1009 | `confirm.py`'s `not_announced` note | its 30s/12s deferral bound is counted from the moment an item becomes `current`, and #997's `pump()` deferral sits UPSTREAM of that — so while a fallback utterance is live the stated bound under-states its own worst case by up to one speaking budget. A stated-guarantee defect, not a runtime one: the refusal is delivered either way |
 
 **Closed, and named here because arguing from a residual that no longer exists
-is the same failure in the other direction:** **#995** (the four remaining
-`client.py` browser wires — the data-channel `open`/`close` status wires and both
-button click handlers — now pinned in `tests/unit/test_client_wires.py`, the
-`pc.ontrack` greet wire having gone in #1001), **#996** (the `speakingBudget`
-watchdog now reports `onNotSpoken`) and **#997** (`pump()` now defers to the
-browser voice, bounded by that same budget). The last two are described in full
-under the watchdog above.
+is the same failure in the other direction:** **#989** (the unheard window is
+bounded on two axes — an arrived-but-empty transcript needs no clock, and a
+missing one ages out on whether the audio buffer closed; see "Bounded await, and
+outcomes that differ"), **#990** (`cancel()` takes the same claim, split on
+`_dispatching` versus `_cancelled` so the losing cancel cannot assert an outcome
+— see "(a) Proposal binding"), **#992** (the buddy's own voice cannot deny — its
+own section below), **#995** (the four remaining `client.py` browser wires — the
+data-channel `open`/`close` status wires and both button click handlers — now
+pinned in `tests/unit/test_client_wires.py`, the `pc.ontrack` greet wire having
+gone in #1001), **#996** (the `speakingBudget` watchdog now reports
+`onNotSpoken`) and **#997** (`pump()` now defers to the browser voice, bounded
+by that same budget). #996 and #997 are described in full under the watchdog
+above.
 
 What they have in common is where they were found: every one came out of a review
 of a MERGED wave rather than out of the wave itself. Defects that survive
 individual review live in the interaction between changes each correct alone.
 
-And several carry a real trade rather than an obvious fix, which is why "just
-close it" is not the whole instruction. #989's staleness bound: too tight and a
-slow transcriber becomes a wrongful refusal, too loose and the loop survives.
+And several carried a real trade rather than an obvious fix, which is why "just
+close it" was not the whole instruction. The rulings live with the mechanisms
+rather than here, but the trades are worth keeping together, because they are
+one argument. #989's staleness bound: too tight and a slow transcriber becomes a
+wrongful refusal, too loose and the loop survives — it took TWO bounds, split on
+whether the audio buffer closed, because one flat age is wrong at one end.
 #992's suppression rule: barge-in over the robot voice is the NORMAL case here,
 so any rule of the form "utterances during fallback speech do not count as
 denials" drops a genuine take-back and the write goes out — the acting-twice
-direction, not a wait. #997's deferral was the same shape and is the worked
-example of pricing it: an unbounded "wait for the browser voice" turns an
-audio-quality defect into a suppression defect, which in a screenless channel is
-strictly worse than the thing being fixed, so the wait is bounded by the budget
-that decides when the page stops believing the voice at all. Price both halves
-before choosing. (#990, #995 and #996 had no such tension — they were plainly
-worth doing.)
+direction, not a wait; the shipped rule is CONTENT, which cannot fire on words
+the buddy never said and so has no such half. #997's deferral was the same shape
+and is the worked example of pricing it: an unbounded "wait for the browser
+voice" turns an audio-quality defect into a suppression defect, which in a
+screenless channel is strictly worse than the thing being fixed, so the wait is
+bounded by the budget that decides when the page stops believing the voice at
+all. Price both halves before choosing.
+
+(#995 and #996 had no such tension. #990 looked like it had none either, and
+that reading was wrong twice: the first fix told a cancel racing the AWAIT that
+the write was already going out, and the second still let a cancel arriving
+between `_succeeded.add` and the claim's release say nothing had been sent. A
+defect whose diagnosis is obvious can still have a fix that is not.)
 
 ### Standing constraints for whoever picks this up
 

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -558,6 +558,20 @@ Three things make the shared claim correct rather than merely shared:
   (no, wait) versus "did you stop it?" (no, and here is why) — and its spoken
   line names the move that is still open, because the one thing the owner asked
   for is the one thing no longer available.
+- **The barrier is ONE lock hold**, and that is the claim the redesign rests
+  on: reading `_cancelled` and then marking `_dispatching` in two holds leaves a
+  gap in which a cancel is told, truthfully by then but wrongly at the moment it
+  spoke, that the write was going out — #990 in its original form, restored by a
+  refactor. Pinned by sweeping *every* observable lock boundary rather than the
+  one that happens to be the barrier today, so moving it does not silence the
+  test.
+- **The terminal facts outrank the claim.** A confirm records its result and
+  only *then* unwinds, so between `_succeeded.add` and `_in_flight.discard` a
+  token is both written and claimed. Testing `_in_flight` first answered a cancel
+  there with "I haven't sent anything" about a write that had gone out — a third
+  window, found by the lock sweep rather than by reading. `_succeeded`/`_failed`
+  are facts about the WRITE; `_in_flight` is a fact about the ATTEMPT, and only
+  the first kind can contradict a spoken claim about sending.
 - **A cancel is never answered with confirm-shaped advice.** The claim is
   shared so the two paths cannot drift, but two of its lines argue for the very
   write just retracted — `no_proposal` says *"Tell me again what you'd like
@@ -570,6 +584,14 @@ Three things make the shared claim correct rather than merely shared:
   re-propose.
 - **No cancel outcome leaves a live proposal behind**, pinned as a property
   over every reachable one rather than at the site that used to break it.
+- **A successful cancel says `cancelled`, not `denied`.** `denied`'s advice —
+  *"Say the phrase again when you're ready"* — is true only of an in-band
+  denial, which leaves the proposal LIVE. A cancel pops it, so following that
+  advice lands on `no_proposal` (*"Tell me again what you'd like sent"*) one
+  turn later: the very line the translation above exists to keep off this path,
+  re-entering through another door. `cancelled` is a pure stand-down — the owner
+  asked for this, so nothing further is required of them, and it deliberately
+  does not offer to set the write up again.
 - It is a **wait** outcome, so `confirm_terminal` stays False: closing the
   handshake here would close it out from under the confirm still running.
 - The announcement requirement is **dropped** (`require_announced=False`). "The
@@ -826,7 +848,8 @@ the set `SPOKEN` is checked against **both ways**:
 | `refused` | say the phrase |
 | `wrong_nonce` | ask what the word was |
 | `quoted_frame` | say confirm and the word on its own — the word was right |
-| `denied` | say the phrase again when you're ready |
+| `denied` | say the phrase again when you're ready — the proposal is still live |
+| `cancelled` | nothing — you retracted it and it is gone |
 | `pending_transcript` | **wait** |
 | `in_flight` | **wait** — that confirm is already running |
 | `cancel_in_flight` | **wait** — the cancel lost the race *to the runner*; it is already going out |

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -1351,6 +1351,40 @@ class TestTheUnheardWindowIsBounded:
         assert convo.spine.confirm(proposal.token).approved is True
         assert len(runner.calls) == 1
 
+    def test_the_committed_grace_is_measured_FROM_THE_COMMIT(
+        self, convo, clock, runner
+    ):
+        """``committed_at``, which the whole two-bound argument rests on.
+
+        The split is "the audio buffer closed, so ASR is overdue" — overdue
+        *from the close*, not from the speech start. Measured from
+        ``received_at`` instead, a long utterance burns its entire grace before
+        the transcript could possibly arrive: a 9-second sentence would age out
+        1 second after committing rather than 10, which is the false-ACCEPT
+        direction (a real denial dropped, the write goes out).
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        long_one = convo.starts_speaking()
+        clock.advance(9.0)  # ...a long sentence
+        convo.ring.commit(long_one, convo._next())
+
+        entry = next(e for e in convo.ring.snapshot() if e.item_id == long_one)
+        assert entry.committed_at > entry.received_at, (
+            "fixture must separate the commit from the speech start, or this "
+            "test cannot tell the two clocks apart"
+        )
+
+        # 5s past the COMMIT — inside the grace. Past the SPEECH START it is
+        # 14s, well beyond it: the two answers differ, which is the point.
+        clock.advance(5.0)
+        assert convo.spine.confirm(proposal.token).reason == "pending_transcript"
+        assert runner.calls == []
+
+        clock.advance(transcript.UNHEARD_COMMITTED_GRACE_S)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
     def test_the_bound_lands_inside_the_TTL_or_it_closes_nothing(self):
         """Both bounds have to retire the entry while the proposal is still
         alive. A bound at or past ``PROPOSAL_TTL_S`` leaves the loop exactly as
@@ -1500,16 +1534,90 @@ class TestCancelTakesTheSameClaim:
     runner was sending. Screenless, the owner hears an affirmative "nothing was
     sent" about a write that went out, and has no way to discover otherwise.
 
-    The false-reject half is priced in the other direction: a cancel refused
-    for the wrong reason leaves a proposal the owner believes is dead.
+    **And the first fix for it re-committed the same defect, inverted** (review
+    round 2). Routing cancel through the claim and calling every claimed token
+    "already going out" is false for most of the claim's life: it is taken at
+    the top of ``confirm``, before the ≤2.5s await and before the judge, so the
+    dominant occupant of ``_in_flight`` is a confirm still DECIDING. The race is
+    therefore split on the thing the sentence is about — ``_dispatching`` (in
+    the runner: the claim is true) versus ``_cancelled`` (a cancel during the
+    await WINS, and the confirm finds out before it dispatches).
     """
 
-    def test_a_cancel_racing_a_dispatching_confirm_does_not_claim_nothing_was_sent(
+    def test_a_cancel_during_the_AWAIT_wins_rather_than_being_told_it_is_too_late(
+        self, runner
+    ):
+        """The dominant window, and the one the first fix got wrong.
+
+        Nothing has been sent while the confirm sits in its bounded await, so
+        "it's already going out" is a false statement AND the proposal it
+        refuses to drop stays pending. Real threads, because ``wait_s=0``
+        provably cannot construct a window for the cancel to land inside.
+        """
+        ring = transcript.TranscriptRing()
+        spine = confirm.ConfirmSpine(ring, wait_s=2.0, runner=runner)
+        convo = Conversation(ring, spine)
+        proposal = convo.announced_proposal()
+
+        verdicts: "list[confirm.Verdict]" = []
+        thread = threading.Thread(
+            target=lambda: verdicts.append(spine.confirm(proposal.token))
+        )
+        thread.start()
+        time.sleep(0.15)  # the confirm is inside its bounded await
+        cancelled = spine.cancel(proposal.token)
+        thread.join()
+
+        assert cancelled.reason == "denied", (
+            "nothing has been sent yet, so the cancel wins outright"
+        )
+        # ...and the confirm does not then write behind the retraction.
+        assert runner.calls == []
+        assert verdicts[0].approved is False
+        # The proposal is really gone — the measured failure was that it stayed
+        # pending after being refused a cancel.
+        assert spine.pending() == []
+        assert spine.confirm(proposal.token).reason == "no_proposal"
+        assert runner.calls == []
+
+    def test_a_cancel_during_the_await_that_then_approves_still_does_not_write(
+        self, runner
+    ):
+        """The barrier itself: the judge APPROVES and the dispatch is refused.
+
+        The previous test's confirm times out, so it would refuse anyway. Here
+        the approval is already in the ring, so only the cancel barrier stands
+        between the verdict and the runner.
+        """
+        ring = transcript.TranscriptRing()
+        spine = confirm.ConfirmSpine(ring, wait_s=2.0, runner=runner)
+        convo = Conversation(ring, spine)
+        proposal = convo.announced_proposal()
+        approval = convo.says("", transcribe=False)
+        phrase = f"confirm {confirm.spoken_nonce(proposal.nonce)}"
+
+        def cancel_then_let_the_approval_land():
+            time.sleep(0.15)              # the confirm is inside the await
+            spine.cancel(proposal.token)  # ...retracted before it wakes
+            ring.transcribe(approval, phrase)
+
+        thread = threading.Thread(target=cancel_then_let_the_approval_land)
+        thread.start()
+        verdict = spine.confirm(proposal.token)
+        thread.join()
+
+        assert verdict.reason == "denied"
+        assert runner.calls == [], "the write must not go out behind a retraction"
+        # The approving utterance is NOT spent: nothing was acted on.
+        spent = [u for u in ring.snapshot() if u.spent]
+        assert spent == []
+
+    def test_a_cancel_racing_a_DISPATCHING_confirm_does_not_claim_nothing_was_sent(
         self, convo, runner
     ):
-        """The re-entrant construction: the cancel arrives from inside the
-        runner, i.e. strictly while the confirm is dispatching."""
-        cancels: list[confirm.Verdict] = []
+        """The one true "too late": the cancel arrives from inside the runner,
+        i.e. strictly while the argv is being dispatched."""
+        cancels: "list[confirm.Verdict]" = []
 
         def reentrant_runner(argv):
             runner(argv)
@@ -1534,10 +1642,71 @@ class TestCancelTakesTheSameClaim:
         assert payload["confirm_terminal"] is False
         assert payload["owner_should_wait"] is True
 
+    def test_only_a_DISPATCHING_confirm_produces_the_too_late_line(self, convo):
+        """The distinction stated as a property rather than inferred from the
+        two tests above: a token that is merely claimed must never produce it."""
+        proposal = convo.announced_proposal()
+        with convo.spine._lock:
+            convo.spine._in_flight.add(proposal.token)
+        assert convo.spine.cancel(proposal.token).reason == "denied"
+
+        second = convo.announced_proposal()
+        with convo.spine._lock:
+            convo.spine._dispatching.add(second.token)
+        assert convo.spine.cancel(second.token).reason == "cancel_in_flight"
+
+    def test_no_cancel_outcome_leaves_a_live_proposal(self, convo, runner):
+        """The false-reject half the review measured, stated as a PROPERTY.
+
+        The shape was "refused cancel, then refused confirm, and the proposal
+        sits to TTL with no second word". Its source was refusing during the
+        await, which the split removes — but the guarantee worth keeping is
+        broader than that one path, so it is asserted over every reachable
+        cancel outcome instead of at the site that used to break it. A cancel
+        the owner spoke must never leave the buddy holding the write.
+
+        Deliberately a sweep rather than a single scenario: the failure was
+        never in one branch, it was in the branch nobody enumerated.
+        """
+        outcomes: "dict[str, object]" = {}
+
+        # denied — the ordinary win.
+        plain = convo.announced_proposal()
+        outcomes[convo.spine.cancel(plain.token).reason] = plain
+
+        # cancel_in_flight — refused from inside the runner.
+        racing = convo.announced_proposal()
+
+        def reentrant(argv):
+            runner(argv)
+            outcomes[convo.spine.cancel(racing.token).reason] = racing
+            return {"success": True}
+
+        convo.spine._runner = reentrant
+        convo.approve(racing)
+        convo.spine.confirm(racing.token)
+        convo.spine._runner = runner
+
+        # replayed — the write really went out.
+        done = convo.announced_proposal()
+        convo.approve(done)
+        assert convo.spine.confirm(done.token).approved is True
+        outcomes[convo.spine.cancel(done.token).reason] = done
+
+        # nothing_to_cancel — a second cancel.
+        outcomes[convo.spine.cancel(plain.token).reason] = plain
+
+        assert set(outcomes) == {
+            "denied", "cancel_in_flight", "replayed", "nothing_to_cancel"
+        }, outcomes
+        live = {p.token for p in convo.spine.pending()}
+        for reason, proposal in outcomes.items():
+            assert proposal.token not in live, reason
+
     def test_the_refused_cancel_still_tells_the_owner_what_happens_next(self):
-        """The false-reject half. A cancel that cannot be honoured is the one
-        moment the owner most needs the next move named — the thing they asked
-        for is the thing that is no longer available."""
+        """A cancel that cannot be honoured is the one moment the owner most
+        needs the next move named — the thing they asked for is the thing that
+        is no longer available."""
         line = confirm.SPOKEN["cancel_in_flight"].lower()
         assert "don't repeat" in line
         assert "tell you how it went" in line
@@ -1573,8 +1742,63 @@ class TestCancelTakesTheSameClaim:
         assert convo.spine.cancel(proposal.token).reason == "denied"
         assert convo.spine.pending() == []
         assert convo.spine._in_flight == set()
+        assert convo.spine._dispatching == set()
         assert convo.spine.confirm(proposal.token).reason == "no_proposal"
         assert runner.calls == []
+
+
+class TestACancelIsNeverAnsweredWithConfirmShapedAdvice:
+    """The shared claim's lines are written for a CONFIRM, and two of them
+    argue for the very write the owner just retracted.
+
+    ``no_proposal`` says *"Tell me again what you'd like sent"* and ``expired``
+    says *"Ask me again and I'll set it up fresh"*. Answering a retraction with
+    either is the system pressing for the thing that was cancelled — in a
+    screenless channel, with nothing on screen to reveal that it is answering
+    the wrong question. Sharing the claim is right; sharing its vocabulary is
+    not.
+    """
+
+    #: The confirm lines that would invite a re-propose, as substrings.
+    RE_PROPOSE_CUES = ("tell me again", "ask me again", "set it up fresh")
+
+    def test_a_second_cancel_does_not_ask_for_the_write_again(self, convo):
+        proposal = convo.announced_proposal()
+        assert convo.spine.cancel(proposal.token).reason == "denied"
+        again = convo.spine.cancel(proposal.token)
+        assert again.reason == "nothing_to_cancel"
+        spoken = again.spoken.lower()
+        for cue in self.RE_PROPOSE_CUES:
+            assert cue not in spoken, cue
+
+    def test_a_cancel_after_the_TTL_does_not_ask_for_the_write_again(
+        self, convo, clock
+    ):
+        proposal = convo.announced_proposal()
+        clock.advance(confirm.PROPOSAL_TTL_S + 1)
+        verdict = convo.spine.cancel(proposal.token)
+        assert verdict.reason == "nothing_to_cancel"
+        spoken = verdict.spoken.lower()
+        for cue in self.RE_PROPOSE_CUES:
+            assert cue not in spoken, cue
+
+    def test_the_confirm_path_keeps_those_lines(self, convo, clock):
+        """The must-fail control. The cues are only wrong for a CANCEL — if a
+        well-meaning edit strips them from the confirm lines too, the tests
+        above would pass while the taxonomy quietly lost its next-move advice.
+        """
+        proposal = convo.announced_proposal()
+        clock.advance(confirm.PROPOSAL_TTL_S + 1)
+        assert "ask me again" in convo.spine.confirm(proposal.token).spoken.lower()
+        assert "tell me again" in confirm.SPOKEN["no_proposal"].lower()
+
+    def test_the_honest_refusals_are_passed_through_unchanged(self, convo, runner):
+        """``replayed`` and ``dispatch_failed`` are TRUE of a cancel and invite
+        no re-propose, so translating them would lose information."""
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert convo.spine.cancel(proposal.token).reason == "replayed"
 
 
 # =============================================================================
@@ -2049,6 +2273,11 @@ class TestOutcomesAreDistinctAndSpoken:
         race_convo.approve(racing)
         race_spine.confirm(racing.token)
         seen |= set(cancelled)
+
+        # nothing_to_cancel: a cancel with nothing of ours to retract. It must
+        # not reuse `no_proposal`/`expired`, whose lines argue for re-proposing
+        # the write the owner just took back.
+        seen.add(convo.spine.cancel("no-such-token").reason)
         return seen
 
     def test_the_attempt_that_retires_the_proposal_says_so(self, convo, runner):
@@ -2738,6 +2967,19 @@ SPOKEN_DENYING_LINES = [
 ]
 
 
+def _is_run_of(utterance: str, line: str) -> bool:
+    """Is *utterance* a contiguous token run of *line*? Independently spelled.
+
+    Deliberately NOT ``confirm._contains_run``: this is the fixture's own check
+    that a clipped-barge-in case is really the shape it claims to be, and using
+    the function under test to validate the input makes the two fail together.
+    """
+    haystack = confirm.normalize(line).split()
+    needle = confirm.normalize(utterance).split()
+    joined = " ".join(haystack)
+    return f" {' '.join(needle)} " in f" {joined} "
+
+
 class TestTheBuddysOwnVoiceCannotDeny:
     """#992 — the echo's OTHER direction, and the one nothing covered.
 
@@ -2816,6 +3058,74 @@ class TestTheBuddysOwnVoiceCannotDeny:
         convo.says("hang on im already working on that one no stop")
         assert convo.spine.confirm(proposal.token).reason == "denied"
         assert runner.calls == []
+
+    #: Real barge-ins whose transcript is a CLIPPED prefix of a `SPOKEN` line —
+    #: the shape the token floor exists to keep on the denying side. Each is 3
+    #: to 5 tokens, which is exactly the range the module's own docstring says
+    #: would be suppressed at a lower floor.
+    CLIPPED_BARGE_INS = (
+        "hang on im",            # 3 tokens
+        "hang on i havent",      # 4
+        "i heard you hold off",  # 5
+    )
+
+    @pytest.mark.parametrize("clipped", CLIPPED_BARGE_INS)
+    def test_a_clipped_barge_in_below_the_floor_still_denies(
+        self, clipped, convo, runner
+    ):
+        """The floor is the entire false-reject budget of this rule, and only
+        the two-token case was pinned.
+
+        At a floor of 3, "hang on im" — a real retraction the transcriber
+        clipped — is read as the buddy's own voice, the denial is dropped and
+        THE WRITE GOES OUT. That is the acting-twice direction. Each of these
+        IS a contiguous run of a `SPOKEN` line, so nothing but the floor keeps
+        it denying.
+        """
+        assert confirm.carries_denial(clipped), clipped
+        assert any(
+            _is_run_of(clipped, line) for line in confirm.SPOKEN.values()
+        ), f"{clipped!r} must be a real run of a SPOKEN line or it proves nothing"
+
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says(clipped)
+        assert convo.spine.confirm(proposal.token).reason == "denied", clipped
+        assert runner.calls == []
+
+    def test_the_floor_exceeds_every_clipped_barge_in_we_priced(self):
+        """Stated as arithmetic, so lowering the constant fails here too rather
+        than only in the scenario above."""
+        longest = max(
+            len(confirm.normalize(c).split()) for c in self.CLIPPED_BARGE_INS
+        )
+        assert confirm._ECHO_MIN_TOKENS > longest
+
+    def test_an_utterance_that_CONTAINS_a_whole_line_is_not_an_echo(self):
+        """"Whole-utterance" is named load-bearing in the module and the wiki,
+        and containment has a direction.
+
+        Reversed — "does the utterance contain a line" — an owner who talks
+        over the tail of the buddy's sentence and is captured with all of it is
+        classified as an echo, and their retraction is dropped.
+        """
+        line = confirm.SPOKEN["denied"]
+        assert confirm.is_buddy_echo(line) is True, "the line itself is an echo"
+        assert confirm.is_buddy_echo(line + " no, stop, don't send it") is False
+
+    def test_a_NON_CONTIGUOUS_subset_of_a_line_is_not_an_echo(self):
+        """"Contiguous" is the other named property, and a subset test passes
+        every assertion above while accepting word salad.
+
+        These are the line's own words, in the line's own order, with words
+        dropped — which is what a human speaking loosely on the same subject
+        looks like, and is not the machine's sentence.
+        """
+        tokens = confirm.normalize(confirm.SPOKEN["denied"]).split()
+        gappy = " ".join(tokens[::2])
+        assert len(gappy.split()) >= confirm._ECHO_MIN_TOKENS, "must clear the floor"
+        assert set(gappy.split()) <= set(tokens), "must be a subset of the line"
+        assert confirm.is_buddy_echo(gappy) is False
 
     def test_a_short_garbled_echo_fails_closed(self, convo, runner):
         """Below the token floor it is treated as a denial: a wrongful refusal

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -1568,7 +1568,7 @@ class TestCancelTakesTheSameClaim:
         cancelled = spine.cancel(proposal.token)
         thread.join()
 
-        assert cancelled.reason == "denied", (
+        assert cancelled.reason == "cancelled", (
             "nothing has been sent yet, so the cancel wins outright"
         )
         # ...and the confirm does not then write behind the retraction.
@@ -1606,7 +1606,7 @@ class TestCancelTakesTheSameClaim:
         verdict = spine.confirm(proposal.token)
         thread.join()
 
-        assert verdict.reason == "denied"
+        assert verdict.reason == "cancelled"
         assert runner.calls == [], "the write must not go out behind a retraction"
         # The approving utterance is NOT spent: nothing was acted on.
         spent = [u for u in ring.snapshot() if u.spent]
@@ -1648,7 +1648,7 @@ class TestCancelTakesTheSameClaim:
         proposal = convo.announced_proposal()
         with convo.spine._lock:
             convo.spine._in_flight.add(proposal.token)
-        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.cancel(proposal.token).reason == "cancelled"
 
         second = convo.announced_proposal()
         with convo.spine._lock:
@@ -1697,7 +1697,7 @@ class TestCancelTakesTheSameClaim:
         outcomes[convo.spine.cancel(plain.token).reason] = plain
 
         assert set(outcomes) == {
-            "denied", "cancel_in_flight", "replayed", "nothing_to_cancel"
+            "cancelled", "cancel_in_flight", "replayed", "nothing_to_cancel"
         }, outcomes
         live = {p.token for p in convo.spine.pending()}
         for reason, proposal in outcomes.items():
@@ -1720,7 +1720,7 @@ class TestCancelTakesTheSameClaim:
         proposal live for its whole TTL over who was talking.
         """
         proposal = convo.propose()  # never announced
-        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.cancel(proposal.token).reason == "cancelled"
         assert convo.spine.confirm(proposal.token).reason == "no_proposal"
         assert runner.calls == []
 
@@ -1739,12 +1739,216 @@ class TestCancelTakesTheSameClaim:
         """The ordinary path is unchanged, and the claim is RELEASED — a marker
         left set would wedge the token for its whole TTL."""
         proposal = convo.announced_proposal()
-        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.cancel(proposal.token).reason == "cancelled"
         assert convo.spine.pending() == []
         assert convo.spine._in_flight == set()
         assert convo.spine._dispatching == set()
         assert convo.spine.confirm(proposal.token).reason == "no_proposal"
         assert runner.calls == []
+
+
+#: Cancel outcomes whose spoken line ASSERTS that nothing was sent. These are
+#: the ones that may never be spoken about a token whose write has run — the
+#: §3.6 over-claim, which is what #990 is.
+ASSERTS_NOTHING_SENT = frozenset({"cancelled", "nothing_to_cancel"})
+
+
+class _ObservableLock:
+    """A lock that lets an observer run at each RELEASE boundary.
+
+    The point is to make "these two operations happen under ONE hold" a
+    testable claim rather than a comment. Every moment the spine's lock is free
+    is a moment another caller can observe it, so firing the observer at each
+    release enumerates exactly the states the outside world can ever see —
+    without needing to know which release is the interesting one, which is what
+    makes the sweep survive a refactor that moves the boundary.
+
+    Single-threaded on purpose: the hook runs while the lock is genuinely free,
+    so there is no race to lose and no sleep to tune. A re-entrancy guard keeps
+    the observer's own lock traffic from re-triggering it.
+    """
+
+    def __init__(self, inner, observer):
+        self._inner = inner
+        self._observer = observer
+        self._firing = False
+        self.releases = 0
+
+    def acquire(self, *args, **kwargs):
+        return self._inner.acquire(*args, **kwargs)
+
+    def release(self):
+        self._inner.release()
+        if self._firing:
+            return
+        self.releases += 1
+        self._firing = True
+        try:
+            self._observer(self.releases)
+        finally:
+            self._firing = False
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.release()
+        return False
+
+
+class TestTheCancelBarrierIsONELockHold:
+    """The invariant the whole #990 redesign rests on, and it had no pin.
+
+    ``_confirm_claimed`` reads ``_cancelled`` and marks ``_dispatching`` in a
+    single hold, and the module comment says why: reading and then marking
+    leaves a window in which a cancel lands after the check and is told —
+    truthfully by then, but wrongly at the moment it spoke — that the write was
+    going out. Split into two holds, a cancel in the gap speaks *"I heard you
+    hold off, so I haven't sent it"* while the runner runs. That is #990 in its
+    ORIGINAL form, restored by a refactor the suite could not see.
+
+    A stated invariant with no test is the defect this run has found repeatedly.
+    So it is asserted the only way that survives the boundary moving: sweep
+    EVERY point at which the spine's lock is observable, and require that none
+    of them produces a cancel claiming nothing was sent while something was.
+    """
+
+    def _run(self, fire_at: int):
+        """One confirm, with a cancel fired at the *fire_at*-th lock release."""
+        ring = transcript.TranscriptRing()
+        runner = RecordingRunner()
+        spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner)
+        convo = Conversation(ring, spine)
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+
+        seen: dict = {}
+
+        def observer(index: int) -> None:
+            if index != fire_at or "cancel" in seen:
+                return
+            seen["cancel"] = spine.cancel(proposal.token).reason
+
+        lock = _ObservableLock(threading.Lock(), observer)
+        spine._lock = lock
+        seen["confirm"] = spine.confirm(proposal.token)
+        seen["writes"] = len(runner.calls)
+        seen["releases"] = lock.releases
+        return seen
+
+    def test_no_observable_moment_lets_a_cancel_deny_a_write_that_happened(self):
+        """The pin. At every lock boundary, the two stories must agree."""
+        probe = self._run(fire_at=0)
+        total = probe["releases"]
+        assert total >= 3, "the confirm must take the lock several times"
+
+        stories = set()
+        for index in range(1, total + 1):
+            seen = self._run(fire_at=index)
+            reason = seen.get("cancel")
+            if reason is None:
+                continue
+            stories.add((reason, seen["writes"] > 0))
+            if seen["writes"]:
+                # Something was sent, so no cancel may CLAIM OTHERWISE. Stated
+                # as the property rather than as an allowed outcome: which
+                # outcome is correct here depends on how far the confirm got
+                # (`cancel_in_flight` mid-runner, `replayed` once recorded),
+                # and pinning one of them would fail on a correct answer — as
+                # this assertion did, on its first run, before it was rewritten
+                # to say what it actually means.
+                assert reason not in ASSERTS_NOTHING_SENT, (
+                    f"release {index}: cancel said {reason!r}, which claims "
+                    f"nothing was sent, while the runner had run"
+                )
+            else:
+                # Nothing was sent, so the confirm must not have written and
+                # the cancel must not have been told it was too late.
+                assert seen["confirm"].approved is False, index
+                assert reason != "cancel_in_flight", (
+                    f"release {index}: cancel said it was too late with nothing sent"
+                )
+
+        # The sweep must actually have exercised BOTH sides of the barrier, or
+        # it passes by never reaching the interesting states.
+        assert len(stories) >= 2, stories
+        assert any(sent for _, sent in stories), "no run reached the runner"
+        assert any(not sent for _, sent in stories), "no run stopped at the barrier"
+
+    def test_the_nothing_sent_set_really_says_nothing_was_sent(self):
+        """The control for the set the sweep is written in terms of.
+
+        A membership list is only as good as its membership: if ``cancelled``
+        ever stops claiming "I haven't sent anything", the sweep above goes on
+        passing while guarding nothing. Derived from the lines, not asserted
+        about them.
+        """
+        for reason in ASSERTS_NOTHING_SENT:
+            line = confirm.SPOKEN[reason].lower()
+            assert "haven't sent" in line, reason
+        # And the complement: the outcomes that may be spoken over a real write
+        # must NOT carry the claim.
+        for reason in ("cancel_in_flight", "replayed", "dispatch_failed"):
+            assert reason not in ASSERTS_NOTHING_SENT
+            assert "haven't sent" not in confirm.SPOKEN[reason].lower(), reason
+
+    def test_a_cancel_after_a_recorded_write_never_says_nothing_was_sent(
+        self, convo, runner
+    ):
+        """The third window the sweep found, kept as a named scenario.
+
+        A confirm records its result and only THEN unwinds the claim, so
+        between ``_succeeded.add`` and ``_in_flight.discard`` a token is both
+        written and claimed. Testing ``_in_flight`` first answered a cancel
+        there with "I haven't sent anything" about a write that had gone out —
+        the same over-claim, in a window nobody had enumerated.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
+        # Reconstruct the window: the write is recorded, the claim not yet
+        # released.
+        with convo.spine._lock:
+            convo.spine._in_flight.add(proposal.token)
+        try:
+            verdict = convo.spine.cancel(proposal.token)
+        finally:
+            with convo.spine._lock:
+                convo.spine._in_flight.discard(proposal.token)
+
+        assert verdict.reason not in ASSERTS_NOTHING_SENT, verdict.reason
+        assert verdict.reason == "replayed"
+
+    def test_the_two_flags_are_never_both_observable(self, convo):
+        """The invariant stated directly as well as behaviourally.
+
+        ``_cancelled`` and ``_dispatching`` are set by the two sides of one
+        decision. If a token can ever be seen carrying both, the barrier was
+        not atomic — a cancel recorded a retraction for a confirm that had
+        already been cleared to dispatch.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        both: list = []
+
+        def observing_runner(argv):
+            with convo.spine._lock:
+                both.append(
+                    convo.spine._cancelled & convo.spine._dispatching
+                )
+            convo.spine.cancel(proposal.token)
+            with convo.spine._lock:
+                both.append(
+                    convo.spine._cancelled & convo.spine._dispatching
+                )
+            return {"success": True}
+
+        convo.spine._runner = observing_runner
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert both == [set(), set()], both
 
 
 class TestACancelIsNeverAnsweredWithConfirmShapedAdvice:
@@ -1764,7 +1968,7 @@ class TestACancelIsNeverAnsweredWithConfirmShapedAdvice:
 
     def test_a_second_cancel_does_not_ask_for_the_write_again(self, convo):
         proposal = convo.announced_proposal()
-        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.cancel(proposal.token).reason == "cancelled"
         again = convo.spine.cancel(proposal.token)
         assert again.reason == "nothing_to_cancel"
         spoken = again.spoken.lower()
@@ -1791,6 +1995,59 @@ class TestACancelIsNeverAnsweredWithConfirmShapedAdvice:
         clock.advance(confirm.PROPOSAL_TTL_S + 1)
         assert "ask me again" in convo.spine.confirm(proposal.token).spoken.lower()
         assert "tell me again" in confirm.SPOKEN["no_proposal"].lower()
+
+    def test_the_HAPPY_PATH_cancel_does_not_name_a_move_that_cannot_work(
+        self, convo, runner
+    ):
+        """The same defect on the outcome nobody looked at: the cancel that
+        SUCCEEDS.
+
+        ``denied`` says "Say the phrase again when you're ready" — true of an
+        in-band denial, which leaves the proposal live, and false of a cancel,
+        which pops it. Following that advice lands on ``no_proposal`` — *"Tell
+        me again what you'd like sent"* — one turn later, which is the exact
+        line ``_cancel_refusal`` exists to keep off this path. So the advice
+        was routed around at one door and re-entered through another.
+        """
+        proposal = convo.announced_proposal()
+        verdict = convo.spine.cancel(proposal.token)
+        assert verdict.reason == "cancelled"
+        assert "say the phrase" not in verdict.spoken.lower()
+
+        # The move it names must be one that WORKS. Following the retired
+        # advice is what this asserts about: saying the phrase now cannot.
+        convo.approve(proposal)
+        after = convo.spine.confirm(proposal.token)
+        assert after.approved is False
+        assert after.reason == "no_proposal"
+        assert runner.calls == []
+
+    def test_the_in_band_denial_KEEPS_that_advice(self, convo, runner):
+        """The must-fail control, and the reason this is two outcomes rather
+        than one reworded line: on the in-band path the proposal is still live,
+        the phrase still works, and telling the owner so is correct."""
+        proposal = convo.announced_proposal()
+        # A confirm word is required to reach the judge's DENIED branch at all
+        # — `classify` returns NO_MATCH before consulting the denial grammar
+        # otherwise, which is `refused`, not `denied`.
+        convo.says("no, don't confirm that")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.reason == "denied"
+        assert "say the phrase again" in verdict.spoken.lower()
+        # ...and it is true: the proposal survived, so the advice can be taken.
+        assert proposal.token in {p.token for p in convo.spine.pending()}
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
+    def test_no_cancel_outcome_argues_for_the_write(self):
+        """Swept over the whole cancel vocabulary rather than the two lines
+        that were wrong, because the failure was a line reached from a path
+        nobody enumerated."""
+        for reason in ("cancelled", "nothing_to_cancel", "cancel_in_flight"):
+            spoken = confirm.SPOKEN[reason].lower()
+            for cue in self.RE_PROPOSE_CUES + ("say the phrase", "say confirm"):
+                assert cue not in spoken, (reason, cue)
 
     def test_the_honest_refusals_are_passed_through_unchanged(self, convo, runner):
         """``replayed`` and ``dispatch_failed`` are TRUE of a cancel and invite
@@ -2273,6 +2530,11 @@ class TestOutcomesAreDistinctAndSpoken:
         race_convo.approve(racing)
         race_spine.confirm(racing.token)
         seen |= set(cancelled)
+
+        # cancelled: the ordinary retraction. Split from `denied` because it
+        # POPS — "say the phrase again" cannot work once it has.
+        retracted = convo.announced_proposal()
+        seen.add(convo.spine.cancel(retracted.token).reason)
 
         # nothing_to_cancel: a cancel with nothing of ours to retract. It must
         # not reuse `no_proposal`/`expired`, whose lines argue for re-proposing

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -30,6 +30,7 @@ a guard; the runner is injected rather than stubbed at the subprocess layer.
 
 import itertools
 import re
+import textwrap
 import threading
 import time
 
@@ -1814,10 +1815,24 @@ class TestTheCancelBarrierIsONELockHold:
     of them produces a cancel claiming nothing was sent while something was.
     """
 
-    def _run(self, fire_at: int):
-        """One confirm, with a cancel fired at the *fire_at*-th lock release."""
+    def _run(self, fire_at: int, *, dispatch_succeeds: bool = True):
+        """One confirm, with a cancel fired at the *fire_at*-th lock release.
+
+        **Parametrised over the dispatch OUTCOME, and that is not decoration.**
+        The first version built a bare ``RecordingRunner()``, so every sweep ran
+        a SUCCEEDING dispatch and half the state space simply did not exist
+        while it swept: nothing ever entered ``_failed``, so the window in which
+        a token is both "dispatch came back failed" and "dispatching" was
+        unreachable — and the sweep reported exhaustive coverage of it. A sweep
+        that is exhaustive over lock releases but not over outcomes is
+        exhaustive in ONE AXIS, which is the shape of a green test that proves
+        the fixture.
+        """
         ring = transcript.TranscriptRing()
-        runner = RecordingRunner()
+        runner = RecordingRunner(
+            {"success": True} if dispatch_succeeds
+            else {"success": False, "error": "target gone"}
+        )
         spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner)
         convo = Conversation(ring, spine)
         proposal = convo.announced_proposal()
@@ -1828,6 +1843,14 @@ class TestTheCancelBarrierIsONELockHold:
         def observer(index: int) -> None:
             if index != fire_at or "cancel" in seen:
                 return
+            # The spine's own record of the write, read at the moment the
+            # cancel speaks. This is what makes "the outcome is already
+            # recorded" a question the assertion can ask, rather than one
+            # inferred from which release index we happen to be at.
+            seen["recorded"] = (
+                proposal.token in spine._succeeded
+                or proposal.token in spine._failed
+            )
             seen["cancel"] = spine.cancel(proposal.token).reason
 
         lock = _ObservableLock(threading.Lock(), observer)
@@ -1837,19 +1860,38 @@ class TestTheCancelBarrierIsONELockHold:
         seen["releases"] = lock.releases
         return seen
 
-    def test_no_observable_moment_lets_a_cancel_deny_a_write_that_happened(self):
+    @pytest.mark.parametrize("dispatch_succeeds", [True, False])
+    def test_no_observable_moment_lets_a_cancel_misreport_the_write(
+        self, dispatch_succeeds
+    ):
         """The pin. At every lock boundary, the two stories must agree."""
-        probe = self._run(fire_at=0)
+        probe = self._run(fire_at=0, dispatch_succeeds=dispatch_succeeds)
         total = probe["releases"]
         assert total >= 3, "the confirm must take the lock several times"
 
         stories = set()
         for index in range(1, total + 1):
-            seen = self._run(fire_at=index)
+            seen = self._run(fire_at=index, dispatch_succeeds=dispatch_succeeds)
             reason = seen.get("cancel")
             if reason is None:
                 continue
             stories.add((reason, seen["writes"] > 0))
+
+            # ONCE THE OUTCOME IS RECORDED, THE CANCEL MUST REPORT IT. The
+            # third and fourth windows are both this rule violated from
+            # different sides: a token sits in `_succeeded`/`_failed` while
+            # still marked claimed (third) or still marked dispatching
+            # (fourth), and cancel answered from the marker instead of from the
+            # record. `cancel_in_flight` is the sharpest case — "it's already
+            # going out ... we can undo it from there" is two definite claims
+            # about a dispatch the system has already recorded it CANNOT
+            # characterise (see `dispatch_failed`'s own line).
+            if seen.get("recorded"):
+                assert reason in ("replayed", "dispatch_failed"), (
+                    f"release {index}: the outcome was already recorded and "
+                    f"cancel said {reason!r}"
+                )
+
             if seen["writes"]:
                 # Something was sent, so no cancel may CLAIM OTHERWISE. Stated
                 # as the property rather than as an allowed outcome: which
@@ -1921,6 +1963,130 @@ class TestTheCancelBarrierIsONELockHold:
 
         assert verdict.reason not in ASSERTS_NOTHING_SENT, verdict.reason
         assert verdict.reason == "replayed"
+
+    @pytest.mark.parametrize(
+        "recorded,marker,expected",
+        [
+            # The THIRD window: outcome recorded, claim not yet released.
+            ("_succeeded", "_in_flight", "replayed"),
+            ("_failed", "_in_flight", "dispatch_failed"),
+            # The FOURTH: outcome recorded, the DISPATCHING marker not yet
+            # cleared. `_dispatching` was tested above both terminal facts, so
+            # a cancel here was told "it's already going out ... we can undo it
+            # from there" about a dispatch already recorded as failed — two
+            # definite claims about the one outcome `dispatch_failed` exists to
+            # say cannot be characterised.
+            ("_succeeded", "_dispatching", "replayed"),
+            ("_failed", "_dispatching", "dispatch_failed"),
+        ],
+    )
+    def test_a_recorded_outcome_outranks_every_in_progress_marker(
+        self, convo, runner, recorded, marker, expected
+    ):
+        """Both halves of the rule, on both markers, as a table.
+
+        The rule this branch introduced — *only facts about the WRITE can
+        contradict a spoken claim about sending* — was applied against
+        ``_in_flight`` and not against ``_dispatching``, and its ``_failed``
+        half was never exercised at all: deleting that check left the whole
+        suite green. A rule stated once and enforced against one of the two
+        markers is the shape both of those defects share, so it is asserted as
+        the cross-product rather than at the site that happened to break.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+
+        with convo.spine._lock:
+            convo.spine._succeeded.discard(proposal.token)
+            getattr(convo.spine, recorded).add(proposal.token)
+            getattr(convo.spine, marker).add(proposal.token)
+        try:
+            verdict = convo.spine.cancel(proposal.token)
+        finally:
+            with convo.spine._lock:
+                getattr(convo.spine, marker).discard(proposal.token)
+
+        assert verdict.reason == expected, (recorded, marker, verdict.reason)
+        assert verdict.reason not in ASSERTS_NOTHING_SENT
+
+    def test_the_barrier_read_and_mark_are_SYNTACTICALLY_inside_one_hold(self):
+        """The blind spot a boundary sweep has BY CONSTRUCTION.
+
+        The sweep fires at lock RELEASES, so it can only see states that a
+        release creates. Move the ``_cancelled`` read outside every lock and
+        there is no release between the read and the mark to fire at — the
+        sweep stays green while a cancel landing there is told "I haven't sent
+        anything" with the runner already called. That is the same bug, in the
+        one form the instrument cannot reach.
+
+        So this one is read off the SOURCE. A structural assertion is the right
+        tool exactly when the property is "these statements are in this scope",
+        which no amount of runtime observation can establish.
+        """
+        import ast
+        import inspect
+
+        source = inspect.getsource(confirm.ConfirmSpine._confirm_claimed)
+        tree = ast.parse(textwrap.dedent(source))
+
+        def holds_the_lock(node) -> bool:
+            return isinstance(node, ast.With) and any(
+                isinstance(item.context_expr, ast.Attribute)
+                and item.context_expr.attr == "_lock"
+                for item in node.items
+            )
+
+        def mentions(node, name: str) -> bool:
+            return any(
+                isinstance(child, ast.Attribute) and child.attr == name
+                for child in ast.walk(node)
+            )
+
+        barriers = [
+            node
+            for node in ast.walk(tree)
+            if holds_the_lock(node)
+            and mentions(node, "_cancelled")
+            and mentions(node, "_dispatching")
+        ]
+        assert len(barriers) == 1, (
+            "the _cancelled read and the _dispatching mark must sit in exactly "
+            f"one `with self._lock` block; found {len(barriers)}"
+        )
+
+        # ...and the two halves of the decision happen nowhere else. Two holds,
+        # a mark placed after the block, or an unlocked read all fail here.
+        #
+        # Scoped to the READ and the MARK, not to every mention: the `finally`
+        # that DISCARDS `_dispatching` is a legitimate second touch, and a
+        # blanket "this name appears once" would forbid releasing the marker at
+        # all. What must be atomic is deciding, not unwinding.
+        barrier = barriers[0]
+        span = range(barrier.lineno, (barrier.end_lineno or barrier.lineno) + 1)
+
+        def is_mark(node) -> bool:
+            return (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add"
+                and isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "_dispatching"
+            )
+
+        stray = [
+            child.lineno
+            for child in ast.walk(tree)
+            if (
+                (isinstance(child, ast.Attribute) and child.attr == "_cancelled")
+                or is_mark(child)
+            )
+            and child.lineno not in span
+        ]
+        assert stray == [], (
+            f"the _cancelled read or the _dispatching mark sits outside the "
+            f"barrier hold, at lines {stray} (relative to _confirm_claimed)"
+        )
 
     def test_the_two_flags_are_never_both_observable(self, convo):
         """The invariant stated directly as well as behaviourally.

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -145,8 +145,17 @@ def clock():
 
 
 @pytest.fixture
-def ring():
-    return transcript.TranscriptRing()
+def ring(clock):
+    """ONE clock across the ring and the spine.
+
+    The ring grew a wall-clock of its own with #989's staleness bounds, and a
+    ring on ``time.monotonic`` under a spine on :class:`FakeClock` is a fixture
+    that CANNOT BUILD the shape those bounds are about: advancing the clock
+    expires the proposal while the never-completing entry sits at age zero
+    forever. That is a green test proving the fixture's shape rather than the
+    code's.
+    """
+    return transcript.TranscriptRing(clock=clock)
 
 
 @pytest.fixture
@@ -1252,62 +1261,127 @@ class TestBoundedAwait:
         assert rejected_verdict.to_dict()["owner_should_wait"] is False
 
 
-class TestTheUnheardWindowHasNoStalenessBound:
-    """The widened ceiling's real price, pinned as behaviour.
+class TestTheUnheardWindowIsBounded:
+    """#989, and it is TWO failures under one name — only one needs a clock.
 
-    Re-reading ``high_seq`` after the await is the intended safety gain — a
-    denial STARTED during the await now blocks. But ``unheard_between`` has no
-    staleness bound of its own, so the cost is not "one ``pending_transcript``
-    wait" as the first version of this PR claimed: **any** ``speech_started``
-    that never completes — a cough, a VAD blip, TTS bleed — sits in the window
-    and refuses every confirm until the TTL expires the proposal.
+    Re-reading ``high_seq`` after the await is the intended safety gain: a
+    denial STARTED during the await blocks. Its price was that any
+    ``speech_started`` with no transcript to follow sat in the window refusing
+    every confirm as a WAIT outcome — no attempt burned, so
+    ``too_many_attempts`` never fired and the owner heard "give me a second"
+    for the whole 120s TTL and then "that one expired". A spoken LOOP, which in
+    a screenless channel is the expensive failure.
 
-    It is a spoken LOOP, not a refusal: ``pending_transcript`` is a WAIT
-    outcome, so it burns no attempt, so ``too_many_attempts`` never fires and
-    the owner is never told the proposal died. They are told "give me a second"
-    for up to the 120s TTL and then, on the next try, "that one expired".
+    The two shapes, because a single flat wall-clock age is wrong at one end
+    whichever value it takes:
 
-    Pinned rather than fixed here: the bound belongs in
-    ``TranscriptRing.unheard_between`` (``transcript.py``), which another
-    worker owns this wave. Nothing in the suite saw this shape —
-    ``test_a_denial_that_lands_as_harmless_lets_the_approval_through`` asserts
-    only the case where the utterance DOES complete.
+    1. **Transcribed but empty** — a cough the model renders as ``""``. There is
+       nothing to wait for and no clock is involved: an empty transcript
+       positively carries no denial. Retired by ``Utterance.transcribed``, at
+       zero false-reject cost.
+    2. **Never transcribed** — a real bound, split on whether the audio buffer
+       CLOSED. Committed: the utterance is over and ASR is merely overdue
+       (``UNHEARD_COMMITTED_GRACE_S``). Not committed: the owner may still be
+       mid-utterance, so the bound must exceed a plausible utterance
+       (``UNHEARD_OPEN_UTTERANCE_S``), or the gate stops waiting for a
+       retraction that is halfway spoken — the acting-twice direction.
     """
 
-    def test_one_never_completing_utterance_refuses_every_confirm_until_ttl(
-        self, convo, clock, runner
+    def test_an_empty_transcript_does_not_hold_the_gate_at_all(
+        self, convo, runner
     ):
+        """Shape 1, and the clock never moves — that is the assertion.
+
+        A cough transcribed as ``""`` is ``complete == False``, which is what
+        put it in the window. It is ``transcribed == True``, which is what takes
+        it out, immediately and with no bound to tune.
+        """
         proposal = convo.announced_proposal()
         convo.approve(proposal)
-        convo.starts_speaking()  # cough / VAD blip: no commit, no transcript
+        cough = convo.starts_speaking()
+        convo.ring.commit(cough, convo._next())
+        convo.ring.transcribe(cough, "")
 
-        for _ in range(confirm.MAX_CONFIRM_ATTEMPTS + 1):
-            verdict = convo.spine.confirm(proposal.token)
-            assert verdict.reason == "pending_transcript"
+        entry = next(e for e in convo.ring.snapshot() if e.item_id == cough)
+        assert entry.complete is False, "fixture must build the empty rendering"
+        assert entry.transcribed is True
+
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
+    def test_a_committed_utterance_with_no_transcript_ages_out_on_the_ASR_grace(
+        self, convo, clock, runner
+    ):
+        """Shape 2a. The buffer closed, so a missing transcript is overdue."""
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        blip = convo.starts_speaking()
+        convo.ring.commit(blip, convo._next())  # ...and no transcript, ever
+
+        # Inside the grace it still holds the gate: this is the half that must
+        # NOT be given up, or a slow transcriber's denial is dropped and the
+        # write goes out with a take-back mid-transcription.
+        clock.advance(transcript.UNHEARD_COMMITTED_GRACE_S - 0.5)
+        assert convo.spine.confirm(proposal.token).reason == "pending_transcript"
         assert runner.calls == []
 
-        # No attempt is burned, so the retirement path that would at least SAY
-        # something never fires. The proposal is alive and unusable.
-        live = {p.token: p for p in convo.spine.pending()}
-        assert live[proposal.token].attempts == 0
+        clock.advance(1.0)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
 
-        # It ends by expiring, up to PROPOSAL_TTL_S later, with nothing having
-        # told the owner anything but "give me a second".
-        clock.advance(confirm.PROPOSAL_TTL_S + 1)
-        assert convo.spine.confirm(proposal.token).reason == "expired"
+    def test_an_open_utterance_gets_the_longer_bound_because_it_may_still_be_spoken(
+        self, convo, clock, runner
+    ):
+        """Shape 2b, and the point is that it is NOT the ASR grace.
+
+        No commit means the owner may still be talking. Ageing this out on the
+        committed grace would stop waiting for a retraction they are in the
+        middle of saying — so the same wall-clock age that retires a committed
+        blip must leave this one holding the gate.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.starts_speaking()  # speech_started only: still mid-utterance
+
+        clock.advance(transcript.UNHEARD_COMMITTED_GRACE_S + 1)
+        assert convo.spine.confirm(proposal.token).reason == "pending_transcript"
         assert runner.calls == []
 
-    def test_the_module_states_this_residual_rather_than_the_cheaper_one(self):
-        """The prose half. A guarantee stated broader than the code gets
-        rounded back up — so the claim is NARROWED at the site, not qualified.
+        clock.advance(transcript.UNHEARD_OPEN_UTTERANCE_S)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
+
+    def test_the_bound_lands_inside_the_TTL_or_it_closes_nothing(self):
+        """Both bounds have to retire the entry while the proposal is still
+        alive. A bound at or past ``PROPOSAL_TTL_S`` leaves the loop exactly as
+        it was and merely renames it."""
+        assert (
+            transcript.UNHEARD_COMMITTED_GRACE_S
+            < transcript.UNHEARD_OPEN_UTTERANCE_S
+            < confirm.PROPOSAL_TTL_S
+        )
+        # And the committed grace has to outlast an ordinary transcript, or the
+        # bound itself becomes the false reject it was chosen to avoid.
+        assert transcript.UNHEARD_COMMITTED_GRACE_S > confirm.APPROVAL_WAIT_S
+
+    def test_the_module_no_longer_states_the_residual_it_fixed(self):
+        """The prose half, in the direction that actually rots.
+
+        ``confirm.py`` stated this residual AT ITS OWN USE SITE — "has no
+        staleness bound", "never completes", "until the TTL expires it" — and
+        those three sentences are false the moment the bound exists. A fix that
+        leaves them ships a lie exactly where the next reader looks.
         """
         source = _flat(_confirm_source())
         for clause in (
             "has no staleness bound",
-            "never completes",
+            "sits in this window and refuses every",
             "until the TTL expires it",
         ):
-            assert clause in source, clause
+            assert clause not in source, clause
+        # And it names where the bound went, so the division of labour between
+        # the two modules is still legible from the caller.
+        assert "The bound lives in TranscriptRing" in source
 
     def test_no_stale_sentence_survives_at_the_use_site(self):
         """The comment at the scan and the comment at the read must describe
@@ -1356,6 +1430,7 @@ class TestSingleUseIsClaimedNotJudged:
         assert convo.spine.confirm(proposal.token).approved is True
         assert len(calls) == 1, "the duplicate must not reach the runner"
         assert nested == ["in_flight"], nested
+
 
     def test_a_confirm_while_another_is_awaiting_never_reaches_the_runner(
         self, runner
@@ -1411,6 +1486,95 @@ class TestSingleUseIsClaimedNotJudged:
         assert spine.confirm(proposal.token).reason == "dispatch_failed"
         # Not in_flight: the failure is reported honestly on the retry.
         assert spine.confirm(proposal.token).reason == "dispatch_failed"
+
+
+class TestCancelTakesTheSameClaim:
+    """#990 — ``cancel()`` bypassed ``_claim()``, so it could speak a FALSE
+    STATEMENT rather than merely lose a race.
+
+    #987 made confirm-vs-confirm safe by construction: the second confirm gets
+    ``in_flight``, a WAIT outcome whose line is worded — deliberately, §3.6 —
+    to avoid claiming nothing was sent, *because the first confirm may be inside
+    the runner*. ``cancel`` was the same shape left uncovered: it popped the
+    proposal and said "I heard you hold off, so I haven't sent it" while the
+    runner was sending. Screenless, the owner hears an affirmative "nothing was
+    sent" about a write that went out, and has no way to discover otherwise.
+
+    The false-reject half is priced in the other direction: a cancel refused
+    for the wrong reason leaves a proposal the owner believes is dead.
+    """
+
+    def test_a_cancel_racing_a_dispatching_confirm_does_not_claim_nothing_was_sent(
+        self, convo, runner
+    ):
+        """The re-entrant construction: the cancel arrives from inside the
+        runner, i.e. strictly while the confirm is dispatching."""
+        cancels: list[confirm.Verdict] = []
+
+        def reentrant_runner(argv):
+            runner(argv)
+            cancels.append(convo.spine.cancel(proposal.token))
+            return {"success": True}
+
+        convo.spine._runner = reentrant_runner
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1, "fixture must have the confirm dispatching"
+
+        (verdict,) = cancels
+        assert verdict.reason == "cancel_in_flight"
+        spoken = verdict.spoken.lower()
+        assert "haven't sent" not in spoken, spoken
+        assert "hold off" not in spoken, spoken
+        # It is not terminal: closing the handshake here would close it out
+        # from under the confirm that is still running.
+        payload = verdict.to_dict()
+        assert payload["confirm_terminal"] is False
+        assert payload["owner_should_wait"] is True
+
+    def test_the_refused_cancel_still_tells_the_owner_what_happens_next(self):
+        """The false-reject half. A cancel that cannot be honoured is the one
+        moment the owner most needs the next move named — the thing they asked
+        for is the thing that is no longer available."""
+        line = confirm.SPOKEN["cancel_in_flight"].lower()
+        assert "don't repeat" in line
+        assert "tell you how it went" in line
+
+    def test_an_unannounced_proposal_can_still_be_cancelled(self, convo, runner):
+        """The claim is shared, MINUS the announcement requirement.
+
+        "The buddy hasn't finished saying it" is a reason to refuse a confirm —
+        the owner cannot have approved what they have not heard. It is not a
+        reason to refuse a RETRACTION, and refusing one would leave the
+        proposal live for its whole TTL over who was talking.
+        """
+        proposal = convo.propose()  # never announced
+        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.confirm(proposal.token).reason == "no_proposal"
+        assert runner.calls == []
+
+    def test_cancelling_a_write_that_already_went_out_says_so(self, convo, runner):
+        """``denied`` here asserted "I haven't sent it" about a completed
+        write. The claim already knows better — it just was not consulted."""
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert convo.spine.cancel(proposal.token).reason == "replayed"
+        assert len(runner.calls) == 1
+
+    def test_a_cancel_that_wins_the_race_still_retires_the_proposal(
+        self, convo, runner
+    ):
+        """The ordinary path is unchanged, and the claim is RELEASED — a marker
+        left set would wedge the token for its whole TTL."""
+        proposal = convo.announced_proposal()
+        assert convo.spine.cancel(proposal.token).reason == "denied"
+        assert convo.spine.pending() == []
+        assert convo.spine._in_flight == set()
+        assert convo.spine.confirm(proposal.token).reason == "no_proposal"
+        assert runner.calls == []
 
 
 # =============================================================================
@@ -1865,6 +2029,26 @@ class TestOutcomesAreDistinctAndSpoken:
         busy_convo.approve(busy)
         busy_spine.confirm(busy.token)
         seen |= set(nested)
+
+        # cancel_in_flight: a CANCEL arriving while a confirm is dispatching
+        # (#990). Same re-entrant construction as in_flight, different caller,
+        # and it must not report `denied` — that line asserts nothing was sent.
+        cancelled = []
+        race_spine = confirm.ConfirmSpine(
+            convo.ring,
+            wait_s=0.0,
+            runner=lambda argv: (
+                cancelled.append(race_spine.cancel(racing.token).reason),
+                {"success": True},
+            )[1],
+            clock=clock,
+        )
+        race_convo = Conversation(convo.ring, race_spine)
+        race_convo.seq = busy_convo.seq + 500
+        racing = race_convo.announced_proposal()
+        race_convo.approve(racing)
+        race_spine.confirm(racing.token)
+        seen |= set(cancelled)
         return seen
 
     def test_the_attempt_that_retires_the_proposal_says_so(self, convo, runner):
@@ -2542,6 +2726,137 @@ class TestTheFallbackEchoCannotApprove:
         result, _, _ = self._mint()
         nonce = result["confirm_phrase"].split()[1]
         assert nonce not in confirm.normalize(self._fallback_speech(result))
+
+
+#: Every ``SPOKEN`` line that would deny if it came back through the mic.
+#: DERIVED from the map, never typed: a new refusal line carrying a denial
+#: trigger is covered the day it is written, and a rewording that removes the
+#: last one fails the control test below rather than silently emptying the
+#: parametrization.
+SPOKEN_DENYING_LINES = [
+    line for line in confirm.SPOKEN.values() if confirm.carries_denial(line)
+]
+
+
+class TestTheBuddysOwnVoiceCannotDeny:
+    """#992 — the echo's OTHER direction, and the one nothing covered.
+
+    Approval by echo is closed structurally: the fallback channel never carries
+    a nonce (#953), which is what the class above proves. ``carries_denial`` has
+    no such gate, and several ``SPOKEN`` lines contain denial triggers — "I
+    heard you hold off…", "Hang on — I'm already working on that one", "I don't
+    have anything pending…". Echoed inside the approval→confirm window, one of
+    those retroactively DENIES the owner's own approval and reports a take-back
+    they never spoke, invisibly.
+
+    **The rule chosen is CONTENT, not timing, and that is the decision.** The
+    obvious rule — "utterances transcribed while the fallback voice is speaking
+    are not denials" — is unusable: barge-in over the robot voice is the normal
+    way to retract in this channel, so it drops genuine take-backs and the
+    write goes out. That is the acting-twice direction, strictly worse than the
+    wrongful refusal it fixes, which costs one re-spoken approval. A content
+    rule cannot fire on words the buddy never said, so it has no such half.
+    """
+
+    def test_the_map_really_does_contain_denial_carrying_lines(self):
+        """The must-fail control for the whole class: if this list is ever
+        empty, the parametrized test below passes vacuously."""
+        assert SPOKEN_DENYING_LINES, (
+            "SPOKEN has no denying line — the echo tests here prove nothing"
+        )
+        assert confirm.carries_denial(confirm.SPOKEN["denied"])
+
+    @pytest.mark.parametrize("echo", SPOKEN_DENYING_LINES)
+    def test_an_echoed_refusal_line_does_not_veto_the_approval(
+        self, echo, convo, runner
+    ):
+        """The whole line, echoed after the approval, must not deny."""
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says(echo)  # the browser voice, back through the mic
+
+        assert confirm.carries_denial(echo), echo
+        assert convo.spine.confirm(proposal.token).approved is True, echo
+        assert len(runner.calls) == 1
+
+    def test_a_real_take_back_over_the_robot_voice_still_denies(
+        self, convo, runner
+    ):
+        """The false-reject half, and the reason the timing rule was refused.
+
+        Every one of these is something an owner actually says while the buddy
+        is mid-sentence. A rule keyed on "was the fallback speaking" drops all
+        of them; the content rule keeps every one, because none is six
+        contiguous tokens of a line the buddy said.
+        """
+        for take_back in (
+            "no",
+            "hold off",
+            "hang on",
+            "no wait, don't send it",
+            "hold off — I heard you but hold off",
+            "stop",
+        ):
+            proposal = convo.announced_proposal()
+            convo.approve(proposal)
+            convo.says(take_back)
+            verdict = convo.spine.confirm(proposal.token)
+            assert verdict.reason == "denied", take_back
+        assert runner.calls == []
+
+    def test_a_barge_in_captured_WITH_the_echo_still_denies(self, convo, runner):
+        """The whole utterance must be the echo, not merely contain one.
+
+        The realistic capture of a barge-in is the tail of the buddy's line and
+        the owner's words in one transcript. That is not a contiguous run of any
+        line, so it denies — the enumeration fails CLOSED.
+        """
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says("hang on im already working on that one no stop")
+        assert convo.spine.confirm(proposal.token).reason == "denied"
+        assert runner.calls == []
+
+    def test_a_short_garbled_echo_fails_closed(self, convo, runner):
+        """Below the token floor it is treated as a denial: a wrongful refusal
+        costs one re-spoken approval, and nothing about being incomplete here
+        can make a write happen."""
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says("hold off")  # three words of the `denied` line
+        assert convo.spine.confirm(proposal.token).reason == "denied"
+        assert runner.calls == []
+
+    def test_the_echo_rule_never_makes_something_approvable(self):
+        """Suppression is only ever subtractive. No ``SPOKEN`` line carries a
+        nonce, so skipping one can never turn an echo into an approval."""
+        for line in confirm.SPOKEN.values():
+            for nonce in confirm.NONCE_WORDS:
+                assert confirm.classify(line, nonce) != confirm.APPROVED, line
+
+    def test_the_rule_is_applied_at_both_scan_sites(self, convo, runner):
+        """The judge's OWN loop, not the post-approval scan.
+
+        ``classify`` returns ``NO_MATCH`` before it ever consults the denial
+        grammar unless the utterance contains a confirm word — so most echoed
+        lines exercise only the scan, and a test built on one of those passes
+        with the loop guard deleted. The ``no_proposal`` line is the one that
+        reaches the loop's ``DENIED`` branch: it says "nothing to **confirm**"
+        and it says "**don't**". Echoed after the approval it is the newest
+        entry, so newest-first reaches it FIRST and returns ``denied`` before
+        the scan below is ever run.
+        """
+        echo = confirm.SPOKEN["no_proposal"]
+        assert confirm.classify(echo, "tango") == confirm.DENIED, (
+            "this echo must reach the judge loop's DENIED branch, or the test "
+            "proves only what the post-approval scan does"
+        )
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+        convo.says(echo)
+        assert convo.ring.snapshot()[-1].text == echo, "echo must be newest"
+        assert convo.spine.confirm(proposal.token).approved is True
+        assert len(runner.calls) == 1
 
 
 class TestHonestLimit:

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -2023,6 +2023,15 @@ class TestTheCancelBarrierIsONELockHold:
         So this one is read off the SOURCE. A structural assertion is the right
         tool exactly when the property is "these statements are in this scope",
         which no amount of runtime observation can establish.
+
+        **This pin checks SCOPE. It does not check ORDER.** Marking
+        ``_dispatching`` before reading ``_cancelled``, both inside the one
+        hold, passes here — and returns without entering the ``try``/``finally``
+        that releases the marker, so the marker leaks and every later cancel is
+        told *"Too late to stop that one — it's already going out"* forever,
+        about a write that never happened. The current order is correct and
+        nothing on this branch does that; the point is that whoever moves these
+        two statements is not protected against it by this test.
         """
         import ast
         import inspect

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -317,7 +317,10 @@ class TestTheWaitInstructionKeysOnTheFlagNotTheOutcomeNames:
     def test_no_wait_outcome_is_named_in_the_prose(self):
         for outcome in confirm.WAIT_OUTCOMES:
             assert outcome not in instructions.VOICE_MODE
-        assert len(confirm.WAIT_OUTCOMES) == 3  # in_flight arrived in W1
+        # A COUNTER, not a cap: the assertion above is the guarantee, and this
+        # line only forces a reader to re-check it whenever the set grows.
+        # in_flight arrived in W1; cancel_in_flight with #990.
+        assert len(confirm.WAIT_OUTCOMES) == 4
 
 
 class TestSpeakability:

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -209,6 +209,54 @@ class TestTheOutcomeTableIsComplete:
         assert "I heard you hold off" in confirm.SPOKEN["denied"]
 
 
+class TestTheResidualTableDoesNotAdvertiseClosedHoles:
+    """The residual table's own header says why this matters: *"a wiki that
+    describes what we meant is how the next contributor designs against
+    something that does not exist"*. That cuts both ways, and the second
+    direction is the one that rots silently — a CLOSED hole left listed as open
+    is a mechanism the next reader believes is missing, so they either rebuild
+    it or route around it. #989, #990 and #992 were the beta gate; each is now
+    described where it lives instead.
+    """
+
+    CLOSED = ("#989", "#990", "#992")
+
+    @staticmethod
+    def _residual_rows() -> "list[str]":
+        """The residual table's rows, from the RAW page.
+
+        Read raw rather than through the flattened ``page`` fixture: this is a
+        LINE-shaped claim, and flattening collapses the whole table onto one
+        line, which is how a line-based assertion here passes (or fails) for a
+        reason that has nothing to do with the table.
+        """
+        raw = WIKI.read_text(encoding="utf-8")
+        table = raw.split("### Known residuals")[1].split("### Standing constraints")[0]
+        return [line for line in table.splitlines() if line.startswith("| #")]
+
+    @pytest.mark.parametrize("issue", CLOSED)
+    def test_the_closed_ones_are_not_listed_as_residuals(self, issue):
+        rows = [r for r in self._residual_rows() if r.startswith(f"| {issue} |")]
+        assert rows == [], rows
+
+    def test_the_mechanisms_they_installed_are_documented(self, page):
+        """And the other direction: removing the row without documenting the
+        fix would leave the page silent about behaviour that now exists."""
+        for claim in (
+            "UNHEARD_COMMITTED_GRACE_S",
+            "UNHEARD_OPEN_UTTERANCE_S",
+            "`cancel()` takes the SAME claim",
+            "The buddy's own voice cannot deny",
+        ):
+            assert claim in page, claim
+
+    def test_the_residual_section_still_has_open_entries(self):
+        """The must-fail control. If the table is ever empty — or the split
+        above stops finding it — the parametrized test passes for the wrong
+        reason."""
+        assert self._residual_rows()
+
+
 class TestTheToolSurfaceIsNotEnumeratedStale:
     """The page listed 9 tools against a live surface many times that size.
 

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -220,7 +220,12 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
     described where it lives instead.
     """
 
-    CLOSED = ("#989", "#990", "#992")
+    #: Every residual this page has retired. **Not just the ones this wave
+    #: closed** — the defect is a stale sentence, and it does not care which
+    #: PR left it behind, so the pin covers #1007's three as well as the beta
+    #: gate's. Extending it was free here and would not have been later: a
+    #: closed hole only accumulates prose.
+    CLOSED = ("#989", "#990", "#992", "#995", "#996", "#997")
 
     @staticmethod
     def _residual_rows() -> "list[str]":

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -26,6 +26,7 @@ asserted on both sides, over `SOURCES` below.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -240,7 +241,7 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         assert rows == [], rows
 
     #: Words that describe a hole as still present. An OPEN marker in the same
-    #: PARAGRAPH as a closed issue id is the defect this catches.
+    #: SENTENCE as a closed issue id is the defect this catches.
     #:
     #: **This enumeration fails open and says so**: an unlisted phrasing slips
     #: through. What bounds it is that the vocabulary is the one a residual
@@ -253,38 +254,54 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         "pinned as behaviour", "pinned in the tests as behaviour", "to-do",
     )
 
-    #: Words marking the paragraph as talking about the CLOSURE or the history,
-    #: so an OPEN marker in that company is a correction rather than a claim.
+    #: Words marking the claim as being about the CLOSURE or the history, so an
+    #: OPEN marker in that company is a correction rather than an assertion.
     #: Same two-sided shape as `_RETIREMENT_MARKERS` above.
+    #:
     #: Deliberately NOT the bare stem "close": this page says "closes the
     #: approval direction" in the same breath as the stale claim it is about,
-    #: so a stem match let the offending paragraph neutralize itself — measured,
-    #: and the same too-loose-marker defect `_RETIREMENT_MARKERS` above records.
+    #: so a stem match let the offending sentence neutralize itself — measured,
+    #: and the same too-loose-marker defect `_RETIREMENT_MARKERS` records.
     CLOSURE_MARKERS = (
         "closed", "was open", "used to", "no longer", "rejected",
         "round 1", "originally",
     )
 
-    @staticmethod
-    def _paragraphs() -> "list[tuple[int, str]]":
-        """The RAW page as (line number, paragraph) pairs.
+    #: Sentence-ish boundaries. Newlines count, because a markdown LIST is one
+    #: block and its bullets are separate claims; `;` counts, because "#992 is
+    #: open; the scan no longer matters much" puts the suppressor in the second
+    #: clause of one sentence.
+    _UNIT_RE = re.compile(r"(?<=[.!?;:])\s+|\n")
 
-        **Paragraph-scoped, not window-scoped, and the difference is a measured
-        false negative.** A ±400-char window around the id caught nothing when
-        the stale paragraph sat immediately above the section that closes it:
-        the closure sentence next door was inside the window and silenced the
-        detector. The real defect was a SELF-CONTAINED paragraph making a claim,
-        so the unit the pin reasons about is a paragraph.
+    @classmethod
+    def _open_claims(cls, raw: str, issue: str) -> "list[str]":
+        """Sentences in *raw* that call *issue* open without retiring the claim.
+
+        **The suppressor is SENTENCE-scoped, and both wider scopes were
+        measured leaking.** A ±400-char window let the closure sentence next
+        door silence a stale paragraph. Block scoping then let a markdown LIST
+        launder one: a bullet saying "closed" suppressed a sibling bullet
+        saying "#992 still open", because a list is a single block. It also
+        missed "#992 remains open. See the table below for what is closed." and
+        "#992 is open; the scan no longer matters much" — a closure word in the
+        NEXT sentence, or the next clause, is not qualifying this one.
+
+        A sentence is the unit a claim is made in, so it is the unit the
+        suppressor gets.
         """
-        raw = WIKI.read_text(encoding="utf-8")
-        out, line = [], 1
-        for block in raw.split("\n\n"):
-            out.append((line, block))
-            line += block.count("\n") + 2
-        return out
+        found = []
+        for unit in cls._UNIT_RE.split(raw):
+            if issue not in unit:
+                continue
+            lowered = unit.lower()
+            if any(m in lowered for m in cls.CLOSURE_MARKERS):
+                continue
+            if any(m in lowered for m in cls.OPEN_MARKERS):
+                found.append(" ".join(unit.split())[:160])
+        return found
 
     @pytest.mark.parametrize("issue", CLOSED)
-    def test_no_PROSE_paragraph_still_calls_them_open(self, issue):
+    def test_no_PROSE_sentence_still_calls_them_open(self, issue):
         """The pin the round-1 version structurally could not be.
 
         That one read residual-TABLE rows, so a paragraph 240 lines above the
@@ -293,39 +310,50 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         page's own "#989/#990/#992 are CLOSED". Removing a table row is not the
         same claim as retiring a sentence, and only one of them was pinned.
         """
-        offences = []
-        for line, block in self._paragraphs():
-            lowered = block.lower()
-            if issue not in block:
-                continue
-            if any(m in lowered for m in self.CLOSURE_MARKERS):
-                continue
-            hit = [m for m in self.OPEN_MARKERS if m in lowered]
-            if hit:
-                offences.append((line, hit))
+        offences = self._open_claims(WIKI.read_text(encoding="utf-8"), issue)
         assert offences == [], offences
 
+    #: Placements a stale claim has actually taken, or was shown to be able to
+    #: take. Each is planted into the REAL page and run through the REAL
+    #: detector below — the round-2 control checked a planted sentence against
+    #: the two tuples and never invoked `_open_claims` at all, so it could not
+    #: have found the list-scoping leak it was supposed to guard.
+    PLACEMENTS = (
+        ("standalone paragraph", "The denial direction is open ({issue})."),
+        (
+            "bullet beside a closed sibling",
+            "- {issue} still open, nobody has taken it.\n"
+            "- The approval direction is closed.",
+        ),
+        (
+            "closure word in the NEXT sentence",
+            "{issue} remains open. See the table below for what is closed.",
+        ),
+        (
+            "closure word in the next CLAUSE",
+            "{issue} is open; the scan no longer matters much.",
+        ),
+    )
+
     @pytest.mark.parametrize("issue", CLOSED)
-    def test_the_prose_pin_can_actually_fire(self, issue):
-        """The must-fail control for the pin above, run per issue.
+    @pytest.mark.parametrize("label,template", PLACEMENTS)
+    def test_the_prose_pin_can_actually_fire(self, issue, label, template):
+        """The must-fail control, and it RUNS THE DETECTOR.
 
         An absence test over a vocabulary is exactly the shape that goes green
         because nothing can match it — six of this file's own claims once did.
-        So the detector is run over a page carrying the sentence it forbids,
-        planted where the real one lived: as its own paragraph, immediately
-        above the section that closes it, which is precisely the placement a
-        window-scoped detector could not see.
+        The round-2 version of this control only compared a planted string to
+        the two tuples, which is a test of the tuples, not of the detector: it
+        passed while the detector was blind to three of the four placements
+        below.
         """
-        planted = (
-            f"The denial direction is open ({issue}), and nobody has taken it."
+        anchor = "### Denial words and denial EXCEPTIONS have opposite bars"
+        raw = WIKI.read_text(encoding="utf-8")
+        assert anchor in raw, "anchor for the planted claim moved"
+        planted = raw.replace(
+            anchor, template.format(issue=issue) + "\n\n" + anchor, 1
         )
-        lowered = planted.lower()
-        assert issue in planted
-        assert any(m in lowered for m in self.OPEN_MARKERS)
-        assert not any(m in lowered for m in self.CLOSURE_MARKERS), (
-            "the planted sentence must not neutralize itself, or the control "
-            "proves only that the closure vocabulary works"
-        )
+        assert self._open_claims(planted, issue), label
 
     def test_the_mechanisms_they_installed_are_documented(self, page):
         """And the other direction: removing the row without documenting the

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -239,6 +239,94 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         rows = [r for r in self._residual_rows() if r.startswith(f"| {issue} |")]
         assert rows == [], rows
 
+    #: Words that describe a hole as still present. An OPEN marker in the same
+    #: PARAGRAPH as a closed issue id is the defect this catches.
+    #:
+    #: **This enumeration fails open and says so**: an unlisted phrasing slips
+    #: through. What bounds it is that the vocabulary is the one a residual
+    #: paragraph actually uses — derived from the paragraph that survived round
+    #: 1 ("the denial direction is **open** (#992)", "**Open**, and priced
+    #: rather than assumed"), not invented.
+    OPEN_MARKERS = (
+        "is open", "are open", "open residual", "remains open", "still open",
+        "open, and priced", "not fixed", "unfixed", "left uncovered",
+        "pinned as behaviour", "pinned in the tests as behaviour", "to-do",
+    )
+
+    #: Words marking the paragraph as talking about the CLOSURE or the history,
+    #: so an OPEN marker in that company is a correction rather than a claim.
+    #: Same two-sided shape as `_RETIREMENT_MARKERS` above.
+    #: Deliberately NOT the bare stem "close": this page says "closes the
+    #: approval direction" in the same breath as the stale claim it is about,
+    #: so a stem match let the offending paragraph neutralize itself — measured,
+    #: and the same too-loose-marker defect `_RETIREMENT_MARKERS` above records.
+    CLOSURE_MARKERS = (
+        "closed", "was open", "used to", "no longer", "rejected",
+        "round 1", "originally",
+    )
+
+    @staticmethod
+    def _paragraphs() -> "list[tuple[int, str]]":
+        """The RAW page as (line number, paragraph) pairs.
+
+        **Paragraph-scoped, not window-scoped, and the difference is a measured
+        false negative.** A ±400-char window around the id caught nothing when
+        the stale paragraph sat immediately above the section that closes it:
+        the closure sentence next door was inside the window and silenced the
+        detector. The real defect was a SELF-CONTAINED paragraph making a claim,
+        so the unit the pin reasons about is a paragraph.
+        """
+        raw = WIKI.read_text(encoding="utf-8")
+        out, line = [], 1
+        for block in raw.split("\n\n"):
+            out.append((line, block))
+            line += block.count("\n") + 2
+        return out
+
+    @pytest.mark.parametrize("issue", CLOSED)
+    def test_no_PROSE_paragraph_still_calls_them_open(self, issue):
+        """The pin the round-1 version structurally could not be.
+
+        That one read residual-TABLE rows, so a paragraph 240 lines above the
+        section that closes #992 could go on calling it open — and did, while
+        naming the two mitigations that section rejects, 1200 lines from the
+        page's own "#989/#990/#992 are CLOSED". Removing a table row is not the
+        same claim as retiring a sentence, and only one of them was pinned.
+        """
+        offences = []
+        for line, block in self._paragraphs():
+            lowered = block.lower()
+            if issue not in block:
+                continue
+            if any(m in lowered for m in self.CLOSURE_MARKERS):
+                continue
+            hit = [m for m in self.OPEN_MARKERS if m in lowered]
+            if hit:
+                offences.append((line, hit))
+        assert offences == [], offences
+
+    @pytest.mark.parametrize("issue", CLOSED)
+    def test_the_prose_pin_can_actually_fire(self, issue):
+        """The must-fail control for the pin above, run per issue.
+
+        An absence test over a vocabulary is exactly the shape that goes green
+        because nothing can match it — six of this file's own claims once did.
+        So the detector is run over a page carrying the sentence it forbids,
+        planted where the real one lived: as its own paragraph, immediately
+        above the section that closes it, which is precisely the placement a
+        window-scoped detector could not see.
+        """
+        planted = (
+            f"The denial direction is open ({issue}), and nobody has taken it."
+        )
+        lowered = planted.lower()
+        assert issue in planted
+        assert any(m in lowered for m in self.OPEN_MARKERS)
+        assert not any(m in lowered for m in self.CLOSURE_MARKERS), (
+            "the planted sentence must not neutralize itself, or the control "
+            "proves only that the closure vocabulary works"
+        )
+
     def test_the_mechanisms_they_installed_are_documented(self, page):
         """And the other direction: removing the row without documenting the
         fix would leave the page silent about behaviour that now exists."""
@@ -562,17 +650,27 @@ class TestTheInterruptTierIsNotOverPromised:
 
 class TestTheOpenResidualsAreNamed:
     """A wiki that describes what we meant is how the next contributor argues
-    from a mechanism that does not exist."""
+    from a mechanism that does not exist.
 
-    @pytest.mark.parametrize("issue", [989, 990, 992, 1009])
+    #989, #990 and #992 were removed from this list when they were closed —
+    leaving them would have been the same defect with its polarity flipped, and
+    for one round it WAS: a paragraph 240 lines above the section that closes
+    #992 still called it open and still recommended the two mitigations that
+    section rejects. `TestTheResidualTableDoesNotAdvertiseClosedHoles` is the
+    pin for that direction, and it reads prose, not only table rows.
+
+    #995/#996/#997 left the same way in #1007, so #1009 is what remains.
+    """
+
+    @pytest.mark.parametrize("issue", [1009])
     def test_residual_is_recorded(self, page, issue):
         assert f"#{issue}" in page
 
-    def test_the_never_completing_utterance_loop_is_described(self, page):
-        assert "no staleness bound" in page
-
-    def test_the_echoed_denial_hole_is_described(self, page):
-        assert "`carries_denial` is not nonce-gated" in page
+    def test_the_ones_that_shipped_a_fix_are_not_in_this_list(self):
+        """The two lists are complements, asserted rather than assumed —
+        an issue in both is a page contradicting itself."""
+        closed = set(TestTheResidualTableDoesNotAdvertiseClosedHoles.CLOSED)
+        assert "#1009" not in closed
 
     def test_the_page_does_not_call_onNotSpoken_a_positive_report_only(self, page):
         """The wiki carried the same sentence ``client.py``'s handler did —

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -272,30 +272,68 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         "round 1", "originally",
     )
 
-    #: Sentence-ish boundaries. Newlines count, because a markdown LIST is one
-    #: block and its bullets are separate claims; `;` counts, because "#992 is
-    #: open; the scan no longer matters much" puts the suppressor in the second
-    #: clause of one sentence.
-    _UNIT_RE = re.compile(r"(?<=[.!?;:])\s+|\n")
+    #: Lines that START A NEW CLAIM rather than continuing one: markdown
+    #: structure. Everything else is a SOFT wrap and gets joined back up.
+    #:
+    #: This file hand-wraps prose — 1351 of its 2345 source lines continue a
+    #: sentence — so splitting on every newline (which is what fixed the bullet
+    #: leak) chopped hand-wrapped sentences in half and put the id and the
+    #: marker in different units. That is not hypothetical: **the actual
+    #: round-1 stale paragraph, in its original wrapping, was not caught** —
+    #: only once unwrapped by hand. A pin that catches the defect that started
+    #: this only in a form it never had is "catches the placement it was built
+    #: from", one level up.
+    _STRUCTURAL_RE = re.compile(r"^\s*(?:[-*+]\s|\||#{1,6}\s|>|\[\^)")
+
+    #: Sentence boundaries WITHIN a joined block. `;` and `:` count, because
+    #: "#992 is open; the scan no longer matters much" puts the suppressor in
+    #: the next clause of one sentence.
+    _SENTENCE_RE = re.compile(r"(?<=[.!?;:])\s+")
+
+    @classmethod
+    def _units(cls, raw: str) -> "list[str]":
+        """*raw* as claims: soft wraps joined, structural lines kept apart."""
+        blocks: list[str] = []
+        for line in raw.splitlines():
+            if not line.strip():
+                blocks.append("")
+                continue
+            if not blocks or blocks[-1] == "" or cls._STRUCTURAL_RE.match(line):
+                blocks.append(line.strip())
+            else:
+                blocks[-1] = blocks[-1] + " " + line.strip()
+        units: list[str] = []
+        for block in blocks:
+            units.extend(cls._SENTENCE_RE.split(block))
+        return units
 
     @classmethod
     def _open_claims(cls, raw: str, issue: str) -> "list[str]":
-        """Sentences in *raw* that call *issue* open without retiring the claim.
+        """Claims in *raw* that call *issue* open without retiring the claim.
 
-        **The suppressor is SENTENCE-scoped, and both wider scopes were
-        measured leaking.** A ±400-char window let the closure sentence next
-        door silence a stale paragraph. Block scoping then let a markdown LIST
-        launder one: a bullet saying "closed" suppressed a sibling bullet
-        saying "#992 still open", because a list is a single block. It also
-        missed "#992 remains open. See the table below for what is closed." and
-        "#992 is open; the scan no longer matters much" — a closure word in the
-        NEXT sentence, or the next clause, is not qualifying this one.
+        **Three scopes were measured leaking before this one.** A ±400-char
+        window let the closure sentence next door silence a stale paragraph.
+        Block scoping let a markdown LIST launder one, because a list is a
+        single block and a bullet saying "closed" suppressed a sibling bullet
+        saying "#992 still open". Splitting on every newline fixed that and
+        broke the opposite way: hand-wrapped prose got chopped mid-sentence, so
+        the id and the marker landed in different units — which is how the
+        ORIGINAL stale paragraph escaped a pin written to catch exactly it.
 
-        A sentence is the unit a claim is made in, so it is the unit the
-        suppressor gets.
+        So: join soft wraps, split hard only before markdown structure, then
+        split the result into sentences. A claim is the unit, whatever the
+        line breaks are doing.
+
+        **Known misses, recorded rather than chased.** A claim split across two
+        sentences by a pronoun ("#992 is the echo hole. It is still open.")
+        carries no id in the sentence that carries the marker. And a table row
+        that mentions both the id and the word "closed" suppresses itself.
+        Both need the id resolved across sentences, which is a different
+        instrument; neither has occurred, and this one now catches every
+        placement that has.
         """
         found = []
-        for unit in cls._UNIT_RE.split(raw):
+        for unit in cls._units(raw):
             if issue not in unit:
                 continue
             lowered = unit.lower()
@@ -337,6 +375,38 @@ class TestTheResidualTableDoesNotAdvertiseClosedHoles:
         (
             "closure word in the next CLAUSE",
             "{issue} is open; the scan no longer matters much.",
+        ),
+        # THE ONE THE CONTROL WAS BLIND TO. Every template above is a single
+        # line, and this file hand-wraps prose — so the control could not
+        # exercise the wrapping, and the pin missed the ACTUAL round-1
+        # paragraph in its ACTUAL form while passing on the same words typed
+        # flat. Reproduced verbatim from the sentence that survived round 1,
+        # line breaks included, because the line breaks were the defect.
+        (
+            "hand-wrapped, as the real stale paragraph was",
+            "**That closes the approval direction only, and the denial "
+            "direction is\nopen ({issue}).** `carries_denial` is not "
+            "nonce-gated, and the fallback\nvoice also speaks inbox notices, "
+            "re-raises and error notices.",
+        ),
+        (
+            "wrapped so the id and the marker are on DIFFERENT lines",
+            "The scan still has the hole {issue}\ndescribes, and it is open.",
+        ),
+        ("heading", "### {issue} is still open"),
+        ("table row", "| {issue} | `_judge` | still open, nobody took it |"),
+        ("blockquote", "> {issue} remains open."),
+        ("nested list", "  - {issue} is open, see above."),
+        # THE ONE THAT MAKES THE STRUCTURAL SPLIT LOAD-BEARING. With terminal
+        # punctuation the sentence split alone separates sibling bullets, so
+        # the bullet placement above passes even with structural splitting
+        # removed — it proved the sentence rule, not the structure rule. A
+        # bullet list without full stops is the shape where only the structure
+        # rule keeps a "closed" sibling from laundering its neighbour, and this
+        # page writes lists both ways.
+        (
+            "bullets with NO terminal punctuation",
+            "- {issue} is open\n- the approval direction is closed",
         ),
     )
 


### PR DESCRIPTION
The three open residuals the owner ruled must not ship in the beta. They are one
job because #989's bound **falsifies three sentences `confirm.py` states at its
own use site** and asserts verbatim in `test_voice_confirm.py` — so taking the
bound without owning `confirm.py` was correctly refused in wave 4, and a partial
fix here would ship a lie at the use site.

## #989 — the unheard window is bounded, in TWO shapes

`transcript.unheard_between` had no staleness bound: any `speech_started` with
no transcript to follow refused every confirm as a WAIT outcome, so no attempt
was burned, `too_many_attempts` never fired, and the owner heard *"give me a
second"* for the whole 120s TTL and then *"that one expired"*. A spoken loop,
which in a screenless channel is the expensive failure.

**One flat wall-clock age cannot price both shapes** — that is the trap in the
obvious fix:

| Shape | Fix | Cost |
|---|---|---|
| Transcribed but **empty** (a cough rendered `""`) | `Utterance.transcribed` — a transcript EVENT arrived. The window filters on that, not on non-empty text | **Zero false-reject.** An empty transcript positively carries no denial |
| **Never transcribed**, buffer CLOSED | `UNHEARD_COMMITTED_GRACE_S` = 10s — the utterance is over, ASR is merely overdue (vs ~2.5s for an ordinary transcript) | A slow transcriber's denial dropped → the write goes out. Hence generous |
| **Never transcribed**, buffer OPEN | `UNHEARD_OPEN_UTTERANCE_S` = 60s — the owner may still be speaking | Ageing this on the committed grace stops waiting for a retraction that is halfway spoken: acting-twice, not a wait |

`complete` still gates `after()`, where the question is different (can this text
approve). Both bounds land well inside `PROPOSAL_TTL_S`, pinned — a bound at the
TTL closes nothing and merely renames the loop.

The prose and the pins at the use site are **rewritten**, not qualified: the
three clauses ("has no staleness bound", "…refuses every confirm", "until the
TTL expires it") are now asserted **absent**, and the caller states where the
bound went instead.

## #990 — `cancel()` takes the same claim

It bypassed `_claim()` entirely, so a cancel racing a dispatching confirm popped
the proposal and said *"I heard you hold off, so I haven't sent it"* while the
runner was sending — the exact over-claim `in_flight`'s wording exists to avoid
(#987), on the sibling path. Screenless that is not a lost cancel: it is an
affirmative "nothing was sent" the owner has no way to check.

- The losing cancel gets its **own** outcome, `cancel_in_flight`, not
  `in_flight` — they answer different questions ("should I confirm again?" vs
  "did you stop it?"), and its line names the move that is still open, because
  the one thing the owner asked for is the one thing no longer available.
- A **WAIT** outcome, so `confirm_terminal` stays False: closing the handshake
  here would close it out from under the confirm still running.
- **The false-reject half:** `require_announced=False`. "The buddy hasn't
  finished saying it" refuses a *confirm* (the owner cannot approve what they
  have not heard); it is no reason to refuse a *retraction*, and refusing one
  would leave the proposal live for its full TTL over who was talking.
- Everything else in the claim now applies to cancel too — a cancel after the
  write really went out says `replayed` rather than asserting it did not.

## #992 — the buddy's own voice cannot deny

Several `SPOKEN` lines carry denial triggers ("I heard you **hold off**…",
"**Hang on** — I'm already working on that one", "I **don't** have anything
pending…"), and `speechSynthesis` is outside echo cancellation. Echoed into the
approval→confirm window, one of those retroactively denies a legitimate
approval.

**The rule is CONTENT, not timing — and that is the decision, not a detail.**
Barge-in over the robot voice is the NORMAL way to retract in this channel, so
any rule of the form *"utterances transcribed during fallback speech do not
count as denials"* drops a genuine take-back and the write goes out: the
acting-twice direction, strictly worse than the wrongful refusal it fixes (one
re-spoken approval, via the newest-first binding). A content rule cannot fire on
words the buddy never said.

`is_buddy_echo`: the **whole** normalized utterance must be a contiguous run of
**≥6 tokens** inside some `SPOKEN` line.

- *Whole-utterance* — a barge-in captured with the echo's tail ("hang on im
  already working on that one no stop") is not a run of any line, so it denies.
- *Six tokens* — the entire false-reject budget, chosen against the collision:
  the triggers are exactly what an owner says, so a 2–3 token floor would
  suppress a real "hold off", and a suppressed retraction WRITES. A short or
  garbled echo misses the floor and **fails closed**.
- Applied at **both** sites. The judge's newest-first loop reaches an echo that
  landed after the approval *before* the post-approval scan does — guarding only
  the scan leaves the loop returning `denied` first.

**Coverage stated honestly:** `SPOKEN` is this module's own taxonomy, so
attacker-influenceable text (a delivered body spoken by `composeNotice`) is not
in it. That text cannot reach this window today for a separate reason —
`client.py`'s `canSpeak` **and** `canInterrupt` both require
`!confirmGate.outstanding()`, and the gate is closed from the moment a proposal
is spoken until its terminal outcome or TTL, which is exactly this window. If
that gate is ever relaxed the rule needs the spoken text fed in rather than read
from `SPOKEN`; the timing mark stays the wrong instrument either way. Recorded
in the module and on the wiki page.

## Method

Every new pin was **watched failing**: 13 mutations of the thing each one
guards, each caught, each run carrying a **must-survive control** so a
collection error cannot read as a clean sweep. One mutation (M9) found a test of
mine that passed for the wrong reason — it exercised only the post-approval scan
because `classify` returns `NO_MATCH` before consulting the denial grammar
unless the utterance contains a confirm word; the test now uses the one line
that reaches the judge loop's `DENIED` branch, and asserts that it does.

The `ring` fixture now shares the `FakeClock` with the spine — a ring on
`time.monotonic` under a spine on a fake clock **cannot construct** the shape
these bounds are about (advancing expires the proposal while the entry sits at
age zero forever).

CI's own invocation, full suite: **6114 passed, 36 skipped, 0 failed**
(baseline 6089).

## Wiki

`docs/wiki/voice-layer.md` reconciled: the residual table no longer advertises
the three as open, each mechanism is documented where it lives, and a new pin
fails if a closed hole is left listed — with its own must-fail control, since an
empty table would make it pass vacuously.

## Note for the `write_tools.py` owner (not touched here)

`cancel_<name>`'s tool description says *"Does nothing and never fails."* There
is now one refusal path (`cancel_in_flight`). The payload shape is unchanged —
cancel already returned `success: False` on its happy path — but the sentence is
worth a word.

Closes #989
Closes #990
Closes #992

Built by [dotdev.dev](https://dotdev.dev)