### PR TITLE
messaging: msg send --body-file (#944); close out #970/#985, already shipped via the spine

### DIFF
--- a/.claude/skills/agentwire-cli/SKILL.md
+++ b/.claude/skills/agentwire-cli/SKILL.md
@@ -193,6 +193,7 @@ agentwire msg send --to name "text"          # queue a message (delivers when th
 agentwire msg send --to name --kind done "PR #312 drafted"  # kinds: note|done|request|escalation|ingest|voice
 agentwire msg send --to name --kind ingest --ref "/path/report.md" "topic"  # PASSIVE: never auto-delivered, pull-only
 agentwire msg send --to @all "team update"   # broadcast to live agent sessions except sender
+agentwire msg send --to name --body-file /tmp/body.md  # code-bearing body, no shell escaping ('-' = stdin)
 agentwire msg inbox -s name                  # peek pending + passive (does not drain/consume)
 agentwire msg pull -s name                   # read + REMOVE passive (ingest) messages — the voluntary pull
 agentwire msg dead -s name                   # list dropped (dead-lettered) msgs + reason/timestamp

--- a/agentwire/core.py
+++ b/agentwire/core.py
@@ -1057,6 +1057,22 @@ def _get_all_machines() -> list[dict]:
         return []
 
 
+def read_body_file(path: str) -> str:
+    """Read a message body from *path*, or stdin when path is ``-`` (#944).
+
+    Free text destined for another agent must never require shell escaping:
+    backticks and ``$(...)`` are command substitution, so the caller's shell
+    eats them silently before the CLI ever sees the text — and the send still
+    reports success. A file (or stdin) removes the question instead of
+    answering it more carefully, same shape as ``gh --body-file``.
+
+    Raises OSError on an unreadable path; callers report it and fail the send.
+    """
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text()
+
+
 def _output_json(data: dict) -> None:
     """Output JSON to stdout."""
     print(json.dumps(data, indent=2))

--- a/agentwire/msg_cli.py
+++ b/agentwire/msg_cli.py
@@ -6,7 +6,7 @@ the recipient's file inbox and the watchdog injects it only when the input box
 is empty and the pane is a safe target — so a worker reporting back never
 clobbers a half-typed human draft.
 
-    agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest|voice] <text>
+    agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest|voice] <text | --body-file PATH>
     agentwire msg inbox [-s <session>]      # peek pending + passive (does not drain/consume)
     agentwire msg pull  [-s <session>]      # read + REMOVE passive (ingest) messages
     agentwire msg dead  [-s <session>]      # list dropped (dead-lettered) msgs
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import json
 
-from . import inbox, pane_manager
+from . import core, inbox, pane_manager
 
 
 def _current_session() -> "str | None":
@@ -34,9 +34,28 @@ def _current_session() -> "str | None":
 
 def cmd_msg_send(args) -> int:
     """Enqueue a message for a session (or @all)."""
-    text = " ".join(args.text) if args.text else ""
+    body_file = getattr(args, "body_file", None)
+    if body_file is not None and args.text:
+        msg = "--body-file and positional text are mutually exclusive"
+        if getattr(args, "json", False):
+            print(json.dumps({"success": False, "error": msg}))
+        else:
+            print(f"Error: {msg}")
+        return 1
+    if body_file is not None:
+        try:
+            text = core.read_body_file(body_file)
+        except OSError as exc:
+            if getattr(args, "json", False):
+                print(json.dumps({"success": False, "error": f"--body-file: {exc}"}))
+            else:
+                print(f"Error: --body-file: {exc}")
+            return 1
+    else:
+        text = " ".join(args.text) if args.text else ""
     if not text.strip():
-        print("Usage: agentwire msg send --to <session> <text>", flush=True)
+        print("Usage: agentwire msg send --to <session> <text | --body-file PATH>",
+              flush=True)
         if getattr(args, "json", False):
             print(json.dumps({"success": False, "error": "empty message"}))
         return 1
@@ -366,7 +385,12 @@ def register_msg_parser(subparsers) -> None:
         "--ref", default="",
         help="Optional machine-readable pointer (e.g. a report path) — surfaced as a typed field; ideal with --kind ingest",
     )
