### PR TITLE
voice buddy: fleet awareness in two tiers — a ledger it pulls, mail it speaks

### DIFF
--- a/agentwire/__main__.py
+++ b/agentwire/__main__.py
@@ -183,7 +183,7 @@ Command Categories:
     #   - diff:   structured git diff for the mobile Review window
     #   - prompts: prompt routing (rides the limits watchdog)
     #   - msg:    polite agent-to-agent inbox (rides the watchdog)
-    from . import alerts_cli, diff_cli, limits_cli, msg_cli, pane_cli, prompts_cli, send_cli  # noqa: I001  # session_cli kept on its own line below to minimize Phase 1 #495 merge conflicts
+    from . import activity_cli, alerts_cli, diff_cli, limits_cli, msg_cli, pane_cli, prompts_cli, send_cli  # noqa: I001  # session_cli kept on its own line below to minimize Phase 1 #495 merge conflicts
     from . import session_cli
     from . import channels_cli, config_cli, portal_cli, tts_cli
     from . import scheduler_cli, ensure_cli, tasks_cli
@@ -199,6 +199,7 @@ Command Categories:
         prompts_cli.register_prompts_parser,
         msg_cli.register_msg_parser,
         alerts_cli.register_alerts_parser,
+        activity_cli.register_activity_parser,
         limits_cli.register_limits_parser,
         pane_cli.register_pane_parser,
         send_cli.register_send_parser,

