### PR TITLE
chore: bump version to 1.69.0

### DIFF
--- a/agentwire/__init__.py
+++ b/agentwire/__init__.py
@@ -1,3 +1,3 @@
 """AgentWire - Multi-session voice web interface for AI coding agents."""
 
-__version__ = "1.68.0"
+__version__ = "1.69.0"


### PR DESCRIPTION
Version bump for the 1.69.0 release, which ships the voice layer (#1011) as an opt-in beta, default OFF.

**Minor, not major.** There is no breaking change: byte-identity with 1.68.0 was proven for every model-facing surface with the flag off — all 24 shipped role files through the live `parse_role_file` path, and all 108 MCP tool descriptions from a real server, with `agentwire` imported from two isolated trees. Upgrading requires nothing of anyone who does not opt in.

Opting in:

```yaml
# ~/.agentwire/config.yaml
beta:
  voice_layer: true
```

plus an OpenAI API key in the usual secrets location. `agentwire doctor` reports both, and prints no part of the key.

Separate PR because direct pushes to `main` no longer work — the ruleset's admin bypass was removed on 2026-08-10, so every change to `main` now goes through a PR with four required checks.

Built by [dotdev.dev](https://dotdev.dev)