### PR TITLE
voice: barge-in cuts the fallback voice too (#1041)

### DIFF
--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -112,6 +112,11 @@ ANNOUNCER_JS = """
 function createAnnouncer(deps) {
   var send = deps.send;
   var speak = deps.speak;
+  // Cuts the fallback voice's AUDIO, immediately (#1041). speak() starts an
+  // utterance this page cannot otherwise recall — speechSynthesis is outside
+  // the WebRTC path, so the model's native barge-in never touches it, and an
+  // owner talking over a fallback-spoken notice was talked straight through.
+  var stopSpeak = deps.stopSpeak || function () {};
   var setTimer = deps.setTimer;
   var clearTimer = deps.clearTimer;
   var onLog = deps.onLog || function () {};
@@ -565,13 +570,45 @@ function createAnnouncer(deps) {
         stopSpeaking(it);
       });
     },
+    // The owner started speaking over the FALLBACK voice (#1041). Native
+    // barge-in covers model audio only — the server truncates the response and
+    // the WebRTC stream stops — while speechSynthesis is outside that path and
+    // used to play straight through, which is the "sometimes she won't shut
+    // up" regime: it correlated exactly with WHAT was playing.
+    //
+    // Synchronous on purpose: the cut lands inside the speech_started event
+    // tick, so the bound on "owner speaks → audio stops" is VAD detection
+    // latency alone, never the utterance's remaining length.
+    //
+    // Both halves priced. The cut utterance settles NOT SPOKEN — through the
+    // same latch as onerror/watchdog, so the browser's own late events for it
+    // are no-ops — which means an inbox notice is released and said again at
+    // the next quiet tick (announced late, never lost: the truncated
+    // confirm-spine outcome line is re-delivered, not dropped mid-word), and
+    // a proposal cut mid-statement never anchors: refusing to approve a
+    // half-stated proposal is what the anchor is FOR. The queue and the armed
+    // fallback timer are deliberately untouched — the owner speaking delays
+    // them (armFallback re-checks ownerSpeaking), it does not discard them.
+    // Cost accepted: an owner who interrupts near the end hears the notice
+    // twice; double-speak is the cheap failure, talked-through is the
+    // expensive one.
+    bargeIn: function () {
+      if (!speaking.length) return 0;
+      var cut = speaking.slice();
+      // Global cancel — everything speechSynthesis holds is ours, and all of
+      // it is audio the owner is now talking over.
+      try { stopSpeak(); } catch (e) {}
+      cut.forEach(function (it) { settleSpeech(it, false); });
+      return cut.length;
+    },
     // Withdraw announcements whose meta matches, queued or current (#963: the
     // owner speaking first CANCELS the greeting; queueing it behind them would
     // greet someone who has already moved on). A withdrawn item's fallback is
     // disarmed and onSpoken never fires for it — it was never heard, and
     // nothing downstream may believe it was. Note what this does NOT
-    // establish: it cannot recall audio the model has already emitted; native
-    // barge-in covers that, this covers the QUEUE and the TIMER.
+    // establish: it cannot recall audio already EMITTED — the model's via
+    // native barge-in, the fallback voice's via bargeIn() above; this covers
+    // the QUEUE and the TIMER.
     cancel: function (match) {
       queue = queue.filter(function (it) { return !match(it.meta); });
       if (current && match(current.meta)) {
@@ -1638,6 +1675,10 @@ async function start() {
         // "browser voice FAILED: interrupted" (#950 defect 3).
         window.speechSynthesis.speak(utterance);
       },
+      // The barge-in cut for the channel above (#1041). cancel() is global —
+      // fine, because everything queued in speechSynthesis is this page's own
+      // fallback audio, and every bit of it is being talked over.
+      stopSpeak: () => window.speechSynthesis.cancel(),
       onSpoken,
       onNotSpoken,
       // The timer's own "never over the owner" re-check (#978 item 3). The
@@ -1765,7 +1806,19 @@ async function start() {
           // playing; this kills the QUEUE and the fallback TIMER.
           ownerSpeaking = true;
           greeted = true;
-          if (announcer) announcer.cancel((m) => !!(m && m.greeting));
+          if (announcer) {
+            announcer.cancel((m) => !!(m && m.greeting));
+            // BARGE-IN ON THE FALLBACK VOICE (#1041): speechSynthesis is
+            // outside the WebRTC path, so native barge-in never stops it —
+            // this does, synchronously, inside this event tick.
+            const cut = announcer.bargeIn();
+            if (cut) log("speak", "barge-in: cut the browser voice (" + cut + " utterance(s))", "tool");
+          }
+          // Instrumentation for the other regime (#1041): model audio is cut
+          // by the SERVER (interrupt_response) and the stream just stops —
+          // this line is what lets a "talked through me" report be correlated
+          // with what was actually playing.
+          if (responseActive) log("speak", "barge-in during a model response — server VAD truncates it", "tool");
           if (payload.item_id) {
             const startSeq = nextSeq();
             speechSeq[payload.item_id] = startSeq;

--- a/agentwire/voice_layer/realtime.py
+++ b/agentwire/voice_layer/realtime.py
@@ -148,7 +148,16 @@ def build_session_request(
                     # 24kHz PCM is what browser mic capture is documented to send.
                     "format": {"type": "audio/pcm", "rate": 24000},
                     "transcription": {"model": DEFAULT_TRANSCRIPTION_MODEL},
-                    "turn_detection": {"type": "semantic_vad"},
+                    # interrupt_response is the server-side half of barge-in
+                    # (#1041): owner speech cancels the in-flight response and
+                    # stops the model's audio stream. It documents to default
+                    # true; stated explicitly because barge-in is a core
+                    # interaction here and a silent default flip would present
+                    # as "she talks through me" with nothing to grep for.
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "interrupt_response": True,
+                    },
                 },
                 "output": {"voice": voice},
             },

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -67,6 +67,10 @@ let speakFails = false;
 // finding F4 lives in: this fixture's shape was the reason nothing saw it.
 let speakDefers = false;
 const pendingSpeech = [];
+// The barge-in cut (#1041): how many times the announcer asked the harness to
+// stop the browser voice's audio. The real dep is speechSynthesis.cancel(),
+// which recalls audio already playing — the one thing speak() cannot undo.
+let stopSpeakCalls = 0;
 
 const announcer = createAnnouncer({
   send: (e) => { if (!channelOpen) return false; events.push(e); return true; },
@@ -76,6 +80,7 @@ const announcer = createAnnouncer({
     if (speakFails) { if (onFail) onFail(); return; }
     if (onDone) onDone();
   },
+  stopSpeak: () => { stopSpeakCalls++; },
   onSpoken: (meta, how) => anchored.push({ meta: meta, how: how }),
   onNotSpoken: (meta) => notSpoken.push(meta),
   ownerSpeaking: () => ownerIsSpeaking,
@@ -113,7 +118,7 @@ function finishSpeech() {
 }
 function report() {
   return JSON.stringify({
-    events, spoken, logs, anchored, notSpoken,
+    events, spoken, logs, anchored, notSpoken, stopSpeakCalls,
     armedTimers: timers.length,
     armedMs: timers.map((t) => t.ms),
     pending: announcer.pending(),
@@ -1323,11 +1328,18 @@ class TestThePageEmbedsTheRealThing:
         """#950 defect 2, both edges, pinned on the page source: the error our
         own best-effort cancel generates is never announced, and only one
         error notice may be pending at a time. Plus defect 3: no cancel()
-        before speak() — it killed the previous utterance mid-word."""
+        before speak() — it killed the previous utterance mid-word. Pinned on
+        the OPERATION, not the string: since #1041 cancel() legitimately
+        exists as the barge-in cut (stopSpeak), so what must hold is that the
+        speak dep itself never cancels."""
         page = client.page("buddy", "tok")
         assert 'if (code === "response_cancel_not_active") break;' in page
         assert "errorNoticePending" in page
-        assert "window.speechSynthesis.cancel()" not in page
+        speak_dep = page.split("speak: (text, onSpokenAloud, onSpeakFailed)", 1)[1]
+        speak_dep = speak_dep.split("stopSpeak:", 1)[0]
+        assert "window.speechSynthesis.cancel()" not in speak_dep
+        # The one cancel in the page is the barge-in cut, nothing else.
+        assert page.count("window.speechSynthesis.cancel()") == 1
 
     def test_stop_resets_the_error_notice_gate(self):
         """The reset must live INSIDE stop(), pinned — a notice pending when a
@@ -3415,3 +3427,110 @@ class TestThePumpDefersToTheBrowserVoice:
         """)
         # Only the promoted item's own 6s fallback remains.
         assert "armed=6000" in report["logs"]