--- a/agentwire/activity_cli.py
+++ b/agentwire/activity_cli.py
@@ -1,0 +1,86 @@
+"""``agentwire activity`` — what the fleet has been doing (#1016).
+
+The read side of :mod:`~agentwire.fleet_activity`. It exists as a CLI verb for
+two reasons, and the second is the load-bearing one:
+
+1. "CLI is the single source of truth" — a store readable only from inside the
+   process tree that writes it is exactly the shape that rule exists to prevent.
+2. The voice layer dispatches **only** through the CLI (see
+   ``voice_layer/tools.py``), so without this verb the buddy could not read the
+   ledger that was built for it.
+
+Read-only, by construction: nothing here writes. Producers record from inside
+the surfaces that generate the events (idle, say, toast, scheduled run), never
+from a verb an agent could be talked into calling.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from . import fleet_activity
+
+#: Widest window the verb will look back over. The ledger is capped at
+#: ``MAX_ENTRIES`` anyway, so this bounds the ANSWER rather than the read: a
+#: request for a week of awareness is a request for history, and
+#: ``agentwire scheduler history`` / the event logs are where history lives.
+MAX_HOURS = 72
+
+
+def cmd_activity_list(args) -> int:
+    json_mode = getattr(args, "json", False)
+    hours = max(1, min(MAX_HOURS, int(getattr(args, "hours", 12) or 12)))
+    entries = fleet_activity.recent(
+        limit=max(1, int(getattr(args, "limit", 50) or 50)),
+        event=getattr(args, "event", "") or "",
+        session=getattr(args, "session", "") or "",
+        window=timedelta(hours=hours),
+    )
+    if json_mode:
+        print(json.dumps({
+            "success": True,
+            "count": len(entries),
+            "window_hours": hours,
+            "ledger": str(fleet_activity.ledger_path()),
+            "activity": entries,
+        }, indent=2))
+        return 0
+    if not entries:
+        print(f"No fleet activity recorded in the last {hours}h.")
+        return 0
+    for entry in entries:
+        # The announced flag is shown, not hidden: "recorded" and "said out
+        # loud" are different facts, and an operator debugging a chatty or a
+        # silent buddy needs to see which one an entry was.
+        mark = "*" if entry.get("announced") else " "
+        print(f"{mark} {entry.get('ts', '')}  {entry.get('event', ''):<16} "
+              f"{entry.get('text', '')}")
+    print()
+    print("* = also queued to fleet-alert subscribers (spoken by the voice buddy at a gap)")
+    return 0
+
+
+def register_activity_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "activity",
+        help="What the fleet has been doing (idle, tasks, toasts, speech)",
+        description=(
+            "The fleet's activity ledger: sessions going idle, scheduled tasks "
+            "finishing, toasts shown to the owner, and everything spoken aloud "
+            "through fleet TTS. This is AWARENESS — a record something can read "
+            "when asked. Only a short, ruled subset is also queued to "
+            "fleet-alert subscribers (see `agentwire alerts`); the rest waits "
+            "here to be looked up."
+        ),
+    )
+    sub = parser.add_subparsers(dest="activity_command", required=True)
+
+    p = sub.add_parser("list", help="Recent activity, newest first")
+    p.add_argument("--limit", type=int, default=50, help="Max entries (default: 50)")
+    p.add_argument("--hours", type=int, default=12,
+                   help=f"How far back to look (1-{MAX_HOURS}, default: 12)")
+    p.add_argument("--event", choices=fleet_activity.EVENTS, help="Only this event type")
+    p.add_argument("-s", "--session", help="Only this session (exact name)")
+    p.add_argument("--json", action="store_true", help="Output JSON")
+    p.set_defaults(func=cmd_activity_list)

--- a/agentwire/channels_cli.py
+++ b/agentwire/channels_cli.py
@@ -307,7 +307,27 @@ def cmd_say(args) -> int:
     def _say_result(rc: int, sink: str, clients: int = 0) -> int:
         """Report which sink actually received the audio (#444): browser
         (played by N connected clients), local speakers / OS voice, or a
-        failed dispatch — instead of a blind "queued"."""
+        failed dispatch — instead of a blind "queued".
+
+        Also the one place fleet TTS is recorded for the voice layer (#1016).
+        Here rather than at the top of the command because the sink is part of
+        the record — "spoken to a browser" and "spoken to the room" are
+        different facts about whether the owner heard it — and because a failed
+        dispatch (rc != 0) is deliberately NOT recorded as spoken.
+
+        This entry is NEVER announced to the buddy, whatever it said. The owner
+        already heard it; a voice channel that reads the audio back is the
+        two-surfaces problem made worse. What the record buys is the opposite —
+        the buddy can see what the fleet has already said and decline to offer
+        it as news.
+        """
+        if rc == 0:
+            from agentwire import fleet_activity
+
+            try:
+                fleet_activity.note_spoke(text, session=session or "", sink=sink)
+            except Exception:  # noqa: BLE001  # speaking is the job; the record is not
+                pass
         if json_mode:
             _output_json({"success": rc == 0, "sink": sink if rc == 0 else None,
                           "clients": clients, "session": session, "toast": toast_ok,

--- a/agentwire/channels_cli.py
+++ b/agentwire/channels_cli.py
@@ -304,16 +304,16 @@ def cmd_say(args) -> int:
     toast_ok = _post_desktop_notification(display, session=session, priority="normal",
                                           timeout=30) if display else None
 
-    def _say_result(rc: int, sink: str, clients: int = 0) -> int:
-        """Report which sink actually received the audio (#444): browser
-        (played by N connected clients), local speakers / OS voice, or a
-        failed dispatch — instead of a blind "queued".
+    def _record_spoken(heard: str, sink: str) -> None:
+        """Record what the owner ACTUALLY heard, for the voice layer (#1016).
 
-        Also the one place fleet TTS is recorded for the voice layer (#1016).
-        Here rather than at the top of the command because the sink is part of
-        the record — "spoken to a browser" and "spoken to the room" are
-        different facts about whether the owner heard it — and because a failed
-        dispatch (rc != 0) is deliberately NOT recorded as spoken.
+        Takes the heard text rather than reading `text` from the enclosing
+        scope, because on the local path those differ: `say` chunks, and a
+        failure on chunk 3 of 4 still played chunks 1 and 2 out loud. Recording
+        the whole string would claim the owner heard a sentence that never
+        played; recording nothing would let the buddy later offer, as news,
+        something they already heard. Both are the same defect — a record that
+        does not match the room.
 
         This entry is NEVER announced to the buddy, whatever it said. The owner
         already heard it; a voice channel that reads the audio back is the
@@ -321,13 +321,20 @@ def cmd_say(args) -> int:
         the buddy can see what the fleet has already said and decline to offer
         it as news.
         """
-        if rc == 0:
-            from agentwire import fleet_activity
+        if not heard.strip():
+            return
+        from agentwire import fleet_activity
 
-            try:
-                fleet_activity.note_spoke(text, session=session or "", sink=sink)
-            except Exception:  # noqa: BLE001  # speaking is the job; the record is not
-                pass
+        try:
+            fleet_activity.note_spoke(heard, session=session or "", sink=sink)
+        except Exception:  # noqa: BLE001  # speaking is the job; the record is not
+            pass
+
+    def _say_result(rc: int, sink: str, clients: int = 0) -> int:
+        """Report which sink actually received the audio (#444): browser
+        (played by N connected clients), local speakers / OS voice, or a
+        failed dispatch — instead of a blind "queued".
+        """
         if json_mode:
             _output_json({"success": rc == 0, "sink": sink if rc == 0 else None,
                           "clients": clients, "session": session, "toast": toast_ok,
@@ -342,6 +349,9 @@ def cmd_say(args) -> int:
 
         if has_connections:
             rc = _remote_say(text, actual_session, portal_url)
+            # One dispatch, one outcome: the browser path is not chunked here.
+            if rc == 0:
+                _record_spoken(text, "browser")
             return _say_result(rc, "browser", clients)
 
     # No portal connections — chunk locally for better TTS quality
@@ -349,14 +359,19 @@ def cmd_say(args) -> int:
     chunks = chunk_text(text)
 
     last_sink = "os-voice"
+    spoken: list[str] = []
     for chunk in chunks:
         result, last_sink = _local_say_dispatch(
             chunk, voice, exaggeration, cfg_weight, tts_config,
             backend=backend, instructions=instructions, language=language, stream=stream
         )
         if result != 0:
+            # Partial: the chunks before this one PLAYED. Record exactly those.
+            _record_spoken(" ".join(spoken), last_sink)
             return _say_result(result, last_sink)
+        spoken.append(chunk)
 
+    _record_spoken(" ".join(spoken), last_sink)
     return _say_result(0, last_sink)
 
 

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1825,17 +1825,24 @@ def _get_agentwire_path() -> str:
 def post_desktop_notification(text: str, session: str | None = None,
                               priority: str = "normal", timeout: float | None = None,
                               artifact: dict | None = None) -> dict:
-    """THE toast call. Every producer goes through here (#1016).
+    """The one call for a toast that carries TEXT, and the seam that records it (#1016).
 
     Returns the portal's parsed response, plus ``success`` — never raises.
 
-    It is the single seam on purpose. There were three toast producers
-    (`agentwire notify-user`, `say --display`, and the MCP ``notify_user``
-    tool), the MCP one POSTing on its own transport — and since agents use MCP
-    and humans use the CLI, the agent-generated toasts were exactly the ones a
-    CLI-side hook could not see. Recording per producer is the shape that
-    leaves the next producer silent, so the record lives here, below all of
-    them, where a new caller inherits it by construction.
+    Every producer of a text toast goes through here: `agentwire notify-user`,
+    the MCP ``notify_user`` tool, `say --display`, and the zombie reaper's
+    high-priority notice. The MCP one used to POST on its own transport — and
+    since agents use MCP and humans use the CLI, the agent-generated toasts
+    were exactly the ones a CLI-side hook could not see. Recording per producer
+    is the shape that leaves the next producer silent, so the record lives
+    here, below all of them, where a new caller inherits it by construction.
+
+    **Not every POST to that endpoint, and the difference is the text.**
+    ``mcp_desktop._announce_artifact`` posts a bodiless click-to-open artifact
+    notice (#817) and deliberately stays where it is: it has no ``text``, so
+    routing it here would write ledger entries reading "toast from : " — an
+    entry with nothing in it is worse than no entry, since the buddy would
+    offer it as something that happened.
 
     **Recorded whether or not the portal took it.** A toast the portal refused
     is the case where the buddy knowing about it matters MOST: nothing reached
@@ -1855,7 +1862,20 @@ def post_desktop_notification(text: str, session: str | None = None,
             "POST", f"{_get_portal_url()}/api/desktop/notification", json=body, timeout=5,
         )
         if response.status_code != 200:
-            result = {"success": False, "error": f"HTTP {response.status_code}"}
+            # The portal's own body says WHICH field was wrong ("text
+            # required", "artifact.url required"), and that message is what the
+            # MCP tool hands back to the agent that called it. A bare "HTTP
+            # 400" is a refusal with no next move — the defect this project
+            # keeps closing — so the body is read and only falls back to the
+            # status line when there isn't one.
+            detail = ""
+            try:
+                body = response.json()
+                detail = str(body.get("error") or "").strip() if isinstance(body, dict) else ""
+            except Exception:  # noqa: BLE001  # not JSON, or no body at all
+                detail = (response.text or "").strip()[:200]
+            result = {"success": False,
+                      "error": f"HTTP {response.status_code}" + (f": {detail}" if detail else "")}
         else:
             data = response.json()
             result = {**data, "success": bool(data.get("success", True))}

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1822,34 +1822,64 @@ def _get_agentwire_path() -> str:
     return os.path.expanduser("~/.local/bin/agentwire")
 
 
-def _post_desktop_notification(text: str, session: str | None = None, priority: str = "normal",
-                               timeout: float | None = None) -> bool:
-    """POST a toast to the portal's desktop-notification endpoint. Best-effort.
+def post_desktop_notification(text: str, session: str | None = None,
+                              priority: str = "normal", timeout: float | None = None,
+                              artifact: dict | None = None) -> dict:
+    """THE toast call. Every producer goes through here (#1016).
 
-    Shared by `agentwire notify-user` and the `say --display` path. Returns True
-    on a 2xx, False on any failure (no portal, network error) — never raises.
-    `timeout` (seconds) overrides the frontend's auto-fade default; 0 = sticky.
+    Returns the portal's parsed response, plus ``success`` — never raises.
+
+    It is the single seam on purpose. There were three toast producers
+    (`agentwire notify-user`, `say --display`, and the MCP ``notify_user``
+    tool), the MCP one POSTing on its own transport — and since agents use MCP
+    and humans use the CLI, the agent-generated toasts were exactly the ones a
+    CLI-side hook could not see. Recording per producer is the shape that
+    leaves the next producer silent, so the record lives here, below all of
+    them, where a new caller inherits it by construction.
+
+    **Recorded whether or not the portal took it.** A toast the portal refused
+    is the case where the buddy knowing about it matters MOST: nothing reached
+    the screen, and the voice channel is what is left.
     """
-    import ssl
-
     body: dict = {"text": text, "priority": priority}
     if session:
         body["session"] = session
     if timeout is not None:
         body["timeout"] = timeout
+    if artifact:
+        body["artifact"] = artifact
+
+    result: dict
     try:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        req = urllib.request.Request(
-            f"{_get_portal_url()}/api/desktop/notification",
-            data=json.dumps(body).encode(),
-            headers={"Content-Type": "application/json", **_portal_auth_headers()},
+        response = portal_request(
+            "POST", f"{_get_portal_url()}/api/desktop/notification", json=body, timeout=5,
         )
-        with urllib.request.urlopen(req, context=ctx, timeout=5):
-            return True
-    except Exception:
-        return False
+        if response.status_code != 200:
+            result = {"success": False, "error": f"HTTP {response.status_code}"}
+        else:
+            data = response.json()
+            result = {**data, "success": bool(data.get("success", True))}
+    except Exception as exc:  # noqa: BLE001  # best-effort: the portal may be down
+        result = {"success": False,
+                  "error": f"Portal not reachable. Is it running? ({exc})"}
+
+    try:
+        from . import fleet_activity
+
+        fleet_activity.note_toast(text, session=session or "", priority=priority)
+    except Exception:  # noqa: BLE001  # awareness must never break the toast
+        pass
+    return result
+
+
+def _post_desktop_notification(text: str, session: str | None = None, priority: str = "normal",
+                               timeout: float | None = None) -> bool:
+    """Did the toast land? The bool-shaped view of :func:`post_desktop_notification`.
+
+    `timeout` (seconds) overrides the frontend's auto-fade default; 0 = sticky.
+    """
+    return post_desktop_notification(
+        text, session=session, priority=priority, timeout=timeout)["success"]
 
 
 def _resolve_posture_from_args(args) -> tuple[str | None, str | None]:

--- a/agentwire/fleet_activity.py
+++ b/agentwire/fleet_activity.py
@@ -74,6 +74,7 @@ quiet fleet is the #885 shape.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -193,6 +194,23 @@ def _read_entries() -> list[dict]:
     return entries
 
 
+def _older_than(entry: dict, cutoff: datetime) -> "bool | None":
+    """Is *entry* older than *cutoff*? ``None`` when its timestamp is unusable.
+
+    Parse AND compare in one guarded step, because the comparison is the half
+    that raises. `fromisoformat` was already wrapped, but a NAIVE timestamp
+    parses fine and then blows up on `<` with `TypeError: can't compare
+    offset-naive and offset-aware datetimes` — outside the guard. That made
+    `agentwire activity list` traceback on one hand-edited line, and falsified
+    the "never raises" contract every producer here is written against (they
+    survived only on their own outer excepts, which is not the same guarantee).
+    """
+    try:
+        return datetime.fromisoformat(str(entry.get("ts"))) < cutoff
+    except (TypeError, ValueError):
+        return None
+
+
 def _trim(path: Path) -> None:
     """Keep the ledger bounded. Best-effort, and never destructive on failure.
 
@@ -284,11 +302,10 @@ def recent(
             continue
         if session and entry.get("session") != session:
             continue
-        try:
-            when = datetime.fromisoformat(str(entry.get("ts")))
-        except (TypeError, ValueError):
+        older = _older_than(entry, cutoff)
+        if older is None:
             continue
-        if when < cutoff:
+        if older:
             # Append order is chronological, so the first entry older than the
             # window ends the walk — every remaining one is older still.
             break
@@ -307,11 +324,10 @@ def _announced_recently(event: str, subject: str, cooldown: timedelta) -> bool:
     """
     cutoff = _now() - cooldown
     for entry in reversed(_read_entries()):
-        try:
-            when = datetime.fromisoformat(str(entry.get("ts")))
-        except (TypeError, ValueError):
+        older = _older_than(entry, cutoff)
+        if older is None:
             continue
-        if when < cutoff:
+        if older:
             return False
         if (
             entry.get("event") == event
@@ -383,15 +399,36 @@ def note(
 # ---------------------------------------------------------------------------
 
 
+#: Roles the OWNER talks to. Checked against both the ROLE axis
+#: (``orchestrator``) and the persona ``roles`` list (``anchor``, Briefing
+#: Mode's terse human-facing replacement for it), because the two axes carry it
+#: differently and either one means the same thing here: this session's idle is
+#: a conversational turn ending, with the owner on the other side of it.
+_INTERACTIVE_ROLES = frozenset({"orchestrator", "anchor"})
+
+
 def _is_delegated(session: str) -> bool:
     """Did somebody hand this session its work?
 
-    The gate on announcing an idle. True for a session with a recorded parent
-    (``created_by``), a worker/reviewer ROLE, or a worktree checkout — the three
-    independent ways #716 says "this is somebody's delegated work". False for a
-    root orchestrator, whose idle is a conversational turn ending rather than a
-    job finishing, and for anything with no record at all: an unknown session is
-    not evidence of delegation, and the failure direction here is silence.
+    The gate on announcing an idle. #716's three axes are INDEPENDENT — a
+    worktree is *location*, a role is *authority* — so this is not a plain OR
+    over them: **authority is consulted first, and it can veto.**
+
+    That ordering is the whole correctness of the gate, and the OR got it
+    wrong. ``agentwire orchestrator`` is sugar for ``worktree --kind
+    orchestrator``, so the owner's blessed durable window has ``role:
+    orchestrator``, ``created_by: ''`` *and* ``worktree_path`` set — two live
+    sessions on this machine are exactly that shape. Under an OR the location
+    axis overruled the role, the interactive window read as delegated work, and
+    the buddy announced "… is idle and done working" every fifteen minutes into
+    a conversation the owner was having with that very session. That is the
+    narrator failure this gate exists to prevent, reached from inside the gate.
+
+    So: an interactive role is never delegated, whatever its location. After
+    that veto, any one of a recorded parent, a worker/reviewer role, or a
+    worktree checkout is enough. Anything with no record at all is not
+    delegated either — an unknown session is not evidence, and the failure
+    direction here is silence.
     """
     from . import core
 
@@ -400,6 +437,10 @@ def _is_delegated(session: str) -> bool:
     except Exception:  # noqa: BLE001
         return False
     if not meta:
+        return False
+    roles = meta.get("roles")
+    persona = {str(r) for r in roles} if isinstance(roles, list) else set()
+    if str(meta.get("role") or "") in _INTERACTIVE_ROLES or (persona & _INTERACTIVE_ROLES):
         return False
     if str(meta.get("created_by") or "").strip():
         return True
@@ -477,11 +518,21 @@ def note_toast(text: str, *, session: str = "", priority: str = "normal") -> dic
     High priority is announced; normal is ledger-only. The distinction is the
     caller's own declaration of urgency about a screen the owner may not be
     looking at — this layer does not second-guess it in either direction.
+
+    **The subject is the toast, not the sender.** Every other producer here has
+    one subject per thing-that-happened (a session, a task name), but a session
+    posts *different* toasts: keying the cooldown on the sender made "build is
+    red" swallow "deploy rolled back" 60 seconds later, and sessionless toasts
+    shared one subject fleet-wide. On the one surface whose caller has declared
+    the message urgent, a false-reject is silence with no screen behind it —
+    the expensive half. So the throttle groups by content, and what it still
+    catches is the case it was for: the same toast repeating.
     """
     high = priority == "high"
     body = f"toast for the owner: {text}" if not session else f"toast from {session}: {text}"
+    digest = hashlib.sha256(str(text).encode("utf-8", "replace")).hexdigest()[:12]
     return note("toast_high" if high else "toast", session=session, text=body,
-                priority=priority)
+                subject=f"{session}:{digest}", priority=priority)
 
 
 def note_spoke(text: str, *, session: str = "", sink: str = "") -> dict:

--- a/agentwire/fleet_activity.py
+++ b/agentwire/fleet_activity.py
@@ -1,0 +1,500 @@
+"""What the fleet DID — the awareness tier, and the ruling on what earns a voice (#1016).
+
+The buddy could already be *told* things: ``msg send --to buddy`` reaches its
+spool, and :mod:`~agentwire.fleet_alerts` gives the machine's own detectors a
+way to address it. What nothing did was emit the fleet's ordinary signals — a
+session going idle, a scheduled task finishing, a toast shown to the owner,
+anything spoken aloud through fleet TTS. So the buddy was blind to the two
+things the owner most wants from it: it could not check in, and it could not
+tell that the fleet had *already said* something out loud.
+
+**The routing was never the hard part; the judgment is.** Everything in the
+buddy's spool eventually gets SPOKEN — the notifier volunteers unread mail at a
+gap (#962) and an ``escalation`` cuts across the buddy's own voice (#967).
+There is no "quiet" kind. So a producer that pushes every lifecycle event into
+the spool does not make the buddy aware, it makes it a narrator: a session that
+goes idle after every conversational turn would buy an utterance every time.
+
+Hence **two tiers, and the split is the whole design**:
+
+**1. The LEDGER (this module's file) — awareness, never volunteered.** Every
+event is appended here, and the buddy reads it only when asked ("what's been
+happening?"). Nothing in it is pushed, so recording an event is free of the
+interrupt question entirely, and the closed list of unprompted paths in
+``instructions.VOICE_MODE`` stays closed — this adds a *pull*, not a fourth
+push. This is also what makes the two audio surfaces one: every ``agentwire
+say`` is recorded here, so the buddy knows what the owner has already heard
+and can decline to repeat it as news.
+
+**2. The SPOOL (ordinary typed mail, via fleet_alerts) — for what a person
+would actually want interrupting a gap.** :data:`ANNOUNCE` is that ruling,
+pinned as data. It is deliberately short, and each entry has to answer "would a
+colleague walk over and tell me this?":
+
+- ``session_idle`` — only for a session somebody DELEGATED (a recorded parent,
+  or a worker/reviewer role, or a worktree checkout). That is the event the
+  owner described wanting: work they handed off has finished and wants a
+  decision. A root orchestrator going idle is a conversational turn ending,
+  not news, and announcing it would fire after every exchange the owner has
+  with their own session — the failure that retires a channel.
+- ``task_completed`` — a scheduled task finished. The owner did not watch it
+  start and cannot see it end; this is the canonical "check in and offer a
+  summary" event. A failed one is a ``request`` rather than a ``done``, by the
+  same inherit-rule shape ``fleet_alerts`` already uses for dead letters: the
+  fleet has made a judgment and the kind should carry it.
+- ``toast_high`` — a ``notify-user --priority high`` toast. The one notify
+  surface that already DECLARES urgency, and it declares it about a screen the
+  owner may not be looking at. An ordinary toast does not qualify; it is
+  ledger-only.
+
+**Not announced, and on purpose.** ``spoke`` (an ``agentwire say``) is never
+announced, whatever it said: the owner already heard it, and a channel that
+repeats audio back at you is worse than one that stays quiet. Portal lifecycle
+churn (``session_created``/``session_closed``/``pane_died``) is ledger-only —
+true, cheap, and not something anyone wants read aloud. Neither of those is an
+oversight; both are answers.
+
+**Nothing here interrupts.** No lifecycle event is ever an ``escalation``. The
+interrupt tier stays exactly the two conditions ``fleet_alerts`` already ruled
+on — the ones nothing clears without a human. An idle session is not burning.
+
+**Throttled per subject, from the ledger itself.** A flapping session must not
+be able to buy an utterance per flap, so an announcement is suppressed when an
+announced record for the same (event, subject) sits inside
+:data:`ANNOUNCE`'s cooldown. The check reads the ledger rather than a second
+state file — the record is written BEFORE the emit decision, so there is
+exactly one thing to keep consistent.
+
+**Every entry point is best-effort.** A producer's job is to do its own job:
+``agentwire say`` must speak and the scheduler must finish its dispatch even if
+this file is unwritable. Failures are logged into the fleet-alert event log
+rather than swallowed, because a producer that cannot be distinguished from a
+quiet fleet is the #885 shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+from . import fleet_alerts
+
+#: Sender stamped on announced activity. Distinct from ``fleet_alerts.SENDER``
+#: so a recipient (and the dead-letter detector) can tell the machine's own
+#: alarms apart from the fleet's ordinary comings and goings. Defined THERE and
+#: re-exported here: the recursion guard in ``inbox`` has to name it, and a
+#: second literal is how the two drift.
+SENDER = fleet_alerts.ACTIVITY_SENDER
+
+#: Events the ledger accepts. A closed set: an unknown event name is a coding
+#: bug at a call site, and a ledger that accepts anything is one nothing can
+#: query by kind.
+EVENTS = (
+    "session_idle",       # a pane-0 session finished a turn and went quiet
+    "task_completed",     # a scheduled task run ended (any status)
+    "toast_high",         # notify-user --priority high
+    "toast",              # notify-user --priority normal
+    "spoke",              # agentwire say — the owner has ALREADY heard this
+    "session_created",
+    "session_closed",
+    "pane_died",
+)
+
+#: THE RULING — which events reach the buddy's spool, and how long before the
+#: same subject may do it again. Membership means "worth interrupting a gap
+#: for"; absence means ledger-only. The kind itself lives in
+#: ``fleet_alerts.DETECTOR_KINDS`` so that "what may interrupt" stays answerable
+#: in one place across detectors and lifecycle alike.
+#:
+#: Cooldowns are per (event, subject), and each one is a claim about how often
+#: the *underlying thing* can honestly be news:
+#:
+#: - ``session_idle`` 15m — a worker can go idle, be nudged, and go idle again
+#:   within a minute; the owner wants "it finished", not each oscillation.
+#: - ``task_completed`` 2m — scheduled runs are minutes-to-hours apart, so this
+#:   only collapses a retry storm on one task name. Two genuinely different
+#:   tasks finishing together are two different subjects and both are said.
+#: - ``toast_high`` 5m — a session that loops on a high-priority toast is the
+#:   realistic bad case, and it must not buy an utterance per loop.
+ANNOUNCE: dict[str, timedelta] = {
+    "session_idle": timedelta(minutes=15),
+    "task_completed": timedelta(minutes=2),
+    "toast_high": timedelta(minutes=5),
+}
+
+#: How many entries the ledger keeps, and the slack before a trim runs. The
+#: file is read whole by :func:`recent` and by the throttle check, so it is
+#: bounded rather than rotated: the buddy wants "recently", never "since
+#: forever", and an unbounded append would put a growing read on every
+#: producer's path.
+#: The trim is AMORTIZED, not exact: it fires only above ``TRIM_AT``, so the
+#: file lives between ``MAX_ENTRIES`` and ``TRIM_AT`` rather than at a fixed
+#: length. Rewriting on every append would put a whole-file write on the say
+#: path for nothing.
+MAX_ENTRIES = 1000
+TRIM_AT = 1300
+
+#: Floor on a serialized entry's length, for the cheap size check in
+#: :func:`_trim`. Deliberately far below a real line (the ISO timestamp alone is
+#: 32 bytes and every entry carries five more keys) — this must never skip a
+#: trim that was due, and being conservative only costs an occasional read.
+_MIN_LINE = 60
+
+#: Default window for :func:`recent`. Anything older is history, not awareness.
+DEFAULT_WINDOW = timedelta(hours=12)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _config_dir() -> Path:
+    """Read through the MODULE, never a from-import (#902) — see fleet_alerts."""
+    from . import core
+
+    return Path(core.CONFIG_DIR)
+
+
+def ledger_path() -> Path:
+    return _config_dir() / "fleet-activity.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# The ledger
+# ---------------------------------------------------------------------------
+
+
+def _read_entries() -> list[dict]:
+    """Every ledger entry in append order. Unparseable lines are skipped.
+
+    A truncated tail (a producer killed mid-write) costs one entry, never the
+    file: the same tolerance ``delivery._entries`` applies to the spool.
+    """
+    path = ledger_path()
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    entries: list[dict] = []
+    for line in raw:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict):
+            entries.append(entry)
+    return entries
+
+
+def _trim(path: Path) -> None:
+    """Keep the ledger bounded. Best-effort, and never destructive on failure.
+
+    Rewritten through a temp file + ``os.replace`` so a crash mid-trim leaves
+    the old ledger intact rather than a half-written one — the same discipline
+    ``fleet_alerts._write_index`` uses, for the same reason.
+    """
+    try:
+        # A stat before a read: the trim runs on every append, and the common
+        # case is a ledger nowhere near the cap. ``_MIN_LINE`` is a floor on a
+        # line's length (the timestamp alone is longer), so a file under this
+        # size cannot hold TRIM_AT entries and needs no read to prove it.
+        if path.stat().st_size < TRIM_AT * _MIN_LINE:
+            return
+    except OSError:
+        return
+    entries = _read_entries()
+    if len(entries) <= TRIM_AT:
+        return
+    keep = entries[-MAX_ENTRIES:]
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(
+            "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in keep),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+
+
+def record(
+    event: str,
+    *,
+    session: str = "",
+    text: str = "",
+    subject: str = "",
+    announced: bool = False,
+    **detail,
+) -> dict:
+    """Append one activity entry. Returns it; never raises.
+
+    *subject* is what the throttle groups by — the session for a lifecycle
+    event, the task name for a scheduled run. It defaults to *session* so a
+    caller can only get it wrong by trying.
+    """
+    if event not in EVENTS:
+        # A coding bug, not an environment failure — but a producer must not
+        # die of it either. Recorded loudly enough to be found.
+        fleet_alerts.log_event("activity_unknown_event", activity_event=event)
+        return {}
+    entry = {
+        "ts": _now().isoformat(),
+        "event": event,
+        "session": session,
+        "subject": subject or session,
+        "text": str(text)[:2000],
+        "announced": bool(announced),
+        **{k: v for k, v in detail.items() if v not in (None, "")},
+    }
+    path = ledger_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        _trim(path)
+    except (OSError, TypeError, ValueError) as exc:
+        fleet_alerts.log_event("activity_write_failed", activity_event=event, error=str(exc))
+    return entry
+
+
+def recent(
+    limit: int = 50,
+    *,
+    event: str = "",
+    session: str = "",
+    window: "timedelta | None" = None,
+) -> list[dict]:
+    """The most recent entries, newest first, within *window* (default 12h).
+
+    Filters are exact matches, never prefixes: the buddy resolves a session
+    name from ``fleet_sessions`` before asking, and a fuzzy match here would
+    answer confidently about the wrong session.
+    """
+    cutoff = _now() - (window or DEFAULT_WINDOW)
+    out: list[dict] = []
+    for entry in reversed(_read_entries()):
+        if event and entry.get("event") != event:
+            continue
+        if session and entry.get("session") != session:
+            continue
+        try:
+            when = datetime.fromisoformat(str(entry.get("ts")))
+        except (TypeError, ValueError):
+            continue
+        if when < cutoff:
+            # Append order is chronological, so the first entry older than the
+            # window ends the walk — every remaining one is older still.
+            break
+        out.append(entry)
+        if len(out) >= max(1, limit):
+            break
+    return out
+
+
+def _announced_recently(event: str, subject: str, cooldown: timedelta) -> bool:
+    """Has an ANNOUNCED entry for this (event, subject) landed inside *cooldown*?
+
+    Reads the ledger rather than a second state file. The record is written
+    before the emit decision, so there is one thing to keep consistent — and a
+    lost ledger costs a duplicate announcement, never a lost one.
+    """
+    cutoff = _now() - cooldown
+    for entry in reversed(_read_entries()):
+        try:
+            when = datetime.fromisoformat(str(entry.get("ts")))
+        except (TypeError, ValueError):
+            continue
+        if when < cutoff:
+            return False
+        if (
+            entry.get("event") == event
+            and entry.get("subject") == subject
+            and entry.get("announced")
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Record + (maybe) announce
+# ---------------------------------------------------------------------------
+
+
+def note(
+    event: str,
+    *,
+    session: str = "",
+    text: str = "",
+    subject: str = "",
+    kind: str = "",
+    exclude: Iterable[str] = (),
+    **detail,
+) -> dict:
+    """Record *event*, and announce it to fleet-alert subscribers if it earns one.
+
+    Returns ``{"recorded": entry, "announced": [names]}``. Never raises: this
+    sits inside producers whose real job is speaking, dispatching or notifying.
+
+    *exclude* names sessions that must not receive the announcement. The event's
+    own session is always excluded — a session hearing about itself is noise —
+    and callers add whoever already heard it by another route (an idle child's
+    parent gets ``notify-parent``; mailing it again is the same news twice).
+    """
+    subject = subject or session
+    cooldown = ANNOUNCE.get(event)
+    throttled = bool(cooldown) and _announced_recently(event, subject, cooldown)
+    will_announce = bool(cooldown) and not throttled
+
+    entry = record(
+        event,
+        session=session,
+        text=text,
+        subject=subject,
+        announced=will_announce,
+        **detail,
+    )
+    if not will_announce:
+        return {"recorded": entry, "announced": [], "throttled": throttled}
+
+    skip = {session, *(exclude or ())} - {""}
+    try:
+        reached = fleet_alerts.emit_for(
+            event,
+            text,
+            kind=kind or None,
+            exclude=skip,
+            sender=SENDER,
+        )
+    except Exception as exc:  # noqa: BLE001  # awareness must not break producers
+        fleet_alerts.log_event("activity_emit_failed", activity_event=event, error=str(exc))
+        reached = []
+    return {"recorded": entry, "announced": reached, "throttled": False}
+
+
+# ---------------------------------------------------------------------------
+# Producer helpers — one per surface, each owning its own wording
+# ---------------------------------------------------------------------------
+
+
+def _is_delegated(session: str) -> bool:
+    """Did somebody hand this session its work?
+
+    The gate on announcing an idle. True for a session with a recorded parent
+    (``created_by``), a worker/reviewer ROLE, or a worktree checkout — the three
+    independent ways #716 says "this is somebody's delegated work". False for a
+    root orchestrator, whose idle is a conversational turn ending rather than a
+    job finishing, and for anything with no record at all: an unknown session is
+    not evidence of delegation, and the failure direction here is silence.
+    """
+    from . import core
+
+    try:
+        meta = core.load_session_metadata(session)
+    except Exception:  # noqa: BLE001
+        return False
+    if not meta:
+        return False
+    if str(meta.get("created_by") or "").strip():
+        return True
+    if str(meta.get("role") or "") in {"worker", "reviewer"}:
+        return True
+    return bool(str(meta.get("worktree_path") or "").strip())
+
+
+def note_session_idle(session: str, text: str, *, parent: str = "") -> dict:
+    """A pane-0 session went idle. Announced only for DELEGATED work.
+
+    The ``--on-idle`` producer already drops infrastructure services before it
+    gets here (they cycle idle constantly and are nobody's delegated work), so
+    this adds exactly one further question: did somebody hand this session its
+    task? See :func:`_is_delegated` for why a root orchestrator is ledger-only.
+    """
+    # The caller's phrasing is already a predicate ("is idle and done working",
+    # from the idle hook), so the session name PREFIXES it rather than being
+    # joined to it — "child is idle — is idle and done working" is what the
+    # obvious concatenation produces, and it is what the owner would hear.
+    body = f"{session} {text}".strip() if text else f"{session} is idle"
+    if not _is_delegated(session):
+        return {"recorded": record("session_idle", session=session, text=body),
+                "announced": [], "throttled": False}
+    return note("session_idle", session=session, text=body, exclude=(parent,) if parent else ())
+
+
+#: Run statuses whose CONDITION already has a detector of its own
+#: (``usage_limit_park``, ``auth_expired`` in ``fleet_alerts``). Recorded, never
+#: announced: the outage is machine-wide and its detector says so once, where
+#: this producer would say it again per task — the same news twice, from the one
+#: subsystem whose whole job is not doing that.
+_DETECTOR_OWNED_STATUSES = frozenset({"usage_limit", "auth_expired"})
+
+#: The one status that means the run did what it was asked. Spelled out rather
+#: than "not failed": ``incomplete`` and ``timeout`` are not successes, and a
+#: negated check would have quietly called them one.
+_TASK_OK = "complete"
+
+
+def note_task_completed(task: str, session: str, status: str, duration: int,
+                        summary: str) -> dict:
+    """A scheduled task run ended.
+
+    The kind carries the fleet's own verdict: a clean run is ``done`` (news),
+    anything else is ``request`` (it wants a person). Same inherit shape
+    ``fleet_alerts`` uses for a dead-lettered escalation — the judgment was
+    already made upstream, and flattening it here would throw it away.
+    """
+    ok = status == _TASK_OK
+    head = f"scheduled task '{task}' {'finished' if ok else status or 'ended'}"
+    body = f"{head}: {summary}".strip() if summary else head
+    if status in _DETECTOR_OWNED_STATUSES:
+        return {
+            "recorded": record("task_completed", session=session, subject=task,
+                               text=body, task=task, status=status, duration=duration),
+            "announced": [],
+            "throttled": False,
+        }
+    return note(
+        "task_completed",
+        session=session,
+        subject=task,
+        text=body,
+        kind="" if ok else "request",
+        task=task,
+        status=status,
+        duration=duration,
+    )
+
+
+def note_toast(text: str, *, session: str = "", priority: str = "normal") -> dict:
+    """The owner was shown a desktop toast.
+
+    High priority is announced; normal is ledger-only. The distinction is the
+    caller's own declaration of urgency about a screen the owner may not be
+    looking at — this layer does not second-guess it in either direction.
+    """
+    high = priority == "high"
+    body = f"toast for the owner: {text}" if not session else f"toast from {session}: {text}"
+    return note("toast_high" if high else "toast", session=session, text=body,
+                priority=priority)
+
+
+def note_spoke(text: str, *, session: str = "", sink: str = "") -> dict:
+    """Something was spoken aloud through fleet TTS. NEVER announced.
+
+    This is the entry that makes the two audio surfaces one. The owner has
+    already heard it, so repeating it back would be the worst thing this
+    feature could do; what the record buys is the opposite — the buddy can see
+    what was said and decline to offer it as news.
+    """
+    return note("spoke", session=session, text=text, sink=sink)
+
+
+def note_lifecycle(event: str, session: str, **detail) -> dict:
+    """A portal lifecycle event (session created/closed, pane died). Ledger-only."""
+    return note(event, session=session, text=f"{session}: {event}", **detail)

--- a/agentwire/fleet_activity.py
+++ b/agentwire/fleet_activity.py
@@ -528,6 +528,12 @@ def note_toast(text: str, *, session: str = "", priority: str = "normal") -> dic
     the expensive half. So the throttle groups by content, and what it still
     catches is the case it was for: the same toast repeating.
     """
+    if not str(text).strip():
+        # Nothing was shown to anybody, so nothing happened worth remembering.
+        # An entry reading "toast from ci: " is worse than no entry: the buddy
+        # would offer it as something that occurred and have nothing to say
+        # about it. Same reason `_announce_artifact` stays off this seam.
+        return {"recorded": {}, "announced": [], "throttled": False}
     high = priority == "high"
     body = f"toast for the owner: {text}" if not session else f"toast from {session}: {text}"
     digest = hashlib.sha256(str(text).encode("utf-8", "replace")).hexdigest()[:12]

--- a/agentwire/fleet_alerts.py
+++ b/agentwire/fleet_alerts.py
@@ -54,6 +54,22 @@ SUBSCRIBE_KEY = "fleet_alerts"
 #: alert about the alert (see ``inbox._escalate_dead_letters``).
 SENDER = "fleet-alerts"
 
+#: Sender stamped on the fleet's ordinary comings and goings
+#: (:mod:`~agentwire.fleet_activity`, #1016). Separate from :data:`SENDER` so a
+#: recipient can tell "the machine is broken" from "the machine did something",
+#: and defined HERE so the recursion guard below can name both without
+#: importing the producer.
+ACTIVITY_SENDER = "fleet-activity"
+
+#: Mail this machine sends itself. A dead-lettered one must not buy an alarm
+#: about the alarm — see ``inbox._alert_dead_letters``, which drops these by
+#: sender. Activity mail joins the set for the same reason plus one of its own:
+#: it is news by construction, so "a 'session went idle' notice was lost" does
+#: not earn a fleet-wide alert. It does still ride the dead-letter owner EMAIL
+#: (``_escalate_dead_letters``), which is deliberately left alone — that path is
+#: last-resort visibility, already coalesced to one message per batch.
+MACHINE_SENDERS = frozenset({SENDER, ACTIVITY_SENDER})
+
 #: How long a lease is good for without renewal. Long enough that a working
 #: session renewed at startup keeps hearing about the fleet for a full day of
 #: use; short enough that a subscriber which ran once last week is not still
@@ -93,11 +109,39 @@ DEFAULT_LEASE = timedelta(hours=12)
 #: looking at the output) and no per-finding throttle state to reuse, so a
 #: producer would re-announce the same durable, passive condition on every
 #: invocation. A dangling PR is not burning anything while it waits.
+#: The four below are DETECTORS — the machine reporting that something is
+#: wrong. The three after them are LIFECYCLE events (#1016): the fleet
+#: reporting that something happened. They share this table because the
+#: question is the same one — what may a producer put in front of a listener,
+#: and how loudly — and answering it in two places is how the two answers
+#: drift. What lifecycle events may NEVER be is ``escalation``: the interrupt
+#: tier stays the two conditions above that nothing clears without a human.
+#: Which lifecycle events reach the spool AT ALL, and how often, is the
+#: separate ruling in :data:`agentwire.fleet_activity.ANNOUNCE`.
+#:
+#: ``session_idle`` → **done**. Work somebody delegated has finished and is
+#:   waiting on a decision. Only ever emitted for a delegated session (a
+#:   recorded parent, a worker/reviewer role, or a worktree) — an interactive
+#:   orchestrator goes idle after every turn, and announcing that would fire
+#:   once per exchange the owner has with their own session.
+#:
+#: ``task_completed`` → **done**, with one inherit rule: a failed or timed-out
+#:   run is emitted as ``request``, because the fleet has already judged it as
+#:   needing a person and flattening that to news throws the judgment away.
+#:   Same shape as ``dead_letter``'s inherit rule above.
+#:
+#: ``toast_high`` → **request**. ``notify-user --priority high`` is the one
+#:   notify surface that declares its own urgency, and it declares it about a
+#:   screen the owner may not be looking at. An ordinary toast is not here at
+#:   all — it never reaches the spool.
 DETECTOR_KINDS: dict[str, str] = {
     "auth_expired": "escalation",
     "blocked_pane_no_parent": "escalation",
     "usage_limit_park": "note",
     "dead_letter": "request",
+    "session_idle": "done",
+    "task_completed": "done",
+    "toast_high": "request",
 }
 
 
@@ -284,6 +328,7 @@ def emit(
     ref: str = "",
     exclude: Iterable[str] = (),
     detector: str = "",
+    sender: str = SENDER,
 ) -> list[str]:
     """Enqueue one typed alert per live subscriber. Returns who was reached.
 
@@ -295,18 +340,26 @@ def emit(
 
     An unknown *kind* DOES raise: it can only be a coding bug at a call site,
     and silently dropping it would leave a detector that looks wired and is not.
+    An unknown *sender* raises for the same reason and one sharper: the
+    dead-letter guard drops our own stranded mail BY SENDER, so a producer that
+    stamped a name outside :data:`MACHINE_SENDERS` would quietly re-enter that
+    loop.
     """
     from . import inbox
 
     if kind not in inbox.KINDS:
         raise ValueError(f"invalid alert kind: {kind!r} (expected one of {inbox.KINDS})")
+    if sender not in MACHINE_SENDERS:
+        raise ValueError(
+            f"invalid alert sender: {sender!r} (expected one of {sorted(MACHINE_SENDERS)})"
+        )
 
     skip = set(exclude)
     targets = [name for name in subscribers() if name not in skip]
     reached: list[str] = []
     for target in targets:
         try:
-            inbox.enqueue(target, text, kind=kind, sender=SENDER, ref=ref)
+            inbox.enqueue(target, text, kind=kind, sender=sender, ref=ref)
         except Exception as exc:
             log_event("emit_failed", to=target, kind=kind, detector=detector, error=str(exc))
             continue

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -748,11 +748,16 @@ def _alert_dead_letters(batch: list[Message], reason: str) -> None:
     otherwise be reported to subscriber B, whose own copy is stuck for the same
     reason, once per drain forever. So our own undelivered alerts are dropped
     by SENDER, and every subscriber named as a recipient is excluded.
+
+    ``MACHINE_SENDERS`` rather than ``SENDER`` alone (#1016): lifecycle activity
+    is emitted under its own sender and is news by construction. "A 'session
+    went idle' notice was lost" is not worth an alert, and it would arrive
+    exactly when the fleet is already noisy enough to be stranding mail.
     """
     from . import fleet_alerts
 
     try:
-        mirrored = [m for m in batch if m.sender != fleet_alerts.SENDER]
+        mirrored = [m for m in batch if m.sender not in fleet_alerts.MACHINE_SENDERS]
         if not mirrored:
             return
         recipients = sorted({m.to for m in mirrored})

--- a/agentwire/mcp_notify.py
+++ b/agentwire/mcp_notify.py
@@ -4,7 +4,6 @@ from .core import run_agentwire_cmd
 from .mcp_core import (
     mcp,
 )
-from .mcp_desktop import _portal_request
 
 
 @mcp.tool()
@@ -91,12 +90,21 @@ def notify_user(text: str, session: str | None = None, priority: str = "normal",
     Returns:
         Notification ID or error description.
     """
-    body = {"text": text, "priority": priority}
-    if session:
-        body["session"] = session
-    if artifact_url:
-        body["artifact"] = {"url": artifact_url, "title": artifact_title or "Artifact"}
-    data = _portal_request("POST", "/api/desktop/notification", body)
+    # Routed through core's shared toast call rather than posting here (#1016).
+    # This tool is the one agents actually reach — CLAUDE.md's rule is MCP for
+    # agents, CLI for humans — so a producer that posts on its own transport is
+    # precisely the one a CLI-side hook cannot see, and agent-generated toasts
+    # were invisible to the fleet's awareness ledger. One seam, below every
+    # producer.
+    from .core import post_desktop_notification
+
+    data = post_desktop_notification(
+        text,
+        session=session,
+        priority=priority,
+        artifact=({"url": artifact_url, "title": artifact_title or "Artifact"}
+                  if artifact_url else None),
+    )
     if not data.get("success"):
         return f"Failed to post notification: {data.get('error', 'Unknown error')}"
     # Honest delivery: how many dashboards saw it live (#444). The toast is

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -21,6 +21,10 @@ from .core import (
     _post_desktop_notification,
 )
 
+#: The ``notify-event`` vocabulary worth remembering (#1016). Deliberately not
+#: the whole vocabulary — see :func:`cmd_notify`.
+_LEDGER_EVENTS = ("session_created", "session_closed", "pane_died")
+
 
 def cmd_notify_parent(args) -> int:
     """Notify parent session (worker→orchestrator communication).
@@ -74,6 +78,24 @@ def cmd_notify_parent(args) -> int:
         resolved = prompt_router.resolve_parent(current_session, current_pane)
         if resolved:
             target_session = resolved[0]
+
+    # Fleet awareness (#1016). An idle is the fleet's own "I finished" signal,
+    # and until now the ONLY thing it reached was a parent — so a listener with
+    # no parent link (the voice buddy) could not know a delegated job had
+    # landed. Recorded here, ABOVE the no-target return, because a root session
+    # going idle is exactly the case that returned early and told nobody.
+    #
+    # `exclude=target_session`: the parent hears this by paste in the lines
+    # below, and the same news twice is how a channel earns being ignored.
+    # Best-effort — the notify is the job, awareness is the bonus.
+    if getattr(args, 'on_idle', False) and current_session and current_pane == 0:
+        from agentwire import fleet_activity
+
+        try:
+            fleet_activity.note_session_idle(
+                current_session, text, parent=target_session or "")
+        except Exception:  # noqa: BLE001  # never break the idle path
+            pass
 
     # Build notification message (--raw sends verbatim — queued messages
     # already carry their own [WORKER SUMMARY ...] / [PROMPT ...] headers)
@@ -215,10 +237,23 @@ def cmd_notify_user(args) -> int:
     json_mode = getattr(args, "json", False)
     if not text.strip():
         return _output_result(False, json_mode, "Usage: agentwire notify-user <text>")
+    priority = getattr(args, "priority", "normal")
     ok = _post_desktop_notification(
-        text, session=getattr(args, "session", None),
-        priority=getattr(args, "priority", "normal"),
+        text, session=getattr(args, "session", None), priority=priority,
     )
+    # Fleet awareness (#1016). A toast is a message to the OWNER on a screen
+    # they may not be looking at — the exact gap the voice channel exists to
+    # cover. Recorded whether or not the portal took it (a toast that failed to
+    # post is the case where the buddy knowing about it matters MOST), and only
+    # a --priority high one is ever spoken: the caller declared that urgency
+    # itself, and this layer neither invents it nor overrules it.
+    from agentwire import fleet_activity
+
+    try:
+        fleet_activity.note_toast(
+            text, session=getattr(args, "session", None) or "", priority=priority)
+    except Exception:  # noqa: BLE001  # never break the toast path
+        pass
     return _output_result(ok, json_mode,
                           "Toast posted." if ok else "Failed to post toast (portal not reachable?)")
 
@@ -241,6 +276,20 @@ def cmd_notify(args) -> int:
 
     if not event:
         return _output_result(False, json_mode, "Event is required")
+
+    # Fleet awareness (#1016) — LEDGER ONLY, and only for the three events that
+    # describe a session's existence. The rest of this verb's vocabulary
+    # (client_attached, pane_focused, window_activity) fires on every glance at
+    # a terminal; recording it would bury the events that mean something under
+    # events that mean somebody moved a mouse. None of the three is ever spoken:
+    # "a session started" is context for a question, not news to volunteer.
+    if event in _LEDGER_EVENTS and session:
+        from agentwire import fleet_activity
+
+        try:
+            fleet_activity.note_lifecycle(event, session)
+        except Exception:  # noqa: BLE001  # tmux hooks must never fail loudly
+            pass
 
     portal_url = _get_portal_url()
     if not portal_url:

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -237,23 +237,13 @@ def cmd_notify_user(args) -> int:
     json_mode = getattr(args, "json", False)
     if not text.strip():
         return _output_result(False, json_mode, "Usage: agentwire notify-user <text>")
-    priority = getattr(args, "priority", "normal")
+    # Fleet awareness (#1016) rides inside _post_desktop_notification, below
+    # every toast producer — see core.post_desktop_notification. Nothing to do
+    # here: a per-producer hook is what leaves the next producer silent.
     ok = _post_desktop_notification(
-        text, session=getattr(args, "session", None), priority=priority,
+        text, session=getattr(args, "session", None),
+        priority=getattr(args, "priority", "normal"),
     )
-    # Fleet awareness (#1016). A toast is a message to the OWNER on a screen
-    # they may not be looking at — the exact gap the voice channel exists to
-    # cover. Recorded whether or not the portal took it (a toast that failed to
-    # post is the case where the buddy knowing about it matters MOST), and only
-    # a --priority high one is ever spoken: the caller declared that urgency
-    # itself, and this layer neither invents it nor overrules it.
-    from agentwire import fleet_activity
-
-    try:
-        fleet_activity.note_toast(
-            text, session=getattr(args, "session", None) or "", priority=priority)
-    except Exception:  # noqa: BLE001  # never break the toast path
-        pass
     return _output_result(ok, json_mode,
                           "Toast posted." if ok else "Failed to post toast (portal not reachable?)")
 

--- a/agentwire/scheduler/report.py
+++ b/agentwire/scheduler/report.py
@@ -16,7 +16,17 @@ from .schedule import _compute_next_eligible, _is_in_flight
 
 
 def _log_event(event: str, **fields) -> None:
-    """Append an event to the scheduler JSONL log."""
+    """Append an event to the scheduler JSONL log.
+
+    Also the seam where a finished run becomes fleet awareness (#1016). Here
+    rather than at the two dispatch call sites for the reason the CLAUDE.md
+    worktree-path and session-name rulings keep re-teaching: a per-call-site
+    copy is what drifts, and a third dispatch path would ship with no awareness
+    and nothing to say so. ``task_completed`` is logged exactly once per run by
+    both the in-place and worktree dispatchers, and it carries the whole story
+    (status, duration, the parsed summary), which is what makes it the right
+    event rather than the convenient one.
+    """
     from agentwire import scheduler as _sched
 
     entry = {
@@ -24,6 +34,22 @@ def _log_event(event: str, **fields) -> None:
         "event": event,
         **fields,
     }
+    if event == "task_completed":
+        # The owner did not watch this start and cannot see it end — this is the
+        # canonical "check in and offer a summary" event. Best-effort: a
+        # dispatch must finish recording its own run whatever this does.
+        from agentwire import fleet_activity
+
+        try:
+            fleet_activity.note_task_completed(
+                task=str(fields.get("task") or ""),
+                session=str(fields.get("session") or ""),
+                status=str(fields.get("status") or ""),
+                duration=int(fields.get("duration") or 0),
+                summary=str(fields.get("summary") or ""),
+            )
+        except Exception:  # noqa: BLE001
+            pass
     try:
         events_path = _sched._sched_config().events_file
     except Exception:

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -738,23 +738,36 @@ function createInboxNotifier(deps) {
   function isMachine(m) { return !!m && !!MACHINE_SENDERS[m.from]; }
   function speaker(m) { return isMachine(m) ? "the fleet" : ((m && m.from) || "someone"); }
 
-  function composeNotice(messages) {
+  // HOW MANY BODIES ONE UTTERANCE MAY CARRY. Speech cannot be skimmed and the
+  // owner cannot predict when it stops, so an unbounded coalesce is a monologue
+  // waiting for a fan-out: ten workers landing in one 5s poll window produced
+  // one ~2500-character utterance, spoken over nothing the owner asked for. The
+  // overflow is NOT dropped and NOT acked — it stays unread and the next quiet
+  // tick says the next three, which is the same "announced late, never lost"
+  // property the interrupt tier already relies on.
+  var MAX_NOTICE_BODIES = 3;
+
+  function composeNotice(messages, waiting) {
     // An escalation in the batch names itself as one — the owner should be
     // able to hear the difference between news and an alarm.
     var prefix = messages.some(isUrgent) ? "Heads up \\u2014 " : "";
+    // Said out loud rather than left implicit: the owner has to be able to tell
+    // "that was everything" from "there is more coming", or a capped batch
+    // sounds exactly like a complete one.
+    var tail = waiting > 0 ? " And " + waiting + " more waiting." : "";
     if (messages.length === 1) {
       var m = messages[0];
       // No verb for machine mail: the body is already a whole statement
       // ("auth-fix is idle and done working"), so any verb here would be the
       // notifier narrating a relationship that does not exist.
-      if (isMachine(m)) return prefix + "From the fleet: " + trimBody(m.text);
+      if (isMachine(m)) return prefix + "From the fleet: " + trimBody(m.text) + tail;
       var verb = isUrgent(m) ? " escalated: " : " got back to you: ";
-      return prefix + (m.from || "someone") + verb + trimBody(m.text);
+      return prefix + (m.from || "someone") + verb + trimBody(m.text) + tail;
     }
     var parts = messages.map(function (msg) {
       return "From " + speaker(msg) + ": " + trimBody(msg.text);
     });
-    return prefix + messages.length + " updates came in. " + parts.join(" ");
+    return prefix + messages.length + " updates came in. " + parts.join(" ") + tail;
   }
 
   function pollOnce() {
@@ -782,10 +795,10 @@ function createInboxNotifier(deps) {
       if (!full && !canInterrupt()) return;
       var take = function (m) { return full || isUrgent(m); };
       var unread = res.messages || [];
-      var claimed = {};
+      var picked = {};
       var fresh = unread.filter(take).filter(function (m) {
-        if (!m || !m.id || seen[m.id] || inFlight[m.id] || claimed[m.id]) return false;
-        claimed[m.id] = true;
+        if (!m || !m.id || seen[m.id] || inFlight[m.id] || picked[m.id]) return false;
+        picked[m.id] = true;
         return true;
       });
       if (!fresh.length) {
@@ -802,7 +815,13 @@ function createInboxNotifier(deps) {
         }
         return;
       }
-      var ids = fresh.map(function (m) { return m.id; });
+      // CAP THE UTTERANCE, not the mail. Only what this notice actually SAYS
+      // is claimed, marked in-flight and eligible to be acked; the rest is
+      // untouched in the spool and the next quiet tick picks it up.
+      var batch = fresh.slice(0, MAX_NOTICE_BODIES);
+      var waiting = fresh.length - batch.length;
+      var claimed = {};
+      var ids = batch.map(function (m) { claimed[m.id] = true; return m.id; });
       ids.forEach(function (id) { inFlight[id] = true; });
       // HOW FAR THIS NOTICE MAY ACK (#970). The cursor is ONE id, so acking
       // through id X marks everything before X read too. The only safe target
@@ -822,15 +841,16 @@ function createInboxNotifier(deps) {
         if (!m || !m.id || !(seen[m.id] || claimed[m.id])) break;
         ackThrough = m.id;
       }
-      onLog("inbox", "volunteering " + fresh.length + " message(s)");
+      onLog("inbox", "volunteering " + batch.length + " message(s)"
+        + (waiting ? " (" + waiting + " held for the next gap)" : ""));
       // inboxMsgs rides along so the page can register request/escalation
       // notices in the re-raise ledger AT THE MOMENT THEY ARE HEARD (its
       // onSpoken) — the ledger must never hold something the owner wasn't
       // actually told.
-      announce(composeNotice(fresh), {
+      announce(composeNotice(batch, waiting), {
         inboxIds: ids,
         ackThrough: ackThrough,
-        inboxMsgs: fresh.map(function (m) {
+        inboxMsgs: batch.map(function (m) {
           return { id: m.id, from: m.from, kind: m.kind, text: m.text };
         }),
       });

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -726,17 +726,33 @@ function createInboxNotifier(deps) {
   // what happened, nothing about what will.
   function isUrgent(m) { return !!m && m.kind === "escalation"; }
 
+  // Mail from the MACHINE rather than from a session (#982, #1016). The
+  // wording matters because these are not replies: "fleet-activity got back to
+  // you" tells the owner a session with a robot's name answered something they
+  // never sent, and "fleet-alerts escalated" names an internal module out loud
+  // as if it were a colleague. Both are sentences the owner HEARS, and the
+  // announcer speaks composeNotice verbatim — the model does not get a chance
+  // to rephrase it. Kept in sync with `fleet_alerts.MACHINE_SENDERS`, which is
+  // the same list on the producing side.
+  var MACHINE_SENDERS = { "fleet-alerts": 1, "fleet-activity": 1 };
+  function isMachine(m) { return !!m && !!MACHINE_SENDERS[m.from]; }
+  function speaker(m) { return isMachine(m) ? "the fleet" : ((m && m.from) || "someone"); }
+
   function composeNotice(messages) {
     // An escalation in the batch names itself as one — the owner should be
     // able to hear the difference between news and an alarm.
     var prefix = messages.some(isUrgent) ? "Heads up \\u2014 " : "";
     if (messages.length === 1) {
       var m = messages[0];
+      // No verb for machine mail: the body is already a whole statement
+      // ("auth-fix is idle and done working"), so any verb here would be the
+      // notifier narrating a relationship that does not exist.
+      if (isMachine(m)) return prefix + "From the fleet: " + trimBody(m.text);
       var verb = isUrgent(m) ? " escalated: " : " got back to you: ";
       return prefix + (m.from || "someone") + verb + trimBody(m.text);
     }
     var parts = messages.map(function (msg) {
-      return "From " + (msg.from || "someone") + ": " + trimBody(msg.text);
+      return "From " + speaker(msg) + ": " + trimBody(msg.text);
     });
     return prefix + messages.length + " updates came in. " + parts.join(" ");
   }

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -301,6 +301,17 @@ ask for the detail they want. A volunteered report that becomes a monologue is \
 worse than silence — the owner did not ask, cannot skim speech, and cannot \
 predict when you will stop.
 
+WHAT THE FLEET ALREADY SAID. Sessions speak out loud too — the fleet has its \
+own text-to-speech, and the owner hears it in the same room as you. \
+fleet_activity is the record of that, along with what the fleet has been \
+doing: sessions going idle, scheduled tasks finishing, toasts put on the \
+owner's screen. Anything marked "spoke" was heard by the owner already, so \
+never deliver it as news; refer back to it instead — "you heard the deploy one \
+go out" — or use it to avoid telling them something twice. And nothing in that \
+record was handed to you: you looked it up, so it answers a question and is \
+never a reason to speak first. When something there IS worth the owner \
+hearing, it reaches you as mail, like everything else.
+
 Ground every volunteered claim in output you actually read — the message's \
 recorded text in buddy_inbox, or the session's own terminal via \
 fleet_session_output — never what you expect the answer to be. A plausible \

--- a/agentwire/voice_layer/surface.py
+++ b/agentwire/voice_layer/surface.py
@@ -307,6 +307,21 @@ VOICE_NATIVE: dict[str, dict] = {
             "reflex that makes the gated nonce worthless."
         ),
     },
+    "fleet_activity": {
+        "grade": "read",
+        "ruling": (
+            "Reads the fleet activity ledger through `agentwire activity list` "
+            "(#1016). No MCP capability exists for it — the producers record "
+            "from inside the surfaces that generate the events, and there is "
+            "deliberately no verb that WRITES an entry, so nothing an agent "
+            "could be talked into calling can forge fleet history. Read by the "
+            "tier-1 rule: it observes a file and no more. Note the tier "
+            "question it does NOT raise — the ledger records that `say` and "
+            "`notify_user` happened, which is observation; both remain "
+            "excluded (clause (b)) because the buddy still cannot USE either "
+            "channel."
+        ),
+    },
     "buddy_sent": {
         "grade": "read",
         "ruling": (

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -337,6 +337,43 @@ def _fleet_network(args: dict) -> dict:
     return run_agentwire_cmd(["network", "status"], json_output=False, timeout=60)
 
 
+_MAX_ACTIVITY_LIMIT = 100
+_MAX_ACTIVITY_HOURS = 72
+
+
+def _fleet_activity(args: dict) -> dict:
+    """The fleet's activity ledger — awareness the buddy PULLS (#1016).
+
+    Deliberately a read and not a push: everything in the buddy's spool gets
+    spoken eventually, so routing ordinary lifecycle churn there would turn the
+    buddy into a narrator. The short list that DOES earn a spoken mention
+    arrives as ordinary mail through ``buddy_inbox``; this is everything else,
+    waiting to be asked about.
+    """
+    from .. import fleet_activity as _activity
+
+    argv = [
+        "activity", "list",
+        "--limit", str(_int_arg(args, "limit", 25, 1, _MAX_ACTIVITY_LIMIT)),
+        "--hours", str(_int_arg(args, "hours", 12, 1, _MAX_ACTIVITY_HOURS)),
+    ]
+    event = args.get("event")
+    if event is not None:
+        # Checked against the ledger's own vocabulary rather than passed
+        # through: `--event` is an argparse `choices` field, so a mis-heard
+        # value would exit(2) with a usage message the buddy would then read
+        # out as if it were an answer.
+        if not isinstance(event, str) or event not in _activity.EVENTS:
+            raise ToolError(
+                f"I don't track an activity kind called '{event}'. The kinds are: "
+                + ", ".join(_activity.EVENTS).replace("_", " ")
+            )
+        argv += ["--event", event]
+    if args.get("session") is not None:
+        argv += ["-s", _session_arg(args)]
+    return run_agentwire_cmd(argv)
+
+
 def _fleet_voice_health(args: dict) -> dict:
     return {
         "success": True,
@@ -720,6 +757,49 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
         name="fleet_network",
         description="Network reachability of the portal and registered machines.",
         run=_fleet_network,
+    ),
+    ReadOnlyTool(
+        name="fleet_activity",
+        description=(
+            "What the fleet has BEEN DOING recently, newest first: sessions going "
+            "idle, scheduled tasks finishing, toasts shown to the owner, sessions "
+            "starting and closing, and everything spoken aloud through the fleet's "
+            "own text-to-speech. Use it when asked what's been happening, what you "
+            "missed, or whether something already ran. Two rules about it. First, "
+            "an entry marked 'spoke' was ALREADY SAID OUT LOUD to the owner by a "
+            "session — they heard it, so never repeat one back as news; refer to it "
+            "("
+            "\"you already heard about the build\") or use it to avoid saying the "
+            "same thing twice. Second, nothing here was put in front of you — it is "
+            "a record you looked up, so it is only ever an answer to a question, "
+            "never something you volunteer."
+        ),
+        run=_fleet_activity,
+        parameters={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": f"How many entries (1-{_MAX_ACTIVITY_LIMIT}, default 25).",
+                },
+                "hours": {
+                    "type": "integer",
+                    "description": f"How far back to look (1-{_MAX_ACTIVITY_HOURS}, default 12).",
+                },
+                "event": {
+                    "type": "string",
+                    "description": (
+                        "Only one kind: session_idle, task_completed, toast_high, "
+                        "toast, spoke, session_created, session_closed, pane_died."
+                    ),
+                },
+                "session": {
+                    "type": "string",
+                    "description": "Only this session, exact name from fleet_sessions.",
+                },
+            },
+            "additionalProperties": False,
+        },
     ),
     ReadOnlyTool(
         name="fleet_voice_health",

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -366,10 +366,18 @@ places is how the two answers drift.
 
 | Event | Kind | Why, and what bounds it |
 |---|---|---|
-| session went idle | `done`, **only if delegated** | The event the owner wanted: work they handed off has finished. "Delegated" means a recorded parent, a worker/reviewer role, or a worktree (#716's axes; any one suffices) — a root orchestrator goes idle after *every* turn, and announcing that fires once per exchange. Throttled 15m per session; the event's parent is excluded, since it hears this by paste from `notify-parent`. |
+| session went idle | `done`, **only if delegated** | The event the owner wanted: work they handed off has finished. Authority is consulted first and can veto — an `orchestrator`/`anchor` role is never delegated whatever its location, because `agentwire orchestrator` is `worktree --kind orchestrator` and an OR over #716's axes let *location* overrule the role, announcing the owner's own durable window every 15 minutes. After that veto, a recorded parent, a worker/reviewer role, or a worktree checkout each suffice. Throttled 15m per session; the event's parent is excluded, since it hears this by paste from `notify-parent`. |
 | scheduled task completed | `done`, `request` if it ended badly | The owner did not watch it start and cannot see it end. The `request` promotion is the dead-letter inherit rule's shape: the fleet already judged it. `usage_limit` / `auth_expired` runs are **not** announced — those conditions have detectors of their own that say it once, machine-wide. Throttled 2m per task. |
-| `notify-user --priority high` | `request` | The one notify surface that declares its own urgency, about a screen the owner may not be looking at. Throttled 5m per session. |
+| `notify-user --priority high` | `request` | The one notify surface that declares its own urgency, about a screen the owner may not be looking at. Throttled 5m per **toast content**, not per sender: keyed on the session, a second, different high toast a minute later was silently never spoken. |
 | ordinary toast, portal lifecycle, **anything spoken** | **not wired** | Ledger-only. `spoke` most deliberately: the owner heard it in the room, and a voice channel that reads the audio back is worse than one that stays quiet. |
+
+**Do not `alerts subscribe` a DELEGATED session.** Subscription is for a
+listener, and a subscribed *worker* closes a loop: the alert is pasted into its
+prompt, which starts a turn, which ends in an idle, which is announced — a
+cycle that sustains itself at the 15m cadence with nobody asking for any of it.
+Nothing autonomous does this (the buddy subscribes itself, and it has no pane
+to paste into); it takes a human running `alerts subscribe` on a worker. The
+subscriber you want is the one that *reads* mail rather than acting on it.
 
 **No lifecycle event is ever an `escalation`.** The interrupt tier stays the two
 conditions nothing clears without a human. What everything else gets is the

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -355,6 +355,29 @@ clear without a human, and is something burning while it waits?*
 | dead-lettered load-bearing mail | `request`, promoted to `escalation` iff the lost message *was* an escalation | Someone must go look at `agentwire msg dead`. The floor is `request` because the realistic bad case is one stuck recipient — 147 dead letters in ~2s, observed — and that shape must not buy 147 interrupts. One alert per **batch**, matching the digest email's coalescing. |
 | dangling PR (`worktree --dangling`) | **not wired** | No autonomous trigger (only `doctor` and the explicit flag, both run by a human already reading the output) and no per-finding throttle state to reuse, so a producer would re-announce the same durable, passive condition every invocation. Nothing is burning while a dangling PR waits. |
 
+### Lifecycle joins the same table (#1016)
+
+Detectors report that something is *wrong*. `agentwire/fleet_activity.py` adds
+the other producer — the fleet reporting that something *happened*: a session
+going idle, a scheduled task finishing, a toast, anything spoken through fleet
+TTS. It shares `DETECTOR_KINDS` because the question is identical (what may a
+producer put in front of a listener, and how loudly), and answering it in two
+places is how the two answers drift.
+
+| Event | Kind | Why, and what bounds it |
+|---|---|---|
+| session went idle | `done`, **only if delegated** | The event the owner wanted: work they handed off has finished. "Delegated" means a recorded parent, a worker/reviewer role, or a worktree (#716's axes; any one suffices) — a root orchestrator goes idle after *every* turn, and announcing that fires once per exchange. Throttled 15m per session; the event's parent is excluded, since it hears this by paste from `notify-parent`. |
+| scheduled task completed | `done`, `request` if it ended badly | The owner did not watch it start and cannot see it end. The `request` promotion is the dead-letter inherit rule's shape: the fleet already judged it. `usage_limit` / `auth_expired` runs are **not** announced — those conditions have detectors of their own that say it once, machine-wide. Throttled 2m per task. |
+| `notify-user --priority high` | `request` | The one notify surface that declares its own urgency, about a screen the owner may not be looking at. Throttled 5m per session. |
+| ordinary toast, portal lifecycle, **anything spoken** | **not wired** | Ledger-only. `spoke` most deliberately: the owner heard it in the room, and a voice channel that reads the audio back is worse than one that stays quiet. |
+
+**No lifecycle event is ever an `escalation`.** The interrupt tier stays the two
+conditions nothing clears without a human. What everything else gets is the
+**ledger** — `~/.agentwire/fleet-activity.jsonl`, read with `agentwire activity
+list`, never pushed at anyone. That split is the design, and it exists because
+everything in a spool is eventually spoken; see
+[voice-layer.md](../voice-layer.md#fleet-awareness-two-tiers-because-everything-in-the-spool-gets-spoken-1016).
+
 **No alert rides an email-shaped throttle.** Each producer stamps its own state
 on a successful *enqueue* — a local write — rather than reusing the stamp that
 gates its owner email. That distinction is load-bearing rather than fussy:
@@ -374,8 +397,9 @@ which is the failure that is hardest to notice — it looks exactly like a quiet
 fleet.
 
 Two guards keep the dead-letter mirror from feeding itself: alerts carry a
-distinct sender (`fleet-alerts`) and are never mirrored, and any subscriber
-named as a *recipient* of the lost batch is excluded. Either alone is
+distinct sender (`fleet-alerts` — or `fleet-activity` for lifecycle; both live
+in `MACHINE_SENDERS`, and `emit` refuses any other) and are never mirrored, and
+any subscriber named as a *recipient* of the lost batch is excluded. Either alone is
 insufficient — with two subscribers, an alert stranded en route to one would
 otherwise be reported to the other, once per drain, forever.
 
@@ -406,7 +430,17 @@ agentwire alerts subscribe <session>     # lease alerts for a session
 agentwire alerts unsubscribe <session>
 agentwire alerts list [--json]           # live leases, with their expiry
 agentwire alerts reindex [--json]        # rebuild the candidate index
+
+agentwire activity list [--limit N] [--hours N] [--event E] [-s SESSION] [--json]
 ```
+
+`activity list` reads the ledger — the awareness tier, which nothing pushes.
+Entries marked `*` were *also* queued to subscribers; showing that flag is the
+point, since "recorded" and "said out loud" are different facts and an operator
+debugging a chatty or a silent buddy needs to tell them apart. There is
+deliberately **no verb that writes an entry**: producers record from inside the
+surfaces that generate the events, so nothing an agent can be talked into
+calling can forge fleet history.
 
 `list` reports the **expiry**, not a boolean, because a lease that stopped being
 renewed stops delivering silently — that is the designed failure direction, and

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -503,14 +503,103 @@ ordinary report sits *ahead* of it, and one id cannot cover the alarm without
 burying the report — so that tick acks nothing, and the full tick that finally
 speaks the report clears both.
 
+### Fleet awareness: two tiers, because everything in the spool gets spoken (#1016)
+
+The buddy could be *told* things — `msg send --to buddy` reaches the spool, and
+fleet detectors can address it (#982/#1002) — but nothing emitted the fleet's
+own ordinary signals. A session went idle, a scheduled task finished, a toast
+went up, a session spoke through fleet TTS, and the buddy knew none of it. So it
+could not check in on delegated work, and fleet TTS and voice mode were two
+disconnected audio surfaces in the same room.
+
+**The routing was never the hard part.** The judgment is, and it turns on one
+property of what already exists: *everything in the spool eventually gets
+spoken*. The notifier volunteers unread mail at a gap; an escalation cuts
+across the buddy's own voice. There is no quiet kind. A producer that pushed
+lifecycle events into the spool would not make the buddy aware — it would make
+it a narrator, and the owner's move against a narrator is to stop listening.
+
+Hence two tiers:
+
+| | Where | Who reads it | Spoken? |
+|---|---|---|---|
+| **Awareness** | `~/.agentwire/fleet-activity.jsonl` (`agentwire activity list`, tool `fleet_activity`) | pulled, on a question | never |
+| **News** | the buddy's spool, as ordinary typed mail | pushed, by `fleet_alerts.emit` | at a gap |
+
+The ledger is a **pull**, not a fourth push — which is what keeps the closed
+list of unprompted paths in `instructions.VOICE_MODE` closed. It is also what
+makes the two audio surfaces one: every `agentwire say` is recorded, and the
+instructions tell the buddy that a `spoke` entry was *already heard by the
+owner*, so it refers back to one rather than delivering it as news.
+
+**What earns the spool** is `fleet_activity.ANNOUNCE`, pinned as data next to
+its kind in `fleet_alerts.DETECTOR_KINDS`:
+
+- **`session_idle` → `done`, and only for DELEGATED work** — a recorded parent,
+  a worker/reviewer role, or a worktree checkout (#716's three axes; any one is
+  enough). A root orchestrator going idle is a conversational turn ending, and
+  announcing that fires once per exchange the owner has with their own session.
+  The event's own parent is excluded, since it already hears this by paste from
+  `notify-parent`; the same news twice is how a channel earns being ignored.
+- **`task_completed` → `done`, `request` when it ended badly** — the canonical
+  check-in event: the owner did not watch it start and cannot see it end. The
+  inherit rule is the dead-letter rule's shape — the fleet already judged it,
+  and flattening that to news throws the judgment away. `usage_limit` and
+  `auth_expired` are ledger-only: both conditions have a detector of their own
+  that says it once, machine-wide, where this would say it again per task.
+- **`toast_high` → `request`** — `notify-user --priority high` is the one
+  notify surface that declares its own urgency, about a screen the owner may
+  not be looking at. An ordinary toast is ledger-only.
+
+**Nothing lifecycle is ever an `escalation`.** The interrupt tier stays the two
+conditions nothing clears without a human. An idle session is not burning.
+
+**Throttled per subject, from the ledger itself** — 15m for an idle, 2m for a
+task, 5m for a high toast. A flapping session records every flap and buys one
+utterance. The check reads the ledger rather than a second state file: the
+record is written *before* the emit decision, so there is one thing to keep
+consistent, and a lost ledger costs a duplicate announcement rather than a lost
+one.
+
+**Producers, and why each sits where it does.** Every one is best-effort — a
+producer's job is its own job:
+
+| Surface | Seam | Recorded |
+|---|---|---|
+| idle hook | `cmd_notify_parent`, `--on-idle`, **above** the no-target return | `session_idle` |
+| `agentwire say` | `cmd_say`'s own result helper | `spoke` (+ the sink; a failed dispatch records nothing) |
+| `agentwire notify-user` | `cmd_notify_user`, whether or not the portal took it | `toast` / `toast_high` |
+| `agentwire notify-event` | `cmd_notify`, three events only | `session_created` / `session_closed` / `pane_died` |
+| scheduler | `report._log_event("task_completed")`, the one seam both dispatchers use | `task_completed` |
+
+Two of those placements are the whole point. The idle producer sits **above**
+the "no parent, nothing to do" return — that early exit is exactly the case
+(a root session finishing) that told nobody. And the scheduler hooks the shared
+event log rather than the two dispatch call sites, because a per-call-site copy
+is what drifts (the same ruling as the worktree-path and session-name SSOTs).
+
+**The fleet is not a colleague, and the notifier now says so.** `composeNotice`
+speaks its output verbatim — the model never rephrases it — so mail from
+`fleet-alerts` / `fleet-activity` rendered as "fleet-activity got back to you:
+…", telling the owner that a session with a robot's name had answered something
+they never sent. Machine senders now render as **"From the fleet: …"**, with no
+verb (the body is already a whole statement), and an escalation keeps its
+"Heads up —" alarm prefix. The JS list is kept in step with
+`fleet_alerts.MACHINE_SENDERS`, which is the same list on the producing side.
+
+`agentwire notify-event`'s other vocabulary — `client_attached`,
+`pane_focused`, `window_activity` — is deliberately absent: it fires on every
+glance at a terminal, and recording it would bury the events that mean
+something under events that mean somebody moved a mouse.
+
 ### The tool surface is an allowlist, not a passthrough
 
 The model chooses *which* tool. It never chooses *what runs*. Every tool builds
 its own argv from validated parameters.
 
-The live surface is **26 read tools plus one gated write spec**, and the spec
+The live surface is **27 read tools plus one gated write spec**, and the spec
 generates three tools (`propose_` / `send_` / `cancel_session_message`), so the
-model sees 29 names. **Do not maintain a list of them here** — an enumeration in
+model sees 30 names. **Do not maintain a list of them here** — an enumeration in
 prose is what went stale last time, and `agentwire buddy tools` prints the exact
 array handed to the model. What belongs in a wiki is the rule that decides what
 may ever appear.

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -579,7 +579,7 @@ producer's job is its own job:
 |---|---|---|
 | idle hook | `cmd_notify_parent`, `--on-idle`, **above** the no-target return | `session_idle` |
 | `agentwire say` | `cmd_say`, per successfully-played chunk | `spoke` (+ the sink) |
-| toasts — CLI `notify-user`, **MCP `notify_user`**, `say --display` | `core.post_desktop_notification`, below all three | `toast` / `toast_high` |
+| text toasts — CLI `notify-user`, **MCP `notify_user`**, `say --display`, and the scheduler's zombie reaper (`priority=high`) | `core.post_desktop_notification`, below all four | `toast` / `toast_high` |
 | `agentwire notify-event` | `cmd_notify`, three events only | `session_created` / `session_closed` / `pane_died` |
 | scheduler | `report._log_event("task_completed")`, the one seam both dispatchers use | `task_completed` |
 
@@ -592,9 +592,16 @@ early exit is exactly the case (a root session finishing) that told nobody.
 producers and the MCP one POSTed on its own, so — since agents use MCP and
 humans use the CLI — a CLI-side hook would have recorded exactly the toasts a
 *human* posted and none of the ones the fleet posts.
-`core.post_desktop_notification` is now the one toast call, and it records
-whether or not the portal took it: a toast the portal refused is the case where
-the voice channel is all that is left. Same reasoning for **the scheduler**,
+`core.post_desktop_notification` is now the one call for a toast that carries
+**text**, and it records whether or not the portal took it: a toast the portal
+refused is the case where the voice channel is all that is left. Enrolling the
+seam rather than the producers also picked up a fourth one the first draft did
+not know about — the scheduler's zombie reaper posts a `priority=high` notice
+when it finds a session crashed at a bare shell, so that now reaches the buddy
+as a spoken `request`, which is right and is what "a new caller inherits it"
+means. What deliberately stays outside is `mcp_desktop._announce_artifact`: the
+#817 click-to-open notice carries no `text`, and a ledger entry with nothing in
+it is worse than no entry. Same reasoning for **the scheduler**,
 which hooks the shared event log rather than the two dispatch call sites — a
 per-call-site copy is what drifts (the ruling the worktree-path and
 session-name SSOTs keep re-teaching).

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -535,12 +535,19 @@ owner*, so it refers back to one rather than delivering it as news.
 **What earns the spool** is `fleet_activity.ANNOUNCE`, pinned as data next to
 its kind in `fleet_alerts.DETECTOR_KINDS`:
 
-- **`session_idle` → `done`, and only for DELEGATED work** — a recorded parent,
-  a worker/reviewer role, or a worktree checkout (#716's three axes; any one is
-  enough). A root orchestrator going idle is a conversational turn ending, and
-  announcing that fires once per exchange the owner has with their own session.
-  The event's own parent is excluded, since it already hears this by paste from
-  `notify-parent`; the same news twice is how a channel earns being ignored.
+- **`session_idle` → `done`, and only for DELEGATED work.** #716's axes are
+  independent — location is not authority — so the gate is **not** an OR over
+  them: an interactive role (`orchestrator` on the role axis, `anchor` on the
+  persona axis) is never delegated *whatever its location*, and only then does
+  a recorded parent / a worker-or-reviewer role / a worktree checkout count.
+  The OR got this wrong in a way worth remembering: `agentwire orchestrator` is
+  sugar for `worktree --kind orchestrator`, so the owner's durable window has
+  `role: orchestrator`, `created_by: ''` **and** `worktree_path` set — the
+  location axis overruled the role, and the buddy announced "… is idle and done
+  working" every fifteen minutes into a conversation the owner was having with
+  that very session. The event's own parent is also excluded, since it already
+  hears this by paste from `notify-parent`; the same news twice is how a
+  channel earns being ignored.
 - **`task_completed` → `done`, `request` when it ended badly** — the canonical
   check-in event: the owner did not watch it start and cannot see it end. The
   inherit rule is the dead-letter rule's shape — the fleet already judged it,
@@ -549,7 +556,11 @@ its kind in `fleet_alerts.DETECTOR_KINDS`:
   that says it once, machine-wide, where this would say it again per task.
 - **`toast_high` → `request`** — `notify-user --priority high` is the one
   notify surface that declares its own urgency, about a screen the owner may
-  not be looking at. An ordinary toast is ledger-only.
+  not be looking at. An ordinary toast is ledger-only. Its throttle subject is
+  the toast's **content**, not its sender: keyed on the session, "build is red"
+  swallowed "deploy rolled back" a minute later, and on the one surface whose
+  caller declared the message urgent a false-reject is silence with no screen
+  behind it.
 
 **Nothing lifecycle is ever an `escalation`.** The interrupt tier stays the two
 conditions nothing clears without a human. An idle session is not burning.
@@ -567,16 +578,31 @@ producer's job is its own job:
 | Surface | Seam | Recorded |
 |---|---|---|
 | idle hook | `cmd_notify_parent`, `--on-idle`, **above** the no-target return | `session_idle` |
-| `agentwire say` | `cmd_say`'s own result helper | `spoke` (+ the sink; a failed dispatch records nothing) |
-| `agentwire notify-user` | `cmd_notify_user`, whether or not the portal took it | `toast` / `toast_high` |
+| `agentwire say` | `cmd_say`, per successfully-played chunk | `spoke` (+ the sink) |
+| toasts — CLI `notify-user`, **MCP `notify_user`**, `say --display` | `core.post_desktop_notification`, below all three | `toast` / `toast_high` |
 | `agentwire notify-event` | `cmd_notify`, three events only | `session_created` / `session_closed` / `pane_died` |
 | scheduler | `report._log_event("task_completed")`, the one seam both dispatchers use | `task_completed` |
 
-Two of those placements are the whole point. The idle producer sits **above**
-the "no parent, nothing to do" return — that early exit is exactly the case
-(a root session finishing) that told nobody. And the scheduler hooks the shared
-event log rather than the two dispatch call sites, because a per-call-site copy
-is what drifts (the same ruling as the worktree-path and session-name SSOTs).
+Three of those placements are the whole point.
+
+**The idle producer sits above the "no parent, nothing to do" return** — that
+early exit is exactly the case (a root session finishing) that told nobody.
+
+**The toast producer sits below every transport.** There were three toast
+producers and the MCP one POSTed on its own, so — since agents use MCP and
+humans use the CLI — a CLI-side hook would have recorded exactly the toasts a
+*human* posted and none of the ones the fleet posts.
+`core.post_desktop_notification` is now the one toast call, and it records
+whether or not the portal took it: a toast the portal refused is the case where
+the voice channel is all that is left. Same reasoning for **the scheduler**,
+which hooks the shared event log rather than the two dispatch call sites — a
+per-call-site copy is what drifts (the ruling the worktree-path and
+session-name SSOTs keep re-teaching).
+
+**`say` records what actually played, not what it was asked to say.** The local
+path chunks, so a failure on chunk 3 of 4 records chunks 1–2 — the owner heard
+those. Recording the whole string would claim they heard a sentence that never
+played; recording nothing would let the buddy offer it back later as news.
 
 **The fleet is not a colleague, and the notifier now says so.** `composeNotice`
 speaks its output verbatim — the model never rephrases it — so mail from
@@ -586,6 +612,18 @@ they never sent. Machine senders now render as **"From the fleet: …"**, with n
 verb (the body is already a whole statement), and an escalation keeps its
 "Heads up —" alarm prefix. The JS list is kept in step with
 `fleet_alerts.MACHINE_SENDERS`, which is the same list on the producing side.
+
+**One utterance carries at most three bodies.** `composeNotice` coalesced every
+unread message, which was fine while mail arrived one reply at a time and is a
+monologue the moment a fan-out lands in one 5s poll window — ten workers, one
+~2500-character utterance, spoken over nothing the owner asked for. Speech
+cannot be skimmed and the owner cannot predict when it stops. The overflow is
+**held, not dropped**: only the spoken messages are claimed, marked in-flight
+and eligible to ack, so the rest stays unread and the next quiet tick says the
+next three — the same "announced late, never lost" property the interrupt tier
+already relies on. The notice says "And N more waiting", because a capped batch
+must not sound like a complete one. This was pre-existing in the notifier;
+#1016 is the first producer that reaches that scale with no human in the loop.
 
 `agentwire notify-event`'s other vocabulary — `client_attached`,
 `pane_focused`, `window_activity` — is deliberately absent: it fires on every

--- a/tests/unit/test_fleet_activity.py
+++ b/tests/unit/test_fleet_activity.py
@@ -548,6 +548,36 @@ def test_a_toast_records_through_the_mcp_tool(isolate, portal):
     assert [m.kind for m in _mail("buddy")] == ["request"]
 
 
+def test_a_refused_toast_keeps_the_portal_s_own_reason(isolate, monkeypatch):
+    """The portal's body names WHICH field was wrong, and that message is what
+    the MCP tool hands back to the agent that called it. A bare "HTTP 400" is a
+    refusal with no next move."""
+    class _Response:
+        status_code = 400
+
+        @staticmethod
+        def json():
+            return {"success": False, "error": "artifact.url required"}
+
+    monkeypatch.setattr("agentwire.core.portal_request", lambda *a, **kw: _Response())
+    from agentwire.mcp_notify import notify_user
+
+    assert "artifact.url required" in notify_user("here is the report", session="ci")
+    # Recorded anyway: a toast the portal refused is the case where the voice
+    # channel is all that is left.
+    assert [e["event"] for e in fleet_activity.recent()] == ["toast"]
+
+
+def test_a_textless_toast_is_not_a_ledger_entry(isolate, portal):
+    """Nothing was shown, so nothing happened worth remembering — an entry with
+    an empty body is one the buddy would offer as news and then have nothing to
+    say about. Same reason `mcp_desktop._announce_artifact` stays off this seam."""
+    from agentwire.mcp_notify import notify_user
+
+    notify_user("   ", session="ci")
+    assert fleet_activity.recent() == []
+
+
 def test_the_briefing_display_card_records_too(isolate, portal, monkeypatch):
     """`say(display=...)` posts its own toast — the third producer."""
     from agentwire import channels_cli

--- a/tests/unit/test_fleet_activity.py
+++ b/tests/unit/test_fleet_activity.py
@@ -165,6 +165,36 @@ def test_root_orchestrator_idle_is_ledger_only(isolate):
     assert [e["event"] for e in fleet_activity.recent()] == ["session_idle"]
 
 
+@pytest.mark.parametrize(
+    "fields",
+    [
+        # THE SHAPE THE VERB ACTUALLY PRODUCES. `agentwire orchestrator` is
+        # sugar for `worktree --kind orchestrator`, so the owner's durable
+        # window carries role=orchestrator, created_by='' AND worktree_path —
+        # two live sessions on this machine look exactly like this. A plain OR
+        # over #716's axes let the LOCATION axis overrule the ROLE and
+        # announced the window the owner was talking to, every 15 minutes.
+        {"role": "orchestrator", "created_by": "",
+         "worktree_path": "/Users/x/worktrees/proj/spike"},
+        # Same veto through the persona axis: Briefing Mode's anchor replaces
+        # the orchestrator role and is likewise who the human talks to.
+        {"role": "worker", "roles": ["anchor", "contributor"],
+         "worktree_path": "/Users/x/worktrees/proj/brief"},
+        # And a spawned orchestrator: created_by is set, so the parent branch
+        # would have fired if authority did not get to veto first.
+        {"role": "orchestrator", "created_by": "boss"},
+    ],
+)
+def test_an_interactive_role_is_never_delegated_whatever_its_location(isolate, fields):
+    buddy = _subscribe()
+    _record("window", **fields)
+
+    fleet_activity.note_session_idle("window", "is idle and done working")
+
+    assert _mail(buddy) == []
+    assert [e["announced"] for e in fleet_activity.recent()] == [False]
+
+
 def test_unknown_session_idle_is_ledger_only(isolate):
     """No record is not evidence of delegation, and the failure direction is quiet."""
     buddy = _subscribe()
@@ -334,6 +364,21 @@ def test_a_corrupt_line_costs_one_entry_not_the_file(isolate):
     assert [e["text"] for e in fleet_activity.recent()] == ["two", "one"]
 
 
+@pytest.mark.parametrize("ts", ["2026-08-11T12:00:00", "not-a-date", 7, None])
+def test_an_unusable_timestamp_never_raises(isolate, ts):
+    """The naive one is the sharp case: it PARSES, then raises on the comparison
+    — outside the guard that wrapped only the parse. That tracebacked
+    `agentwire activity list` on a single hand-edited line, and falsified the
+    "never raises" contract every producer here is written against."""
+    fleet_activity.record("spoke", session="a", text="fine")
+    with open(fleet_activity.ledger_path(), "a") as fh:
+        fh.write(json.dumps({"event": "spoke", "ts": ts, "text": "odd",
+                             "session": "a", "subject": "a"}) + "\n")
+
+    assert [e["text"] for e in fleet_activity.recent()] == ["fine"]
+    assert fleet_activity.note_spoke("still works", session="a")["announced"] == []
+
+
 def test_the_ledger_stays_bounded(isolate):
     for i in range(fleet_activity.TRIM_AT + 20):
         fleet_activity.record("spoke", session="a", text=str(i))
@@ -452,12 +497,34 @@ def test_a_service_session_going_idle_is_not_even_recorded(isolate, monkeypatch)
     assert fleet_activity.recent() == []
 
 
-def test_a_toast_records_through_the_notify_cli(isolate, monkeypatch):
+@pytest.fixture
+def portal(monkeypatch):
+    """A portal that accepts toasts, patched at core's ONE HTTP call.
+
+    Deliberately not patched at `_post_desktop_notification`: that is the seam
+    under test. A test that stubs it proves the producer called *something*,
+    which is exactly the assurance that let the MCP producer ship unrecorded.
+    """
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"success": True, "id": "n1", "clients": 1}
+
+    calls = []
+    monkeypatch.setattr(
+        "agentwire.core.portal_request",
+        lambda method, url, **kw: calls.append((method, url, kw.get("json"))) or _Response(),
+    )
+    return calls
+
+
+def test_a_toast_records_through_the_notify_cli(isolate, portal, monkeypatch):
     from agentwire import notify_cli
     from agentwire.notify_cli import cmd_notify_user
 
     _subscribe()
-    monkeypatch.setattr(notify_cli, "_post_desktop_notification", lambda *a, **kw: True)
     monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 0)
 
     cmd_notify_user(_ns(text=["build", "is", "red"], session="ci",
@@ -467,17 +534,69 @@ def test_a_toast_records_through_the_notify_cli(isolate, monkeypatch):
     assert [m.kind for m in _mail("buddy")] == ["request"]
 
 
+def test_a_toast_records_through_the_mcp_tool(isolate, portal):
+    """The producer agents actually reach. CLAUDE.md's rule is MCP for agents
+    and CLI for humans, so a CLI-side hook sees exactly the toasts a human
+    posted — and none of the ones the fleet posts. It POSTed on its own
+    transport; now every toast producer goes through one seam."""
+    _subscribe()
+    from agentwire.mcp_notify import notify_user
+
+    notify_user("deploy needs a decision", session="ci", priority="high")
+
+    assert [e["event"] for e in fleet_activity.recent()] == ["toast_high"]
+    assert [m.kind for m in _mail("buddy")] == ["request"]
+
+
+def test_the_briefing_display_card_records_too(isolate, portal, monkeypatch):
+    """`say(display=...)` posts its own toast — the third producer."""
+    from agentwire import channels_cli
+
+    _say_env(channels_cli, monkeypatch, rc=0)
+    channels_cli.cmd_say(_ns(text=["spoken", "headline"], json=True, voice=None,
+                             exaggeration=None, cfg=None, session=None,
+                             display="**the richer card**", backend=None,
+                             instructions=None, language="English", stream=False))
+
+    assert {e["event"] for e in fleet_activity.recent()} == {"toast", "spoke"}
+
+
 def test_a_toast_the_portal_refused_is_still_recorded(isolate, monkeypatch):
     """The case where awareness matters MOST: the screen never got it."""
     from agentwire import notify_cli
     from agentwire.notify_cli import cmd_notify_user
 
-    monkeypatch.setattr(notify_cli, "_post_desktop_notification", lambda *a, **kw: False)
+    def unreachable(*a, **kw):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("agentwire.core.portal_request", unreachable)
     monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 1)
 
     cmd_notify_user(_ns(text=["heads", "up"], session="ci", priority="normal", json=False))
 
     assert [e["event"] for e in fleet_activity.recent()] == ["toast"]
+
+
+def test_different_high_toasts_are_not_throttled_into_silence(isolate, portal, monkeypatch):
+    """The cooldown groups by CONTENT, not by sender. Keying it on the session
+    made 'build is red' swallow 'deploy rolled back' a minute later — and on the
+    one surface whose caller declared the message urgent, a false-reject is
+    silence with no screen behind it."""
+    from agentwire import notify_cli
+    from agentwire.notify_cli import cmd_notify_user
+
+    _subscribe()
+    monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 0)
+
+    cmd_notify_user(_ns(text=["build", "is", "red"], session="ci", priority="high", json=False))
+    cmd_notify_user(_ns(text=["deploy", "rolled", "back"], session="ci",
+                        priority="high", json=False))
+    # …and the case the throttle IS for: the same toast, again.
+    cmd_notify_user(_ns(text=["build", "is", "red"], session="ci", priority="high", json=False))
+
+    spoken = [m.text for m in _mail("buddy")]
+    assert len(spoken) == 2
+    assert any("red" in t for t in spoken) and any("rolled back" in t for t in spoken)
 
 
 def test_portal_churn_is_not_recorded(isolate, monkeypatch):
@@ -522,22 +641,26 @@ def test_other_scheduler_events_are_not_activity(isolate, monkeypatch):
     assert fleet_activity.recent() == []
 
 
-def test_speaking_records_the_sink_through_the_say_cli(isolate, monkeypatch):
-    """The say path's own result helper is what records, so the sink is part of
-    the record and a FAILED dispatch is never recorded as spoken."""
-    from agentwire import channels_cli
-
-    _subscribe()
+def _say_env(channels_cli, monkeypatch, *, rc: int = 0, browser: bool = True):
+    """Everything `cmd_say` reaches outside itself, stubbed."""
     monkeypatch.setattr(channels_cli, "load_config", lambda: {"tts": {}})
     monkeypatch.setattr(channels_cli, "get_voice_from_config", lambda: None)
     monkeypatch.setattr(channels_cli, "_get_current_tmux_session", lambda: "worker-1")
     monkeypatch.setattr(channels_cli, "_infer_session_from_path", lambda: None)
-    monkeypatch.setattr(channels_cli, "_handle_voice_notifications",
-                        lambda *a, **kw: None)
+    monkeypatch.setattr(channels_cli, "_handle_voice_notifications", lambda *a, **kw: None)
     monkeypatch.setattr(channels_cli, "_get_portal_url", lambda: "https://portal")
     monkeypatch.setattr(channels_cli, "_check_portal_connections",
-                        lambda s, url: (True, s, 2))
-    monkeypatch.setattr(channels_cli, "_remote_say", lambda *a, **kw: 0)
+                        lambda s, url: (browser, s, 2))
+    monkeypatch.setattr(channels_cli, "_remote_say", lambda *a, **kw: rc)
+
+
+def test_speaking_records_the_sink_through_the_say_cli(isolate, monkeypatch):
+    """The sink is part of the record, and a FAILED dispatch is never recorded
+    as spoken."""
+    from agentwire import channels_cli
+
+    _subscribe()
+    _say_env(channels_cli, monkeypatch, rc=0)
 
     channels_cli.cmd_say(_ns(text=["the", "build", "is", "green"], json=True,
                              voice=None, exaggeration=None, cfg=None, session=None,
@@ -555,16 +678,7 @@ def test_speaking_records_the_sink_through_the_say_cli(isolate, monkeypatch):
 def test_a_failed_say_is_not_recorded_as_spoken(isolate, monkeypatch):
     from agentwire import channels_cli
 
-    monkeypatch.setattr(channels_cli, "load_config", lambda: {"tts": {}})
-    monkeypatch.setattr(channels_cli, "get_voice_from_config", lambda: None)
-    monkeypatch.setattr(channels_cli, "_get_current_tmux_session", lambda: "worker-1")
-    monkeypatch.setattr(channels_cli, "_infer_session_from_path", lambda: None)
-    monkeypatch.setattr(channels_cli, "_handle_voice_notifications",
-                        lambda *a, **kw: None)
-    monkeypatch.setattr(channels_cli, "_get_portal_url", lambda: "https://portal")
-    monkeypatch.setattr(channels_cli, "_check_portal_connections",
-                        lambda s, url: (True, s, 2))
-    monkeypatch.setattr(channels_cli, "_remote_say", lambda *a, **kw: 1)
+    _say_env(channels_cli, monkeypatch, rc=1)
 
     channels_cli.cmd_say(_ns(text=["nobody", "heard", "this"], json=True,
                              voice=None, exaggeration=None, cfg=None, session=None,
@@ -572,3 +686,35 @@ def test_a_failed_say_is_not_recorded_as_spoken(isolate, monkeypatch):
                              language="English", stream=False))
 
     assert fleet_activity.recent() == []
+
+
+def test_a_partly_spoken_say_records_exactly_what_played(isolate, monkeypatch):
+    """The local path CHUNKS. A failure on chunk 3 of 4 still played 1 and 2
+    out loud — recording the whole string claims the owner heard a sentence
+    that never played, and recording nothing lets the buddy later offer, as
+    news, something they already heard."""
+    from agentwire import channels_cli
+
+    _say_env(channels_cli, monkeypatch, browser=False)
+    monkeypatch.setattr(channels_cli, "chunk_text", None, raising=False)
+    monkeypatch.setattr("agentwire.utils.chunker.chunk_text",
+                        lambda t: ["first part.", "second part.", "third part."])
+    played = []
+
+    def dispatch(chunk, *a, **kw):
+        if len(played) == 2:
+            return 1, "os-voice"
+        played.append(chunk)
+        return 0, "os-voice"
+
+    monkeypatch.setattr(channels_cli, "_local_say_dispatch", dispatch)
+
+    channels_cli.cmd_say(_ns(text=["first part. second part. third part."], json=True,
+                             voice=None, exaggeration=None, cfg=None, session=None,
+                             display=None, backend=None, instructions=None,
+                             language="English", stream=False))
+
+    entries = fleet_activity.recent()
+    assert [e["event"] for e in entries] == ["spoke"]
+    assert entries[0]["text"] == "first part. second part."
+    assert "third part" not in entries[0]["text"]

--- a/tests/unit/test_fleet_activity.py
+++ b/tests/unit/test_fleet_activity.py
@@ -1,0 +1,574 @@
+"""The fleet's own signals reach the buddy — and the ruling on which ones SPEAK (#1016).
+
+Same two-directional shape as ``test_fleet_alerts``, because this producer has
+the same two ways to be wrong and they are not equally cheap:
+
+* **The false-REJECT half** — the state before this module. The idle handler,
+  the notify family and the scheduler all knew a job had finished, and none of
+  that reached a listener without a parent link, so the buddy could not check
+  in on work the owner had delegated.
+* **The false-ACCEPT half, which is the expensive one.** Everything in the
+  buddy's spool is eventually SPOKEN — the notifier volunteers unread mail at a
+  gap (#962). So a producer that spools the fleet's ordinary churn does not add
+  a feature, it turns the buddy into a narrator, and the owner's move against a
+  narrator is to stop listening. That is why the ruling
+  (:data:`fleet_activity.ANNOUNCE` plus the kinds in
+  ``fleet_alerts.DETECTOR_KINDS``) is pinned here as DATA: widening what may
+  speak has to be a deliberate edit to a test that says why.
+
+The sharpest single case is ``spoke``. A session that speaks through fleet TTS
+is heard by the owner in the room; a buddy that reads it back is the two-surface
+problem made worse, not solved. It is recorded and never announced, and that is
+asserted directly rather than left to follow from a table.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agentwire import core, fleet_activity, fleet_alerts, inbox
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    """A throwaway config dir: session records, inboxes, ledger and event logs."""
+    root = tmp_path / "agentwire"
+    (root / "sessions").mkdir(parents=True)
+    monkeypatch.setattr(core, "CONFIG_DIR", root)
+    monkeypatch.setattr(inbox, "INBOX_ROOT", root / "inbox")
+    monkeypatch.setattr(inbox, "EVENTS_FILE", root / "inbox-events.jsonl")
+    monkeypatch.setattr(inbox, "live_sessions", lambda: None)
+    return root
+
+
+def _record(name: str, **fields) -> None:
+    core.store_session_metadata(name, {"created_at": "x", **fields})
+
+
+def _subscribe(name: str = "buddy", **fields) -> str:
+    _record(name, **fields)
+    fleet_alerts.subscribe(name)
+    return name
+
+
+def _mail(session: str) -> list:
+    return inbox.list_messages(session) + inbox.list_ingest(session)
+
+
+def _at(module, monkeypatch, when: datetime) -> None:
+    monkeypatch.setattr(module, "_now", lambda: when)
+
+
+# =============================================================================
+# The ruling, pinned as data
+# =============================================================================
+
+
+def test_announceable_events_have_a_kind():
+    """Every event that may speak must have a ruled kind, in the shared table.
+
+    The two tables are deliberately separate axes — ANNOUNCE says *whether and
+    how often*, DETECTOR_KINDS says *how loudly* — so an event listed in one
+    and missing from the other is a producer that looks wired and raises
+    KeyError at the moment it fires.
+    """
+    for event in fleet_activity.ANNOUNCE:
+        assert event in fleet_alerts.DETECTOR_KINDS, event
+
+
+def test_no_lifecycle_event_is_ever_an_escalation():
+    """The interrupt tier stays the two conditions nothing clears without a human.
+
+    An escalation cuts across the buddy's own speech (#967). Nothing in a
+    session going idle or a task finishing is burning while it waits, and an
+    escalation that turns out to be ignorable retires the tier for the one that
+    was not.
+    """
+    for event in fleet_activity.ANNOUNCE:
+        assert fleet_alerts.DETECTOR_KINDS[event] != "escalation", event
+
+
+def test_ordinary_churn_is_not_announceable():
+    """The ledger-only events, named. Adding one here is a deliberate edit."""
+    for event in ("spoke", "toast", "session_created", "session_closed", "pane_died"):
+        assert event not in fleet_activity.ANNOUNCE, event
+
+
+# =============================================================================
+# spoke — the two-audio-surfaces case
+# =============================================================================
+
+
+def test_spoken_audio_is_recorded_but_never_announced(isolate):
+    """The owner already heard it. Reading it back is worse than silence."""
+    buddy = _subscribe()
+    fleet_activity.note_spoke("the build is green", session="worker-1", sink="browser")
+
+    assert _mail(buddy) == []
+    entries = fleet_activity.recent()
+    assert [e["event"] for e in entries] == ["spoke"]
+    assert entries[0]["text"] == "the build is green"
+    assert entries[0]["sink"] == "browser"
+    assert entries[0]["announced"] is False
+
+
+# =============================================================================
+# session_idle — delegated work only
+# =============================================================================
+
+
+def test_delegated_session_going_idle_is_announced(isolate):
+    buddy = _subscribe()
+    _record("auth-fix", created_by="orchestrator")
+
+    fleet_activity.note_session_idle("auth-fix", "is idle and done working")
+
+    messages = _mail(buddy)
+    assert len(messages) == 1
+    assert messages[0].kind == "done"
+    assert messages[0].sender == fleet_activity.SENDER
+    # The name PREFIXES the caller's predicate — this is a sentence the owner
+    # hears out loud, and the obvious concatenation says "is idle" twice.
+    assert messages[0].text == "auth-fix is idle and done working"
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"role": "worker"},
+        {"role": "reviewer"},
+        {"worktree_path": "/Users/x/worktrees/proj/auth"},
+    ],
+)
+def test_every_delegation_axis_counts(isolate, fields):
+    """#716's three axes are independent — a worker with no recorded parent is
+    still somebody's delegated work, and so is a worktree checkout."""
+    buddy = _subscribe()
+    _record("child", **fields)
+    fleet_activity.note_session_idle("child", "done")
+    assert len(_mail(buddy)) == 1
+
+
+def test_root_orchestrator_idle_is_ledger_only(isolate):
+    """The false-accept half. An interactive session goes idle after EVERY turn;
+    announcing that fires once per exchange the owner has with their own
+    session, which is how a channel earns being ignored."""
+    buddy = _subscribe()
+    _record("orchestrator", role="orchestrator", created_by="")
+
+    fleet_activity.note_session_idle("orchestrator", "is idle and done working")
+
+    assert _mail(buddy) == []
+    assert [e["event"] for e in fleet_activity.recent()] == ["session_idle"]
+
+
+def test_unknown_session_idle_is_ledger_only(isolate):
+    """No record is not evidence of delegation, and the failure direction is quiet."""
+    buddy = _subscribe()
+    fleet_activity.note_session_idle("never-registered", "done")
+    assert _mail(buddy) == []
+    assert len(fleet_activity.recent()) == 1
+
+
+def test_the_parent_is_excluded_from_the_announcement(isolate):
+    """The parent hears this by paste from notify-parent. The same news twice is
+    exactly what makes a channel skippable."""
+    _record("boss")
+    fleet_alerts.subscribe("boss")
+    buddy = _subscribe("buddy")
+    _record("child", created_by="boss")
+
+    fleet_activity.note_session_idle("child", "done", parent="boss")
+
+    assert _mail("boss") == []
+    assert len(_mail(buddy)) == 1
+
+
+def test_a_session_never_hears_about_itself(isolate):
+    _subscribe("child", created_by="boss")
+    fleet_activity.note_session_idle("child", "done")
+    assert _mail("child") == []
+
+
+# =============================================================================
+# task_completed — the kind carries the fleet's verdict
+# =============================================================================
+
+
+def test_completed_task_is_news(isolate):
+    buddy = _subscribe()
+    fleet_activity.note_task_completed(
+        task="weekly-stars", session="s", status="complete", duration=42,
+        summary="7 new stars")
+    messages = _mail(buddy)
+    assert [m.kind for m in messages] == ["done"]
+    assert "weekly-stars" in messages[0].text and "7 new stars" in messages[0].text
+
+
+@pytest.mark.parametrize("status", ["failed", "incomplete", "timeout"])
+def test_a_run_that_ended_badly_asks_for_a_person(isolate, status):
+    """`request`, not `done`: the fleet already judged this as needing somebody,
+    and flattening that to news throws the judgment away."""
+    buddy = _subscribe()
+    fleet_activity.note_task_completed(
+        task="t", session="s", status=status, duration=1, summary="")
+    assert [m.kind for m in _mail(buddy)] == ["request"]
+
+
+@pytest.mark.parametrize("status", ["usage_limit", "auth_expired"])
+def test_detector_owned_failures_are_not_announced_twice(isolate, status):
+    """Both conditions are machine-wide and have their own detector, which says
+    it once. This producer would say it again per task."""
+    buddy = _subscribe()
+    fleet_activity.note_task_completed(
+        task="t", session="s", status=status, duration=1, summary="")
+    assert _mail(buddy) == []
+    assert [e["status"] for e in fleet_activity.recent()] == [status]
+
+
+# =============================================================================
+# toasts
+# =============================================================================
+
+
+def test_high_priority_toast_speaks_and_an_ordinary_one_does_not(isolate):
+    buddy = _subscribe()
+    fleet_activity.note_toast("build is red", session="ci", priority="high")
+    fleet_activity.note_toast("build is green", session="ci", priority="normal")
+
+    messages = _mail(buddy)
+    assert [m.kind for m in messages] == ["request"]
+    assert "red" in messages[0].text
+    assert {e["event"] for e in fleet_activity.recent()} == {"toast_high", "toast"}
+
+
+# =============================================================================
+# Throttling
+# =============================================================================
+
+
+def test_a_flapping_session_buys_one_utterance_not_many(isolate, monkeypatch):
+    buddy = _subscribe()
+    _record("flapper", created_by="boss")
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+
+    _at(fleet_activity, monkeypatch, start)
+    fleet_activity.note_session_idle("flapper", "done")
+    _at(fleet_activity, monkeypatch, start + timedelta(minutes=1))
+    result = fleet_activity.note_session_idle("flapper", "done again")
+
+    assert result["throttled"] is True
+    assert result["announced"] == []
+    assert len(_mail(buddy)) == 1
+    # Recorded both times: the ledger is the awareness tier, and suppressing
+    # the RECORD would lose the thing the buddy is meant to be able to look up.
+    assert len(fleet_activity.recent(event="session_idle")) == 2
+
+
+def test_the_cooldown_expires(isolate, monkeypatch):
+    buddy = _subscribe()
+    _record("flapper", created_by="boss")
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+
+    _at(fleet_activity, monkeypatch, start)
+    fleet_activity.note_session_idle("flapper", "done")
+    _at(fleet_activity, monkeypatch,
+        start + fleet_activity.ANNOUNCE["session_idle"] + timedelta(seconds=1))
+    fleet_activity.note_session_idle("flapper", "done again")
+
+    assert len(_mail(buddy)) == 2
+
+
+def test_the_throttle_is_per_subject(isolate):
+    """Two different tasks finishing together are two pieces of news."""
+    buddy = _subscribe()
+    fleet_activity.note_task_completed(task="a", session="s", status="complete",
+                                       duration=1, summary="")
+    fleet_activity.note_task_completed(task="b", session="s", status="complete",
+                                       duration=1, summary="")
+    assert len(_mail(buddy)) == 2
+
+
+# =============================================================================
+# The ledger itself
+# =============================================================================
+
+
+def test_recent_is_newest_first_and_filterable(isolate):
+    fleet_activity.record("spoke", session="a", text="one")
+    fleet_activity.record("session_idle", session="b", text="two")
+    fleet_activity.record("spoke", session="b", text="three")
+
+    assert [e["text"] for e in fleet_activity.recent()] == ["three", "two", "one"]
+    assert [e["text"] for e in fleet_activity.recent(event="spoke")] == ["three", "one"]
+    assert [e["text"] for e in fleet_activity.recent(session="b")] == ["three", "two"]
+    assert [e["text"] for e in fleet_activity.recent(limit=1)] == ["three"]
+
+
+def test_entries_older_than_the_window_are_history_not_awareness(isolate, monkeypatch):
+    now = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    _at(fleet_activity, monkeypatch, now - timedelta(hours=20))
+    fleet_activity.record("spoke", session="a", text="ancient")
+    _at(fleet_activity, monkeypatch, now)
+    fleet_activity.record("spoke", session="a", text="fresh")
+
+    assert [e["text"] for e in fleet_activity.recent()] == ["fresh"]
+    assert len(fleet_activity.recent(window=timedelta(hours=48))) == 2
+
+
+def test_an_unknown_event_is_refused_not_recorded(isolate):
+    """A closed vocabulary: a typo must not become a category nothing queries."""
+    assert fleet_activity.record("session_exploded", session="a") == {}
+    assert fleet_activity.recent() == []
+
+
+def test_a_corrupt_line_costs_one_entry_not_the_file(isolate):
+    fleet_activity.record("spoke", session="a", text="one")
+    with open(fleet_activity.ledger_path(), "a") as fh:
+        fh.write("{not json\n")
+    fleet_activity.record("spoke", session="a", text="two")
+
+    assert [e["text"] for e in fleet_activity.recent()] == ["two", "one"]
+
+
+def test_the_ledger_stays_bounded(isolate):
+    for i in range(fleet_activity.TRIM_AT + 20):
+        fleet_activity.record("spoke", session="a", text=str(i))
+    lines = fleet_activity.ledger_path().read_text().splitlines()
+    # Amortized, not exact: the trim fires only above TRIM_AT, so the file lives
+    # between the two bounds. Asserting equality with MAX_ENTRIES would be
+    # asserting a whole-file rewrite per append, which is the cost the slack
+    # exists to avoid.
+    assert fleet_activity.MAX_ENTRIES <= len(lines) <= fleet_activity.TRIM_AT
+    # The TAIL is what survives — trimming from the wrong end would keep the
+    # oldest entries and answer "what just happened" with last week.
+    assert json.loads(lines[-1])["text"] == str(fleet_activity.TRIM_AT + 19)
+
+
+def test_an_unwritable_ledger_never_breaks_a_producer(isolate, monkeypatch):
+    """Speaking, toasting and dispatching are the jobs; awareness is the bonus."""
+    monkeypatch.setattr(fleet_activity, "ledger_path",
+                        lambda: isolate / "nope" / "\0" / "ledger.jsonl")
+    assert fleet_activity.note_spoke("hello")["announced"] == []
+
+
+def test_an_unreachable_inbox_never_breaks_a_producer(isolate, monkeypatch):
+    _subscribe()
+    _record("child", created_by="boss")
+
+    def boom(*a, **kw):
+        raise OSError("inbox on fire")
+
+    monkeypatch.setattr(fleet_alerts, "emit_for", boom)
+    result = fleet_activity.note_session_idle("child", "done")
+    assert result["announced"] == []
+    assert len(fleet_activity.recent()) == 1
+
+
+# =============================================================================
+# Sender discipline — the recursion guard
+# =============================================================================
+
+
+def test_activity_mail_carries_its_own_sender(isolate):
+    buddy = _subscribe()
+    fleet_activity.note_task_completed(task="t", session="s", status="complete",
+                                       duration=1, summary="")
+    assert _mail(buddy)[0].sender == fleet_activity.SENDER
+    assert fleet_activity.SENDER != fleet_alerts.SENDER
+
+
+def test_a_lost_activity_notice_does_not_alert_about_itself(isolate):
+    """The dead-letter alert path drops our own stranded mail BY SENDER. Activity
+    joins that set: it is news by construction, and an alert about a lost
+    'session went idle' would land exactly when the fleet is already noisy
+    enough to be stranding mail."""
+    assert fleet_activity.SENDER in fleet_alerts.MACHINE_SENDERS
+
+
+def test_a_foreign_sender_is_refused(isolate):
+    """It can only be a coding bug, and swallowing it would re-open the loop the
+    guard above closes."""
+    _subscribe()
+    with pytest.raises(ValueError):
+        fleet_alerts.emit("x", kind="note", sender="some-agent")
+
+
+# =============================================================================
+# The WIRING — a producer nobody calls is a feature that does not exist
+# =============================================================================
+#
+# The module above can be perfect and the fleet still blind: what makes this
+# feature real is that four live surfaces call it. So each producer is driven
+# through the function the fleet actually reaches (the CLI handler, the
+# scheduler's own event log), never through a re-implementation of it — the
+# "deployment is the executing path" lesson, applied to a producer.
+
+
+def _ns(**kw):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(**kw)
+
+
+def test_an_idle_session_records_through_the_notify_cli(isolate, monkeypatch):
+    from agentwire import notify_cli, pane_manager, prompt_router, services
+    from agentwire.notify_cli import cmd_notify_parent
+
+    _subscribe()
+    _record("child", created_by="orch")
+    monkeypatch.setattr(pane_manager, "get_current_session", lambda: "child")
+    monkeypatch.setattr(pane_manager, "get_current_pane_index", lambda: 0)
+    monkeypatch.setattr(prompt_router, "resolve_parent", lambda s, p: ("orch", 0))
+    monkeypatch.setattr(services, "is_service_session", lambda s: False)
+    monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 0)
+
+    cmd_notify_parent(_ns(text=["is", "idle"], to=None, json=False, quiet=True,
+                          raw=False, on_idle=True, queued=True))
+
+    assert [e["event"] for e in fleet_activity.recent()] == ["session_idle"]
+    assert len(_mail("buddy")) == 1
+
+
+def test_a_service_session_going_idle_is_not_even_recorded(isolate, monkeypatch):
+    """Services cycle idle constantly and are nobody's delegated work. The
+    existing skip runs BEFORE this producer, and that ordering is the whole
+    reason the ledger isn't dominated by the portal."""
+    from agentwire import pane_manager, services
+    from agentwire.notify_cli import cmd_notify_parent
+
+    _subscribe()
+    _record("agentwire-portal", created_by="orch")
+    monkeypatch.setattr(pane_manager, "get_current_session", lambda: "agentwire-portal")
+    monkeypatch.setattr(pane_manager, "get_current_pane_index", lambda: 0)
+    monkeypatch.setattr(services, "is_service_session", lambda s: True)
+
+    cmd_notify_parent(_ns(text=["is", "idle"], to=None, json=True, quiet=True,
+                          raw=False, on_idle=True, queued=True))
+
+    assert fleet_activity.recent() == []
+
+
+def test_a_toast_records_through_the_notify_cli(isolate, monkeypatch):
+    from agentwire import notify_cli
+    from agentwire.notify_cli import cmd_notify_user
+
+    _subscribe()
+    monkeypatch.setattr(notify_cli, "_post_desktop_notification", lambda *a, **kw: True)
+    monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 0)
+
+    cmd_notify_user(_ns(text=["build", "is", "red"], session="ci",
+                        priority="high", json=False))
+
+    assert [e["event"] for e in fleet_activity.recent()] == ["toast_high"]
+    assert [m.kind for m in _mail("buddy")] == ["request"]
+
+
+def test_a_toast_the_portal_refused_is_still_recorded(isolate, monkeypatch):
+    """The case where awareness matters MOST: the screen never got it."""
+    from agentwire import notify_cli
+    from agentwire.notify_cli import cmd_notify_user
+
+    monkeypatch.setattr(notify_cli, "_post_desktop_notification", lambda *a, **kw: False)
+    monkeypatch.setattr(notify_cli, "_output_result", lambda *a, **kw: 1)
+
+    cmd_notify_user(_ns(text=["heads", "up"], session="ci", priority="normal", json=False))
+
+    assert [e["event"] for e in fleet_activity.recent()] == ["toast"]
+
+
+def test_portal_churn_is_not_recorded(isolate, monkeypatch):
+    """`notify-event` fires on every glance at a terminal. Recording all of it
+    would bury the events that mean something."""
+    from agentwire import notify_cli
+    from agentwire.notify_cli import cmd_notify
+
+    monkeypatch.setattr(notify_cli, "_get_portal_url", lambda: "")
+    for event in ("client_attached", "pane_focused", "window_activity"):
+        cmd_notify(_ns(event=event, session="s", pane=None, pane_id=None,
+                       old_name=None, new_name=None, json=True))
+    assert fleet_activity.recent() == []
+
+    cmd_notify(_ns(event="session_closed", session="s", pane=None, pane_id=None,
+                   old_name=None, new_name=None, json=True))
+    assert [e["event"] for e in fleet_activity.recent()] == ["session_closed"]
+
+
+def test_a_finished_scheduled_run_records_through_the_scheduler(isolate, monkeypatch):
+    """Driven through the scheduler's own event log, which is the seam BOTH
+    dispatch paths (in-place and worktree) go through exactly once per run."""
+    from agentwire.scheduler import report
+
+    _subscribe()
+    monkeypatch.setattr(report, "append_event", lambda *a, **kw: None)
+
+    report._log_event("task_completed", task="weekly-stars", session="s",
+                      status="complete", duration=90, summary="7 new stars")
+
+    entries = fleet_activity.recent()
+    assert [e["event"] for e in entries] == ["task_completed"]
+    assert entries[0]["task"] == "weekly-stars"
+    assert [m.kind for m in _mail("buddy")] == ["done"]
+
+
+def test_other_scheduler_events_are_not_activity(isolate, monkeypatch):
+    from agentwire.scheduler import report
+
+    monkeypatch.setattr(report, "append_event", lambda *a, **kw: None)
+    report._log_event("task_skipped", task="t", session="s", reason="lock_conflict")
+    assert fleet_activity.recent() == []
+
+
+def test_speaking_records_the_sink_through_the_say_cli(isolate, monkeypatch):
+    """The say path's own result helper is what records, so the sink is part of
+    the record and a FAILED dispatch is never recorded as spoken."""
+    from agentwire import channels_cli
+
+    _subscribe()
+    monkeypatch.setattr(channels_cli, "load_config", lambda: {"tts": {}})
+    monkeypatch.setattr(channels_cli, "get_voice_from_config", lambda: None)
+    monkeypatch.setattr(channels_cli, "_get_current_tmux_session", lambda: "worker-1")
+    monkeypatch.setattr(channels_cli, "_infer_session_from_path", lambda: None)
+    monkeypatch.setattr(channels_cli, "_handle_voice_notifications",
+                        lambda *a, **kw: None)
+    monkeypatch.setattr(channels_cli, "_get_portal_url", lambda: "https://portal")
+    monkeypatch.setattr(channels_cli, "_check_portal_connections",
+                        lambda s, url: (True, s, 2))
+    monkeypatch.setattr(channels_cli, "_remote_say", lambda *a, **kw: 0)
+
+    channels_cli.cmd_say(_ns(text=["the", "build", "is", "green"], json=True,
+                             voice=None, exaggeration=None, cfg=None, session=None,
+                             display=None, backend=None, instructions=None,
+                             language="English", stream=False))
+
+    entries = fleet_activity.recent()
+    assert [e["event"] for e in entries] == ["spoke"]
+    assert entries[0]["sink"] == "browser"
+    assert entries[0]["session"] == "worker-1"
+    # And it stayed out of the spool — the owner heard it in the room.
+    assert _mail("buddy") == []
+
+
+def test_a_failed_say_is_not_recorded_as_spoken(isolate, monkeypatch):
+    from agentwire import channels_cli
+
+    monkeypatch.setattr(channels_cli, "load_config", lambda: {"tts": {}})
+    monkeypatch.setattr(channels_cli, "get_voice_from_config", lambda: None)
+    monkeypatch.setattr(channels_cli, "_get_current_tmux_session", lambda: "worker-1")
+    monkeypatch.setattr(channels_cli, "_infer_session_from_path", lambda: None)
+    monkeypatch.setattr(channels_cli, "_handle_voice_notifications",
+                        lambda *a, **kw: None)
+    monkeypatch.setattr(channels_cli, "_get_portal_url", lambda: "https://portal")
+    monkeypatch.setattr(channels_cli, "_check_portal_connections",
+                        lambda s, url: (True, s, 2))
+    monkeypatch.setattr(channels_cli, "_remote_say", lambda *a, **kw: 1)
+
+    channels_cli.cmd_say(_ns(text=["nobody", "heard", "this"], json=True,
+                             voice=None, exaggeration=None, cfg=None, session=None,
+                             display=None, backend=None, instructions=None,
+                             language="English", stream=False))
+
+    assert fleet_activity.recent() == []

--- a/tests/unit/test_mcp_tools_args.py
+++ b/tests/unit/test_mcp_tools_args.py
@@ -216,32 +216,49 @@ class TestVoiceTools:
         assert "parked" in result
 
 
+def _toast_response(**fields):
+    """A 200 from the portal's notification endpoint, as `requests` returns it."""
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"success": True, "id": "n1", "clients": 1, **fields}
+
+    return _Response()
+
+
 class TestNotifyUserArtifactParams:
     """#822: notify_user's artifact_url/artifact_title params (#821) had zero
     test coverage — cover the body it builds for /api/desktop/notification."""
 
-    @patch("agentwire.mcp_notify._portal_request")
+    # Patched at core's ONE portal call, not at a transport inside mcp_notify:
+    # since #1016 every toast producer (CLI, MCP, `say --display`) goes through
+    # `core.post_desktop_notification`, so this asserts the body that actually
+    # reaches /api/desktop/notification.
+
+    @patch("agentwire.core.portal_request")
     def test_artifact_url_sets_artifact_body_with_default_title(self, mock_req):
         from agentwire.mcp_notify import notify_user
-        mock_req.return_value = _success(id="n1", clients=1)
+        mock_req.return_value = _toast_response()
         notify_user(text="ready", artifact_url="report.html")
-        body = mock_req.call_args[0][2]
+        body = mock_req.call_args.kwargs["json"]
         assert body["artifact"] == {"url": "report.html", "title": "Artifact"}
 
-    @patch("agentwire.mcp_notify._portal_request")
+    @patch("agentwire.core.portal_request")
     def test_artifact_title_overrides_default(self, mock_req):
         from agentwire.mcp_notify import notify_user
-        mock_req.return_value = _success(id="n1", clients=1)
+        mock_req.return_value = _toast_response()
         notify_user(text="ready", artifact_url="report.html", artifact_title="Q3 Report")
-        body = mock_req.call_args[0][2]
+        body = mock_req.call_args.kwargs["json"]
         assert body["artifact"] == {"url": "report.html", "title": "Q3 Report"}
 
-    @patch("agentwire.mcp_notify._portal_request")
+    @patch("agentwire.core.portal_request")
     def test_no_artifact_url_omits_artifact_body(self, mock_req):
         from agentwire.mcp_notify import notify_user
-        mock_req.return_value = _success(id="n1", clients=1)
+        mock_req.return_value = _toast_response()
         notify_user(text="plain toast", artifact_title="ignored without a url")
-        body = mock_req.call_args[0][2]
+        body = mock_req.call_args.kwargs["json"]
         assert "artifact" not in body
 
 

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -757,6 +757,32 @@ class TestTheBuddyClock:
         assert "body 4" in second and "body 5" in second
         assert "more waiting" not in second
 
+    def test_an_escalation_behind_the_cap_waits_one_tick_no_longer(self):
+        """The cap's one real cost, bounded and pinned. An escalation sitting at
+        position 4+ of a full-gate batch is pushed to the next tick — and that
+        tick says it whether or not the gate is still full, because the
+        interrupt path filters to urgent messages only. Delay is one 5s poll;
+        the failure this rules out is the escalation waiting behind an ordinary
+        report indefinitely."""
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "w1", kind: "done", text: "one" },
+              { id: "m2", from: "w2", kind: "done", text: "two" },
+              { id: "m3", from: "w3", kind: "done", text: "three" },
+              { id: "m4", from: "fleet-alerts", kind: "escalation",
+                text: "login expired" },
+            ];
+            await notifier.pollOnce();
+            logs.push("first: " + announcedCalls[0].text);
+            speakable = false;          // the buddy is now mid-chatter
+            interruptable = true;       // …but the interrupt tier is open
+            await notifier.pollOnce();
+        """)
+        assert "login expired" not in report["announced"][0]["text"]
+        assert report["announced"][0]["text"].endswith("And 1 more waiting.")
+        assert len(report["announced"]) == 2
+        assert "login expired" in report["announced"][1]["text"]
+
     def test_machine_mail_is_not_narrated_as_a_reply(self):
         """#1016. The fleet's own senders are not colleagues, and the announcer
         speaks composeNotice VERBATIM — the model never gets to rephrase it. So

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -722,6 +722,41 @@ class TestTheBuddyClock:
     volunteers replies — through the injected announce(), never its own
     speaking path."""
 
+    def test_a_fan_out_is_capped_into_utterances_not_a_monologue(self):
+        """#1016. Speech cannot be skimmed and the owner cannot predict when it
+        stops, so an unbounded coalesce is a monologue waiting for a fan-out —
+        ten workers landing in one 5s poll window was one ~2500-char utterance.
+        The overflow is HELD, not dropped: it stays unread and the next quiet
+        tick says it."""
+        report = run_notifier("""
+            spool = [];
+            for (var i = 1; i <= 5; i++) {
+              spool.push({ id: "m" + i, from: "w" + i, kind: "done", text: "body " + i });
+            }
+            await notifier.pollOnce();
+        """)
+        first = report["announced"][0]
+        assert "body 1" in first["text"] and "body 3" in first["text"]
+        assert "body 4" not in first["text"]
+        assert first["text"].endswith("And 2 more waiting.")
+        assert first["meta"]["inboxIds"] == ["m1", "m2", "m3"]
+        # And the ack stops at the spoken run — the held mail is not buried.
+        assert first["meta"]["ackThrough"] == "m3"
+
+    def test_the_held_overflow_is_spoken_on_the_next_gap(self):
+        report = run_notifier("""
+            spool = [];
+            for (var i = 1; i <= 5; i++) {
+              spool.push({ id: "m" + i, from: "w" + i, kind: "done", text: "body " + i });
+            }
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+        """)
+        assert len(report["announced"]) == 2
+        second = report["announced"][1]["text"]
+        assert "body 4" in second and "body 5" in second
+        assert "more waiting" not in second
+
     def test_machine_mail_is_not_narrated_as_a_reply(self):
         """#1016. The fleet's own senders are not colleagues, and the announcer
         speaks composeNotice VERBATIM — the model never gets to rephrase it. So

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -722,6 +722,43 @@ class TestTheBuddyClock:
     volunteers replies — through the injected announce(), never its own
     speaking path."""
 
+    def test_machine_mail_is_not_narrated_as_a_reply(self):
+        """#1016. The fleet's own senders are not colleagues, and the announcer
+        speaks composeNotice VERBATIM — the model never gets to rephrase it. So
+        "fleet-activity got back to you" would tell the owner a session with a
+        robot's name answered something they never sent."""
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "fleet-activity", kind: "done",
+                       text: "auth-fix is idle and done working" }];
+            await notifier.pollOnce();
+        """)
+        text = report["announced"][0]["text"]
+        assert text == "From the fleet: auth-fix is idle and done working"
+        assert "got back to you" not in text
+
+    def test_a_machine_escalation_still_sounds_like_an_alarm(self):
+        report = run_notifier("""
+            spool = [{ id: "m1", from: "fleet-alerts", kind: "escalation",
+                       text: "login expired; every turn is being refused" }];
+            speakable = false; interruptable = true;
+            await notifier.pollOnce();
+        """)
+        text = report["announced"][0]["text"]
+        assert text.startswith("Heads up")
+        assert "login expired" in text
+
+    def test_a_mixed_batch_names_the_session_and_the_fleet_differently(self):
+        report = run_notifier("""
+            spool = [
+              { id: "m1", from: "minecraft", kind: "done", text: "PR is up" },
+              { id: "m2", from: "fleet-activity", kind: "done", text: "nightly task finished" },
+            ];
+            await notifier.pollOnce();
+        """)
+        text = report["announced"][0]["text"]
+        assert "From minecraft: PR is up" in text
+        assert "From the fleet: nightly task finished" in text
+
     def test_three_replies_are_one_utterance(self):
         report = run_notifier("""
             spool = [

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -524,6 +524,37 @@ class TestToolAllowlist:
         assert result["count"] == 1
         assert result["messages"][0]["text"] == "PR is up"
 
+    def test_fleet_activity_builds_its_own_argv(self, monkeypatch):
+        """The awareness read (#1016) — clamped, and dispatched through the CLI."""
+        seen = {}
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.run_agentwire_cmd",
+            lambda args, **kw: seen.setdefault("args", args) or {"success": True},
+        )
+        tools.dispatch("fleet_activity", {"limit": 10 ** 9, "hours": 3,
+                                          "event": "spoke", "session": "worker-1"}, "b")
+        assert seen["args"] == [
+            "activity", "list",
+            "--limit", str(tools._MAX_ACTIVITY_LIMIT),
+            "--hours", "3",
+            "--event", "spoke",
+            "-s", "worker-1",
+        ]
+
+    def test_fleet_activity_refuses_an_event_it_does_not_track(self):
+        """`--event` is an argparse `choices` field: a mis-heard value would exit
+        the CLI with a usage message, which the buddy would then read out as if
+        it were an answer. Refused HERE, with the real vocabulary spoken back."""
+        result = tools.dispatch("fleet_activity", {"event": "session_exploded"}, "b")
+        assert result["success"] is False
+        assert result["must_speak"] is True
+        assert "session idle" in result["error"]
+
+    def test_fleet_activity_validates_a_session_name_like_every_other_read(self):
+        result = tools.dispatch("fleet_activity", {"session": "--help"}, "b")
+        assert result["success"] is False
+        assert "valid session name" in result["error"]
+
     def test_tool_defs_are_valid_realtime_function_entries(self):
         for entry in tools.realtime_tool_defs():
             assert entry["type"] == "function"


### PR DESCRIPTION
The buddy could be *told* things (`msg send --to buddy`, fleet detectors since #982/#1002) but nothing emitted the fleet's own signals — a session going idle, a scheduled task finishing, a toast, anything spoken through fleet TTS. So it could not check in on delegated work, and fleet TTS and voice mode were two disconnected audio surfaces in the same room.

**The routing was never the hard part.** Everything in the buddy's spool is eventually SPOKEN — the notifier volunteers unread mail at a gap (#962), an escalation cuts across its own voice (#967), and there is no quiet kind. A producer that spooled lifecycle churn would not make the buddy aware, it would make it a narrator, and the owner's move against a narrator is to stop listening.

## Two tiers

| | Where | Who reads it | Spoken? |
|---|---|---|---|
| **Awareness** | `~/.agentwire/fleet-activity.jsonl` — `agentwire activity list`, read-only tool `fleet_activity` | pulled, on a question | never |
| **News** | the buddy's spool, as ordinary typed mail via `fleet_alerts` | pushed | at a gap |

The ledger is a **pull, not a fourth push**, so the closed list of unprompted paths in `instructions.VOICE_MODE` stays closed. It is also what joins the two audio surfaces: every `agentwire say` is recorded, and the buddy is told that a `spoke` entry was *already heard by the owner* — so it refers back to one instead of reading the audio back.

## What earns the spool (`fleet_activity.ANNOUNCE`, kinds in `fleet_alerts.DETECTOR_KINDS`)

- **`session_idle` → `done`, only for DELEGATED work** — a recorded parent, a worker/reviewer role, or a worktree (#716's axes; any one suffices). A root orchestrator goes idle after *every* turn. The event's parent is excluded — it hears this by paste from `notify-parent`.
- **`task_completed` → `done`, `request` when it ended badly** — the canonical check-in event. `usage_limit` / `auth_expired` runs are ledger-only: both conditions have detectors of their own that say it once, machine-wide.
- **`toast_high` → `request`** — the one notify surface that declares its own urgency, about a screen the owner may not be looking at.
- Ledger-only: ordinary toasts, portal lifecycle, and **everything spoken**.

**No lifecycle event is ever an `escalation`** — the interrupt tier stays the two conditions nothing clears without a human. Throttled per subject (15m / 2m / 5m) off the ledger itself, so a flapping session records every flap and buys one utterance.

## Producers (all best-effort — a producer's job is its own job)

| Surface | Seam |
|---|---|
| idle hook | `cmd_notify_parent --on-idle`, **above** the no-target return — a root session finishing is exactly the case that told nobody |
| `agentwire say` | `cmd_say`'s result helper (records the sink; a failed dispatch records nothing) |
| `agentwire notify-user` | `cmd_notify_user`, whether or not the portal took it |
| `agentwire notify-event` | `cmd_notify`, three events only (not `client_attached`/`pane_focused`/`window_activity`) |
| scheduler | `report._log_event("task_completed")` — the one seam both dispatchers use, rather than two call-site copies |

## Also

- Machine mail no longer renders as "fleet-activity got back to you…" — the announcer speaks `composeNotice` verbatim, so machine senders now say **"From the fleet: …"**; an escalation keeps its alarm prefix.
- A dead-lettered activity notice no longer alerts about itself (`fleet_alerts.MACHINE_SENDERS`; `emit` refuses any other sender).

## Constraint

Read-only throughout: no new write path, no new confirm-spine surface, and deliberately **no verb that writes a ledger entry** — producers record from inside the surfaces that generate the events, so nothing an agent can be talked into calling can forge fleet history. `fleet_activity` carries a written tier ruling in `surface.py`.

## Verification

- `tests/unit/test_fleet_activity.py` (41 new) — the ruling pinned as data, both failure directions, and the WIRING driven through each live surface. Each wiring test was mutation-checked: unwiring the say / scheduler / idle producer fails exactly its own test.
- 3 new node-driven notifier tests for the machine-sender wording; 3 new tool tests (argv, clamping, refusals).
- Full suite: `6180 passed`. Four `tests/unit/test_beta_flag.py` failures are **pre-existing on this base** (verified against a stashed clean tree at `origin/main` = `1d5c13c`) — fixtures drifted from main's rendered role/MCP output; untouched here.
- Not verifiable in-worktree: the live drain → spool hop needs the installed tool, so the end-to-end was exercised in-process (idle → `fleet_alerts.emit` → `inbox.flush_session` → buddy spool, confirmed) rather than against the running fleet.

Docs: `docs/wiki/voice-layer.md` (new section) and `docs/wiki/sessions/messaging.md` (lifecycle joins the alert ruling table, new CLI).

Closes #1016

Built by [dotdev.dev](https://dotdev.dev)