### PR TITLE
voice-layer: close the three client.py residuals — wires pinned, watchdog releases, pump defers

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -164,15 +164,17 @@ function createAnnouncer(deps) {
   // canInterrupt — letting a volunteered notice or an escalation be announced
   // over the browser voice.
   //
-  // What it does NOT rule out, stated because the previous version of this
-  // comment claimed the whole of #950: the budget never gates the announcer's
-  // own FIFO. armFallback nulls `current`, starts speak(), and calls pump() in
-  // the SAME tick, and pump() consults `current` and `queue` only — never
-  // `speaking`. So a second must_speak item queued behind a long notice is
-  // promoted and its response.create goes out while the browser voice is
-  // starting the first one's audio: two voices, at any watchdog length,
-  // reached without the watchdog firing at all. That path is a live residual
-  // and a separate decision, not something the scaling closes.
+  // What the scaling itself does not rule out — and what now does. The budget
+  // gates pending()/anchorPending(), which are the NOTIFIER's gates; it said
+  // nothing about the announcer's own FIFO. armFallback nulls `current`,
+  // starts speak(), and calls pump() in the SAME tick, so a second must_speak
+  // item queued behind a long notice was promoted and its response.create went
+  // out while the browser voice was starting the first one's audio: two
+  // voices, at any watchdog length, reached without the watchdog firing at all
+  // (#997). pump() now defers while `speaking` is non-empty — see the bound
+  // there, which is this same budget rather than a new number, because this is
+  // exactly how long the page is willing to BELIEVE the browser voice is
+  // talking.
   //
   // The per-character rate is deliberately SLOWER than any real voice (~7
   // characters a second against a typical 15). The two directions are not
@@ -335,17 +337,38 @@ function createAnnouncer(deps) {
       // dropped with no onend/onerror would leave the gates shut forever.
       speaking.push(item);
       var budget = speakingBudget(say);
+      // Kept on the item because pump()'s deferral bound reads it: the
+      // longest this page will believe this utterance is playing is the same
+      // number that decides when to stop believing it (#997).
+      item.speakBudget = budget;
       item.speakTimer = setTimer(function () {
         onLog("fallback", "no end event within " + budget + "ms");
-        stopSpeaking(item);
+        // NOT SPOKEN — and saying so is the fix for #996. The watchdog used to
+        // call stopSpeaking() alone: it reopened the gates (its stated scope,
+        // done correctly) but released nothing, so the ids stayed in the
+        // notifier's inFlight map for the life of the page. Since #970 that is
+        // no longer data loss — nothing announced is cursor-past, so a reload
+        // recovers it — but a permanently-inFlight id wedges the contiguity
+        // walk, so everything after it is spoken and never acked and a reload
+        // REPEATS it. Suppression until reload, then duplicates.
+        //
+        // Both halves, since this is the announcer deciding the owner did not
+        // hear something. False-reject (a slow but LIVE utterance declared
+        // dropped) costs a re-announcement — the owner hears it twice — and
+        // the margin against it is the #993 budget, measured conservative by
+        // 2.6-4.5x against every plausible macOS system voice. False-accept
+        // (staying silent) costs the notice until a reload the owner has no
+        // way to know they need. Double-speak is the cheap failure here, which
+        // is the same trade carriedTheReason already makes.
+        settleSpeech(item, false);
       }, budget);
       try {
         speak(
           say,
-          function () { stopSpeaking(item); onSpoken(item.meta, "fallback"); },
-          function () { stopSpeaking(item); onNotSpoken(item.meta); }
+          function () { settleSpeech(item, true); },
+          function () { settleSpeech(item, false); }
         );
-      } catch (e) { stopSpeaking(item); onSpoken(item.meta, "fallback"); }
+      } catch (e) { settleSpeech(item, true); }
       pump();
     }, fallbackMs);
   }
@@ -365,8 +388,104 @@ function createAnnouncer(deps) {
     speaking = speaking.filter(function (it) { return it !== item; });
   }
 
