### PR TITLE
confirm spine: NATO nonce alphabet (measured), near-miss diagnosis, gate-then-speak

### DIFF
--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -251,10 +251,39 @@ MAX_CONFIRM_ATTEMPTS = 5
 #: pass — and folding a spelling for a word we no longer mint is machinery with
 #: nothing to do. The selection rule replaces both: **one morpheme, no
 #: en-US/en-GB split.**
+#:
+#: **The base vocabulary is the NATO phonetic alphabet (#1039)** — designed for
+#: exactly this job and familiar to the owner — filtered by the admission test
+#: above, MEASURED against the real transcriber (``gpt-4o-mini-transcribe``)
+#: rather than assumed. ``tools/nonce_stt_probe.py`` synthesizes each candidate
+#: inside the real phrase ("confirm <word>") at three macOS voices (en-US,
+#: en-GB, en-AU) and admits a word only when every transcription across three
+#: runs renders it as exactly its canonical token. Measured 2026-08-13; the
+#: failures are the tuple's negative space and each is the harbor/harbour or
+#: digit failure reached through a different door:
+#:
+#: - ``alfa``/``alpha`` — BOTH spellings failed: rendered ``alpha`` or ``elva``.
+#: - ``juliett`` — the ICAO spelling never comes back; the transcriber emits
+#:   ``juliet``, which is the spelling admitted instead.
+#: - ``x-ray`` — segments as ``x ray``, both spellings, every run.
+#: - ``mike`` — rendered ``mic`` and ``my``. A homophone of a word this channel
+#:   is ABOUT is the worst candidate the alphabet contained.
+#: - ``papa`` — rendered ``popup``/``pop up``; one run also glued the phrase
+#:   into ``confirme papa``.
+#: - ``sierra`` — one run heard "confirms the error", i.e. the PHRASE itself
+#:   dissolved, not just the word.
+#: - ``foxtrot`` — rendered ``vostrot`` in one run of nine samples; unstable.
+#: - ``quebec`` — rendered ``québec`` (diacritic) in one run; ``normalize``
+#:   strips no diacritics, so that is a second spelling.
+#: - ``whiskey`` — measured stable across nine samples, but excluded by the
+#:   standing selection rule: ``whisky`` is a live en-GB/spirits split, the
+#:   harbor/harbour shape with a thinner measurement than the rule demands.
+#:
+#: Re-run the probe before adding a word; a word failing ANY run stays out.
 NONCE_WORDS = (
-    "tango", "banjo", "violet", "cobalt", "meadow", "falcon", "amber",
-    "kestrel", "juniper", "onyx", "saffron", "walrus", "domino", "pelican",
-    "quartz", "thistle", "vertigo", "narwhal", "gumbo", "lantern",
+    "bravo", "charlie", "delta", "echo", "golf", "hotel", "india", "juliet",
+    "kilo", "lima", "november", "oscar", "romeo", "tango", "uniform",
+    "victor", "yankee", "zulu",
 )
 
 #: Digit spellings, kept for normalization only. Nothing MINTS a digit nonce;
@@ -777,6 +806,75 @@ def classify(text: str, nonce: str) -> str:
 def matches_nonce(text: str, nonce: str) -> bool:
     """Convenience predicate: does *text* approve *nonce* outright?"""
     return classify(text, nonce) == APPROVED
