### PR TITLE
topology: render a synthetic graft as a graft, not recorded lineage

### DIFF
--- a/agentwire/static/css/desktop.css
+++ b/agentwire/static/css/desktop.css
@@ -7258,6 +7258,20 @@ body.sidebar-pinned { --hud-left: var(--sidebar-width); }
     text-overflow: ellipsis;
 }
 
+/* Synthetic-graft note (#955) — a repo-scoped ghost grafted under the focused
+   family by _scopedGhosts draws NO connector wire (topology-render.js skips it),
+   so this line is what carries the relationship: "placed here because it shares
+   your repo", never "your child". Distinct channel from the ghost dash, which
+   only says "no live session". */
+.topology-ghost-graft {
+    font-size: 9.5px;
+    font-style: italic;
+    color: color-mix(in srgb, var(--text-muted) 80%, transparent);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* Read-only git-status badges (#801) — reuses the sidebar's `.sidebar-git-badge`
    + `.git-*` classes (sidebar/sessions-section.js's `renderGitBadges`) so a
    worktree reads identically whether it's a live session or a ghost; only the

--- a/agentwire/static/js/session-hud-controller.js
+++ b/agentwire/static/js/session-hud-controller.js
@@ -235,10 +235,12 @@ class HudController {
         for (const g of this._ghosts) {
             if (g.parent && knownNames.has(g.parent)) { out.push(g); continue; }
             if (!g.projectPath || repoNameFromPath(g.projectPath) === repo) {
-                // `parent` here is display-only (grafts the card under the
-                // focused family's wire) — `syntheticParent` tells
-                // `_adoptGhost` not to record it as the real creator, since
-                // this ghost never actually had one.
+                // `parent` here is display-only (places the card inside the
+                // focused family's block). `syntheticParent` makes the graft
+                // render AS a graft (#955): topology-render.js draws no
+                // connector wire and shows a "same repo — not a recorded
+                // child" note, and `_adoptGhost` refuses to record it as the
+                // real creator, since this ghost never actually had one.
                 out.push({ ...g, parent: this._contextSession, syntheticParent: true });
             }
         }

--- a/agentwire/static/js/topology-render.js
+++ b/agentwire/static/js/topology-render.js
@@ -415,6 +415,14 @@ export class TopologyView {
             entry.nameEl.title = label === name ? '' : name;
         }
 
+        // Only ghosts can be grafted (#955) — _scopedGhosts fabricates parents
+        // exclusively for session-less worktree cards — but keep the toggle
+        // unconditional so a card re-rendered without the flag (adopted, or the
+        // view re-rooted) sheds the note.
+        const isGraft = isGhost && !!session.syntheticParent;
+        entry.graftEl.hidden = !isGraft;
+        entry.card.classList.toggle('topology-card--grafted', isGraft);
+
         if (isGhost) {
             this._renderGhostCard(entry, session);
             return; // ghost cards skip the live-state/role/self styling below
@@ -540,6 +548,14 @@ export class TopologyView {
         meta.className = 'topology-card-meta';
         meta.append(machineEl, ghostInfoEl);
 
+        // "This wire-less card is here because it shares your repo" (#955) —
+        // shown only for _scopedGhosts' synthetic grafts, so a recorded-lineage
+        // ghost and a repo-scoped graft never read the same.
+        const graftEl = document.createElement('div');
+        graftEl.className = 'topology-ghost-graft';
+        graftEl.textContent = 'same repo — not a recorded child';
+        graftEl.hidden = true;
+
         const ghostGitEl = document.createElement('div');
         ghostGitEl.className = 'topology-ghost-git';
         ghostGitEl.hidden = true;
@@ -560,13 +576,13 @@ export class TopologyView {
         noteEl.hidden = true;
         ghostActions.append(cleanupBtn, adoptBtn, noteEl);
 
-        card.append(top, pulseEl, meta, ghostGitEl, ghostActions);
+        card.append(top, pulseEl, meta, graftEl, ghostGitEl, ghostActions);
 
         const entry = {
             card, dot, nameEl, roleEl, machineEl, metaEl: meta, pulseEl, menuBtn, state: null, tintVar: null, session: null,
             expanded: false, expandSlot: null, expandDispose: null,
             isSelf: false, selfDispose: null,
-            isGhost: false, ghostBadge, ghostInfoEl, ghostGitEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
+            isGhost: false, ghostBadge, ghostInfoEl, graftEl, ghostGitEl, ghostActions, cleanupBtn, adoptBtn, noteEl,
             ghostConfirm: null, ghostConfirmTimer: null, ghostBusy: false,
             menuEl: null, menuOpen: false, resetKill: null,
         };
@@ -830,6 +846,12 @@ export class TopologyView {
         for (const [name, session] of byName) {
             const parentName = session.parent;
             if (!name || !parentName || parentName === name || !byName.has(parentName)) continue;
+            // A synthetic graft (#955) gets NO wire: the `parent` was fabricated
+            // by _scopedGhosts purely to place the card in the focused family's
+            // block, and a connector identical to recorded lineage asserts a
+            // parentage the data doesn't hold. Placement + the on-card note
+            // carry the "same repo" relationship instead.
+            if (session.syntheticParent) continue;
             const childEntry = this._cards.get(name);
             const parentEntry = this._cards.get(parentName);
             if (!childEntry || !parentEntry) continue;


### PR DESCRIPTION
The topology view drew `_scopedGhosts`' synthetic display-only parent wire with exactly the same appearance as a recorded lineage edge — an unattached root read as the focused session's child, inviting "clean up my children" on a card that is nobody's child.

Fix (issue's option 1+3):

- **No wire for a graft**: `_redrawLinks` skips the connector when `session.syntheticParent` is set. Placement still comes from the fabricated `parent` (the card stays grouped in the focused family's block), so #801's visibility goal survives while the view asserts nothing.
- **A word on the card**: grafted ghost cards show *"same repo — not a recorded child"* (`.topology-ghost-graft`, plus a `topology-card--grafted` class). Distinct channel from the ghost dash, which only signals "no live session" — a ghost with a genuine recorded creator keeps its dashed wire and no note.
- `_adoptGhost` continues to refuse persisting a synthetic parent (unchanged).

Verification: `node --check --input-type=module` clean on both edited JS files; full suite `uv run --extra dev pytest` → 6496 passed, 4 failed in `test_beta_flag.py` which fail identically with the change stashed (they diff fixtures against `origin/main`; pre-existing branch drift, unrelated to portal static files). Live-portal rendering can only be confirmed after merge + rebuild/restart.

Closes #955

Built by [dotdev.dev](https://dotdev.dev)