### PR TITLE
buddy: surface the OpenAI error body when connect/mint fails

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -1315,6 +1315,31 @@ function log(who, text, cls) {
   $log.scrollTop = $log.scrollHeight;
 }
 
+// The status code alone hid "You have no credits remaining" behind a bare
+// 429 for a whole debugging session (#1037). When the body is the standard
+// OpenAI error envelope, say what it said — and say whether retrying can
+// help: insufficient_quota / credit_balance_exhausted is terminal, while a
+// plain rate-limit stays exactly the message it was, so a retryable blip
+// never reads as permanent (both halves priced). Unparseable bodies fall
+// back to the bare status — never less than before.
+function describeApiFailure(prefix, status, bodyText) {
+  let detail = "";
+  let terminal = false;
+  try {
+    const err = (JSON.parse(bodyText) || {}).error;
+    if (err && (err.message || err.code)) {
+      const parts = [];
+      if (err.message) parts.push(err.message);
+      if (err.code) parts.push("[" + err.code + "]");
+      detail = ": " + parts.join(" ");
+      terminal = ["insufficient_quota", "credit_balance_exhausted"]
+        .some((c) => c === err.code || c === err.type);
+    }
+  } catch (e) { /* not JSON — the bare status is the fallback */ }
+  return prefix + " (" + status + ")" + detail
+    + (terminal ? " — add credits; retrying won't help" : "");
+}
+
 async function post(path, body) {
   const res = await fetch(path, {
     method: "POST",
@@ -1827,7 +1852,13 @@ async function start() {
         "Content-Type": "application/sdp",
       },
     });
-    if (!answer.ok) throw new Error("realtime connect failed (" + answer.status + ")");
+    if (!answer.ok) {
+      // Read the body BEFORE throwing: OpenAI delivers the real reason there
+      // ("You have no credits remaining"), and discarding it reduced a
+      // terminal condition to a retry-me status code (#1037).
+      const bodyText = await answer.text().catch(() => "");
+      throw new Error(describeApiFailure("realtime connect failed", answer.status, bodyText));
+    }
     await pc.setRemoteDescription({ type: "answer", sdp: await answer.text() });
   } catch (err) {
     log("error", String(err && err.message || err), "err");

--- a/agentwire/voice_layer/realtime.py
+++ b/agentwire/voice_layer/realtime.py
@@ -176,6 +176,41 @@ def parse_session_response(payload: dict, requested_model: str) -> dict:
     }
 
 