+
+
+class TestBargeInCutsTheFallbackVoice:
+    """#1041. The owner speaking over the BROWSER voice must stop its audio.
+
+    Native barge-in covers model audio only — the server truncates the response
+    and the WebRTC stream stops — while speechSynthesis is outside that path
+    and used to play straight through. The inconsistency the owner reported
+    correlated exactly with WHAT was playing: model replies cut off, announced
+    notices talked through them. bargeIn() is the missing half.
+    """
+
+    def test_the_cut_is_synchronous_and_settles_not_spoken(self):
+        """The bound on "owner speaks -> audio stops" is one event tick: no
+        timer stands between bargeIn() and the stop, so the residual latency
+        is VAD detection alone, never the utterance's remaining length."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("worker-a got back to you: done.", { inboxIds: ["m1"] });
+            fireTimers();                       // fallback fires; audio starts
+            const cut = announcer.bargeIn();    // owner starts speaking
+            logs.push("cut=" + cut);
+        """)
+        assert report["stopSpeakCalls"] == 1
+        assert any("cut=1" in line for line in report["logs"])
+        # Settled NOT SPOKEN — the ids are released so the notice is said
+        # again at the next quiet tick: announced late, never lost.
+        assert report["notSpoken"] == [{"inboxIds": ["m1"]}]
+        assert report["anchored"] == []
+        assert report["pending"] == 0
+
+    def test_a_late_end_event_after_the_cut_is_a_no_op(self):
+        """speechSynthesis.cancel() makes the browser fire its own onend or
+        onerror for the recalled utterance — the settle latch must make that
+        arrival mean nothing, or a cut notice is reported heard AND retried."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("worker-a got back to you: done.", { inboxIds: ["m1"] });
+            fireTimers();
+            announcer.bargeIn();
+            finishSpeech();                     // the browser's late onend
+        """)
+        assert report["anchored"] == []
+        assert len(report["notSpoken"]) == 1
+
+    def test_nothing_speaking_means_no_cut(self):
+        """bargeIn is scoped to fallback AUDIO in flight. A queued item or an
+        armed fallback timer is not audio, and the owner speaking merely
+        delays those (armFallback re-checks ownerSpeaking) — cutting them
+        would convert a delay into a drop."""
+        report = run_announcer("""
+            announcer.announce("worker-a got back to you: done.", { inboxIds: ["m1"] });
+            const cut = announcer.bargeIn();    // fallback timer armed, no audio yet
+            logs.push("cut=" + cut);
+        """)
+        assert report["stopSpeakCalls"] == 0
+        assert any("cut=0" in line for line in report["logs"])
+        assert report["notSpoken"] == []
+        assert report["pending"] == 1           # still owed to the owner
+
+    def test_a_proposal_cut_mid_statement_never_anchors(self):
+        """The confirm-spine half of the pricing: a half-stated proposal must
+        not open the approval window — refusing that is what the anchor is
+        for, and the on-screen not-spoken record says why."""
+        report = run_announcer("""
+            speakDefers = true;
+            announcer.announce("Restart the portal. Say confirm tango.", { anchor: "p1" });
+            fireTimers();
+            announcer.bargeIn();
+        """)
+        assert report["anchored"] == []
+        assert report["notSpoken"] == [{"anchor": "p1"}]
+        assert report["anchorPending"] is False
+
+    def test_ten_consecutive_barge_ins_each_stop_the_audio(self):
+        """The acceptance shape from #1041: N consecutive trials, every one
+        cut, none talked through — reliability, not a lucky regime."""
+        report = run_announcer("""
+            speakDefers = true;
+            for (let i = 0; i < 10; i++) {
+              announcer.announce("notice " + i, { inboxIds: ["m" + i] });
+              fireTimers();                     // audio starts
+              if (announcer.bargeIn() !== 1) logs.push("MISSED " + i);
+            }
+        """)
+        assert report["stopSpeakCalls"] == 10
+        assert len(report["notSpoken"]) == 10
+        assert not any("MISSED" in line for line in report["logs"])
+
+
+class TestThePageWiresBargeIn:
+    """The page slice: speech_started must actually call the cut, and the
+    announcer must actually be handed speechSynthesis.cancel."""
+
+    def test_speech_started_cuts_the_browser_voice(self):
+        page = client.page("buddy", "tok")
+        started = page.split('case "input_audio_buffer.speech_started":', 1)[1]
+        started = started.split("break;", 1)[0]
+        assert "announcer.bargeIn()" in started
+        # Instrumentation (#1041): every barge-in correlates with WHAT was
+        # playing — the fallback voice (cut count) or a model response.
+        assert "cut the browser voice" in started
+        assert "server VAD truncates" in started
+
+    def test_the_announcer_is_handed_the_real_cancel(self):
+        page = client.page("buddy", "tok")
+        assert "stopSpeak: () => window.speechSynthesis.cancel()" in page

