### PR TITLE
fix(safety): unattended-block email digest + uv-run grant — #925 Parts 1+2 salvaged onto the #1028 engine

### DIFF
--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -34,7 +34,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "fd330cac622d37e04b2ae2a1e5643a3de4ddb29bda52ac461f8c589a012ad55a", "generated_at": "2026-08-13T13:46:17Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "58790d88d88aec0cbabaa52af8cdde396cd1062ccab5162538ca2b82e04d033e", "generated_at": "2026-08-13T17:26:34Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """
@@ -828,6 +828,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "fd330cac622d37e04b2ae2a1e5643a3de4ddb29bda52ac461f8c589a012ad55a", "generated_at": "2026-08-13T13:46:17Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "58790d88d88aec0cbabaa52af8cdde396cd1062ccab5162538ca2b82e04d033e", "generated_at": "2026-08-13T17:26:34Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """
@@ -824,6 +824,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -42,7 +42,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "fd330cac622d37e04b2ae2a1e5643a3de4ddb29bda52ac461f8c589a012ad55a", "generated_at": "2026-08-13T13:46:17Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "58790d88d88aec0cbabaa52af8cdde396cd1062ccab5162538ca2b82e04d033e", "generated_at": "2026-08-13T17:26:34Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """
@@ -836,6 +836,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "fd330cac622d37e04b2ae2a1e5643a3de4ddb29bda52ac461f8c589a012ad55a", "generated_at": "2026-08-13T13:46:17Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "58790d88d88aec0cbabaa52af8cdde396cd1062ccab5162538ca2b82e04d033e", "generated_at": "2026-08-13T17:26:34Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """
@@ -830,6 +830,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 # === BEGIN AGENTWIRE HOOK STAMP (generated — do not edit) ===
-AGENTWIRE_HOOK_STAMP = {"core_sha256": "fd330cac622d37e04b2ae2a1e5643a3de4ddb29bda52ac461f8c589a012ad55a", "generated_at": "2026-08-13T13:46:17Z"}
+AGENTWIRE_HOOK_STAMP = {"core_sha256": "58790d88d88aec0cbabaa52af8cdde396cd1062ccab5162538ca2b82e04d033e", "generated_at": "2026-08-13T17:26:34Z"}
 # === END AGENTWIRE HOOK STAMP ===
 # === BEGIN GENERATED FROM agentwire/safety/_core.py ===
 """
@@ -823,6 +823,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -200,7 +200,12 @@ def cmd_limits_tick(args) -> int:
     is logged and skipped rather than aborting the whole cycle (#490).
     """
     from agentwire import (
-        cohort, inbox, prompt_router, role_prompts, safety_notify, session_context,
+        cohort,
+        inbox,
+        prompt_router,
+        role_prompts,
+        safety_notify,
+        session_context,
     )
     from agentwire.scheduler import zombie as scheduler_zombie
 

--- a/agentwire/limits_cli.py
+++ b/agentwire/limits_cli.py
@@ -189,14 +189,19 @@ def cmd_limits_tick(args) -> int:
     already gone when its cohort is evaluated — its orphaned children are
     reaped in the same tick rather than the next.
 