+#: Error codes/types where retrying is spending the owner's patience on a
+#: guaranteed no: the account has to change, not the timing. A bare 429 hid
+#: "You have no credits remaining" for a whole debugging session (#1037).
+TERMINAL_ERROR_CODES = frozenset({"insufficient_quota", "credit_balance_exhausted"})
+
+
+def describe_error_body(status: int, body: str) -> str:
+    """Render ``(status): <what OpenAI actually said>`` for an error response.
+
+    Parses ``error.message``/``error.code`` when the body is the standard
+    OpenAI JSON error envelope, and appends "retrying won't help" for the
+    terminal codes. Anything unparseable falls back to the raw (truncated)
+    body next to the status — never less information than before (#1037).
+    """
+    detail = body[:500]
+    err: dict = {}
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict) and isinstance(parsed.get("error"), dict):
+            err = parsed["error"]
+    except json.JSONDecodeError:
+        pass
+    if err.get("message") or err.get("code"):
+        parts = [str(err["message"])] if err.get("message") else []
+        if err.get("code"):
+            parts.append(f"[{err['code']}]")
+        detail = " ".join(parts)
+    terminal = (
+        err.get("code") in TERMINAL_ERROR_CODES
+        or err.get("type") in TERMINAL_ERROR_CODES
+    )
+    suffix = " — add credits; retrying won't help" if terminal else ""
+    return f"({status}): {detail}{suffix}"
+
+
 def mint_session(
     *,
     instructions: str,
@@ -210,8 +245,10 @@ def mint_session(
         with send(request, timeout=30) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", "replace")[:500]
-        raise RealtimeError(f"realtime mint failed ({exc.code}): {detail}", exc.code)
+        body = exc.read().decode("utf-8", "replace")
+        raise RealtimeError(
+            f"realtime mint failed {describe_error_body(exc.code, body)}", exc.code
+        )
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
         raise RealtimeError(f"realtime mint failed: {exc}")
     return parse_session_response(payload, model)

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -604,6 +604,67 @@ class TestRealtime:
         with pytest.raises(realtime.RealtimeError):
             realtime.parse_session_response(payload, "gpt-realtime-2.1")
 
+    def test_terminal_error_body_names_the_reason_and_says_dont_retry(self):
+        """A bare 429 hid "no credits remaining" for a debugging session
+        (#1037): the body's message must ride next to the status, and a
+        terminal code must say retrying won't help."""
+        body = json.dumps({"error": {
+            "message": "You have no credits remaining. Add credits to continue.",
+            "type": "insufficient_quota",
+            "code": "credit_balance_exhausted",
+        }})
+        rendered = realtime.describe_error_body(429, body)
+        assert "You have no credits remaining" in rendered
+        assert "[credit_balance_exhausted]" in rendered
+        assert "(429)" in rendered
+        assert "retrying won't help" in rendered
+
+    def test_terminal_type_alone_is_enough(self):
+        """OpenAI puts insufficient_quota in ``type`` on some errors; the
+        hint must not depend on which field carries it."""
+        body = json.dumps({"error": {"message": "quota", "type": "insufficient_quota"}})
+        assert "retrying won't help" in realtime.describe_error_body(429, body)
+
+    def test_plain_rate_limit_stays_retryable(self):
+        """Both halves priced (#1037): a retryable blip must never read as
+        permanent, so a plain rate-limit gets no terminal hint."""
+        body = json.dumps({"error": {
+            "message": "Rate limit reached", "type": "requests", "code": "rate_limit_exceeded",
+        }})
+        rendered = realtime.describe_error_body(429, body)
+        assert "Rate limit reached" in rendered
+        assert "retrying won't help" not in rendered
+
+    @pytest.mark.parametrize("body", ["", "<html>gateway timeout</html>", '{"nope": 1}'])
+    def test_unparseable_body_falls_back_to_status_plus_raw(self, body):
+        rendered = realtime.describe_error_body(502, body)
+        assert "(502)" in rendered
+        assert body[:500] in rendered
+        assert "retrying won't help" not in rendered
+
+    def test_mint_http_error_carries_the_parsed_body(self, monkeypatch):
+        """The mint path itself (not just the helper) must surface it."""
+        import io
+        import urllib.error
+
+        monkeypatch.setenv(realtime.API_KEY_ENV, "sk-test")
+
+        def opener(request, timeout):
+            raise urllib.error.HTTPError(
+                realtime.CLIENT_SECRETS_URL, 429, "Too Many Requests", {},
+                io.BytesIO(json.dumps({"error": {
+                    "message": "You have no credits remaining.",
+                    "type": "insufficient_quota",
+                    "code": "credit_balance_exhausted",
+                }}).encode("utf-8")),
+            )
+
+        with pytest.raises(realtime.RealtimeError) as exc:
+            realtime.mint_session(instructions="x", tools=[], opener=opener)
+        assert "no credits remaining" in str(exc.value)
+        assert "retrying won't help" in str(exc.value)
+        assert exc.value.status == 429
+
     def test_missing_api_key_names_the_blessed_location(self, monkeypatch):
         monkeypatch.delenv(realtime.API_KEY_ENV, raising=False)
         with pytest.raises(realtime.RealtimeError, match=r"~/\.agentwire"):
@@ -713,6 +774,19 @@ class TestBridge:
 
         page = client.page("buddy", 'tok"with-quote')
         assert 'const TOKEN = "tok\\"with-quote"' in page
+
+    def test_connect_failure_reads_the_body_not_just_the_status(self):
+        """#1037: the page must read the OpenAI error body on a failed
+        connect and carry the terminal don't-retry hint — a bare status is
+        only the fallback for unparseable bodies."""
+        from agentwire.voice_layer import client
+
+        page = client.page("buddy", "tok")
+        assert "describeApiFailure" in page
+        assert "await answer.text()" in page
+        assert "retrying won't help" in page
+        assert "insufficient_quota" in page
+        assert "credit_balance_exhausted" in page
 
     def test_default_port_avoids_the_portal(self):
         from agentwire.voice_layer import server


### PR DESCRIPTION
The buddy page reduced a realtime connect failure to `realtime connect failed (429)`, discarding the body that said "You have no credits remaining" (insufficient_quota / credit_balance_exhausted) — a terminal condition rendered as a retry-me status.

- **Connect path (page JS)**: reads the response body before throwing; `describeApiFailure` parses `error.message`/`error.code` when the body is the standard OpenAI JSON envelope and renders both next to the status in the error card.
- **Terminal vs retryable**: `insufficient_quota` / `credit_balance_exhausted` (matched on `code` or `type`) append "add credits; retrying won't help"; a plain rate-limit stays exactly the message it was — a retryable blip never reads as permanent.
- **Fallback preserved**: unparseable bodies still render the bare status (+ raw truncated body on the mint side).
- **/mint path**: `realtime.describe_error_body` gives the mint `HTTPError` the same treatment; the bridge already relays `str(RealtimeError)` to the page.

Tests: helper rendering (terminal by code, terminal by type, retryable, unparseable fallback), mint HTTPError path, and page-string pins on the connect path. Full suite green (6844 passed), served JS `node --check`ed.

Closes #1037

Built by [dotdev.dev](https://dotdev.dev)