### PR TITLE
voice buddy: enumerate the voices, pick one live, stop re-announcing registration

### DIFF
--- a/agentwire/buddy_cli.py
+++ b/agentwire/buddy_cli.py
@@ -29,6 +29,26 @@ from .voice_layer import delivery, identity, realtime, tools
 #: project keeps closing, and here the owner is often not even at a screen.
 BETA_KEY = "beta.voice_layer"
 
+#: The one ``--voice`` help string, shared by register/mint/serve (#1017).
+#:
+#: Enumerated here rather than declared as argparse ``choices=``, deliberately.
+#: ``choices`` does print the set and does reject early — but its rejection is
+#: argparse's own ("invalid choice"), which cannot say what the default is, is
+#: case-SENSITIVE (so a spoken-then-typed "Cedar" would be refused for no
+#: reason), and exits before any handler runs, which means the ``--json``
+#: caller gets a parser usage dump on stderr instead of a JSON error object.
+#: :func:`_check_voice` does all three properly, and this string is what makes
+#: the list discoverable without reaching the error at all.
+#:
+#: No percent signs anywhere in it: argparse runs help through printf-style
+#: interpolation, and a lone one raises at parse time.
+_VOICE_HELP = (
+    "Realtime voice, one of: " + realtime.voice_list()
+    + f" (default: {realtime.DEFAULT_VOICE}; cedar and marin are the newer, "
+    "more natural pair). Fixed for a session — switch it live from the picker "
+    "on the buddy page."
+)
+
 
 def _refuse_beta(json_mode: bool) -> int:
     """Refuse a buddy command because the beta flag is off.
@@ -127,20 +147,75 @@ def _fail(message: str, json_mode: bool) -> int:
     return 1
 
 
+def _check_voice(args) -> "int | None":
+    """Refuse an unknown ``--voice`` before anything is written or spent.
+
+    Early, and in every verb that takes one: the alternative is a bridge that
+    starts, connects, and then produces no audio at all — which in a screenless
+    channel is indistinguishable from a mic problem, an API outage, or the
+    buddy simply having nothing to say. The refusal carries the whole list,
+    because ten closed values are short enough to print and guessing is what
+    put the typo there.
+
+    Returns an exit code to propagate, or ``None`` when the voice is fine.
+    """
+    voice = getattr(args, "voice", "")
+    if not voice:
+        return None
+    try:
+        args.voice = realtime.validate_voice(voice)
+    except realtime.RealtimeError as exc:
+        return _fail(str(exc), getattr(args, "json", False))
+    return None
+
+
 def cmd_buddy_register(args) -> int:
     json_mode = getattr(args, "json", False)
+    refused = _check_voice(args)
+    if refused is not None:
+        return refused
+    # Read BEFORE the write: what changed is only knowable against the record
+    # that was there. Re-announcing a full registration over a one-word voice
+    # change reads like a second identity was created (#1017).
     try:
+        delta = identity.registration_delta(
+            args.name, model=args.model, voice=args.voice
+        )
         metadata = identity.register(args.name, model=args.model, voice=args.voice)
     except identity.BuddyError as exc:
         return _fail(str(exc), json_mode)
     status = identity.status(args.name)
+    changes = delta["changes"]
+    payload = {
+        "success": True,
+        "created": not delta["registered"],
+        "changes": changes,
+        "buddy": status,
+        "metadata": metadata,
+    }
+    if delta["registered"]:
+        lines = [
+            f"{field} → {change['to']}"
+            + (f" (was {change['from']})" if change["from"] else "")
+            for field, change in sorted(changes.items())
+        ]
+        return _emit(
+            payload,
+            json_mode,
+            [f"Voice buddy '{args.name}' is already registered."]
+            + [f"  updated {line}" for line in lines]
+            + ([] if lines else ["  nothing to change."]),
+        )
     return _emit(
-        {"success": True, "buddy": status, "metadata": metadata},
+        payload,
         json_mode,
         [
             f"Registered voice buddy '{args.name}'.",
             f"  inbox:  {status['inbox_dir']}",
             f"  spool:  {status['spool_path']}",
+            f"  voice:  {status['realtime_voice'] or realtime.DEFAULT_VOICE} (default)"
+            if not status["realtime_voice"]
+            else f"  voice:  {status['realtime_voice']}",
             "",
             f"Other sessions can now reach it: agentwire msg send --to {args.name} ...",
             "It has no tmux session — its mail is spooled, not pasted.",
@@ -164,6 +239,8 @@ def cmd_buddy_status(args) -> int:
             f"  role:        {status['role']} (not in the fleet topology)",
             f"  delivery:    {status['delivery']} (spooled, no tmux pane)",
             f"  registered:  {status['registered_at']}",
+            f"  voice:       {status['realtime_voice'] or realtime.DEFAULT_VOICE}"
+            + ("" if status["realtime_voice"] else " (default)"),
             f"  pending:     {status['pending']} message(s) awaiting the next drain",
             f"  unread:      {status['unread']} spooled message(s)",
         ],
@@ -253,6 +330,9 @@ def cmd_buddy_mint(args) -> int:
     json_mode = getattr(args, "json", False)
     from .voice_layer import instructions as buddy_instructions
 
+    refused = _check_voice(args)
+    if refused is not None:
+        return refused
     if not identity.is_registered(args.name):
         return _fail(_no_buddy(args.name), json_mode)
     try:
@@ -260,7 +340,8 @@ def cmd_buddy_mint(args) -> int:
             instructions=buddy_instructions.build_instructions(),
             tools=tools.realtime_tool_defs(),
             model=args.model or realtime.DEFAULT_MODEL,
-            voice=args.voice or realtime.DEFAULT_VOICE,
+            # Explicit flag → the buddy's recorded voice → the default.
+            voice=identity.resolve_voice(args.name, args.voice),
         )
     except realtime.RealtimeError as exc:
         return _fail(str(exc), json_mode)
@@ -280,6 +361,9 @@ def cmd_buddy_serve(args) -> int:
     """Serve the browser client on localhost until interrupted."""
     from .voice_layer import server
 
+    refused = _check_voice(args)
+    if refused is not None:
+        return refused
     if not identity.is_registered(args.name):
         return _fail(_no_buddy(args.name), getattr(args, "json", False))
     # Renew the fleet-alert lease (#982) — a buddy being started is a buddy that
@@ -294,6 +378,8 @@ def cmd_buddy_serve(args) -> int:
         args.name, port=args.port, model=args.model, voice=args.voice
     )
     print(f"buddy '{args.name}' listening on {url}")
+    print(f"voice: {identity.resolve_voice(args.name, args.voice)} "
+          f"(switch it on the page — no restart needed)")
     print("Open that URL in a browser and click Start talking. Ctrl-C to stop.")
     try:
         while True:
@@ -327,7 +413,7 @@ def register_buddy_parser(subparsers) -> None:
 
     reg = _common(sub.add_parser("register", help="Create the buddy's session identity"))
     reg.add_argument("--model", default="", help=f"Realtime model (default: {realtime.DEFAULT_MODEL})")
-    reg.add_argument("--voice", default="", help=f"Realtime voice (default: {realtime.DEFAULT_VOICE})")
+    reg.add_argument("--voice", default="", metavar="VOICE", help=_VOICE_HELP)
     reg.set_defaults(func=beta_gated(cmd_buddy_register))
 
     _common(sub.add_parser("status", help="Show the buddy's identity and mail counts")).set_defaults(
@@ -359,12 +445,12 @@ def register_buddy_parser(subparsers) -> None:
 
     mint = _common(sub.add_parser("mint", help="Mint an ephemeral Realtime session"))
     mint.add_argument("--model", default="")
-    mint.add_argument("--voice", default="")
+    mint.add_argument("--voice", default="", metavar="VOICE", help=_VOICE_HELP)
     mint.set_defaults(func=beta_gated(cmd_buddy_mint))
 
     srv = _common(sub.add_parser("serve", help="Serve the browser client on localhost"))
     srv.add_argument("--port", type=int, default=8788,
                      help="Port on 127.0.0.1 (default: 8788 — never a portal port)")
     srv.add_argument("--model", default="")
-    srv.add_argument("--voice", default="")
+    srv.add_argument("--voice", default="", metavar="VOICE", help=_VOICE_HELP)
     srv.set_defaults(func=beta_gated(cmd_buddy_serve))

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -94,6 +94,8 @@ from __future__ import annotations
 import html
 import json
 
+from . import realtime
+
 #: The announcer, kept separate from the page so tests can run it under ``node``
 #: with a fake ``send``/``speak``/timer and assert on the DATA CHANNEL. Spliced
 #: into the page by :func:`page`; also exported by :func:`announcer_source` for
@@ -1098,6 +1100,12 @@ _PAGE = """<!doctype html>
   button.stop { background: transparent; color: var(--fg); }
   button:disabled { opacity: .45; cursor: not-allowed; }
   #status { color: var(--muted); margin-left: 12px; font-size: 13px; }
+  label.voice { color: var(--muted); font-size: 13px; margin-left: 12px; }
+  select {
+    font: inherit; font-size: 14px; padding: 8px 10px; border-radius: var(--radius);
+    border: 1px solid var(--border); background: #0d1117; color: var(--fg);
+  }
+  select:disabled { opacity: .45; cursor: not-allowed; }
   #log {
     margin-top: 20px; border: 1px solid var(--border); border-radius: var(--radius);
     padding: 14px; height: 60vh; overflow-y: auto; background: #0d1117;
