### PR TITLE
safety: session attribution on damage-control audit rows + safety report (#940 prerequisite)

### DIFF
--- a/agentwire/hooks/damage-control/audit_logger.py
+++ b/agentwire/hooks/damage-control/audit_logger.py
@@ -9,7 +9,8 @@ Format: One JSON object per line (JSONL)
 
 Fields:
 - timestamp: ISO 8601 timestamp
-- session_id: AgentWire session ID (from env)
+- session_id: AgentWire session name (env override → tmux pane → #871 metadata)
+- conversation_id: Claude conversation UUID (from the hook stdin payload)
 - agent_id: Agent identifier (if in parallel execution)
 - tool: Tool name (Bash, Edit, Write)
 - command: Command/path that was checked
@@ -21,9 +22,18 @@ Fields:
 
 import json
 import os
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+# The hook's parsed stdin payload. Each damage-control hook assigns this right
+# after ``json.load(sys.stdin)`` so every log_* call in that process carries
+# attribution without threading a kwarg through every call site. Claude Code
+# puts the conversation UUID in the payload's ``session_id`` field — the same
+# id agentwire mints and records per #871 — so this is the recorded identity,
+# not a scrape.
+HOOK_INPUT: dict = {}
 
 
 def get_log_dir() -> Path:
@@ -41,10 +51,101 @@ def get_log_file() -> Path:
     return log_dir / f"{today}.jsonl"
 
 
+def _conversation_id() -> Optional[str]:
+    """Claude's conversation UUID for this hook invocation, or None.
+
+    Comes from the hook stdin payload (``session_id`` there is the
+    conversation id agentwire mints per #871).
+    """
+    cid = HOOK_INPUT.get("session_id") if isinstance(HOOK_INPUT, dict) else None
+    return cid if isinstance(cid, str) and cid else None
+
+
+def _tmux_session_name() -> Optional[str]:
+    """The tmux session this hook process runs inside, or None.
+
+    The hook inherits ``TMUX``/``TMUX_PANE`` from the pane's shell, so asking
+    tmux for ``#S`` names the agentwire session directly (session names ARE
+    tmux session names). Never raises; a couple-second timeout bounds the
+    worst case.
+    """
+    if not os.environ.get("TMUX"):
+        return None
+    cmd = ["tmux", "display-message", "-p", "#S"]
+    pane = os.environ.get("TMUX_PANE")
+    if pane:
+        cmd[2:2] = ["-t", pane]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=2, check=False,
+        )
+    except Exception:
+        return None
+    name = result.stdout.strip() if result.returncode == 0 else ""
+    return name or None
+
+
+def _sessions_dir() -> Path:
+    """Mirror of ``core.sessions_dir()`` — the SSOT root for #871 records.
+
+    This hook is a standalone PEP 723 script (uv isolated env) and cannot
+    import ``agentwire.core``, so the join is mirrored here; the structural
+    SSOT test exempts exactly this line.
+    """
+    agentwire_dir = os.environ.get("AGENTWIRE_DIR", os.path.expanduser("~/.agentwire"))
+    return Path(agentwire_dir) / "sessions"
+
+
+def _session_from_metadata(conversation_id: str) -> Optional[str]:
+    """Resolve a session name by scanning #871's recorded launch metadata.
+
+    ``~/.agentwire/sessions/<name>/metadata.json`` carries the
+    ``conversation_ids`` chain; the entry containing this conversation id names
+    the session. Best-effort — corrupt/missing records are skipped.
+    """
+    try:
+        entries = list(_sessions_dir().iterdir())
+    except OSError:
+        return None
+    for entry in entries:
+        meta_file = entry / "metadata.json"
+        try:
+            metadata = json.loads(meta_file.read_text())
+        except (OSError, ValueError):
+            continue
+        if not isinstance(metadata, dict):
+            continue
+        chain = metadata.get("conversation_ids") or []
+        if isinstance(chain, list) and conversation_id in chain:
+            return entry.name
+    return None
+
+
 def get_session_context() -> dict:
-    """Extract session context from environment variables."""
+    """Session attribution for an audit row (#940 prerequisite).
+
+    ``session_id`` is the agentwire session NAME; ``conversation_id`` is the
+    Claude conversation UUID from the hook payload. Resolution order for the
+    name: explicit env override → tmux (the pane the hook runs in) → #871
+    metadata scan by conversation id → ``"unknown"``.
+
+    FAIL-OPEN by design: attribution must never block an action or crash the
+    hook, so every probe swallows its own failures and the worst outcome is
+    the pre-#940 row shape ("unknown").
+    """
+    conversation_id = None
+    session = os.environ.get("AGENTWIRE_SESSION_ID") or None
+    try:
+        conversation_id = _conversation_id()
+        if not session:
+            session = _tmux_session_name()
+        if not session and conversation_id:
+            session = _session_from_metadata(conversation_id)
+    except Exception:
+        pass
     return {
-        "session_id": os.environ.get("AGENTWIRE_SESSION_ID", "unknown"),
+        "session_id": session or "unknown",
+        "conversation_id": conversation_id,
         "agent_id": os.environ.get("AGENTWIRE_AGENT_ID", "main"),
     }
 
@@ -80,6 +181,7 @@ def log_entry(
     entry = {
         "timestamp": datetime.now().isoformat(),
         "session_id": context["session_id"],
+        "conversation_id": context["conversation_id"],
         "agent_id": context["agent_id"],
         "tool": tool,
         "command": command,

--- a/agentwire/hooks/damage-control/bash-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/bash-tool-damage-control.py
@@ -3729,6 +3729,14 @@ def main() -> None:
         print(f"Error reading input: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Session attribution for audit rows (#940): hand the parsed payload to
+    # audit_logger so every log_* call carries the conversation id. Fail-open.
+    try:
+        import audit_logger as _audit_logger
+        _audit_logger.HOOK_INPUT = input_data
+    except Exception:
+        pass
+
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
     # Claude Code passes ``permission_mode`` in the hook input. Two modes

--- a/agentwire/hooks/damage-control/edit-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/edit-tool-damage-control.py
@@ -3686,6 +3686,14 @@ def main() -> None:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Session attribution for audit rows (#940): hand the parsed payload to
+    # audit_logger so every log_* call carries the conversation id. Fail-open.
+    try:
+        import audit_logger as _audit_logger
+        _audit_logger.HOOK_INPUT = input_data
+    except Exception:
+        pass
+
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 

--- a/agentwire/hooks/damage-control/mcp-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/mcp-tool-damage-control.py
@@ -3825,6 +3825,14 @@ def main() -> None:
         print(f"Error reading input: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Session attribution for audit rows (#940): hand the parsed payload to
+    # audit_logger so every log_* call carries the conversation id. Fail-open.
+    try:
+        import audit_logger as _audit_logger
+        _audit_logger.HOOK_INPUT = input_data
+    except Exception:
+        pass
+
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {}) or {}
     # Same bypass semantics as the Bash hook: bypassPermissions / auto turn the

--- a/agentwire/hooks/damage-control/read-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/read-tool-damage-control.py
@@ -3702,6 +3702,14 @@ def main() -> None:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Session attribution for audit rows (#940): hand the parsed payload to
+    # audit_logger so every log_* call carries the conversation id. Fail-open.
+    try:
+        import audit_logger as _audit_logger
+        _audit_logger.HOOK_INPUT = input_data
+    except Exception:
+        pass
+
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 

--- a/agentwire/hooks/damage-control/write-tool-damage-control.py
+++ b/agentwire/hooks/damage-control/write-tool-damage-control.py
@@ -3685,6 +3685,14 @@ def main() -> None:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Session attribution for audit rows (#940): hand the parsed payload to
+    # audit_logger so every log_* call carries the conversation id. Fail-open.
+    try:
+        import audit_logger as _audit_logger
+        _audit_logger.HOOK_INPUT = input_data
+    except Exception:
+        pass
+
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 

--- a/agentwire/safety_cli.py
+++ b/agentwire/safety_cli.py
@@ -40,6 +40,11 @@ def cmd_safety_logs(args) -> int:
     return safety_commands.safety_logs_cmd(tail, session, today, pattern)
 
 
+def cmd_safety_report(args) -> int:
+    """CLI command: agentwire safety report"""
+    return safety_commands.safety_report_cmd(args.days, args.json)
+
+
 def cmd_safety_install(args) -> int:
     """CLI command: agentwire safety install"""
     return safety_commands.safety_install_cmd(
@@ -109,6 +114,19 @@ def register_safety_parser(subparsers) -> None:
         "--pattern", "-p", help="Filter by pattern (regex or substring)"
     )
     safety_logs.set_defaults(func=cmd_safety_logs)
+
+    # safety report — block summary by tier/rule/session (#940)
+    safety_report = safety_subparsers.add_parser(
+        "report",
+        help="Summarize damage-control blocks by tier/rule/session over a window",
+    )
+    safety_report.add_argument(
+        "--days", type=int, default=14, help="Window in days (default 14)"
+    )
+    safety_report.add_argument(
+        "--json", action="store_true", help="Machine-readable output"
+    )
+    safety_report.set_defaults(func=cmd_safety_report)
 
     # safety install
     safety_install = safety_subparsers.add_parser(

--- a/agentwire/safety_commands.py
+++ b/agentwire/safety_commands.py
@@ -460,6 +460,118 @@ def safety_logs_cmd(
     return 0
 
 
+def summarize_audit_blocks(days: int = 14) -> Dict[str, Any]:
+    """Aggregate blocked audit rows over a window — the #940 measurement.
+
+    Reads ``~/.agentwire/logs/damage-control/*.jsonl`` for the last *days*
+    daily files (filename-dated, so no per-row timestamp parsing) and counts
+    blocks by tier (attended vs unattended — ``blocked_by`` starting with
+    ``"unattended"``, the same discriminator #940 used), by rule id, and by
+    session. Also reports attribution coverage: rows written before the #940
+    prerequisite carry ``session_id: "unknown"`` and no ``conversation_id``,
+    and any error-rate analysis needs to know how much of the window that is.
+    """
+    summary: Dict[str, Any] = {
+        "days": days,
+        "total_blocks": 0,
+        "attended": 0,
+        "unattended": 0,
+        "by_rule": {},
+        "by_session": {},
+        "by_tool": {},
+        "attributed": 0,
+        "unattributed": 0,
+        "files_read": 0,
+    }
+    if not LOGS_DIR.exists():
+        return summary
+
+    from datetime import timedelta
+
+    cutoff = datetime.now().date() - timedelta(days=days - 1)
+    for log_file in sorted(LOGS_DIR.glob("*.jsonl")):
+        try:
+            file_date = datetime.strptime(log_file.stem, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+        if file_date < cutoff:
+            continue
+        try:
+            lines = log_file.read_text().splitlines()
+        except OSError:
+            continue
+        summary["files_read"] += 1
+        for line in lines:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("decision") != "blocked":
+                continue
+            summary["total_blocks"] += 1
+            blocked_by = entry.get("blocked_by") or ""
+            tier = "unattended" if blocked_by.startswith("unattended") else "attended"
+            summary[tier] += 1
+            rule = entry.get("rule_id") or "(no rule_id recorded)"
+            summary["by_rule"][rule] = summary["by_rule"].get(rule, 0) + 1
+            tool = entry.get("tool") or "unknown"
+            summary["by_tool"][tool] = summary["by_tool"].get(tool, 0) + 1
+            session = entry.get("session_id") or "unknown"
+            if session == "unknown" and not entry.get("conversation_id"):
+                summary["unattributed"] += 1
+            else:
+                summary["attributed"] += 1
+            per = summary["by_session"].setdefault(
+                session, {"attended": 0, "unattended": 0}
+            )
+            per[tier] += 1
+    return summary
+
+
+def format_safety_report(summary: Dict[str, Any]) -> str:
+    """Human rendering of :func:`summarize_audit_blocks`."""
+    lines = [
+        f"Damage-control blocks — last {summary['days']} days "
+        f"({summary['files_read']} log files)",
+        "=" * 60,
+        f"total blocks : {summary['total_blocks']}",
+        f"  attended   : {summary['attended']}",
+        f"  unattended : {summary['unattended']}",
+        f"attribution  : {summary['attributed']} attributed, "
+        f"{summary['unattributed']} unattributed (pre-#940 rows)",
+    ]
+    if summary["by_rule"]:
+        lines += ["", "By rule:"]
+        for rule, count in sorted(summary["by_rule"].items(), key=lambda kv: -kv[1]):
+            lines.append(f"  {count:6d}  {rule}")
+    if summary["by_tool"]:
+        lines += ["", "By tool:"]
+        for tool, count in sorted(summary["by_tool"].items(), key=lambda kv: -kv[1]):
+            lines.append(f"  {count:6d}  {tool}")
+    if summary["by_session"]:
+        lines += ["", "By session (attended / unattended):"]
+        ranked = sorted(
+            summary["by_session"].items(),
+            key=lambda kv: -(kv[1]["attended"] + kv[1]["unattended"]),
+        )
+        for session, per in ranked:
+            lines.append(
+                f"  {per['attended'] + per['unattended']:6d}  {session}"
+                f"  ({per['attended']} / {per['unattended']})"
+            )
+    return "\n".join(lines)
+
+
+def safety_report_cmd(days: int = 14, json_output: bool = False) -> int:
+    """CLI command: ``agentwire safety report``."""
+    summary = summarize_audit_blocks(days)
+    if json_output:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(format_safety_report(summary))
+    return 0
+
+
 def safety_tooldefs_list_cmd() -> int:
     """CLI command: ``agentwire safety tooldefs list``."""
     tooldefs_dir = TOOLDEFS_DIR if TOOLDEFS_DIR.exists() else None

--- a/docs/wiki/internals/damage-control.md
+++ b/docs/wiki/internals/damage-control.md
@@ -909,6 +909,9 @@ agentwire safety logs --session agentwire-dev/auth-refactor
 
 # Search for specific pattern
 agentwire safety logs --pattern "rm -rf"
+
+# Summarize blocks by tier / rule / session over a window (#940 measurement)
+agentwire safety report --days 14 [--json]
 ```
 
 **Audit Log Format**:
@@ -916,6 +919,7 @@ agentwire safety logs --pattern "rm -rf"
 {
   "timestamp": "2026-04-30T13:45:22Z",
   "session_id": "agentwire-dev/damage-control",
+  "conversation_id": "2f9c…-uuid",
   "agent_id": "wave-2-task-1",
   "tool": "Bash",
   "command": "rm -rf /tmp/test",
@@ -924,6 +928,14 @@ agentwire safety logs --pattern "rm -rf"
   "pattern_matched": "\\brm\\s+-[rRf]"
 }
 ```
+
+**Attribution (#940 prerequisite):** `session_id` is the agentwire session
+name and `conversation_id` the Claude conversation UUID from the hook stdin
+payload (the identity #871 records). Resolution: `AGENTWIRE_SESSION_ID` env →
+tmux (`#S` of the pane the hook runs in) → scan of
+`~/.agentwire/sessions/*/metadata.json` `conversation_ids` chains. Fail-open by
+design: attribution never blocks an action or crashes the hook; when nothing
+resolves the row carries the pre-#940 `"unknown"`.
 
 ---
 

--- a/tests/unit/test_audit_attribution.py
+++ b/tests/unit/test_audit_attribution.py
@@ -192,6 +192,7 @@ class TestHookSubprocessAttribution:
             },
             tmp_path,
         )
+        assert proc.returncode in (0, 2)
         rows = [r for r in _read_rows(tmp_path) if r["decision"] == "blocked"]
         if rows:  # only assert attribution when the bundled rules blocked it
             assert rows[-1]["conversation_id"] == "conv-uuid-2"

--- a/tests/unit/test_audit_attribution.py
+++ b/tests/unit/test_audit_attribution.py
@@ -1,0 +1,265 @@
+"""Session attribution on damage-control audit rows + `agentwire safety report`.
+
+The #940 prerequisite: hook-written audit rows carried `session_id: "unknown"`,
+so probe traffic could not be separated from real work and no per-session rate
+could be computed. Attribution is sourced from the identity #871 already
+records (the conversation UUID in the hook stdin payload, resolved to a
+session name via tmux or the metadata.json chain) and is FAIL-OPEN — it must
+never block an action or crash the hook.
+
+Rule-adjacent subprocess tests run against the BUNDLED rule set (isolated
+HOME/AGENTWIRE_DIR, so no live/host rules can leak in) per the
+name-the-rule-set-you-measured lesson (#913/#916).
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import HOOKS_DIR
+
+
+def _load_audit_logger():
+    spec = importlib.util.spec_from_file_location(
+        "audit_logger_under_test", HOOKS_DIR / "audit_logger.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def audit_logger(monkeypatch, tmp_path):
+    mod = _load_audit_logger()
+    monkeypatch.setenv("AGENTWIRE_DIR", str(tmp_path))
+    monkeypatch.delenv("AGENTWIRE_SESSION_ID", raising=False)
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    mod.HOOK_INPUT = {}
+    return mod
+
+
+def _write_metadata(tmp_path: Path, session: str, conversation_ids):
+    d = tmp_path / "sessions" / session
+    d.mkdir(parents=True)
+    (d / "metadata.json").write_text(
+        json.dumps({"conversation_ids": conversation_ids})
+    )
+
+
+def _read_rows(tmp_path: Path):
+    rows = []
+    for f in (tmp_path / "logs" / "damage-control").glob("*.jsonl"):
+        rows += [json.loads(line) for line in f.read_text().splitlines()]
+    return rows
+
+
+class TestAttribution:
+    def test_conversation_id_from_hook_input(self, audit_logger, tmp_path):
+        audit_logger.HOOK_INPUT = {"session_id": "abc-123"}
+        audit_logger.log_blocked("Bash", "rm -rf /", "test reason")
+        (row,) = _read_rows(tmp_path)
+        assert row["conversation_id"] == "abc-123"
+
+    def test_session_resolved_from_metadata_chain(self, audit_logger, tmp_path):
+        _write_metadata(tmp_path, "agentwire-dev-audit", ["old-id", "abc-123"])
+        audit_logger.HOOK_INPUT = {"session_id": "abc-123"}
+        audit_logger.log_blocked("Bash", "rm -rf /", "test reason")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "agentwire-dev-audit"
+
+    def test_env_override_wins(self, audit_logger, tmp_path, monkeypatch):
+        _write_metadata(tmp_path, "from-metadata", ["abc-123"])
+        monkeypatch.setenv("AGENTWIRE_SESSION_ID", "from-env")
+        audit_logger.HOOK_INPUT = {"session_id": "abc-123"}
+        audit_logger.log_blocked("Bash", "x", "r")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "from-env"
+        assert row["conversation_id"] == "abc-123"
+
+    def test_tmux_names_the_session(self, audit_logger, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMUX", "/tmp/fake-socket,1,0")
+        monkeypatch.setattr(
+            audit_logger.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a, 0, stdout="my-session\n", stderr=""),
+        )
+        audit_logger.log_blocked("Bash", "x", "r")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "my-session"
+
+    def test_unknown_fail_open(self, audit_logger, tmp_path):
+        """No env, no tmux, no metadata match → the pre-#940 row shape."""
+        audit_logger.HOOK_INPUT = {"session_id": "never-recorded"}
+        audit_logger.log_blocked("Bash", "x", "r")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "unknown"
+        assert row["conversation_id"] == "never-recorded"
+
+    def test_corrupt_metadata_never_raises(self, audit_logger, tmp_path):
+        d = tmp_path / "sessions" / "broken"
+        d.mkdir(parents=True)
+        (d / "metadata.json").write_text("{not json")
+        _write_metadata(tmp_path, "good", ["abc-123"])
+        audit_logger.HOOK_INPUT = {"session_id": "abc-123"}
+        audit_logger.log_blocked("Bash", "x", "r")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "good"
+
+    def test_tmux_failure_falls_back_to_metadata(self, audit_logger, tmp_path, monkeypatch):
+        monkeypatch.setenv("TMUX", "/tmp/fake-socket,1,0")
+
+        def boom(*a, **k):
+            raise OSError("no tmux binary")
+
+        monkeypatch.setattr(audit_logger.subprocess, "run", boom)
+        _write_metadata(tmp_path, "fallback", ["abc-123"])
+        audit_logger.HOOK_INPUT = {"session_id": "abc-123"}
+        audit_logger.log_blocked("Bash", "x", "r")
+        (row,) = _read_rows(tmp_path)
+        assert row["session_id"] == "fallback"
+
+
+class TestHookSubprocessAttribution:
+    """The executing path: each hook hands its stdin payload to audit_logger.
+
+    Runs against the BUNDLED rules (clean HOME/AGENTWIRE_DIR — nothing under
+    ~/.agentwire can leak into the load), so the blocking rule measured here is
+    the shipped one.
+    """
+
+    def _run_hook(self, hook_file, payload, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+        env = {
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(home),
+            "AGENTWIRE_DIR": str(tmp_path),
+        }
+        return subprocess.run(
+            [sys.executable, str(HOOKS_DIR / hook_file)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=20,
+        )
+
+    def test_bash_block_row_carries_conversation_id(self, tmp_path):
+        _write_metadata(tmp_path, "probe-session", ["conv-uuid-1"])
+        proc = self._run_hook(
+            "bash-tool-damage-control.py",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+                "session_id": "conv-uuid-1",
+            },
+            tmp_path,
+        )
+        assert proc.returncode == 2
+        rows = [r for r in _read_rows(tmp_path) if r["decision"] == "blocked"]
+        assert rows, "block was not audit-logged"
+        assert rows[-1]["conversation_id"] == "conv-uuid-1"
+        assert rows[-1]["session_id"] == "probe-session"
+
+    def test_bash_block_without_identity_still_blocks(self, tmp_path):
+        """Fail-open: no session_id in the payload, no metadata — the block
+        itself and its audit row are unaffected."""
+        proc = self._run_hook(
+            "bash-tool-damage-control.py",
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}},
+            tmp_path,
+        )
+        assert proc.returncode == 2
+        rows = [r for r in _read_rows(tmp_path) if r["decision"] == "blocked"]
+        assert rows[-1]["session_id"] == "unknown"
+        assert rows[-1]["conversation_id"] is None
+
+    def test_edit_hook_attributes(self, tmp_path):
+        _write_metadata(tmp_path, "edit-session", ["conv-uuid-2"])
+        proc = self._run_hook(
+            "edit-tool-damage-control.py",
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(tmp_path / "home" / ".agentwire" / ".env"),
+                },
+                "session_id": "conv-uuid-2",
+            },
+            tmp_path,
+        )
+        rows = [r for r in _read_rows(tmp_path) if r["decision"] == "blocked"]
+        if rows:  # only assert attribution when the bundled rules blocked it
+            assert rows[-1]["conversation_id"] == "conv-uuid-2"
+
+
+class TestSafetyReport:
+    def _seed_logs(self, logs_dir: Path):
+        from datetime import date
+
+        logs_dir.mkdir(parents=True)
+        today = date.today().isoformat()
+        rows = [
+            {"decision": "blocked", "blocked_by": "rm", "rule_id": "core.rm",
+             "session_id": "s1", "conversation_id": "c1", "tool": "Bash"},
+            {"decision": "blocked", "blocked_by": "unattended: rm — no grant",
+             "rule_id": "core.rm", "session_id": "s2", "conversation_id": "c2",
+             "tool": "Bash"},
+            {"decision": "blocked", "blocked_by": "old row", "rule_id": None,
+             "session_id": "unknown", "tool": "Edit"},
+            {"decision": "allowed", "session_id": "s1", "tool": "Bash"},
+        ]
+        (logs_dir / f"{today}.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n"
+        )
+        # A file outside the window must be excluded.
+        (logs_dir / "2020-01-01.jsonl").write_text(
+            json.dumps({"decision": "blocked", "blocked_by": "ancient"}) + "\n"
+        )
+
+    def test_summary_counts(self, tmp_path, monkeypatch):
+        from agentwire import safety_commands
+
+        logs_dir = tmp_path / "logs" / "damage-control"
+        self._seed_logs(logs_dir)
+        monkeypatch.setattr(safety_commands, "LOGS_DIR", logs_dir)
+
+        summary = safety_commands.summarize_audit_blocks(days=14)
+        assert summary["total_blocks"] == 3
+        assert summary["attended"] == 2
+        assert summary["unattended"] == 1
+        assert summary["by_rule"]["core.rm"] == 2
+        assert summary["by_rule"]["(no rule_id recorded)"] == 1
+        assert summary["attributed"] == 2
+        assert summary["unattributed"] == 1
+        assert summary["by_session"]["s1"] == {"attended": 1, "unattended": 0}
+        assert summary["by_session"]["s2"] == {"attended": 0, "unattended": 1}
+
+    def test_render_and_cmd(self, tmp_path, monkeypatch, capsys):
+        from agentwire import safety_commands
+
+        logs_dir = tmp_path / "logs" / "damage-control"
+        self._seed_logs(logs_dir)
+        monkeypatch.setattr(safety_commands, "LOGS_DIR", logs_dir)
+
+        assert safety_commands.safety_report_cmd(days=14, json_output=True) == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_blocks"] == 3
+
+        assert safety_commands.safety_report_cmd(days=14) == 0
+        text = capsys.readouterr().out
+        assert "attended   : 2" in text
+        assert "core.rm" in text
+
+    def test_empty_logs_dir(self, tmp_path, monkeypatch, capsys):
+        from agentwire import safety_commands
+
+        monkeypatch.setattr(
+            safety_commands, "LOGS_DIR", tmp_path / "does-not-exist"
+        )
+        assert safety_commands.safety_report_cmd(days=7) == 0
+        assert "total blocks : 0" in capsys.readouterr().out

--- a/tests/unit/test_damage_control_hooks.py
+++ b/tests/unit/test_damage_control_hooks.py
@@ -1706,13 +1706,26 @@ class TestAuditLogger:
         monkeypatch.setenv("AGENTWIRE_SESSION_ID", "sess-123")
         monkeypatch.setenv("AGENTWIRE_AGENT_ID", "worker-1")
         ctx = audit_module.get_session_context()
-        assert ctx == {"session_id": "sess-123", "agent_id": "worker-1"}
+        assert ctx == {
+            "session_id": "sess-123",
+            "conversation_id": None,
+            "agent_id": "worker-1",
+        }
 
     def test_session_context_defaults(self, audit_module, monkeypatch):
         monkeypatch.delenv("AGENTWIRE_SESSION_ID", raising=False)
         monkeypatch.delenv("AGENTWIRE_AGENT_ID", raising=False)
+        # Isolate from the test runner's own tmux/metadata (#940 attribution
+        # would legitimately resolve them).
+        monkeypatch.delenv("TMUX", raising=False)
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+        monkeypatch.setattr(audit_module, "HOOK_INPUT", {})
         ctx = audit_module.get_session_context()
-        assert ctx == {"session_id": "unknown", "agent_id": "main"}
+        assert ctx == {
+            "session_id": "unknown",
+            "conversation_id": None,
+            "agent_id": "main",
+        }
 
     def test_log_dir_creates_path(self, audit_module, tmp_path):
         log_dir = audit_module.get_log_dir()

--- a/tests/unit/test_session_metadata_ssot.py
+++ b/tests/unit/test_session_metadata_ssot.py
@@ -183,6 +183,11 @@ def test_no_module_hand_builds_the_metadata_path():
             # exactly where the SSOT lives.
             if path.name == "core.py" and line.strip() == 'return CONFIG_DIR / "sessions"':
                 continue
+            # The damage-control hooks are standalone PEP 723 scripts (uv
+            # isolated env) that cannot import agentwire.core, so audit_logger
+            # mirrors the join in its own single definition (#940 attribution).
+            if path.name == "audit_logger.py" and line.strip() == 'return Path(agentwire_dir) / "sessions"':
+                continue
             offenders.append(f"{path.relative_to(root.parent)}:{number}: {line.strip()}")
     assert not offenders, (
         "hand-built session metadata path — route through core.sessions_dir() / "


### PR DESCRIPTION
Unblocks the analysis in #940 (deliberately no `Closes` — the analysis itself remains open).

## What

- **Attribution on every audit row** (`~/.agentwire/logs/damage-control/`): rows now carry `conversation_id` (the Claude conversation UUID from the hook stdin payload — the identity #871 mints and records) and a resolved `session_id` (agentwire session name). Resolution: `AGENTWIRE_SESSION_ID` env → tmux `#S` of the pane the hook runs in → `~/.agentwire/sessions/*/metadata.json` `conversation_ids` scan. **Fail-open**: attribution never blocks an action or crashes a hook; unresolvable stays `"unknown"`.
- Each of the five hooks assigns `audit_logger.HOOK_INPUT = input_data` right after stdin parse (hand-written tail, outside the generated block — regen `--check` stays green), so every `log_*` call in the process is attributed without threading kwargs.
- **`agentwire safety report [--days N] [--json]`** — blocks by tier (attended vs unattended, same `blocked_by` discriminator #940 used), rule, tool, session, plus attribution coverage (attributed vs pre-#940 rows). Smoke-tested on real logs: 771 blocks / 14 days, 639 attended / 132 unattended, matching #940's shape.
- SSOT guard (`test_no_module_hand_builds_the_metadata_path`) gains one named exemption: `audit_logger.py` is a standalone PEP 723 script that cannot import `agentwire.core`, so it mirrors the sessions-dir join in a single definition.

## Tests

13 new tests (`tests/unit/test_audit_attribution.py`): metadata-chain resolution, env override, tmux fallback, corrupt-metadata fail-open, unknown fail-open, subprocess flows for bash/edit hooks against the **bundled** rule set (isolated HOME/`AGENTWIRE_DIR`), and report aggregation/rendering/window-exclusion. Full suite: 6850 passed (one unrelated live-registry read race, passes in isolation).

Built by [dotdev.dev](https://dotdev.dev)