-    send_parser.add_argument("text", nargs="+", help="Message text")
+    send_parser.add_argument(
+        "--body-file", dest="body_file", default=None, metavar="PATH",
+        help="Read the message body from PATH ('-' for stdin) instead of "
+             "positional text — code-bearing bodies need no shell escaping (#944)",
+    )
+    send_parser.add_argument("text", nargs="*", help="Message text (or --body-file)")
     send_parser.add_argument("--json", action="store_true", help="Output JSON")
     send_parser.set_defaults(func=cmd_msg_send)
 

--- a/agentwire/notify_cli.py
+++ b/agentwire/notify_cli.py
@@ -19,6 +19,7 @@ from .core import (
     _output_result,
     _portal_auth_headers,
     _post_desktop_notification,
+    read_body_file,
 )
 
 #: The ``notify-event`` vocabulary worth remembering (#1016). Deliberately not
@@ -44,11 +45,24 @@ def cmd_notify_parent(args) -> int:
         agentwire notify "Worker 1 completed task"
         agentwire notify --to agentwire "Build finished"
     """
-    text = " ".join(args.text) if args.text else ""
     json_mode = getattr(args, 'json', False)
+    body_file = getattr(args, "body_file", None)
+    if body_file is not None and args.text:
+        return _output_result(
+            False, json_mode,
+            "--body-file and positional text are mutually exclusive")
+    if body_file is not None:
+        try:
+            text = read_body_file(body_file)
+        except OSError as exc:
+            return _output_result(False, json_mode, f"--body-file: {exc}")
+    else:
+        text = " ".join(args.text) if args.text else ""
 
-    if not text:
-        return _output_result(False, json_mode, "Usage: agentwire notify-parent <message>")
+    if not text.strip():
+        return _output_result(
+            False, json_mode,
+            "Usage: agentwire notify-parent <message | --body-file PATH>")
 
     target_session = getattr(args, 'to', None)
     current_session = pane_manager.get_current_session()
@@ -336,7 +350,12 @@ def cmd_notify(args) -> int:
 def register_notify_parser(subparsers) -> None:
     # === notify command (worker→parent) ===
     notify_cmd_parser = subparsers.add_parser("notify-parent", help="Notify parent session (worker→orchestrator)")
-    notify_cmd_parser.add_argument("text", nargs="*", help="Notification message")
+    notify_cmd_parser.add_argument("text", nargs="*", help="Notification message (or --body-file)")
+    notify_cmd_parser.add_argument(
+        "--body-file", dest="body_file", default=None, metavar="PATH",
+        help="Read the message body from PATH ('-' for stdin) instead of "
+             "positional text — code-bearing bodies need no shell escaping (#944)",
+    )
     notify_cmd_parser.add_argument("--to", type=str, metavar="SESSION", help="Target session (default: parent from .agentwire.yml)")
     notify_cmd_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress output")
     notify_cmd_parser.add_argument("--raw", action="store_true",

--- a/docs/wiki/sessions/messaging.md
+++ b/docs/wiki/sessions/messaging.md
@@ -483,9 +483,11 @@ skipped automatically because their pane 0 doesn't run an agent.
 ## CLI
 
 ```bash
-agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest|voice] [--ref <path>] <text>
+agentwire msg send --to <session|@all> [--kind note|done|request|escalation|ingest|voice] [--ref <path>] <text | --body-file PATH>
 agentwire msg send --to agentwire-dev-fix-nav --kind done "PR #312 drafted"
 agentwire msg send --to anchor --kind ingest --ref /path/report.md "auth findings"  # passive
+agentwire msg send --to reviewer --kind request --body-file /tmp/findings.md       # code-bearing body, no escaping
+git diff --stat | agentwire msg send --to orch --body-file -                       # '-' reads stdin
 agentwire msg inbox [-s <session>]   # peek pending + passive (does not drain/consume)
 agentwire msg pull  [-s <session>]   # read + REMOVE passive (ingest) messages
 agentwire msg dead  [-s <session>]   # list dropped (dead-lettered) msgs + why
@@ -493,6 +495,15 @@ agentwire msg dead  --purge [-s <session>] [--older-than 7d]  # clear the gravey
 agentwire msg flush [-s <session>] [--force]  # attempt a drain now (gated unless --force)
 agentwire msg purge [<session>]      # drop a session's PENDING queue (self-heal a wedged inbox)
 ```
+
+`--body-file PATH` (`-` for stdin, same shape as `gh --body-file`) exists
+because a body **about code** carries backticks and `$(...)`, which the
+caller's shell executes as command substitution before `msg` ever sees the
+text — a word silently vanishes and the send still reports `Queued` (#944).
+Mutually exclusive with positional text. `notify-parent` takes the same flag;
+`council ask` already had `--file`/stdin. The MCP `msg_send` tool needs no
+equivalent: it passes structured arguments and never transits a shell, which
+is why the two paths differ in risk.
 
 `msg send` to a named session that doesn't currently exist still queues (the
 session may be about to be created) but **warns in the confirmation** — text

--- a/tests/unit/test_msg_cli.py
+++ b/tests/unit/test_msg_cli.py
@@ -213,3 +213,61 @@ class TestDeadLister:
         rc = msg_cli.cmd_msg_dead(_ns(purge=True, older_than="lol"))
         assert rc == 2
         assert "Invalid --older-than" in capsys.readouterr().err
+
+
+class TestSendBodyFile:
+    """--body-file (#944): a code-bearing body never transits shell argv."""
+
+    HOSTILE = "run `voice` then $(rm -rf /) and `ingest`\nline two\n"
+
+    def _live(self, monkeypatch):
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"orch"})
+
+    def test_body_file_preserved_verbatim(self, isolate, monkeypatch, tmp_path):
+        self._live(monkeypatch)
+        p = tmp_path / "body.md"
+        p.write_text(self.HOSTILE)
+        rc = msg_cli.cmd_msg_send(_ns(to="orch", body_file=str(p)))
+        assert rc == 0
+        msgs = inbox.list_messages("orch")
+        assert len(msgs) == 1
+        # Backticks and $() intact — the whole point of the flag.
+        assert msgs[0].text == self.HOSTILE
+
+    def test_dash_reads_stdin(self, isolate, monkeypatch):
+        import io
+
+        self._live(monkeypatch)
+        monkeypatch.setattr("sys.stdin", io.StringIO(self.HOSTILE))
+        rc = msg_cli.cmd_msg_send(_ns(to="orch", body_file="-"))
+        assert rc == 0
+        assert inbox.list_messages("orch")[0].text == self.HOSTILE
+
+    def test_mutually_exclusive_with_text(self, isolate, tmp_path, capsys):
+        p = tmp_path / "body.md"
+        p.write_text("x")
+        rc = msg_cli.cmd_msg_send(_ns(to="orch", body_file=str(p), text=["hi"]))
+        assert rc == 1
+        assert "mutually exclusive" in capsys.readouterr().out
+        assert inbox.list_messages("orch") == []
+
+    def test_unreadable_path_fails_loudly(self, isolate, tmp_path, capsys):
+        rc = msg_cli.cmd_msg_send(
+            _ns(to="orch", body_file=str(tmp_path / "nope.md"), json=True))
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is False and "--body-file" in out["error"]
+        assert inbox.list_messages("orch") == []
+
+    def test_empty_file_is_empty_message(self, isolate, tmp_path, capsys):
+        p = tmp_path / "empty.md"
+        p.write_text("   \n")
+        rc = msg_cli.cmd_msg_send(_ns(to="orch", body_file=str(p)))
+        assert rc == 1
+        assert "Usage" in capsys.readouterr().out
+
+    def test_positional_text_path_unchanged(self, isolate, monkeypatch):
+        self._live(monkeypatch)
+        rc = msg_cli.cmd_msg_send(_ns(to="orch", text=["plain", "words"]))
+        assert rc == 0
+        assert inbox.list_messages("orch")[0].text == "plain words"