@@ -1124,6 +1132,8 @@ _PAGE = """<!doctype html>
 <div>
   <button id="start">Start talking</button>
   <button id="stop" class="stop" disabled>Stop</button>
+  <label class="voice" for="voice">voice</label>
+  <select id="voice">__VOICE_OPTIONS__</select>
   <span id="status">idle</span>
 </div>
 <div id="log"></div>
@@ -1141,6 +1151,12 @@ const $log = document.getElementById("log");
 const $status = document.getElementById("status");
 const $start = document.getElementById("start");
 const $stop = document.getElementById("stop");
+const $voice = document.getElementById("voice");
+
+// The voice this page will mint with. Seeded from the bridge, which resolved
+// it from `--voice` → the buddy's record → the default, so a reload comes back
+// showing whatever was last chosen rather than silently reverting (#1017).
+let currentVoice = __VOICE__;
 
 let pc = null, dc = null, micStream = null, audioEl = null;
 let responseActive = false;
@@ -1515,8 +1531,18 @@ async function start() {
   $start.disabled = true;
   setStatus("minting session…");
   try {
-    const session = await post("/mint", {});
+    // The voice rides the mint, because a voice change IS a new session: the
+    // API fixes the voice once the model has emitted audio, and the buddy
+    // greets on connect, so there is never a live session whose voice a
+    // `session.update` could still change (#1017).
+    const session = await post("/mint", { voice: currentVoice });
     if (!session.success) throw new Error(session.error || "mint failed");
+    // The bridge is the authority on what it actually minted with — a voice it
+    // refused or normalised must show in the picker, not just in the log.
+    if (session.voice) { currentVoice = session.voice; $voice.value = session.voice; }
+    if (session.voice_persisted === false) {
+      log("error", "voice not saved for next time: " + (session.voice_persist_error || ""), "err");
+    }
     // The clock's ORIGIN, from the bridge (#978). Seeded here — before the
     // data channel exists, so nothing has emitted an event and nothing has
     // called nextSeq() yet. No `|| 0` default: a bridge that did not answer
@@ -1813,8 +1839,40 @@ function stop() {
   setStatus("idle");
 }
 
+// One click, and the reconnect is the mechanism rather than the price (#1017).
+// Before this, changing voice meant Ctrl-C the bridge, re-serve with a
+// different --voice, and reload the page by hand — three steps for a setting
+// with ten values. It cannot be a `session.update`: the Realtime API fixes the
+// voice once the model has emitted audio, and the buddy greets on connect.
+//
+// The greet latch is deliberately RELEASED here, against the #963 rule that a
+// reconnect stays quiet. That rule is about a reconnect the owner did not ask
+// for, where a re-greet is noise. This one they asked for, and the entire
+// observable result of it is how the buddy SOUNDS — a silent switch is
+// indistinguishable from a switch that did not happen, in a channel where the
+// owner has no screen. So it speaks, in the new voice, which is the answer.
+async function switchVoice() {
+  const chosen = $voice.value;
+  if (chosen === currentVoice) return;
+  currentVoice = chosen;
+  const wasLive = !!pc;
+  log("speak", "voice → " + chosen, "tool");
+  if (!wasLive) { setStatus("idle · " + chosen); return; }
+  // Locked for the round trip: a second change mid-reconnect would tear down
+  // the session the first one is still building.
+  $voice.disabled = true;
+  try {
+    stop();
+    greeted = false;
+    await start();
+  } finally {
+    $voice.disabled = false;
+  }
+}
+
 $start.addEventListener("click", start);
 $stop.addEventListener("click", stop);
+$voice.addEventListener("change", switchVoice);
 </script>
 </body>
 </html>
@@ -1867,8 +1925,33 @@ def confirm_gate_source() -> str:
     return CONFIRM_GATE_JS
 
 
-def page(buddy: str, token: str) -> str:
-    """Render the client page for one buddy + one run token."""
+def voice_options(selected: str) -> str:
+    """The picker's ``<option>`` list, from the one enumeration (#1017).
+
+    Rendered server-side from :data:`realtime.VOICES` rather than built in JS
+    from an injected array: the list the owner picks from is then the same list
+    the bridge validates against, with no second copy to drift. The two the
+    docs single out are labelled, so the choice reads as a recommendation
+    rather than ten equal strings.
+    """
+    labels = {"cedar": "cedar (newer)", "marin": "marin (newer)"}
+    return "".join(
+        '<option value="{v}"{sel}>{label}</option>'.format(
+            v=html.escape(voice),
+            sel=" selected" if voice == selected else "",
+            label=html.escape(labels.get(voice, voice)),
+        )
+        for voice in realtime.VOICES
+    )
+
+
+def page(buddy: str, token: str, voice: str = "") -> str:
+    """Render the client page for one buddy + one run token.
+
+    *voice* is what the bridge resolved, so a reload shows the voice actually
+    in use rather than the default.
+    """
+    voice = voice or realtime.DEFAULT_VOICE
     return (
         _PAGE.replace("__ANNOUNCER__", ANNOUNCER_JS)
         .replace("__NOTIFIER__", INBOX_NOTIFIER_JS)
@@ -1876,5 +1959,7 @@ def page(buddy: str, token: str) -> str:
         .replace("__RERAISE__", RERAISE_JS)
         .replace("__OUTCOME_ROUTER__", OUTCOME_ROUTER_JS)
         .replace("__BUDDY__", html.escape(buddy))
+        .replace("__VOICE_OPTIONS__", voice_options(voice))
+        .replace("__VOICE__", json.dumps(voice))
         .replace("__TOKEN__", json.dumps(token))
     )

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -1857,13 +1857,19 @@ async function switchVoice() {
   currentVoice = chosen;
   const wasLive = !!pc;
   log("speak", "voice → " + chosen, "tool");
+  // ABOVE the idle return, not inside the live branch. `stop()` deliberately
+  // leaves `greeted` set (#963), so the ordinary Stop → pick → Start sequence
+  // would otherwise connect on the new voice and say nothing at all — the
+  // silent switch this whole gesture exists to avoid, reached by the calmer
+  // of the two routes to it. The asymmetry had no reason: the owner asked for
+  // the change in both cases, and in both cases hearing it is the answer.
+  greeted = false;
   if (!wasLive) { setStatus("idle · " + chosen); return; }
   // Locked for the round trip: a second change mid-reconnect would tear down
   // the session the first one is still building.
   $voice.disabled = true;
   try {
     stop();
-    greeted = false;
     await start();
   } finally {
     $voice.disabled = false;
@@ -1933,13 +1939,17 @@ def voice_options(selected: str) -> str:
     the bridge validates against, with no second copy to drift. The two the
     docs single out are labelled, so the choice reads as a recommendation
     rather than ten equal strings.
+
+    The "(newer)" label is derived from the ORDER of :data:`realtime.VOICES`
+    rather than from a second hard-coded pair — a re-encoded claim next to the
+    thing it claims about is the drift this module keeps closing.
     """
-    labels = {"cedar": "cedar (newer)", "marin": "marin (newer)"}
+    newer = realtime.VOICES[:2]
     return "".join(
         '<option value="{v}"{sel}>{label}</option>'.format(
             v=html.escape(voice),
             sel=" selected" if voice == selected else "",
-            label=html.escape(labels.get(voice, voice)),
+            label=html.escape(f"{voice} (newer)" if voice in newer else voice),
         )
         for voice in realtime.VOICES
     )

--- a/agentwire/voice_layer/identity.py
+++ b/agentwire/voice_layer/identity.py
@@ -52,6 +52,21 @@ class BuddyError(Exception):
     """A buddy identity operation could not be completed."""
 
 
