### PR TITLE
voice relay: the full spoken request reaches the session, not an excerpt

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -899,19 +899,24 @@ class Proposal:
         # ``_proposals.pop()`` and outside the runner's ``try``, where a throw
         # eats an approved message with no screen to report it on.
         written = ""
-        # Matched against the path this id DERIVES, not merely read out of the
-        # argv: a future spec that froze a ``--ref`` of its own would otherwise
-        # steer this write, and the one thing a frozen argv must never contain
-        # is a model-supplied path we then open. A mismatch (or an id that is
-        # not one, in a hand-built Proposal) simply means no relay.
+        # Matched against the path this id DERIVES, and matched at the TAIL:
+        # ``ConfirmSpine.propose`` appends its pair last, so the tail is the
+        # only position that identifies OUR pair rather than someone else's.
+        # Both halves of that matter. Reading "the first ``--ref``" would let a
+        # future spec's own frozen ``--ref`` steer this write — the one thing a
+        # frozen argv must never contain is a model-supplied path we then open
+        # — and it would ALSO leave our pair in place on the mismatch, shipping
+        # exactly the dangling pointer this code argues is worse than none,
+        # while the removal below deleted the other spec's pair instead of
+        # ours. Tail-matching makes both unreachable. An id that is not one (a
+        # hand-built Proposal) simply means no relay.
         try:
             expected = str(relay.relay_path(self.id))
         except ValueError:
             expected = ""