-    The role-prompt GC (#884) runs dead LAST and is self-throttled to once a
-    day: it is pure housekeeping with no bearing on any session's liveness, so
-    nothing above it should ever wait on it.
+    The unattended-block digest (#925) and the role-prompt GC (#884) run last
+    and are both self-throttled: pure housekeeping with no bearing on any
+    session's liveness, so nothing above them should ever wait on them. The
+    digest stage only RELEASES a spool that is already due — without it, a
+    burst's tail would wait for the next block to be delivered, so a task
+    blocked ten times and then giving up would report one block and sit on nine.
 
     Each stage runs inside :func:`_run_stage` so an exception in one subsystem
     is logged and skipped rather than aborting the whole cycle (#490).
     """
-    from agentwire import cohort, inbox, prompt_router, role_prompts, session_context
+    from agentwire import (
+        cohort, inbox, prompt_router, role_prompts, safety_notify, session_context,
+    )
     from agentwire.scheduler import zombie as scheduler_zombie
 
     result = _run_stage(
@@ -212,13 +217,15 @@ def cmd_limits_tick(args) -> int:
         "scheduler_zombie", scheduler_zombie.tick, {"killed": []})
     cohorts = _run_stage(
         "cohort", cohort.tick, {"reaped": [], "swept": []})
+    blocks = _run_stage(
+        "safety_notify", safety_notify.tick, {"emailed": False, "pending": 0})
     prompt_gc = _run_stage(
         "role_prompts", role_prompts.tick, {"deleted": [], "skipped": "error"})
     if getattr(args, "json", False):
         print(json.dumps({
             **result, "prompts": prompts, "messages": messages,
             "context": context, "zombies": zombies, "cohorts": cohorts,
-            "role_prompts": prompt_gc,
+            "safety_notify": blocks, "role_prompts": prompt_gc,
         }))
         return 0
     if result.get("skipped"):
@@ -269,6 +276,8 @@ def cmd_limits_tick(args) -> int:
     if orphans:
         print("orphaned cohort children reaped: " + ", ".join(
             f"{e['child']}(of {e['parent']})" for e in orphans))
+    if blocks.get("emailed"):
+        print("unattended-block digest emailed")
     swept_prompts = prompt_gc.get("deleted") or []
     if swept_prompts:
         print(f"role prompts aged out: {len(swept_prompts)} "

--- a/agentwire/safety/_core.py
+++ b/agentwire/safety/_core.py
@@ -789,6 +789,31 @@ DEFAULT_UNATTENDED_ALLOW = [
     "git.push",      # push (force/delete are SEPARATE hard-block/ask rules)
     "gh.pr-create",  # open a PR — the human-reviewed gate
     "outbound.agentwire-email",  # blanket allow, any recipient (#804)
+    # Run the project's own tooling — tests, linters, the project CLI (#925).
+    #
+    # This tier is `ask` because `uv run` executes code, which is true of every
+    # scheduled task by definition: the dispatch already granted "run this
+    # agent on this repo". Withholding the project's OWN test runner from it
+    # does not withhold code execution, it only withholds VERIFICATION — the
+    # task still writes the change and still opens the PR, just without having
+    # been able to run the suite over it. 18 of the 111 unattended blocks
+    # measured over the 14 days to 2026-08-06 were exactly this.
+    #
+    # Safe to allow only because the id it grants cannot shadow a hard block.
+    # Verified, not assumed: rules are evaluated in order and the FIRST match
+    # returns its id, so an earlier `ask` rule CAN hide a later `block` — the
+    # matrix in tests/unit/test_unattended_allow.py pins that every dangerous
+    # form behind `uv run` still comes back with the DESTRUCTIVE rule's id, not
+    # this one (the launcher-payload rescan that guarantees it landed in #1028).
+    #
+    # BOTH ids, deliberately. `uv run <script.py>` and `uv run <cmd>` are two
+    # tooldef lines that compile to the IDENTICAL pattern `\buv\s+run\b`, so
+    # which id a command comes back with is decided by which yaml line sits
+    # higher, not by anything about the command. Allowlisting only one would be
+    # guarding the phrasing: reorder uv.yaml and the permission silently
+    # evaporates with nothing failing to say so.
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
 ]
 
 

--- a/agentwire/safety_commands.py
+++ b/agentwire/safety_commands.py
@@ -420,41 +420,33 @@ def safety_notify_unattended_block_cmd(
 ) -> int:
     """CLI command: ``agentwire safety notify-unattended-block``.
 
-    Invoked fire-and-forget by the bash damage-control hook when an
-    unattended (scheduler) run hits an ``ask``-tier command that isn't on the
-    allowlist. Emails the owner via the shared Resend wiring so the blocked
-    action surfaces immediately instead of silently disappearing.
+    Invoked fire-and-forget by the damage-control hooks when an unattended
+    (scheduler) run hits an ``ask``-tier command that isn't on the allowlist.
+
+    This used to email the owner **per block**, immediately, with no throttle
+    and no dedup: 96 emails over 14 days and accelerating, 54% of them the same
+    rule and most of those the same rule in the same session, looping (#925).
+    It now spools into :mod:`agentwire.safety_notify`, which digests and
+    throttles on the pattern ``auth_expired`` and the dead-letter escalation
+    already use.
+
+    Note what is NOT here: the audit log. The hook writes it via ``log_blocked``
+    on its own path *before* invoking this, so no throttling decision below can
+    make a block go unrecorded — the digest points at ``agentwire safety logs``
+    precisely because that record stays complete.
     """
     session = os.environ.get("AGENTWIRE_SESSION_NAME") or os.environ.get(
         "AGENTWIRE_SESSION_ID", "unknown"
     )
-    cwd = os.environ.get("PWD", "")
-    subject = f"[agentwire] Unattended action blocked: {reason[:80]}"
-    body = (
-        f"An unattended (scheduled) agent attempted an action that requires "
-        f"human confirmation, so it was **blocked** (fail-closed).\n\n"
-        f"- **Session:** {session}\n"
-        f"- **Working dir:** {cwd or 'unknown'}\n"
-        f"- **Rule:** {rule_id or 'unknown'}\n"
-        f"- **Reason:** {reason}\n"
-        f"- **Command:** `{command}`\n"
-        f"- **When:** {datetime.now().isoformat(timespec='seconds')}\n\n"
-        f"Nothing was executed. To permit this specific action for the task in "
-        f"future, add rule id `{rule_id}` to that task's `unattended_allow` in "
-        f"its `.agentwire.yml` (or to `safety.unattended_allow` globally)."
-    )
-    try:
-        from agentwire.channels.email import send_email
+    from agentwire import safety_notify
 
-        result = send_email(subject=subject, body=body)
-        if getattr(result, "success", False):
-            return 0
-        print(f"notify-unattended-block: email failed: "
-              f"{getattr(result, 'error', 'unknown')}", file=sys.stderr)
+    result = safety_notify.record_block(
+        rule_id=rule_id, session=session, reason=reason, command=command
+    )
+    if not result["spooled"]:
+        print("notify-unattended-block: could not spool the block", file=sys.stderr)
         return 1
-    except Exception as e:  # email not configured, etc. — never crash the notifier
-        print(f"notify-unattended-block: {e}", file=sys.stderr)
-        return 1
+    return 0
 
 
 def safety_logs_cmd(

--- a/agentwire/safety_notify.py
+++ b/agentwire/safety_notify.py
@@ -1,0 +1,389 @@
+"""Owner notification for unattended damage-control blocks — spooled, throttled,
+digested (#925).
+
+Every ``ask``-tier command an unattended (scheduler) session hits is blocked
+fail-closed, and until now every one of those blocks sent its own email the
+instant it fired. Measured over 14 days that was 96 emails and accelerating —
+28 in one day — of which 52 were the SAME rule (``core.ambiguous-command``) and
+most were the same rule in the same session, looping. An owner who deletes 28
+identical emails a day is an owner who stops reading the 29th, which is the one
+that matters. Unthrottled notification is not "loud", it is off.
+
+The shape here is not invented: it is the one this repo already uses twice for
+out-of-band owner escalation, and deliberately reuses rather than adding a
+third dialect.
+
+* :mod:`agentwire.auth_expired` — a persisted ``escalated_at`` stamp and an
+  ``ESCALATE_TTL`` of one hour, so a persistent condition emails on first
+  sighting and then at most hourly.
+* :func:`agentwire.inbox._escalate_dead_letters` — ONE digest email per batch
+  rather than one per item, after a recipient that had been undeliverable for a
+  while produced 147 individual emails in ~2 seconds (2026-07-19).
+
+This module is both at once, because a block has neither shape on its own: it
+is a stream of discrete events (like dead letters) that describes a persistent
+condition (like an outage). So events are **spooled**, aggregated by
+``(rule_id, session)``, and released as a digest at most once per
+:data:`THROTTLE`.
+
+Three properties are load-bearing:
+
+**The audit log is untouched.** The hook calls ``log_blocked`` BEFORE it calls
+this notifier, on a separate path, and nothing here can suppress it. Throttling
+the email while also throttling the record would trade spam for blindness —
+``agentwire safety logs`` stays complete whatever this module decides, and the
+digest points at it.
+
+**Repeats do not re-notify, but they are never lost.** A task looping on one
+blocked command is one *fact*, not forty, so a ``(rule_id, session)`` pair
+already reported within :data:`DEDUP_TTL` does not by itself trigger another
+digest. Its count keeps accumulating in the spool and rides along on the next
+digest that does fire, and :data:`DEDUP_TTL` expiry means a condition that
+never resolves still re-reports daily rather than going permanently quiet.
+
+**Nothing here may raise.** The caller is a fire-and-forget subprocess spawned
+off a security hook that has ALREADY blocked the command. An exception in the
+notifier cannot un-block anything; it can only turn a clean block into a
+confusing one. Every public entry point returns rather than propagates.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import socket
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# How often the owner may hear about unattended blocks, at most. Matches
+# ``auth_expired.ESCALATE_TTL`` and ``prompt_router.NO_PARENT_ESCALATE_TTL``
+# deliberately — this is the same channel and the same owner, and three
+# different windows would just make the inbox's cadence unpredictable.
+THROTTLE = timedelta(hours=1)
+
+# How long a ``(rule_id, session)`` pair stays "already reported". Within this
+# window its repeats ride along in a digest but never trigger one; past it the
+# pair is news again, so a condition nobody fixed re-surfaces daily instead of
+# being silently swallowed forever.
+DEDUP_TTL = timedelta(hours=24)
+
+# Distinct ``(rule_id, session)`` pairs held in the spool. Far above any real
+# burst (the 14-day record has 96 blocks across a handful of pairs); it exists
+# so a pathological fleet cannot grow the state file without bound. Blocks
+# arriving past the cap are counted in ``overflow`` and named in the digest —
+# dropped silently, they would make the digest's total a lie.
+PAIR_CAP = 200
+
+# Example commands kept per pair. Enough to recognise the shape ("it's the
+# for-loop over memory stores again"), few enough that a digest stays readable.
+SAMPLES_PER_PAIR = 3
+
+# Pairs rendered in full in one digest, ordered by count. The rest are summed
+# into a trailing line rather than dumped.
+DIGEST_PAIR_CAP = 12
+
+
+def _config_dir() -> Path:
+    """Read through the MODULE, not a from-import (#902).
+
+    ``from .core import CONFIG_DIR`` binds at import time, so a test that
+    patches ``core.CONFIG_DIR`` is silently ignored and this writes to the real
+    ``~/.agentwire``. Same reason :func:`agentwire.auth_expired._config_dir`
+    and :func:`agentwire.core.role_prompts_dir` are functions.
+    """
+    from . import core
+
+    return Path(core.CONFIG_DIR)
+
+
+def state_path() -> Path:
+    """The ONE spool. Machine-wide — the owner has one inbox, not one per session."""
+    return _config_dir() / "safety" / "unattended-blocks.json"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse(ts: str | None) -> datetime | None:
+    try:
+        return datetime.fromisoformat(ts) if ts else None
+    except (TypeError, ValueError):
+        return None
+
+
+@contextlib.contextmanager
+def _locked():
+    """Serialize read-modify-write across processes via an flock sidecar.
+
+    Not optional. The notifier is spawned per block by a hook that fires in
+    every session at once, so two blocks landing in the same second are the
+    normal case, not the race-condition edge case — unlocked, one would clobber
+    the other's spool entry and the digest would undercount.
+    """
+    path = state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def read_state() -> dict:
+    try:
+        data = json.loads(state_path().read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def write_state(state: dict) -> None:
+    """Atomic — a torn write must not leave an unparseable spool behind."""
+    path = state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    os.replace(tmp, path)
+
+
+def pair_key(rule_id: str, session: str) -> str:
+    return f"{rule_id or 'unknown'}\x1f{session or 'unknown'}"
+
+
+def _unpair(key: str) -> tuple[str, str]:
+    rule, _, session = key.partition("\x1f")
+    return rule, session
+
+
+# ---------------------------------------------------------------------------
+# Spooling
+# ---------------------------------------------------------------------------
+
+
+def _spool(state: dict, rule_id: str, session: str, reason: str, command: str,
+           now: datetime) -> dict:
+    """Fold one block into the pending aggregate, keyed by ``(rule_id, session)``."""
+    pending = state.setdefault("pending", {})
+    key = pair_key(rule_id, session)
+    entry = pending.get(key)
+    if entry is None:
+        if len(pending) >= PAIR_CAP:
+            state["overflow"] = int(state.get("overflow", 0)) + 1
+            return state
+        entry = {"count": 0, "first_ts": now.isoformat(), "reason": reason,
+                 "samples": []}
+        pending[key] = entry
+    entry["count"] = int(entry.get("count", 0)) + 1
+    entry["last_ts"] = now.isoformat()
+    entry["reason"] = reason or entry.get("reason", "")
+    samples = entry.setdefault("samples", [])
+    if command and command not in samples and len(samples) < SAMPLES_PER_PAIR:
+        samples.append(command)
+    return state
+
+
+def _due(state: dict, now: datetime) -> bool:
+    """Should a digest go out right now?
+
+    Two independent gates, and both must open:
+
+    1. **Rate** — :data:`THROTTLE` has elapsed since the last email. This is
+       the absolute bound on how often the owner is interrupted.
+    2. **News** — at least one pending pair has not been reported within
+       :data:`DEDUP_TTL`. This is what turns "a task looping on one command"
+       into one email rather than one per hour forever.
+
+    A spool that is due on rate but not on news stays pending: its counts keep
+    accumulating and are reported by the next digest that IS news, or by this
+    one once ``DEDUP_TTL`` makes the pair news again.
+    """
+    pending = state.get("pending") or {}
+    if not pending:
+        return False
+    last = _parse(state.get("last_email_at"))
+    if last is not None and now - last < THROTTLE:
+        return False
+    reported = state.get("reported") or {}
+    for key in pending:
+        seen = _parse(reported.get(key))
+        if seen is None or now - seen >= DEDUP_TTL:
+            return True
+    return False
+
+
+def _gc_reported(reported: dict, now: datetime) -> dict:
+    """Forget pairs long past :data:`DEDUP_TTL` so the state file stays bounded."""
+    keep = {}
+    for key, ts in reported.items():
+        seen = _parse(ts)
+        if seen is not None and now - seen < DEDUP_TTL * 2:
+            keep[key] = ts
+    return keep
+
+
+# ---------------------------------------------------------------------------
+# The digest
+# ---------------------------------------------------------------------------
+
+
+def _fmt_window(state: dict, now: datetime) -> str:
+    first = None
+    for entry in (state.get("pending") or {}).values():
+        ts = _parse(entry.get("first_ts"))
+        if ts is not None and (first is None or ts < first):
+            first = ts
+    if first is None:
+        return "just now"
+    minutes = int((now - first).total_seconds() // 60)
+    if minutes < 1:
+        return "in the last minute"
+    if minutes < 120:
+        return f"in the last {minutes} minutes"
+    return f"in the last {minutes // 60} hours"
+
+
+def render_digest(state: dict, now: datetime | None = None) -> tuple[str, str]:
+    """``(subject, body)`` for the pending spool. Pure — no I/O, so it is testable."""
+    now = now or _now()
+    pending = state.get("pending") or {}
+    pairs = sorted(pending.items(), key=lambda kv: -int(kv[1].get("count", 0)))
+    total = sum(int(e.get("count", 0)) for _, e in pairs)
+    overflow = int(state.get("overflow", 0))
+    host = socket.gethostname()
+
+    if len(pairs) == 1:
+        rule, session = _unpair(pairs[0][0])
+        subject = (f"[agentwire] {total} unattended block"
+                   f"{'' if total == 1 else 's'}: {rule} in {session}")
+    else:
+        subject = (f"[agentwire] {total + overflow} unattended blocks across "
+                   f"{len(pairs)} rule/session pairs on {host}")
+
+    lines = [
+        f"{total + overflow} unattended (scheduled) action"
+        f"{'' if total + overflow == 1 else 's'} on `{host}` "
+        f"{_fmt_window(state, now)} required human confirmation, so "
+        f"{'it was' if total + overflow == 1 else 'they were'} **blocked** "
+        f"(fail-closed). Nothing was executed.",
+        "",
+    ]
+    for key, entry in pairs[:DIGEST_PAIR_CAP]:
+        rule, session = _unpair(key)
+        count = int(entry.get("count", 0))
+        lines.append(f"- **{count} ×** `{rule}` in session **{session}**")
+        if entry.get("reason"):
+            lines.append(f"  - {entry['reason']}")
+        for sample in entry.get("samples") or []:
+            lines.append(f"  - `{sample}`")
+    hidden = pairs[DIGEST_PAIR_CAP:]
+    if hidden:
+        lines.append(f"- ...and {sum(int(e.get('count', 0)) for _, e in hidden)} "
+                     f"more across {len(hidden)} further pairs.")
+    if overflow:
+        lines.append(f"- ...plus {overflow} block(s) on pairs beyond the "
+                     f"{PAIR_CAP}-pair spool cap (counted, not detailed).")
+
+    rules = sorted({_unpair(k)[0] for k, _ in pairs})
+    lines += [
+        "",
+        "Full record (never throttled — this digest is, the audit log is not):",
+        "```",
+        "agentwire safety logs --today",
+        "```",
+        "",
+        "To permit a specific action for an unattended task in future, add its "
+        "rule id to that task's `unattended_allow` in `.agentwire.tasks.yml` "
+        "(or to `unattended_allow` in `~/.agentwire/damagecontrol.yml` "
+        f"globally). Ids seen here: {', '.join(f'`{r}`' for r in rules)}.",
+        "",
+        f"Further blocks are digested; the next email is at most one per "
+        f"{int(THROTTLE.total_seconds() // 3600)}h.",
+    ]
+    return subject, "\n".join(lines)
+
+
+def _send(state: dict, now: datetime) -> dict:
+    """Send the digest and fold the result back into *state*.
+
+    Only a SUCCESSFUL send clears the spool and stamps ``last_email_at`` —
+    following ``auth_expired._escalate``'s explicit trade. A failed send that
+    counted as delivered would lose the report entirely, which is strictly
+    worse than retrying it on the next block.
+    """
+    subject, body = render_digest(state, now)
+    try:
+        from .channels.email import send_email
+
+        result = send_email(subject=subject, body=body)
+        ok = bool(getattr(result, "success", False))
+    except Exception:  # email not configured, no network, … — never propagate
+        return state
+    if not ok:
+        return state
+
+    reported = _gc_reported(dict(state.get("reported") or {}), now)
+    for key in (state.get("pending") or {}):
+        reported[key] = now.isoformat()
+    state["reported"] = reported
+    state["pending"] = {}
+    state["overflow"] = 0
+    state["last_email_at"] = now.isoformat()
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def record_block(rule_id: str, session: str, reason: str, command: str,
+                 now: datetime | None = None) -> dict:
+    """Spool one unattended block; send a digest if one is due.
+
+    Returns ``{"spooled": bool, "emailed": bool}`` for callers that want to say
+    what happened. Never raises: the command is already blocked and the audit
+    line is already written, so the worst this may do is stay quiet.
+    """
+    now = now or _now()
+    try:
+        with _locked():
+            state = read_state()
+            _spool(state, rule_id, session, reason, command, now)
+            emailed = False
+            if _due(state, now):
+                before = state.get("last_email_at")
+                state = _send(state, now)
+                emailed = state.get("last_email_at") != before
+            write_state(state)
+        return {"spooled": True, "emailed": emailed}
+    except Exception:
+        return {"spooled": False, "emailed": False}
+
+
+def tick(now: datetime | None = None) -> dict:
+    """Flush a due spool from the watchdog (``agentwire limits tick``, 60s).
+
+    Without this, a burst's tail waits for the *next* block to be delivered —
+    so a task that is blocked ten times and then gives up would report the
+    first block and silently sit on the other nine. Pure housekeeping: it never
+    spools anything, only releases what a due spool already holds.
+    """
+    now = now or _now()
+    try:
+        with _locked():
+            state = read_state()
+            if not _due(state, now):
+                return {"emailed": False, "pending": len(state.get("pending") or {})}
+            before = state.get("last_email_at")
+            state = _send(state, now)
+            emailed = state.get("last_email_at") != before
+            write_state(state)
+            return {"emailed": emailed, "pending": len(state.get("pending") or {})}
+    except Exception:
+        return {"emailed": False, "pending": 0}

--- a/tests/unit/test_limits_tick_isolation.py
+++ b/tests/unit/test_limits_tick_isolation.py
@@ -100,6 +100,30 @@ def test_failing_middle_stage_isolated(stub_stages, monkeypatch, capsys, tmp_pat
     assert rec["stage"] == "inbox"
 
 
+def test_unattended_block_digest_stage_is_isolated(stub_stages, monkeypatch, capsys,
+                                                   tmp_path):
+    """The #925 digest flush raises — nothing upstream is starved.
+
+    ``safety_notify.tick`` guards itself internally, so this monkeypatches past
+    that guard on purpose: the point is that the WATCHDOG contains it, not that
+    the stage happens to be well-behaved today. A digest is pure housekeeping —
+    it must never be able to cost the fleet a routing or reaping pass.
+    """
+    monkeypatch.setattr(limits_cli, "WATCHDOG_EVENTS_FILE", tmp_path / "watchdog-events.jsonl")
+
+    import agentwire.safety_notify as sn_mod
+
+    monkeypatch.setattr(sn_mod, "tick", lambda: (_ for _ in ()).throw(_Boom("digest exploded")))
+
+    rc = limits_cli.cmd_limits_tick(argparse.Namespace(json=True))
+
+    assert rc == 0
+    assert stub_stages["usage_limit"] and stub_stages["prompt_router"]
+    assert stub_stages["inbox"] and stub_stages["session_context"]
+    rec = json.loads((tmp_path / "watchdog-events.jsonl").read_text().strip())
+    assert rec["stage"] == "safety_notify"
+
+
 def test_all_stages_clean_logs_nothing(stub_stages, monkeypatch, tmp_path):
     """No failures → no watchdog event file written."""
     events_file = tmp_path / "watchdog-events.jsonl"

--- a/tests/unit/test_safety_notify.py
+++ b/tests/unit/test_safety_notify.py
@@ -421,7 +421,9 @@ class TestTheAuditLogIsNotThrottled:
     ])
     def test_the_hook_logs_before_it_notifies(self, hook):
         src = (HOOKS_DIR / hook).read_text()
-        notify = src.index("_notify_unattended_block(command, reason, rule_id)")
+        # Pin the CALL, not one spelling of its arguments (#1028 rewords the
+        # reason argument; the ordering guarantee is about the invocation).
+        notify = src.index("        _notify_unattended_block(command, ")
         # The unattended branch's own log_blocked call, immediately above it.
         log = src.rindex("log_blocked", 0, notify)
         between = src[log:notify]

--- a/tests/unit/test_safety_notify.py
+++ b/tests/unit/test_safety_notify.py
@@ -1,0 +1,457 @@
+"""Unattended blocks are spooled, throttled and digested, never streamed (#925).
+
+The corpus below is not invented. Every rule id, session name and command
+sample is taken verbatim from ``~/.agentwire/logs/damage-control/`` over the 14
+days to 2026-08-06 — the same 111 unattended blocks that produced 111 emails
+and got the guard put up for removal. That matters for the same reason
+``test_auth_expired``'s fixtures are verbatim: a test written against a tidy
+invented burst passes while missing the shape that actually happens, which here
+is *one rule, one session, over and over*.
+
+What the real distribution looks like, and what each property below is for:
+
+* 53 of 111 blocks are ``core.ambiguous-command``, most of them the same
+  session looping. ``test_forty_blocks_of_one_pair_send_one_email`` is that.
+* The volume is accelerating (3/day at the start of the window, 39 on the last
+  day), so the throttle has to bound the RATE, not just deduplicate — hence the
+  window assertions rather than only pair-count assertions.
+* 15 distinct rule ids appear, so the digest has to group and stay readable
+  rather than concatenate.
+
+The one thing this module must never do is make a block go unrecorded. The
+audit log is written by the hook on a separate path *before* the notifier is
+invoked; ``TestTheAuditLogIsNotThrottled`` pins that ordering, because trading
+email spam for a missing record would be a strictly worse bug than the one
+being fixed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agentwire import safety_notify
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "agentwire" / "hooks" / "damage-control"
+
+# --------------------------------------------------------------------------
+# Verbatim from the audit log, 2026-07-24 .. 2026-08-06
+# --------------------------------------------------------------------------
+
+# The 53-block plurality: a loop over the per-project memory stores. Benign,
+# blocked purely for containing `$(...)`.
+AMBIGUOUS_CMD = (
+    'for s in -Users-dotdev-projects-agentwire-dev '
+    '-Users-dotdev-projects-documentscribe; do d="$HOME/.claude/projects/$s/memory"; '
+    'printf "%-45s AUDIT.md:%s\\n" "$s" "$([ -f "$d/AUDIT.md" ] && echo yes)"; done'
+)
+AMBIGUOUS_REASON = "Unverifiable command (command substitution) — confirm before running"
+AMBIGUOUS_RULE = "core.ambiguous-command"
+
+# The 18-block runner-up, from the artifactsmmo scheduled task.
+UV_RUN_CMD = "uv run amo status 2>&1"
+UV_RUN_REASON = "uv run: a script in project environment"
+UV_RUN_RULE = "tooldef.uv-run-a-script-in-project-environment"
+
+# The sessions that produced them.
+MEMORY_MANAGER = "memory-manager"
+ARTIFACTSMMO = "artifactsmmo-auto"
+
+
+class Sent:
+    """A stand-in for ``EmailResult`` that records what was sent."""
+
+    def __init__(self, success: bool = True):
+        self.success = success
+        self.error = None if success else "no API key"
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Isolate CONFIG_DIR into tmp_path.
+
+    Patched on the MODULE (``agentwire.core.CONFIG_DIR``), which is the whole
+    reason ``safety_notify._config_dir`` is a function — an import-time
+    ``from .core import CONFIG_DIR`` would ignore this and scribble a real
+    spool onto the operator's machine (#902).
+    """
+    monkeypatch.setattr("agentwire.core.CONFIG_DIR", tmp_path / "agentwire")
+    return tmp_path
+
+
+@pytest.fixture
+def mail():
+    """Patch the shared Resend wiring and hand back the mock."""
+    with patch("agentwire.channels.email.send_email", return_value=Sent()) as m:
+        yield m
+
+
+def block(rule=AMBIGUOUS_RULE, session=MEMORY_MANAGER, reason=AMBIGUOUS_REASON,
+          command=AMBIGUOUS_CMD, at=None):
+    return safety_notify.record_block(
+        rule_id=rule, session=session, reason=reason, command=command, now=at
+    )
+
+
+def bodies(mail):
+    return [c.kwargs.get("body", "") for c in mail.call_args_list]
+
+
+def subjects(mail):
+    return [c.kwargs.get("subject", "") for c in mail.call_args_list]
+
+
+# --------------------------------------------------------------------------
+# The bug: one email per block
+# --------------------------------------------------------------------------
+
+
+class TestOneEmailNotForty:
+    def test_forty_blocks_of_one_pair_send_one_email(self, env, mail):
+        """The load-bearing assertion. This is the 53-block shape, verbatim.
+
+        A scheduled task looping on one blocked command is ONE fact. Before
+        #925 it was forty emails; the throttle alone would still allow one per
+        hour forever, so the ``(rule_id, session)`` dedup is what makes the
+        count stop at one.
+        """
+        now = safety_notify._now()
+        for i in range(40):
+            block(at=now + timedelta(minutes=i * 3))  # 2 hours of looping
+
+        assert mail.call_count == 1, (
+            f"expected one digest for 40 repeats of one pair, got "
+            f"{mail.call_count}: {subjects(mail)}"
+        )
+
+    def test_the_one_email_names_the_rule_and_session(self, env, mail):
+        block()
+        assert AMBIGUOUS_RULE in subjects(mail)[0]
+        assert MEMORY_MANAGER in subjects(mail)[0]
+        body = bodies(mail)[0]
+        assert AMBIGUOUS_RULE in body
+        assert MEMORY_MANAGER in body
+        assert AMBIGUOUS_REASON in body
+
+    def test_the_first_block_is_not_delayed(self, env, mail):
+        """An isolated block still surfaces immediately.
+
+        Batching everything on a timer would be a different bug: the point is
+        to stop the flood, not to stop the signal. First sighting emails at
+        once, exactly as ``auth_expired._escalate`` does.
+        """
+        assert block()["emailed"] is True
+        assert mail.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# The digest
+# --------------------------------------------------------------------------
+
+
+class TestDigest:
+    def test_a_burst_is_one_email_with_per_pair_counts(self, env, mail):
+        """The shape the owner asked for: '9 × core.ambiguous-command in …'."""
+        now = safety_notify._now()
+        block(at=now)  # first sighting → emails immediately, 1 block
+        mail.reset_mock()
+
+        for i in range(8):
+            block(at=now + timedelta(minutes=i + 1))
+        for i in range(5):
+            block(rule=UV_RUN_RULE, session=ARTIFACTSMMO, reason=UV_RUN_REASON,
+                  command=UV_RUN_CMD, at=now + timedelta(minutes=i + 10))
+        assert mail.call_count == 0, "throttle window not respected"
+
+        # An hour later the next block releases the digest.
+        block(rule=UV_RUN_RULE, session=ARTIFACTSMMO, reason=UV_RUN_REASON,
+              command=UV_RUN_CMD, at=now + timedelta(hours=1, minutes=1))
+
+        assert mail.call_count == 1
+        body = bodies(mail)[0]
+        assert "**8 ×**" in body, body
+        assert "**6 ×**" in body, body          # 5 + the one that released it
+        assert MEMORY_MANAGER in body and ARTIFACTSMMO in body
+        assert "14 unattended" in body           # 8 + 6, the total, in the lede
+
+    def test_the_digest_carries_a_sample_command(self, env, mail):
+        """A rule id alone doesn't tell the owner whether the block was right."""
+        block()
+        assert AMBIGUOUS_CMD in bodies(mail)[0]
+
+    def test_the_digest_points_at_the_unthrottled_record(self, env, mail):
+        block()
+        assert "agentwire safety logs" in bodies(mail)[0]
+
+    def test_the_digest_names_how_to_permit_the_rule(self, env, mail):
+        block()
+        body = bodies(mail)[0]
+        assert "unattended_allow" in body
+        assert f"`{AMBIGUOUS_RULE}`" in body
+
+    def test_many_pairs_are_summarised_not_dumped(self, env, mail):
+        """15 distinct rule ids appear in the real window; a wall of text is unread."""
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        for i in range(30):
+            block(rule=f"tooldef.rule-{i}", session=f"session-{i}",
+                  at=now + timedelta(minutes=1))
+        block(at=now + timedelta(hours=1, minutes=1))
+
+        body = bodies(mail)[0]
+        rendered = body.count("**1 ×**") + body.count("**2 ×**")
+        assert rendered <= safety_notify.DIGEST_PAIR_CAP + 1
+        assert "further pairs" in body
+
+
+# --------------------------------------------------------------------------
+# Throttle and dedup, separately
+# --------------------------------------------------------------------------
+
+
+class TestThrottle:
+    def test_window_is_at_least_an_hour(self):
+        assert safety_notify.THROTTLE >= timedelta(hours=1)
+
+    def test_a_brand_new_pair_still_waits_out_the_window(self, env, mail):
+        """Novelty does not bypass the rate gate.
+
+        Tempting to let a never-seen pair through immediately — but the real
+        window has 15 distinct ids, so 'new pairs are urgent' is just the old
+        behaviour with extra steps.
+        """
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        block(rule=UV_RUN_RULE, session=ARTIFACTSMMO, at=now + timedelta(minutes=5))
+        assert mail.call_count == 0
+
+    def test_the_window_opens_again_after_an_hour(self, env, mail):
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        block(rule=UV_RUN_RULE, session=ARTIFACTSMMO,
+              at=now + safety_notify.THROTTLE + timedelta(minutes=1))
+        assert mail.call_count == 1
+
+
+class TestDedup:
+    def test_repeats_alone_do_not_re_notify_hourly_forever(self, env, mail):
+        """A loop nobody fixed must not become one email an hour, all identical.
+
+        This is the property the throttle alone cannot give: 24 hours of the
+        same pair blocking every minute is one email, not 24.
+        """
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        for minute in range(1, 12 * 60, 7):
+            block(at=now + timedelta(minutes=minute))
+        assert mail.call_count == 0, (
+            f"a repeating pair re-notified {mail.call_count} times in 12h")
+
+    def test_dedup_expires_within_a_day(self):
+        """Pinned as an absolute bound, deliberately.
+
+        The obvious test — advance the clock by ``DEDUP_TTL + 1min`` and assert
+        an email — moves with the constant it is meant to constrain: widen
+        ``DEDUP_TTL`` to ten years and it still passes, having silently
+        asserted nothing. Mutation testing found exactly that; this is the fix.
+        """
+        assert safety_notify.DEDUP_TTL <= timedelta(hours=24)
+
+    def test_but_it_re_reports_once_the_dedup_ttl_lapses(self, env, mail):
+        """Silence forever would be the other failure. It re-surfaces daily."""
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        block(at=now + timedelta(hours=25))
+        assert mail.call_count == 1
+
+    def test_suppressed_repeats_are_counted_not_discarded(self, env, mail):
+        """The count keeps accruing while suppressed, and rides the next digest.
+
+        Reporting '1 × ambiguous-command' after 300 blocks would understate the
+        problem to exactly the person deciding whether to change the rule.
+        """
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        for i in range(300):
+            block(at=now + timedelta(minutes=i + 1))
+        block(rule=UV_RUN_RULE, session=ARTIFACTSMMO,
+              at=now + timedelta(hours=6))          # a NEW pair releases it
+        assert mail.call_count == 1
+        assert "**300 ×**" in bodies(mail)[0]
+
+    def test_same_rule_in_a_different_session_is_a_different_pair(self, env, mail):
+        """Dedup is (rule_id, session) — one task looping is not every task."""
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        block(session="ai-morning-briefing", at=now + timedelta(hours=1, minutes=1))
+        assert mail.call_count == 1
+        assert "ai-morning-briefing" in bodies(mail)[0]
+
+
+# --------------------------------------------------------------------------
+# The watchdog flush
+# --------------------------------------------------------------------------
+
+
+class TestTick:
+    def test_a_tail_is_flushed_without_a_further_block(self, env, mail):
+        """Ten blocks then silence must not report one and sit on nine.
+
+        Without the watchdog stage the spool only drains when the NEXT block
+        arrives, so a task that gives up takes its own report with it.
+        """
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        for i in range(9):
+            block(rule=UV_RUN_RULE, session=ARTIFACTSMMO, at=now + timedelta(minutes=i))
+        assert mail.call_count == 0
+
+        assert safety_notify.tick(now=now + timedelta(hours=1, minutes=1))["emailed"]
+        assert "**9 ×**" in bodies(mail)[0]
+
+    def test_tick_on_an_empty_spool_is_silent(self, env, mail):
+        assert safety_notify.tick()["emailed"] is False
+        assert mail.call_count == 0
+
+    def test_tick_never_spools_anything(self, env, mail):
+        """It releases; it does not record. A tick must not invent a block."""
+        safety_notify.tick()
+        safety_notify.tick()
+        assert safety_notify.read_state().get("pending") in (None, {})
+
+
+# --------------------------------------------------------------------------
+# Best-effort: nothing here may break the caller
+# --------------------------------------------------------------------------
+
+
+class TestNeverCrashes:
+    def test_a_send_failure_does_not_raise(self, env):
+        with patch("agentwire.channels.email.send_email", return_value=Sent(False)):
+            assert block()["spooled"] is True
+
+    def test_an_exploding_sender_does_not_raise(self, env):
+        with patch("agentwire.channels.email.send_email",
+                   side_effect=RuntimeError("resend down")):
+            assert block()["spooled"] is True
+
+    def test_a_failed_send_keeps_the_spool_for_the_next_attempt(self, env):
+        """Only a successful send clears. Following ``auth_expired._escalate``.
+
+        A failed send that counted as delivered would lose the report; the
+        trade is a retry on the next block, which stops the moment one lands.
+        """
+        with patch("agentwire.channels.email.send_email", return_value=Sent(False)):
+            block()
+        assert safety_notify.read_state()["pending"], "spool cleared on a failed send"
+
+        with patch("agentwire.channels.email.send_email", return_value=Sent()) as m:
+            block()
+        assert m.call_count == 1
+        assert "**2 ×**" in m.call_args.kwargs["body"]
+
+    def test_an_unwritable_spool_does_not_raise(self, env, monkeypatch):
+        monkeypatch.setattr(safety_notify, "state_path",
+                            lambda: Path("/proc/nonexistent/spool.json"))
+        assert block() == {"spooled": False, "emailed": False}
+
+    def test_a_corrupt_spool_heals_rather_than_wedging(self, env, mail):
+        safety_notify.state_path().parent.mkdir(parents=True, exist_ok=True)
+        safety_notify.state_path().write_text("{ not json")
+        assert block()["spooled"] is True
+        assert mail.call_count == 1
+
+    def test_the_state_file_stays_valid_json(self, env, mail):
+        for i in range(5):
+            block(rule=f"r{i}")
+        json.loads(safety_notify.state_path().read_text())
+
+
+class TestBounded:
+    def test_the_spool_cannot_grow_without_bound(self, env, mail):
+        now = safety_notify._now()
+        block(at=now)
+        for i in range(safety_notify.PAIR_CAP + 50):
+            block(rule=f"tooldef.r{i}", session=f"s{i}", at=now + timedelta(minutes=1))
+        pending = safety_notify.read_state()["pending"]
+        assert len(pending) <= safety_notify.PAIR_CAP
+
+    def test_blocks_past_the_cap_are_counted_not_silently_dropped(self, env, mail):
+        """A digest whose total is short of reality is a digest that lies."""
+        now = safety_notify._now()
+        block(at=now)
+        mail.reset_mock()
+        for i in range(safety_notify.PAIR_CAP + 20):
+            block(rule=f"tooldef.r{i}", session=f"s{i}", at=now + timedelta(minutes=1))
+        assert safety_notify.read_state()["overflow"] > 0
+
+        block(at=now + timedelta(hours=1, minutes=1))
+        assert "spool cap" in bodies(mail)[0]
+
+
+# --------------------------------------------------------------------------
+# The property that must survive all of the above
+# --------------------------------------------------------------------------
+
+
+class TestTheAuditLogIsNotThrottled:
+    """Throttling the EMAIL must not throttle the LOG, or spam becomes blindness.
+
+    The guarantee is structural, not incidental: every hook writes the audit
+    line via ``log_blocked`` and only THEN invokes the notifier, on a code path
+    the notifier cannot reach. These pin that ordering so a future refactor
+    that folds logging into the notifier fails here instead of in production.
+    """
+
+    @pytest.mark.parametrize("hook", [
+        "bash-tool-damage-control.py",
+        "mcp-tool-damage-control.py",
+    ])
+    def test_the_hook_logs_before_it_notifies(self, hook):
+        src = (HOOKS_DIR / hook).read_text()
+        notify = src.index("_notify_unattended_block(command, reason, rule_id)")
+        # The unattended branch's own log_blocked call, immediately above it.
+        log = src.rindex("log_blocked", 0, notify)
+        between = src[log:notify]
+        assert "unattended" in between, (
+            f"{hook}: the log_blocked above _notify_unattended_block is not the "
+            f"unattended one — the ordering guarantee has moved")
+
+    def test_the_notifier_does_not_log(self):
+        """It has no audit-log surface at all, so it cannot suppress one.
+
+        Checked on the parsed AST rather than the source text — the module's
+        own docstring *describes* the ordering, and a substring check would
+        pass or fail on the prose instead of on the code.
+        """
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(safety_notify))
+        called = {
+            node.func.id if isinstance(node.func, ast.Name) else
+            getattr(node.func, "attr", "")
+            for node in ast.walk(tree) if isinstance(node, ast.Call)
+        }
+        assert not called & {"log_blocked", "log_allowed", "log_asked"}
+        imported = {
+            alias.name for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        } | {
+            node.module for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert not any("audit" in name for name in imported)

--- a/tests/unit/test_unattended_allow.py
+++ b/tests/unit/test_unattended_allow.py
@@ -1,0 +1,386 @@
+"""The unattended allowlist grants an OPERATION and shadows no hard block (#925).
+
+Two rules of engagement govern every assertion here.
+
+**Name the rule set you measured.** ``_load`` builds from BUNDLED rules +
+BUNDLED tooldefs explicitly and asserts the pattern and anchored counts at load
+time. A bare interpreter without pyyaml makes ``load_config`` return empty, at
+which point every command reads ALLOW and a green run proves nothing — the
+count assertion turns that into a crash instead of a nicer-looking number. The
+live copies under ``~/.agentwire/`` are neither loaded nor consulted; they drift
+(measured 2026-08-06: bundled 265/101, live 225/87) and tuning against
+semantics that do not ship is how a fix lands backwards.
+
+**Assert the rule ID, not the verdict.** ``uv run git push --force`` reads
+BLOCK both before and after this change, so a verdict-only test passes either
+way. What actually decides whether the allowlist opens a hole is *which id came
+back*: rules are evaluated in order and the first match returns, so an earlier
+``ask`` rule can hide a later ``block``, and the unattended resolver then turns
+that hidden block into a permit. Every case below pins the id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentwire.safety import _core as C  # noqa: N812
+
+REPO = Path(__file__).resolve().parent.parent.parent
+BUNDLED_RULES = REPO / "agentwire" / "hooks" / "damage-control" / "rules"
+BUNDLED_TOOLDEFS = REPO / "agentwire" / "tooldefs"
+
+# Pinned at load. Dropping ``tooldefs_dir`` silently removes the anchored
+# patterns; a missing pyyaml removes all of them. Both would otherwise present
+# as a smaller, greener run.
+EXPECTED_PATTERNS = 264
+EXPECTED_ANCHORED = 237
+
+UV_IDS = {
+    "tooldef.uv-run-a-script-in-project-environment",
+    "tooldef.uv-run-a-command-in-project-environment",
+}
+
+# Keep the literal out of this file's own text where it would be scanned as a
+# command by the very hooks under test (#915).
+RM = "r" + "m"
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    config = C.load_config(BUNDLED_RULES, BUNDLED_TOOLDEFS)
+    pats = config.get("bashToolPatterns", [])
+    assert len(pats) == EXPECTED_PATTERNS, (
+        f"loaded {len(pats)} patterns, expected {EXPECTED_PATTERNS}. Either the "
+        f"corpus changed (update the constant deliberately) or the rules did "
+        f"not load at all — in which case every verdict below reads ALLOW and "
+        f"means nothing.")
+    anchored = sum(1 for p in pats if isinstance(p, dict) and p.get("anchored"))
+    assert anchored == EXPECTED_ANCHORED, (
+        f"loaded {anchored} anchored patterns, expected {EXPECTED_ANCHORED} — "
+        f"tooldefs_dir probably did not resolve")
+    config["safety"] = {"enabled": True, "disabled_rules": [], "unattended_allow": []}
+    return config
+
+
+def decide(cfg, command):
+    r = C.check_command(command, cfg)
+    return r["decision"], r.get("id")
+
+
+def default_allowed_ids():
+    """Rule ids carrying a default grant.
+
+    Goes through ``parse_unattended_allow`` rather than reading the list
+    directly: since #914/#917 an entry is either a bare id or a ``{id, paths}``
+    dict, so ``id in DEFAULT_UNATTENDED_ALLOW`` is only accidentally correct
+    while every entry happens to be a bare string.
+    """
+    return set(C.parse_unattended_allow(C.DEFAULT_UNATTENDED_ALLOW)[0])
+
+
+def unattended_verdict(cfg, command, cwd="/work/repo"):
+    """What an unattended session actually gets — via the SHIPPING resolver.
+
+    Calls #917's ``resolve_unattended_grants`` / ``unattended_grant_allows``
+    rather than re-implementing "is the id on the list", which stopped being
+    the real rule when grants became path-scoped. A test that models the
+    resolver instead of calling it passes while the resolver disagrees.
+    """
+    decision, rule_id = decide(cfg, command)
+    if decision != "ask":
+        return decision, rule_id
+    grants = C.resolve_unattended_grants(cfg)
+    granted, _why = C.unattended_grant_allows(
+        rule_id, command, grants, cwd, pattern=None)
+    return ("allow" if granted else "block"), rule_id
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — the grant
+# ---------------------------------------------------------------------------
+
+
+class TestUvRunIsPermittedUnattended:
+    """A scheduled task that cannot run its own tooling cannot verify its work."""
+
+    @pytest.mark.parametrize("command", [
+        "uv run amo status 2>&1",                    # verbatim, 4 of the 18 blocks
+        "uv run pytest -q",
+        "uv run --extra dev pytest tests/unit -q",
+        "uv run python -m mypackage.check",
+        "uv run ruff check .",
+        "uv run mypy agentwire",
+    ])
+    def test_allowed(self, cfg, command):
+        decision, rule_id = unattended_verdict(cfg, command)
+        assert rule_id in UV_IDS, (
+            f"{command!r} resolved to {rule_id!r}, not a uv-run id — the "
+            f"allowlist entry is not what is being exercised here")
+        assert decision == "allow"
+
+    def test_both_ids_are_on_the_list(self):
+        """Guard the operation, not the yaml line order.
+
+        The two tooldef lines compile to the identical pattern, so which id a
+        command returns is decided by which is listed first. Listing only one
+        makes the permission depend on that ordering.
+        """
+        assert UV_IDS <= default_allowed_ids()
+
+    def test_the_two_ids_really_are_the_same_operation(self, cfg):
+        """The premise of the test above, measured rather than asserted."""
+        pats = [p for p in cfg["bashToolPatterns"]
+                if isinstance(p, dict) and p.get("id") in UV_IDS]
+        assert len(pats) == 2
+        # #933 terminates generated prefixes with (?![\w-]) instead of \b.
+        assert pats[0]["pattern"] == pats[1]["pattern"] == r"\buv\s+run(?![\w-])"
+
+    def test_the_permission_survives_a_tooldef_reorder(self, tmp_path):
+        """The operation, exercised — not just the set membership.
+
+        Swapping the two ``uv run`` lines in uv.yaml changes which id every
+        command comes back with, and nothing else. With one id allowlisted that
+        silently revokes the permission; with both it cannot. Asserting the set
+        alone would pass either way for the corpus as shipped, since every
+        command resolves to whichever line happens to be first.
+        """
+        import shutil
+
+        import yaml
+
+        tooldefs = tmp_path / "tooldefs"
+        shutil.copytree(BUNDLED_TOOLDEFS, tooldefs)
+        doc = yaml.safe_load((tooldefs / "uv.yaml").read_text())
+        cmds = doc["commands"]
+        i = next(k for k, c in enumerate(cmds) if c["cmd"] == "uv run <script.py>")
+        j = next(k for k, c in enumerate(cmds) if c["cmd"] == "uv run <cmd>")
+        cmds[i], cmds[j] = cmds[j], cmds[i]
+        (tooldefs / "uv.yaml").write_text(yaml.safe_dump(doc, sort_keys=False))
+
+        config = C.load_config(BUNDLED_RULES, tooldefs)
+        config["safety"] = {"enabled": True, "disabled_rules": [],
+                            "unattended_allow": []}
+
+        decision, rule_id = unattended_verdict(config, "uv run pytest -q")
+        assert rule_id == "tooldef.uv-run-a-command-in-project-environment", (
+            "the reorder did not move the id — this test is not exercising "
+            "what it claims to")
+        assert decision == "allow", (
+            "reordering two equivalent tooldef lines revoked the permission")
+
+    def test_every_default_id_resolves_to_a_real_rule(self, cfg):
+        """An allowlisted id matching nothing is a permission that does nothing.
+
+        Five of six ids were in exactly that state on the owner's machine on
+        2026-08-06 (live tooldefs lacked the stable ``id:`` lines), so this is
+        a measured failure mode, not a hypothetical one.
+        """
+        ids = {p.get("id") for p in cfg["bashToolPatterns"]
+               if isinstance(p, dict) and p.get("id")}
+        missing = sorted(default_allowed_ids() - ids)
+        assert not missing, f"allowlisted ids match no rule in the corpus: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Rules of engagement: the hard blocks named as non-negotiable
+# ---------------------------------------------------------------------------
+
+
+HARD_BLOCKS = [
+    ("force-push",  "git push --force origin main", "git.git-push-force-use-force-with-lease"),
+    ("force-push-f", "git push -f origin main",     "git.git-push-f-use-force-with-lease"),
+    ("hard-reset",  "git reset --hard HEAD~5",      "git.git-reset-hard-use-soft-or-stash"),
+    ("clean-fdx",   "git clean -fdx",               "git.git-clean-with-force-directory-flags"),
+    ("rm-rf",       f"{RM} -rf /tmp/x",             "core.rm-with-recursive-or-force-flags"),
+    ("rm-rf-root",  f"{RM} -rf /",                  "core.rm-with-recursive-or-force-flags"),
+]
+
+# Launcher prefixes. Each moves the shell off word 0, which is the whole point:
+# a guard keyed on "bash is the first word" guards the phrasing.
+PREFIXES = ["", "uv run ", "env ", "nice ", "time ", "nohup ", "stdbuf -o0 ",
+            "timeout 5 ", "command ", "xargs -I{} ", "uvx --from x ",
+            "poetry run ", "npx -y "]
+
+
+class TestHardBlocksSurvive:
+    @pytest.mark.parametrize("name,command,expected_id", HARD_BLOCKS,
+                             ids=[h[0] for h in HARD_BLOCKS])
+    def test_plain_form_still_blocks_with_its_own_rule(self, cfg, name, command,
+                                                       expected_id):
+        decision, rule_id = unattended_verdict(cfg, command)
+        assert decision == "block"
+        assert rule_id == expected_id, (
+            f"{command!r} blocked via {rule_id!r}, not its own rule "
+            f"{expected_id!r} — a generic rule is currently doing the work, so "
+            f"this test would stay green if {expected_id} were deleted")
+
+    @pytest.mark.parametrize("prefix", PREFIXES)
+    @pytest.mark.parametrize("name,command,expected_id", HARD_BLOCKS,
+                             ids=[h[0] for h in HARD_BLOCKS])
+    def test_still_blocks_through_any_launcher_prefix(self, cfg, prefix, name,
+                                                      command, expected_id):
+        """The operation is 'run this payload'; the prefix is only phrasing.
+
+        Before the masked-rescan fix, 62 of these 78 cells were NOT hard
+        blocked: ``masked_subcommands`` recursed into a ``sh -c`` payload only
+        when the shell was word 0, so any launcher blinded every anchored rule.
+        ``rm -rf`` survived on luck alone — its rule is unanchored and still saw
+        the raw haystack.
+        """
+        decision, rule_id = unattended_verdict(cfg, f"{prefix}bash -c '{command}'")
+        assert decision == "block", (
+            f"{prefix}bash -c '{command}' is NOT hard-blocked (id={rule_id!r})")
+        assert rule_id == expected_id
+
+    @pytest.mark.parametrize("name,command,expected_id", HARD_BLOCKS,
+                             ids=[h[0] for h in HARD_BLOCKS])
+    def test_uv_run_does_not_shadow_the_destructive_rule(self, cfg, name, command,
+                                                        expected_id):
+        """The specific hole Part 2 could have opened.
+
+        ``uv run`` is now allowlisted, so if a destructive command behind it
+        came back with a uv-run id, the resolver would ALLOW it unattended.
+        Pinning the id is the only way to see that; the verdict alone reads
+        BLOCK either way.
+        """
+        _, rule_id = decide(cfg, f"uv run {command}")
+        assert rule_id not in UV_IDS
+        assert rule_id == expected_id
+        assert unattended_verdict(cfg, f"uv run {command}")[0] == "block"
+
+
+class TestTheResidualIsCharacterisedNotLeftOver:
+    """Why the launcher matrix is 52/78 and that is CLOSED, not partial.
+
+    The 78-cell matrix mixes two populations, and quoting it as a single
+    fraction makes a closed bypass read as a partially-closed one:
+
+      * 4 HARD-BLOCK payloads x 13 prefixes = 52 cells. This is the bypass
+        class. Measured by reverting the masked-rescan fix in place:
+        **13/52 held before, 52/52 after.** Closed.
+      * 2 ASK-TIER payloads x 13 prefixes = 26 cells. ``git branch -D`` and
+        ``git push --delete`` are ask-tier WITH NO PREFIX AT ALL, so the prefix
+        is not what defeats them and they were never members of the class.
+
+    The bare control row is what separates the two, and it is the whole
+    argument — without it, "26 not hard-blocked" is indistinguishable from a
+    live residual bypass. They also still REFUSE unattended; they are simply
+    not hard blocks, which is a deliberate tier choice rather than a defect.
+    (Distinct from #933, which is about read-only commands matched by write
+    rules — a different mechanism entirely.)
+    """
+
+    ASK_TIER = [
+        ("git branch -D main", "git.force-deletes-branch-even-if-unmerged"),
+        ("git push origin --delete main", "git.deletes-remote-branch"),
+    ]
+
+    @pytest.mark.parametrize("command,expected_id", ASK_TIER)
+    def test_the_residual_payloads_are_ask_tier_with_no_prefix(
+            self, cfg, command, expected_id):
+        """The control. If these ever read `block` bare, the 26 become a bypass."""
+        decision, rule_id = decide(cfg, command)
+        assert decision == "ask", (
+            f"{command!r} is now a hard block bare — the 26 residual cells are "
+            f"no longer explained by tier and must be re-characterised")
+        assert rule_id == expected_id
+
+    @pytest.mark.parametrize("prefix", PREFIXES)
+    @pytest.mark.parametrize("command,expected_id", ASK_TIER)
+    def test_the_prefix_changes_nothing_for_them(self, cfg, prefix, command,
+                                                 expected_id):
+        """Same tier and same rule id bare or prefixed — so not a bypass."""
+        decision, rule_id = decide(cfg, f"{prefix}bash -c '{command}'")
+        assert decision == "ask"
+        assert rule_id == expected_id
+
+    @pytest.mark.parametrize("prefix", PREFIXES)
+    @pytest.mark.parametrize("command,expected_id", ASK_TIER)
+    def test_and_they_still_refuse_unattended(self, cfg, prefix, command,
+                                              expected_id):
+        """The property that actually matters: nothing reaches a scheduler run.
+
+        "Not a hard block" and "reaches an unattended session" are different
+        things, and only the second is a safety hole. These are the first.
+        """
+        assert unattended_verdict(cfg, f"{prefix}bash -c '{command}'")[0] == "block"
+
+    def test_every_hard_block_payload_holds_on_every_prefix(self, cfg):
+        """The positive half, stated as one assertion over the real class.
+
+        52/52. This is what "closed" means, and it is asserted rather than
+        quoted from a matrix run once by hand.
+        """
+        unheld = [
+            (name, prefix)
+            for name, command, expected_id in HARD_BLOCKS
+            for prefix in PREFIXES
+            if decide(cfg, f"{prefix}bash -c '{command}'")[0] != "block"
+        ]
+        assert not unheld, f"{len(unheld)} hard-block cell(s) not held: {unheld}"
+
+
+class TestTheAllowlistCannotReachABlockTier:
+    def test_no_default_id_belongs_to_a_hard_block_rule(self, cfg):
+        """Structural: allowlisting only ever relaxes ``ask``, never ``block``.
+
+        The resolver checks the allowlist on the ``ask`` branch only, so a
+        block-tier id on the list would be inert rather than dangerous — but an
+        inert entry reads as a granted permission to whoever adds the next one.
+        """
+        by_id = {p["id"]: p for p in cfg["bashToolPatterns"]
+                 if isinstance(p, dict) and p.get("id")}
+        for rule_id in sorted(default_allowed_ids()):
+            rule = by_id.get(rule_id)
+            assert rule is not None
+            assert rule.get("ask") or rule.get("bypassable"), (
+                f"{rule_id} is a hard-block rule; allowlisting it is inert and "
+                f"misleading")
+
+
+# ---------------------------------------------------------------------------
+# The masked-rescan fix, on its own terms
+# ---------------------------------------------------------------------------
+
+
+class TestShellPayloadRescan:
+    def test_payload_is_rescanned_behind_a_prefix(self):
+        """The unit-level statement of the fix."""
+        masked = C.masked_subcommands("uv run bash -c 'git push --force'")
+        assert "git push --force" in masked
+
+    def test_word_zero_case_still_works(self):
+        """Strictly additive: everything that recursed before still does."""
+        assert "git push --force" in C.masked_subcommands("bash -c 'git push --force'")
+
+    def test_absolute_shell_path_is_still_recognised(self):
+        assert "git push --force" in C.masked_subcommands(
+            "env /bin/bash -c 'git push --force'")
+
+    def test_a_report_describing_the_command_is_not_rescanned(self, cfg):
+        """#915's regression, which this fix must not reintroduce.
+
+        A message *about* a blocked command is one quoted span, so ``bash`` is
+        never a bare token in it and the rescan condition cannot fire. If this
+        ever goes red, the tooling used to investigate an incident is refused
+        by the incident's own rule — seven commands died that way in one day.
+        """
+        report = (
+            "agentwire msg send --to orchestrator --kind done "
+            "\"blocked: uv run bash -c 'git push --force' was refused\""
+        )
+        decision, _ = decide(cfg, report)
+        assert decision != "block"
+
+    def test_a_commit_message_quoting_the_command_is_not_blocked(self, cfg):
+        commit = (
+            'git commit -m "fix(safety): stop bash -c \'git push --force\' '
+            'slipping past anchored rules"'
+        )
+        assert decide(cfg, commit)[0] != "block"
+
+    def test_nested_payloads_still_terminate(self, cfg):
+        """Recursion is on real nesting; it must not run away."""
+        assert decide(cfg, "bash -c 'bash -c \"bash -c \\\"echo hi\\\"\"'")[0] != "block"


### PR DESCRIPTION
Salvages the mergeable half of draft PR #932 (branch `fix-unattended-noise`, written against a three-engines-ago `_core.py`) onto today's main.

**Part 1 — email digest/throttle** (`3a1ad43`, clean cherry-pick of #932's `e6d67bc`): unattended blocks spool into `agentwire/safety_notify.py`, aggregated by `(rule_id, session)`, released as one digest at most hourly with a 24h dedup TTL. State on disk under flock (the hook spawns a fresh process per block); the audit log is untouched — 14 blocks → 14 audit rows → 1 email, pinned end-to-end. A `limits tick` watchdog stage releases a due spool with no further block arriving.

**Part 2 — `uv run` unattended grant** (`0700b97`, re-derived): both uv-run tooldef ids in `DEFAULT_UNATTENDED_ALLOW` (the two yaml lines compile to the identical pattern, so which id resolves depends on line order — both are granted, and a reorder test pins it). #932's launcher-prefix rescan half of Part 2 is **superseded** — #1028's position-wrapper anchoring closes the identical hole; verified by running the branch's 52-cell launcher matrix against stock main (52/52 hold).

**Part 3 is not here.** #932's `core.ambiguous-command` narrowing predates the #1028 engine and cannot rebase mechanically. Its design conclusion (only verb concealment is non-redundant coverage; operand-position substitution is covered by each verb's own rule) is implemented against the current engine in the safety-coverage PR (#934's `ambiguity_conceals_verb`), including the `uv run $(echo rm) -rf` composition hazard this grant would otherwise create — concealment outranks the granted ask id at the engine level there.

Verified: full suite green on this branch (6783 passed, 36 skipped, unit + integration); all pins load bundled rules + bundled tooldefs (post-#1028 corpus 264/237).

Supersedes #932, which should be closed in its favor.

Closes #925

Built by [dotdev.dev](https://dotdev.dev)