+def _valid_voice(voice: str) -> str:
+    """:func:`realtime.validate_voice`, re-raised as a :class:`BuddyError`.
+
+    One failure contract per module. Every caller of this module already
+    catches ``BuddyError`` and nothing catches ``RealtimeError``, so letting
+    the transport layer's exception escape from ``register`` would mean a
+    second, uncaught contract at the only call site that has one — reachable
+    the moment anything registers a buddy without pre-validating the flag.
+    """
+    try:
+        return realtime.validate_voice(voice)
+    except realtime.RealtimeError as exc:
+        raise BuddyError(str(exc)) from exc
+
+
 def validate_name(name: str) -> str:
     if not name or not _NAME_RE.match(name) or ".." in name:
         raise BuddyError(
@@ -81,7 +96,7 @@ def register(name: str = DEFAULT_NAME, *, model: str = "", voice: str = "") -> d
     fresh registration from a voice change without reading the record twice.
     """
     validate_name(name)
-    voice = realtime.validate_voice(voice)
+    voice = _valid_voice(voice)
     metadata = core.load_session_metadata(name)
 
     if metadata and metadata.get("kind") != KIND:
@@ -142,7 +157,7 @@ def registration_delta(name: str, *, model: str = "", voice: str = "") -> dict:
     with no arguments changes nothing and is still not a first registration.
     """
     validate_name(name)
-    voice = realtime.validate_voice(voice)
+    voice = _valid_voice(voice)
     before = core.load_session_metadata(name)
     changes = {}
     for field, key, wanted in (
@@ -172,12 +187,12 @@ def resolve_voice(name: str, requested: str = "") -> str:
     before anything guarantees a record exists, and refusing here would turn a
     missing record into a bridge that will not start.
     """
-    explicit = realtime.validate_voice(requested)
+    explicit = _valid_voice(requested)
     if explicit:
         return explicit
     try:
-        recorded = realtime.validate_voice(registered_voice(name))
-    except (BuddyError, realtime.RealtimeError):
+        recorded = _valid_voice(registered_voice(name))
+    except BuddyError:
         # A record carrying a voice we no longer accept (an id retired
         # upstream) must not wedge the bridge — fall through to the default.
         recorded = ""
@@ -192,7 +207,7 @@ def set_voice(name: str, voice: str) -> str:
     else is a caller bug rather than a typo the owner made.
     """
     validate_name(name)
-    voice = realtime.validate_voice(voice)
+    voice = _valid_voice(voice)
     if not voice:
         raise BuddyError("set_voice needs a voice")
     metadata = core.load_session_metadata(name)

--- a/agentwire/voice_layer/identity.py
+++ b/agentwire/voice_layer/identity.py
@@ -31,7 +31,7 @@ import json
 import re
 
 from .. import core, fleet_alerts
-from . import delivery
+from . import delivery, realtime
 
 #: Session-record marker. Anything reading the session store can use this to
 #: tell "not an agent session" without inferring it from missing keys.
@@ -75,8 +75,13 @@ def register(name: str = DEFAULT_NAME, *, model: str = "", voice: str = "") -> d
 
     Merge-preserving like ``record_session_launch``: re-registering keeps
     ``created_at`` and anything else already on the record.
+
+    Idempotent in the record it writes and, since #1017, in what the CLI SAYS
+    about it — see :func:`registration_delta`, which is how the caller tells a
+    fresh registration from a voice change without reading the record twice.
     """
     validate_name(name)
+    voice = realtime.validate_voice(voice)
     metadata = core.load_session_metadata(name)
 
     if metadata and metadata.get("kind") != KIND:
@@ -120,6 +125,86 @@ def register(name: str = DEFAULT_NAME, *, model: str = "", voice: str = "") -> d
     inbox_dir(name).mkdir(parents=True, exist_ok=True)
     delivery.session_state_dir(name).mkdir(parents=True, exist_ok=True)
     return metadata
+
+
+def registration_delta(name: str, *, model: str = "", voice: str = "") -> dict:
+    """What a :func:`register` call with these arguments would CHANGE.
+
+    Read before the write, so ``agentwire buddy register`` can say "updated
+    voice to marin" instead of re-announcing a registration that already
+    happened (#1017). The full blurb names the inbox, the spool and how other
+    sessions reach the buddy — true and useful exactly once; printed again over
+    a one-word voice change it reads like a second identity was created.
+
+    Returns ``{"registered": bool, "changes": {field: {"from": …, "to": …}}}``.
+    ``registered`` is about the record that exists NOW, so the caller does not
+    have to infer "was this new?" from an empty change set — re-registering
+    with no arguments changes nothing and is still not a first registration.
+    """
+    validate_name(name)
+    voice = realtime.validate_voice(voice)
+    before = core.load_session_metadata(name)
+    changes = {}
+    for field, key, wanted in (
+        ("model", "realtime_model", model),
+        ("voice", "realtime_voice", voice),
+    ):
+        if wanted and before.get(key) != wanted:
+            changes[field] = {"from": before.get(key), "to": wanted}
+    return {"registered": before.get("kind") == KIND, "changes": changes}
+
+
+def registered_voice(name: str) -> str:
+    """The voice recorded for *name*, or ``""`` if it has none.
+
+    A recorded voice that nothing reads is a setting that silently does not
+    work, which is what ``register --voice`` was before #1017: ``serve`` and
+    ``mint`` both fell straight through to :data:`realtime.DEFAULT_VOICE`.
+    """
+    recorded = core.load_session_metadata(validate_name(name)).get("realtime_voice")
+    return recorded if isinstance(recorded, str) else ""
+
+
+def resolve_voice(name: str, requested: str = "") -> str:
+    """The voice to actually use: explicit → recorded → default.
+
+    Tolerates an unregistered name on purpose — the bridge is constructed
+    before anything guarantees a record exists, and refusing here would turn a
+    missing record into a bridge that will not start.
+    """
+    explicit = realtime.validate_voice(requested)
+    if explicit:
+        return explicit
+    try:
+        recorded = realtime.validate_voice(registered_voice(name))
+    except (BuddyError, realtime.RealtimeError):
+        # A record carrying a voice we no longer accept (an id retired
+        # upstream) must not wedge the bridge — fall through to the default.
+        recorded = ""
+    return recorded or realtime.DEFAULT_VOICE
+
+
+def set_voice(name: str, voice: str) -> str:
+    """Record *voice* as the buddy's voice, so it survives the next ``serve``.
+
+    Raises rather than warning on an unknown voice: this is reached from the
+    page's picker, whose options come from :data:`realtime.VOICES`, so anything
+    else is a caller bug rather than a typo the owner made.
+    """
+    validate_name(name)
+    voice = realtime.validate_voice(voice)
+    if not voice:
+        raise BuddyError("set_voice needs a voice")
+    metadata = core.load_session_metadata(name)
+    if metadata.get("kind") != KIND:
+        raise BuddyError(_not_a_buddy(name))
+    metadata["realtime_voice"] = voice
+    core.store_session_metadata(name, metadata)
+    return voice
+
+
+def _not_a_buddy(name: str) -> str:
+    return f"'{name}' is not a registered voice buddy"
 
 
 def is_registered(name: str) -> bool:
@@ -177,6 +262,9 @@ def status(name: str = DEFAULT_NAME) -> dict:
         "delivery": metadata.get(delivery.DELIVERY_KEY),
         "registered_at": metadata.get("registered_at"),
         "realtime_model": metadata.get("realtime_model"),
+        # Reported because it is now READ by serve/mint (#1017). A setting the
+        # status page cannot show is one the owner has to guess at.
+        "realtime_voice": metadata.get("realtime_voice"),
         "inbox_dir": str(box),
         "spool_path": str(delivery.spool_path(name)),
         "pending": pending,

--- a/agentwire/voice_layer/realtime.py
+++ b/agentwire/voice_layer/realtime.py
@@ -38,8 +38,40 @@ CALLS_URL = "https://api.openai.com/v1/realtime/calls"
 #: /v1/models 404s it). A mint that succeeds proves nothing about the model.
 DEFAULT_MODEL = "gpt-realtime-2.1"
 
+#: Every voice the Realtime API accepts, newest first (docs, fetched
+#: 2026-08-11). ``cedar`` and ``marin`` are the two the docs single out as the
+#: newer, more natural ones; the remaining eight predate them.
+#:
+#: Enumerated here rather than left as "any string" (#1017) because the failure
+#: mode of a typo is the model-id footgun one level down: the mint endpoint is
+#: not a validator. Whether it rejects an unknown VOICE is **not measured** —
+#: what is known is that it returns 200 for a model that does not exist, so a
+#: successful mint proves nothing, and in a screenless channel the owner's
+#: evidence for "cedarr" being wrong is a buddy that never speaks. Validating
+#: locally turns that into a sentence with the list in it, before the key is
+#: spent.
+#:
+#: Ordered, not a set: this tuple is what ``--help``, the picker on the page,
+#: and the error message all enumerate, and the owner reads them in this order.
+VOICES = (
+    "cedar", "marin", "alloy", "ash", "ballad",
+    "coral", "echo", "sage", "shimmer", "verse",
+)
+
 #: One of the newer natural voices.
 DEFAULT_VOICE = "cedar"
+
+#: **The voice is fixed for the life of a realtime session.** The docs are
+#: explicit: "Once the model has emitted audio in a session, the ``voice``
+#: cannot be modified for that session." A ``session.update`` before the first
+#: audio would take, but the buddy greets on connect (#963), so by the time
+#: anyone picks a different voice the session has always emitted audio.
+#:
+#: That is why the picker on the page RECONNECTS instead of sending a
+#: ``session.update``: the only honest mid-call voice change is a new session,
+#: and the thing worth engineering is that it costs one click rather than a
+#: kill, a re-serve and a manual reload. See :mod:`~agentwire.voice_layer.client`.
+VOICE_IS_SESSION_FIXED = True
 
 #: Transcribes the OWNER's audio, for the on-screen transcript and the log.
 #: Independent of the conversational model above.
@@ -52,6 +84,33 @@ class RealtimeError(Exception):
     def __init__(self, message: str, status: int = 0):
         super().__init__(message)
         self.status = status
+
+
+def voice_list() -> str:
+    """The voices as one comma-separated line — one wording, three surfaces."""
+    return ", ".join(VOICES)
+
+
+def validate_voice(voice: str) -> str:
+    """Return *voice*, or raise :class:`RealtimeError` naming every valid one.
+
+    Empty means "unspecified" and is the caller's problem to default, not an
+    error: every ``--voice`` on the CLI defaults to ``""``.
+
+    Case-folded, because "Cedar" is a transcription of the same choice and
+    refusing it would be a false reject with nothing behind it. Anything else
+    refuses — including a name that merely looks plausible, which is the whole
+    point: the list is short, closed, and printed in the refusal.
+    """
+    if not voice:
+        return ""
+    normalized = voice.strip().lower()
+    if normalized not in VOICES:
+        raise RealtimeError(
+            f"unknown realtime voice {voice!r} — valid voices are: {voice_list()} "
+            f"(default: {DEFAULT_VOICE})"
+        )
+    return normalized
 
 
 def api_key() -> str:
@@ -125,7 +184,13 @@ def mint_session(
     voice: str = DEFAULT_VOICE,
     opener=None,
 ) -> dict:
-    """Mint an ephemeral Realtime session. ``opener`` is injectable for tests."""
+    """Mint an ephemeral Realtime session. ``opener`` is injectable for tests.
+
+    The voice is validated HERE as well as at every caller, deliberately: this
+    is the last line before the owner's API key is spent, and a bad voice that
+    gets past it costs a session that connects and then sounds like nothing.
+    """
+    voice = validate_voice(voice) or DEFAULT_VOICE
     body = json.dumps(
         build_session_request(
             instructions=instructions, tools=tools, model=model, voice=voice

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -274,9 +274,16 @@ class BuddyBridge:
     def switch_voice(self, voice: str) -> dict:
         """Adopt *voice* for this bridge, and persist it for the next run.
 
-        Called from :meth:`mint` when the page's picker sends one. Validated
-        BEFORE anything is spent or written — an unknown voice is a refusal
-        with the list in it, never a session that connects and sounds wrong.
+        Called from :meth:`mint` **after** the session it was minted for
+        exists. The ordering is deliberate: adopting before the mint left a
+        failed mint (an upstream 500) with the bridge and the record both
+        moved to a voice that was never spoken, so a reload came back showing
+        a setting the owner has no evidence for. A voice sticks once it has
+        been minted with, and not before.
+
+        Validation is separate and happens FIRST, in :meth:`mint` — an unknown
+        voice must refuse before anything is spent, which is the opposite
+        ordering and the reason the two are not one call.
 
         The persist is best-effort and guarded, on the same rule every optional
         extra in this package follows (``store_session_metadata`` raises by
@@ -342,10 +349,15 @@ class BuddyBridge:
         behind the client's counter, so the next base is that much less clear
         of the last epoch — bounded by the gap, not by anything smaller.
         """
-        # Before the epoch and before the key: a refused voice must cost
-        # nothing, not a burnt sequence epoch.
+        # Validated before the epoch and before the key: a refused voice must
+        # cost nothing, not a burnt sequence epoch. ADOPTED after the mint —
+        # see switch_voice. A non-dict body is treated as no body: `/mint`
+        # ignored its payload entirely until this argument existed, and a
+        # bridge that 500s on `[1]` where it used to answer is a regression
+        # dressed as a feature.
+        body = payload if isinstance(payload, dict) else {}
         try:
-            switched = self.switch_voice((payload or {}).get("voice") or "")
+            requested = realtime.validate_voice(body.get("voice") or "")
         except realtime.RealtimeError as exc:
             return {"success": False, "error": str(exc)}
         seq_base = self.ring.reserve_epoch(MINT_SEQ_GAP, MAX_SEQ)
@@ -355,8 +367,11 @@ class BuddyBridge:
             instructions=buddy_instructions.build_instructions(),
             tools=tools.realtime_tool_defs(),
             model=self.model,
-            voice=self.voice,
+            # The REQUESTED voice, minted with before it is adopted. A raise
+            # here propagates to the handler's 502 with nothing moved.
+            voice=requested or self.voice,
         )
+        switched = self.switch_voice(requested)
         return {
             "success": True,
             "seq_base": seq_base,

--- a/agentwire/voice_layer/server.py
+++ b/agentwire/voice_layer/server.py
@@ -48,7 +48,7 @@ import secrets
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-from . import client, confirm, realtime, tools, transcript, write_tools
+from . import client, confirm, identity, realtime, tools, transcript, write_tools
 from . import instructions as buddy_instructions
 
 #: Not 8765 (portal SSL) and not 8100 (portal HTTP) — a spike must never
@@ -166,7 +166,9 @@ class BuddyBridge:
         self.buddy = buddy
         self.token = token
         self.model = model or realtime.DEFAULT_MODEL
-        self.voice = voice or realtime.DEFAULT_VOICE
+        # Explicit flag → the buddy's recorded voice → the default (#1017).
+        # `register --voice` used to write a key nothing read.
+        self.voice = identity.resolve_voice(buddy, voice)
         # One ring and one gate per bridge — per CONVERSATION, in effect. Not
         # module-level: a process-global store of pending writes would outlive
         # the conversation that proposed them.
@@ -269,8 +271,45 @@ class BuddyBridge:
         anchored = self.spine.announce(proposal_id.strip(), seq)
         return {"success": True, "anchored": anchored, "seq": seq}
 
-    def mint(self) -> dict:
+    def switch_voice(self, voice: str) -> dict:
+        """Adopt *voice* for this bridge, and persist it for the next run.
+
+        Called from :meth:`mint` when the page's picker sends one. Validated
+        BEFORE anything is spent or written — an unknown voice is a refusal
+        with the list in it, never a session that connects and sounds wrong.
+
+        The persist is best-effort and guarded, on the same rule every optional
+        extra in this package follows (``store_session_metadata`` raises by
+        design, #885): the owner's live call must not fail because the record
+        could not be updated. What they lose is stickiness across the next
+        ``serve``, and they lose it loudly in the returned payload rather than
+        silently.
+        """
+        voice = realtime.validate_voice(voice)
+        if not voice or voice == self.voice:
+            return {"changed": False, "voice": self.voice}
+        self.voice = voice
+        persisted, error = True, ""
+        try:
+            identity.set_voice(self.buddy, voice)
+        except Exception as exc:  # noqa: BLE001  # never fatal to a live call
+            persisted, error = False, str(exc)
+        result = {"changed": True, "voice": voice, "voice_persisted": persisted}
+        if error:
+            result["voice_persist_error"] = error
+        return result
+
+    def mint(self, payload: "dict | None" = None) -> dict:
         """Mint an ephemeral client secret — and the page's CLOCK ORIGIN (#978).
+
+        An optional ``voice`` in the body switches the buddy's voice for this
+        session and every later one (#1017). It rides ``/mint`` rather than a
+        route of its own because a voice change IS a new session: the API fixes
+        the voice once the model has emitted audio (see
+        :data:`~agentwire.voice_layer.realtime.VOICE_IS_SESSION_FIXED`), and
+        the buddy greets on connect, so there is no live call whose voice could
+        be updated in place. The page therefore tears down and re-mints — the
+        one click is the product; the reconnect is the mechanism.
 
         The logical clock the confirm gate orders on is assigned by the client,
         because the client is the only place that sees data-channel event
@@ -303,6 +342,12 @@ class BuddyBridge:
         behind the client's counter, so the next base is that much less clear
         of the last epoch — bounded by the gap, not by anything smaller.
         """
+        # Before the epoch and before the key: a refused voice must cost
+        # nothing, not a burnt sequence epoch.
+        try:
+            switched = self.switch_voice((payload or {}).get("voice") or "")
+        except realtime.RealtimeError as exc:
+            return {"success": False, "error": str(exc)}
         seq_base = self.ring.reserve_epoch(MINT_SEQ_GAP, MAX_SEQ)
         if not seq_base:
             return {"success": False, "error": "sequence space exhausted"}
@@ -312,7 +357,14 @@ class BuddyBridge:
             model=self.model,
             voice=self.voice,
         )
-        return {"success": True, "seq_base": seq_base, **session}
+        return {
+            "success": True,
+            "seq_base": seq_base,
+            "voice": self.voice,
+            "voice_changed": switched["changed"],
+            **{k: v for k, v in switched.items() if k.startswith("voice_")},
+            **session,
+        }
 
     def tool_call(self, payload: dict) -> dict:
         name = payload.get("name")
@@ -377,7 +429,11 @@ def _handler_factory(bridge: BuddyBridge):
                 return
             path = self.path.split("?", 1)[0]
             if path == "/":
-                page = client.page(bridge.buddy, bridge.token).encode("utf-8")
+                # The voice comes off the BRIDGE, not off a constant: a switch
+                # made in one tab is what a reload must come back showing.
+                page = client.page(
+                    bridge.buddy, bridge.token, voice=bridge.voice
+                ).encode("utf-8")
                 self._send(200, page, "text/html; charset=utf-8")
                 return
             self._json(404, {"success": False, "error": "not found"})
@@ -416,7 +472,7 @@ def _handler_factory(bridge: BuddyBridge):
 
             if path == "/mint":
                 try:
-                    self._json(200, bridge.mint())
+                    self._json(200, bridge.mint(payload))
                 except realtime.RealtimeError as exc:
                     self._json(502, {"success": False, "error": str(exc)})
                 return

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -132,6 +132,7 @@ data. Where the design hypothesis and the docs disagreed, the docs won.
 | **Function-call events** | Tools declared as `session.tools[]`. Calls arrive on `response.done` as `output[]` items with `type: "function_call"`, carrying `name`, `arguments` (a JSON **string**), `call_id`. Result returns as `conversation.item.create` → `function_call_output`, then `response.create`. | — |
 | **Turn detection** | `semantic_vad` (default) decides turns from *what was said*, not a silence timer. Or `null` for manual control. `create_response` / `interrupt_response` can be disabled independently. | ⚠️ Unstated. `semantic_vad` matters here — the owner thinking out loud about the fleet pauses mid-sentence constantly. |
 | **Barge-in** | Native and free. `input_audio_buffer.speech_started` fires, the in-flight response emits `response.cancelled`. Over WebRTC the browser handles playback truncation; only WebSocket clients must hand-send `conversation.item.truncate`. | ✅ Supported — better than assumed, and needs no code on WebRTC. |
+| **Voices** | Ten, closed: `cedar`, `marin`, `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`. The docs single out `cedar`/`marin` as the newer, more natural pair. **Fixed per session:** "Once the model has emitted audio in a session, the `voice` cannot be modified for that session." | ⚠️ Unstated. Matters twice — see [The voice list](#the-voice-list-and-why-switching-costs-a-reconnect-1017). |
 | **Audio format** | 24kHz PCM in (`{"type": "audio/pcm", "rate": 24000}`) for browser mic capture. Input transcription is a **separate** model (`gpt-4o-mini-transcribe`) from the conversational one. | ⚠️ Unstated. Two models, not one. |
 
 **One correction worth stating plainly:** the model is `gpt-realtime-2.1`, not
@@ -164,6 +165,71 @@ GET /v1/models/gpt-realtime-2.1  → 200  id=gpt-realtime-2.1  owned_by=system
 Corroborated by DocumentScribe's own `DEFAULT_REALTIME_MODEL`, which is the
 same string. When these ids rotate — and they will — verify with
 `GET /v1/models/<id>`, never with a mint.
+
+### The voice list, and why switching costs a reconnect (#1017)
+
+The voices are enumerated once, in `realtime.VOICES`, and that one tuple feeds
+all three surfaces the owner can meet: `--help` on `register`/`mint`/`serve`,
+the picker on the buddy page, and the refusal text when a name is wrong.
+
+```bash
+agentwire buddy register buddy --voice marin   # persisted on the record
+agentwire buddy serve buddy --voice ash        # explicit flag wins for this run
+agentwire buddy serve buddy --voice cedarr
+# → unknown realtime voice 'cedarr' — valid voices are: cedar, marin, alloy,
+#   ash, ballad, coral, echo, sage, shimmer, verse (default: cedar)
+```
+
+Resolution is **explicit flag → the buddy's recorded voice → `cedar`**. Before
+#1017 the middle term did not exist: `register --voice` wrote `realtime_voice`
+onto the record and nothing ever read it, so the flag looked like a setting and
+behaved like a comment.
+
+**Why validate locally at all.** Not because the mint endpoint is known to
+accept a bad voice — that is *not measured*. Because of the footgun one section
+up: the mint endpoint is not a validator, it returns 200 for a model that does
+not exist, so a successful mint is not evidence about anything it was handed.
+The cost of being wrong is paid in the worst channel we have — the owner is not
+looking at a screen, and "the buddy never spoke" reads identically as a dead
+mic, an API outage, or a typo in a voice name. Ten closed values are short
+enough to print in the error, so they are.
+
+Every `--voice` refuses **before** the record is written, the sequence epoch is
+reserved, or the API key is spent. That ordering is the point: a refusal that
+already cost you something is a worse refusal.
+
+**Switching is a reconnect, and it has to be.** The API fixes the voice once the
+model has emitted audio, and the buddy greets on connect (#963) — so by the time
+anyone wants a different voice, `session.update` is already closed to them.
+There is no honest mid-call voice change; there is only a new session.
+
+What #1017 buys is therefore not a new capability, it is the **cost** of the one
+that existed: Ctrl-C the bridge → re-serve with a different `--voice` → reload
+the page, three steps for a ten-value setting, becomes one click on a `<select>`
+on the page. The picker posts the chosen voice with `/mint`, the bridge
+validates it, adopts it, and persists it to the record so the next `serve` comes
+back on it; the page tears the peer connection down and rebuilds it.
+
+Two decisions inside that are deliberate and would otherwise look like bugs:
+
+- **The switch re-greets**, against the #963 rule that a reconnect stays quiet.
+  That rule is about reconnects the owner did not ask for, where a re-greet is
+  noise. This one they asked for, and its *entire* observable result is how the
+  buddy sounds — a silent switch is indistinguishable from a switch that did not
+  happen, to someone with no screen. So it speaks, in the new voice, which is
+  the answer to the question they asked.
+- **A failed persist does not fail the call.** `store_session_metadata` raises
+  by design (#885); an unwritable record must cost stickiness across the next
+  `serve`, never the live conversation. It is reported on the page rather than
+  swallowed.
+
+**`register` on an existing buddy is idempotent in what it SAYS, too.** It always
+was in what it wrote (merge-preserving, `created_at` kept), but it re-printed
+the full blurb — inbox path, spool path, "other sessions can now reach it" —
+over a one-word voice change, which reads like a second identity was created.
+It now prints `updated voice → marin (was cedar)`, or `nothing to change`.
+`--json` carries `created` and a `changes` map, computed against the record that
+was there **before** the write.
 
 ---
 
@@ -2034,7 +2100,16 @@ agentwire buddy inbox --ack      # read and mark read
 
 # talk to it (needs OPENAI_API_KEY in ~/.agentwire/.env, chmod 600)
 agentwire buddy serve buddy      # → http://127.0.0.1:8788/
+
+# pick a voice — see `--help` for the list, or the picker on the page
+agentwire buddy register buddy --voice marin   # sticks; prints "updated voice → marin"
+agentwire buddy serve buddy --voice ash        # just this run
 ```
+
+The page carries a **voice picker** (#1017): changing it reconnects in one
+click and persists the choice, because the API fixes a session's voice once the
+model has spoken — see
+[The voice list](#the-voice-list-and-why-switching-costs-a-reconnect-1017).
 
 `buddy call` runs a tool through the same dispatch path the model reaches, with
 **no spine wired**, so a write tool there is refused outright rather than

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -210,7 +210,7 @@ on the page. The picker posts the chosen voice with `/mint`, the bridge
 validates it, adopts it, and persists it to the record so the next `serve` comes
 back on it; the page tears the peer connection down and rebuilds it.
 
-Two decisions inside that are deliberate and would otherwise look like bugs:
+Four decisions inside that are deliberate and would otherwise look like bugs:
 
 - **The switch re-greets**, against the #963 rule that a reconnect stays quiet.
   That rule is about reconnects the owner did not ask for, where a re-greet is
@@ -218,10 +218,33 @@ Two decisions inside that are deliberate and would otherwise look like bugs:
   buddy sounds — a silent switch is indistinguishable from a switch that did not
   happen, to someone with no screen. So it speaks, in the new voice, which is
   the answer to the question they asked.
+- **The greet latch is released on BOTH branches**, live and idle. `stop()`
+  deliberately leaves `greeted` set, so a release scoped to the live branch
+  leaves the *ordinary* sequence silent: talk, press Stop, pick a voice, press
+  Start — connects on the new voice and says nothing. Same failure, calmer
+  route. The first cut of #1017 had exactly that asymmetry and a node test that
+  built the state and asserted everything except the latch.
+- **A voice is adopted after the mint succeeds, never before.** Adopting first
+  left an upstream 500 with the bridge *and* the record moved to a voice that
+  was never spoken: the page got its 502, the call never happened, and a reload
+  came back showing a setting with no evidence behind it. It is still *minted*
+  with, or "don't adopt" would be indistinguishable from ignoring the picker.
 - **A failed persist does not fail the call.** `store_session_metadata` raises
   by design (#885); an unwritable record must cost stickiness across the next
   `serve`, never the live conversation. It is reported on the page rather than
   swallowed.
+
+**One residual, open and named.** `speechSynthesis` utterances already handed to
+the browser survive `stop()` — deliberately, since cancelling them is #950
+defect 3 — so a switch made *while the fallback voice is mid-announcement*
+genuinely overlaps the old robot voice with the new session's greet. The
+teardown itself is clean (`stop()` is synchronous: data channel, peer
+connection, mic tracks, `announcer.teardown()`, in that order, before `start()`
+is awaited), and the model's own audio dies with the peer connection. It is only
+the browser voice that can straddle the switch, and this feature makes that
+one click reachable where it previously took three steps. Audible, not unsafe:
+nothing is approved by it — the announcer is torn down, so the straddling
+utterance anchors nothing.
 
 **`register` on an existing buddy is idempotent in what it SAYS, too.** It always
 was in what it wrote (merge-preserving, `created_at` kept), but it re-printed

--- a/tests/unit/test_voice_fleet_alerts.py
+++ b/tests/unit/test_voice_fleet_alerts.py
@@ -36,11 +36,15 @@ class TestBuddyLease:
         assert fleet_alerts.subscribers() == ["buddy"]
 
     def test_registering_does_not_disturb_the_identity_record(self, isolate):
-        identity.register("buddy", model="m", voice="v")
+        # A REAL voice, not a placeholder: register validates against
+        # realtime.VOICES since #1017, and the model id deliberately still
+        # does not (it is verified with GET /v1/models, not by this process).
+        identity.register("buddy", model="m", voice="marin")
         meta = core.load_session_metadata("buddy")
         assert meta["kind"] == identity.KIND
         assert meta[delivery.DELIVERY_KEY] == delivery.VOICE_ADAPTER
         assert meta["realtime_model"] == "m"
+        assert meta["realtime_voice"] == "marin"
 
     def test_unregistering_stops_production(self, isolate):
         identity.register("buddy")

--- a/tests/unit/test_voice_picker.py
+++ b/tests/unit/test_voice_picker.py
@@ -1,0 +1,461 @@
+"""Voice selection: enumeration, the live picker, and register-vs-update (#1017).
+
+Three paper cuts from the first live session, and what they have in common is
+that each one is invisible from inside the code — they are only defects if you
+are the owner, on a phone, with no screen to read:
+
+1. ``--voice`` took any string. A typo produced a bridge that connects and then
+   sounds like nothing, which is indistinguishable from a dead mic.
+2. Changing voice meant Ctrl-C, re-serve, reload. Ten values, three steps.
+3. ``register --voice`` on an existing buddy re-printed the whole registration
+   blurb, which reads like a second identity was created.
+
+The pins below are chosen so a regression fails as a BEHAVIOUR failure: the
+enumeration is read out of :data:`realtime.VOICES` wherever it is asserted (a
+second literal list in a test is the drift it exists to catch), and the picker's
+wire is executed as itself, extracted from the page the server actually serves
+— the #995 rule that a wire nothing runs can be cut with the suite still green.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from agentwire import buddy_cli, core, inbox
+from agentwire.voice_layer import client, identity, realtime, server
+from tests.page_slice import page_slice
+
+needs_node = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is needed to run the client's own JS"
+)
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(inbox, "INBOX_ROOT", tmp_path / "inbox")
+    monkeypatch.setattr(inbox, "EVENTS_FILE", tmp_path / "inbox-events.jsonl")
+    return tmp_path
+
+
+# =============================================================================
+# 1. The enumeration
+# =============================================================================
+
+
+class TestTheVoicesAreEnumerated:
+    def test_the_documented_ten_are_all_there(self):
+        """Derived from the docs fetch (2026-08-11), asserted as a SET so the
+        ordering stays free to be the reading order the owner sees."""
+        assert set(realtime.VOICES) == {
+            "alloy", "ash", "ballad", "cedar", "coral",
+            "echo", "marin", "sage", "shimmer", "verse",
+        }
+
+    def test_the_default_is_one_of_them(self):
+        assert realtime.DEFAULT_VOICE in realtime.VOICES
+
+    def test_the_newer_pair_leads_the_list(self):
+        """The order is a recommendation, and the picker renders it verbatim."""
+        assert realtime.VOICES[:2] == ("cedar", "marin")
+
+    @pytest.mark.parametrize("voice", realtime.VOICES)
+    def test_every_listed_voice_validates(self, voice):
+        assert realtime.validate_voice(voice) == voice
+
+    def test_an_unknown_voice_refuses_with_the_whole_list(self):
+        with pytest.raises(realtime.RealtimeError) as exc:
+            realtime.validate_voice("cedarr")
+        message = str(exc.value)
+        assert "cedarr" in message
+        for voice in realtime.VOICES:
+            assert voice in message
+
+    def test_case_is_folded_rather_than_refused(self):
+        """A false reject here costs a real setting for a spelling nobody
+        would call wrong."""
+        assert realtime.validate_voice("Cedar") == "cedar"
+        assert realtime.validate_voice(" MARIN ") == "marin"
+
+    def test_empty_means_unspecified_not_invalid(self):
+        assert realtime.validate_voice("") == ""
+
+    def test_the_help_text_lists_every_voice(self):
+        for voice in realtime.VOICES:
+            assert voice in buddy_cli._VOICE_HELP
+        assert realtime.DEFAULT_VOICE in buddy_cli._VOICE_HELP
+
+    def test_the_help_text_carries_no_percent_sign(self):
+        """argparse interpolates help printf-style; a lone `percent` raises at
+        parse time, which would take out `--help` for the whole CLI."""
+        assert "%" not in buddy_cli._VOICE_HELP
+
+    def test_every_voice_flag_carries_the_help(self):
+        """All three verbs, or the list is discoverable from whichever one the
+        owner did not happen to run."""
+        import argparse
+
+        # argparse exits the process on --help, so the help string is read off
+        # the parser's actions rather than by rendering it.
+        parser = argparse.ArgumentParser()
+        buddy_cli.register_buddy_parser(parser.add_subparsers(dest="command"))
+        verbs = parser._subparsers._group_actions[0].choices["buddy"] \
+            ._subparsers._group_actions[0].choices
+        found = {
+            verb: action.help
+            for verb in ("register", "mint", "serve")
+            for action in verbs[verb]._actions
+            if action.dest == "voice"
+        }
+        assert found == {verb: buddy_cli._VOICE_HELP
+                         for verb in ("register", "mint", "serve")}
+
+
+class TestABadVoiceFailsEarly:
+    """Before the record, before the epoch, before the key is spent."""
+
+    def _args(self, voice, **extra):
+        return SimpleNamespace(
+            name="buddy", voice=voice, model="", json=False, port=0, **extra
+        )
+
+    def test_register_refuses_and_writes_nothing(self, isolate, capsys):
+        assert buddy_cli.cmd_buddy_register(self._args("cedarr")) == 1
+        assert not identity.is_registered("buddy")
+        assert "cedarr" in capsys.readouterr().err
+
+    def test_mint_refuses_before_touching_the_api(self, isolate, monkeypatch):
+        identity.register("buddy")
+        monkeypatch.setattr(
+            realtime, "mint_session",
+            lambda **k: pytest.fail("the API key was spent on an invalid voice"),
+        )
+        assert buddy_cli.cmd_buddy_mint(self._args("nope")) == 1
+
+    def test_serve_refuses_before_binding_a_socket(self, isolate, monkeypatch):
+        identity.register("buddy")
+        monkeypatch.setattr(
+            server, "serve", lambda *a, **k: pytest.fail("bound a socket anyway")
+        )
+        assert buddy_cli.cmd_buddy_serve(self._args("nope")) == 1
+
+    def test_the_json_caller_gets_a_json_error(self, isolate, capsys):
+        """The reason `choices=` was not used: argparse would exit with a usage
+        dump on stderr and no parseable object at all."""
+        args = self._args("nope")
+        args.json = True
+        assert buddy_cli.cmd_buddy_register(args) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["success"] is False
+        assert "nope" in payload["error"]
+
+    def test_mint_session_itself_refuses_too(self):
+        """The last line before the key is spent, pinned independently of its
+        callers — a new call site must not be able to route around them."""
+        with pytest.raises(realtime.RealtimeError):
+            realtime.mint_session(instructions="", tools=[], voice="nope")
+
+
+# =============================================================================
+# 2. A recorded voice is a voice that is USED
+# =============================================================================
+
+
+class TestTheRecordedVoiceIsRead:
+    """`register --voice` used to write a key nothing ever read."""
+
+    def test_resolution_is_explicit_then_recorded_then_default(self, isolate):
+        identity.register("buddy", voice="marin")
+        assert identity.resolve_voice("buddy", "ash") == "ash"
+        assert identity.resolve_voice("buddy") == "marin"
+        assert identity.resolve_voice("nobody") == realtime.DEFAULT_VOICE
+
+    def test_a_retired_recorded_voice_falls_back_instead_of_wedging(self, isolate):
+        """An id retired upstream must cost the default, never the bridge."""
+        identity.register("buddy")
+        meta = core.load_session_metadata("buddy")
+        meta["realtime_voice"] = "voice-that-openai-retired"
+        core.store_session_metadata("buddy", meta)
+        assert identity.resolve_voice("buddy") == realtime.DEFAULT_VOICE
+
+    def test_the_bridge_picks_the_recorded_voice_up(self, isolate):
+        identity.register("buddy", voice="ballad")
+        assert server.BuddyBridge("buddy", "tok").voice == "ballad"
+
+    def test_an_explicit_flag_still_wins_at_the_bridge(self, isolate):
+        identity.register("buddy", voice="ballad")
+        assert server.BuddyBridge("buddy", "tok", voice="echo").voice == "echo"
+
+    def test_status_reports_it(self, isolate):
+        identity.register("buddy", voice="sage")
+        assert identity.status("buddy")["realtime_voice"] == "sage"
+
+
+# =============================================================================
+# 3. The picker: one click, and the reconnect is the mechanism
+# =============================================================================
+
+
+class TestTheMintCarriesTheVoice:
+    @pytest.fixture
+    def bridge(self, isolate, monkeypatch):
+        identity.register("buddy")
+        minted = []
+
+        def fake_mint(**kwargs):
+            minted.append(kwargs)
+            return {"id": "sess", "client_secret": "sk", "expires_at": 1,
+                    "model": kwargs["model"], "calls_url": "u"}
+
+        monkeypatch.setattr(realtime, "mint_session", fake_mint)
+        return server.BuddyBridge("buddy", "tok"), minted
+
+    def test_a_mint_with_no_voice_uses_the_bridges(self, bridge):
+        bridge_obj, minted = bridge
+        result = bridge_obj.mint({})
+        assert result["success"] is True
+        assert minted[0]["voice"] == realtime.DEFAULT_VOICE
+        assert result["voice_changed"] is False
+
+    def test_a_mint_with_a_voice_switches_and_reports_it(self, bridge):
+        bridge_obj, minted = bridge
+        result = bridge_obj.mint({"voice": "marin"})
+        assert minted[0]["voice"] == "marin"
+        assert result["voice"] == "marin"
+        assert result["voice_changed"] is True
+
+    def test_the_switch_sticks_for_the_next_serve(self, bridge):
+        bridge_obj, _ = bridge
+        bridge_obj.mint({"voice": "marin"})
+        assert identity.registered_voice("buddy") == "marin"
+        assert server.BuddyBridge("buddy", "tok").voice == "marin"
+
+    def test_an_unknown_voice_refuses_without_spending_the_key(self, bridge):
+        bridge_obj, minted = bridge
+        result = bridge_obj.mint({"voice": "nope"})
+        assert result["success"] is False
+        assert "nope" in result["error"]
+        assert minted == []
+
+    def test_a_refused_voice_does_not_burn_a_sequence_epoch(self, bridge):
+        """The epoch is reserved per page load and the space is finite —
+        a rejected picker value must not advance it."""
+        bridge_obj, _ = bridge
+        bridge_obj.mint({"voice": "nope"})
+        assert bridge_obj.ring.high_seq == 0
+
+    def test_a_failed_persist_is_reported_not_swallowed(self, bridge, monkeypatch):
+        """The live call must survive an unwritable record — the owner loses
+        stickiness, and is told so rather than finding out next serve."""
+        bridge_obj, minted = bridge
+        monkeypatch.setattr(
+            identity, "set_voice",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")),
+        )
+        result = bridge_obj.mint({"voice": "marin"})
+        assert result["success"] is True
+        assert minted[0]["voice"] == "marin"
+        assert result["voice_persisted"] is False
+        assert "read-only" in result["voice_persist_error"]
+
+
+class TestThePageRendersThePicker:
+    def test_every_voice_is_an_option(self):
+        page = client.page("buddy", "tok")
+        for voice in realtime.VOICES:
+            assert f'value="{voice}"' in page
+
+    def test_the_current_voice_is_the_selected_one(self):
+        page = client.page("buddy", "tok", voice="marin")
+        assert '<option value="marin" selected>' in page
+        assert '<option value="cedar">' in page
+
+    def test_the_page_defaults_to_the_default_voice(self):
+        assert '<option value="cedar" selected>' in client.page("buddy", "tok")
+
+    def test_the_served_page_shows_the_bridges_current_voice(self, isolate):
+        """A switch made in one tab is what a RELOAD must come back showing."""
+        identity.register("buddy")
+        bridge = server.BuddyBridge("buddy", "tok")
+        bridge.switch_voice("verse")
+        page = client.page(bridge.buddy, bridge.token, voice=bridge.voice)
+        assert '<option value="verse" selected>' in page
+
+
+@needs_node
+class TestTheVoicePickerWire:
+    """The wire, executed as itself (#995).
+
+    A picker that renders and does nothing is the worst of the three outcomes
+    here: the owner sees the voice change on screen and hears the old one, and
+    has no way to tell which half lied.
+    """
+
+    def _program(self, *, live: bool, pick: str, current: str = "cedar") -> str:
+        page = client.page("buddy", "tok")
+        switch = page_slice(
+            page, r"async function switchVoice\(\) \{", r"\n\}\n",
+            "the switchVoice body",
+            shape=r"\$voice\.value[\s\S]*await start\(\)[\s\S]*\}$",
+        )
+        wire = page_slice(
+            page, r'\$voice\.addEventListener\("change"', r";", "the voice change wire",
+            shape=r'^\$voice\.addEventListener\("change",\s*\w+\);$',
+        )
+        return "\n".join([
+            "const events = [];",
+            f"let currentVoice = {json.dumps(current)};",
+            "let greeted = true;",
+            f"let pc = {'{}' if live else 'null'};",
+            f"const $voice = {{ value: {json.dumps(pick)}, disabled: false }};",
+            "const handlers = {};",
+            "$voice.addEventListener = (n, fn) => { handlers[n] = fn; };",
+            'function log(who, text) { events.push("log:" + text); }',
+            'function setStatus(text) { events.push("status:" + text); }',
+            'function stop() { events.push("stop"); pc = null; }',
+            "async function start() {",
+            '  events.push("start:" + currentVoice + ":greeted=" + greeted);',
+            "  pc = {};",
+            "}",
+            switch,
+            wire,
+            'await handlers["change"]();',
+            "console.log(JSON.stringify({ events, currentVoice, "
+            "disabled: $voice.disabled, wired: Object.keys(handlers) }));",
+        ])
+
+    def _run(self, program: str) -> dict:
+        result = subprocess.run(
+            ["node", "--input-type=module", "-e", program],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"node failed: {result.stderr.strip()}")
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_the_change_event_is_wired_to_switch_voice(self):
+        report = self._run(self._program(live=True, pick="marin"))
+        assert report["wired"] == ["change"]
+
+    def test_a_live_call_is_torn_down_and_rebuilt_on_the_new_voice(self):
+        report = self._run(self._program(live=True, pick="marin"))
+        assert report["events"] == [
+            "log:voice → marin", "stop", "start:marin:greeted=false",
+        ]
+        assert report["currentVoice"] == "marin"
+
+    def test_the_switch_re_greets_so_the_owner_hears_the_new_voice(self):
+        """Deliberately against the #963 quiet-reconnect rule: this reconnect
+        was ASKED for, and its only observable result is how the buddy sounds."""
+        report = self._run(self._program(live=True, pick="ash"))
+        assert "start:ash:greeted=false" in report["events"]
+
+    def test_picking_the_same_voice_does_nothing_at_all(self):
+        report = self._run(self._program(live=True, pick="cedar"))
+        assert report["events"] == []
+
+    def test_an_idle_page_records_the_choice_without_connecting(self):
+        report = self._run(self._program(live=False, pick="marin"))
+        assert "stop" not in report["events"]
+        assert not [e for e in report["events"] if e.startswith("start:")]
+        assert report["currentVoice"] == "marin"
+
+    def test_the_picker_is_re_enabled_after_the_reconnect(self):
+        """Locked for the round trip, released in a `finally` — a picker left
+        disabled by a failed reconnect is a setting the owner cannot retry."""
+        report = self._run(self._program(live=True, pick="marin"))
+        assert report["disabled"] is False
+
+
+class TestTheMintBodyReachesTheBridge:
+    def test_the_page_posts_the_voice_it_is_showing(self):
+        page = client.page("buddy", "tok")
+        assert 'post("/mint", { voice: currentVoice })' in page
+
+    def test_the_handler_forwards_the_body(self):
+        """A `/mint` handler calling `bridge.mint()` with no payload is the
+        one-line mutation that makes the whole picker inert."""
+        import inspect
+
+        source = inspect.getsource(server._handler_factory)
+        assert "bridge.mint(payload)" in source
+
+
+# =============================================================================
+# 4. register vs. update
+# =============================================================================
+
+
+class TestRegisterIsIdempotentInWhatItSays:
+    def _args(self, **extra):
+        fields = {"name": "buddy", "voice": "", "model": "", "json": False}
+        fields.update(extra)
+        return SimpleNamespace(**fields)
+
+    def test_the_first_registration_announces_itself(self, isolate, capsys):
+        assert buddy_cli.cmd_buddy_register(self._args()) == 0
+        out = capsys.readouterr().out
+        assert "Registered voice buddy 'buddy'." in out
+        assert "inbox:" in out
+
+    def test_a_voice_change_says_updated_and_nothing_else(self, isolate, capsys):
+        buddy_cli.cmd_buddy_register(self._args())
+        capsys.readouterr()
+        assert buddy_cli.cmd_buddy_register(self._args(voice="marin")) == 0
+        out = capsys.readouterr().out
+        assert "updated voice → marin" in out
+        assert "Registered voice buddy" not in out
+        # The blurb's contents, not just its first line: naming the inbox and
+        # the "other sessions can now reach it" line is what read as a second
+        # identity being created.
+        assert "inbox:" not in out
+        assert "msg send --to" not in out
+
+    def test_the_previous_voice_is_named(self, isolate, capsys):
+        buddy_cli.cmd_buddy_register(self._args(voice="marin"))
+        capsys.readouterr()
+        buddy_cli.cmd_buddy_register(self._args(voice="ash"))
+        assert "was marin" in capsys.readouterr().out
+
+    def test_re_registering_with_nothing_to_change_says_so(self, isolate, capsys):
+        buddy_cli.cmd_buddy_register(self._args(voice="marin"))
+        capsys.readouterr()
+        buddy_cli.cmd_buddy_register(self._args(voice="marin"))
+        out = capsys.readouterr().out
+        assert "already registered" in out
+        assert "nothing to change" in out
+
+    def test_the_record_is_still_updated(self, isolate):
+        buddy_cli.cmd_buddy_register(self._args())
+        buddy_cli.cmd_buddy_register(self._args(voice="marin"))
+        assert identity.registered_voice("buddy") == "marin"
+
+    def test_json_says_created_and_names_the_change(self, isolate, capsys):
+        args = self._args(json=True)
+        buddy_cli.cmd_buddy_register(args)
+        first = json.loads(capsys.readouterr().out)
+        assert first["created"] is True and first["changes"] == {}
+
+        buddy_cli.cmd_buddy_register(self._args(json=True, voice="marin"))
+        second = json.loads(capsys.readouterr().out)
+        assert second["created"] is False
+        assert second["changes"] == {"voice": {"from": None, "to": "marin"}}
+
+    def test_the_delta_is_read_before_the_write(self, isolate):
+        """Against the record that WAS there — computing it after register()
+        would report every change as no change, silently."""
+        identity.register("buddy", voice="marin")
+        delta = identity.registration_delta("buddy", voice="ash")
+        assert delta == {
+            "registered": True,
+            "changes": {"voice": {"from": "marin", "to": "ash"}},
+        }
+        assert identity.registered_voice("buddy") == "marin"
+
+    def test_an_unregistered_name_is_not_an_update(self, isolate):
+        assert identity.registration_delta("buddy", voice="ash")["registered"] is False

--- a/tests/unit/test_voice_picker.py
+++ b/tests/unit/test_voice_picker.py
@@ -330,6 +330,18 @@ class TestThePageRendersThePicker:
         assert '<option value="marin" selected>' in page
         assert '<option value="cedar">' in page
 
+    def test_the_newer_pair_is_labelled_and_nothing_else_is(self):
+        """The label derives from ``VOICES[:2]``, and that derivation needs its
+        own pin: swapping it for a hard-coded ``("alloy", "ash")`` left the
+        whole suite green, which makes the structural win unenforced. Both
+        halves — the two that carry it, and the eight that must not.
+        """
+        page = client.page("buddy", "tok")
+        for voice in realtime.VOICES[:2]:
+            assert f">{voice} (newer)<" in page, voice
+        for voice in realtime.VOICES[2:]:
+            assert f">{voice}<" in page, voice
+
     def test_the_page_defaults_to_the_default_voice(self):
         assert '<option value="cedar" selected>' in client.page("buddy", "tok")
 

--- a/tests/unit/test_voice_picker.py
+++ b/tests/unit/test_voice_picker.py
@@ -154,6 +154,20 @@ class TestABadVoiceFailsEarly:
         assert payload["success"] is False
         assert "nope" in payload["error"]
 
+    def test_identity_raises_its_own_error_type(self, isolate):
+        """One failure contract per module. ``register`` is caught as a
+        ``BuddyError`` at its only call site, so a ``RealtimeError`` escaping
+        it would be an uncaught second contract — unreachable today only
+        because the CLI pre-validates, which is not a guarantee."""
+        for call in (
+            lambda: identity.register("buddy", voice="cedarr"),
+            lambda: identity.registration_delta("buddy", voice="cedarr"),
+            lambda: identity.set_voice("buddy", "cedarr"),
+            lambda: identity.resolve_voice("buddy", "cedarr"),
+        ):
+            with pytest.raises(identity.BuddyError):
+                call()
+
     def test_mint_session_itself_refuses_too(self):
         """The last line before the key is spent, pinned independently of its
         callers — a new call site must not be able to route around them."""
@@ -249,6 +263,47 @@ class TestTheMintCarriesTheVoice:
         bridge_obj.mint({"voice": "nope"})
         assert bridge_obj.ring.high_seq == 0
 
+    def test_a_failed_mint_adopts_nothing(self, bridge, monkeypatch):
+        """A voice sticks once it has been MINTED with, and not before.
+
+        Adopting first left an upstream 500 with the bridge and the record both
+        moved to a voice that was never spoken — the page got its 502, the call
+        never happened, and a reload came back showing a setting the owner has
+        no evidence for.
+        """
+        bridge_obj, _ = bridge
+        monkeypatch.setattr(
+            realtime, "mint_session",
+            lambda **k: (_ for _ in ()).throw(realtime.RealtimeError("upstream 500")),
+        )
+        with pytest.raises(realtime.RealtimeError):
+            bridge_obj.mint({"voice": "marin"})
+        assert bridge_obj.voice == realtime.DEFAULT_VOICE
+        assert identity.registered_voice("buddy") == ""
+
+    def test_the_failed_mint_was_still_attempted_on_the_new_voice(self, bridge, monkeypatch):
+        """The other half: not adopting must not mean not honouring. Without
+        this, "nothing moved" is equally satisfied by ignoring the picker."""
+        seen = []
+        bridge_obj, _ = bridge
+        monkeypatch.setattr(
+            realtime, "mint_session",
+            lambda **k: seen.append(k["voice"]) or (_ for _ in ()).throw(
+                realtime.RealtimeError("upstream 500")
+            ),
+        )
+        with pytest.raises(realtime.RealtimeError):
+            bridge_obj.mint({"voice": "marin"})
+        assert seen == ["marin"]
+
+    @pytest.mark.parametrize("body", [None, [1], "x", 7])
+    def test_a_non_dict_body_is_treated_as_no_body(self, bridge, body):
+        """`/mint` ignored its payload entirely until this argument existed —
+        a bridge that 500s on `[1]` where it used to answer is a regression."""
+        bridge_obj, minted = bridge
+        assert bridge_obj.mint(body)["success"] is True
+        assert minted[0]["voice"] == realtime.DEFAULT_VOICE
+
     def test_a_failed_persist_is_reported_not_swallowed(self, bridge, monkeypatch):
         """The live call must survive an unwritable record — the owner loses
         stickiness, and is told so rather than finding out next serve."""
@@ -325,7 +380,7 @@ class TestTheVoicePickerWire:
             switch,
             wire,
             'await handlers["change"]();',
-            "console.log(JSON.stringify({ events, currentVoice, "
+            "console.log(JSON.stringify({ events, currentVoice, greeted, "
             "disabled: $voice.disabled, wired: Object.keys(handlers) }));",
         ])
 
@@ -364,6 +419,31 @@ class TestTheVoicePickerWire:
         assert "stop" not in report["events"]
         assert not [e for e in report["events"] if e.startswith("start:")]
         assert report["currentVoice"] == "marin"
+
+    def test_an_idle_switch_also_releases_the_greet_latch(self):
+        """The calmer route to the same silent switch, and it is the ORDINARY
+        one: talk (greeted), press Stop, pick a voice, press Start.
+
+        ``stop()`` deliberately leaves ``greeted`` set (#963), so a release
+        that lives only in the live branch means that sequence connects on the
+        new voice and says nothing — the exact failure the live branch's
+        re-greet exists to prevent. The fixture starts from ``greeted = true``
+        precisely because that is the state the sequence arrives in; asserting
+        the events without asserting the latch is how the first version of
+        this harness built the bug and looked away.
+        """
+        report = self._run(self._program(live=False, pick="marin"))
+        assert report["greeted"] is False
+
+    def test_a_live_switch_releases_it_too(self):
+        report = self._run(self._program(live=True, pick="marin"))
+        assert report["greeted"] is False
+
+    def test_declining_to_switch_leaves_the_latch_alone(self):
+        """The release is scoped to an actual change — picking the voice you
+        are already on must not re-greet you."""
+        report = self._run(self._program(live=True, pick="cedar"))
+        assert report["greeted"] is True
 
     def test_the_picker_is_re_enabled_after_the_reconnect(self):
         """Locked for the round trip, released in a `finally` — a picker left

--- a/tests/unit/test_voice_wiki_accuracy.py
+++ b/tests/unit/test_voice_wiki_accuracy.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import pytest
 
 from agentwire import inbox
-from agentwire.voice_layer import confirm, server, tools, write_tools
+from agentwire.voice_layer import confirm, realtime, server, tools, write_tools
 
 WIKI = Path(__file__).resolve().parents[2] / "docs" / "wiki" / "voice-layer.md"
 VOICE_LAYER = Path(confirm.__file__).parent
@@ -477,6 +477,35 @@ class TestTheToolSurfaceIsNotEnumeratedStale:
         """
         assert "the gate is LIVENESS, not the `@` character" in page
         assert "local **by demonstration**" in page
+
+
+class TestTheVoiceListIsDocumentedFromTheCode(object):
+    """The enumeration the owner reads must be the one the code enforces.
+
+    Derived, not literal: an eleventh voice added to ``realtime.VOICES`` and not
+    to the page is exactly the drift a hand-written list in this file would
+    reproduce rather than catch. #1017's whole premise is that the list is
+    discoverable, and a page listing nine of ten is worse than one listing none
+    — the missing one reads as unsupported.
+    """
+
+    def test_every_voice_appears(self, page):
+        for voice in realtime.VOICES:
+            assert f"`{voice}`" in page, voice
+
+    def test_the_default_is_named_as_the_default(self, page):
+        assert f"default: {realtime.DEFAULT_VOICE}" in page
+
+    def test_the_page_says_the_voice_is_fixed_once_audio_is_emitted(self, page):
+        """The reason the picker reconnects instead of sending session.update.
+        Without this sentence the reconnect reads as laziness."""
+        assert "cannot be modified for that session" in page
+        assert realtime.VOICE_IS_SESSION_FIXED is True
+
+    def test_the_page_does_not_claim_the_mint_validates_the_voice(self, page):
+        """It is NOT measured, and the model-id footgun is what happens when a
+        page rounds "unverified" up to "checked upstream"."""
+        assert "not measured" in page
 
 
 class TestTheBridgeRoutesAreDocumented:


### PR DESCRIPTION
Three voice-selection paper cuts from the first live session. What they have in common is that each is invisible from inside the code — they only bite the owner, on a phone, with no screen.

## 1. The voices are enumerated, and a typo fails early

`realtime.VOICES` is the one list (`cedar, marin, alloy, ash, ballad, coral, echo, sage, shimmer, verse`, docs fetched 2026-08-11) and it feeds all three surfaces the owner can meet: `--help` on `register`/`mint`/`serve`, the `<select>` on the page, and the refusal text.

```
$ agentwire buddy serve buddy --voice cedarr
unknown realtime voice 'cedarr' — valid voices are: cedar, marin, alloy, ash,
ballad, coral, echo, sage, shimmer, verse (default: cedar)
```

Refused **before** the record is written, the sequence epoch reserved, or the API key spent. Case-folded, so a spoken-then-typed "Cedar" is not a false reject.

Why validate locally at all: not because the mint endpoint is known to reject a bad voice — that is *not measured*, and the page says so. Because the mint endpoint is **not a validator** (the #1011 footgun: 200 OK for a model that does not exist), and the cost of being wrong lands in the worst channel we have — "the buddy never spoke" reads identically as a dead mic, an outage, or a typo.

Deliberately not argparse `choices=`: it is case-sensitive, cannot name the default, and exits before any handler, so a `--json` caller gets a usage dump instead of an error object.

## 2. A voice picker on the page — one click, not kill + re-serve + reload

It cannot be a mid-session `session.update`: *"Once the model has emitted audio in a session, the `voice` cannot be modified for that session"*, and the buddy greets on connect (#963). There is no honest mid-call voice change; there is only a new session.

So what this ships is the **cost** of the change that already existed: three steps for a ten-value setting becomes one click. The picker posts its choice with `/mint`; the bridge validates, adopts and persists it to the buddy's record; the page tears the peer connection down and rebuilds it.

Two deliberate decisions that would otherwise look like bugs:
- **The switch re-greets**, against #963's quiet-reconnect rule. That rule is about reconnects the owner did not ask for. This one they asked for, and its entire observable result is how the buddy *sounds* — a silent switch is indistinguishable from one that did not happen.
- **A failed persist does not fail the call.** `store_session_metadata` raises by design (#885); an unwritable record costs stickiness across the next `serve`, never the live conversation — and it is reported on the page, not swallowed.

## 3. `register --voice` on an existing buddy updates, it does not re-announce

```
Voice buddy 'buddy' is already registered.
  updated voice → ash (was marin)
```

…or `nothing to change`. `--json` carries `created` and a `changes` map, computed against the record that was there **before** the write. The full blurb (inbox path, spool path, "other sessions can now reach it") is true and useful exactly once.

**Bonus fix found on the way:** `register --voice` wrote `realtime_voice` and *nothing ever read it* — `serve` and `mint` fell straight through to the default, so the flag looked like a setting and behaved like a comment. Resolution is now **explicit flag → recorded voice → `cedar`**, everywhere, and `buddy status` reports it.

## Verification

- **A real browser against a live bridge**: the picker renders all ten with the recorded voice selected, an idle switch logs and updates status, `POST /mint {voice}` switches + persists, and a reload comes back on the new voice. An invalid voice is refused over HTTP with the list.
- **55 new unit tests** (`tests/unit/test_voice_picker.py`), six of them node-run against the `switchVoice` wire **extracted from the page the server actually serves** (#995's rule). Mutation-checked both ways: rewiring `change` to `stop` and deleting the `greeted = false` line each turn tests red.
- Wiki pins are **derived** from `realtime.VOICES`, so an eleventh voice cannot ship undocumented.
- Full unit suite: `6190 passed`. The 4 `test_beta_flag.py` failures are **pre-existing on a clean `main` checkout** (verified by stashing) and untouched by this branch.

Docs: new section in `docs/wiki/voice-layer.md` — the list, the resolution order, why switching costs a reconnect, and the two deliberate decisions above.

Closes #1017

Built by [dotdev.dev](https://dotdev.dev)