### PR TITLE
fleet listings: SSOT service-session predicate, services collapse to "N services healthy" (#1038)

### DIFF
--- a/agentwire/doctor_cli.py
+++ b/agentwire/doctor_cli.py
@@ -160,14 +160,21 @@ def cmd_network_status(args) -> int:
         capture_output=True,
         text=True,
     )
+    # Services vs work uses the one SSOT predicate (#1038) — the old
+    # startswith("agentwire") filter hid the real `agentwire` orchestrator
+    # session and every agentwire-dev worktree along with the services.
+    from . import services as _services_mod
     if result.returncode == 0:
-        sessions = [s for s in result.stdout.strip().split("\n") if s and not s.startswith("agentwire")]
+        all_names = [s for s in result.stdout.strip().split("\n") if s]
+        sessions = [s for s in all_names if not _services_mod.is_service_session(s)]
+        svc_count = len(all_names) - len(sessions)
+        svc_note = f"  (+{svc_count} services)" if svc_count else ""
         if sessions:
-            print(f"  {hostname:<16}{len(sessions)} sessions    {', '.join(sessions[:5])}")
+            print(f"  {hostname:<16}{len(sessions)} sessions    {', '.join(sessions[:5])}{svc_note}")
             if len(sessions) > 5:
                 print(f"  {'':<16}... and {len(sessions) - 5} more")
         else:
-            print(f"  {hostname:<16}0 sessions")
+            print(f"  {hostname:<16}0 sessions{svc_note}")
     else:
         print(f"  {hostname:<16}(no tmux server)")
 
@@ -178,7 +185,8 @@ def cmd_network_status(args) -> int:
 
         result = _run_remote(machine_id, "tmux list-sessions -F '#{session_name}' 2>/dev/null")
         if result.returncode == 0 and result.stdout.strip():
-            sessions = [s for s in result.stdout.strip().split("\n") if s]
+            sessions = [s for s in result.stdout.strip().split("\n")
+                        if s and not _services_mod.is_service_session(s)]
             if sessions:
                 print(f"  {machine_id:<16}{len(sessions)} sessions    {', '.join(sessions[:5])}")
                 if len(sessions) > 5:

