### PR TITLE
test/CI hygiene: #1023 #947 #948 #945

### DIFF
--- a/agentwire/beta.py
+++ b/agentwire/beta.py
@@ -176,7 +176,18 @@ def gated_doc(fn):
     wrong, so the property is pinned over the WHOLE registry —
     ``test_no_published_description_carries_a_marker`` fails on any published
     description containing a marker, whatever put it there.
+
+    The resolution happens ONCE, at import, against whatever flag state the
+    process started with — so any later reader that wants to verify the
+    resolved text needs to know which flags it was resolved WITH, not which
+    flags are on now. ``__beta_enabled__`` records exactly that (and
+    ``__beta_raw_doc__`` the pre-resolution text), which is what lets the
+    byte-identity tests hold on a machine with a beta flag enabled instead of
+    silently asserting the developer's personal config (#1023).
     """
-    if fn.__doc__:
-        fn.__doc__ = render(fn.__doc__)
+    if fn.__doc__ and "beta:" in fn.__doc__:
+        enabled = enabled_flags()
+        fn.__beta_raw_doc__ = fn.__doc__
+        fn.__beta_enabled__ = frozenset(enabled)
+        fn.__doc__ = render(fn.__doc__, enabled=enabled)
     return fn

--- a/agentwire/hooks_cli.py
+++ b/agentwire/hooks_cli.py
@@ -314,9 +314,15 @@ def _install_managed_file(source: Path, target: Path, force: bool = False, copy:
         target.unlink()
     if copy:
         shutil.copy2(source, target)
+        # Only the copied file gets a chmod. On the symlink path, chmod
+        # FOLLOWS the link — and when the package is a source checkout, the
+        # link points at a tracked file, so a chmod aimed at the install
+        # lands in the repo and dirties every dev's tree (#947). Execution
+        # through a symlink uses the target's mode, and the packaged hook
+        # scripts ship 755, so the link needs no chmod of its own.
+        target.chmod(0o755)
     else:
         target.symlink_to(source.resolve())
-    target.chmod(0o755)
     return True
 
 

--- a/scripts/ci_verdict.sh
+++ b/scripts/ci_verdict.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# ci_verdict <pr-number>
+#
+# One command that implements the repo's CI-provenance rules as tool behaviour
+# instead of reviewer discipline. Read-only; queries GitHub only. Built from
+# the thirteen instrument defects catalogued on #945 — each property below
+# names the defect it closes.
+#
+#   * FULL 40-char SHA, derived here from the PR — never typed, never a short
+#     SHA. An interface that DERIVES the identifier inherits none of the ways
+#     a hand-held identifier can be wrong.
+#   * SERVER-SIDE filter (`--commit <sha>`) — client-side filtering over a
+#     repo-scoped page inherits the pagination defect, and the partial is a
+#     knife-edge, not a region: a page boundary inside the run cluster returns
+#     1-of-3 looking like a complete answer. Server-side is immune to CHURN
+#     (not to truncation; moot at a handful of runs per SHA).
+#   * NON-EMPTY refusal — an empty set is the most stable set there is, and a
+#     zero is never evidence of a cause. Retention aging, the post-push
+#     scheduling window, a non-trigger-target commit, a held fork PR, and a
+#     bad query are all byte-identical to "checks did not run". Refuses with
+#     the differential rather than classifying.
+#   * NAME-BASED FLOOR, not a count — pytest, ruff and security have no path
+#     filter, so every PR expects all three BY NAME; path-filtered workflows
+#     (tts-smoke) can only ADD, and the addition is derived from the PR's own
+#     changed paths, never from the runs observed (an expected set derived
+#     from the result being checked proves nothing). A count cannot see a
+#     workflow that never started, because the missing thing is not a quantity.
+#   * steps==0 DISCRIMINATOR — a run-level `failure` can be a job that never
+#     ran a step (queued 15 min, cancelled). `conclusion != success` with
+#     `steps == 0` is "never started", whatever the conclusion string says,
+#     and without depending on provider wording ("Set up job" etc.).
+#   * ATTEMPT per run — GREEN ON ATTEMPT N, never "no red": a re-run erases
+#     the red it replaces, so attempt-1's failing step is fetched and shown.
+#   * PRINTS names and counts unconditionally, so a human can notice what the
+#     tool cannot.
+#   * No exit status is read through a pipe, and no command substitution is
+#     trusted for control flow without checking the substitution's own result
+#     — $(cmd) discards the exit code, so a tool that prints something
+#     usable-looking on failure becomes a silent garbage source.
+#
+# Exit: 0 green · 1 red / floor violation / refusal · 2 pending — do not conclude
+set -u
+
+PR="${1:?usage: ci_verdict <pr-number>}"
+REPO_SLUG="${GH_REPO:-dotdevdotdev/agentwire-dev}"
+
+# The always-valid floor: every workflow on main with NO path filter. Derived
+# from .github/workflows/*.yml triggers, not from any observed run set — keep
+# it in sync with the workflows, not with what a PR happened to produce.
+FLOOR_NAMES=(pytest ruff security)
+# Path-filtered workflows and the filters that add them to the expected set.
+TTS_SMOKE_PATHS='^(pyproject\.toml|uv\.lock|agentwire/tts/|\.github/workflows/tts-smoke\.yml)'
+
+PRJSON=$(gh pr view "$PR" -R "$REPO_SLUG" --json headRefOid,isCrossRepository,state 2>/dev/null)
+[ -n "$PRJSON" ] || { echo "could not read PR #$PR on $REPO_SLUG — refusing to query"; exit 1; }
+SHA=$(printf '%s' "$PRJSON" | jq -r .headRefOid)
+CROSS=$(printf '%s' "$PRJSON" | jq -r .isCrossRepository)
+[ ${#SHA} -eq 40 ] || { echo "could not resolve a full 40-char head SHA (got '${SHA}')"; exit 1; }
+echo "PR #$PR  head $SHA  cross-repo=$CROSS"
+
+# Expected set: the unconditional floor, plus tts-smoke iff this PR's own
+# changed paths reach its filter.
+EXPECTED=("${FLOOR_NAMES[@]}")
+if gh pr diff "$PR" -R "$REPO_SLUG" --name-only 2>/dev/null | grep -qE "$TTS_SMOKE_PATHS"; then
+  EXPECTED+=(tts-smoke)
+fi
+echo "expected workflows (by name, from triggers): ${EXPECTED[*]}"
+
+RUNS=$(gh run list -R "$REPO_SLUG" --limit 60 --commit "$SHA" \
+        --json databaseId,name,status,conclusion,attempt --jq '.')
+N=$(printf '%s' "$RUNS" | jq 'length')
+echo "runs at this SHA: $N"
+
+if [ "$N" -eq 0 ]; then
+  echo "ZERO runs — REFUSING to classify. Emptiness is never evidence of a cause."
+  echo "  Indistinguishable at this level:"
+  echo "    - polled inside the post-push scheduling window (seconds; poll again)"
+  echo "    - run records aged out of retention (old SHA — 0 runs means NOTHING there)"
+  echo "    - the SHA is not a trigger target (intermediate commit of a multi-commit PR)"
+  if [ "$CROSS" = "true" ]; then
+    echo "    - CROSS-REPO PR: workflows may be held awaiting maintainer approval."
+    echo "      The remedy is approval, not a re-run — a re-run of nothing does nothing."
+  fi
+  echo "    - a bad query (which would impersonate 'checks did not run')"
+  exit 1
+fi
+
+printf "\n%-12s %-10s %-9s %-12s %s\n" STATUS CONCL ATTEMPT RUN NAME
+printf '%s' "$RUNS" | jq -r '.[] | [.status,(.conclusion//"-"),.attempt,.databaseId,.name] | @tsv' |
+while IFS=$'\t' read -r st cc at id nm; do
+  printf "%-12s %-10s %-9s %-12s %s\n" "$st" "$cc" "$at" "$id" "$nm"
+done
+
+# NAME floor — detects a workflow that never started, which no count can.
+MISSING=()
+for want in "${EXPECTED[@]}"; do
+  FOUND=$(printf '%s' "$RUNS" | jq --arg n "$want" '[.[] | select(.name==$n)] | length')
+  [ "$FOUND" -gt 0 ] || MISSING+=("$want")
+done
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo
+  echo "FLOOR VIOLATION: expected workflow(s) NEVER STARTED at this SHA: ${MISSING[*]}"
+  echo "  Not pending, not red — absent. Do NOT conclude green from what is present."
+  exit 1
+fi
+
+# Re-run archaeology: a red that was re-run away still gets classified.
+echo
+printf '%s' "$RUNS" | jq -r '.[] | select(.attempt > 1) | [.databaseId,.attempt,.name] | @tsv' |
+while IFS=$'\t' read -r id at nm; do
+  [ -z "$id" ] && continue
+  echo "ATTEMPT $at on '$nm' — a red was re-run away. Classifying attempt 1:"
+  c1=$(gh run view "$id" -R "$REPO_SLUG" --attempt 1 --json conclusion --jq .conclusion 2>/dev/null)
+  step=$(gh run view "$id" -R "$REPO_SLUG" --attempt 1 --log-failed 2>/dev/null |
+         awk -F'\t' 'NF>1{print $2}' | sort -u | head -3 | paste -sd, -)
+  echo "    attempt 1: ${c1:-?}   failing step(s): ${step:-<none captured>}"
+done
+
+# steps==0 discriminator on every non-green run at the CURRENT attempt:
+# separates "never ran a step" (provider/runner — category 3) from a real
+# failure, independent of whether the conclusion reads failure or cancelled.
+NEVER_STARTED=0
+REAL_RED=0
+echo
+echo "jobs of non-green runs (steps==0 means the job NEVER STARTED):"
+while IFS=$'\t' read -r id nm; do
+  [ -z "$id" ] && continue
+  JOBS=$(gh api "repos/$REPO_SLUG/actions/runs/$id/jobs?per_page=100" \
+          --jq '[.jobs[] | {name, conclusion: (.conclusion//"pending"), steps: (.steps|length)}]' 2>/dev/null)
+  [ -n "$JOBS" ] || { echo "    $nm/$id: could not read jobs — classify by hand"; REAL_RED=$((REAL_RED+1)); continue; }
+  while IFS=$'\t' read -r jn jc js; do
+    [ -z "$jn" ] && continue
+    echo "    $nm / $jn: $jc  steps=$js"
+    if [ "$jc" != "success" ] && [ "$jc" != "skipped" ] && [ "$jc" != "pending" ]; then
+      if [ "$js" -eq 0 ]; then NEVER_STARTED=$((NEVER_STARTED+1)); else REAL_RED=$((REAL_RED+1)); fi
+    fi
+  done < <(printf '%s' "$JOBS" | jq -r '.[] | [.name,.conclusion,.steps] | @tsv')
+done < <(printf '%s' "$RUNS" | jq -r '.[] | select(.status=="completed" and .conclusion!="success" and .conclusion!="skipped") | [.databaseId,.name] | @tsv')
+
+NONTERM=$(printf '%s' "$RUNS" | jq '[.[] | select(.status!="completed")] | length')
+# A pending run's conclusion is the EMPTY STRING, not null — excluding only
+# null counts every pending run as a failure (measured on a live PR; a
+# finished-PR-only validation cannot see it).
+BAD=$(printf '%s' "$RUNS" | jq '[.[] | select((.conclusion//"") != "" and .conclusion!="success" and .conclusion!="skipped")] | length')
+MAXATT=$(printf '%s' "$RUNS" | jq '[.[].attempt] | max')
+
+echo
+echo "VERDICT: $N runs · expected by name: ${EXPECTED[*]} (all present) · $NONTERM not terminal · $BAD non-success · max attempt $MAXATT"
+if [ "$NONTERM" -gt 0 ]; then
+  echo "  PENDING — do not conclude."
+  exit 2
+fi
+if [ "$BAD" -gt 0 ]; then
+  if [ "$REAL_RED" -eq 0 ] && [ "$NEVER_STARTED" -gt 0 ]; then
+    echo "  RED-SHAPED, but every failing job has steps=0: nothing executed."
+    echo "  Provenance category 3 IF supersession is excluded — check by hand:"
+    echo "    no concurrency block in the workflow files, and the branch tip unmoved."
+    echo "  No signal about the code either direction; the remedy is a re-run."
+  else
+    echo "  RED — at least one job ran steps and did not succeed. Classify before deciding."
+  fi
+  exit 1
+fi
+if [ "$MAXATT" -gt 1 ]; then
+  echo "  GREEN ON ATTEMPT $MAXATT (not 'no red' — see the attempt-1 classification above)."
+else
+  echo "  GREEN ON ATTEMPT 1 — no red on any attempt at this SHA."
+fi
+exit 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,48 @@ def _real_agentwire_home_untouched():
         pytest.fail(failure, pytrace=False)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _source_tree_untouched():
+    """Mirror backstop to the one above: no test may modify the SOURCE (#947).
+
+    ``_real_agentwire_home_untouched`` catches writes into the real
+    ``~/.agentwire``; nothing covered the reverse direction — an operation
+    aimed at the install landing in the checkout. It happened: the installed
+    ``queue-processor.sh`` is a symlink into the package, macOS ``chmod``
+    follows symlinks, and the suite's hook-install path chmod'd a tracked
+    file to 755 on every run. Every dev dirtied their tree; ``git commit -a``
+    re-committed the mode change silently.
+
+    Snapshot ``git status`` over ``agentwire/`` at session start, compare at
+    session end — content and mode changes both surface as ``M`` entries.
+    Only NEW entries fail, so running the suite in an intentionally dirty
+    working tree stays legal.
+    """
+    import subprocess
+
+    root = Path(__file__).parent.parent
+
+    def _status() -> "set[str] | None":
+        proc = subprocess.run(
+            ["git", "status", "--porcelain", "--", "agentwire/"],
+            cwd=root, capture_output=True, text=True,
+        )
+        return set(proc.stdout.splitlines()) if proc.returncode == 0 else None
+
+    before = _status()
+    yield
+    if before is None:  # not a git checkout (installed package, sdist) — nothing to guard
+        return
+    after = _status()
+    new = sorted((after or set()) - before)
+    if new:
+        pytest.fail(
+            "the test suite modified tracked source files (#947 — an operation "
+            "aimed at the install landed in the checkout?):\n  " + "\n  ".join(new),
+            pytrace=False,
+        )
+
+
 @pytest.fixture(autouse=True)
 def _no_real_outbound_email(request, monkeypatch):
     """No test may send real email — ever.

--- a/tests/integration/test_tmux_name_rewrite.py
+++ b/tests/integration/test_tmux_name_rewrite.py
@@ -62,6 +62,24 @@ def tmux_sock():
             ["tmux", "-S", socket, *args], capture_output=True, text=True
         )
 
