### PR TITLE
fix: keep ordinary CLI stderr silent (#1018)

### DIFF
--- a/agentwire/config.py
+++ b/agentwire/config.py
@@ -1010,11 +1010,14 @@ def load_config(config_path: Optional[Path] = None) -> Config:
     # Apply environment variable overrides
     data = _apply_env_overrides(data)
 
-    # Debug logging for STT config
+    # Debug logging for STT config. DEBUG, not INFO (#1018): config loading is
+    # not an event anyone asked to be told about, and at INFO it printed on
+    # ordinary CLI commands the moment anything in the process configured the
+    # root logger.
     import logging
     logger = logging.getLogger(__name__)
     if 'stt' in data:
-        logger.info(f"STT config after env overrides: {data['stt']}")
+        logger.debug(f"STT config after env overrides: {data['stt']}")
 
     return _dict_to_config(data)
 

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -8,6 +8,7 @@ from here — never the reverse — so there is no circular import.
 
 import datetime
 import json
+import logging
 import os
 import shlex
 import shutil
@@ -33,6 +34,80 @@ from .worktree import git_common_dir, git_root, main_worktree, parse_session_nam
 
 # Default config directory
 CONFIG_DIR = Path.home() / ".agentwire"
+
+logger = logging.getLogger(__name__)
+
+
+def run_agentwire_cmd(
+    args: list[str],
+    json_output: bool = True,
+    timeout: int = 30,
+) -> dict:
+    """Run agentwire CLI command and return result.
+
+    Lives here rather than in ``mcp_core`` (#1018): it is a plain subprocess
+    wrapper with no MCP in it, and importing it from ``mcp_core`` meant every
+    consumer — including ``buddy_cli``, which ``build_parser()`` imports on
+    EVERY CLI invocation — constructed the FastMCP singleton and reconfigured
+    the root logger as an import side effect.
+
+    Args:
+        args: Command arguments (e.g., ["list", "--sessions"])
+        json_output: Whether to add --json flag and parse output
+        timeout: Command timeout in seconds (default: 30)
+
+    Returns:
+        Dict with 'success', 'output', and possibly other fields from JSON output.
+        For JSON responses without 'success' field, wraps data with success=True.
+    """
+    cmd = ["agentwire"] + args
+    if json_output:
+        cmd.append("--json")
+
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        # Try to parse JSON output
+        if json_output and result.stdout.strip():
+            try:
+                data = json.loads(result.stdout)
+                # Handle JSON arrays (e.g., history list returns [...])
+                if isinstance(data, list):
+                    return {
+                        "success": result.returncode == 0,
+                        "items": data,
+                    }
+                # If the response is valid JSON but doesn't have 'success',
+                # wrap it with success based on return code
+                if "success" not in data:
+                    return {
+                        "success": result.returncode == 0,
+                        **data,
+                    }
+                return data
+            except json.JSONDecodeError:
+                pass
+
+        # Fall back to raw output
+        return {
+            "success": result.returncode == 0,
+            "output": result.stdout.strip(),
+            "error": result.stderr.strip() if result.returncode != 0 else None,
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "Command timed out"}
+    except FileNotFoundError:
+        return {"success": False, "error": "agentwire command not found"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 
 def role_prompts_dir() -> Path:

--- a/agentwire/mcp_channels.py
+++ b/agentwire/mcp_channels.py
@@ -2,9 +2,9 @@
 
 import json
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_chrome.py
+++ b/agentwire/mcp_chrome.py
@@ -7,7 +7,8 @@ be identified and closed by whoever tears the session down — `worktree_remove`
 checks this registry during teardown and reports anything still tracked.
 """
 
-from .mcp_core import get_caller_session, mcp, run_agentwire_cmd
+from .core import run_agentwire_cmd
+from .mcp_core import get_caller_session, mcp
 
 
 @mcp.tool()

--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -48,8 +48,14 @@ def configure_logging() -> None:
 # Guarded by ``getattr`` deliberately: an upstream rename of ``Settings`` must
 # not take the entire MCP tool surface down with it (#874 was exactly that
 # failure — an SDK bump that removed a module we import at load time). The cost
-# of the guard is that the warning could return silently, which is what
-# ``tests/unit/test_cli_stderr_clean.py`` exists to notice.
+# is that the guard degrades to a silent no-op, so the degradation is pinned
+# structurally rather than by the warning:
+# ``test_mcp_core_rebuilds_settings_before_it_constructs_the_server`` fails on
+# the rename AND on a reordering that put this after the construction below.
+# Watching for the warning itself would NOT do: only pydantic-settings >= 2.15
+# emits it, ``uv.lock`` pins 2.14.2, and constructing ``FastMCP`` completes the
+# model as a side effect — so both obvious probes are green under the deps CI
+# actually runs.
 _fastmcp_settings = getattr(_fastmcp_server, "Settings", None)
 if _fastmcp_settings is not None:
     _fastmcp_settings.model_rebuild()

--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -1,26 +1,58 @@
 """Shared MCP server foundation.
 
 Holds the singleton ``mcp = FastMCP(...)`` instance plus the cross-domain
-helpers (CLI runner, result formatters) that every ``mcp_*`` domain module
-imports. Mirrors ``core.py`` for the CLI split (#495).
+result formatters that every ``mcp_*`` domain module imports. Mirrors
+``core.py`` for the CLI split (#495).
+
+**Importing this module builds an MCP server.** Only ``mcp_*`` modules and the
+``mcp_server`` entrypoint may import it — the CLI-runner helper that used to
+live here now sits in :mod:`agentwire.core`, because a non-MCP consumer of it
+(``buddy_cli``, which ``build_parser()`` imports on EVERY invocation) dragged
+the whole FastMCP construction into ordinary CLI startup (#1018).
 """
 
-import json
 import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import mcp.server.fastmcp.server as _fastmcp_server
 from mcp.server.fastmcp import FastMCP
 
-# Configure logging to stderr (stdout is reserved for MCP JSON-RPC)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    stream=sys.stderr,
-)
 logger = logging.getLogger("agentwire-mcp")
+
+
+def configure_logging() -> None:
+    """Send MCP server logs to stderr (stdout is the JSON-RPC channel).
+
+    Called by :func:`agentwire.mcp_server.run_server`, NOT at import time:
+    ``basicConfig`` mutates the ROOT logger, so doing it on import turned every
+    library INFO record in the whole process into CLI stderr noise (#1018).
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+
+
+# ``FastMCP``'s own settings model annotates ``lifespan`` with a forward
+# reference to ``FastMCP`` itself, which is defined further down the same
+# module — so at class-creation time it is unresolved, and pydantic-settings
+# >= 2.15 warns about it on every instantiation. The library ships no
+# ``model_rebuild()`` call of its own; do it here, once the module (and hence
+# the referenced class) is fully imported. This is the exact remedy the warning
+# names, and it is a no-op on versions that already resolve it.
+#
+# Guarded by ``getattr`` deliberately: an upstream rename of ``Settings`` must
+# not take the entire MCP tool surface down with it (#874 was exactly that
+# failure — an SDK bump that removed a module we import at load time). The cost
+# of the guard is that the warning could return silently, which is what
+# ``tests/unit/test_cli_stderr_clean.py`` exists to notice.
+_fastmcp_settings = getattr(_fastmcp_server, "Settings", None)
+if _fastmcp_settings is not None:
+    _fastmcp_settings.model_rebuild()
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -87,72 +119,6 @@ def get_caller_session() -> str | None:
     except (subprocess.TimeoutExpired, OSError):
         pass
     return None
-
-
-def run_agentwire_cmd(
-    args: list[str],
-    json_output: bool = True,
-    timeout: int = 30,
-) -> dict:
-    """Run agentwire CLI command and return result.
-
-    Args:
-        args: Command arguments (e.g., ["list", "--sessions"])
-        json_output: Whether to add --json flag and parse output
-        timeout: Command timeout in seconds (default: 30)
-
-    Returns:
-        Dict with 'success', 'output', and possibly other fields from JSON output.
-        For JSON responses without 'success' field, wraps data with success=True.
-    """
-    cmd = ["agentwire"] + args
-    if json_output:
-        cmd.append("--json")
-
-    logger.debug(f"Running: {' '.join(cmd)}")
-
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-
-        # Try to parse JSON output
-        if json_output and result.stdout.strip():
-            try:
-                data = json.loads(result.stdout)
-                # Handle JSON arrays (e.g., history list returns [...])
-                if isinstance(data, list):
-                    return {
-                        "success": result.returncode == 0,
-                        "items": data,
-                    }
-                # If the response is valid JSON but doesn't have 'success',
-                # wrap it with success based on return code
-                if "success" not in data:
-                    return {
-                        "success": result.returncode == 0,
-                        **data,
-                    }
-                return data
-            except json.JSONDecodeError:
-                pass
-
-        # Fall back to raw output
-        return {
-            "success": result.returncode == 0,
-            "output": result.stdout.strip(),
-            "error": result.stderr.strip() if result.returncode != 0 else None,
-        }
-
-    except subprocess.TimeoutExpired:
-        return {"success": False, "error": "Command timed out"}
-    except FileNotFoundError:
-        return {"success": False, "error": "agentwire command not found"}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
 
 
 def _delivery_result(data: dict, where: str) -> str:

--- a/agentwire/mcp_council.py
+++ b/agentwire/mcp_council.py
@@ -1,8 +1,8 @@
 """MCP tools — council domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_handoff.py
+++ b/agentwire/mcp_handoff.py
@@ -1,8 +1,8 @@
 """MCP tools — handoff domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_history.py
+++ b/agentwire/mcp_history.py
@@ -1,8 +1,8 @@
 """MCP tools — history domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_listen.py
+++ b/agentwire/mcp_listen.py
@@ -1,8 +1,8 @@
 """MCP tools — listen domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_lock.py
+++ b/agentwire/mcp_lock.py
@@ -1,8 +1,8 @@
 """MCP tools — lock domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_machine.py
+++ b/agentwire/mcp_machine.py
@@ -1,9 +1,9 @@
 """MCP tools — machine domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     format_machines,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_msg.py
+++ b/agentwire/mcp_msg.py
@@ -1,10 +1,10 @@
 """MCP tools — msg domain."""
 
 from .beta import gated_doc
+from .core import run_agentwire_cmd
 from .mcp_core import (
     get_caller_session,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_notify.py
+++ b/agentwire/mcp_notify.py
@@ -1,8 +1,8 @@
 """MCP tools — notify domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 from .mcp_desktop import _portal_request
 

--- a/agentwire/mcp_pane.py
+++ b/agentwire/mcp_pane.py
@@ -1,9 +1,9 @@
 """MCP tools — pane domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     _delivery_result,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_projects.py
+++ b/agentwire/mcp_projects.py
@@ -1,10 +1,10 @@
 """MCP tools — projects domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     format_projects,
     format_roles,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_scheduler.py
+++ b/agentwire/mcp_scheduler.py
@@ -1,8 +1,8 @@
 """MCP tools — scheduler domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_scratchpad.py
+++ b/agentwire/mcp_scratchpad.py
@@ -1,8 +1,8 @@
 """MCP tools — scratchpad domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_server.py
+++ b/agentwire/mcp_server.py
@@ -37,11 +37,12 @@ from . import (
     mcp_wiki,  # noqa: F401
     mcp_worktree,  # noqa: F401
 )
-from .mcp_core import get_portal_url, logger, mcp
+from .mcp_core import configure_logging, get_portal_url, logger, mcp
 
 
 def run_server():
     """Run the MCP server on stdio transport."""
+    configure_logging()
     logger.info("Starting AgentWire MCP server")
     logger.info(f"Portal URL: {get_portal_url()}")
     mcp.run(transport="stdio")

--- a/agentwire/mcp_services.py
+++ b/agentwire/mcp_services.py
@@ -1,8 +1,8 @@
 """MCP tools — services domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_session.py
+++ b/agentwire/mcp_session.py
@@ -1,12 +1,12 @@
 """MCP tools — session domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     _delivery_result,
     _mcp_result,
     format_sessions,
     get_caller_session,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_status.py
+++ b/agentwire/mcp_status.py
@@ -1,9 +1,9 @@
 """MCP tools — status domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     get_portal_url,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_task.py
+++ b/agentwire/mcp_task.py
@@ -1,8 +1,8 @@
 """MCP tools — task domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_tunnels.py
+++ b/agentwire/mcp_tunnels.py
@@ -1,8 +1,8 @@
 """MCP tools — tunnels domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_voice.py
+++ b/agentwire/mcp_voice.py
@@ -2,11 +2,11 @@
 
 import base64
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     format_voices,
     get_portal_url,
     mcp,
-    run_agentwire_cmd,
 )
 
 

--- a/agentwire/mcp_worktree.py
+++ b/agentwire/mcp_worktree.py
@@ -1,9 +1,9 @@
 """MCP tools — worktree domain."""
 
+from .core import run_agentwire_cmd
 from .mcp_core import (
     get_caller_session,
     mcp,
-    run_agentwire_cmd,
 )
 from .worktree import teardown_session_note
 

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1303,7 +1303,7 @@ SPOKEN = {
     #
     # "nothing was sent" was a definite claim the system cannot verify:
     # `run_agentwire_cmd` returns success=False on `subprocess.TimeoutExpired`
-    # (mcp_core.py:150), and a timed-out CLI may already have enqueued. Pairing
+    # (core.py), and a timed-out CLI may already have enqueued. Pairing
     # that false certainty with "ask me again" invited a re-propose that
     # DOUBLE-DELIVERS — the acting-twice failure, reached through a spoken line
     # asserting more than the system knows.

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -36,7 +36,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Callable
 
-from ..mcp_core import run_agentwire_cmd
+from ..core import run_agentwire_cmd
 from . import delivery, outbox
 from .confirm import strip_controls
 

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable
 
-from ..mcp_core import run_agentwire_cmd
+from ..core import run_agentwire_cmd
 from .confirm import spoken_nonce, strip_controls
 from .tools import ToolError, _session_arg
 

--- a/tests/unit/test_cli_stderr_clean.py
+++ b/tests/unit/test_cli_stderr_clean.py
@@ -1,0 +1,170 @@
+"""Ordinary CLI commands must write NOTHING to stderr (#1018).
+
+Two symptoms, one root cause. ``build_parser()`` imports every ``*_cli``
+module, and ``buddy_cli`` reached ``voice_layer.tools`` → ``mcp_core`` for one
+subprocess helper. Importing ``mcp_core`` does two things no CLI invocation
+asked for:
+
+1. constructs the FastMCP singleton, whose settings model carries an
+   unresolved forward reference — pydantic-settings >= 2.15 warns about it on
+   every instantiation; and
+2. calls ``logging.basicConfig(level=INFO)``, which configures the ROOT logger
+   for the whole process, promoting library INFO records (the STT config line)
+   into CLI stderr.
+
+The output assertions below are the user-visible pin, but they can only fail on
+a machine whose pydantic-settings actually emits that warning. So the
+structural invariants are pinned separately: they fail on every version, and
+they are what a future refactor would actually break.
+"""
+
+import logging
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Commands that touch no tmux server and mutate nothing, but do load config
+#: (so the STT code path actually runs) and build the full parser.
+REPRESENTATIVE_COMMANDS = [
+    ["--version"],
+    ["roles", "list", "--json"],
+    ["projects", "list", "--json"],
+]
+
+
+def _fake_home(tmp_path: Path) -> Path:
+    """A HOME with a config that has an ``stt`` section.
+
+    Without the section the STT log line never executes at all and the stderr
+    assertion passes for the wrong reason — the failure mode this suite keeps
+    finding (a green test measuring a fixture that cannot express the bug).
+    """
+    home = tmp_path / "home"
+    cfg = home / ".agentwire"
+    cfg.mkdir(parents=True)
+    (cfg / "config.yaml").write_text(textwrap.dedent("""\
+        stt:
+          backend: default
+        """))
+    return home
+
+
+@pytest.mark.parametrize("argv", REPRESENTATIVE_COMMANDS,
+                         ids=lambda a: " ".join(a))
+def test_command_writes_nothing_to_stderr(argv, tmp_path):
+    """A healthy command is silent on stderr — no warnings, no INFO records."""
+    home = _fake_home(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, "-m", "agentwire", *argv],
+        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+             "HOME": str(home),
+             "PYTHONPATH": str(REPO_ROOT)},
+    )
+    assert proc.stderr == "", (
+        f"`agentwire {' '.join(argv)}` polluted stderr:\n{proc.stderr}"
+    )
+
+
+def test_stt_config_line_is_not_emitted_at_info(tmp_path, monkeypatch, caplog):
+    """The config loader's STT line is DEBUG, and the fixture proves it runs.
+
+    Asserting only "no INFO record" would pass on a config with no ``stt``
+    section at all, so the DEBUG assertion is the control: if it is missing,
+    the code path never executed and the INFO assertion measured nothing.
+    """
+    from agentwire import config as config_mod
+
+    home = _fake_home(tmp_path)
+    monkeypatch.setenv("HOME", str(home))
+
+    with caplog.at_level(logging.DEBUG, logger=config_mod.__name__):
+        config_mod.load_config(home / ".agentwire" / "config.yaml")
+
+    stt_records = [r for r in caplog.records if "STT config" in r.getMessage()]
+    assert stt_records, "STT config path did not run — fixture is wrong"
+    assert all(r.levelno == logging.DEBUG for r in stt_records), (
+        f"STT config logged above DEBUG: {[r.levelname for r in stt_records]}"
+    )
+
+
+def test_building_the_parser_does_not_build_an_mcp_server():
+    """The structural pin: no CLI import path may reach ``mcp_core``.
+
+    Version-independent, unlike the stderr assertions — this fails the moment
+    any ``*_cli`` module reaches for an MCP helper again, which is how both
+    symptoms got in.
+    """
+    probe = textwrap.dedent("""\
+        import sys
+        import agentwire.__main__ as m
+        m.build_parser()
+        leaked = sorted(
+            n for n in sys.modules
+            if n == "agentwire.mcp_core" or n.startswith("mcp.server")
+        )
+        print(",".join(leaked))
+        """)
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
+             "PYTHONPATH": str(REPO_ROOT)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "", (
+        "build_parser() imported MCP server modules: " + proc.stdout.strip()
+    )
+
+
+def test_root_logger_is_untouched_by_building_the_parser():
+    """No import may call ``logging.basicConfig`` on the CLI's behalf.
+
+    A handler on the root logger is what turned every library INFO record into
+    CLI stderr; asserting on the absence of one catches a re-introduction
+    wherever it happens, not just in ``mcp_core``.
+    """
+    probe = textwrap.dedent("""\
+        import logging
+        import agentwire.__main__ as m
+        m.build_parser()
+        print(len(logging.getLogger().handlers))
+        """)
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
+             "PYTHONPATH": str(REPO_ROOT)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "0", (
+        f"root logger gained {proc.stdout.strip()} handler(s) at import time"
+    )
+
+
+def test_importing_mcp_core_emits_no_settings_warning():
+    """The MCP server path is clean too — its stderr is the client's log.
+
+    ``mcp_core`` resolves the ``lifespan`` forward reference with
+    ``Settings.model_rebuild()`` before constructing FastMCP. Vacuous on a
+    pydantic-settings old enough not to warn; real on >= 2.15.
+    """
+    probe = textwrap.dedent("""\
+        import warnings
+        warnings.simplefilter("error")
+        import agentwire.mcp_core  # noqa: F401
+        print("ok")
+        """)
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
+             "PYTHONPATH": str(REPO_ROOT)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"

--- a/tests/unit/test_cli_stderr_clean.py
+++ b/tests/unit/test_cli_stderr_clean.py
@@ -12,10 +12,21 @@ asked for:
    for the whole process, promoting library INFO records (the STT config line)
    into CLI stderr.
 
-The output assertions below are the user-visible pin, but they can only fail on
-a machine whose pydantic-settings actually emits that warning. So the
-structural invariants are pinned separately: they fail on every version, and
-they are what a future refactor would actually break.
+**Which of these pins is live depends on the installed dependencies, so say so
+rather than claim a blanket guarantee.** Measured against the unfixed tree:
+
+- ``uv.lock`` (pydantic-settings 2.14.2 / mcp 1.27.2 — what CI runs): 5 of the
+  7 go red. The two that do not are the ``--version`` and ``roles list``
+  stderr assertions; neither command loads config, and 2.14.2 emits no warning,
+  so there is nothing for them to catch there. They are the forward-looking
+  half — they bite the moment the pinned deps move up.
+- pydantic-settings 2.15.0 / mcp 1.29.0 (the versions that reproduce the
+  reported symptom): all 7 go red.
+
+Every half of the bug therefore has at least one live control under the locked
+set: the STT line via ``projects list`` and the log-level test, and the
+pydantic warning via the two structural pins, which key on state and ordering
+rather than on the warning and so hold on every version.
 """
 
 import logging
@@ -93,14 +104,32 @@ def test_stt_config_line_is_not_emitted_at_info(tmp_path, monkeypatch, caplog):
     )
 
 
-def test_building_the_parser_does_not_build_an_mcp_server():
+
+
+def _probe(code: str, home: Path) -> subprocess.CompletedProcess:
+    """Run a probe in a fresh interpreter against an isolated HOME.
+
+    Isolated deliberately: a probe reading the developer's real
+    ``~/.agentwire`` makes its result machine-dependent, which is the opposite
+    of what a pin is for.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+             "HOME": str(home),
+             "PYTHONPATH": str(REPO_ROOT)},
+    )
+
+
+def test_building_the_parser_does_not_build_an_mcp_server(tmp_path):
     """The structural pin: no CLI import path may reach ``mcp_core``.
 
     Version-independent, unlike the stderr assertions — this fails the moment
     any ``*_cli`` module reaches for an MCP helper again, which is how both
     symptoms got in.
     """
-    probe = textwrap.dedent("""\
+    proc = _probe("""\
         import sys
         import agentwire.__main__ as m
         m.build_parser()
@@ -109,62 +138,95 @@ def test_building_the_parser_does_not_build_an_mcp_server():
             if n == "agentwire.mcp_core" or n.startswith("mcp.server")
         )
         print(",".join(leaked))
-        """)
-    proc = subprocess.run(
-        [sys.executable, "-c", probe],
-        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
-        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
-             "PYTHONPATH": str(REPO_ROOT)},
-    )
+        """, _fake_home(tmp_path))
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.strip() == "", (
         "build_parser() imported MCP server modules: " + proc.stdout.strip()
     )
 
 
-def test_root_logger_is_untouched_by_building_the_parser():
+def test_root_logger_is_untouched_by_building_the_parser(tmp_path):
     """No import may call ``logging.basicConfig`` on the CLI's behalf.
 
     A handler on the root logger is what turned every library INFO record into
     CLI stderr; asserting on the absence of one catches a re-introduction
     wherever it happens, not just in ``mcp_core``.
     """
-    probe = textwrap.dedent("""\
+    proc = _probe("""\
         import logging
         import agentwire.__main__ as m
         m.build_parser()
         print(len(logging.getLogger().handlers))
-        """)
-    proc = subprocess.run(
-        [sys.executable, "-c", probe],
-        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
-        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
-             "PYTHONPATH": str(REPO_ROOT)},
-    )
+        """, _fake_home(tmp_path))
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.strip() == "0", (
         f"root logger gained {proc.stdout.strip()} handler(s) at import time"
     )
 
 
-def test_importing_mcp_core_emits_no_settings_warning():
+def test_mcp_core_rebuilds_settings_before_it_constructs_the_server(tmp_path):
     """The MCP server path is clean too — its stderr is the client's log.
 
-    ``mcp_core`` resolves the ``lifespan`` forward reference with
-    ``Settings.model_rebuild()`` before constructing FastMCP. Vacuous on a
-    pydantic-settings old enough not to warn; real on >= 2.15.
+    Pinned on ORDERING, and measured at the only instant that discriminates.
+    Two facts make the obvious assertions useless here, both verified rather
+    than assumed:
+
+    - Only pydantic-settings >= 2.15 warns about the unresolved forward
+      reference, and ``uv.lock`` pins 2.14.2 — so a warning-based assertion is
+      vacuous under exactly the dependency set CI runs, which is no control at
+      all for the headline symptom of #1018.
+    - ``Settings.__pydantic_complete__`` read *after* importing ``mcp_core`` is
+      True on the unfixed tree too: constructing ``FastMCP()`` completes the
+      model as a side effect of validation (which is why upstream warns instead
+      of raising). Sampled there, the flag cannot tell the trees apart.
+
+    What actually distinguishes them is whether the model was ALREADY complete
+    at the moment ``mcp_core`` constructed the server — i.e. that the rebuild
+    runs first. So spy on ``FastMCP.__init__`` and sample the flag inside it.
+    Version-independent, and it pins the ordering the fix depends on, which
+    nothing else does.
+
+    The ``RENAMED`` branch is not redundant: ``mcp_core`` guards the rebuild
+    with ``getattr`` so an upstream rename cannot take the whole tool surface
+    down, and that guard degrades to a silent no-op. This is what notices it.
     """
-    probe = textwrap.dedent("""\
-        import warnings
-        warnings.simplefilter("error")
-        import agentwire.mcp_core  # noqa: F401
-        print("ok")
-        """)
-    proc = subprocess.run(
-        [sys.executable, "-c", probe],
-        capture_output=True, text=True, timeout=120, cwd=REPO_ROOT,
-        env={"PATH": "/usr/bin:/bin", "HOME": str(Path.home()),
-             "PYTHONPATH": str(REPO_ROOT)},
-    )
+    proc = _probe("""\
+        import mcp.server.fastmcp.server as s
+
+        settings = getattr(s, "Settings", None)
+        if settings is None:
+            print("RENAMED")
+        else:
+            sampled = {}
+            original = s.FastMCP.__init__
+
+            def spy(self, *args, **kwargs):
+                # Sample BEFORE delegating: the constructor itself completes
+                # the model, so after the call every tree looks identical.
+                sampled.setdefault("complete", settings.__pydantic_complete__)
+                return original(self, *args, **kwargs)
+
+            s.FastMCP.__init__ = spy
+            import agentwire.mcp_core  # noqa: F401  (constructs the singleton)
+
+            if "complete" not in sampled:
+                print("NEVER_CONSTRUCTED")
+            else:
+                print("complete" if sampled["complete"] else "INCOMPLETE")
+        """, _fake_home(tmp_path))
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip() == "ok"
+    verdict = proc.stdout.strip()
+    assert verdict != "RENAMED", (
+        "upstream renamed FastMCP's Settings model — mcp_core's getattr guard "
+        "is now a silent no-op and the lifespan warning is back in every MCP "
+        "client's log"
+    )
+    assert verdict != "NEVER_CONSTRUCTED", (
+        "mcp_core no longer constructs FastMCP through FastMCP.__init__ — this "
+        "probe is measuring nothing; re-point it before trusting it"
+    )
+    assert verdict == "complete", (
+        "mcp_core constructed FastMCP while its Settings model still had an "
+        "unresolved forward reference — Settings.model_rebuild() did not run "
+        "first, and pydantic-settings >= 2.15 warns on every instantiation"
+    )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -240,10 +240,10 @@ class TestFormatVoicesBehavior:
 
 class TestRunAgentwireCmd:
     def setup_method(self):
-        from agentwire.mcp_core import run_agentwire_cmd
+        from agentwire.core import run_agentwire_cmd
         self.fn = run_agentwire_cmd
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_successful_json(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -256,7 +256,7 @@ class TestRunAgentwireCmd:
         cmd = mock_run.call_args[0][0]
         assert cmd == ["agentwire", "list", "--json"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_json_array_wrapping(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -267,7 +267,7 @@ class TestRunAgentwireCmd:
         assert result["success"] is True
         assert result["items"] == [{"id": 1}, {"id": 2}]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_json_without_success_key(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -278,7 +278,7 @@ class TestRunAgentwireCmd:
         assert result["success"] is True
         assert result["data"] == "hello"
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_json_parse_failure_falls_back(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -289,7 +289,7 @@ class TestRunAgentwireCmd:
         assert result["success"] is True
         assert result["output"] == "not json"
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_nonzero_returncode(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=1,
@@ -300,7 +300,7 @@ class TestRunAgentwireCmd:
         assert result["success"] is False
         assert "session not found" in result["error"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_json_output_false(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -313,41 +313,41 @@ class TestRunAgentwireCmd:
         cmd = mock_run.call_args[0][0]
         assert "--json" not in cmd
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_timeout_expired(self, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="agentwire", timeout=30)
         result = self.fn(["long-cmd"])
         assert result["success"] is False
         assert "timed out" in result["error"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_file_not_found(self, mock_run):
         mock_run.side_effect = FileNotFoundError()
         result = self.fn(["list"])
         assert result["success"] is False
         assert "not found" in result["error"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_command_construction(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
         self.fn(["new", "-s", "test"])
         cmd = mock_run.call_args[0][0]
         assert cmd == ["agentwire", "new", "-s", "test", "--json"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_custom_timeout(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
         self.fn(["spawn"], timeout=120)
         assert mock_run.call_args[1]["timeout"] == 120
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_generic_exception(self, mock_run):
         mock_run.side_effect = OSError("permission denied")
         result = self.fn(["list"])
         assert result["success"] is False
         assert "permission denied" in result["error"]
 
-    @patch("agentwire.mcp_core.subprocess.run")
+    @patch("agentwire.core.subprocess.run")
     def test_empty_stdout_nonzero(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
         result = self.fn(["x"])


### PR DESCRIPTION
Every `agentwire` invocation printed a pydantic-settings `IncompleteFieldDefinitionWarning` about an unresolved `lifespan` forward reference, and some commands added an STT config INFO line. Both came from **one** root cause: `build_parser()` imports `buddy_cli` → `voice_layer.tools` → `mcp_core` for a single subprocess helper, and importing `mcp_core` constructs the FastMCP singleton (the warning) *and* calls `logging.basicConfig(level=INFO)` on the **root** logger (which promoted every library INFO record into CLI stderr).

## What changed

- **`run_agentwire_cmd` moves to `core.py`** — the documented home for shared stateless CLI helpers. It contains no MCP, and it was the only reason a non-MCP module imported `mcp_core`. All 23 consumers updated; no re-export shim left behind.
- **`mcp_core.configure_logging()`** replaces the import-time `basicConfig`, called from `mcp_server.run_server()` — the one place that actually owns the process's stderr.
- **`Settings.model_rebuild()`** before FastMCP is constructed, resolving the upstream forward reference exactly where the warning says to, so `agentwire mcp`'s stderr (which is the client's log) is clean too. Guarded by `getattr` so an upstream rename can't take the whole tool surface down — #874's failure shape.
- **STT config line demoted INFO → DEBUG.** The comment above it already called it debug logging.

Not a blanket warning filter: with the fix reverted the warning still fires — it just no longer has a path into ordinary CLI startup, and is resolved rather than hidden on the path that legitimately builds an MCP server.

## Verification

`tests/unit/test_cli_stderr_clean.py` pins it from both ends: stderr is byte-empty on representative commands (against a fixture HOME whose config **has** an `stt:` section — without it the STT path never executes and the assertion passes for the wrong reason), plus structural pins that hold on every dependency version.

**Which pins are live depends on the installed deps, so here is the measurement rather than a blanket claim.** Against the unfixed tree:

| dependency set | fails on unfixed tree |
|---|---|
| `uv.lock` — pydantic-settings 2.14.2 / mcp 1.27.2 (what CI runs) | **5 of 7** |
| pydantic-settings 2.15.0 / mcp 1.29.0 (versions that reproduce) | **7 of 7** |

The two that don't fire under the lock are the `--version` and `roles list` stderr assertions — neither command loads config, and 2.14.2 emits no warning, so there is nothing there for them to catch. They are the forward-looking half. Both halves of the bug do have a live control under the locked set: the STT line via `projects list` + the log-level test, and the pydantic warning via the structural pins.

That last point came out of review, which correctly found the first revision had **no** control for the pydantic half under the locked deps. The suggested fix — asserting `Settings.__pydantic_complete__` after importing `mcp_core` — turned out not to discriminate either: constructing `FastMCP()` completes the model as a side effect of validation (which is *why* upstream warns instead of raising), so the flag reads True on both trees, verified on 2.14.2 and 2.15.0. What separates them is **ordering** — whether the model was already complete *when* `mcp_core` constructed the server — so the pin spies on `FastMCP.__init__` and samples the flag before delegating. Version-independent, catches the `getattr` guard degrading to a no-op, and reports `NEVER_CONSTRUCTED` so re-pointing the construction can't silently make it vacuous.

Full suite green — 6138 unit + 170 integration. The 4 `test_beta_flag.py::*matches_origin_main` failures are pre-existing on this base (identical with the branch's `agentwire/` reverted to the base commit). `ruff check agentwire/ tests/` clean.

Closes #1018

Built by [dotdev.dev](https://dotdev.dev)