--- a/tests/unit/test_notify_cli.py
+++ b/tests/unit/test_notify_cli.py
@@ -93,3 +93,27 @@ class TestQueuedRendersUniquely:
             assert cmd_notify_parent(_args()) == 0
         rendered = [m.render() for m in inbox.list_messages("orch")]
         assert len(rendered) == 2 and rendered[0] != rendered[1]
+
+
+class TestBodyFile:
+    """--body-file (#944): same rail as `msg send`, shared core helper."""
+
+    def test_body_file_verbatim(self, isolate, worktree_child, tmp_path):
+        p = tmp_path / "body.md"
+        p.write_text("done: run `agentwire doctor` and $(true)")
+        assert cmd_notify_parent(_args(text=[], body_file=str(p))) == 0
+        msgs = inbox.list_messages("orch")
+        assert len(msgs) == 1
+        assert msgs[0].text == "done: run `agentwire doctor` and $(true)"
+
+    def test_mutually_exclusive(self, isolate, worktree_child, tmp_path):
+        p = tmp_path / "body.md"
+        p.write_text("x")
+        assert cmd_notify_parent(_args(body_file=str(p))) == 1
+        assert inbox.list_messages("orch") == []
+
+    def test_unreadable_fails(self, isolate, worktree_child, tmp_path):
+        rc = cmd_notify_parent(
+            _args(text=[], body_file=str(tmp_path / "nope.md")))
+        assert rc == 1
+        assert inbox.list_messages("orch") == []


