### PR TITLE
fix: bound the coalesced drain paste by line count and char length (#930)

### DIFF
--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -948,6 +948,52 @@ def _dedup_landed(session: str, messages: list[Message]) -> list[Message]:
     return consumed
 
 
+# ── Coalesced-paste bounds (#930) ─────────────────────────────────────────
+# The #689 swallowed-Enter heal reads the input box, and Claude Code's box
+# stops showing the full paste in TWO independent regimes governed by
+# DIFFERENT variables (measured in a live pane — issue #930):
+#
+#   LINE COUNT — 4+ rendered lines collapse to the "[Pasted text]" chip
+#   (4 lines chip at 87 chars; the same 87 chars on ONE line render as text).
+#   The stuck test then matches nothing, so a drain that coalesced 4+
+#   messages wedges EVERY one of them: never healed, never dead-lettered,
+#   therefore never emailed. Routine on a busy fleet (`wait --children`
+#   with four reporting children IS the 4-message coalesce).
+#
+#   CHARACTER LENGTH — a long single-line paste WINDOWS (the box shows a
+#   bounded tail) well before it chips: 520 chars healed, 540 missed, at
+#   80×24. So "not a chip" is not evidence the heal will fire, and a fix
+#   scoped to the line-count cliff leaves this regime open.
+#
+# Both bounds therefore apply to the coalesced paste; neither substitutes
+# for the other. The char bound sits under the voice layer's measured
+# worst-case-clear (~385 against the 520 boundary) because a shorter pane
+# windows sooner and this fleet runs 64-column panes. A single message
+# whose own render exceeds the char bound is pasted alone — the drain
+# cannot split one message; bounding bodies at enqueue is a separate
+# decision (#930 leaves it open).
+PASTE_MAX_LINES = 3
+PASTE_MAX_CHARS = 380
+
+
+def _paste_batch(messages: list[Message]) -> list[Message]:
+    """Oldest-first prefix of *messages* that fits ONE safe coalesced paste.
+
+    Bounded by ``PASTE_MAX_LINES`` and ``PASTE_MAX_CHARS`` (see above).
+    Always returns at least one message so an oversized single message still
+    moves rather than starving the queue.
+    """
+    batch = [messages[0]]
+    total = len(messages[0].render())
+    for msg in messages[1:]:
+        line = msg.render()
+        if len(batch) >= PASTE_MAX_LINES or total + 1 + len(line) > PASTE_MAX_CHARS:
+            break
+        batch.append(msg)
+        total += 1 + len(line)
+    return batch
+
+
 def _cohort_held(session: str, messages: list[Message]) -> list[Message]:
     """Messages from *session*'s still-pending fan-out children (#852).
 
@@ -973,8 +1019,10 @@ def _cohort_held(session: str, messages: list[Message]) -> list[Message]:
 def flush_session(session: str, force: bool = False) -> dict:
     """Attempt to drain one session's inbox now.
 
-    Delivers oldest-first, coalescing all queued messages into a single paste
-    (one submit) when the box is empty. On any refusal the messages stay put,
+    Delivers oldest-first, coalescing queued messages into bounded pastes
+    (≤``PASTE_MAX_LINES`` messages / ≤``PASTE_MAX_CHARS`` chars each, #930 —
+    a bigger blob stops rendering fully in the input box, which blinds the
+    #689 swallowed-Enter heal) when the box is empty. On any refusal the messages stay put,
     their ``attempts`` bump, and over the cap they dead-letter. Never raises.
 
     *force* (the ``msg flush --force`` escape hatch) bypasses the empty-box /
@@ -1151,42 +1199,56 @@ def flush_session(session: str, force: bool = False) -> dict:
 
             _clear_box_state(session)  # box is empty — reset the static counter
 
-        rendered = "\n".join(m.render() for m in messages)
-        delivered, reason = prompt_router.safe_deliver(session, 0, rendered)
-        if not delivered:
-            # delivery_unverified means the box-cleared confirm failed — but the
-            # paste may have LANDED. Consume any message now visible on scrollback
-            # (idempotent delivery) so a false-negative can't cause re-injection.
-            # Other reasons (gone/parked/non-agent/dialog) never pasted, so there's
-            # nothing to dedup.
-            consumed = (
-                _dedup_landed(session, messages)
-                if reason == "delivery_unverified"
-                else []
-            )
-            consumed_ids = {m.id for m in consumed}
-            remaining = [m for m in messages if m.id not in consumed_ids]
-            if not remaining:
+        # Deliver in bounded batches (#930): a coalesced paste over the line
+        # or char bound stops being fully visible in the input box (chip /
+        # windowing), which blinds the #689 stuck test — the exact heal that
+        # makes a swallowed Enter recoverable. safe_deliver confirms the box
+        # cleared before returning True, so pasting the next batch immediately
+        # is safe; on any refusal the un-attempted tail stays pending with NO
+        # penalty (the target didn't refuse those — we never pasted them).
+        delivered_total = pre_consumed
+        while messages:
+            batch = _paste_batch(messages)
+            rendered = "\n".join(m.render() for m in batch)
+            delivered, reason = prompt_router.safe_deliver(session, 0, rendered)
+            if not delivered:
+                # delivery_unverified means the box-cleared confirm failed — but
+                # the paste may have LANDED. Consume any message now visible on
+                # scrollback (idempotent delivery) so a false-negative can't
+                # cause re-injection. Other reasons (gone/parked/non-agent/
+                # dialog) never pasted, so there's nothing to dedup.
+                consumed = (
+                    _dedup_landed(session, batch)
+                    if reason == "delivery_unverified"
+                    else []
+                )
+                consumed_ids = {m.id for m in consumed}
+                remaining = [m for m in batch if m.id not in consumed_ids]
+                delivered_total += len(consumed)
+                if not remaining:
+                    messages = messages[len(batch):]
+                    continue
+                dead = _bump_attempts(remaining, reason)
+                _log_event(
+                    "deferred", to=session, count=len(remaining), reason=reason,
+                )
                 return {
-                    "session": session, "delivered": pre_consumed + len(consumed),
-                    "deferred": False, "reason": "delivered",
+                    "session": session, "delivered": delivered_total,
+                    "deferred": True, "reason": reason, "dead": dead,
                 }
-            dead = _bump_attempts(remaining, reason)
-            _log_event("deferred", to=session, count=len(remaining), reason=reason)
-            return {
-                "session": session, "delivered": pre_consumed + len(consumed),
-                "deferred": True, "reason": reason, "dead": dead,
-            }
 
-        for msg in messages:
-            if msg.path is not None:
-                msg.path.unlink(missing_ok=True)
-        _log_event(
-            "delivered", to=session, count=len(messages),
-            kinds=[m.kind for m in messages],
-        )
+            for msg in batch:
+                if msg.path is not None:
+                    msg.path.unlink(missing_ok=True)
+            _log_event(
+                "delivered", to=session, count=len(batch),
+                kinds=[m.kind for m in batch],
+            )
+            delivered_total += len(batch)
+            messages = messages[len(batch):]
+
         return {
-            "session": session, "delivered": pre_consumed + len(messages),
+            "session": session, "delivered": delivered_total,
             "deferred": False, "reason": "delivered",
         }
     except Exception as exc:  # draining must never break the watchdog

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -344,6 +344,77 @@ class TestFlush:
         assert sent[0].count("[MSG from") == 3
         assert inbox.list_messages("s") == []
 
+    def test_four_plus_coalesce_never_exceeds_line_bound(self, isolate, monkeypatch):
+        # #930 regression (the chip regime): 4+ rendered lines in ONE paste
+        # collapse to the "[Pasted text]" chip, blinding the #689 stuck test —
+        # a swallowed Enter then wedges EVERY message in the paste, permanently
+        # (never healed, never dead-lettered, never emailed). The drain must
+        # never paste more than PASTE_MAX_LINES messages per blob.
+        for i in range(5):
+            inbox.enqueue("s", f"report {i}", sender="x")
+        sent = _patch_delivery(monkeypatch, empty=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 5 and not res["deferred"]
+        assert inbox.list_messages("s") == []
+        assert len(sent) == 2  # 3 + 2 — never a 5-line blob
+        for paste in sent:
+            assert len(paste.split("\n")) <= inbox.PASTE_MAX_LINES
+
+    def test_three_messages_still_one_paste(self, isolate, monkeypatch):
+        # The other side of the #930 line bound: 3 messages measured as fully
+        # healable (3 of 3 stuck hits at 386 chars) must stay a SINGLE paste.
+        for i in range(3):
+            inbox.enqueue("s", f"m{i}", sender="x")
+        sent = _patch_delivery(monkeypatch, empty=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 3
+        assert len(sent) == 1
+
+    def test_char_bound_splits_below_line_bound(self, isolate, monkeypatch):
+        # #930 regression (the windowing regime): character length governs
+        # independently of line count — 530 chars on ONE line windows with no
+        # chip and the heal misses. Two messages whose coalesced render
+        # exceeds PASTE_MAX_CHARS must split even though 2 ≤ PASTE_MAX_LINES.
+        inbox.enqueue("s", "a" * 250, sender="x")
+        inbox.enqueue("s", "b" * 250, sender="x")
+        sent = _patch_delivery(monkeypatch, empty=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 2 and not res["deferred"]
+        assert len(sent) == 2
+        for paste in sent:
+            assert len(paste) <= inbox.PASTE_MAX_CHARS
+
+    def test_small_pair_stays_one_paste(self, isolate, monkeypatch):
+        # Both-sides for the char bound: a pair comfortably under it coalesces.
+        inbox.enqueue("s", "short one", sender="x")
+        inbox.enqueue("s", "short two", sender="x")
+        sent = _patch_delivery(monkeypatch, empty=True)
+        inbox.flush_session("s")
+        assert len(sent) == 1
+
+    def test_oversized_single_message_pastes_alone(self, isolate, monkeypatch):
+        # A single message over the char bound can't be split — it goes alone
+        # (never starves the queue), and its neighbors go in their own paste.
+        inbox.enqueue("s", "x" * 600, sender="x")
+        inbox.enqueue("s", "tail", sender="x")
+        sent = _patch_delivery(monkeypatch, empty=True)
+        res = inbox.flush_session("s")
+        assert res["delivered"] == 2
+        assert len(sent) == 2
+        assert "x" * 600 in sent[0] and "tail" in sent[1]
+
+    def test_batch_failure_defers_only_attempted_batch(self, isolate, monkeypatch):
+        # A refusal mid-drain penalizes only the batch that was actually
+        # pasted-at; the un-attempted tail stays pending with attempts == 0.
+        for i in range(5):
+            inbox.enqueue("s", f"r{i}", sender="x")
+        _patch_delivery(monkeypatch, empty=True, deliver=(False, "target_not_agent"))
+        res = inbox.flush_session("s")
+        assert res["deferred"] and res["reason"] == "target_not_agent"
+        msgs = inbox.list_messages("s")
+        assert len(msgs) == 5
+        assert [m.attempts for m in msgs] == [1, 1, 1, 0, 0]
+
     def test_empty_inbox_noop(self, isolate, monkeypatch):
         _patch_delivery(monkeypatch, empty=True)
         res = inbox.flush_session("s")


### PR DESCRIPTION
## Problem (#930)

The `msg` drain coalesced the entire pending queue into one newline-joined paste. Claude Code's input box stops fully rendering that blob in **two independent regimes**, each governed by a different variable (measured in a live pane on the issue):

- **Line count** — 4+ rendered lines collapse to the `[Pasted text]` chip (4 lines chip at 87 chars; the same 87 chars on one line render as text).
- **Character length** — a long single-line paste *windows* (box shows a bounded tail) well before it chips: 520 chars healed, 540 missed, at 80×24.

In either regime the #689 stuck test matches nothing, so a swallowed Enter wedges **every message in the paste** — never healed, never dead-lettered, therefore never emailed. Routine on a busy fleet: a parent whose four children report at once *is* the 4-message coalesce.

## Fix

`flush_session` now delivers in **bounded batches**: each paste holds ≤`PASTE_MAX_LINES` (3) messages and ≤`PASTE_MAX_CHARS` (380, conservative for the fleet's 64-column panes) — both bounds, since neither substitutes for the other. `safe_deliver` confirms the box cleared before returning, so successive batches paste safely in one drain pass. A refusal penalizes only the batch actually pasted-at; the un-attempted tail stays pending with no penalty. An oversized single message pastes alone (the drain can't split one message — bounding bodies at enqueue is the follow-up #930 leaves open).

## Tests

Regression tests assert both regimes from **both sides** (3 messages stay one paste / 5 split; small pair coalesces / big pair splits on chars), plus oversized-single and partial-failure penalty scoping. Verified must-fail: neutralizing the bounds turns all four regime tests red.

Full suite: 6502 passed; the 4 `test_beta_flag.py` failures are pre-existing on origin/main in this environment (live beta-flag gate vs fixture, unrelated to messaging).

Note per the issue: the boundary numbers are pane-geometry-dependent; the bounds here are conservative constants, not a claim of the exact boundary. Driving a real pane to measure the boundary as a function of geometry remains open on #930's checklist.

Closes #930

Built by [dotdev.dev](https://dotdev.dev)