+    # Precondition, asserted rather than commented (#948): these tests measure
+    # the name-rewrite mapping of the tmux SERVER actually running here, and
+    # some environments' tmux does not rewrite at all — the sweep then reads
+    # back its own probe string unchanged and every content assertion fails
+    # with output that says "your substitution set is wrong", sending the
+    # reader to the branch's code instead of to the environment. Probe one
+    # character KNOWN to be rewritten (a literal '.') and require that it
+    # changed, so a marker-less run fails with one diagnostic sentence.
+    probed = _real_name(run, "a.b")
+    if probed == "a.b":
+        run("kill-server")
+        pytest.fail(
+            "tmux here does not rewrite session names ('a.b' came back "
+            "unchanged) — this environment cannot measure the mapping these "
+            "tests exist to verify (see pytestmark). If this is CI, the "
+            "requires_tmux marker was not deselected.",
+            pytrace=False,
+        )
     yield run
     run("kill-server")
 

--- a/tests/unit/test_beta_flag.py
+++ b/tests/unit/test_beta_flag.py
@@ -72,9 +72,12 @@ class TestFixtureIsHonest:
             )
             if proc.returncode != 0:
                 pytest.skip("origin/main not fetched in this checkout")
-            assert proc.stdout == _fixture(name), (
-                f"tests/fixtures/main_roles/{name} has drifted from origin/main — "
-                "regenerate it, do not edit it by hand"
+            # Rendered flag-OFF, not raw: since the voice layer merged, main's
+            # raw files carry the beta markers too, and the fixture's meaning
+            # is "the non-voice baseline" — what a flag-off user receives.
+            assert beta_mod.apply_beta_blocks(proc.stdout, enabled=set()) == _fixture(name), (
+                f"tests/fixtures/main_roles/{name} has drifted from origin/main's "
+                "flag-off rendering — regenerate it, do not edit it by hand"
             )
 
     def test_the_fixture_is_not_just_the_branch(self):
@@ -470,7 +473,17 @@ class TestMcpSchemaIsByteIdenticalToMain:
         # ...and the attribute is the ast-extracted source text, compiled and
         # then gate-resolved. Both links byte-exact ⇒ raw equality with main
         # (asserted below) carries through to the published schema.
-        assert registered["msg_send"] == _as_shipped("msg_send")
+        #
+        # Resolved with the flags recorded AT import — not with this test's
+        # (hermetic, redirected-$HOME) flag state, and not with the host's
+        # live config either. The suite imports the package before the home
+        # redirect, so on a machine with beta.voice_layer on the import-time
+        # render genuinely includes the voice prose; comparing it against a
+        # read of the current flag state made the suite's verdict a function
+        # of the developer's personal opt-in (#1023).
+        assert registered["msg_send"] == _as_shipped(
+            "msg_send", enabled=set(mcp_msg.msg_send.__beta_enabled__)
+        )
 
     def test_no_published_description_carries_a_marker(self):
         """Every tool in the LIVE registry, not just the one we know about.
@@ -538,11 +551,27 @@ class TestMcpSchemaIsByteIdenticalToMain:
         stripping the ends could never have absorbed it, and would only ever
         have absorbed a real leading/trailing-whitespace regression.
         """
-        from agentwire import beta as live_beta
         from agentwire import mcp_msg
 
-        expected = _as_shipped("msg_send", enabled=live_beta.enabled_flags())
+        # ``__beta_enabled__`` existing at all is the wiring proof: only
+        # ``gated_doc`` writes it. Its VALUE is the flag set the import-time
+        # resolution actually ran with — which is the only set the shipped
+        # docstring can be compared against. Reading the CURRENT flag state
+        # here instead made this test fail on any machine whose host config
+        # enables the flag (#1023): import resolved under the real home,
+        # the comparison ran under the suite's redirected one.
+        recorded = getattr(mcp_msg.msg_send, "__beta_enabled__", None)
+        assert recorded is not None, "gated_doc did not run on msg_send"
+        expected = _as_shipped("msg_send", enabled=set(recorded))
         assert (mcp_msg.msg_send.__doc__ or "") == expected
+        # And both resolutions are exercised regardless of what the host had
+        # on at import — the shape the recorded state happened to produce is
+        # asserted above; the OTHER shape must also be constructible and
+        # distinct, or the gate is decoration.
+        on = _as_shipped("msg_send", enabled={"voice_layer"})
+        off = _as_shipped("msg_send", enabled=set())
+        assert on != off
+        assert "beta:" not in on and "beta:" not in off
 
     def test_the_voice_prose_is_present_when_enabled(self):
         on = beta_mod.render(
@@ -575,8 +604,12 @@ class TestMcpSchemaIsByteIdenticalToMain:
                     continue
                 if any(getattr(d.func if isinstance(d, ast.Call) else d, "attr", None) == "tool"
                        for d in node.decorator_list):
-                    assert main.get(node.name) == (ast.get_docstring(node, clean=False) or ""), (
-                        f"fixture drifted from origin/main for {node.name}"
+                    # Rendered flag-OFF: main's raw source carries the beta
+                    # markers too, post-merge — the fixture snapshots the
+                    # non-voice baseline, not main's marker scaffolding.
+                    raw = ast.get_docstring(node, clean=False) or ""
+                    assert main.get(node.name) == beta_mod.apply_beta_blocks(raw, enabled=set()), (
+                        f"fixture drifted from origin/main's flag-off rendering for {node.name}"
                     )
 
     def test_the_fixture_is_not_just_the_branch(self):

--- a/tests/unit/test_hooks_install.py
+++ b/tests/unit/test_hooks_install.py
@@ -82,6 +82,20 @@ class TestInstallManagedFile:
         assert target.read_text() == source.read_text()
         assert target.stat().st_mode & 0o111  # executable
 
+    def test_symlink_install_never_chmods_the_source(self, source, target_dir):
+        """#947: chmod follows symlinks, so a chmod aimed at the installed
+        link lands on the SOURCE — which, in a dev checkout, is a tracked
+        file. The suite itself was the reproducer: every run flipped
+        ``agentwire/hooks/queue-processor.sh`` to 755 in every dev's tree.
+        The symlink path must leave the source's mode alone entirely."""
+        import os
+
+        os.chmod(source, 0o644)
+        target = target_dir / "hook.sh"
+        assert _install_managed_file(source, target) is True
+        assert target.is_symlink()
+        assert (source.stat().st_mode & 0o777) == 0o644
+
     def test_current_file_untouched(self, source, target_dir):
         target = target_dir / "hook.sh"
         _install_managed_file(source, target, copy=True)


### PR DESCRIPTION
Four test/CI-hygiene issues, one branch.

**#1023 — beta MCP-schema tests hermetic.** The suite imports the package before the per-test `$HOME` redirect, so `gated_doc` resolves docstrings under the HOST's real flags — while the tests re-read flags under the hermetic fake home. On a `beta.voice_layer: true` machine those two states diverge and the byte-identity tests fail with nothing wrong. `gated_doc` now records `__beta_raw_doc__` + `__beta_enabled__` (the set it actually resolved with), and the tests compare against the recorded state; both flag shapes are additionally constructed hermetically in the same test. Second, distinct cause inside the same 4 failures: the fixture-honesty checks compared fixtures to origin/main **raw**, but post-merge main's raw source carries the beta markers too — they now compare against origin/main **rendered flag-off**, which is what the fixtures mean. 62/62 green with the host flag on, off, and absent.

**#947 — no more chmod-through-symlink.** `_install_managed_file` chmod'd the target on both paths; on the symlink path chmod follows the link into the package — which in a dev checkout is a tracked file. The chmod now lives only on the copy path (the packaged hook scripts ship 755, so a symlink needs none). Plus the mirror backstop the issue asked for: a session-scoped conftest fixture snapshots `git status` over `agentwire/` and fails the run if the suite modified tracked source, and a unit test pins that a symlink install leaves a 644 source at 644.

**#948 — precondition, not comment.** The `tmux_sock` fixture now probes `a.b` and fails with one diagnostic sentence ("tmux here does not rewrite session names — this environment cannot measure the mapping") when the readback comes back unchanged, instead of every content assertion failing with output that points at the branch's code.

**#945 — `scripts/ci_verdict.sh`.** The preserved `~/.agentwire/scripts` version plus every correction from the thread: server-side `--commit` on a derived 40-char SHA; name-based floor (pytest/ruff/security from the workflow triggers, tts-smoke added only when the PR's changed paths reach its filter — never derived from the observed runs); zero-runs refusal listing the cause differential (scheduling window, retention aging, non-trigger-target, cross-repo held PR via `isCrossRepository`); `steps==0` never-started discriminator at job level (`per_page=100`); attempt-1 archaeology for re-run-away reds; empty-string-conclusion pending handling; no exit status through a pipe. Validated live: #1022 → exit 0 GREEN ON ATTEMPT 1; #937 → exit 0 GREEN ON ATTEMPT 2 with both attempt-1 reds classified; bad PR number → refusal, exit 1.

Full suite: 6501 passed, 36 skipped.

Closes #1023
Closes #947
Closes #948
Closes #945

Built by [dotdev.dev](https://dotdev.dev)