+
+
+def _edit_distance(a: str, b: str) -> int:
+    """Plain Levenshtein distance. Inputs are short normalized tokens."""
+    if len(a) < len(b):
+        a, b = b, a
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        current = [i]
+        for j, cb in enumerate(b, 1):
+            current.append(min(
+                previous[j] + 1,
+                current[j - 1] + 1,
+                previous[j - 1] + (ca != cb),
+            ))
+        previous = current
+    return previous[-1]
+
+
+def near_miss_heard(text: str, nonce: str) -> str:
+    """The token *text* rendered CLOSE to *nonce*, or ``""`` when none did.
+
+    The false-reject half of the gate, made diagnosable (#1039): when the
+    transcriber renders the code word as ``tang go`` or ``tangle``, the
+    taxonomy used to answer ``refused`` — "say confirm and then the word I gave
+    you" — which reads to the owner as "you were not heard at all". Naming what
+    WAS heard turns the retry into one word instead of a renegotiation.
+
+    This is messaging only, never matching: a near miss REFUSES exactly as it
+    always did, burns an attempt exactly as it always did, and nothing here can
+    approve. The bounds are what keep the diagnosis honest:
+
+    - Candidates are single normalized tokens and adjacent-pair merges (the
+      segmentation failure: ``tang go``), fillers removed.
+    - Distance is bounded (1 for a nonce of four letters or fewer, else 2) —
+      beyond that, "close" would be a guess spoken as a fact.
+    - **Distance zero is excluded.** An utterance carrying the exact nonce
+      without the confirm framing stays ``refused``, because the heard word is
+      spoken back in the refusal line and the fallback channel must never
+      carry the nonce (#953). Structural, not cosmetic: this function's return
+      value is guaranteed to differ from *nonce*.
+    - A candidate at or under the bound must also be STRICTLY closer to this
+      nonce than to every other word in :data:`NONCE_WORDS`, and never one of
+      them outright — a near miss must not cross into another live token, and
+      an exact other-alphabet word is ``wrong_nonce`` territory, not this.
+    """
+    target = normalize(nonce)
+    bound = 1 if len(target) <= 4 else 2
+    tokens = [t for t in normalize(text).split() if t not in _FILLERS]
+    candidates = list(tokens)
+    candidates.extend(a + b for a, b in zip(tokens, tokens[1:]))
+    best = ""
+    best_distance = bound + 1
+    for candidate in candidates:
+        if candidate == target or candidate in NONCE_WORDS:
+            continue
+        if candidate in _CONFIRM_WORDS or candidate in _DENIAL_WORDS:
+            continue
+        distance = _edit_distance(candidate, target)
+        if distance == 0 or distance > bound or distance >= best_distance:
+            continue
+        if any(
+            _edit_distance(candidate, other) <= distance
+            for other in NONCE_WORDS
+            if other != nonce
+        ):
+            continue
+        best, best_distance = candidate, distance
+    return best
 
 
 def request_utterance_from(ring) -> str:
@@ -1390,6 +1488,16 @@ SPOKEN = {
         "I didn't hear the confirmation phrase, so I haven't sent anything. "
         "Say confirm and then the word I gave you."
     ),