--- a/agentwire/inbox.py
+++ b/agentwire/inbox.py
@@ -644,7 +644,16 @@ def resolve_targets(to: str, sender: "str | None") -> list[str]:
     else is a single literal session name.
     """
     if to == BROADCAST_TOKEN:
-        return [s for s in _live_agent_sessions() if s != sender]
+        # Infrastructure services are excluded from broadcast (#1038) — an
+        # @all message is addressed to working sessions; pasting it into the
+        # idle-nag bridge or another service session is pure noise. A service
+        # can still be messaged by name.
+        from .services import is_service_session
+
+        return [
+            s for s in _live_agent_sessions()
+            if s != sender and not is_service_session(s)
+        ]
     return [_validate_session(to)]
 
 

--- a/agentwire/mcp_core.py
+++ b/agentwire/mcp_core.py
@@ -186,9 +186,19 @@ def _mcp_result(data: dict, on_success: str, operation: str = "complete operatio
 
 
 def format_sessions(data: dict) -> str:
-    """Format sessions list for LLM consumption."""
-    sessions = data.get("sessions", [])
+    """Format sessions list for LLM consumption.
+
+    Infrastructure service sessions (portal, scheduler, stt, …) are collapsed
+    into one summary line — they're support plumbing, not user-facing work
+    (#1038). An unhealthy service is still listed individually and loudly.
+    """
+    all_rows = data.get("sessions", [])
+    sessions = [s for s in all_rows
+                if not s.get("service") or s.get("service_healthy") is False]
+    svc = data.get("services") or {}
     if not sessions:
+        if svc.get("count"):
+            return f"No user-facing sessions. Services: {svc.get('line')}"
         return "No active sessions."
 
     lines = ["Active sessions:"]
@@ -199,7 +209,13 @@ def format_sessions(data: dict) -> str:
         path = s.get("path", "")
         posture = s.get("posture", "unknown")
         parked = " [PARKED: usage limit, auto-resumes after reset]" if s.get("usage_limit") else ""
-        lines.append(f"  - {name} ({machine}): {windows} window(s), posture={posture}, path={path}{parked}")
+        unhealthy = ""
+        if s.get("service"):
+            unhealthy = f" ⚠ SERVICE UNHEALTHY: {s.get('service_detail', 'unknown')}"
+        lines.append(f"  - {name} ({machine}): {windows} window(s), posture={posture}, path={path}{parked}{unhealthy}")
+
+    if svc.get("count"):
+        lines.append(f"Services: {svc.get('line')}")
 
     return "\n".join(lines)
 

--- a/agentwire/pane_cli.py
+++ b/agentwire/pane_cli.py
@@ -246,7 +246,7 @@ def cmd_list(args) -> int:
     remote_only = getattr(args, 'remote', False)
     machine_filter = getattr(args, 'machine', None)
     show_context = getattr(args, 'context', False)
-    show_sessions = getattr(args, 'sessions', False) or show_context
+    show_sessions = getattr(args, 'sessions', False) or show_context or getattr(args, 'services', False)
 
     # Check if we're inside a tmux session
     current_session = pane_manager.get_current_session()
@@ -288,9 +288,16 @@ def cmd_list(args) -> int:
     for machine_sessions in remote_by_machine.values():
         all_sessions.extend(machine_sessions)
 
+    # Classify infrastructure services vs user-facing work (#1038) — one SSOT
+    # predicate (services.is_service_session), shared with the portal sidebar.
+    from . import services as services_mod
+    services_mod.annotate_service_sessions(all_sessions)
+    svc_summary = services_mod.service_sessions_summary(all_sessions)
+    show_services = getattr(args, 'services', False)
+
     # Output
     if json_mode:
-        _output_json({"success": True, "sessions": all_sessions})
+        _output_json({"success": True, "sessions": all_sessions, "services": svc_summary})
         return 0
 
     # Text output - grouped by machine
@@ -317,6 +324,11 @@ def cmd_list(args) -> int:
     # Display all sessions grouped by machine
     for machine_id, sessions in sorted(all_machines.items(), key=lambda x: (x[0] is not None, x[0])):
         label = machine_id if machine_id else "local"
+        # Healthy services collapse into the summary line below; an unhealthy
+        # one stays in the listing so it surfaces loudly (#1038).
+        if not show_services:
+            sessions = [s for s in sessions
+                        if not s.get("service") or s.get("service_healthy") is False]
         print(f"{label}:")
         if sessions:
             for s in sessions:
@@ -333,10 +345,18 @@ def cmd_list(args) -> int:
                     else:
                         flag = " ⚠ LOW" if ctx.get("flagged") else ""
                         ctx_marker = f"  ctx={ctx['remaining_pct']}% left{flag}"
-                print(f"  {display_name}: {s['windows']} window(s) ({s['path']}){parked_marker}{ctx_marker}")
+                svc_marker = ""
+                if s.get("service"):
+                    svc_marker = (f" [service — UNHEALTHY: {s.get('service_detail')}]"
+                                  if s.get("service_healthy") is False
+                                  else " [service]")
+                print(f"  {display_name}: {s['windows']} window(s) ({s['path']}){parked_marker}{ctx_marker}{svc_marker}")
         else:
             print("  (no sessions)")
         print()
+
+    if not show_services and svc_summary["count"]:
+        print(f"Services: {svc_summary['line']}  (--services to list them)")
 
     return 0
 
@@ -1142,6 +1162,9 @@ def register_pane_parser(subparsers) -> None:
     list_parser.add_argument("--remote", action="store_true", help="Only show remote sessions")
     list_parser.add_argument("--machine", help="Filter by specific machine ID")
     list_parser.add_argument("--sessions", action="store_true", help="Show sessions instead of panes")
+    list_parser.add_argument("--services", action="store_true",
+                             help="List infrastructure service sessions inline instead of "
+                                  "collapsing healthy ones into the summary line (implies --sessions)")
     list_parser.add_argument("--context", action="store_true",
                              help="Annotate each session with its Claude Code context headroom "
                                   "(remaining %%); flags sessions running low (implies --sessions)")

--- a/agentwire/services.py
+++ b/agentwire/services.py
@@ -91,6 +91,7 @@ _BUILTIN_SERVICE_SESSIONS = frozenset({
     "agentwire-stt",
     "agentwire-kokoro",
     "agentwire-scheduler",
+    "agentwire-buddy",
 })
 
 
@@ -114,6 +115,73 @@ def is_service_session(name: str) -> bool:
         return any(s.name == bare for s in load_config().services.custom)
     except Exception:
         return False
+
+
+# ─────────────────────────────────────────────────────────────
+# Fleet-listing classification (#1038)
+# ─────────────────────────────────────────────────────────────
+#
+# Every surface that enumerates the fleet (`agentwire list --sessions`, the
+# MCP sessions_list, the buddy's fleet_sessions tool, doctor's session
+# roll-up) uses THESE helpers to separate infrastructure services from
+# user-facing work, so a service session is summarized ("N services healthy")
+# instead of presented as delegated work. An UNHEALTHY service still surfaces
+# loudly — suppression applies to healthy infrastructure only.
+
+
+def annotate_service_sessions(sessions: list[dict]) -> None:
+    """Mark each session row (from `list --sessions`) with `service: bool`.
+
+    Local service rows also get `service_healthy` + `service_detail` from a
+    cheap pane-liveness probe. Remote rows (name carries `@machine`) are
+    counted but not probed — a per-listing SSH healthcheck would make every
+    fleet query pay for it — and read as healthy with an honest detail.
+    """
+    for s in sessions:
+        name = s.get("name", "")
+        if not is_service_session(name):
+            s["service"] = False
+            continue
+        s["service"] = True
+        bare = name.split("@")[0]
+        if s.get("machine"):
+            s["service_healthy"] = True
+            s["service_detail"] = "remote (not probed)"
+        elif s.get("usage_limit"):
+            s["service_healthy"] = False
+            s["service_detail"] = "parked: usage limit"
+        elif _tmux_pane_dead(bare):
+            tail = _tmux_pane_tail(bare)
+            s["service_healthy"] = False
+            s["service_detail"] = f"process exited: {tail}" if tail else "process exited"
+        else:
+            s["service_healthy"] = True
+            s["service_detail"] = "running"
+
+
+def service_sessions_summary(sessions: list[dict]) -> dict:
+    """One-line roll-up of the service rows in an annotated session list.
+
+    Returns ``{"count", "names", "unhealthy": [{"name","detail"}], "line"}``.
+    ``line`` is the default rendering every channel shares — the voice channel
+    especially pays per word, so healthy infrastructure collapses to one
+    sentence while anything unhealthy is named in it.
+    """
+    rows = [s for s in sessions if s.get("service")]
+    unhealthy = [
+        {"name": s.get("name", ""), "detail": s.get("service_detail", "unhealthy")}
+        for s in rows if s.get("service_healthy") is False
+    ]
+    count = len(rows)
+    names = [s.get("name", "") for s in rows]
+    if not count:
+        line = "No service sessions running."
+    elif not unhealthy:
+        line = f"{count} service session(s) healthy ({', '.join(names)})."
+    else:
+        bad = "; ".join(f"{u['name']}: {u['detail']}" for u in unhealthy)
+        line = f"{count} service session(s), {len(unhealthy)} UNHEALTHY — {bad}."
+    return {"count": count, "names": names, "unhealthy": unhealthy, "line": line}
 
 
 def _source_dir() -> str:

--- a/agentwire/static/js/service-classification.js
+++ b/agentwire/static/js/service-classification.js
@@ -14,6 +14,7 @@ const SERVICE_SESSIONS = new Set([
     'agentwire-kokoro',  // default-tier Kokoro TTS shim subprocess (:8102)
     'agentwire-scheduler',
     'agentwire-notifications',
+    'agentwire-buddy',
 ]);
 
 export function isService(name) { return SERVICE_SESSIONS.has(name); }

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -197,7 +197,22 @@ class ReadOnlyTool:
 
 
 def _fleet_sessions(args: dict) -> dict:
-    return run_agentwire_cmd(["list", "--sessions"])
+    """Live sessions, with infrastructure services suppressed by default (#1038).
+
+    Spoken lists pay per word, so healthy service sessions (portal, scheduler,
+    stt, …) collapse to the one-line summary already in the payload; an
+    UNHEALTHY service stays in the list — it IS news. Pass
+    ``include_services=true`` when the owner is asking about the services
+    themselves.
+    """
+    data = run_agentwire_cmd(["list", "--sessions"])
+    if not data.get("success") or args.get("include_services") is True:
+        return data
+    data["sessions"] = [
+        s for s in data.get("sessions", [])
+        if not s.get("service") or s.get("service_healthy") is False
+    ]
+    return data
 
 
 def _fleet_worktrees(args: dict) -> dict:
@@ -482,9 +497,24 @@ READ_ONLY_TOOLS: tuple[ReadOnlyTool, ...] = (
         description=(
             "List every live agentwire session with its role, parent and activity. "
             "This is the answer to 'what is running' and the source of truth for "
-            "exact session names."
+            "exact session names. Infrastructure services (portal, scheduler, "
+            "stt, …) are collapsed into the 'services' summary line unless one "
+            "is unhealthy — pass include_services=true only when the owner asks "
+            "about the services themselves."
         ),
         run=_fleet_sessions,
+        parameters={
+            "type": "object",
+            "properties": {
+                "include_services": {
+                    "type": "boolean",
+                    "description": (
+                        "List healthy infrastructure service sessions inline "
+                        "instead of collapsing them into the summary."
+                    ),
+                },
+            },
+        },
     ),
     ReadOnlyTool(
         name="fleet_worktrees",

--- a/tests/unit/test_inbox.py
+++ b/tests/unit/test_inbox.py
@@ -1345,3 +1345,23 @@ class TestStuckInBox:
         remaining = inbox.list_messages("s")
         assert len(remaining) == 1 and "beta" in remaining[0].text
         assert pasted == []
+
+
+class TestBroadcastServiceExclusion:
+    """#1038 — @all never fans out to infrastructure service sessions."""
+
+    def test_at_all_excludes_services(self, isolate, monkeypatch):
+        from agentwire import services
+        monkeypatch.setattr(
+            inbox, "_live_agent_sessions",
+            lambda: ["a", "agentwire-notifications", "orch"])
+        monkeypatch.setattr(
+            services, "is_service_session",
+            lambda s: s == "agentwire-notifications")
+        written = inbox.enqueue("@all", "team update", sender="orch")
+        assert sorted(m.to for m in written) == ["a"]
+
+    def test_service_still_reachable_by_name(self, isolate, monkeypatch):
+        monkeypatch.setattr(inbox, "_live_agent_sessions", lambda: ["a"])
+        written = inbox.enqueue("agentwire-notifications", "direct", sender="orch")
+        assert [m.to for m in written] == ["agentwire-notifications"]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -567,3 +567,53 @@ class TestTtsToolPromptFetch:
         # With no shim prompt at import time, no capabilities section
         if not mcp_server._TTS_TOOL_PROMPT:
             assert "Backend capabilities" not in mcp_server._SAY_DESCRIPTION
+
+
+class TestFormatSessionsServiceGrouping:
+    """#1038 — services collapse into the summary line; unhealthy ones stay loud."""
+
+    def _data(self):
+        return {
+            "sessions": [
+                {"name": "documentscribe", "machine": None, "windows": 1,
+                 "path": "/p", "posture": "bypass", "service": False},
+                {"name": "agentwire-portal", "machine": None, "windows": 1,
+                 "path": "/q", "posture": "bypass", "service": True,
+                 "service_healthy": True, "service_detail": "running"},
+            ],
+            "services": {"count": 1, "unhealthy": [],
+                         "line": "1 service session(s) healthy (agentwire-portal)."},
+        }
+
+    def test_healthy_service_suppressed_into_summary(self):
+        from agentwire.mcp_core import format_sessions
+        out = format_sessions(self._data())
+        assert "documentscribe" in out
+        assert "  - agentwire-portal" not in out
+        assert "Services: 1 service session(s) healthy" in out
+
+    def test_unhealthy_service_surfaces_loudly(self):
+        from agentwire.mcp_core import format_sessions
+        data = self._data()
+        data["sessions"][1].update(service_healthy=False, service_detail="process exited")
+        data["services"] = {"count": 1,
+                            "unhealthy": [{"name": "agentwire-portal", "detail": "process exited"}],
+                            "line": "1 service session(s), 1 UNHEALTHY — agentwire-portal: process exited."}
+        out = format_sessions(data)
+        assert "agentwire-portal" in out
+        assert "SERVICE UNHEALTHY" in out
+
+    def test_only_services_running(self):
+        from agentwire.mcp_core import format_sessions
+        data = self._data()
+        data["sessions"] = [data["sessions"][1]]
+        out = format_sessions(data)
+        assert "No user-facing sessions" in out
+        assert "healthy" in out
+
+    def test_unannotated_payload_still_lists_everything(self):
+        # Backward shape safety: rows without the `service` key list as before.
+        from agentwire.mcp_core import format_sessions
+        out = format_sessions({"sessions": [
+            {"name": "a", "machine": None, "windows": 1, "path": "/a"}]})
+        assert "  - a" in out

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -292,3 +292,62 @@ class TestServicesCLI:
 
     def test_unknown_service(self, cli, capsys):
         assert cli.cmd_services_up(self._args(name="nope")) == 1
+
+
+class TestFleetListingClassification:
+    """#1038 — one SSOT predicate applied across fleet listings."""
+
+    def _rows(self):
+        return [
+            {"name": "documentscribe", "machine": None},
+            {"name": "agentwire-portal", "machine": None},
+            {"name": "agentwire-scheduler", "machine": "studio"},
+        ]
+
+    def test_builtin_buddy_is_service(self):
+        assert services.is_service_session("agentwire-buddy")
+
+    def test_annotate_marks_services_and_probes_local(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda name: False)
+        rows = self._rows()
+        services.annotate_service_sessions(rows)
+        assert rows[0]["service"] is False
+        assert rows[1]["service"] is True and rows[1]["service_healthy"] is True
+        # remote row: counted, never probed
+        assert rows[2]["service"] is True
+        assert rows[2]["service_detail"] == "remote (not probed)"
+
+    def test_dead_pane_reads_unhealthy(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda name: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda name: "boom")
+        rows = [{"name": "agentwire-portal", "machine": None}]
+        services.annotate_service_sessions(rows)
+        assert rows[0]["service_healthy"] is False
+        assert "boom" in rows[0]["service_detail"]
+
+    def test_parked_service_is_unhealthy(self, monkeypatch):
+        rows = [{"name": "agentwire-portal", "machine": None, "usage_limit": True}]
+        services.annotate_service_sessions(rows)
+        assert rows[0]["service_healthy"] is False
+        assert "usage limit" in rows[0]["service_detail"]
+
+    def test_summary_healthy_line(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda name: False)
+        rows = self._rows()
+        services.annotate_service_sessions(rows)
+        summary = services.service_sessions_summary(rows)
+        assert summary["count"] == 2
+        assert summary["unhealthy"] == []
+        assert "2 service session(s) healthy" in summary["line"]
+
+    def test_summary_names_the_unhealthy(self, monkeypatch):
+        monkeypatch.setattr(services, "_tmux_pane_dead", lambda name: True)
+        monkeypatch.setattr(services, "_tmux_pane_tail", lambda name: "")
+        rows = [{"name": "agentwire-portal", "machine": None}]
+        services.annotate_service_sessions(rows)
+        summary = services.service_sessions_summary(rows)
+        assert "UNHEALTHY" in summary["line"]
+        assert "agentwire-portal" in summary["line"]
+
+    def test_summary_empty(self):
+        assert services.service_sessions_summary([])["count"] == 0

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -718,3 +718,35 @@ class TestBridge:
         from agentwire.voice_layer import server
 
         assert server.DEFAULT_PORT not in (8100, 8765, 8101)
+
+
+class TestFleetSessionsServiceSuppression:
+    """#1038 — spoken fleet lists suppress healthy services, keep unhealthy ones."""
+
+    def _payload(self):
+        return {
+            "success": True,
+            "sessions": [
+                {"name": "documentscribe", "service": False},
+                {"name": "agentwire-portal", "service": True, "service_healthy": True},
+                {"name": "agentwire-stt", "service": True, "service_healthy": False,
+                 "service_detail": "process exited"},
+            ],
+            "services": {"count": 2, "line": "…"},
+        }
+
+    def test_healthy_services_dropped_by_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.run_agentwire_cmd",
+            lambda cmd: self._payload())
+        data = tools._fleet_sessions({})
+        names = [s["name"] for s in data["sessions"]]
+        assert names == ["documentscribe", "agentwire-stt"]
+        assert data["services"]["count"] == 2
+
+    def test_include_services_lists_everything(self, monkeypatch):
+        monkeypatch.setattr(
+            "agentwire.voice_layer.tools.run_agentwire_cmd",
+            lambda cmd: self._payload())
+        data = tools._fleet_sessions({"include_services": True})
+        assert len(data["sessions"]) == 3


### PR DESCRIPTION
Fleet listings kept presenting service sessions (portal, scheduler, stt, kokoro, notifications, buddy) as user-facing work. This applies the one existing SSOT predicate — `services.is_service_session()`, the Python mirror of the sidebar's `service-classification.js` allowlist — across every enumeration surface, with no second list.

- **`agentwire list --sessions`**: rows annotated (`service`, `service_healthy`, `service_detail` from a cheap pane-liveness probe; remote rows counted, honestly not probed), JSON gains a `services` summary, human output collapses healthy services into one `Services: N service session(s) healthy (…)` line. `--services` lists them inline. An unhealthy service stays in the listing with its detail.
- **MCP `sessions_list`** (`format_sessions`): same grouping; unhealthy services render `⚠ SERVICE UNHEALTHY: <detail>`.
- **Buddy `fleet_sessions`** (voice pays per word): healthy services dropped from the rows by default, summary retained; `include_services=true` opts back in; unhealthy always surfaces.
- **Doctor "Worker Sessions"**: replaces its forked `startswith("agentwire")` filter — which also hid the real `agentwire` orchestrator session and every agentwire-dev worktree — with the SSOT predicate, plus a `(+N services)` note.
- **`@all` broadcast**: service sessions excluded; direct by-name delivery unaffected.
- `agentwire-buddy` added to both lockstep allowlists (Python + JS).

Verified: full suite green (6851 passed), plus live smoke — `agentwire list --sessions` now ends with `Services: 6 service session(s) healthy (agentwire-buddy, agentwire-kokoro, agentwire-notifications, agentwire-portal, agentwire-scheduler, agentwire-stt).`

Closes #1038

Built by [dotdev.dev](https://dotdev.dev)