### PR TITLE
voice confirm spine: build throws speak, cancel's description stops lying, the deferral bound is whole

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -469,18 +469,16 @@ function createAnnouncer(deps) {
     // case is therefore one budget, and it is bounded even if the watchdog is
     // broken.
     //
-    // WHAT THIS DELAY IS UPSTREAM OF, said here because it falsifies a
-    // sentence in another file: the announcer's own two bounded deferrals are
+    // WHAT THIS DELAY IS UPSTREAM OF, said here because the bound it adds is
+    // stated in another file: the announcer's own two bounded deferrals are
     // counted from the moment an item becomes `current`, and confirm.py's
-    // not_announced note bounds the wait for that refusal in units of
-    // fallbackMs on that basis. A refusal queued while a fallback utterance is
-    // live now waits HERE first, so that note under-states the worst case by
-    // up to one speaking budget in exactly that state. The trade is still the
-    // right one — the owner is listening to the buddy for the whole wait
-    // rather than sitting in silence — but the number over there is no longer
-    // the whole story. Filed as #1009 rather than left living here as a
-    // comment: confirm.py was owned elsewhere the wave this landed in, and an
-    // unfiled residual is worse than a filed one.
+    // not_announced note counts THIS deferral on top of that arithmetic — one
+    // speaking budget in front of the fallbackMs intervals, in exactly the
+    // state where a fallback utterance is live (#1009). The trade is still
+    // the right one — the owner is listening to the buddy for the whole wait
+    // rather than sitting in silence, so the deferral extends the wait and
+    // never the silence. Change this bound and that note's pins fail with it:
+    // the note derives its numbers from these constants.
     if (speaking.length && !force) {
       if (!pumpDeferTimer) {
         var bound = pumpBound();

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -895,9 +895,11 @@ class Proposal:
         prefix = list(self.argv_prefix)
         # The full relay (#1015) is written HERE, at execution, not at propose:
         # a proposal the owner cancels or lets expire must leave nothing on
-        # disk. ``write_relay`` never raises — this line sits after the
-        # ``_proposals.pop()`` and outside the runner's ``try``, where a throw
-        # eats an approved message with no screen to report it on.
+        # disk. ``write_relay`` never raises — this runs after the
+        # ``_proposals.pop()`` with the utterance spent, and while a throw now
+        # degrades to a spoken ``build_failed`` (#1005) rather than silence,
+        # that outcome still costs the owner the message and a re-propose, so
+        # a relay miss must not be allowed to buy it.
         written = ""
         # Matched against the path this id DERIVES, and matched at the TAIL:
         # ``ConfirmSpine.propose`` appends its pair last, so the tail is the
@@ -1126,10 +1128,14 @@ def _lead_safe(text: str) -> str:
     :func:`render_body`, with this function merely usually-right: it stripped
     only the first dash RUN, so ``"- - force a restart"`` reached the assert and
     raised. ``render_body`` is called from ``Proposal.build_argv()``, which
-    ``ConfirmSpine.confirm`` runs **after** ``_proposals.pop()`` and **outside**
-    the runner's ``try`` — the proposal is already consumed and the approving
-    utterance already spent, so the raise destroyed the message with no retry
-    and, for a screenless owner, nothing anywhere saying why.
+    ``ConfirmSpine.confirm`` runs **after** ``_proposals.pop()`` — the proposal
+    is already consumed and the approving utterance already spent, and at the
+    time this shipped nothing guarded that path, so the raise destroyed the
+    message with no retry and, for a screenless owner, nothing anywhere saying
+    why. (#1005 has since put a structural guard around ``build_argv`` — a
+    throw there now degrades to a spoken ``build_failed`` — but that outcome
+    still costs the owner the message, so totality here remains the cheaper
+    property, not a redundant one.)
 
     So: no raise on this path, and no ``assert`` either. An assert is compiled
     out by ``python -O``, which turned the incomplete strip into the *silent*
@@ -1341,10 +1347,21 @@ SPOKEN = {
     # `responseActive` TRUE, so pump() cancels that one and creates OURS, and
     # the server's ack of our create sets `sawCreate` while the item is still
     # current. The owner-speaking leg (`maxOwnerDeferrals`, 3) never cared which
-    # response is running. So at `fallbackMs` 6000 the bound here is the
-    # announcer's general worst case, 5 intervals — 30s — dropping to 4 (24s)
-    # only in the sub-case where our own create is never acked at all. The
-    # deadlock sentence above was written against 2 intervals, 12s.
+    # response is running. So at `fallbackMs` 6000 the announcer's own half of
+    # the wait is its general worst case, 5 intervals — 30s — dropping to 4
+    # (24s) only in the sub-case where our own create is never acked at all.
+    # The deadlock sentence above was written against 2 intervals, 12s.
+    #
+    # And that half is not the whole wait (#997, closed by #1009). Both
+    # deferrals are counted from the moment this refusal becomes `current` in
+    # the announcer's FIFO, and pump() holds a queued item UPSTREAM of that
+    # while a fallback utterance is still playing — bounded by that
+    # utterance's own speaking budget (30s floor + 140ms/char, client.py's
+    # speakingBudget). So in the one state where the browser voice is
+    # mid-utterance when this refusal is queued, the worst case is one
+    # speaking budget in front of the 30s above, and a coalesced five-reply
+    # notice puts minutes there, not seconds. The interval arithmetic above is
+    # complete only when nothing is being spoken.
     #
     # The deadlock argument survives the bigger number, and not by calling 30s
     # tolerable. It survives because a deferral is not a suppression: each is
@@ -1357,7 +1374,11 @@ SPOKEN = {
     # most one unspent deferral still lands between their silence and the
     # speech. That bounds the silence anyone can be left in waiting for THIS
     # refusal at 12s, whatever the 30s above does to the buddy's own patience.
-    # A deadlock needs both parties waiting; only one of them ever is.
+    # The pump leg does not add to it: it is taken only while a fallback
+    # utterance is PLAYING — audio the owner is hearing the whole time — so it
+    # too extends the wait and never the silence, which is why the deferral
+    # was chosen over talking over it. A deadlock needs both parties waiting;
+    # only one of them ever is.
     "not_announced": (
         "Hang on — I haven't finished telling you what I'd send yet."
     ),
@@ -1466,6 +1487,17 @@ SPOKEN = {
     "dispatch_failed": (
         "That failed partway and I can't tell whether it took effect. "
         "Check that session before asking me again."
+    ),
+    # The argv could not even be BUILT (#1005): the throw landed between the
+    # pop and the runner, so — unlike `dispatch_failed`, whose whole line is
+    # the uncertainty — the system positively knows the runner was never
+    # called and nothing went out. That difference is the owner's next move:
+    # here a re-propose is SAFE and is the only remedy (the utterance is
+    # spent, the proposal popped), while `dispatch_failed`'s "check that
+    # session" would send them to verify a write that provably never left.
+    "build_failed": (
+        "Something broke on my side before anything went out, so nothing "
+        "was sent. Ask me again and I'll set it up fresh."
     ),
 }
 
@@ -1583,7 +1615,7 @@ REASONS = frozenset(
     {
         "no_proposal", "expired", "not_announced", "replayed", "refused",
         "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
-        "too_many_attempts", "dispatch_failed", "in_flight",
+        "too_many_attempts", "dispatch_failed", "build_failed", "in_flight",
         "cancel_in_flight", "nothing_to_cancel", "cancelled",
     }
 )
@@ -1922,23 +1954,37 @@ class ConfirmSpine:
         with self._lock:
             self._proposals.pop(token, None)
 
-        # RESIDUAL, stated rather than implied (#1004 review). This line sits
-        # after the pop and outside the try below, so anything it throws eats
-        # the proposal with the approving utterance already spent — silent loss
-        # to an owner who is not watching a screen. The concrete lead-dash
-        # hazard that used to live here is closed by TOTALITY, not by position:
-        # build_argv, _reply_target, render_body, _lead_safe, _clip, _one_line,
-        # reply_nudge and strip_controls are all total on str, so there is no
-        # raise path left. A FUTURE throw is the open part.
+        # GUARDED ON ITS OWN, not folded into the runner's except (#1005).
+        # This line still runs after the pop with the approving utterance
+        # already spent, and every function on the path is total on str — but
+        # totality was the only thing standing between a future edit and
+        # silent loss of an approved message, and nothing enforced it. Now a
+        # throw degrades STRUCTURALLY to a spoken outcome.
         #
-        # Moving it inside the try is NOT the one-line change it looks like:
-        # `argv` would be unbound in the except, and `record_write` /
-        # `verdict.argv` both need a defined value — so it forces a ruling on
-        # what `buddy_sent` shows for a write whose argv never existed, and
-        # `buddy_sent` is precisely the surface the persona is told to trust
-        # for "what did you send". That is its own change, deliberately not
-        # rushed in alongside the kind migration.
-        argv = proposal.build_argv()
+        # The ruling the move forced, priced on both halves: a build_argv
+        # throw means the runner was NEVER called, so unlike `dispatch_failed`
+        # the system positively knows nothing went out. Reusing that reason
+        # here would claim uncertainty it does not have and send the owner to
+        # check a session nothing was sent to — so this is its own outcome,
+        # `build_failed`, whose line admits the loss and invites the
+        # re-propose that is safe here and unsafe there. `buddy_sent` gets a
+        # record with an EMPTY argv and success False: `delivery_state` reads
+        # that as "it never went out, the reason is in detail", which is
+        # literally true. And the token is deliberately marked NEITHER
+        # `_failed` nor `_succeeded` — `_failed` would answer the retry with
+        # "check that session"; unmarked, a retry lands on `no_proposal` and a
+        # cancel on `nothing_to_cancel`, both of which are true.
+        try:
+            argv = proposal.build_argv()
+        except Exception as exc:
+            outbox.record_write(  # #958; never raises
+                proposal,
+                [],
+                {"success": False, "error": f"build_argv raised before dispatch: {exc}"},
+            )
+            return Verdict(
+                approved=False, reason="build_failed", utterance=verdict.utterance
+            )
         verdict.argv = argv
         if self._runner is not None:
             try:

--- a/agentwire/voice_layer/write_tools.py
+++ b/agentwire/voice_layer/write_tools.py
@@ -291,10 +291,22 @@ def gated_triple(spec: WriteSpec) -> tuple:
             send,
         ),
         (
+            # "Does nothing and never fails" was true before #990 routed
+            # cancel through the shared claim, and stale after — and a tool
+            # description is MODEL-FACING: a model told cancelling is free has
+            # no reason to check the outcome or relay a refusal, which in a
+            # screenless channel is how a refused cancel becomes silence
+            # (#1008). Narrowed, not qualified: it states what cancel does,
+            # that it can refuse, and the one move its refusals must never
+            # invite.
             f"cancel_{spec.name}",
             (
                 f"Drop a proposal for {spec.action} the owner declined or "
-                "changed their mind about. Does nothing and never fails."
+                "changed their mind about. It performs no write itself, but it "
+                "CAN refuse: too late when the write is already going out, and "
+                "nothing-to-cancel when no proposal is pending. Always relay "
+                "the outcome's say line to the owner — and never re-propose a "
+                "write the owner just retracted."
             ),
             token_schema,
             cancel,

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -1191,6 +1191,7 @@ the set `SPOKEN` is checked against **both ways**:
 | `nothing_to_cancel` | nothing — there was nothing of ours left to take back |
 | `too_many_attempts` | ask again from the top; that proposal is gone |
 | `dispatch_failed` | check that session, *then* decide — it may have gone out |
+| `build_failed` | ask again — the argv never got built, so the runner never ran and nothing went out (#1005) |
 
 `refused` and `pending_transcript` demand *opposite* behaviour. Collapsing them
 trains the owner to repeat into a system that needed them to hold still. Four

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -3084,6 +3084,36 @@ class TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound:
         assert "a deferral is not a suppression" in note
         assert "not the owner's silence" in note
 
+    def test_the_note_counts_the_pump_deferral_and_derives_its_numbers(self):
+        """#1009. #997 put a delay strictly UPSTREAM of both counted deferrals
+        — pump() holds a queued item while a fallback utterance plays, bounded
+        by that utterance's speaking budget — so the paragraph's interval
+        arithmetic stopped being a complete bound in exactly the state where a
+        fallback utterance is live. The rewritten note states that leg, and
+        its numbers are DERIVED here from ``client.py``'s constants the same
+        way the interval numbers are: transcription across two files with
+        nothing connecting them is how the first number went stale, and the
+        second one after it."""
+        src = client.ANNOUNCER_JS
+        fallback, _owner = self._constants()
+        base_mult = int(
+            re.search(r"deps\.speakingMaxMs \|\| fallbackMs \* (\d+)", src).group(1)
+        )
+        per_char = int(
+            re.search(r"deps\.speakingMsPerChar === undefined \? (\d+)", src).group(1)
+        )
+        floor_s = fallback * base_mult // 1000
+        note = _source_prose(confirm.__file__)
+        # The pump leg, with the budget stated from the constants that bound it.
+        assert f"{floor_s}s floor + {per_char}ms/char" in note
+        assert "one speaking budget in front of" in note
+        # Narrowed, not qualified: the interval numbers are named as complete
+        # only in the no-audio state, rather than left reading as the bound.
+        assert "complete only when nothing is being spoken" in note
+        # And the silence claim survives for the stated reason — the pump leg
+        # is taken only behind audio the owner is hearing.
+        assert "extends the wait and never the silence" in note
+
     def test_the_ordinary_path_here_takes_both_legs_and_speaks_on_fire_five(self):
         """The ordinary path here takes BOTH legs and speaks on fire five.
 
@@ -3212,21 +3242,19 @@ class TestThePumpDefersToTheBrowserVoice:
         assert "false-reject (promoting too early)" in prose
 
     def test_the_comment_names_the_bound_this_delay_pushes_out(self):
-        """The cross-file half, and the reason it is written down rather than
-        assumed obvious: ``confirm.py``'s not_announced note bounds the wait for
-        that refusal in units of ``fallbackMs``, counted from the moment the
-        item becomes ``current``. This deferral happens BEFORE that, so in the
-        one state where a fallback utterance is live the note under-states its
-        own worst case. A behaviour change that silently falsifies a sentence
-        elsewhere is the defect class this whole layer keeps finding; naming it
-        in the file that caused it is the cheapest place it survives."""
+        """The cross-file half: ``confirm.py``'s not_announced note counts its
+        wait in ``fallbackMs`` intervals from the moment the item becomes
+        ``current``, and this deferral happens BEFORE that. #1009 closed the
+        gap — the note now counts this leg too — so the comment here must
+        state the closed relationship and no longer claim the note under-states
+        its own worst case (a comment claiming a defect that no longer exists
+        is the same drift with its polarity reversed)."""
         prose = _page_prose()
         assert "confirm.py's not_announced note" in prose
-        assert "under-states the worst case by up to one speaking budget" in prose
-        # And it is FILED, not merely commented. A caveat that lives only in a
-        # comment is invisible to the board the owner reads, and the ruling for
-        # this beta is that nothing known-open ships unfiled.
-        assert "Filed as #1009" in prose
+        assert "counts THIS deferral on top of that arithmetic" in prose
+        assert "under-states the worst case" not in prose
+        # And the wave-ownership clause went with the fix (#1009 scope 3).
+        assert "owned elsewhere the wave this landed in" not in prose
 
     def test_a_queued_item_is_not_pumped_into_the_starting_browser_voice(self):
         """The reproduction from #997, inverted.

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -2725,6 +2725,17 @@ class TestOutcomesAreDistinctAndSpoken:
         race_spine.confirm(racing.token)
         seen |= set(cancelled)
 
+        # build_failed: the argv could not be built — popped, never dispatched
+        # (#1005). Distinct from dispatch_failed because the runner never ran.
+        broken = convo.announced_proposal()
+        convo.approve(broken)
+
+        def _boom():
+            raise RuntimeError("render blew up")
+
+        broken.build_argv = _boom
+        seen.add(convo.spine.confirm(broken.token).reason)
+
         # cancelled: the ordinary retraction. Split from `denied` because it
         # POPS — "say the phrase again" cannot work once it has.
         retracted = convo.announced_proposal()
@@ -2906,6 +2917,96 @@ class TestOutcomesAreDistinctAndSpoken:
 # =============================================================================
 
 
+class TestABuildFailureIsSpokenNotSilent:
+    """#1005. ``build_argv`` runs after ``_proposals.pop()``, with the approving
+    utterance already spent — so before this, anything it threw destroyed an
+    APPROVED message with nothing anywhere saying why, which is the worst place
+    in the system to lose one. It is now guarded on its own, not folded into
+    the runner's except: the two failures are different facts. A runner failure
+    may have partially written ("I can't tell whether it took effect"); a
+    ``build_argv`` throw means the runner was NEVER called, so the system
+    positively knows nothing went out and may honestly invite a re-propose.
+
+    Both halves priced: the false-accept (claiming ``dispatch_failed``'s
+    uncertainty here) would send the owner to verify a session nothing was sent
+    to, and would leave re-propose looking unsafe when it is the exact remedy;
+    the false-reject half is the utterance already spent — one re-propose, and
+    the line says so.
+    """
+
+    def _broken(self, convo):
+        proposal = convo.announced_proposal()
+        convo.approve(proposal)
+
+        def boom():
+            raise RuntimeError("render blew up")
+
+        # Instance attribute shadows the method: the one throw site #1005 names.
+        proposal.build_argv = boom
+        return proposal
+
+    def test_the_throw_degrades_to_a_spoken_outcome_not_a_raise(self, convo, runner):
+        proposal = self._broken(convo)
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.approved is False
+        assert verdict.reason == "build_failed"
+        payload = verdict.to_dict()
+        assert payload["must_speak"] is True
+        assert payload["say"].strip()
+        # Terminal: the handshake ends here, the owner is not told to wait.
+        assert payload["owner_should_wait"] is False
+        assert payload["confirm_terminal"] is True
+        # The runner was never reached — that is what separates this from
+        # dispatch_failed, and what makes "nothing was sent" true.
+        assert runner.calls == []
+
+    def test_the_line_states_the_certainty_it_actually_has(self):
+        line = confirm.SPOKEN["build_failed"].lower()
+        assert "nothing was sent" in line
+        assert "ask me again" in line
+        # It must NOT borrow dispatch_failed's hedge: the runner never ran, so
+        # "I can't tell" would be false uncertainty, and "check that session"
+        # sends the owner to verify a write that provably never went out.
+        assert "can't tell" not in line
+        assert "check that session" not in line
+
+    def test_a_retry_and_a_cancel_are_answered_truthfully(self, convo, runner):
+        """Deliberately NEITHER ``_failed`` nor ``_succeeded``: marking
+        ``_failed`` would make the retry say "check that session before asking
+        me again" about a write the system knows never went out. Unmarked, the
+        retry lands on ``no_proposal`` ("tell me again what you'd like sent")
+        and a cancel on ``nothing_to_cancel`` — both true, both naming the
+        owner's real next move."""
+        proposal = self._broken(convo)
+        assert convo.spine.confirm(proposal.token).reason == "build_failed"
+        assert convo.spine.confirm(proposal.token).reason == "no_proposal"
+        assert convo.spine.cancel(proposal.token).reason == "nothing_to_cancel"
+        assert runner.calls == []
+
+    def test_the_failure_is_recorded_so_buddy_sent_can_answer(
+        self, convo, runner, monkeypatch
+    ):
+        """The #1005 ruling on what ``buddy_sent`` shows for a proposal popped
+        but never dispatched: a record with an EMPTY argv and success False,
+        which ``delivery_state`` reads as ``dispatch_failed`` — whose meaning
+        in the outbox ("it never went out, the reason is in detail") is
+        literally true of a build failure."""
+        records = []
+        monkeypatch.setattr(
+            confirm.outbox,
+            "record_write",
+            lambda proposal, argv, result: records.append((proposal, argv, result)),
+        )
+        proposal = self._broken(convo)
+        convo.spine.confirm(proposal.token)
+        assert len(records) == 1
+        recorded, argv, result = records[0]
+        assert recorded is proposal
+        assert argv == []
+        assert result["success"] is False
+        assert "render blew up" in result["error"]
+
+
 class TestWriteToolSurface:
     @pytest.fixture
     def live(self, monkeypatch):
@@ -3014,6 +3115,34 @@ class TestWriteToolSurface:
         assert argv[8] == "--ref"
         assert argv[9] == str(relay.relay_path(proposal.id))
         assert len(argv) == 11
+
+    def test_the_cancel_description_tells_the_model_cancel_can_refuse(self):
+        """#1008. The description is part of the prompt the buddy reasons
+        over. "Does nothing and never fails" was falsified by #990 (the shared
+        claim gave cancel real refusal paths) — a model that believes it has
+        no reason to check the outcome or relay a refusal, and it was also
+        mis-instructing the ``no_proposal`` path into re-proposing the very
+        write the owner retracted. Pinned, because a model-facing description
+        drifting from the code had no test at all."""
+        descriptions = {
+            name: description
+            for name, description, _schema, _fn in write_tools.WRITE_TOOL_SPECS
+        }
+        for name, description in descriptions.items():
+            if not name.startswith("cancel_"):
+                continue
+            lowered = description.lower()
+            # The stale claims, swept with the phrasings spine-races-rev used.
+            for stale in (
+                "does nothing", "never fails", "cannot fail", "always succeeds",
+                "never refus", "refusing is free", "never gated",
+            ):
+                assert stale not in lowered, (name, stale)
+            # And the true ones: it can refuse, and a refusal must reach the
+            # owner rather than invite a re-propose of a retracted write.
+            assert "can refuse" in lowered, name
+            assert "say line" in lowered, name
+            assert "never re-propose" in lowered, name
 
     def test_cancel_never_writes(self, convo, runner, live):
         proposal = convo.announced_proposal()


### PR DESCRIPTION
Resolves four confirm-spine issues, each priced on both halves of its guard (screenless channel: a wrongful refusal is a silent loop, a wrongful approval writes).

## #1005 — build_argv guarded, silent loss → spoken outcome
`build_argv()` ran after `_proposals.pop()` and outside the runner's `try`: any throw destroyed an approved message with the utterance already spent and nothing anywhere saying why. It now runs inside its own guard, and the ruling the issue asked for is made explicit:

- A `build_argv` throw means the runner was **never called**, so unlike `dispatch_failed` the system positively knows nothing went out. It is therefore its own terminal outcome, `build_failed` — reusing `dispatch_failed` would claim uncertainty the system doesn't have and send the owner to check a session nothing was sent to (the false-accept half), while leaving re-propose looking unsafe when it is the exact remedy.
- `buddy_sent` ruling: `record_write` gets the proposal with an **empty argv** and `success: False`; `delivery_state` reads that as "it never went out, the reason is in detail" — literally true here.
- The token is deliberately in **neither** `_failed` nor `_succeeded`: a retry lands on `no_proposal` ("tell me again what you'd like sent") and a cancel on `nothing_to_cancel` — both true, both naming the real next move. The false-reject half is the already-spent utterance: one re-propose, and the line says so.
- Must-fail control watched failing first: the new test raised straight out of `confirm()` on the unmodified code.

## #1008 — cancel_<name> description
"Does nothing and never fails" was falsified by #990/#1006 and is model-facing — a model that believes cancel is free has no reason to relay a refusal, which screenless becomes silence. Rewritten (narrowed, not qualified): it states what cancel does, that it CAN refuse, and that a retracted write is never re-proposed. Pinned with a sweep over the stale phrasings `spine-races-rev` enumerated; previously this description had no test at all.

## #1009 — the not_announced bound covers the pump leg
The paragraph's interval arithmetic (30s/24s/12s) counted from the moment the refusal becomes `current`; #997's `pump()` deferral sits strictly upstream, bounded by the in-flight utterance's speaking budget. The paragraph now states that leg — one speaking budget (30s floor + 140ms/char) in front of the intervals, with the arithmetic named complete only when nothing is being spoken — and keeps the 12s silence bound with the reason it survives (the pump leg plays only behind audio the owner is hearing). The new numbers are DERIVED from `client.py`'s constants in `TestTheNotAnnouncedDeadlockParagraphStatesTheRealBound`, same as the existing ones. `client.py`'s `pump()` comment drops the wave-ownership clause and the now-closed under-statement claim; its pin asserts the closed relationship and that the stale claim is gone.

## #976 — verified fixed, closing
All seven findings shipped via #987 and the issue was left open. Re-ran every repro against the live `raw → normalize → classify` pipeline in this worktree: mask overreach denies (both compositions + `carries_denial`), "never confirm tango" / "you should never confirm tango" deny, `harbor`/`ripcord` are out of the alphabet, "confirm, uh, tango" approves, "can't wait" no longer denies, the ceiling is re-read after the await (`confirm.py` `_confirm_claimed`), and single-use is enforced at `_claim`. Nothing further to change.

## Tests
`tests/unit/test_voice_*` + doctor-voice: **1099 passed**. Full suite: remaining failures (portal/server/tts/scheduler files) reproduce identically on the clean tree in this environment — pre-existing, untouched by this diff.

Closes #1005
Closes #1008
Closes #1009
Closes #976

Built by [dotdev.dev](https://dotdev.dev)