+    # A refusal that can NAME what was heard (#1039). ``{heard}`` is filled by
+    # :attr:`Verdict.spoken` from ``heard_word``, which ``near_miss_heard``
+    # guarantees is never the nonce itself — the fallback voice speaks this
+    # line, and the fallback channel must never carry the nonce (#953). The
+    # advice is the full phrase, not the bare word, because the bare word does
+    # not approve and advice that cannot work is the taxonomy's cardinal sin.
+    "near_miss": (
+        "I heard {heard} — close, but not quite the code word, so I haven't "
+        "sent anything. Say confirm and the word I gave you, once more."
+    ),
     "wrong_nonce": (
         "That was a different code word, so I haven't sent anything. "
         "Ask me what the word was and I'll say it again."
@@ -1614,7 +1722,8 @@ WAIT_OUTCOMES = frozenset(
 REASONS = frozenset(
     {
         "no_proposal", "expired", "not_announced", "replayed", "refused",
-        "wrong_nonce", "quoted_frame", "denied", "pending_transcript",
+        "near_miss", "wrong_nonce", "quoted_frame", "denied",
+        "pending_transcript",
         "too_many_attempts", "dispatch_failed", "build_failed", "in_flight",
         "cancel_in_flight", "nothing_to_cancel", "cancelled",
     }
@@ -1642,12 +1751,23 @@ class Verdict:
     #: whenever two proposals interleave. Empty means the write has no session
     #: target, and the key is then omitted rather than shipped empty.
     acted_session: str = ""
+    #: The near-miss token, set only on ``reason == "near_miss"``. Filled into
+    #: the spoken line so the owner hears what WAS heard (#1039). Guaranteed by
+    #: :func:`near_miss_heard` to never be the nonce.
+    heard_word: str = ""
 
     @property
     def spoken(self) -> str:
         if self.approved:
             return ""
-        return SPOKEN.get(self.reason) or "I couldn't do that, so nothing was sent."
+        line = SPOKEN.get(self.reason) or "I couldn't do that, so nothing was sent."
+        if self.reason == "near_miss":
+            # The template needs a word; an empty one (a hand-built Verdict)
+            # degrades to the plain refused line rather than speaking a blank.
+            if not self.heard_word:
+                return SPOKEN["refused"]
+            return line.format(heard=self.heard_word)
+        return line
 
     def to_dict(self) -> dict:
         if self.approved:
@@ -2220,6 +2340,21 @@ class ConfirmSpine:
                 return Verdict(
                     approved=False, reason="wrong_nonce", utterance=wrong_nonce.text
                 )
+            # Before the generic refusal: did any usable entry render the code
+            # word CLOSE to right (#1039)? Newest first, same order the judge
+            # binds approvals. Messaging only — still a refusal, still burns an
+            # attempt — but the spoken line names what was heard, so the retry
+            # is one word rather than a renegotiation. Denials never reach
+            # here: the loop above returns on DENIED before this runs.
+            for entry in reversed(usable):
+                heard = near_miss_heard(entry.text, proposal.nonce)
+                if heard:
+                    return Verdict(
+                        approved=False,
+                        reason="near_miss",
+                        utterance=entry.text,
+                        heard_word=heard,
+                    )
             return Verdict(
                 approved=False, reason="refused", utterance=usable[-1].text
             )
@@ -2374,6 +2509,7 @@ __all__ = [
     "is_buddy_echo",
     "matches_nonce",
     "mint_nonce",
+    "near_miss_heard",
     "normalize",
     "render_body",
     "reply_nudge",

--- a/agentwire/voice_layer/instructions.py
+++ b/agentwire/voice_layer/instructions.py
@@ -235,6 +235,17 @@ against your impression of it. So do not skip saying it, do not invent a differe
 phrase, and do not call send_session_message on a "yeah" or a nod. If you do, it \
 will simply be refused and you will be told why.
 
+GATE FIRST, THEN SPEAK. When the owner says the confirm phrase, do not \
+acknowledge it — no "great", no "okay, I'll send it out", not a word about the \
+outcome — until send_session_message has returned. The check runs in code and \
+it can refuse; a promise you spoke before the check ruled becomes a \
+contradiction one breath later, and the owner, who cannot see a screen, hears \
+the system arguing with itself. Call the tool silently, then speak the "say" \
+line the result hands back — that line IS the outcome, and it is the first \
+thing you say. If the result names what was heard instead of the code word, \
+pass that on exactly: telling them what landed is what makes the retry one \
+word instead of an argument.
+
 SAY "QUEUED", NEVER "SENT". Passing a message queues it; it lands when that session \
 is free, which may be a minute later. Say "queued it, it'll land when they're free". \
 Never say "sent", "done", or "I've told them" — the owner cannot see whether it \

--- a/docs/wiki/voice-layer.md
+++ b/docs/wiki/voice-layer.md
@@ -992,6 +992,31 @@ fold token-for-token (`rip cord` is two tokens), and folding a spelling for a
 word nothing mints is machinery with nothing to do. The rule replaces both —
 **one morpheme, no en-US/en-GB split.**
 
+**The base vocabulary is the NATO phonetic alphabet (#1039), filtered by that
+same admission test — MEASURED, not assumed.** `tools/nonce_stt_probe.py`
+synthesizes each candidate inside the real phrase ("confirm <word>") at three
+macOS voices and sends it to the real transcription model; a word joins only if
+every transcription across three runs renders exactly its canonical token.
+Measured 2026-08-13, eight NATO words failed: `alfa`/`alpha` (both spellings —
+rendered `alpha` or `elva`), `juliett` (comes back `juliet`, which is admitted
+instead), `x-ray` (segments as `x ray`), `mike` (`mic`, `my`), `papa`
+(`popup`), `sierra` (one run dissolved the phrase into "confirms the error"),
+`foxtrot` (`vostrot`, one run of nine), `quebec` (`québec`, a diacritic second
+spelling). `whiskey` measured stable but is excluded by the standing
+no-en-US/en-GB-split rule (`whisky`). The shipped alphabet is the 18 survivors,
+pinned in the tests with a minimum pairwise edit distance of 3.
+
+**`near_miss` is the false-reject half made diagnosable (#1039).** When a
+transcription renders the code word close-but-wrong (`tangle`, `tang go`), the
+verdict names what WAS heard — "I heard tangle — close, but not quite the code
+word" — so the retry is one word, not a renegotiation. Messaging only, never
+matching: it refuses exactly as `refused` did, burns an attempt, and cannot
+approve. Bounds keep the diagnosis honest: edit distance ≤ 2 (≤ 1 for short
+nonces), single tokens plus adjacent-pair merges, strictly closer to this nonce
+than to any other alphabet word, denial/confirm/alphabet words excluded — and
+**distance zero is excluded by design**, because the heard word is spoken back
+in the refusal and the fallback channel must never carry the nonce (#953).
+
 Disfluencies are skipped **between the confirm word and the nonce**, for the same
 reason the denial grammar strips them before matching: "confirm, uh, tango" is
 the phrase, said by someone hesitating before a code word, which is exactly how
@@ -1181,6 +1206,7 @@ the set `SPOKEN` is checked against **both ways**:
 | `not_announced` | **wait** — the buddy hasn't finished saying it |
 | `replayed` | nothing — it already went out |
 | `refused` | say the phrase |
+| `near_miss` | say the phrase once more — the line names what WAS heard (#1039) |
 | `wrong_nonce` | ask what the word was |
 | `quoted_frame` | say confirm and the word on its own — the word was right |
 | `denied` | say the phrase again when you're ready — the proposal is still live |

--- a/tests/unit/test_voice_confirm.py
+++ b/tests/unit/test_voice_confirm.py
@@ -236,7 +236,7 @@ class TestNonceGrammar:
 
     def test_a_wrong_nonce_is_its_own_outcome(self):
         """"repeat it" and "ask what the code was" are different advice."""
-        assert confirm.classify("confirm violet", "tango") == confirm.WRONG_NONCE
+        assert confirm.classify("confirm bravo", "tango") == confirm.WRONG_NONCE
         assert confirm.classify("confirm tango", "tango") == confirm.APPROVED
 
     def test_no_nonce_word_has_a_second_transcriber_rendering(self):
@@ -307,7 +307,7 @@ class TestNonceGrammar:
         assert confirm.classify("confirm the tango step", "tango") == confirm.NO_MATCH
         # and the wrong-nonce scan uses the same skipping, or a hesitated
         # wrong code word reports "say it again" instead of "ask me the word".
-        assert confirm.classify("confirm, uh, violet", "tango") == confirm.WRONG_NONCE
+        assert confirm.classify("confirm, uh, bravo", "tango") == confirm.WRONG_NONCE
 
     def test_an_exception_never_masks_the_token_after_its_own_span(self):
         """BLOCKER: the masking loop ate one token too many.
@@ -2576,6 +2576,152 @@ class TestAttribution:
 
 
 # =============================================================================
+# The NATO alphabet and the near-miss diagnosis (#1039)
+# =============================================================================
+
+
+class TestTheNonceAlphabetIsNato:
+    """The base vocabulary is the NATO phonetic alphabet, filtered by the
+    one-transcriber-rendering admission test — MEASURED via
+    tools/nonce_stt_probe.py against gpt-4o-mini-transcribe (2026-08-13),
+    never assumed. These pins hold the measured shape."""
+
+    #: The words the measurement REJECTED, each with its observed failure
+    #: rendering recorded at NONCE_WORDS. Their absence is the measurement.
+    MEASURED_REJECTS = {
+        "alfa", "alpha", "juliett", "mike", "papa", "quebec", "sierra",
+        "foxtrot", "xray", "x-ray", "whiskey", "whisky",
+    }
+
+    def test_every_word_survives_its_own_normalization(self):
+        """A word normalize() rewrites can never match its own transcript."""
+        for word in confirm.NONCE_WORDS:
+            assert confirm.normalize(word) == word, word
+
+    def test_the_measured_rejects_are_absent(self):
+        assert not self.MEASURED_REJECTS & set(confirm.NONCE_WORDS)
+
+    def test_one_token_one_morpheme_lowercase(self):
+        for word in confirm.NONCE_WORDS:
+            assert word.isalpha() and word.islower(), word
+            assert " " not in word and "-" not in word, word
+
+    def test_words_are_mutually_distinct_beyond_the_near_miss_bound(self):
+        """Pairwise edit distance >= 3, so a near miss within the bound of 2
+        can never sit as close to another live token as to its own."""
+        words = confirm.NONCE_WORDS
+        for i, a in enumerate(words):
+            for b in words[i + 1:]:
+                assert confirm._edit_distance(a, b) >= 3, (a, b)
+
+    def test_no_word_collides_with_the_grammar(self):
+        grammar = set(confirm._DENIAL_WORDS) | set(confirm._FILLERS) | set(
+            confirm._CONFIRM_WORDS
+        )
+        assert not grammar & set(confirm.NONCE_WORDS)
+
+    def test_the_alphabet_is_large_enough_to_mint_from(self):
+        """MAX outstanding proposals in practice is single digits; exhaustion
+        must stay unreachable."""
+        assert len(confirm.NONCE_WORDS) >= 15
+
+
+class TestNearMissDiagnosis:
+    """#1039 part 3: a refusal that can name what WAS heard does so — and it
+    is messaging ONLY. Nothing here approves, and the deny side is untouched."""
+
+    def test_a_one_letter_slip_is_named(self):
+        assert confirm.near_miss_heard("confirm tangle", "tango") == "tangle"
+
+    def test_a_segmented_nonce_is_diagnosed(self):
+        """"tang go" names the close fragment; the adjacent-pair merge exists
+        for renderings no single token gets close to."""
+        assert confirm.near_miss_heard("confirm tang go", "tango") == "tang"
+        # The merge wins only when it is strictly closer than any one token.
+        assert confirm.near_miss_heard("confirm tan goz", "tango") == "tangoz"
+
+    def test_the_exact_nonce_is_never_the_heard_word(self):
+        """Distance zero is excluded BY DESIGN: the heard word is spoken back
+        in the refusal, and the fallback channel never carries the nonce
+        (#953). A bare exact nonce stays a plain refusal."""
+        assert confirm.near_miss_heard("tango", "tango") == ""
+        # A segmentation whose merge IS the nonce reports the near fragment,
+        # never the reassembled nonce itself.
+        assert confirm.near_miss_heard("tan go", "tango") == "tan"
+
+    def test_it_never_crosses_into_another_live_token(self):
+        for word in confirm.NONCE_WORDS:
+            heard = confirm.near_miss_heard(f"confirm {word}", "tango")
+            assert heard == "", word
+
+    def test_far_words_are_not_called_close(self):
+        assert confirm.near_miss_heard("confirm banana", "tango") == ""
+        assert confirm.near_miss_heard("Yeah.", "tango") == ""
+
+    def test_denial_words_are_never_diagnosed_as_near_misses(self):
+        """"no" is one edit from several short words in principle; the grammar
+        words are excluded outright so a retraction can never be answered with
+        "close, say it once more"."""
+        assert confirm.near_miss_heard("no", "onyx") == ""
+
+    def test_the_gate_speaks_the_heard_word_and_never_the_nonce(
+        self, convo, runner
+    ):
+        proposal = convo.announced_proposal()
+        convo.says(f"confirm {proposal.nonce}z")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.approved is False
+        assert verdict.reason == "near_miss"
+        assert runner.calls == []
+        line = verdict.spoken
+        assert verdict.heard_word == f"{proposal.nonce}z"
+        assert verdict.heard_word in line
+        # The nonce itself must not ride the refusal line (#953) — as a WORD;
+        # the heard token necessarily contains it as a substring here.
+        assert proposal.nonce not in confirm.normalize(line).split()
+
+    def test_a_near_miss_still_burns_an_attempt(self, convo):
+        proposal = convo.announced_proposal()
+        for _ in range(confirm.MAX_CONFIRM_ATTEMPTS - 1):
+            convo.says(f"confirm {proposal.nonce}z")
+            assert convo.spine.confirm(proposal.token).reason == "near_miss"
+        convo.says(f"confirm {proposal.nonce}z")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.reason == "too_many_attempts"
+
+    def test_a_denial_outranks_a_near_miss(self, convo, runner):
+        proposal = convo.announced_proposal()
+        convo.says(f"no, confirm {proposal.nonce}z")
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.reason == "denied"
+        assert runner.calls == []
+
+    def test_a_correct_approval_after_a_near_miss_still_writes(
+        self, convo, runner
+    ):
+        """The recovery the diagnosis exists for: one more word, and it goes."""
+        proposal = convo.announced_proposal()
+        convo.says(f"confirm {proposal.nonce}z")
+        assert convo.spine.confirm(proposal.token).reason == "near_miss"
+        convo.approve(proposal)
+        verdict = convo.spine.confirm(proposal.token)
+        assert verdict.approved is True
+        assert len(runner.calls) == 1
+
+    def test_a_hand_built_verdict_with_no_heard_word_degrades_to_refused(self):
+        verdict = confirm.Verdict(approved=False, reason="near_miss")
+        assert verdict.spoken == confirm.SPOKEN["refused"]
+
+    def test_wrong_nonce_outranks_near_miss(self, convo):
+        """An exact OTHER alphabet word is wrong_nonce — a different diagnosis
+        with different advice — never a near miss of this one."""
+        proposal = convo.announced_proposal()
+        other = next(w for w in confirm.NONCE_WORDS if w != proposal.nonce)
+        convo.says(f"confirm {other}")
+        assert convo.spine.confirm(proposal.token).reason == "wrong_nonce"
+
+
+# =============================================================================
 # Outcomes speak, and say different things
 # =============================================================================
 
@@ -2605,6 +2751,13 @@ class TestOutcomesAreDistinctAndSpoken:
         convo.says("Yeah.")
         cases["refused"] = convo.spine.confirm(rejected.token)
 
+        # The code word rendered one letter off — the transcriber's doing, not
+        # the owner's (#1039). Any one-char mutation is within the bound and,
+        # with pairwise alphabet distances >= 3, never closer to another word.
+        near = convo.announced_proposal()
+        convo.says(f"confirm {near.nonce}z")
+        cases["near_miss"] = convo.spine.confirm(near.token)
+
         denied = convo.announced_proposal()
         convo.says(f"no, confirm {confirm.spoken_nonce(denied.nonce)}")
         cases["denied"] = convo.spine.confirm(denied.token)
@@ -2625,7 +2778,7 @@ class TestOutcomesAreDistinctAndSpoken:
             assert line.strip(), f"{label} refused silently"
             assert len(line) > 25, label
             spoken.add(line)
-        assert len(spoken) == 7, "outcomes must not share a spoken line"
+        assert len(spoken) == 8, "outcomes must not share a spoken line"
 
     def test_the_wait_outcomes_are_flagged_as_such(self, convo, clock):
         for label, verdict in self._outcomes(convo, clock).items():
@@ -3431,7 +3584,7 @@ class TestTheQuotedFrameGuard:
         """The frame quoting a DIFFERENT word is a different problem — the
         owner needs this proposal's code, so wrong_nonce's advice is right."""
         assert confirm.classify(
-            "to approve say confirm violet", "tango"
+            "to approve say confirm bravo", "tango"
         ) == confirm.WRONG_NONCE
 
     def test_a_hesitated_frame_is_still_the_frame(self):
@@ -3876,12 +4029,12 @@ class TestTheNonceNeverLeavesTheGate:
         is not a request, so selection skips it — falling back to the real
         request sentence, false-reject half covered by the fallback below."""
         convo.says("tell the orchestrator to restart the portal")
-        convo.says("confirm walrus")
+        convo.says("confirm zulu")
         proposal = convo.announced_proposal(instruction="restart the portal")
         convo.approve(proposal)
         convo.spine.confirm(proposal.token)
         body = runner.calls[0][-1]
-        assert "walrus" not in body
+        assert "zulu" not in body
         assert 'said: "tell the orchestrator to restart the portal"' in body
 
     def test_an_empty_ring_at_propose_still_delivers(self, convo, runner):

--- a/tests/unit/test_voice_persona.py
+++ b/tests/unit/test_voice_persona.py
@@ -332,3 +332,33 @@ class TestSpeakability:
         assert "`" not in body
         assert "- " not in body  # no bullet lists in a spoken prompt
         assert "response.create" not in body
+
+
+class TestGateFirstThenSpeak:
+    """#1039 part 1. Observed live: the buddy said "ok great, I'll send it
+    out" BEFORE the matcher ruled, then contradicted itself one line later.
+    The prompt must forbid pre-acknowledgment, and the outcome line must be
+    the tool result's own "say" — the spine's spoken template — never the
+    model's optimistic guess. Prose is not the mechanism (the gate is), but a
+    prompt that INVITES the contradiction is a defect of its own."""
+
+    def test_the_rule_is_present_and_orders_gate_before_speech(self):
+        text = instructions.VOICE_MODE
+        assert "GATE FIRST, THEN SPEAK" in text
+        assert "until send_session_message has returned" in text
+
+    def test_the_outcome_line_is_the_tool_results_say(self):
+        assert 'speak the "say" line the result hands back' in (
+            instructions.VOICE_MODE
+        )
+
+    def test_it_forbids_the_observed_pre_acknowledgment_shape(self):
+        text = instructions.VOICE_MODE
+        assert "do not acknowledge it" in text
+        # The observed contradiction, named so the rule stays anchored to it.
+        assert "I'll send it out" in text
+
+    def test_the_near_miss_relay_is_named(self):
+        """The heard-word diagnosis only helps if the model passes it on
+        verbatim rather than paraphrasing it away."""
+        assert "names what was heard" in instructions.VOICE_MODE

--- a/tools/nonce_stt_probe.py
+++ b/tools/nonce_stt_probe.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["requests", "python-dotenv"]
+# ///
+"""Measure nonce-candidate spelling stability under the REAL transcriber.
+
+The admission test for ``confirm.NONCE_WORDS`` (documented at the tuple) is
+"one TRANSCRIBER RENDERING each" — a claim about ``gpt-4o-mini-transcribe``,
+not about orthography, and two of the original twenty words failed it
+(``harbor`` -> ``harbour``, ``ripcord`` -> ``rip cord``). #1039 adopts the NATO
+phonetic alphabet as the base vocabulary, and this probe is the measurement:
+every candidate is synthesized inside the real phrase ("confirm <word>") at
+several macOS voices, sent to the real transcription model, and admitted only
+if EVERY transcription renders it as exactly its canonical token after
+``confirm.normalize``.
+
+Synthesized speech is not the owner's voice, but the property under test is the
+transcriber's orthographic prior (which spelling it emits for a word it heard),
+not acoustic robustness — and a word that can't survive clean synthesized audio
+has no business in the alphabet.
+
+Usage: ``tools/nonce_stt_probe.py [--rounds N]`` (default 3 voices x 1 round).
+Requires OPENAI_API_KEY in ``~/.agentwire/.env`` and macOS ``/usr/bin/say``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+# NATO alphabet, canonical ICAO spellings, plus the spellings the issue names
+# as suspected hazards so the failure is measured rather than assumed.
+CANDIDATES = [
+    "alfa", "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+    "hotel", "india", "juliett", "juliet", "kilo", "lima", "mike", "november",
+    "oscar", "papa", "quebec", "romeo", "sierra", "tango", "uniform", "victor",
+    "whiskey", "xray", "x-ray", "yankee", "zulu",
+]
+
+VOICES = ["Samantha", "Daniel", "Karen"]
+
+_PUNCT_RE = re.compile(r"[^\w\s]+")
+
+
+def normalize(text: str) -> str:
+    return _PUNCT_RE.sub(" ", text.lower()).strip()
+
+
+def transcribe(path: Path, key: str) -> str:
+    with path.open("rb") as fh:
+        resp = requests.post(
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers={"Authorization": f"Bearer {key}"},
+            files={"file": (path.name, fh, "audio/wav")},
+            data={"model": "gpt-4o-mini-transcribe", "language": "en"},
+            timeout=60,
+        )
+    resp.raise_for_status()
+    return resp.json()["text"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rounds", type=int, default=1)
+    args = parser.parse_args()
+
+    load_dotenv(Path.home() / ".agentwire" / ".env")
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        print("OPENAI_API_KEY not found", file=sys.stderr)
+        return 1
+
+    results: dict[str, dict] = {}
+    with tempfile.TemporaryDirectory() as tmp:
+        for word in CANDIDATES:
+            spoken = word.replace("-", " ")
+            renderings: list[str] = []
+            for voice in VOICES:
+                for round_index in range(args.rounds):
+                    wav = Path(tmp) / f"{word}-{voice}-{round_index}.wav"
+                    subprocess.run(
+                        ["/usr/bin/say", "-v", voice, "-o", str(wav),
+                         "--data-format=LEI16@16000", f"confirm {spoken}"],
+                        check=True,
+                    )
+                    text = transcribe(wav, key)
+                    renderings.append(text)
+            tokens_per = [normalize(t).split() for t in renderings]
+            # The nonce token(s) are whatever follows "confirm" in each
+            # transcription; the admission test is that this is exactly the
+            # canonical one-token spelling, every time.
+            tails = []
+            for tokens in tokens_per:
+                try:
+                    idx = tokens.index("confirm")
+                    tails.append(" ".join(tokens[idx + 1:]))
+                except ValueError:
+                    tails.append(" ".join(tokens))
+            canonical = normalize(word).replace(" ", "")
+            passed = all(t == canonical for t in tails)
+            results[word] = {
+                "pass": passed,
+                "renderings": sorted(set(renderings)),
+                "tails": sorted(set(tails)),
+            }
+            status = "PASS" if passed else "FAIL"
+            print(f"{status:4} {word:10} tails={sorted(set(tails))}")
+
+    passing = [w for w, r in results.items() if r["pass"]]
+    print("\npassing:", passing)
+    print(json.dumps(results, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Resolves the spoken-approval fragility from live owner feedback, without loosening the deny side.

**Gate first, then speak (part 1).** `instructions.py` VOICE_MODE gains a GATE FIRST, THEN SPEAK rule: no acknowledgment of the confirm phrase until `send_session_message` returns; the first thing spoken is the result's own `say` line (the spine's spoken template), and a near-miss `say` is relayed verbatim. Pinned in `test_voice_persona.py`.

**NATO alphabet, measured (part 2).** `NONCE_WORDS` is now the NATO phonetic alphabet filtered by the existing one-transcriber-rendering admission test — measured against the real `gpt-4o-mini-transcribe` via the new `tools/nonce_stt_probe.py` (three macOS voices × three runs; fail-any-run = out). Measured rejects, each recorded at the tuple: `alfa`/`alpha` (→`alpha`/`elva`), `juliett` (→`juliet`, which is admitted instead), `x-ray` (→`x ray`), `mike` (→`mic`/`my`), `papa` (→`popup`), `sierra` (→"confirms the error"), `foxtrot` (→`vostrot`), `quebec` (→`québec`). `whiskey` measured stable but excluded under the standing no-en-US/en-GB-split rule. 18 survivors ship, pinned with pairwise edit distance ≥ 3.

**Near-miss diagnosis (part 3).** New `near_miss` verdict: when the code word came back close-but-wrong (`tangle`, `tang go`), the refusal names what WAS heard and asks for the phrase once more. Messaging only — refuses like `refused`, burns an attempt, cannot approve. Bounds: edit distance ≤ 2 (≤ 1 for ≤4-letter nonces), tokens + adjacent-pair merges, strictly closer to this nonce than any other alphabet word, grammar words excluded, and distance zero excluded by design so the refusal line never carries the nonce (#953).

Safety: the #976 denial/adversarial suite passes unchanged; the both-ways SPOKEN/REASONS guard covers `near_miss`; wiki outcome table updated. Full suite: 6858 passed.

Closes #1039

Built by [dotdev.dev](https://dotdev.dev)