-  function pump() {
+  // The one place a fallback utterance gets an OUTCOME, and exactly once.
+  //
+  // Three callers can reach this for the same item — utterance.onend,
+  // utterance.onerror, and the watchdog — and until #996 only the first two
+  // reported anything, so the third was silent. Making the watchdog report
+  // makes the LATCH load-bearing rather than tidy: without it a watchdog
+  // firing at the budget and a late onend arriving afterwards would release
+  // the ids (re-announce) and then ack them (mark heard), in that order, which
+  // is a notice announced twice and acked once. First outcome wins; the rest
+  // are the same utterance being described again.
+  function settleSpeech(item, spoken) {
+    if (!item || item.speechSettled) return;
+    item.speechSettled = true;
+    stopSpeaking(item);
+    if (spoken) onSpoken(item.meta, "fallback");
+    else onNotSpoken(item.meta);
+    // The queue was waiting on this audio (#997) — promote now rather than on
+    // the deferral's backstop timer.
+    pump();
+  }
+
+  // #997's deferral. Cleared whenever the pump actually promotes, and on
+  // teardown.
+  var pumpDeferTimer = null;
+
+  function releasePump() {
+    if (pumpDeferTimer) { clearTimer(pumpDeferTimer); pumpDeferTimer = null; }
+  }
+
+  // How long the pump may wait for the browser voice: the budget of the
+  // utterance actually in flight, never a new constant. See pump().
+  function pumpBound() {
+    var bound = speakingBaseMs;
+    speaking.forEach(function (it) {
+      if (it.speakBudget > bound) bound = it.speakBudget;
+    });
+    return bound;
+  }
+
+  // `force` is the bound expiring, and nothing else sets it.
+  function pump(force) {
     if (current || !queue.length) return;
+    // NEVER OVER THE BUDDY'S OWN VOICE (#997). The budget above gates
+    // pending()/anchorPending() — the NOTIFIER's gates — and said nothing
+    // about this FIFO, so an item queued behind a long fallback utterance was
+    // promoted in the same tick that utterance started and its response.create
+    // went out over it: the two-voices defect (#950), reached with no watchdog
+    // fire and no gate violated.
+    //
+    // BOUNDED, and the bound is the whole design: an unbounded defer converts
+    // an audio-quality defect into a SUPPRESSION defect, which is strictly
+    // worse in a screenless channel. Both halves priced:
+    //
+    //   false-accept (waiting too long): the queued item is delayed behind
+    //     audio the owner IS CURRENTLY HEARING. Not silence — the buddy is
+    //     talking the whole time — and it ends when that audio does, because
+    //     settleSpeech pumps.
+    //   false-reject (promoting too early): two voices at once, which is the
+    //     defect this exists to stop.
+    //
+    // So the bound is the SPEAKING BUDGET of the utterance in flight (#993:
+    // 30s floor + 140ms/char), not a new number — that is precisely how long
+    // this page is willing to BELIEVE the browser voice is talking. Past it
+    // the watchdog has already declared the utterance dropped (#996), emptied
+    // `speaking` and pumped; this timer is the backstop for the case where it
+    // somehow has not, and it promotes rather than staying mute. The worst
+    // case is therefore one budget, and it is bounded even if the watchdog is
+    // broken.
+    //
+    // WHAT THIS DELAY IS UPSTREAM OF, said here because it falsifies a
+    // sentence in another file: the announcer's own two bounded deferrals are
+    // counted from the moment an item becomes `current`, and confirm.py's
+    // not_announced note bounds the wait for that refusal in units of
+    // fallbackMs on that basis. A refusal queued while a fallback utterance is
+    // live now waits HERE first, so that note under-states the worst case by
+    // up to one speaking budget in exactly that state. The trade is still the
+    // right one — the owner is listening to the buddy for the whole wait
+    // rather than sitting in silence — but the number over there is no longer
+    // the whole story, and confirm.py is owned elsewhere this wave.
+    if (speaking.length && !force) {
+      if (!pumpDeferTimer) {
+        var bound = pumpBound();
+        onLog("pump", "deferred — the browser voice is speaking (bound " +
+          bound + "ms)");
+        var handle = setTimer(function () {
+          // Only the LIVE deferral may force. A cleared timer that fires
+          // anyway — a fake-timer harness, a browser running a just-cancelled
+          // callback — must not promote over a voice nothing is waiting on.
+          if (pumpDeferTimer !== handle) return;
+          pumpDeferTimer = null;
+          onLog("pump", "deferral bound reached — promoting anyway");
+          pump(true);
+        }, bound);
+        pumpDeferTimer = handle;
+      }
+      return;
+    }
+    releasePump();
     current = queue.shift();
     var item = current;
 
@@ -420,7 +539,19 @@ function createAnnouncer(deps) {
       queue.forEach(disarm);
       queue = [];
       if (current) { disarm(current); current = null; }
-      speaking.slice().forEach(stopSpeaking);
+      releasePump();
+      // LATCHED, not merely removed from `speaking`. stopSpeaking cancels our
+      // watchdog but cannot cancel the utterance's own onend, which the
+      // browser fires whenever it fires — and that callback closes over the
+      // item and would have anchored a proposal on the bridge from a torn-down
+      // session, which is #978 item 4 in the one leg the reference-nulling fix
+      // did not reach. Settling here with no outcome is the same statement the
+      // rest of this function makes: a torn-down item was not heard, and
+      // nothing downstream may believe it was.
+      speaking.slice().forEach(function (it) {
+        it.speechSettled = true;
+        stopSpeaking(it);
+      });
     },
     // Withdraw announcements whose meta matches, queued or current (#963: the
     // owner speaking first CANCELS the greeting; queueing it behind them would

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -353,13 +353,23 @@ function createAnnouncer(deps) {
         // REPEATS it. Suppression until reload, then duplicates.
         //
         // Both halves, since this is the announcer deciding the owner did not
-        // hear something. False-reject (a slow but LIVE utterance declared
-        // dropped) costs a re-announcement — the owner hears it twice — and
-        // the margin against it is the #993 budget, measured conservative by
-        // 2.6-4.5x against every plausible macOS system voice. False-accept
-        // (staying silent) costs the notice until a reload the owner has no
-        // way to know they need. Double-speak is the cheap failure here, which
-        // is the same trade carriedTheReason already makes.
+        // hear something.
+        //
+        // FALSE-REJECT — a slow but LIVE utterance declared dropped — costs
+        // more than "the owner hears it twice", and the cheap phrasing hid it:
+        // stopSpeaking empties `speaking` but CANNOT cancel the browser's
+        // audio (there is no cancel() on this path, deliberately — #950 defect
+        // 3), so the re-announcement pumps while the first utterance is still
+        // playing. The owner hears it twice SIMULTANEOUSLY, for whatever is
+        // left of the utterance. That reopens #997 for exactly that window, on
+        // purpose: overlapping speech the owner can still parse beats a notice
+        // they never get. What keeps the window rare rather than routine is
+        // the #993 budget, measured conservative by 2.6-4.5x against every
+        // plausible macOS system voice.
+        //
+        // FALSE-ACCEPT — staying silent — costs the notice until a reload the
+        // owner has no way to know they need. Double-speak is still the cheap
+        // failure here, which is the same trade carriedTheReason makes.
         settleSpeech(item, false);
       }, budget);
       try {
@@ -466,7 +476,9 @@ function createAnnouncer(deps) {
     // up to one speaking budget in exactly that state. The trade is still the
     // right one — the owner is listening to the buddy for the whole wait
     // rather than sitting in silence — but the number over there is no longer
-    // the whole story, and confirm.py is owned elsewhere this wave.
+    // the whole story. Filed as #1009 rather than left living here as a
+    // comment: confirm.py was owned elsewhere the wave this landed in, and an
+    // unfiled residual is worse than a filed one.
     if (speaking.length && !force) {
       if (!pumpDeferTimer) {
         var bound = pumpBound();
@@ -1352,11 +1364,23 @@ function onSpoken(meta, how) {
   forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
 }
 
-// The evidence-of-NOT-spoken counterpart to onSpoken (#978 item 5). Reached
-// only from the browser voice's own `onerror` — a positive report that the
-// utterance failed, never a guess. Everything keyed on "was this heard" has to
-// be told, or the announcement is neither delivered nor retried: the state it
-// leaves behind is indistinguishable from success.
+// The not-spoken counterpart to onSpoken (#978 item 5, #996). TWO callers, and
+// they are not the same kind of evidence:
+//
+//   - `utterance.onerror` — a POSITIVE report from speechSynthesis that this
+//     utterance failed;
+//   - the speaking watchdog — an INFERENCE from the ABSENCE of any end event
+//     past a budget deliberately slower than any real voice. It is a guess,
+//     and it is a guess made in one direction on purpose: the utterance it
+//     describes has already outlived the longest time this page will believe
+//     a voice is talking (#996).
+//
+// What they share is the only thing this handler needs — a state that is
+// indistinguishable from success downstream unless something says otherwise,
+// leaving the announcement neither delivered nor retried. A *throw* from
+// speak() is the third state and is deliberately NOT routed here: it means we
+// cannot know, and "assume heard" is the safe reading, because claiming
+// not-spoken would replay a notice the owner may well have heard.
 function onNotSpoken(meta) {
   if (!meta) return;
   if (meta.errorNotice) {

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -892,23 +892,40 @@ The browser voice is watchdogged too (`speakingBudget` = a 30s floor plus 140ms
 per character, deliberately slower than any real voice): `speechSynthesis` can
 drop an utterance without firing `onend` OR `onerror`, and `speaking` is what
 `pending()` and `anchorPending()` count, so without a bound the false-reject half
-is an **unbounded mute**. Two residuals on that watchdog, both open and both
-narrower than "the budget prevents two voices":
+is an **unbounded mute**. Two residuals sat on that watchdog and both are now
+closed — read them as what the mechanism does, not as what it used to miss:
 
-- **#996** — the watchdog calls `stopSpeaking()` only. It fires neither
-  `onSpoken` nor `onNotSpoken`, so on the exact event it exists to recover from
-  the notice's ids stay in `inFlight` for the life of the session: never acked,
-  never released, never re-announced. The cursor never advanced, so a page reload
-  does recover it — and the owner has no way to know a reload is what is needed.
-- **#997** — the budget gates the *notifier's* gates, never the announcer's own
-  FIFO. `armFallback` nulls `current`, starts `speak()`, and calls `pump()` in the
-  same tick, and `pump()` consults `current` and `queue` only. So a second
-  `must_speak` item queued behind a long notice is promoted and its
-  `response.create` goes out while the browser voice is starting the first one's
-  audio — **two voices, at any watchdog length, reached without the watchdog
-  firing at all.** Safety-neutral (nothing is suppressed or lost) and an
-  audio-quality defect, but it is the condition the budget's own comment used to
-  claim it ruled out.
+- **#996 — the watchdog RELEASES the notice.** It used to call `stopSpeaking()`
+  only: the gates reopened (its stated scope, done correctly) but nothing was
+  released, so on the exact event it exists to recover from the ids stayed in
+  `inFlight` for the life of the page — never acked, never released, never
+  re-announced. Since #970 that is not data loss (nothing announced is
+  cursor-past, so a reload recovers it) but a permanently-`inFlight` id wedges
+  the contiguity walk, so everything after it is spoken and never acked and a
+  reload *repeats* it: suppression until reload, then duplicates. It now fires
+  `onNotSpoken`, which is the same path a `speechSynthesis` `onerror` takes, so
+  the next gated tick says it again. The false-reject half — a slow but LIVE
+  utterance declared dropped — costs a second telling, against a budget measured
+  2.6-4.5x conservative; double-speak is the cheap failure here, as it is for
+  `carriedTheReason`. And exactly one outcome per utterance: `onend`, `onerror`
+  and the watchdog all route through one latch, or the watchdog's release and a
+  late `onend`'s ack would both land and the notice would be said twice and
+  acked once.
+- **#997 — `pump()` defers to the browser voice, BOUNDED.** The budget gates the
+  *notifier's* gates and never the announcer's own FIFO, so a second `must_speak`
+  item queued behind a long notice was promoted in the same tick `armFallback`
+  started the audio, and its `response.create` went out over it — two voices, at
+  any watchdog length, reached without the watchdog firing at all.
+  `pump()` now holds while `speaking` is non-empty and promotes the moment the
+  audio ends. **The bound is the trade**: an unbounded defer converts an
+  audio-quality defect into a suppression defect, which in a screenless channel
+  is strictly worse. It is the `speakingBudget` of the utterance in flight — not
+  a new constant — because that is exactly how long the page is willing to
+  believe the browser voice is talking; past it the #996 watchdog has already
+  declared the utterance dropped and pumped, and the timer is the backstop that
+  **promotes rather than staying mute** if it somehow has not. So the false-accept
+  half is a wait behind audio the owner is currently hearing, and the false-reject
+  half is the two voices this closes.
 
 The other half of the timer is `onNotSpoken` — positive evidence an utterance was
 NOT spoken, reached only from `speechSynthesis`'s own `onerror`. Before it, the
@@ -1716,12 +1733,14 @@ than "mid-handshake work is rolled back", and nothing here rolls anything back.
 restart invalidates the open tab — its POSTs 401 rather than half-working — so
 the acceptance path is *reload, then Start talking*, and the greeting is what
 says the whole approval path came back up (a heard greeting proves model audio,
-which #950 made the write path fail-closed on). #995 records that the wires
-arming that greet have no pin at all: cutting `maybeGreet()` out of
-`pc.ontrack` leaves the entire suite green — **measured, 5736 unit tests, zero
-failures**. `tests/unit/test_buddy_restart.py` executes both arming legs,
-extracted from the page the server actually serves, and each cut now turns it
-red.
+which #950 made the write path fail-closed on). #995 recorded that the wires
+arming that greet had no pin at all: cutting `maybeGreet()` out of `pc.ontrack`
+left the entire suite green — **measured, 5736 unit tests, zero failures**.
+`tests/unit/test_buddy_restart.py` executes both arming legs, extracted from the
+page the server actually serves, and each cut now turns it red. The four other
+wires #995 named — the data-channel `open`/`close` status wires and both button
+click handlers — are pinned the same way in `tests/unit/test_client_wires.py`,
+sharing one extractor (`tests/page_slice.py`) rather than a second idiom.
 
 ---
 
@@ -1983,25 +2002,33 @@ exist**, so these are listed here as well as inline.
 | #989 | `transcript.unheard_between` | no staleness bound: one never-completing `speech_started` (a cough, a VAD blip, TTS bleed) refuses every confirm as a WAIT outcome — no attempt burned, so the proposal loops on "give me a second" for the whole 120s TTL and then expires |
 | #990 | `confirm.cancel()` | bypasses `_claim()`, so a cancel racing a dispatching confirm says "I haven't sent it" while the runner is sending — the exact over-claim `in_flight`'s wording exists to avoid, on the sibling path |
 | #992 | `_judge`'s post-approval scan | `carries_denial` is not nonce-gated, and the fallback voice speaks message BODIES any session can send — so an echoed "no, stop, don't" retroactively denies a legitimate approval. Remotely triggerable; invisible to the owner |
-| #995 | `client.py` browser wires | five event→handler wires (`pc.ontrack`, which arms the greet-as-health-check; the data-channel `open`/`close` status wires; and both button click handlers) have no pin at all — cut any of them and all voice tests stay green |
-| #996 | the `speakingBudget` watchdog | fires neither `onSpoken` nor `onNotSpoken`, so on the exact dropped-utterance event it exists to recover from, the notice's ids stay in `inFlight` for the session: never acked, never released, never re-announced |
-| #997 | the announcer's `pump()` | the speaking budget gates the notifier's gates, never the announcer's own FIFO — so a queued `must_speak` item is promoted while the browser voice is starting the previous one. Two voices, at any watchdog length. Audio-quality, not safety |
+
+**Closed, and named here because arguing from a residual that no longer exists
+is the same failure in the other direction:** **#995** (the four remaining
+`client.py` browser wires — the data-channel `open`/`close` status wires and both
+button click handlers — now pinned in `tests/unit/test_client_wires.py`, the
+`pc.ontrack` greet wire having gone in #1001), **#996** (the `speakingBudget`
+watchdog now reports `onNotSpoken`) and **#997** (`pump()` now defers to the
+browser voice, bounded by that same budget). The last two are described in full
+under the watchdog above.
 
 What they have in common is where they were found: every one came out of a review
 of a MERGED wave rather than out of the wave itself. Defects that survive
 individual review live in the interaction between changes each correct alone.
 
-And three of the six carry a real trade rather than an obvious fix, which is why
-"just close it" is not the whole instruction. #989's staleness bound: too tight
-and a slow transcriber becomes a wrongful refusal, too loose and the loop
-survives. #992's suppression rule: barge-in over the robot voice is the NORMAL
-case here, so any rule of the form "utterances during fallback speech do not
-count as denials" drops a genuine take-back and the write goes out — the
-acting-twice direction, not a wait. #997's deferral: an unbounded "wait for the
-browser voice" turns an audio-quality defect into a suppression defect, which in
-a screenless channel is strictly worse than the thing being fixed. Price both
-halves before choosing. (#990, #995 and #996 have no such tension — they are
-plainly worth doing.)
+And several carry a real trade rather than an obvious fix, which is why "just
+close it" is not the whole instruction. #989's staleness bound: too tight and a
+slow transcriber becomes a wrongful refusal, too loose and the loop survives.
+#992's suppression rule: barge-in over the robot voice is the NORMAL case here,
+so any rule of the form "utterances during fallback speech do not count as
+denials" drops a genuine take-back and the write goes out — the acting-twice
+direction, not a wait. #997's deferral was the same shape and is the worked
+example of pricing it: an unbounded "wait for the browser voice" turns an
+audio-quality defect into a suppression defect, which in a screenless channel is
+strictly worse than the thing being fixed, so the wait is bounded by the budget
+that decides when the page stops believing the voice at all. Price both halves
+before choosing. (#990, #995 and #996 had no such tension — they were plainly
+worth doing.)
 
 ### Standing constraints for whoever picks this up
 

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -905,9 +905,15 @@ closed — read them as what the mechanism does, not as what it used to miss:
   reload *repeats* it: suppression until reload, then duplicates. It now fires
   `onNotSpoken`, which is the same path a `speechSynthesis` `onerror` takes, so
   the next gated tick says it again. The false-reject half — a slow but LIVE
-  utterance declared dropped — costs a second telling, against a budget measured
-  2.6-4.5x conservative; double-speak is the cheap failure here, as it is for
-  `carriedTheReason`. And exactly one outcome per utterance: `onend`, `onerror`
+  utterance declared dropped — costs more than "a second telling":
+  `stopSpeaking` empties `speaking` but cannot cancel the browser's audio, so
+  the re-announcement pumps while the first utterance is still playing and the
+  owner hears it **twice, simultaneously**, for whatever is left of it. That
+  reopens #997 for exactly that window, deliberately — overlapping speech the
+  owner can still parse beats a notice they never get — and what keeps the
+  window rare is the budget measured 2.6-4.5x conservative. Double-speak is
+  still the cheap failure here, as it is for `carriedTheReason`.
+  And exactly one outcome per utterance: `onend`, `onerror`
   and the watchdog all route through one latch, or the watchdog's release and a
   late `onend`'s ack would both land and the notice would be said twice and
   acked once.
@@ -927,13 +933,20 @@ closed — read them as what the mechanism does, not as what it used to miss:
   half is a wait behind audio the owner is currently hearing, and the false-reject
   half is the two voices this closes.
 
-The other half of the timer is `onNotSpoken` — positive evidence an utterance was
-NOT spoken, reached only from `speechSynthesis`'s own `onerror`. Before it, the
-page merely logged that error, so an announcement demonstrably not spoken was
-also never released: its id sat in the notifier's map and suppressed every later
-tick for the rest of the session. A *throw* from `speak()` is different — it
-means we cannot know, and "assume heard" is the safe reading there, because
-claiming not-spoken would replay a notice the owner may well have heard.
+The other half of the timer is `onNotSpoken`, and since #996 it has **two callers
+carrying different kinds of evidence**. `speechSynthesis`'s own `onerror` is a
+*positive report* that the utterance failed — before it existed the page merely
+logged that error, so an announcement demonstrably not spoken was also never
+released: its id sat in the notifier's map and suppressed every later tick for
+the rest of the session. The speaking watchdog is an *inference* from the
+absence of any end event past a budget deliberately slower than any real voice —
+a guess, made in one direction on purpose, about an utterance that has already
+outlived the longest time this page will believe a voice is talking. Both leave
+a state indistinguishable from success unless something says otherwise, which is
+all this handler needs. A *throw* from `speak()` is the third state and is
+deliberately not routed here — it means we cannot know, and "assume heard" is
+the safe reading, because claiming not-spoken would replay a notice the owner
+may well have heard.
 
 ### Success must not over-claim either
 
@@ -2002,6 +2015,7 @@ exist**, so these are listed here as well as inline.
 | #989 | `transcript.unheard_between` | no staleness bound: one never-completing `speech_started` (a cough, a VAD blip, TTS bleed) refuses every confirm as a WAIT outcome — no attempt burned, so the proposal loops on "give me a second" for the whole 120s TTL and then expires |
 | #990 | `confirm.cancel()` | bypasses `_claim()`, so a cancel racing a dispatching confirm says "I haven't sent it" while the runner is sending — the exact over-claim `in_flight`'s wording exists to avoid, on the sibling path |
 | #992 | `_judge`'s post-approval scan | `carries_denial` is not nonce-gated, and the fallback voice speaks message BODIES any session can send — so an echoed "no, stop, don't" retroactively denies a legitimate approval. Remotely triggerable; invisible to the owner |
+| #1009 | `confirm.py`'s `not_announced` note | its 30s/12s deferral bound is counted from the moment an item becomes `current`, and #997's `pump()` deferral sits UPSTREAM of that — so while a fallback utterance is live the stated bound under-states its own worst case by up to one speaking budget. A stated-guarantee defect, not a runtime one: the refusal is delivered either way |
 
 **Closed, and named here because arguing from a residual that no longer exists
 is the same failure in the other direction:** **#995** (the four remaining

--- a/tests/page_slice.py
+++ b/tests/page_slice.py
@@ -1,0 +1,40 @@
+"""Cut a region out of the served buddy page, failing loudly if it moved.
+
+One implementation, shared by every file that pins a browser-event wire
+(#995). It arrived in ``tests/unit/test_buddy_restart.py`` with #1001 and was
+lifted here the moment a second file needed it: two copies of an extractor
+whose whole job is to fail honestly is two chances for one of them to fail
+quietly instead.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def page_slice(page: str, start_pat: str, end_pat: str, what: str, *, shape: str) -> str:
+    """Return the region of *page* from *start_pat* through *end_pat*.
+
+    Extraction rather than a copy, for the reason ``announcer_source`` gives:
+    a test that re-derives its subject proves something about the copy. And a
+    silent miss here would be the worst outcome — the wire could be gone and
+    the test would still be green, which is the #995 failure repeated by the
+    test written to close it.
+
+    "Loudly" has to cover the PARTIAL match too. A start anchor that still hits
+    while the end anchor has drifted yields a syntactically broken fragment,
+    and what the reader then sees is an opaque node ``SyntaxError`` rather than
+    "the anchor moved". So each slice declares the *shape* it must still have —
+    chosen to be invariant under the mutations these tests exist to catch, so a
+    cut wire fails as a behaviour failure and never as a stale-anchor one.
+    """
+    start = re.search(start_pat, page)
+    assert start, f"anchor for {what} not found — the page moved, this test is stale"
+    end = re.search(end_pat, page[start.start():])
+    assert end, f"end anchor for {what} not found — the page moved, this test is stale"
+    region = page[start.start():start.start() + end.end()]
+    assert re.search(shape, region), (
+        f"extracted {what} does not have the shape this test assumes — the page "
+        f"moved and the extraction is stale, NOT a behaviour failure. Got:\n{region}"
+    )
+    return region

--- a/tests/unit/test_buddy_restart.py
+++ b/tests/unit/test_buddy_restart.py
@@ -222,9 +222,18 @@ def _greet_program(*, fire: str) -> str:
     )
     ontrack = _slice(
         page, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire",
-        # An assignment of an arrow function, ending in a statement. True with
-        # or without the maybeGreet() call inside it.
-        shape=r"^pc\.ontrack\s*=\s*\([\s\S]*=>[\s\S]*;\s*$",
+        # An assignment of an arrow function with a BALANCED brace body. True
+        # with or without the maybeGreet() call inside it, which is what keeps
+        # a cut wire failing as a behaviour failure.
+        #
+        # Tightened from `=>[\s\S]*;` while closing #995's other four wires:
+        # the end anchor is "the first `;` at end of line", so a REFLOWED
+        # handler — formatting only, wire intact — truncates at its first
+        # statement, and the old shape accepted that fragment because it too
+        # ends in `;`. The reader then got an opaque node SyntaxError instead
+        # of "the anchor moved", which is the degradation this guard exists to
+        # prevent. Demanding the closing brace is what a fragment cannot fake.
+        shape=r"^pc\.ontrack\s*=\s*\([^()]*\)\s*=>\s*\{[^{}]*\}\s*;\s*$",
     )
     session_created = _slice(
         page, r'case "session\.created":', r"break;", "the session.created wire",
@@ -316,6 +325,32 @@ class TestBothGreetWiresAreLoadBearing:
         )
         assert len(report["announced"]) == 1
         assert report["notifierStarts"] == 2  # the notifier wire ran both times
+
+    def test_a_reflowed_ontrack_says_the_anchor_moved(self):
+        """The guard, measured on this slice too.
+
+        Reflowing the wire one statement per line changes nothing but
+        whitespace — the greet is still armed — and before the shape was
+        tightened the truncated fragment was accepted and node died on it. A
+        reader debugging that sees a SyntaxError and no clue which line moved.
+        """
+        page = _page()
+        original = [ln for ln in page.splitlines() if "pc.ontrack =" in ln]
+        assert len(original) == 1, "the wire this test reflows is not where it was"
+        reflowed = page.replace(original[0], "\n".join([
+            "    pc.ontrack = (e) => {",
+            "      audioEl.srcObject = e.streams[0];",
+            "      audioAttached = true;",
+            "      maybeGreet();",
+            "    };",
+        ]))
+        assert "maybeGreet();" in reflowed, "the reflow broke the wire it reflows"
+        with pytest.raises(AssertionError) as excinfo:
+            _slice(
+                reflowed, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire",
+                shape=r"^pc\.ontrack\s*=\s*\([^()]*\)\s*=>\s*\{[^{}]*\}\s*;\s*$",
+            )
+        assert "does not have the shape this test assumes" in str(excinfo.value)
 
     def test_the_session_created_wire_also_starts_the_inbox_notifier(self):
         """Ordering that the wire encodes: the notifier starts AFTER the greeting

--- a/tests/unit/test_buddy_restart.py
+++ b/tests/unit/test_buddy_restart.py
@@ -31,6 +31,7 @@ import urllib.request
 import pytest
 
 from agentwire.voice_layer import client, server
+from tests.page_slice import page_slice
 
 # ─────────────────────────────────────────────────────────────
 # A real serve() → kill → serve() cycle
@@ -205,32 +206,9 @@ def _page() -> str:
     return client.page("buddy", "tok")
 
 
-def _slice(page: str, start_pat: str, end_pat: str, what: str, *, shape: str) -> str:
-    """Cut a region out of the served page, failing loudly if the anchor moved.
-
-    Extraction rather than a copy, for the reason ``announcer_source`` gives:
-    a test that re-derives its subject proves something about the copy. And a
-    silent miss here would be the worst outcome — the wire could be gone and
-    this file would still be green, which is the #995 failure repeated by the
-    test written to close it.
-
-    "Loudly" has to cover the PARTIAL match too. A start anchor that still hits
-    while the end anchor has drifted yields a syntactically broken fragment,
-    and what the reader then sees is an opaque node ``SyntaxError`` rather than
-    "the anchor moved". So each slice declares the *shape* it must still have —
-    chosen to be invariant under the mutations these tests exist to catch, so a
-    cut wire fails as a behaviour failure and never as a stale-anchor one.
-    """
-    start = re.search(start_pat, page)
-    assert start, f"anchor for {what} not found — the page moved, this test is stale"
-    end = re.search(end_pat, page[start.start():])
-    assert end, f"end anchor for {what} not found — the page moved, this test is stale"
-    region = page[start.start():start.start() + end.end()]
-    assert re.search(shape, region), (
-        f"extracted {what} does not have the shape this test assumes — the page "
-        f"moved and the extraction is stale, NOT a behaviour failure. Got:\n{region}"
-    )
-    return region
+#: The slicer moved to :mod:`tests.page_slice` when the rest of #995's wires
+#: got pinned in ``test_client_wires.py`` — one extractor, not two.
+_slice = page_slice
 
 
 def _greet_program(*, fire: str) -> str:

--- a/tests/unit/test_buddy_restart.py
+++ b/tests/unit/test_buddy_restart.py
@@ -211,16 +211,17 @@ def _page() -> str:
 _slice = page_slice
 
 
-def _greet_program(*, fire: str) -> str:
-    page = _page()
-    greet_block = _slice(
-        page, r"const GREETING\s*=", r"function maybeGreet\(\)\s*\{[\s\S]*?\n\}",
-        "the greeting block",
-        # Shape, not behaviour: the declarations and the function's existence.
-        # Whether maybeGreet's BODY still greets is what the tests decide.
-        shape=r"let greeted[\s\S]*function maybeGreet\(\)\s*\{[\s\S]*\}\s*$",
-    )
-    ontrack = _slice(
+def _ontrack_slice(page: str) -> str:
+    """The ``pc.ontrack`` wire, cut out of *page*.
+
+    A FUNCTION rather than an inline call, so the reflow test below exercises
+    the anchors and the shape THIS program uses instead of a copy of them. The
+    first version hardcoded its own copy of the regex, which made the tightening
+    unpinned: reverting the shape here left every file green while the test
+    still claimed to prove the diagnostic. Same fix as ``test_client_wires.py``,
+    which is where it was got right first.
+    """
+    return _slice(
         page, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire",
         # An assignment of an arrow function with a BALANCED brace body. True
         # with or without the maybeGreet() call inside it, which is what keeps
@@ -235,6 +236,18 @@ def _greet_program(*, fire: str) -> str:
         # prevent. Demanding the closing brace is what a fragment cannot fake.
         shape=r"^pc\.ontrack\s*=\s*\([^()]*\)\s*=>\s*\{[^{}]*\}\s*;\s*$",
     )
+
+
+def _greet_program(*, fire: str) -> str:
+    page = _page()
+    greet_block = _slice(
+        page, r"const GREETING\s*=", r"function maybeGreet\(\)\s*\{[\s\S]*?\n\}",
+        "the greeting block",
+        # Shape, not behaviour: the declarations and the function's existence.
+        # Whether maybeGreet's BODY still greets is what the tests decide.
+        shape=r"let greeted[\s\S]*function maybeGreet\(\)\s*\{[\s\S]*\}\s*$",
+    )
+    ontrack = _ontrack_slice(page)
     session_created = _slice(
         page, r'case "session\.created":', r"break;", "the session.created wire",
         shape=r'^case "session\.created":[\s\S]*break;$',
@@ -346,10 +359,7 @@ class TestBothGreetWiresAreLoadBearing:
         ]))
         assert "maybeGreet();" in reflowed, "the reflow broke the wire it reflows"
         with pytest.raises(AssertionError) as excinfo:
-            _slice(
-                reflowed, r"pc\.ontrack\s*=", r";\s*\n", "the pc.ontrack wire",
-                shape=r"^pc\.ontrack\s*=\s*\([^()]*\)\s*=>\s*\{[^{}]*\}\s*;\s*$",
-            )
+            _ontrack_slice(reflowed)
         assert "does not have the shape this test assumes" in str(excinfo.value)
 
     def test_the_session_created_wire_also_starts_the_inbox_notifier(self):

--- a/tests/unit/test_client_wires.py
+++ b/tests/unit/test_client_wires.py
@@ -70,18 +70,34 @@ def _run(program: str) -> dict:
 # ─────────────────────────────────────────────────────────────
 
 
-def _status_program(*, fire: str) -> str:
-    page = _page()
+#: The shape each dc status wire must still have, and it is doing more work
+#: than it looks. The end anchor is "the first ``;`` at end of line", which a
+#: reflowed handler — formatting only, wire intact — satisfies at the FIRST
+#: statement of the body, yielding a syntactically broken fragment. A loose
+#: shape (``=>[\s\S]*\);``) matches that fragment, because the ``);`` of the
+#: truncated call inside it stands in for the listener's own. The reader then
+#: gets an opaque node ``SyntaxError`` instead of "the anchor moved" — which is
+#: the exact degradation #995 names by name, reproduced by the test written to
+#: close it.
+#:
+#: So the shape demands the arrow function's own terminator: either a BALANCED
+#: brace body with nothing nested (``{[^{}]*}``) or a single expression with no
+#: statement break in it, and then the call's ``);``. A truncated fragment has
+#: neither. Still invariant under the mutations these tests exist to catch — an
+#: emptied body is ``{}``, which matches — so a cut wire fails as a behaviour
+#: failure and never as a stale-anchor one.
+_ARROW_BODY = r"(?:\{[^{}]*\}|[^;{}]*)"
+
+
+def _status_program(*, fire: str, page: str | None = None) -> str:
+    page = _page() if page is None else page
     open_wire = page_slice(
         page, r'dc\.addEventListener\("open"', r";\s*\n", "the dc open wire",
-        # Shape, not behaviour: a listener registration ending in a statement.
-        # True with or without the setStatus/$stop lines inside it, which is
-        # what keeps a cut wire failing as a behaviour failure.
-        shape=r'^dc\.addEventListener\("open",\s*\([\s\S]*=>[\s\S]*\);\s*$',
+        shape=r'^dc\.addEventListener\("open",\s*\(\)\s*=>\s*' + _ARROW_BODY + r"\s*\);\s*$",
     )
     close_wire = page_slice(
         page, r'dc\.addEventListener\("close"', r";\s*\n", "the dc close wire",
-        shape=r'^dc\.addEventListener\("close",\s*\([\s\S]*=>[\s\S]*\);\s*$',
+        shape=r'^dc\.addEventListener\("close",\s*\(\)\s*=>\s*' + _ARROW_BODY + r"\s*\);\s*$",
     )
     return "\n".join([
         "const statuses = [];",
@@ -192,6 +208,78 @@ class TestTheStartAndStopButtons:
     def test_a_full_session_is_start_then_stop(self):
         report = _run(_click_program(fire="clickStart(); clickStop();"))
         assert report["fired"] == ["start", "stop"]
+
+
+@needs_node
+class TestAMovedAnchorSaysSoInsteadOfCrashingNode:
+    """The partial-anchor guard, MEASURED rather than claimed.
+
+    ``page_slice``'s guarantee is that a drifted anchor reads as "the page
+    moved" and never as an opaque node ``SyntaxError`` — and the guarantee is
+    only as good as the shape each call site declares. It was NOT good enough
+    here on first submission: reflowing either dc status wire across several
+    lines (formatting only, the wire fully intact) truncated the region at the
+    first statement and the loose shape accepted the wreckage, so node blew up.
+    That is the exact degradation #995 names, reproduced by the tests written
+    to close it — and the PR body claimed coverage that did not exist, which is
+    worse than the gap.
+
+    So the claim is a test now. The reflow below changes nothing but whitespace:
+    every one of these pages still WIRES the handler, and a reader looking at
+    the failure has to be told that.
+    """
+
+    #: ONE STATEMENT PER LINE, which is what a formatter actually produces and
+    #: is also the strictly stronger control: it puts a line-ending ``;`` after
+    #: a statement that closes a paren, so the truncated region ends in ``);``
+    #: and a loose shape is fooled by it. A reflow that packs the body onto one
+    #: line does not reproduce the defect at all — the region ends in
+    #: ``false;`` — and a fixture that cannot reproduce the failure is the
+    #: fixture-shaped blind spot this whole file exists to avoid.
+    BODIES = {
+        "open": ['setStatus("listening");', "$stop.disabled = false;"],
+        "close": ['setStatus("closed");'],
+    }
+
+    def _reflowed(self, event: str) -> str:
+        page = _page()
+        original = [ln for ln in page.splitlines()
+                    if f'dc.addEventListener("{event}"' in ln]
+        assert len(original) == 1, "the wire this test reflows is not where it was"
+        body = "\n".join(f"      {line}" for line in self.BODIES[event])
+        return page.replace(
+            original[0],
+            f'    dc.addEventListener("{event}", () => {{\n{body}\n    }});',
+        )
+
+    @pytest.mark.parametrize("event", ["open", "close"])
+    def test_a_reflowed_wire_reports_a_moved_anchor(self, event):
+        with pytest.raises(AssertionError) as excinfo:
+            _status_program(fire="", page=self._reflowed(event))
+        message = str(excinfo.value)
+        assert "does not have the shape this test assumes" in message
+        assert "NOT a behaviour failure" in message
+
+    @pytest.mark.parametrize("event", ["open", "close"])
+    def test_the_reflow_really_did_leave_the_wire_intact(self, event):
+        """The control. If the reflow broke the wire, the assertion above would
+        be reporting a genuine defect and would prove nothing about anchors."""
+        reflowed = self._reflowed(event)
+        assert f'dc.addEventListener("{event}"' in reflowed
+        for statement in self.BODIES[event]:
+            assert statement in reflowed
+
+    @pytest.mark.parametrize("event", ["open", "close"])
+    def test_the_reflow_is_what_a_loose_shape_would_have_swallowed(self, event):
+        """And the discriminator: the truncated region a loose shape accepted
+        ends in ``);``, which is why it passed for the listener's own
+        terminator. Asserted directly, so a future reflow that stops producing
+        that ending cannot silently turn the two tests above into no-ops."""
+        page = self._reflowed(event)
+        start = page.index(f'dc.addEventListener("{event}"')
+        truncated = page[start:page.index(";\n", start) + 1]
+        assert truncated.endswith(");")
+        assert truncated.count("{") > truncated.count("}")
 
 
 class TestTheWiresArePresentAtAll:

--- a/tests/unit/test_client_wires.py
+++ b/tests/unit/test_client_wires.py
@@ -1,0 +1,214 @@
+"""The remaining unpinned browser-event wires in ``client.py`` (#995).
+
+#995's shape: a single line wires a browser event to a code path, and nothing
+asserts the wire exists. The tests that look like they cover it assert a
+parameter name in a signature, or assert the downstream function behaves —
+never that the event handler calls it. Cut the line and the whole suite stays
+green.
+
+#993 closed two instances (``utterance.onerror`` / ``utterance.onend``) and
+#1001 closed the worst one (``pc.ontrack`` → ``maybeGreet()``, pinned in
+``test_buddy_restart.py``). Four were left, and they are what this file pins:
+
+    client.py  dc.addEventListener("open",  …)   status → "listening", stop enabled
+    client.py  dc.addEventListener("close", …)   status → "closed"
+    client.py  $start.addEventListener("click", start)
+    client.py  $stop.addEventListener("click", stop)
+
+Same technique as ``test_buddy_restart.py``, and deliberately the SAME
+extractor (:func:`tests.page_slice.page_slice`) rather than a second idiom —
+including its guard against a partial anchor match, which otherwise degrades
+to an opaque node ``SyntaxError`` instead of saying "the anchor moved".
+
+Why these two pairs are worth a node run rather than a substring assertion.
+The substring half is here too (``TestTheWiresArePresentAtAll``) and it is what
+gives the honest message when a whole line is deleted — but a substring cannot
+tell ``("click", start)`` from ``("click", stop)``, and it cannot tell a status
+wire that fires from one that sets the wrong thing. Both of those are live
+mutations: the start/stop pair is the owner's only entry and exit point, and a
+swapped pair makes the page unusable while every existing test stays green.
+
+What this does NOT establish: that the browser ever fires these events. That
+half is not in reach of a unit harness and is not what #995 is about — the
+claim under test is that the page WIRES them, which is exactly what a mutation
+can silently remove.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from agentwire.voice_layer import client
+from tests.page_slice import page_slice
+
+#: Applied per CLASS rather than per module: the presence checks at the bottom
+#: are pure string work and are the half that must still run on a machine
+#: without node.
+needs_node = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is needed to run the client's own JS"
+)
+
+
+def _page() -> str:
+    return client.page("buddy", "tok")
+
+
+def _run(program: str) -> dict:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", program],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+# ─────────────────────────────────────────────────────────────
+# The data-channel status wires
+# ─────────────────────────────────────────────────────────────
+
+
+def _status_program(*, fire: str) -> str:
+    page = _page()
+    open_wire = page_slice(
+        page, r'dc\.addEventListener\("open"', r";\s*\n", "the dc open wire",
+        # Shape, not behaviour: a listener registration ending in a statement.
+        # True with or without the setStatus/$stop lines inside it, which is
+        # what keeps a cut wire failing as a behaviour failure.
+        shape=r'^dc\.addEventListener\("open",\s*\([\s\S]*=>[\s\S]*\);\s*$',
+    )
+    close_wire = page_slice(
+        page, r'dc\.addEventListener\("close"', r";\s*\n", "the dc close wire",
+        shape=r'^dc\.addEventListener\("close",\s*\([\s\S]*=>[\s\S]*\);\s*$',
+    )
+    return "\n".join([
+        "const statuses = [];",
+        "const $stop = { disabled: true };",
+        "function setStatus(text) { statuses.push(text); }",
+        "const handlers = {};",
+        "const dc = { addEventListener: (name, fn) => { handlers[name] = fn; } };",
+        open_wire,
+        close_wire,
+        'function fireOpen() { handlers["open"](); }',
+        'function fireClose() { handlers["close"](); }',
+        fire,
+        "console.log(JSON.stringify({ statuses, stopDisabled: $stop.disabled, "
+        "wired: Object.keys(handlers).sort() }));",
+    ])
+
+
+@needs_node
+class TestTheDataChannelStatusWires:
+    """Connection state is the one thing the owner can only learn from the page.
+
+    Screenless makes the *absence* of these wires indistinguishable from a
+    connection that is merely slow: the buddy says nothing either way. So the
+    status text is the whole signal, and nothing asserted it was wired.
+    """
+
+    def test_both_events_are_registered(self):
+        report = _run(_status_program(fire=""))
+        assert report["wired"] == ["close", "open"]
+
+    def test_the_open_wire_says_listening_and_enables_stop(self):
+        report = _run(_status_program(fire="fireOpen();"))
+        assert report["statuses"] == ["listening"]
+        # The stop button is the owner's exit. Enabled by the OPEN event, not by
+        # start() — a page that connects and leaves stop disabled traps them.
+        assert report["stopDisabled"] is False
+
+    def test_the_close_wire_says_closed(self):
+        report = _run(_status_program(fire="fireClose();"))
+        assert report["statuses"] == ["closed"]
+
+    def test_a_close_does_not_enable_stop(self):
+        """The two handlers are independent, and the assertion above would pass
+        for a page that had wired the open body to `close`."""
+        report = _run(_status_program(fire="fireClose();"))
+        assert report["stopDisabled"] is True
+
+    def test_a_reconnect_sequence_ends_on_the_last_event(self):
+        report = _run(_status_program(fire="fireOpen(); fireClose(); fireOpen();"))
+        assert report["statuses"] == ["listening", "closed", "listening"]
+
+
+# ─────────────────────────────────────────────────────────────
+# The owner's entry and exit points
+# ─────────────────────────────────────────────────────────────
+
+
+def _click_program(*, fire: str) -> str:
+    page = _page()
+    start_wire = page_slice(
+        page, r'\$start\.addEventListener\("click"', r";", "the start click wire",
+        shape=r'^\$start\.addEventListener\("click",\s*\w+\);$',
+    )
+    stop_wire = page_slice(
+        page, r'\$stop\.addEventListener\("click"', r";", "the stop click wire",
+        shape=r'^\$stop\.addEventListener\("click",\s*\w+\);$',
+    )
+    return "\n".join([
+        "const fired = [];",
+        'function start() { fired.push("start"); }',
+        'function stop() { fired.push("stop"); }',
+        "const startHandlers = {}, stopHandlers = {};",
+        "const $start = { addEventListener: (n, fn) => { startHandlers[n] = fn; } };",
+        "const $stop = { addEventListener: (n, fn) => { stopHandlers[n] = fn; } };",
+        start_wire,
+        stop_wire,
+        'function clickStart() { startHandlers["click"](); }',
+        'function clickStop() { stopHandlers["click"](); }',
+        fire,
+        "console.log(JSON.stringify({ fired, startEvents: Object.keys(startHandlers), "
+        "stopEvents: Object.keys(stopHandlers) }));",
+    ])
+
+
+@needs_node
+class TestTheStartAndStopButtons:
+    """The owner's entry and exit points, which nothing asserted at all.
+
+    A swap here — ``$start`` wired to ``stop`` — is the mutation a presence
+    check cannot see, and it costs the whole page: Start talking tears down a
+    session that was never built, and the buddy is silent for a reason the
+    owner has no screen to read.
+    """
+
+    def test_both_buttons_listen_for_a_click(self):
+        report = _run(_click_program(fire=""))
+        assert report["startEvents"] == ["click"]
+        assert report["stopEvents"] == ["click"]
+
+    def test_clicking_start_calls_start_and_nothing_else(self):
+        report = _run(_click_program(fire="clickStart();"))
+        assert report["fired"] == ["start"]
+
+    def test_clicking_stop_calls_stop_and_nothing_else(self):
+        report = _run(_click_program(fire="clickStop();"))
+        assert report["fired"] == ["stop"]
+
+    def test_a_full_session_is_start_then_stop(self):
+        report = _run(_click_program(fire="clickStart(); clickStop();"))
+        assert report["fired"] == ["start", "stop"]
+
+
+class TestTheWiresArePresentAtAll:
+    """The honest message when a whole line is deleted.
+
+    The node tests above go red on a deleted wire too — but through
+    ``page_slice``'s "the page moved, this test is stale" assertion, which
+    reads as a maintenance problem rather than as the defect. These say the
+    true thing, and they are the cheap half that keeps working if node is
+    unavailable (every test above skips without it).
+    """
+
+    @pytest.mark.parametrize("wire", [
+        'dc.addEventListener("open"',
+        'dc.addEventListener("close"',
+        '$start.addEventListener("click", start)',
+        '$stop.addEventListener("click", stop)',
+    ])
+    def test_the_wire_is_in_the_served_page(self, wire):
+        assert wire in _page(), f"the wire `{wire}` is gone from the page (#995)"

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -90,6 +90,19 @@ function fireTimers() {
   timers = [];
   due.forEach((t) => t.fn());
 }
+// Fire exactly ONE armed timer, by its position in the armed list.
+//
+// fireTimers() fires everything, which cannot express "this timer came due and
+// that one did not" — and #997's deferral backstop is precisely a timer whose
+// job is to cover the case where the speaking watchdog does NOT fire. Both are
+// armed at the same budget, so they are indistinguishable by `ms`; position is
+// the only handle a fake clock has on them.
+function fireTimerAt(i) {
+  const t = timers[i];
+  if (!t) throw new Error("no timer armed at index " + i);
+  timers = timers.filter((x) => x !== t);
+  t.fn();
+}
 // The browser voice reaches the end of its utterance.
 function finishSpeech() {
   const due = pendingSpeech.splice(0);
@@ -2704,6 +2717,142 @@ class TestTheSpeakingWatchdogScalesWithTheUtterance:
         assert self._watchdog_ms(json.dumps("Hi.")) >= 30_000
 
 
+class TestTheSpeakingWatchdogReleasesTheNotice:
+    """#996. The watchdog called ``stopSpeaking()`` and nothing else.
+
+    It reopened the gates — its stated scope, done correctly — but fired
+    neither ``onSpoken`` nor ``onNotSpoken``, so the ids of a dropped utterance
+    stayed in the notifier's ``inFlight`` map for the life of the page. Since
+    #970 that is no longer data loss (nothing announced is cursor-past, so a
+    reload recovers every dropped-utterance case) but a permanently-``inFlight``
+    id wedges the contiguity walk, so everything after it is spoken and never
+    acked and a reload REPEATS it. Suppression until reload, then duplicates.
+
+    The watchdog is the ONE case with no event at all: ``speechSynthesis`` can
+    drop an utterance firing neither ``onend`` nor ``onerror``, which is the
+    exact event this timer exists to recover from. Reporting it not-spoken is
+    the same "positive evidence" discipline as the rest — the evidence is the
+    absence of an end event past a budget measured 2.6-4.5x conservative
+    (#993), which is as positive as this channel gets.
+
+    Both halves, because this is the announcer deciding the owner heard
+    nothing: the false-reject (a slow but live utterance) costs a second
+    telling, and the false-accept costs the notice until a reload the owner has
+    no way to know they need. That asymmetry is what the whole file is built
+    on.
+    """
+
+    def _dropped_utterance(self, extra: str = "") -> dict:
+        """A notice whose fallback audio starts and then simply never ends.
+
+        `speakDefers` is what makes this reachable at all: a fixture whose
+        speak() calls back synchronously has no window between "started" and
+        "finished", so the watchdog could never be the thing that resolves an
+        utterance and this defect was structurally invisible.
+        """
+        return run_announcer(f"""
+            speakDefers = true;
+            announcer.announce("Two updates came in.", {{ inboxIds: ["m1", "m2"] }});
+            fireTimers();              // the fallback fires; the voice starts
+            logs.push("mid: notSpoken=" + notSpoken.length +
+                      " anchored=" + anchored.length);
+            fireTimers();              // ...and the utterance never ends
+            {extra}
+        """)
+
+    def test_the_watchdog_reports_the_notice_not_spoken(self):
+        report = self._dropped_utterance()
+        # Nothing was decided while the voice was believed to be talking.
+        assert "mid: notSpoken=0 anchored=0" in report["logs"]
+        # ...and the watchdog releases it, which is what makes the next gated
+        # tick say it again instead of the ids sitting in inFlight forever.
+        assert report["notSpoken"] == [{"inboxIds": ["m1", "m2"]}]
+        assert report["anchored"] == []
+
+    def test_it_still_reopens_the_gates(self):
+        """The watchdog's original job, unchanged — the release is additional,
+        not a replacement. A fix that released the ids but left the item in
+        `speaking` would trade one silence for another."""
+        report = self._dropped_utterance('logs.push("pending=" + announcer.pending());')
+        assert "pending=0" in report["logs"]
+
+    def test_a_late_end_event_cannot_ack_what_the_watchdog_released(self):
+        """The latch, and it is load-bearing rather than tidy.
+
+        Without it the watchdog releases the ids (so the next tick re-announces)
+        and a late `onend` then acks them (marking them heard) — a notice said
+        twice and acked once, from the same utterance described by two
+        different events.
+        """
+        report = self._dropped_utterance("finishSpeech();")
+        assert len(report["notSpoken"]) == 1
+        assert report["anchored"] == []
+
+    def test_an_end_event_that_arrives_first_still_acks_and_disarms(self):
+        """The ordinary path, unchanged: real speech ends, the item is spoken,
+        and the watchdog it disarmed cannot then contradict that."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+            fireTimers();
+            finishSpeech();
+            fireTimers();              // whatever is left must not re-decide
+        """)
+        assert report["anchored"] == [{"meta": {"inboxIds": ["m1"]}, "how": "fallback"}]
+        assert report["notSpoken"] == []
+
+    def test_a_reported_error_settles_it_once(self):
+        """The third caller. `onerror` already reported (#978 item 5); what is
+        new is that the watchdog cannot report it a second time."""
+        report = run_announcer("""
+            speakDefers = true;
+            speakFails = true;
+            announcer.announce("Two updates came in.", { inboxIds: ["m1"] });
+            fireTimers();
+            finishSpeech();            // onerror
+            fireTimers();
+        """)
+        assert report["notSpoken"] == [{"inboxIds": ["m1"]}]
+        assert report["anchored"] == []
+
+    def test_a_dropped_proposal_announcement_is_reported_too(self):
+        """The anchor case. Nothing to retry — a proposal is announced once and
+        the spine's TTL ends it — but the page logs "it cannot be approved"
+        from onNotSpoken, which is the difference between the owner hearing
+        `not_announced` for 120s with no explanation and being told."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Say confirm tango to send it.", { anchor: "p1" });
+            fireTimers();
+            fireTimers();
+        """)
+        assert report["notSpoken"] == [{"anchor": "p1"}]
+        # And it is NOT anchored: a proposal the owner never heard must never
+        # be treated as stated.
+        assert report["anchored"] == []
+
+    def test_a_torn_down_utterance_reports_nothing_at_all(self):
+        """teardown()'s own statement, extended to the leg it did not reach.
+
+        stop() cannot cancel the utterance's `onend` — the browser fires it
+        whenever it fires — and that callback would have anchored a proposal on
+        the bridge from a dead session (#978 item 4). Settling with NO outcome
+        is deliberate: a torn-down item was neither heard nor demonstrably
+        unheard, and the anchor is the one thing that must never be guessed.
+        """
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Say confirm tango to send it.", { anchor: "p1" });
+            fireTimers();
+            announcer.teardown();
+            finishSpeech();            // the browser gets round to it anyway
+            fireTimers();
+        """)
+        assert report["anchored"] == []
+        assert report["notSpoken"] == []
+        assert report["pending"] == 0
+
+
 # =============================================================================
 # Wave-2 prose: two guarantees stated broader than the code
 # =============================================================================
@@ -2853,16 +3002,30 @@ class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
         assert len(report["spoken"]) == 1
 
 
-class TestTheSpeakingBudgetCommentDoesNotClaimThePumpPath:
-    """``speakingBaseMs`` claimed the scaled budget kept the MODEL from
-    starting a response over the browser voice — the whole of #950. It does
-    not. The budget gates ``pending()``/``anchorPending()``, which are the
-    NOTIFIER's gates; the announcer's own FIFO never consults ``speaking``.
+class TestThePumpDefersToTheBrowserVoice:
+    """#997, and the class it replaces is the reason it reads this way.
 
-    Behaviour deliberately unchanged (a separate decision). This class pins the
-    COMMENT: the residual is reproduced, so if the pump path is ever fixed this
-    fails and whoever fixes it has to come back and delete the paragraph that
-    calls it live.
+    That class REPRODUCED this defect and pinned the comment naming it a live
+    residual — a canary, deliberately asserting the broken behaviour so that
+    fixing it would fail here and force the paragraph to be rewritten. It did
+    exactly that. Both of its behavioural assertions inverted the moment pump()
+    started deferring, which is the whole point of a canary and is also the
+    hazard: an expected-fail canary and a live guarantee are identical at the
+    moment of failure, and nothing re-labels the test. So it is re-labelled by
+    hand — every sentence below now asserts the FIX, and the residual paragraph
+    it used to protect is gone from ``client.py``.
+
+    What is pinned:
+
+    - the reproduction, inverted: the queued item does NOT reach the channel
+      while the browser voice is starting;
+    - it is promoted the moment that audio ends, so the defer is a delay and
+      never a suppression;
+    - the BOUND, derived from the same ``speakingBudget`` the watchdog uses
+      rather than from a new constant, and taken at its two ends (the 30s floor
+      and a long coalesced notice);
+    - the backstop firing promotes rather than staying mute — the half that
+      makes "bounded" true even if the watchdog never empties ``speaking``.
     """
 
     def _prose(self) -> str:
@@ -2875,22 +3038,58 @@ class TestTheSpeakingBudgetCommentDoesNotClaimThePumpPath:
         ]
         return " ".join(" ".join(lines).split())
 
+    def _budget(self, text: str) -> int:
+        """The bound, derived from ``client.py``'s own constants rather than
+        transcribed — the deferral must never acquire a number of its own, and
+        a test carrying a copy of 140 would not notice if it did."""
+        src = client.announcer_source()
+        base = re.search(r"deps\.speakingMaxMs \|\| fallbackMs \* (\d+)", src)
+        per_char = re.search(r"deps\.speakingMsPerChar === undefined \? (\d+)", src)
+        assert base and per_char, "the budget constants moved — this test is stale"
+        return 6000 * int(base.group(1)) + len(text) * int(per_char.group(1))
+
     def test_the_comment_no_longer_claims_the_defect_is_ruled_out(self):
         prose = self._prose()
         assert "which reopens both gates and lets the MODEL start a response" not in prose
-        assert "`current` and `queue` only — never `speaking`" in prose
-        assert "live residual" in prose
+        # And no longer calls the pump path live, either — the sentence that
+        # class existed to keep honest is now a sentence about a closed defect.
+        assert "That path is a live residual" not in prose
+        assert "pump() now defers while `speaking` is non-empty" in prose
 
     def test_the_comment_names_the_gates_the_budget_actually_covers(self):
         prose = self._prose()
         assert "reopens the NOTIFIER's gates — canSpeak and canInterrupt" in prose
 
-    def test_a_queued_item_is_pumped_into_the_starting_browser_voice(self):
-        """The reproduction. A long notice falls back to the browser voice; a
-        second must_speak item is queued behind it. armFallback nulls
-        `current`, starts speak(), and calls pump() in the same tick — so the
-        second item's response.create goes out while the first is still only
-        STARTING to be spoken aloud."""
+    def test_the_comment_states_the_bound_and_prices_both_halves(self):
+        """The trap #997 names, kept stated in the code that implements it: an
+        unbounded defer is a suppression defect, which is worse than the audio
+        defect it fixes."""
+        prose = self._prose()
+        assert "BOUNDED, and the bound is the whole design" in prose
+        assert "false-accept (waiting too long)" in prose
+        assert "false-reject (promoting too early)" in prose
+
+    def test_the_comment_names_the_bound_this_delay_pushes_out(self):
+        """The cross-file half, and the reason it is written down rather than
+        assumed obvious: ``confirm.py``'s not_announced note bounds the wait for
+        that refusal in units of ``fallbackMs``, counted from the moment the
+        item becomes ``current``. This deferral happens BEFORE that, so in the
+        one state where a fallback utterance is live the note under-states its
+        own worst case. A behaviour change that silently falsifies a sentence
+        elsewhere is the defect class this whole layer keeps finding; naming it
+        in the file that caused it is the cheapest place it survives."""
+        prose = self._prose()
+        assert "confirm.py's not_announced note" in prose
+        assert "under-states the worst case by up to one speaking budget" in prose
+
+    def test_a_queued_item_is_not_pumped_into_the_starting_browser_voice(self):
+        """The reproduction from #997, inverted.
+
+        A long notice falls back to the browser voice; a second must_speak item
+        is queued behind it. armFallback still nulls `current`, starts speak(),
+        and calls pump() in the same tick — but pump() now sees `speaking` and
+        holds, so only ONE response.create has gone out.
+        """
         report = run_announcer(f"""
             speakDefers = true;
             announcer.announce({json.dumps("x" * 1250)});
@@ -2900,21 +3099,115 @@ class TestTheSpeakingBudgetCommentDoesNotClaimThePumpPath:
         """)
         # The browser voice has started and has NOT ended.
         assert len(report["spoken"]) == 1
-        # ...and the queued item was promoted onto the channel anyway.
-        assert len(creates(report)) == 2
+        # ...and nothing was promoted over it.
+        assert len(creates(report)) == 1
+        # Still owed, not dropped: pending() counts it, so canSpeak stays shut.
         assert "speaking=1 pending=2" in report["logs"]
+        assert any("deferred — the browser voice is speaking" in line
+                   for line in report["logs"])
 
-    def test_the_watchdog_did_not_have_to_fire_for_that(self):
-        """The part that makes it a residual rather than a symptom of the flat
-        bound: the overlap above happens at the fallback fire, with the
-        speaking watchdog freshly armed and nowhere near due."""
+    def test_it_is_promoted_the_moment_that_audio_ends(self):
+        """Deferral, not suppression — and on the ORDINARY path it costs no
+        timer at all: the utterance's own end event pumps."""
         report = run_announcer(f"""
             speakDefers = true;
             announcer.announce({json.dumps("x" * 1250)});
             announcer.announce("Your worktree run failed.");
             fireTimers();
+            logs.push("mid: creates=" + events.filter(
+                (e) => e.type === "response.create").length);
+            finishSpeech();
         """)
-        # Two timers are armed: the promoted item's own 6s fallback, and the
-        # speaking watchdog for the utterance now being started. The watchdog
-        # is the one this claim is about, and it is nowhere near due.
-        assert max(report["armedMs"]) > 30_000
+        assert "mid: creates=1" in report["logs"]
+        assert len(creates(report)) == 2
+        assert "Your worktree run failed." in creates(report)[1]["response"]["instructions"]
+
+    def test_the_deferral_bound_is_the_speaking_budget_of_the_utterance(self):
+        """The bound is the #993 budget of the audio actually in flight — the
+        longest this page believes the browser voice is talking — not a new
+        constant. ~205s for the coalesced five-reply notice #997 reproduced."""
+        text = "x" * 1250
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps(text)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+        """)
+        budget = self._budget(text)
+        # Two timers: the speaking watchdog and the pump deferral, at the same
+        # budget by construction. The promoted item's own 6s fallback is NOT
+        # armed — nothing was promoted.
+        assert report["armedMs"] == [budget, budget]
+        assert budget > 200_000
+
+    def test_a_short_utterance_defers_only_for_the_floor(self):
+        """The other end of the same derivation: no per-char stretch, so the
+        wait is the 30s floor. A bound that did not scale would read the same
+        here and differently above."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Done.");
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+        """)
+        assert report["armedMs"] == [self._budget("Done."), self._budget("Done.")]
+        assert self._budget("Done.") == 30_000 + 5 * 140
+
+    def test_the_backstop_promotes_rather_than_staying_mute(self):
+        """The half that makes "bounded" true rather than intended.
+
+        Fire ONLY the deferral timer, leaving the item in `speaking` — the
+        state where the watchdog has somehow not run. The queued item goes out
+        anyway. An unbounded defer would be a screenless mute, which is the
+        trade #997 forbids.
+        """
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+            fireTimerAt(1);            // the pump deferral, NOT the watchdog
+            logs.push("still speaking=" + announcer.pending());
+        """)
+        assert len(creates(report)) == 2
+        # The utterance is still believed to be playing — this is the backstop
+        # firing over it, deliberately, because the alternative is silence.
+        assert any("deferral bound reached" in line for line in report["logs"])
+        assert len(report["spoken"]) == 1
+
+    def test_fire_timer_at_fires_exactly_one(self):
+        """A control on the harness helper the test above depends on. If
+        ``fireTimerAt`` fired everything it would be ``fireTimers`` under
+        another name, and the backstop test would prove nothing about the
+        watchdog not running."""
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+            logs.push("before=" + timers.map((t) => t.ms).join(","));
+            fireTimerAt(1);
+            logs.push("after=" + timers.map((t) => t.ms).join(","));
+            logs.push("notSpoken=" + notSpoken.length);
+        """)
+        assert "before=205000,205000" in report["logs"]
+        # The deferral is consumed and the speaking WATCHDOG is still armed —
+        # the 6000 is the newly promoted item's own fallback. Had fireTimerAt
+        # fired everything, the watchdog would have run too and reported the
+        # utterance not spoken.
+        assert "after=205000,6000" in report["logs"]
+        assert "notSpoken=0" in report["logs"]
+
+    def test_the_deferral_does_not_leak_a_timer_once_it_resolves(self):
+        """The deferral timer is cleared when the pump promotes, so a resolved
+        wait leaves nothing armed to force a second promotion later."""
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();
+            finishSpeech();            // the audio ends; the queued item goes
+            logs.push("armed=" + timers.map((t) => t.ms).join(","));
+        """)
+        # Only the promoted item's own 6s fallback remains.
+        assert "armed=6000" in report["logs"]

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -2831,6 +2831,44 @@ class TestTheSpeakingWatchdogReleasesTheNotice:
         # be treated as stated.
         assert report["anchored"] == []
 
+    def test_the_false_reject_leg_is_priced_as_what_it_actually_does(self):
+        """"The owner hears it twice" was the cheap phrasing and it hid the
+        cost. ``stopSpeaking`` empties ``speaking`` but cannot cancel the
+        browser's audio — there is no ``cancel()`` on this path, deliberately
+        (#950 defect 3) — so the re-announcement pumps while the first
+        utterance is still playing: twice SIMULTANEOUSLY, which reopens #997
+        for that window. Still the right trade, and now stated as the trade it
+        is rather than a milder one."""
+        prose = _page_prose()
+        assert "The owner hears it twice SIMULTANEOUSLY" in prose
+        assert "CANNOT cancel the browser's audio" in prose
+        assert "reopens #997 for exactly that window" in prose
+
+    def test_the_page_really_does_not_cancel_the_browser_voice(self):
+        """The behavioural half of that claim, and the reason the sentence is
+        true rather than pessimistic: nothing on the fallback path calls
+        ``speechSynthesis.cancel()``. If that ever changes, the paragraph above
+        is over-stating the cost and this fails alongside it."""
+        page = client.page("buddy", "tok")
+        speak_dep = page.split("speak: (text, onSpokenAloud, onSpeakFailed) =>", 1)[1]
+        speak_dep = speak_dep.split("window.speechSynthesis.speak(utterance);", 1)[0]
+        assert "speechSynthesis.cancel" not in speak_dep
+
+    def test_the_handler_no_longer_calls_itself_never_a_guess(self):
+        """``onNotSpoken``'s own header said "reached only from the browser
+        voice's own onerror — a positive report that the utterance failed,
+        never a guess". This change makes the WATCHDOG a second caller, and the
+        watchdog IS a guess: it infers failure from the ABSENCE of an end
+        event. Same class as the ``speakingBaseMs`` paragraph corrected
+        alongside it — a guarantee written broader than the code, which gets
+        rounded back up by the next reader — so it is REWRITTEN, not qualified.
+        """
+        prose = _page_prose()
+        assert "never a guess" not in prose
+        assert "an INFERENCE from the ABSENCE of any end event" in prose
+        # And the third state stays out of it: a throw is "we cannot know".
+        assert "deliberately NOT routed here" in prose
+
     def test_a_torn_down_utterance_reports_nothing_at_all(self):
         """teardown()'s own statement, extended to the leg it did not reach.
 
@@ -2856,6 +2894,20 @@ class TestTheSpeakingWatchdogReleasesTheNotice:
 # =============================================================================
 # Wave-2 prose: two guarantees stated broader than the code
 # =============================================================================
+
+
+def _page_prose() -> str:
+    """The served page's JS comments as flat prose.
+
+    Flattened so an assertion survives a re-wrap: these sentences are 80 columns
+    wide and every one of them spans a line break. One implementation, because a
+    second copy is one more thing that can quietly stop matching what it reads.
+    """
+    lines = [
+        line.strip().removeprefix("//").strip()
+        for line in client.page("buddy", "tok").splitlines()
+    ]
+    return " ".join(" ".join(lines).split())
 
 
 def _source_prose(path: str) -> str:
@@ -3028,16 +3080,6 @@ class TestThePumpDefersToTheBrowserVoice:
       makes "bounded" true even if the watchdog never empties ``speaking``.
     """
 
-    def _prose(self) -> str:
-        """The page's JS comments as flat prose, so an assertion survives a
-        re-wrap — these sentences are 80 columns wide and every one of them
-        spans a line break."""
-        lines = [
-            line.strip().removeprefix("//").strip()
-            for line in client.page("buddy", "tok").splitlines()
-        ]
-        return " ".join(" ".join(lines).split())
-
     def _budget(self, text: str) -> int:
         """The bound, derived from ``client.py``'s own constants rather than
         transcribed — the deferral must never acquire a number of its own, and
@@ -3049,7 +3091,7 @@ class TestThePumpDefersToTheBrowserVoice:
         return 6000 * int(base.group(1)) + len(text) * int(per_char.group(1))
 
     def test_the_comment_no_longer_claims_the_defect_is_ruled_out(self):
-        prose = self._prose()
+        prose = _page_prose()
         assert "which reopens both gates and lets the MODEL start a response" not in prose
         # And no longer calls the pump path live, either — the sentence that
         # class existed to keep honest is now a sentence about a closed defect.
@@ -3057,14 +3099,14 @@ class TestThePumpDefersToTheBrowserVoice:
         assert "pump() now defers while `speaking` is non-empty" in prose
 
     def test_the_comment_names_the_gates_the_budget_actually_covers(self):
-        prose = self._prose()
+        prose = _page_prose()
         assert "reopens the NOTIFIER's gates — canSpeak and canInterrupt" in prose
 
     def test_the_comment_states_the_bound_and_prices_both_halves(self):
         """The trap #997 names, kept stated in the code that implements it: an
         unbounded defer is a suppression defect, which is worse than the audio
         defect it fixes."""
-        prose = self._prose()
+        prose = _page_prose()
         assert "BOUNDED, and the bound is the whole design" in prose
         assert "false-accept (waiting too long)" in prose
         assert "false-reject (promoting too early)" in prose
@@ -3078,9 +3120,13 @@ class TestThePumpDefersToTheBrowserVoice:
         own worst case. A behaviour change that silently falsifies a sentence
         elsewhere is the defect class this whole layer keeps finding; naming it
         in the file that caused it is the cheapest place it survives."""
-        prose = self._prose()
+        prose = _page_prose()
         assert "confirm.py's not_announced note" in prose
         assert "under-states the worst case by up to one speaking budget" in prose
+        # And it is FILED, not merely commented. A caveat that lives only in a
+        # comment is invisible to the board the owner reads, and the ruling for
+        # this beta is that nothing known-open ships unfiled.
+        assert "Filed as #1009" in prose
 
     def test_a_queued_item_is_not_pumped_into_the_starting_browser_voice(self):
         """The reproduction from #997, inverted.
@@ -3197,6 +3243,36 @@ class TestThePumpDefersToTheBrowserVoice:
         # utterance not spoken.
         assert "after=205000,6000" in report["logs"]
         assert "notSpoken=0" in report["logs"]
+
+    def test_a_cleared_deferral_that_fires_anyway_does_nothing(self):
+        """The stale-handle guard, pinned — it survived removal until this.
+
+        The state is reachable in one batch: the speaking watchdog and the
+        deferral come due together, the watchdog runs first, settleSpeech pumps
+        and the promotion CLEARS the deferral — and the batch then calls the
+        cleared callback anyway. A real ``clearTimeout`` would not, which is
+        why nothing saw this; a fake clock does, and so does a browser running
+        a just-cancelled callback.
+
+        What the guard is worth is narrow and worth saying: ``pump(true)``
+        would return immediately anyway, since the promotion set ``current``.
+        The observable cost is the LOG — "promoting anyway" written after
+        nothing was promoted over anything, in the one log a reader consults to
+        find out whether the buddy talked over itself. A misleading record of a
+        deferral decision is the thing this whole class exists to prevent.
+        """
+        report = run_announcer(f"""
+            speakDefers = true;
+            announcer.announce({json.dumps("x" * 1250)});
+            announcer.announce("Your worktree run failed.");
+            fireTimers();      // the fallback fires; the deferral arms
+            fireTimers();      // watchdog + deferral together, watchdog first
+        """)
+        # The watchdog resolved it, so the queued item did go out...
+        assert len(creates(report)) == 2
+        assert len(report["notSpoken"]) == 1
+        # ...and the cleared deferral said nothing about having done it.
+        assert not any("deferral bound reached" in line for line in report["logs"])
 
     def test_the_deferral_does_not_leak_a_timer_once_it_resolves(self):
         """The deferral timer is cleared when the pump promotes, so a resolved

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -516,7 +516,7 @@ class TestTheOpenResidualsAreNamed:
     """A wiki that describes what we meant is how the next contributor argues
     from a mechanism that does not exist."""
 
-    @pytest.mark.parametrize("issue", [989, 990, 992])
+    @pytest.mark.parametrize("issue", [989, 990, 992, 1009])
     def test_residual_is_recorded(self, page, issue):
         assert f"#{issue}" in page
 
@@ -526,6 +526,16 @@ class TestTheOpenResidualsAreNamed:
     def test_the_echoed_denial_hole_is_described(self, page):
         assert "`carries_denial` is not nonce-gated" in page
 
+    def test_the_page_does_not_call_onNotSpoken_a_positive_report_only(self, page):
+        """The wiki carried the same sentence ``client.py``'s handler did —
+        "positive evidence ... reached only from `speechSynthesis`'s own
+        `onerror`" — and #996 made the watchdog a second caller whose evidence
+        is an INFERENCE, not a report. Left alone it contradicted this page's
+        own #996 bullet twenty-five lines above it, in the same section."""
+        assert "reached only from `speechSynthesis`'s own `onerror`" not in page
+        assert "two callers carrying different kinds of evidence" in page
+        assert "a guess, made in one direction on purpose" in page
+
     @pytest.mark.parametrize("issue", [995, 996, 997])
     def test_a_closed_one_is_not_still_listed_as_a_hole(self, page, issue):
         """The other direction, and it is not symmetric with the assertion
@@ -534,7 +544,11 @@ class TestTheOpenResidualsAreNamed:
         place they would look. These three were closed together; the row is
         gone and the closure is recorded instead."""
         table = page.split("| # | Where | The hole |", 1)[1].split("**Closed", 1)[0]
-        assert f"#{issue}" not in table
+        # Keyed on the ROW, not on the mention. #1009's row describes the debt
+        # #997's fix left behind and so names it — a bare substring check read
+        # that as "#997 is still listed", which is the pin failing for a reason
+        # that has nothing to do with what it guards.
+        assert f"| #{issue} |" not in table
         assert f"#{issue}" in page
 
 

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -516,7 +516,7 @@ class TestTheOpenResidualsAreNamed:
     """A wiki that describes what we meant is how the next contributor argues
     from a mechanism that does not exist."""
 
-    @pytest.mark.parametrize("issue", [989, 990, 992, 995, 996, 997])
+    @pytest.mark.parametrize("issue", [989, 990, 992])
     def test_residual_is_recorded(self, page, issue):
         assert f"#{issue}" in page
 
@@ -525,6 +525,17 @@ class TestTheOpenResidualsAreNamed:
 
     def test_the_echoed_denial_hole_is_described(self, page):
         assert "`carries_denial` is not nonce-gated" in page
+
+    @pytest.mark.parametrize("issue", [995, 996, 997])
+    def test_a_closed_one_is_not_still_listed_as_a_hole(self, page, issue):
+        """The other direction, and it is not symmetric with the assertion
+        above: a residual listed after it is closed sends the next contributor
+        to build around a hole that is not there, and this table is the one
+        place they would look. These three were closed together; the row is
+        gone and the closure is recorded instead."""
+        table = page.split("| # | Where | The hole |", 1)[1].split("**Closed", 1)[0]
+        assert f"#{issue}" not in table
+        assert f"#{issue}" in page
 
 
 class TestTheDeliverySeamNoLongerClaimsItNeverInterrupts:


### PR DESCRIPTION
Closes #995, #996, #997 — the three open `client.py` residuals gating the beta. Filed on the way out: #1009.

Base is `voice-confirm-spine` (9d30741, 6089 passed). **Full suite here: 6129 passed / 0 failed.** `confirm.py` and `transcript.py` are untouched — the sibling owns them this wave.

## #995 — four unpinned browser-event wires

The dc `open`/`close` status wires and both button click handlers. Cut any one and the whole suite stayed green.

Pinned in `tests/unit/test_client_wires.py`, following `test_buddy_restart.py` rather than inventing a second idiom — the extractor moved to `tests/page_slice.py` so there is one implementation of a helper whose whole job is to fail honestly.

Two halves, because neither covers the other: **node-executed** (a substring cannot tell `("click", start)` from `("click", stop)`, and a swapped pair makes the page unusable while every test stays green) and **presence** (the honest message when a whole line is deleted, and the half that still runs without node).

**The partial-anchor guard, measured rather than claimed.** An earlier revision of this body said the guard was covered and it was not: reflowing either dc status wire across several lines — formatting only, wire intact — truncated the region at the first statement, the loose shape accepted the wreckage, and node died with `SyntaxError: Unexpected end of input` instead of the extractor saying "the anchor moved". That is the exact degradation #995 names, reproduced by the tests written to close it.

Both shapes now demand the arrow function's own terminator — a balanced brace body or a statement-break-free expression, then the call's `);` — which a truncated fragment cannot fake and an emptied body still matches. **The claim is a test now**: a reflow fixture (one statement per line, because packing the body onto one line does not reproduce the defect at all), a control that the reflow left the wire intact, and a discriminator asserting the truncated region really does end in `);`. `test_buddy_restart.py`'s `pc.ontrack` slice had the same latent gap and is closed the same way, so **all five #995 wires report honestly**; #1001's mutation still fails behaviourally there, verified.

## #996 — the watchdog releases the notice

The `speakingMaxMs` watchdog called `stopSpeaking()` only. It reopened the gates — its stated scope, correct — but released nothing, so on the one event it exists to recover from the ids stayed in `inFlight` for the page's life.

Severity taken from the correction comment, not the issue body: since #970 nothing announced is cursor-past, so this is **suppression until reload, then duplicates** (a permanently-`inFlight` id wedges the contiguity walk), not data loss. The stale `strayIds` direction was ignored — the fix is against the current file.

It now fires `onNotSpoken`, so the next gated tick says it again — **with no reload**.

**Both halves, priced at their real size.** The false-reject leg is *not* "the owner hears it twice": `stopSpeaking` empties `speaking` but cannot cancel the browser's audio (no `cancel()` on that path, deliberately — #950 defect 3), so the re-announcement pumps while the first utterance is still playing. The owner hears it **twice, simultaneously**, for whatever is left of it — which reopens #997 for exactly that window, on purpose, because overlapping speech the owner can still parse beats a notice they never get. What keeps the window rare is the #993 budget, 2.6-4.5x conservative. The false-accept leg costs the notice until a reload the owner has no way to know they need.

That makes the **latch** load-bearing rather than tidy: `onend`, `onerror` and the watchdog now route through one `settleSpeech`, first outcome wins. Without it the watchdog's release and a late `onend`'s ack both land — a notice said twice and acked once. `teardown` latches too, closing **#978 item 4 in the leg the reference-nulling fix never reached**: a torn-down utterance's `onend` could still anchor a proposal on the bridge from a dead session.

`onNotSpoken`'s own header claimed it was "reached only from the browser voice's own `onerror` — a positive report ... never a guess". The watchdog makes that false — it infers failure from an *absence* — so the header is **rewritten, not qualified**: two callers, two kinds of evidence, and the `throw` case named as the third state deliberately not routed there. The wiki carried the same sentence, 25 lines above this PR's own #996 bullet, and got the same rewrite. Both pinned, both watched red against the old wording.

## #997 — pump() defers to the browser voice, bounded

`pump()` consulted `current` and `queue` only, so a `must_speak` item queued behind a long notice was promoted in the same tick `armFallback` started the audio — two voices, at any watchdog length, with no watchdog fire and no gate violated. It now holds while `speaking` is non-empty and promotes the moment the audio ends.

**The bound.** It is the `speakingBudget` of the utterance in flight (30s floor + 140ms/char), **not a new constant** — that is exactly how long the page is willing to *believe* the browser voice is talking, and past it the #996 watchdog has already declared the utterance dropped and pumped. The timer is the backstop for the case where it somehow has not, and it **promotes rather than staying mute**.

- *false-accept (waiting too long)*: the queued item waits behind audio the owner **is currently hearing** — not silence — and it ends when that audio does.
- *false-reject (promoting too early)*: two voices, the defect being closed.

An unbounded defer would convert an audio-quality defect into a suppression defect, strictly worse in a screenless channel. That is why the wait is bounded by the same number that decides when to stop believing the voice at all.

The `client.py:151-161` comment changed with the code, and the tests that pinned that wording now pin the fix.

## #1009 — filed, not left as a comment

This deferral sits **upstream** of the announcer's own two bounded deferrals, which are counted from the moment an item becomes `current`. So `confirm.py`'s `not_announced` note — which bounds that refusal's wait in units of `fallbackMs` — under-states its worst case by up to one speaking budget while a fallback utterance is live. `confirm.py` is the sibling's this wave, so it is **filed as #1009**, listed in the wiki's open-residuals table and pinned there, with the issue number in the `client.py` comment. A stated-guarantee defect, not a runtime one: the refusal is delivered either way.

## Method

Every pin was watched failing. **24 mutations across both rounds, all red**, scripted rather than eyeballed:

| target | mutations |
|---|---|
| #995 | 4 wires deleted · 2 handler bodies gutted · buttons swapped |
| #995 shapes | the loose shape restored (both dc wires red) · `maybeGreet()` cut with the tightened `ontrack` shape, still failing behaviourally |
| #996 | watchdog reverted to `stopSpeaking()` · latch removed · teardown latch removed · onerror leg silenced · the old "never a guess" header · the old wiki sentence · the cheap "hears it twice" phrasing · a `speechSynthesis.cancel()` added to the speak path |
| #997 | pump gate removed · defer made unbounded · bound replaced by a flat constant · end-of-audio pump removed · the stale-handle guard removed |
| wiki | a closed residual put back in the open table (twice — the pin is keyed on the ROW, since #1009's row names #997) |

The old #997 class was an expected-fail canary; both of its behavioural assertions inverted here, so it is **re-labelled by hand** rather than quietly left passing — a canary and a live guarantee are identical at the moment of failure and nothing re-labels them for you.

The harness gained `fireTimerAt()` — `fireTimers()` cannot express "the backstop ran and the watchdog did not" — with its own control asserting it fires exactly one and leaves the watchdog armed.

Built by [dotdev.dev](https://dotdev.dev)