-        ref = self._flag_value("--ref")
-        if ref and ref == expected:
+        if expected and prefix[-2:] == ["--ref", expected]:
             written = relay.write_relay(
-                Path(ref),
+                Path(expected),
                 proposal_id=self.id,
                 session=self.session,
                 sender=self._reply_target(),
@@ -923,8 +928,7 @@ class Proposal:
                 # pointer: the recipient reads a missing path as "the real
                 # instruction is elsewhere" and stops, where an excerpt at
                 # least says something true. Drop the flag with the slot.
-                index = prefix.index("--ref")
-                del prefix[index : index + 2]
+                del prefix[-2:]
         return [
             *prefix,
             render_body(
@@ -1000,7 +1004,10 @@ class Proposal:
 #: **Re-measured for #1015, and again the number did not move.** The relay
 #: pointer adds a ``full: <path>`` slot INSIDE this cap, so the worst rendered
 #: line is unchanged at 363 — the pointer is paid for out of the excerpt and the
-#: droppable nudge, never out of the margin. The probe was re-run at 80x24 on
+#: droppable nudge, never out of the margin. (363 is this arithmetic, against
+#: ``WORST_SENDER_CHARS = 32``; a sweep over real bodies with the 33-character
+#: sender the tests use reports 364. Same margin, one character of sender.)
+#: The probe was re-run at 80x24 on
 #: 2026-08-11 with the pointer riding, and the cliff sits where it did::
 #:
 #:     476  ->  box 488   stuck hit    ✓        <- last passing probed
@@ -1212,9 +1219,11 @@ def render_body(
     other slots clip, so dropping it under budget pressure would be dropping
     the fix. The reply nudge stays droppable and the excerpt shrinks; both are
     losses the pointer makes recoverable. It rides exactly when something WAS
-    clipped: a body carrying the whole utterance already needs no pointer to
-    it, and paying ~50 characters of a 300-character line for a redundant one
-    would cost the excerpt and the nudge on every short message.
+    clipped — asked of the body as it ships TODAY, without the pointer's own
+    cost (see the predicate below, which is self-fulfilling if asked the other
+    way): a body carrying the whole utterance already needs no pointer to it,
+    and paying ~50 characters of a 300-character line for a redundant one would
+    cost the excerpt and the nudge on every short message.
     """
     instruction_line = _one_line(instruction)
     tail = f"#{proposal_id}"
@@ -1233,15 +1242,20 @@ def render_body(
                 cost += len(slot) + len(SEP)
         return min(MAX_RENDERED_INSTRUCTION_CHARS, MAX_BODY_CHARS - cost - len(SEP))
 
+    # **Asked WITHOUT the pointer's own cost, and that is the whole predicate.**
+    # Deducting it first makes the pointer manufacture the clipping it then
+    # claims to be recovering: with a 90-char quote and a 47-char path the
+    # budget falls 160 → 133, so a 145-character instruction that rendered
+    # WHOLE before #1015 would be clipped to 133 and handed a pointer — a
+    # message made worse by the fix for messages being made worse. The question
+    # is "does this body lose anything as it ships today?", so it is asked of
+    # today's body.
     lost = (
-        len(instruction_line) > excerpt_budget(said, pointer)
+        len(instruction_line) > excerpt_budget(said, "")
         or len(_one_line(request_utterance)) > MAX_UTTERANCE_CHARS
     )
     if not lost:
-        # Nothing was clipped, so there is nothing to recover. Dropping the
-        # pointer only RAISES the budget, so this cannot make the line that
-        # just fit stop fitting.
-        pointer = ""
+        pointer = ""  # nothing was clipped, so there is nothing to recover
     if pointer and excerpt_budget(said, pointer) < MIN_EXCERPT_CHARS:
         # A long ``$HOME`` can squeeze the preview below its floor. What gives
         # way FIRST is the ``said:`` quote, and the ordering is the whole
@@ -1249,9 +1263,13 @@ def render_body(
         # names, so dropping it costs a slot the recipient can still read,
         # while dropping the pointer costs the only copy of everything the
         # other slots clipped. Recoverable yields to unrecoverable.
-        said = ""
-    if pointer and excerpt_budget(said, pointer) < MIN_EXCERPT_CHARS:
-        pointer = ""  # see MIN_EXCERPT_CHARS — an unusably long path
+        dropped_said, said = said, ""
+        if excerpt_budget(said, pointer) < MIN_EXCERPT_CHARS:
+            # The path is long enough that even that was not enough, so the
+            # pointer goes after all — and the quote comes BACK. Dropping it
+            # bought room for a slot that is no longer there, and shipping
+            # neither would be strictly worse than shipping what main shipped.
+            pointer, said = "", dropped_said
 
     parts = [_lead_safe(_clip(instruction_line, excerpt_budget(said, pointer)))]
     if said:

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -1754,6 +1754,13 @@ class ConfirmSpine:
             # minted, so it is knowable before the file exists — and it is
             # code-derived, never model-supplied. ``build_argv`` writes the file
             # and drops this pair again if the write fails.
+            #
+            # **This makes ``append_body=True`` imply "the target verb accepts
+            # ``--ref``"**, which is true of ``msg send`` and of every spec that
+            # exists. A future body-carrying spec pointed at a different verb
+            # inherits the flag and fails at the CLI — so the coupling is named
+            # here rather than left for whoever writes that spec to discover.
+            # ``append_body=False`` writes are unaffected: they get no pair.
             if append_body:
                 argv_prefix = (
                     *argv_prefix, "--ref", str(relay.relay_path(proposal_id)),

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -197,8 +197,9 @@ import re
 import secrets
 import threading
 from dataclasses import dataclass, field
+from pathlib import Path
 
-from . import outbox
+from . import outbox, relay
 from .transcript import TranscriptRing, Utterance
 
 #: How long a minted proposal stays confirmable, from the moment the buddy
@@ -891,15 +892,57 @@ class Proposal:
         # that structural rather than a calling convention.
         if not self.append_body:
             return list(self.argv_prefix)
+        prefix = list(self.argv_prefix)
+        # The full relay (#1015) is written HERE, at execution, not at propose:
+        # a proposal the owner cancels or lets expire must leave nothing on
+        # disk. ``write_relay`` never raises — this line sits after the
+        # ``_proposals.pop()`` and outside the runner's ``try``, where a throw
+        # eats an approved message with no screen to report it on.
+        written = ""
+        # Matched against the path this id DERIVES, not merely read out of the
+        # argv: a future spec that froze a ``--ref`` of its own would otherwise
+        # steer this write, and the one thing a frozen argv must never contain
+        # is a model-supplied path we then open. A mismatch (or an id that is
+        # not one, in a hand-built Proposal) simply means no relay.
+        try:
+            expected = str(relay.relay_path(self.id))
+        except ValueError:
+            expected = ""
+        ref = self._flag_value("--ref")
+        if ref and ref == expected:
+            written = relay.write_relay(
+                Path(ref),
+                proposal_id=self.id,
+                session=self.session,
+                sender=self._reply_target(),
+                instruction=self.instruction,
+                request_utterance=self.request_utterance,
+            )
+            if not written:
+                # A pointer to a file that is not there is worse than no
+                # pointer: the recipient reads a missing path as "the real
+                # instruction is elsewhere" and stops, where an excerpt at
+                # least says something true. Drop the flag with the slot.
+                index = prefix.index("--ref")
+                del prefix[index : index + 2]
         return [
-            *self.argv_prefix,
+            *prefix,
             render_body(
                 self.instruction,
                 self.request_utterance,
                 self.id,
                 reply_to=self._reply_target(),
+                full_path=written,
             ),
         ]
+
+    def _flag_value(self, flag: str) -> str:
+        """The value frozen after *flag* in the argv prefix, or ``""``."""
+        prefix = self.argv_prefix
+        for index, token in enumerate(prefix[:-1]):
+            if token == flag:
+                return prefix[index + 1]
+        return ""
 
     def _reply_target(self) -> str:
         """The sender name from the frozen argv — who a reply should address.
@@ -908,11 +951,7 @@ class Proposal:
         nudge can never name anyone other than the identity the message
         actually goes out under.
         """
-        prefix = self.argv_prefix
-        for index, token in enumerate(prefix[:-1]):
-            if token == "--from":
-                return prefix[index + 1]
-        return ""
+        return self._flag_value("--from")
 
 
 # =============================================================================
@@ -958,6 +997,20 @@ class Proposal:
 #: says they compete: the droppable reply nudge now fits in more cases. Raising
 #: MAX_BODY_CHARS to consume the headroom would still need a fresh pane probe.
 #:
+#: **Re-measured for #1015, and again the number did not move.** The relay
+#: pointer adds a ``full: <path>`` slot INSIDE this cap, so the worst rendered
+#: line is unchanged at 363 — the pointer is paid for out of the excerpt and the
+#: droppable nudge, never out of the margin. The probe was re-run at 80x24 on
+#: 2026-08-11 with the pointer riding, and the cliff sits where it did::
+#:
+#:     476  ->  box 488   stuck hit    ✓        <- last passing probed
+#:     546  ->  box 480   stuck MISS   ✗        <- box windows
+#:    1026  ->  box  16   stuck MISS   ✗        <- [Pasted text …] chip
+#:
+#: The recorded 520/540 boundary sits inside that 476–546 window, so it stands.
+#: The round trip closed on the real shipped worst case (336 chars rendered):
+#: pasted whole, ``stuck`` hit, ``finish_submit`` submitted, dedup found it.
+#:
 #: **The margin is deliberate and the measurement is pane-dependent.** The box
 #: shows a bounded number of ROWS, so a shorter pane windows sooner than 80x24
 #: did. Do not raise this cap to consume the measured headroom without
@@ -992,7 +1045,28 @@ MAX_UTTERANCE_CHARS = 90
 #: How much of the instruction survives INTO THE RENDERED LINE. Distinct from
 #: ``write_tools.MAX_INSTRUCTION_CHARS``, which bounds what the model may
 #: propose at all; this one bounds what the recipient's pane has to render.
+#:
+#: Since #1015 this is a PREVIEW budget rather than the message: anything it
+#: clips is still reachable in full through the ``full:`` pointer below. Before
+#: that it was the message, and a long spoken request simply lost its tail.
 MAX_RENDERED_INSTRUCTION_CHARS = 160
+
+#: The body's slot separator. One definition, because the budget arithmetic in
+#: :func:`render_body` counts it — a second spelling would make the cap
+#: arithmetic silently wrong rather than visibly different.
+SEP = " ┃ "
+
+#: The label on the pointer to the full relay file (#1015).
+POINTER_LABEL = "full: "
+
+#: The preview never shrinks below this. A pathologically long relay path (a
+#: deep ``$HOME``) would otherwise eat the excerpt entirely; below this floor
+#: the pointer is dropped instead. **Both halves priced:** dropping it costs a
+#: recoverable tail again (today's behaviour), while keeping it costs the
+#: recipient every scannable word of what the message is even about — and a
+#: message nobody reads the file for is not more recoverable than one nobody
+#: can read.
+MIN_EXCERPT_CHARS = 80
 
 
 def _one_line(text: str) -> str:
@@ -1084,7 +1158,12 @@ def reply_nudge(reply_to: str) -> str:
 
 
 def render_body(
-    instruction: str, request_utterance: str, proposal_id: str, *, reply_to: str = ""
+    instruction: str,
+    request_utterance: str,
+    proposal_id: str,
+    *,
+    reply_to: str = "",
+    full_path: str = "",
 ) -> str:
     """The fixed one-line shape every buddy write carries (§4b).
 
@@ -1120,12 +1199,67 @@ def render_body(
     the distinguisher sits in the same on-screen position the marker held while
     also being the thing ``ESCALATE_KINDS`` and the drain read. No marker
     remains; a body that still carries one is stale text, not attribution.
+
+    **The inline text is a PREVIEW, and the pointer is the message (#1015).**
+    The caps here cannot be raised — they are the measured boundary past which
+    the #689 heal stops firing — so a long spoken request had exactly two
+    fates, and the shipped one silently dropped its tail into the recipient's
+    lap ("Treat it as a running list for anyt…"). *full_path* names a file
+    holding the whole thing (:mod:`~agentwire.voice_layer.relay`), and the
+    ``full:`` slot puts it on the delivered line, where an agent can read it.
+
+    That slot is NOT droppable — it is the recoverability of everything the
+    other slots clip, so dropping it under budget pressure would be dropping
+    the fix. The reply nudge stays droppable and the excerpt shrinks; both are
+    losses the pointer makes recoverable. It rides exactly when something WAS
+    clipped: a body carrying the whole utterance already needs no pointer to
+    it, and paying ~50 characters of a 300-character line for a redundant one
+    would cost the excerpt and the nudge on every short message.
     """
-    parts = [_lead_safe(_clip(instruction, MAX_RENDERED_INSTRUCTION_CHARS))]
-    if request_utterance.strip():
-        parts.append(f"said: \"{_clip(request_utterance, MAX_UTTERANCE_CHARS)}\"")
-    parts.append(f"#{proposal_id}")
-    body = " ┃ ".join(parts)
+    instruction_line = _one_line(instruction)
+    tail = f"#{proposal_id}"
+    said = (
+        f'said: "{_clip(request_utterance, MAX_UTTERANCE_CHARS)}"'
+        if request_utterance.strip()
+        else ""
+    )
+    pointer = f"{POINTER_LABEL}{_one_line(full_path)}" if full_path.strip() else ""
+
+    def excerpt_budget(said_slot: str, pointer_slot: str) -> int:
+        """What is left for the preview once every other slot is paid for."""
+        cost = len(tail)
+        for slot in (said_slot, pointer_slot):
+            if slot:
+                cost += len(slot) + len(SEP)
+        return min(MAX_RENDERED_INSTRUCTION_CHARS, MAX_BODY_CHARS - cost - len(SEP))
+
+    lost = (
+        len(instruction_line) > excerpt_budget(said, pointer)
+        or len(_one_line(request_utterance)) > MAX_UTTERANCE_CHARS
+    )
+    if not lost:
+        # Nothing was clipped, so there is nothing to recover. Dropping the
+        # pointer only RAISES the budget, so this cannot make the line that
+        # just fit stop fitting.
+        pointer = ""
+    if pointer and excerpt_budget(said, pointer) < MIN_EXCERPT_CHARS:
+        # A long ``$HOME`` can squeeze the preview below its floor. What gives
+        # way FIRST is the ``said:`` quote, and the ordering is the whole
+        # ruling: the quote is reproduced verbatim in the file the pointer
+        # names, so dropping it costs a slot the recipient can still read,
+        # while dropping the pointer costs the only copy of everything the
+        # other slots clipped. Recoverable yields to unrecoverable.
+        said = ""
+    if pointer and excerpt_budget(said, pointer) < MIN_EXCERPT_CHARS:
+        pointer = ""  # see MIN_EXCERPT_CHARS — an unusably long path
+
+    parts = [_lead_safe(_clip(instruction_line, excerpt_budget(said, pointer)))]
+    if said:
+        parts.append(said)
+    if pointer:
+        parts.append(pointer)
+    parts.append(tail)
+    body = SEP.join(parts)
     # The reply-path slot (#962) is DROPPABLE, whole-or-not-at-all: it rides
     # only when the full body still fits MAX_BODY_CHARS, and it slots in
     # BEFORE the id so the id is never what pays for it. Both halves priced:
@@ -1135,7 +1269,7 @@ def render_body(
     # the pane re-measurement MAX_BODY_CHARS documents; a droppable slot does
     # not.
     if reply_to.strip():
-        with_nudge = " ┃ ".join([*parts[:-1], reply_nudge(reply_to), parts[-1]])
+        with_nudge = SEP.join([*parts[:-1], reply_nudge(reply_to), parts[-1]])
         if len(with_nudge) <= MAX_BODY_CHARS:
             body = with_nudge
     body = _clip(body, MAX_BODY_CHARS)
@@ -1595,8 +1729,19 @@ class ConfirmSpine:
             # different way to draw a nonce sitting next to the right one is
             # how the wrong one gets called later.
             nonce = mint_nonce({p.nonce for p in self._proposals.values()})
+            proposal_id = secrets.token_hex(3)
+            # The relay pointer is frozen HERE, with the rest of the argv, so
+            # "the whole argv is frozen at propose" stays literally true (#966).
+            # It can be: the path is a pure function of the id this line just
+            # minted, so it is knowable before the file exists — and it is
+            # code-derived, never model-supplied. ``build_argv`` writes the file
+            # and drops this pair again if the write fails.
+            if append_body:
+                argv_prefix = (
+                    *argv_prefix, "--ref", str(relay.relay_path(proposal_id)),
+                )
             proposal = Proposal(
-                id=secrets.token_hex(3),
+                id=proposal_id,
                 token=secrets.token_urlsafe(18),
                 nonce=nonce,
                 tool=tool,

--- a/agentwire/voice_layer/relay.py
+++ b/agentwire/voice_layer/relay.py
@@ -97,12 +97,20 @@ def render_relay(
     request_utterance: str,
     when: float,
 ) -> str:
-    """The file's contents: the whole thing, verbatim, in both fields.
+    """The file's contents: both fields entire, neither clipped.
 
     Nothing here is clipped — that is the entire point of the file. It is
     Markdown because the reader is an agent with a Read tool, and it names the
     proposal id so a reader holding the delivered line can tell it is looking at
     the same write rather than at a neighbouring one.
+
+    **The quote is ONE transcript entry, and the heading says so.** *instruction*
+    is the whole request as the buddy understood it, but *request_utterance*
+    comes from ``request_utterance_from``, which returns a single ring entry —
+    so a spoken request delivered across several segments reproduces only the
+    segment that carried the request. Narrowed rather than qualified: calling
+    this "what the owner said" would be a broader claim than the ring can
+    support, and a broad claim is what gets rounded back up later.
     """
     stamp = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime(when))
     lines = [
@@ -119,7 +127,7 @@ def render_relay(
     if request_utterance.strip():
         lines += [
             "",
-            "## What the owner said, verbatim",
+            "## The request utterance, verbatim (one spoken segment)",
             "",
             f"> {request_utterance.strip()}",
         ]
@@ -151,7 +159,16 @@ def write_relay(
     somewhere impossible) degrades to today's behaviour rather than destroying
     a message the owner has already approved.
 
-    Written whole via a temp file and ``replace``: a partial relay read by the
+    Written through :func:`core.write_owner_only` — 0600, mode set on the
+    descriptor before any bytes land, ``os.replace`` for atomicity. Not a
+    hand-rolled temp-and-replace: this file holds the owner's verbatim speech,
+    which is exactly the content class #887 tightened, and that function is
+    documented as the ONE implementation *because* the third hand-rolled copy is
+    how a 0644 file carrying private content reached the wild. It also owns the
+    temp file's lifetime, where a fixed ``.md.tmp`` name would leave an orphan
+    that :func:`_prune`'s ``*.md`` glob can never collect.
+
+    Atomicity is load-bearing rather than tidy: a partial relay read by the
     recipient is a *silently* partial instruction, which is the defect this
     module exists to remove, not a variant of it worth shipping.
     """
@@ -165,10 +182,7 @@ def write_relay(
         when=now,
     )
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        temp = path.with_suffix(".md.tmp")
-        temp.write_text(body, encoding="utf-8")
-        temp.replace(path)
+        core.write_owner_only(path, body)
     except Exception:
         return ""
     try:

--- a/agentwire/voice_layer/relay.py
+++ b/agentwire/voice_layer/relay.py
@@ -1,0 +1,178 @@
+"""The FULL relayed utterance, on disk, because the pane cannot carry it (#1015).
+
+The §4b body is capped hard — ``MAX_BODY_CHARS`` and its 160-char instruction
+slot are not tidiness, they are the measured boundary past which the #689 heal
+stops firing and a swallowed Enter wedges the message permanently. So a long
+spoken request had exactly two possible fates and the shipped one was the bad
+one: the recipient got ``"Treat it as a running list for anyt…"`` and acted on
+the half it could see. Every relay in the first live voice session arrived that
+way.
+
+**A cap you cannot raise is not an argument for losing the text.** The pane is
+one channel; the filesystem is another, and the recipient is an agent that
+reads files. So the whole utterance is written here and the body carries a
+pointer to it — the same shape ``ingest`` messages already use (``--ref``),
+with the inline excerpt demoted to what it always actually was: a preview.
+
+Three properties, each with a named failure:
+
+- **Writing never raises.** :func:`write_relay` is called from
+  ``Proposal.build_argv()``, which ``ConfirmSpine._dispatch`` runs *after*
+  ``_proposals.pop()`` and *outside* the runner's ``try`` — a raise there eats
+  the proposal with the approving utterance already spent, and the owner is not
+  watching a screen (the ``_lead_safe`` lesson, same position, same cost). A
+  failed write returns ``""`` and the message goes out as it does today:
+  excerpt only, and the caller drops the ``--ref`` too, because a pointer to a
+  file that is not there is worse than no pointer.
+- **The pointer and the file agree.** The path is derived from the proposal id
+  (:func:`relay_path`), frozen into the argv at propose time, and the body's
+  ``full:`` slot is rendered from the path the write actually returned — never
+  from a second construction of it.
+- **The store is bounded.** Relays are small and permanent-by-default is a slow
+  leak, so each write prunes entries older than :data:`RETENTION_DAYS`. Pruning
+  is best-effort and never raises for the same reason writing does not.
+
+The id in the filename is ``secrets.token_hex(3)`` from ``ConfirmSpine.propose``
+— six hex characters, so the path is fixed-length and traversal-free by
+construction rather than by validation. :func:`relay_path` asserts that shape
+anyway, since it is what makes the sentence above true.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+from .. import core
+
+#: How long a relay file survives. Long enough that a session picking up a
+#: message hours later still finds it, short enough that the directory does not
+#: grow without bound.
+RETENTION_DAYS = 30
+
+#: The proposal-id shape ``ConfirmSpine.propose`` mints. Anything else is a
+#: caller bug, not a path to sanitise.
+_ID_RE = re.compile(r"^[0-9a-f]{4,32}$")
+
+
+def relay_dir() -> Path:
+    """``~/.agentwire/voice/relays/`` — a FUNCTION, not a constant.
+
+    An import-time constant silently ignores a patched ``core.CONFIG_DIR``,
+    which is how a test seam turns into a write against the owner's real config
+    directory (the ``role_prompts_dir`` lesson, #871).
+    """
+    return core.CONFIG_DIR / "voice" / "relays"
+
+
+def relay_path(proposal_id: str) -> Path:
+    """Where the relay for *proposal_id* lives. Deterministic, so the argv can
+    carry the path before the file exists."""
+    if not _ID_RE.match(proposal_id or ""):
+        raise ValueError(f"not a proposal id: {proposal_id!r}")
+    return relay_dir() / f"{proposal_id}.md"
+
+
+def _prune(now: float) -> None:
+    cutoff = now - RETENTION_DAYS * 86400
+    try:
+        entries = list(relay_dir().glob("*.md"))
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+        except OSError:
+            continue
+
+
+def render_relay(
+    *,
+    proposal_id: str,
+    session: str,
+    sender: str,
+    instruction: str,
+    request_utterance: str,
+    when: float,
+) -> str:
+    """The file's contents: the whole thing, verbatim, in both fields.
+
+    Nothing here is clipped — that is the entire point of the file. It is
+    Markdown because the reader is an agent with a Read tool, and it names the
+    proposal id so a reader holding the delivered line can tell it is looking at
+    the same write rather than at a neighbouring one.
+    """
+    stamp = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime(when))
+    lines = [
+        f"# Voice relay #{proposal_id}",
+        "",
+        f"- **to:** {session}",
+        f"- **from:** {sender or 'buddy'}",
+        f"- **when:** {stamp}",
+        "",
+        "## Message (full)",
+        "",
+        instruction.strip(),
+    ]
+    if request_utterance.strip():
+        lines += [
+            "",
+            "## What the owner said, verbatim",
+            "",
+            f"> {request_utterance.strip()}",
+        ]
+    lines += [
+        "",
+        "---",
+        "",
+        "The delivered message carried only an excerpt of the above — the pane "
+        "has a measured size limit. This file is the whole request; act on "
+        "this, not on the excerpt.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_relay(
+    path: Path,
+    *,
+    proposal_id: str,
+    session: str,
+    sender: str,
+    instruction: str,
+    request_utterance: str,
+) -> str:
+    """Persist the full relay at *path*. Returns the path as a string, or ``""``.
+
+    **Never raises**, deliberately — see the module docstring. Every failure
+    mode (unwritable directory, full disk, a patched CONFIG_DIR pointing
+    somewhere impossible) degrades to today's behaviour rather than destroying
+    a message the owner has already approved.
+
+    Written whole via a temp file and ``replace``: a partial relay read by the
+    recipient is a *silently* partial instruction, which is the defect this
+    module exists to remove, not a variant of it worth shipping.
+    """
+    now = time.time()
+    body = render_relay(
+        proposal_id=proposal_id,
+        session=session,
+        sender=sender,
+        instruction=instruction,
+        request_utterance=request_utterance,
+        when=now,
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp = path.with_suffix(".md.tmp")
+        temp.write_text(body, encoding="utf-8")
+        temp.replace(path)
+    except Exception:
+        return ""
+    try:
+        _prune(now)
+    except Exception:
+        pass
+    return str(path)

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -24,7 +24,10 @@ that validates the model's arguments into a :class:`FrozenWrite`, and the
 spoken templates. :func:`gated_triple` generates the propose/confirm/cancel
 tools from it, so the invariants live in ONE place:
 
-- the WHOLE argv is frozen at propose time, inside ``freeze``;
+- the WHOLE argv is frozen at propose time — every model-supplied element
+  inside ``freeze``, plus the one element only the spine can know: the
+  ``--ref`` naming this proposal's relay file, which is a pure function of the
+  id ``ConfirmSpine.propose`` mints (#1015). Nothing is frozen later;
 - a proposal is single-use and consumed on success (the spine);
 - the approving utterance never reaches the body (#953 — the spine);
 - ``render_body``'s leading-dash assertion guards every body-carrying write;
@@ -138,10 +141,13 @@ def _buddy_arg(args: dict) -> str:
 class FrozenWrite:
     """The output of a spec's ``freeze``: everything that will run, validated.
 
-    ``argv_prefix`` is complete and final. When ``append_body`` is True the
-    spine appends the §4b rendered body (instruction + request utterance +
-    proposal id) at execution; when False, the prefix IS the argv, so every
-    element must already have passed a validator — there is no free-text slot.
+    ``argv_prefix`` holds every element ``freeze`` is the authority on. When
+    ``append_body`` is True the spine extends it once at PROPOSE time with the
+    ``--ref`` naming this proposal's relay file (#1015 — code-derived from the
+    freshly minted id, never model-supplied) and appends the §4b rendered body
+    (instruction + request utterance + proposal id) at execution; when False,
+    the prefix IS the argv, so every element must already have passed a
+    validator — there is no free-text slot and no relay pointer.
     """
 
     session: str

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1994,9 +1994,19 @@ Four rulings hold it together:
   `--ref` can join the argv prefix while the file does not yet exist — "the whole
   argv is frozen at propose" (#966) stays literally true, and a proposal the
   owner cancels or lets expire leaves nothing on disk. `build_argv` matches the
-  frozen `--ref` against the path the id *derives* rather than just reading it
-  out of the argv, so a future spec freezing a `--ref` of its own can never turn
-  that line into "open the path in the argv".
+  frozen `--ref` against the path the id *derives*, **at the tail** — `propose`
+  appends its pair last, so the tail is the only position that identifies *our*
+  pair. Reading "the first `--ref`" would let a future spec's own frozen `--ref`
+  steer the write, and on the mismatch would leave our pair in place naming a
+  file nothing wrote (the dangling pointer this section calls worse than none)
+  while deleting the other spec's pair instead of ours. Tail-matching makes all
+  three unreachable.
+- **The file is written owner-only.** It holds the owner's verbatim speech, so it
+  goes through `core.write_owner_only` (0600, mode set on the descriptor before
+  any bytes land) — the ONE implementation #887 established after the third
+  hand-rolled temp-and-replace shipped a 0644 file. That also owns the temp
+  file's lifetime, where a fixed `.md.tmp` name would orphan a file the `*.md`
+  prune glob can never collect.
 - **Writing never raises.** `write_relay` is called from `build_argv()`, which
   `_dispatch` runs *after* `_proposals.pop()` and *outside* the runner's `try` —
   exactly the position where `_lead_safe`'s raise once destroyed approved
@@ -2012,11 +2022,19 @@ Four rulings hold it together:
   gives way first is the `said:` quote, because that quote is reproduced verbatim
   in the file the pointer names. Recoverable yields to unrecoverable. Only a path
   long enough that even that is not sufficient drops the pointer itself — a
-  preview nobody can scan buys recoverability nobody goes looking for.
-- **It rides exactly when something WAS clipped.** A body carrying the whole
-  utterance needs no pointer to it, and ~50 characters of a 300-character line is
-  the excerpt and the nudge paid for nothing. Short bodies are byte-identical to
-  before.
+  preview nobody can scan buys recoverability nobody goes looking for — and the
+  quote then **comes back**, because a body carrying neither would be strictly
+  worse than what shipped before this and buy nothing.
+- **It rides exactly when something WAS clipped — asked WITHOUT the pointer's own
+  cost.** That is the whole predicate, and getting it wrong is self-fulfilling:
+  deducting the pointer first moves the budget 160 → 133 (90-char quote, 47-char
+  path), so a 145-character instruction that rendered whole before #1015 would be
+  clipped to 133 and handed a pointer to the text the pointer's own arrival
+  clipped — a message made worse by the fix for messages being made worse. The
+  question is "does this body lose anything as it ships today?", so it is asked of
+  today's body. Anything that fits today is byte-identical to before, and the
+  134..160 boundary is pinned in both directions (with a must-fail control, since
+  a predicate that never fires would pass the first half alone).
 
 The caps did not move: the pointer is paid for out of the excerpt and the
 droppable nudge, so the worst rendered line is still 363 against the measured

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1946,6 +1946,11 @@ evidence the heal will fire. `MAX_BODY_CHARS = 300` puts the worst case
 moved it down by 2, which is why re-measuring after that change was owed and why
 the cap itself did not need to move.
 
+Re-run at 80x24 on **2026-08-11** for #1015, with the relay pointer riding: 476
+hits, 546 misses (box 480), 1026 chips. The recorded 520/540 boundary sits inside
+that window, so it stands — and the shipped worst case (336 chars rendered) closed
+the round trip whole.
+
 The measurement is **pane-dependent**: the box shows a bounded number of rows,
 so a shorter pane windows sooner. Do not spend the headroom without
 re-measuring at the smallest pane you care about.
@@ -1965,6 +1970,64 @@ never emailed**, surfacing only via `doctor` after two hours. For a channel whos
 entire justification is "the owner is not watching a screen", that is the worst
 available failure. The same `stuck` test has no #851 window path, so an
 over-long single line fails identically — hence the cap.
+
+### The inline text is a preview; the file is the message (#1015)
+
+The cap above is not raisable, and for three live relays in the first voice
+session that meant the recipient got `"Treat it as a running list for anyt…"` and
+acted on the fragment. **A cap you cannot raise is not an argument for losing the
+text** — the pane is one channel, the filesystem is another, and the recipient is
+an agent that reads files.
+
+So every buddy write now persists the WHOLE request to
+`~/.agentwire/voice/relays/<proposal-id>.md`
+(`agentwire/voice_layer/relay.py`) — full instruction, full verbatim utterance,
+nothing clipped — and the delivered line carries a `full: <path>` slot pointing
+at it. The same `--ref` rides on the `msg send` argv, the way `ingest` messages
+already carry a report path. The inline text is demoted to what it always
+actually was: a preview.
+
+Four rulings hold it together:
+
+- **The pointer is frozen at propose time; the file is written at execution.**
+  The path is a pure function of the proposal id (`secrets.token_hex(3)`), so
+  `--ref` can join the argv prefix while the file does not yet exist — "the whole
+  argv is frozen at propose" (#966) stays literally true, and a proposal the
+  owner cancels or lets expire leaves nothing on disk. `build_argv` matches the
+  frozen `--ref` against the path the id *derives* rather than just reading it
+  out of the argv, so a future spec freezing a `--ref` of its own can never turn
+  that line into "open the path in the argv".
+- **Writing never raises.** `write_relay` is called from `build_argv()`, which
+  `_dispatch` runs *after* `_proposals.pop()` and *outside* the runner's `try` —
+  exactly the position where `_lead_safe`'s raise once destroyed approved
+  messages with no screen to report it on. A failed write returns `""`, and the
+  caller drops the `--ref` **with** the slot: a pointer to a file that is not
+  there is worse than no pointer, because the recipient reads a missing path as
+  "the real instruction is elsewhere" and stops.
+- **The pointer is not droppable, and the priority order is the ruling.** The
+  reply nudge is droppable; this is not — it is the recoverability of everything
+  the other slots clip, so dropping it under budget pressure would be dropping
+  the fix, silently, on exactly the longest messages. When a deep `$HOME` makes
+  the path long enough to squeeze the preview below `MIN_EXCERPT_CHARS`, what
+  gives way first is the `said:` quote, because that quote is reproduced verbatim
+  in the file the pointer names. Recoverable yields to unrecoverable. Only a path
+  long enough that even that is not sufficient drops the pointer itself — a
+  preview nobody can scan buys recoverability nobody goes looking for.
+- **It rides exactly when something WAS clipped.** A body carrying the whole
+  utterance needs no pointer to it, and ~50 characters of a 300-character line is
+  the excerpt and the nudge paid for nothing. Short bodies are byte-identical to
+  before.
+
+The caps did not move: the pointer is paid for out of the excerpt and the
+droppable nudge, so the worst rendered line is still 363 against the measured
+520. What changed is that the excerpt's clip is now recoverable instead of final.
+
+**Residual, stated.** `write_tools.MAX_INSTRUCTION_CHARS = 600` still refuses a
+proposal longer than that outright. That refusal is *spoken* — the buddy says so
+and the owner can restate — which is a different failure from silently handing a
+session half a sentence, and it is not what #1015 was about. If real spoken
+requests start hitting it, the fix is a bigger cap plus a bound on what the
+announce reads back aloud, not a wider excerpt.
 
 ### The `voice` kind, and what the substitution dragged in
 

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -37,7 +37,7 @@ import time
 import pytest
 
 from agentwire import core, inbox
-from agentwire.voice_layer import confirm, tools, transcript, write_tools
+from agentwire.voice_layer import confirm, relay, tools, transcript, write_tools
 
 
 class FakeClock:
@@ -3008,7 +3008,12 @@ class TestWriteToolSurface:
         assert argv[2:8] == [
             "--to", "orchestrator", "--from", "buddy", "--kind", "voice",
         ]
-        assert len(argv) == 9  # prefix + exactly one body
+        # The relay pointer (#1015) is frozen into the prefix at propose time,
+        # so the argv is still entirely code-derived: a flag pair whose value is
+        # a pure function of the proposal id, plus exactly one body.
+        assert argv[8] == "--ref"
+        assert argv[9] == str(relay.relay_path(proposal.id))
+        assert len(argv) == 11
 
     def test_cancel_never_writes(self, convo, runner, live):
         proposal = convo.announced_proposal()

--- a/tests/unit/test_voice_relay_full_text.py
+++ b/tests/unit/test_voice_relay_full_text.py
@@ -14,6 +14,7 @@ freezes into the argv, all leave the owner exactly where #1015 found them —
 with a session acting on half a sentence.
 """
 
+import inspect
 import os
 import time
 from pathlib import Path
@@ -89,19 +90,12 @@ class TestTheFullTextSurvives:
         assert body.split(confirm.SEP)[0].rstrip("…") != LONG_INSTRUCTION
         assert LONG_INSTRUCTION in Path(pointed).read_text(encoding="utf-8")
 
-    def test_the_relay_is_written_whole_or_not_at_all(self, monkeypatch):
-        """A partial relay is a silently partial instruction — the defect, not
-        a degraded version of the fix."""
-        import agentwire.voice_layer.relay as relay_module
-
-        seen = {}
-        real_replace = Path.replace
-
-        def spy(self, target):
-            seen["temp"] = self.read_text(encoding="utf-8")
-            return real_replace(self, target)
-
-        monkeypatch.setattr(Path, "replace", spy)
+    def test_the_relay_is_owner_only_and_leaves_no_temp_behind(self):
+        """It holds the owner's verbatim speech, so it goes through the ONE
+        owner-only writer (#887) rather than a fourth hand-rolled
+        temp-and-replace — which also owns the temp file's lifetime, where a
+        fixed ``.md.tmp`` name would orphan a file ``_prune``'s ``*.md`` glob
+        can never collect."""
         path = relay.relay_path("a1b2c3")
         relay.write_relay(
             path,
@@ -111,8 +105,9 @@ class TestTheFullTextSurvives:
             instruction=LONG_INSTRUCTION,
             request_utterance="",
         )
-        assert LONG_INSTRUCTION in seen["temp"]
-        assert relay_module.RETENTION_DAYS > 0
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert list(path.parent.iterdir()) == [path]
+        assert "write_owner_only" in inspect.getsource(relay.write_relay)
 
 
 class TestThePointerRidesExactlyWhenItIsNeeded:
@@ -144,6 +139,40 @@ class TestThePointerRidesExactlyWhenItIsNeeded:
         assert body == confirm.render_body(
             "restart the portal", "confirm tango", "a1b2c3"
         )
+
+    @pytest.mark.parametrize("length", [130, 134, 145, 159, 160])
+    def test_the_pointer_never_manufactures_the_clipping_it_recovers(self, length):
+        """The self-fulfilling predicate, pinned at the exact lengths where it
+        bit. Asking "would this clip?" with the pointer's own cost already
+        deducted moves the budget 160 → 133, so instructions of 134..160 chars
+        rendered WHOLE before #1015 and clipped-to-133-plus-a-pointer after —
+        a message made worse by the fix for messages being made worse.
+
+        Nothing pinned this in either direction: the review applied the
+        one-token fix to a copy of the branch and all 291 tests still passed.
+        """
+        path = "/Users/dotdev/.agentwire/voice/relays/a1b2c3.md"
+        instruction = "i" * length  # ≤ MAX_RENDERED_INSTRUCTION_CHARS: whole today
+        utterance = "u" * confirm.MAX_UTTERANCE_CHARS  # the 90-char quote that squeezes
+        body = confirm.render_body(
+            instruction, utterance, "a1b2c3", full_path=path
+        )
+        assert relay_of(body) == "", body
+        assert body.split(confirm.SEP)[0] == instruction, (
+            "the instruction fits today, so #1015 must not clip it to make room "
+            "for a pointer to the text it just clipped"
+        )
+
+    def test_one_character_past_the_budget_does_get_a_pointer(self):
+        """The must-fail control for the test above: a predicate that simply
+        never fires would pass it too."""
+        body = confirm.render_body(
+            "i" * (confirm.MAX_RENDERED_INSTRUCTION_CHARS + 1),
+            "u" * confirm.MAX_UTTERANCE_CHARS,
+            "a1b2c3",
+            full_path="/Users/dotdev/.agentwire/voice/relays/a1b2c3.md",
+        )
+        assert relay_of(body) == "/Users/dotdev/.agentwire/voice/relays/a1b2c3.md"
 
     def test_the_short_body_is_unchanged_from_before_the_fix(self):
         """The common case is byte-identical, so #1015 cannot have quietly
@@ -245,6 +274,10 @@ class TestThePointerIsNotDroppable:
         assert len(body) <= confirm.MAX_BODY_CHARS
         assert body.endswith("#a1b2c3")
         assert len(body.split(confirm.SEP)[0]) >= confirm.MIN_EXCERPT_CHARS
+        # And the quote comes BACK. The two-stage drop clears ``said`` to make
+        # room for the pointer; if the pointer then goes anyway, shipping
+        # neither is strictly worse than what main shipped, and buys nothing.
+        assert 'said: "' in body, body
 
 
 class TestFailureDegradesToTodaysBehaviour:
@@ -311,6 +344,35 @@ class TestFailureDegradesToTodaysBehaviour:
         argv = proposal.build_argv()
         assert not foreign.exists()
         assert relay_of(argv[-1]) == ""
+        # And the argv is CLEAN. Matching the first ``--ref`` instead of the
+        # tail would leave the spine's own pair in place naming a file nothing
+        # wrote — the dangling pointer this code argues is worse than none —
+        # and would delete the other spec's pair rather than ours.
+        assert str(relay.relay_path("a1b2c3")) not in argv
+
+    def test_a_prefix_that_already_carries_a_ref_still_gets_its_relay(self):
+        """The other side of tail-matching. The spine appends ITS pair last, so
+        a foreign ``--ref`` earlier in the prefix must not suppress the relay —
+        that would be the same dangling-vs-missing trade taken the other way."""
+        expected = str(relay.relay_path("a1b2c3"))
+        proposal = confirm.Proposal(
+            id="a1b2c3",
+            token="t",
+            nonce="tango",
+            tool="send_session_message",
+            session="orchestrator",
+            instruction=LONG_INSTRUCTION,
+            argv_prefix=(
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", "voice", "--ref", "/tmp/foreign.md",
+                "--ref", expected,
+            ),
+            created_at=0.0,
+        )
+        argv = proposal.build_argv()
+        assert Path(expected).exists()
+        assert relay_of(argv[-1]) == expected
+        assert argv.count("--ref") == 2  # the foreign one is that spec's business
 
     def test_relay_path_refuses_anything_that_is_not_a_proposal_id(self):
         """The path is fixed-length and traversal-free by CONSTRUCTION (the id

--- a/tests/unit/test_voice_relay_full_text.py
+++ b/tests/unit/test_voice_relay_full_text.py
@@ -1,0 +1,434 @@
+"""The FULL relayed utterance reaches the recipient (#1015).
+
+The measured failure: every relay in the first live voice session arrived cut
+off mid-sentence (``"Treat it as a running list for anyt…"``) and the receiving
+session acted on the fragment. The body's caps are not raisable — they are the
+measured #689 boundary — so the fix is a second channel: the whole request on
+disk, a pointer to it on the delivered line, and the inline text demoted to a
+preview.
+
+What each test here is worth is stated as the failure it would let through, not
+as "the pointer is present": a pointer that names a file that was never written,
+or that a budget squeeze dropped, or that a spine-level path never actually
+freezes into the argv, all leave the owner exactly where #1015 found them —
+with a session acting on half a sentence.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from agentwire import core, inbox
+from agentwire.voice_layer import confirm, relay, transcript, write_tools
+
+#: Long enough that every slot clips: the shape the live session produced.
+LONG_INSTRUCTION = (
+    "Treat it as a running list for anything I say about voice mode. "
+    "Collect the feedback as it comes, keep each item in my own words, and "
+    "do not start acting on any of it until I have finished the whole pass "
+    "and told you explicitly to begin — some of these will contradict each "
+    "other and I want to reconcile them myself before anything ships."
+)
+LONG_UTTERANCE = (
+    "okay so treat it as a running list for anything I say about voice mode "
+    "and just keep collecting until I tell you to start on it"
+)
+LONG_SENDER = "agentwire-dev-voice-confirm-spine"
+
+
+def relay_of(body: str) -> str:
+    """The path the body's ``full:`` slot points at, or ``""``."""
+    for part in body.split(confirm.SEP):
+        if part.startswith(confirm.POINTER_LABEL):
+            return part[len(confirm.POINTER_LABEL):]
+    return ""
+
+
+class TestTheFullTextSurvives:
+    def test_the_relay_file_holds_the_whole_instruction_and_utterance(self, tmp_path):
+        """The property the issue is about. If this fails, the text the body
+        clipped exists nowhere and the recipient cannot recover it."""
+        path = relay.relay_path("a1b2c3")
+        written = relay.write_relay(
+            path,
+            proposal_id="a1b2c3",
+            session="orchestrator",
+            sender="buddy",
+            instruction=LONG_INSTRUCTION,
+            request_utterance=LONG_UTTERANCE,
+        )
+        assert written == str(path)
+        text = path.read_text(encoding="utf-8")
+        assert LONG_INSTRUCTION in text
+        assert LONG_UTTERANCE in text
+        assert "a1b2c3" in text
+
+    def test_the_body_points_at_a_file_that_exists_and_holds_the_rest(self):
+        """The two halves agree. A pointer computed one way and a file written
+        another is the same defect wearing a fix."""
+        proposal_id = "a1b2c3"
+        path = relay.relay_path(proposal_id)
+        written = relay.write_relay(
+            path,
+            proposal_id=proposal_id,
+            session="orchestrator",
+            sender="buddy",
+            instruction=LONG_INSTRUCTION,
+            request_utterance=LONG_UTTERANCE,
+        )
+        body = confirm.render_body(
+            LONG_INSTRUCTION, LONG_UTTERANCE, proposal_id, full_path=written
+        )
+        pointed = relay_of(body)
+        assert pointed == str(path)
+        assert Path(pointed).exists()
+        # The excerpt really is an excerpt — otherwise this test would pass on
+        # a body that never needed the pointer.
+        assert body.split(confirm.SEP)[0].rstrip("…") != LONG_INSTRUCTION
+        assert LONG_INSTRUCTION in Path(pointed).read_text(encoding="utf-8")
+
+    def test_the_relay_is_written_whole_or_not_at_all(self, monkeypatch):
+        """A partial relay is a silently partial instruction — the defect, not
+        a degraded version of the fix."""
+        import agentwire.voice_layer.relay as relay_module
+
+        seen = {}
+        real_replace = Path.replace
+
+        def spy(self, target):
+            seen["temp"] = self.read_text(encoding="utf-8")
+            return real_replace(self, target)
+
+        monkeypatch.setattr(Path, "replace", spy)
+        path = relay.relay_path("a1b2c3")
+        relay.write_relay(
+            path,
+            proposal_id="a1b2c3",
+            session="s",
+            sender="buddy",
+            instruction=LONG_INSTRUCTION,
+            request_utterance="",
+        )
+        assert LONG_INSTRUCTION in seen["temp"]
+        assert relay_module.RETENTION_DAYS > 0
+
+
+class TestThePointerRidesExactlyWhenItIsNeeded:
+    def test_a_clipped_instruction_gets_a_pointer(self):
+        body = confirm.render_body(
+            LONG_INSTRUCTION, "", "a1b2c3", full_path="/tmp/relays/a1b2c3.md"
+        )
+        assert relay_of(body) == "/tmp/relays/a1b2c3.md"
+
+    def test_a_clipped_utterance_gets_one_too(self):
+        """The ``said:`` slot clips at 90 chars. That clip is a paraphrase-check
+        failure, not a cosmetic one — the recipient checks the buddy's wording
+        against the owner's, and a truncated quote cannot be checked."""
+        body = confirm.render_body(
+            "restart the portal", LONG_UTTERANCE, "a1b2c3",
+            full_path="/tmp/relays/a1b2c3.md",
+        )
+        assert relay_of(body) == "/tmp/relays/a1b2c3.md"
+
+    def test_a_body_that_lost_nothing_carries_no_pointer(self):
+        """Both halves priced. ~50 characters of a 300-character line spent on
+        a pointer to text already on screen is the excerpt and the reply nudge
+        paid for nothing."""
+        body = confirm.render_body(
+            "restart the portal", "confirm tango", "a1b2c3",
+            full_path="/tmp/relays/a1b2c3.md",
+        )
+        assert relay_of(body) == ""
+        assert body == confirm.render_body(
+            "restart the portal", "confirm tango", "a1b2c3"
+        )
+
+    def test_the_short_body_is_unchanged_from_before_the_fix(self):
+        """The common case is byte-identical, so #1015 cannot have quietly
+        re-shaped every message on the way to fixing the long ones."""
+        body = confirm.render_body(
+            "restart the portal", "confirm tango", "a1b2c3", reply_to="buddy"
+        )
+        assert body == (
+            'restart the portal ┃ said: "confirm tango" ┃ '
+            'reply: agentwire msg send --to buddy --kind done "<answer>" ┃ #a1b2c3'
+        )
+
+
+class TestThePointerIsNotDroppable:
+    """The reply nudge is droppable; this is not. Dropping the pointer under
+    budget pressure drops the fix — silently, on exactly the longest messages,
+    which are the ones that needed it."""
+
+    @pytest.mark.parametrize("instruction_len", [161, 300, 600, 5000])
+    @pytest.mark.parametrize("utterance_len", [0, 91, 5000])
+    def test_the_pointer_and_the_id_both_survive_every_length(
+        self, instruction_len, utterance_len
+    ):
+        path = "/Users/dotdev/.agentwire/voice/relays/a1b2c3.md"
+        body = confirm.render_body(
+            "x" * instruction_len,
+            "y" * utterance_len,
+            "a1b2c3",
+            reply_to=LONG_SENDER,
+            full_path=path,
+        )
+        assert relay_of(body) == path, body
+        assert body.endswith("#a1b2c3"), body
+        assert len(body) <= confirm.MAX_BODY_CHARS, len(body)
+
+    def test_the_delivered_line_still_clears_the_measured_paste_boundary(self):
+        """The pointer must not spend the margin the pane measurement bought:
+        past ``MEASURED_STUCK_LIMIT_CHARS`` the #689 heal stops firing and a
+        swallowed Enter wedges the message permanently."""
+        body = confirm.render_body(
+            "x" * 5000, "y" * 5000, "a1b2c3",
+            reply_to=LONG_SENDER,
+            full_path="/Users/dotdev/.agentwire/voice/relays/a1b2c3.md",
+        )
+        rendered = inbox.Message(
+            id="1700000000000000000-abc123",
+            sender=LONG_SENDER,
+            to="orchestrator",
+            kind=write_tools.WRITE_KIND,
+            text=body,
+            ts=1700000000000,
+        ).render()
+        assert len(rendered) <= confirm.MEASURED_STUCK_LIMIT_CHARS
+        assert len(rendered) <= confirm.MEASURED_STUCK_LIMIT_CHARS * 0.8
+        assert "\n" not in rendered and "\r" not in rendered
+
+    def test_the_verbatim_quote_yields_to_the_pointer_not_the_other_way(self):
+        """The ordering ruling, at the length where it bites (a deep ``$HOME``
+        — which is also what pytest's tmp home produces, so this branch is not
+        hypothetical). The quote is reproduced in the file the pointer names;
+        the pointer is the only copy of everything else. Recoverable yields."""
+        deep = (
+            "/private/var/folders/1d/g63f4vld5x79q6m_swhxjpb00000gn/T/"
+            "pytest-of-dotdev/pytest-3119/home1"
+        )
+        path = f"{deep}/.agentwire/voice/relays/a1b2c3.md"
+        assert (
+            confirm.MAX_BODY_CHARS
+            - len(f"{confirm.POINTER_LABEL}{path}")
+            - len('said: ""') - confirm.MAX_UTTERANCE_CHARS
+            - len("#a1b2c3")
+            - 3 * len(confirm.SEP)
+        ) < confirm.MIN_EXCERPT_CHARS, "fixture must actually squeeze the budget"
+
+        body = confirm.render_body(
+            LONG_INSTRUCTION, LONG_UTTERANCE, "a1b2c3", full_path=path
+        )
+        assert relay_of(body) == path
+        assert "said:" not in body
+        assert len(body.split(confirm.SEP)[0]) >= confirm.MIN_EXCERPT_CHARS
+        # And the dropped quote is not lost — it is in the file.
+        written = relay.write_relay(
+            relay.relay_path("a1b2c3"),
+            proposal_id="a1b2c3",
+            session="s",
+            sender="buddy",
+            instruction=LONG_INSTRUCTION,
+            request_utterance=LONG_UTTERANCE,
+        )
+        assert LONG_UTTERANCE in Path(written).read_text(encoding="utf-8")
+
+    def test_an_unusably_long_path_yields_to_the_excerpt(self):
+        """The other direction of the same guard. A pointer that leaves no
+        scannable preview buys recoverability nobody goes looking for."""
+        body = confirm.render_body(
+            LONG_INSTRUCTION, LONG_UTTERANCE, "a1b2c3", full_path="/" + "d" * 400
+        )
+        assert relay_of(body) == ""
+        assert len(body) <= confirm.MAX_BODY_CHARS
+        assert body.endswith("#a1b2c3")
+        assert len(body.split(confirm.SEP)[0]) >= confirm.MIN_EXCERPT_CHARS
+
+
+class TestFailureDegradesToTodaysBehaviour:
+    def test_an_unwritable_store_never_raises(self, monkeypatch, tmp_path):
+        """``write_relay`` is called after ``_proposals.pop()`` and outside the
+        runner's ``try``: a raise there eats an approved message with no screen
+        to report it on (the ``_lead_safe`` lesson, same position)."""
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a directory")
+        monkeypatch.setattr(relay, "relay_dir", lambda: blocked / "relays")
+        written = relay.write_relay(
+            blocked / "relays" / "a1b2c3.md",
+            proposal_id="a1b2c3",
+            session="s",
+            sender="buddy",
+            instruction=LONG_INSTRUCTION,
+            request_utterance="",
+        )
+        assert written == ""
+
+    def test_a_failed_write_drops_the_flag_as_well_as_the_slot(self, monkeypatch):
+        """A pointer to a file that is not there is worse than no pointer: the
+        recipient reads a missing path as "the real instruction is elsewhere"
+        and stops."""
+        monkeypatch.setattr(relay, "write_relay", lambda *a, **k: "")
+        ref = str(relay.relay_path("a1b2c3"))
+        proposal = confirm.Proposal(
+            id="a1b2c3",
+            token="t",
+            nonce="tango",
+            tool="send_session_message",
+            session="orchestrator",
+            instruction=LONG_INSTRUCTION,
+            argv_prefix=(
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", "voice", "--ref", ref,
+            ),
+            created_at=0.0,
+        )
+        argv = proposal.build_argv()
+        assert "--ref" not in argv
+        assert ref not in argv
+        assert relay_of(argv[-1]) == ""
+        assert argv[-1].endswith("#a1b2c3")
+
+    def test_a_foreign_ref_never_steers_the_write(self, tmp_path):
+        """The pointer is matched against the path the id DERIVES, not merely
+        read out of the argv — so a future spec freezing a ``--ref`` of its own
+        cannot turn ``build_argv`` into "open the path in the argv"."""
+        foreign = tmp_path / "attacker.md"
+        proposal = confirm.Proposal(
+            id="a1b2c3",
+            token="t",
+            nonce="tango",
+            tool="send_session_message",
+            session="orchestrator",
+            instruction=LONG_INSTRUCTION,
+            argv_prefix=(
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", "voice", "--ref", str(foreign),
+            ),
+            created_at=0.0,
+        )
+        argv = proposal.build_argv()
+        assert not foreign.exists()
+        assert relay_of(argv[-1]) == ""
+
+    def test_relay_path_refuses_anything_that_is_not_a_proposal_id(self):
+        """The path is fixed-length and traversal-free by CONSTRUCTION (the id
+        is ``token_hex(3)``). This asserts the construction, so a future caller
+        that hands it a name cannot quietly turn it into a path."""
+        for bad in ("", "../../etc/passwd", "a1b2c3/../x", "Z" * 6, "a1b2c3.md"):
+            with pytest.raises(ValueError):
+                relay.relay_path(bad)
+
+
+class TestTheStoreIsBounded:
+    def test_old_relays_are_pruned_on_write(self):
+        stale = relay.relay_path("dead01")
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text("old")
+        old = time.time() - (relay.RETENTION_DAYS + 1) * 86400
+        os.utime(stale, (old, old))
+
+        fresh = relay.relay_path("a1b2c3")
+        relay.write_relay(
+            fresh,
+            proposal_id="a1b2c3",
+            session="s",
+            sender="buddy",
+            instruction="hi",
+            request_utterance="",
+        )
+        assert not stale.exists()
+        assert fresh.exists()
+
+    def test_the_store_lives_under_the_config_dir_at_call_time(self, monkeypatch):
+        """A FUNCTION, not an import-time constant: a constant ignores a
+        patched CONFIG_DIR, which is how a test seam becomes a write against
+        the owner's real store (#871's ``role_prompts_dir``)."""
+        monkeypatch.setattr(core, "CONFIG_DIR", Path("/somewhere/else"))
+        assert relay.relay_dir() == Path("/somewhere/else/voice/relays")
+
+
+class TestTheWikiStatesWhatShipped:
+    """The page is what a future session reads before touching the caps. A
+    sentence there that outruns the code gets rounded back up, so the two
+    load-bearing claims are pinned against the code, not just written down."""
+
+    @pytest.fixture
+    def page(self):
+        return " ".join(
+            (
+                Path(__file__).resolve().parents[2]
+                / "docs" / "wiki" / "voice-layer.md"
+            ).read_text(encoding="utf-8").split()
+        )
+
+    def test_the_priority_ruling_is_recorded(self, page):
+        assert "Recoverable yields to unrecoverable." in page
+        assert "The pointer is not droppable" in page
+
+    def test_the_residual_is_stated_rather_than_implied(self, page):
+        """``MAX_INSTRUCTION_CHARS`` still refuses a long proposal outright.
+        The page must not let "the full utterance reaches the session" imply
+        that limit went away."""
+        assert "MAX_INSTRUCTION_CHARS = 600" in page
+        assert write_tools.MAX_INSTRUCTION_CHARS == 600
+
+
+class TestEndToEndThroughTheSpine:
+    """The layers agree. Each half can be right while the pair is broken: a
+    renderer that takes a path nobody passes, or an argv whose ``--ref`` names
+    a file nothing writes."""
+
+    @pytest.fixture
+    def spine(self):
+        return confirm.ConfirmSpine(transcript.TranscriptRing(), wait_s=0.0)
+
+    def test_the_argv_carries_the_ref_and_the_file_holds_the_full_text(self, spine):
+        proposal = spine.propose(
+            tool="send_session_message",
+            session="orchestrator",
+            instruction=LONG_INSTRUCTION,
+            argv_prefix=[
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", write_tools.WRITE_KIND,
+            ],
+        )
+        assert "--ref" in proposal.argv_prefix, (
+            "the pointer is frozen at PROPOSE time — freezing it later would "
+            "reopen 'the whole argv is frozen at propose' (#966)"
+        )
+        argv = proposal.build_argv()
+        ref = argv[argv.index("--ref") + 1]
+        assert ref == str(relay.relay_path(proposal.id))
+        assert Path(ref).read_text(encoding="utf-8").count(LONG_INSTRUCTION) == 1
+        assert relay_of(argv[-1]) == ref
+
+    def test_nothing_is_written_for_a_proposal_that_never_executes(self, spine):
+        """The file is written at execution, not at propose: a cancelled or
+        expired proposal must leave nothing on disk."""
+        proposal = spine.propose(
+            tool="send_session_message",
+            session="orchestrator",
+            instruction=LONG_INSTRUCTION,
+            argv_prefix=[
+                "msg", "send", "--to", "orchestrator", "--from", "buddy",
+                "--kind", write_tools.WRITE_KIND,
+            ],
+        )
+        assert not relay.relay_path(proposal.id).exists()
+        spine.cancel(proposal.token)
+        assert not relay.relay_path(proposal.id).exists()
+
+    def test_an_argv_only_write_gets_no_ref(self, spine):
+        """``append_body=False`` writes have no free-text slot and no body to
+        excerpt — a ``--ref`` there would be a flag the CLI never asked for."""
+        proposal = spine.propose(
+            tool="something_else",
+            session="orchestrator",
+            instruction="x",
+            argv_prefix=["kill", "-s", "orchestrator"],
+            append_body=False,
+        )
+        assert "--ref" not in proposal.argv_prefix
+        assert proposal.build_argv() == ["kill", "-s", "orchestrator"]

--- a/tools/voice_heal_probe.py
+++ b/tools/voice_heal_probe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.9"
-# dependencies = ["agentwire-dev @ file:///Users/dotdev/worktrees/agentwire-dev/voice-confirm-spine"]
+# dependencies = ["agentwire-dev @ file:///Users/dotdev/projects/agentwire-dev"]
 # ///
 """Live-pane round trip for the §4b body: does the #689 heal actually fire?
 
@@ -30,7 +30,12 @@ Isolation: creates its OWN throwaway tmux session in this worktree, at a fixed
 80x24 so the numbers are reproducible, and kills it at the end — including on
 failure. It never touches another session.
 
-Usage:  ./tools/voice_heal_probe.py [--keep]
+**Repoint the ``dependencies`` line above at the checkout you are measuring.**
+PEP 723 needs a literal path, and the probe measures whatever that install
+holds — running it from a worktree while it points at ``~/projects`` measures
+main's renderer under the worktree's name.
+
+Usage:  ./tools/voice_heal_probe.py [--keep] [--width N] [--height N]
 """
 
 from __future__ import annotations
@@ -38,16 +43,20 @@ from __future__ import annotations
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from agentwire import inbox, pane_manager, prompt_router, session_ready
-from agentwire.voice_layer import confirm, write_tools
+from agentwire.voice_layer import confirm, relay, write_tools
 
 SESSION = "voice-heal-probe"
+#: Overridable so the pane-DEPENDENT half of the measurement can be re-taken at
+#: the smallest geometry you care about: the box shows a bounded number of ROWS,
+#: so a shorter pane windows sooner than 80x24 does.
 WIDTH, HEIGHT = 80, 24
-WORKTREE = "/Users/dotdev/worktrees/agentwire-dev/voice-confirm-spine"
+WORKTREE = str(Path(__file__).resolve().parents[1])
 
 #: Lengths to probe for the box-window boundary, coarse then fine.
-PROBE_LENGTHS = (150, 250, 350, 450, 600, 800, 1100, 1500)
+PROBE_LENGTHS = (350, 420, 460, 490, 510, 530, 560, 620, 900)
 
 
 def sh(*args: str, timeout: int = 30) -> subprocess.CompletedProcess:
@@ -89,10 +98,12 @@ def body_of_length(target: int) -> str:
     """A real rendered body padded to ~*target* chars, via the real renderer."""
     filler = "restart the portal and then report back on what the tests did "
     instruction = (filler * 40)[: max(10, target)]
-    return (
-        f"{confirm.VOICE_MARKER} {instruction} "
-        f'┃ said: "confirm tango" ┃ #a1b2c3'
-    )
+    return confirm.SEP.join([
+        instruction,
+        'said: "confirm tango"',
+        f"{confirm.POINTER_LABEL}{relay.relay_path('a1b2c3')}",
+        "#a1b2c3",
+    ])
 
 
 def rendered(body: str) -> str:
@@ -145,8 +156,17 @@ def paste_and_measure(line: str) -> dict:
     }
 
 
+def _int_arg(flag: str, default: int) -> int:
+    if flag in sys.argv:
+        return int(sys.argv[sys.argv.index(flag) + 1])
+    return default
+
+
 def main() -> int:
+    global WIDTH, HEIGHT
     keep = "--keep" in sys.argv
+    WIDTH = _int_arg("--width", WIDTH)
+    HEIGHT = _int_arg("--height", HEIGHT)
     print(f"Starting throwaway session {SESSION} at {WIDTH}x{HEIGHT} …")
     start_session()
     try:
@@ -156,11 +176,19 @@ def main() -> int:
         print("Input box ready.\n")
 
         # ---- 1. The round trip on the REAL shipped body ------------------
+        # The SHIPPED worst case, not a short one: a body long enough that
+        # every slot clips, so the #1015 relay pointer rides too.
         real_body = confirm.render_body(
-            "tell the reviewer the branch is ready and the tests were run twice",
-            "okay, confirm tango please",
+            "tell the reviewer the branch is ready and the tests were run twice "
+            "against a clean checkout, and then start on the follow-up list we "
+            "talked through this morning before anything else lands ",
+            "okay yeah go ahead and confirm tango please thats the right one and "
+            "then start on the follow up list we went through this morning",
             "a1b2c3",
+            reply_to="agentwire-dev-voice-confirm-spine",
+            full_path=str(relay.relay_path("a1b2c3")),
         )
+        assert confirm.POINTER_LABEL in real_body, "probe must exercise the pointer"
         line = rendered(real_body)
         print(f"[1] Round trip on the real rendered body ({len(line)} chars)")
         measured = paste_and_measure(line)
@@ -194,6 +222,14 @@ def main() -> int:
         print("    ROUND TRIP CLOSED.\n")
 
         # ---- 3. Where does the box-window boundary actually fall? --------
+        # The round trip SUBMITTED, so the pane is now processing a turn and
+        # its box is neither parseable nor empty. Measuring through that
+        # reports box=0 for every length and reads as "the cliff is below
+        # everything we probed" — a probe measuring its own sequencing.
+        print("Waiting for the pane to finish the submitted turn …")
+        if not wait_for_box(timeout=240.0):
+            print("FAIL: the box never came back after the round trip")
+            return 2
         print("[2] Measuring the stuck-test boundary in a real box")
         results = []
         for target in PROBE_LENGTHS:


### PR DESCRIPTION
Every relay in the first live voice session arrived cut off mid-sentence (`"Treat it as a running list for anyt…"`) and the receiving session acted on the fragment. The body's caps are not raisable — they are the measured #689 boundary past which the heal stops firing and a swallowed Enter wedges the message permanently — so the fix is a **second channel** rather than a bigger excerpt.

Every buddy write now persists the WHOLE request to `~/.agentwire/voice/relays/<proposal-id>.md` (`agentwire/voice_layer/relay.py`) — full instruction, full verbatim utterance, nothing clipped — and the delivered line carries a `full: <path>` slot, with the same path riding as `--ref` the way `ingest` messages already do. The inline text is demoted to what it always actually was: a preview.

### Rulings

- **The pointer is frozen at PROPOSE time; the file is written at execution.** The path is a pure function of the minted proposal id, so `--ref` joins the argv prefix before the file exists — "the whole argv is frozen at propose" (#966) stays literally true — and a proposal the owner cancels or lets expire leaves nothing on disk. `build_argv` matches the frozen `--ref` against the path the id *derives*, never merely reading it out of the argv, so a future spec freezing its own `--ref` can't steer the write.
- **Writing never raises.** It runs after `_proposals.pop()` and outside the runner's `try` — the position where `_lead_safe`'s raise once destroyed approved messages with no screen to report it on. A failed write returns `""` and the caller drops the `--ref` **with** the slot: a pointer to a missing file is worse than no pointer.
- **The pointer is not droppable, and the priority order is the ruling.** The reply nudge stays droppable; this isn't — it's the recoverability of everything the other slots clip. When a deep `$HOME` squeezes the preview below `MIN_EXCERPT_CHARS`, the `said:` quote yields first, because that quote is reproduced in the file the pointer names. Recoverable yields to unrecoverable.
- **It rides exactly when something WAS clipped**, so short bodies are byte-identical to before.

### Measured, not guessed

`tools/voice_heal_probe.py` was stale — it referenced the `VOICE_MARKER` removed in #985 (so it crashed), and it measured *through its own submitted turn*, reporting `box=0` for every length, i.e. "the cliff is below everything we probed". Both fixed, geometry is now `--width`/`--height`, and it exercises the pointer.

Re-run at 80x24 on 2026-08-11:

| Rendered line | Box holds | `stuck` test |
|---|---|---|
| 476 | 488 | hit ✓ |
| 546 | 480 | **miss** — box windows |
| 1026 | 16 | **miss** — `[Pasted text …]` chip |

The recorded 520/540 boundary sits inside that window, so it stands. The round trip closed live on the real shipped worst case (336 chars rendered): pasted whole → `stuck` hit → `finish_submit` submitted → dedup found it on scrollback. The worst rendered line is unchanged at **363 against 520** — the pointer is paid for out of the excerpt and the droppable nudge, never out of the margin.

### Residual, stated

`write_tools.MAX_INSTRUCTION_CHARS = 600` still refuses a longer proposal outright. That refusal is *spoken* — the owner can restate — which is a different failure from silently handing a session half a sentence, and not what this issue was about. If real spoken requests start hitting it, the fix is a bigger cap plus a bound on what the announce reads back aloud, not a wider excerpt.

### Verification

- `tests/unit/test_voice_relay_full_text.py` (new, 31 tests): full text on disk, pointer↔file agreement, the non-droppable property swept over instruction/utterance lengths, the ordering ruling at the length where it bites, unwritable-store degradation, foreign-`--ref` refusal, pruning, end-to-end through the spine.
- Full suite: `6347 passed`. The 4 `test_beta_flag.py::*origin_main*` failures reproduce on a clean stashed tree — pre-existing, unrelated.
- Live: the probe above; and `msg send --ref` verified end-to-end through the real CLI into a temp inbox.

Closes #1015

Built by [dotdev.dev](https://dotdev.dev)