--- a/tests/unit/test_voice_layer.py
+++ b/tests/unit/test_voice_layer.py
@@ -581,6 +581,9 @@ class TestRealtime:
         assert session["model"] == realtime.DEFAULT_MODEL
         assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
         assert session["audio"]["input"]["turn_detection"]["type"] == "semantic_vad"
+        # The server-side half of barge-in (#1041): stated, not defaulted — a
+        # silent default flip would present as "she talks through me".
+        assert session["audio"]["input"]["turn_detection"]["interrupt_response"] is True
         assert session["audio"]["output"]["voice"] == realtime.DEFAULT_VOICE
         assert session["tool_choice"] == "auto"
         # Reads plus the one gated write (Slice 1) — every allowlisted tool.


### PR DESCRIPTION
Owner barge-in was inconsistent because there are two audio regimes and only one had barge-in. Model audio over WebRTC is truncated server-side by semantic VAD the moment the owner speaks. The browser `speechSynthesis` fallback voice — announced notices, refusals, escalations — is outside the WebRTC path, and nothing ever stopped it: `speech_started` only cancelled queued greeting items. So a model reply cut off instantly while an announced notice talked straight through, which is exactly the correlation the issue predicted.

**Fix**
- `announcer.bargeIn()` — on `input_audio_buffer.speech_started`, synchronously cancel the fallback audio via an injected `stopSpeak` (`window.speechSynthesis.cancel()`). Cut items settle NOT SPOKEN through the existing settle latch: inbox notices are released and re-spoken at the next quiet tick (a truncated confirm-spine outcome line is re-delivered, never lost mid-word), a half-stated proposal never anchors (refusing that is what the anchor is for), and the browser's late end events for the recalled utterance are no-ops. Queued items / armed timers are untouched — owner speech delays them, never drops them.
- Instrumentation: each barge-in logs what was playing (fallback cut count, or "model response active — server VAD truncates it"), so any future report is attributable to a layer.
- `realtime.build_session_request` now states `interrupt_response: true` explicitly (it documents to default true; a silent default flip would present as this same symptom with nothing to grep for).

**Acceptance / bound** — the cut is synchronous inside the `speech_started` event tick, so owner-speech-to-audio-stop is bounded by VAD detection latency alone, never the utterance's remaining length; pinned by node tests including 10 consecutive barge-in trials across both an inbox notice and a proposal.

Full suite: 6840 passed; the only failures are pre-existing `TestAgainstRealTmux` timing flakes (pass in isolation with this change).

Closes #1041

Built by [dotdev.dev](https://dotdev.dev)