### PR DESCRIPTION
## #944 — `msg send --body-file` (the code in this PR)

A message body **about code** carries backticks and `$(...)`; the caller's shell executes them before the CLI sees the text, and the send still reports `Queued` — silent word loss, measured three times in one afternoon. This removes the question instead of answering it more carefully, same shape as `gh --body-file`:

- `agentwire msg send --to <s> --body-file PATH` (`-` = stdin), mutually exclusive with positional text; empty/unreadable file fails loudly, nothing enqueued.
- `notify-parent` takes the same flag (the issue names it as the sibling hazard); `council ask` already had `--file`/stdin.
- One shared helper, `core.read_body_file()` — no per-CLI copies.
- **MCP `msg_send` deliberately gets no equivalent**: it passes structured arguments and never transits a shell, which is why the two paths differ in risk. Documented in `docs/wiki/sessions/messaging.md` and the CLI skill.
- Tests: hostile body (backticks + `$()`) preserved byte-for-byte through file and stdin, mutual exclusion, unreadable path, empty file, and the positional path unchanged — for both `msg send` and `notify-parent`.

Closes #944

## #970 and #985 — verified already on main, closing by this PR's lines

Both were implemented on the `voice-confirm-spine` branch (PRs #1000 and #1004, merged 2026-08-10) and reached main when the spine merged (b2908d0 / PR #1011) — but the Closes lines lived on the spine-bound PRs, so GitHub never auto-closed the issues. Verified present on main today:

- **#970**: `delivery.advance_cursor` + `buddy_inbox(ack_through=…)` exist (`agentwire/voice_layer/delivery.py`), presence-gated (`"ack_through" in args`) per the round-2 review; the `strayReplies`/`strayIds` workaround is deleted from the tree (zero grep hits); #969's race test survives against the simplified implementation.
- **#985**: `voice` is in `inbox.KINDS` and `ESCALATE_KINDS` per the owner ruling (active, dead-letter-escalates, NOT an interrupt — written into `inbox.py` and the wiki kind table); the three hand-written `("done","escalation")` tuples are consolidated into `inbox.load_bearing()`, which `doctor_cli` and `session_cli` both call; the `_cohort_held` sender-vs-kind seam is tested and `voice` is deliberately out of `cohort.REPORT_KINDS`.

Closes #970
Closes #985

## Verification

Full suite: **6511 passed, 36 skipped, 4 failed** — all 4 failures are `tests/unit/test_beta_flag.py` fixture-vs-origin/main guards that fail identically on a pristine main checkout and have had main's pytest CI red since #1019. Pre-existing, unrelated to this diff, and not fixable by regeneration alone (the class's own control assumes the branch differs from main, which stopped being true at the spine merge). Filed with a ruling request as #1031.

Built by [dotdev.dev](https://dotdev.dev)