### PR TITLE
voice ux: hold notices behind proposals, anchor at render, tame the fallback voice (#1048)

### DIFF
--- a/agentwire/fleet_activity.py
+++ b/agentwire/fleet_activity.py
@@ -387,6 +387,12 @@ def note(
             kind=kind or None,
             exclude=skip,
             sender=SENDER,
+            # Stable identity for the voice layer (#1048): dedups a repeat of
+            # the same event about the same subject across message ids, and
+            # lets the staleness gate check the SUBJECT session's liveness —
+            # "auth-fix is idle and done working" about a torn-down session is
+            # not news, whatever the machine sender's own liveness says.
+            ref=f"activity:{event}:{subject}",
         )
     except Exception as exc:  # noqa: BLE001  # awareness must not break producers
         fleet_alerts.log_event("activity_emit_failed", activity_event=event, error=str(exc))

--- a/agentwire/prompt_router.py
+++ b/agentwire/prompt_router.py
@@ -701,7 +701,15 @@ def _alert_no_parent(
         )
         reached = fleet_alerts.emit_for(
             "blocked_pane_no_parent",
-            f"{session} (pane {pane_index}) is blocked on a {info.kind} prompt "
+            # The ref is the alert's STABLE IDENTITY across re-raises (#1048):
+            # this alert re-fires every NO_PARENT_ESCALATE_TTL while the same
+            # prompt stays up, each time as a new message id, and a listener
+            # that dedups by id speaks every one. Keyed on the prompt hash, so
+            # a genuinely different question is a new identity — and the voice
+            # layer's staleness gate verifies the marker by this same key
+            # before speaking, so an answered prompt is dropped, not replayed.
+            ref=f"prompt:{session}:{pane_index}:{info.content_hash()}",
+            text=f"{session} (pane {pane_index}) is blocked on a {info.kind} prompt "
             f"and is a root session — there is no parent to route it to, so "
             f"nothing will answer it automatically.{waited} Question: "
             f"{info.question} Answer with: agentwire prompts answer -s "

--- a/agentwire/voice_layer/client.py
+++ b/agentwire/voice_layer/client.py
@@ -315,7 +315,18 @@ function createAnnouncer(deps) {
         armFallback(item);
         return;
       }
-      onLog("fallback", "no spoken confirmation within " + fallbackMs + "ms");
+      // The 6s-miss, with its cause attached (#1048). The miss rate was the
+      // diagnostic question — "why does the model's confirmation go missing?"
+      // — and the dominant answer is interrupts: every announce() of a queued
+      // item cancels whatever response is in flight, so under a notice
+      // firehose each announcement's own model turn was cancelled by the next
+      // notice before its transcript could disarm the timer. Counting cancels
+      // seen while THIS item was current makes the correlation measurable
+      // from the log alone, before/after.
+      onLog("fallback", "no spoken confirmation within " + fallbackMs + "ms"
+        + (item.cancels
+          ? " (" + item.cancels + " response(s) cancelled while this was pending — interrupt-correlated)"
+          : ""));
       if (current === item) current = null;
       // The owner DID hear it — in a robot voice, but they heard it. Anything
       // keyed on "was this spoken" (the proposal anchor) must be told so here,
@@ -541,6 +552,7 @@ function createAnnouncer(deps) {
         sawCreate: false,
         deferred: false,
         ownerDeferrals: 0,
+        cancels: 0,
       });
       pump();
     },
@@ -632,8 +644,10 @@ function createAnnouncer(deps) {
     onResponseCancelled: function () {
       responseActive = false;
       // Whatever was in flight is dead, so it can no longer be "our audio
-      // still playing" — the deferral signal must not outlive it.
-      if (current) current.sawCreate = false;
+      // still playing" — the deferral signal must not outlive it. Counted for
+      // the 6s-miss diagnosis (#1048): a cancel while this item is current is
+      // the interrupt that most plausibly cost it its spoken confirmation.
+      if (current) { current.sawCreate = false; current.cancels += 1; }
     },
     // Returns true ONLY when this transcript is the model speaking the
     // CURRENT scripted announcement — i.e. exactly when it disarms. The page's
@@ -741,8 +755,21 @@ function createInboxNotifier(deps) {
   var onLog = deps.onLog || function () {};
   var pollMs = deps.pollMs;
   var seen = deps.seen;
+  // Page-lifetime map of stable notice IDENTITIES the owner has heard (#1048).
+  // The no-parent detector re-raises the same blocked prompt as a NEW message
+  // (new id) every alert TTL, so id-keyed `seen` cannot dedup it — each
+  // re-raise was a fresh spoken notice, the same dead alert 3x in one gap. A
+  // message's `ref` is its identity across re-raises (prompt hash included, so
+  // a CHANGED prompt is a new identity and speaks again): one speech per
+  // identity, then only on state change.
+  var seenRefs = deps.seenRefs || {};
   var canInterrupt = deps.canInterrupt || function () { return false; };
   var reRaise = deps.reRaise || null;
+
+  // Stale/duplicate drops the bridge reported, logged ONCE each — the poll
+  // returns them every 5s until the cursor moves past, and a log line per
+  // tick buries the screen the reason exists for.
+  var droppedLogged = {};
 
   // Announced this session but not yet confirmed spoken. Per-notifier on
   // purpose: if the session dies mid-announcement the map dies with it, so
@@ -777,19 +804,35 @@ function createInboxNotifier(deps) {
   // owner cannot predict when it stops, so an unbounded coalesce is a monologue
   // waiting for a fan-out: ten workers landing in one 5s poll window produced
   // one ~2500-character utterance, spoken over nothing the owner asked for. The
-  // overflow is NOT dropped and NOT acked — it stays unread and the next quiet
-  // tick says the next three, which is the same "announced late, never lost"
-  // property the interrupt tier already relies on.
+  // overflow past the cap is COLLAPSED, not queued for later airtime (#1048):
+  // it is named by count and sender in the summary tail, claimed and acked
+  // with the batch, and never read out at a later tick — serial replay of a
+  // backlog was the spam. The bodies stay in the spool for anyone who asks.
   var MAX_NOTICE_BODIES = 3;
 
-  function composeNotice(messages, waiting) {
+  function composeNotice(messages, rest) {
     // An escalation in the batch names itself as one — the owner should be
     // able to hear the difference between news and an alarm.
     var prefix = messages.some(isUrgent) ? "Heads up \\u2014 " : "";
-    // Said out loud rather than left implicit: the owner has to be able to tell
-    // "that was everything" from "there is more coming", or a capped batch
-    // sounds exactly like a complete one.
-    var tail = waiting > 0 ? " And " + waiting + " more waiting." : "";
+    // THE BACKLOG COLLAPSES TO A SUMMARY (#1048). "And N more waiting" used to
+    // mean "the next quiet tick reads the next three bodies" — a firehose
+    // replayed serially, gap after gap. The overflow is now CLAIMED by this
+    // notice: named by count and sender, never read out, and acked with the
+    // batch. The bodies stay on disk (the spool is append-only) for anyone who
+    // asks; what they never get again is airtime.
+    var tail = "";
+    if (rest && rest.length) {
+      var names = [];
+      var seenName = {};
+      rest.forEach(function (msg) {
+        var who = speaker(msg);
+        if (!seenName[who]) { seenName[who] = true; names.push(who); }
+      });
+      var listed = names.slice(0, 3).join(", ")
+        + (names.length > 3 ? " and others" : "");
+      tail = " Plus " + rest.length + " more from " + listed
+        + " \\u2014 I've collapsed those; ask me if you want them.";
+    }
     if (messages.length === 1) {
       var m = messages[0];
       // No verb for machine mail: the body is already a whole statement
@@ -826,6 +869,16 @@ function createInboxNotifier(deps) {
       // speaking or a confirm handshake is outstanding. #962's rule survives
       // intact where it was about the human; the leg it loses is only
       // "wait for the buddy's own chatter to finish".
+      // The bridge dropped these at the staleness gate (#1048) — a prompt no
+      // longer live, a sender torn down, mail past the freshness TTL. Never
+      // spoken; the REASON goes on screen, once per id, so a dropped notice
+      // is auditable rather than silently missing.
+      (res.dropped || []).forEach(function (d) {
+        if (!d || !d.id || droppedLogged[d.id]) return;
+        droppedLogged[d.id] = true;
+        onLog("inbox", "stale notice dropped (" + (d.reason || "stale") + "): "
+          + (d.from || "?") + " " + (d.id || ""));
+      });
       var full = canSpeak();
       if (!full && !canInterrupt()) return;
       var take = function (m) { return full || isUrgent(m); };
@@ -833,6 +886,17 @@ function createInboxNotifier(deps) {
       var picked = {};
       var fresh = unread.filter(take).filter(function (m) {
         if (!m || !m.id || seen[m.id] || inFlight[m.id] || picked[m.id]) return false;
+        // A re-raise of an identity the owner already heard: not fresh news.
+        // Marked `seen` so the contiguity walk below can ack past it — the
+        // whole point is that it never replays (#1048).
+        if (m.ref && seenRefs[m.ref]) {
+          seen[m.id] = true;
+          if (!droppedLogged[m.id]) {
+            droppedLogged[m.id] = true;
+            onLog("inbox", "re-raised notice deduped (already heard): " + m.id);
+          }
+          return false;
+        }
         picked[m.id] = true;
         return true;
       });
@@ -850,13 +914,16 @@ function createInboxNotifier(deps) {
         }
         return;
       }
-      // CAP THE UTTERANCE, not the mail. Only what this notice actually SAYS
-      // is claimed, marked in-flight and eligible to be acked; the rest is
-      // untouched in the spool and the next quiet tick picks it up.
-      var batch = fresh.slice(0, MAX_NOTICE_BODIES);
-      var waiting = fresh.length - batch.length;
+      // CAP THE UTTERANCE — and CLAIM the whole backlog (#1048). Escalations
+      // outrank news for the read-in-full slots (stable within each tier);
+      // everything past the cap is collapsed into the summary tail, claimed
+      // and acked WITH the batch, never replayed serially at later ticks.
+      var ordered = fresh.filter(isUrgent).concat(
+        fresh.filter(function (m) { return !isUrgent(m); }));
+      var batch = ordered.slice(0, MAX_NOTICE_BODIES);
+      var rest = ordered.slice(MAX_NOTICE_BODIES);
       var claimed = {};
-      var ids = batch.map(function (m) { claimed[m.id] = true; return m.id; });
+      var ids = ordered.map(function (m) { claimed[m.id] = true; return m.id; });
       ids.forEach(function (id) { inFlight[id] = true; });
       // HOW FAR THIS NOTICE MAY ACK (#970). The cursor is ONE id, so acking
       // through id X marks everything before X read too. The only safe target
@@ -877,17 +944,21 @@ function createInboxNotifier(deps) {
         ackThrough = m.id;
       }
       onLog("inbox", "volunteering " + batch.length + " message(s)"
-        + (waiting ? " (" + waiting + " held for the next gap)" : ""));
+        + (rest.length ? " (" + rest.length + " collapsed into the summary)" : ""));
       // inboxMsgs rides along so the page can register request/escalation
       // notices in the re-raise ledger AT THE MOMENT THEY ARE HEARD (its
       // onSpoken) — the ledger must never hold something the owner wasn't
-      // actually told.
-      announce(composeNotice(batch, waiting), {
+      // actually told. Only the READ-IN-FULL batch registers: a collapsed
+      // message was named, not stated, and re-raising it later would remind
+      // the owner of something they were never told. `ref` rides along so
+      // onSpoken can commit the identity to seenRefs (#1048).
+      announce(composeNotice(batch, rest), {
         inboxIds: ids,
         ackThrough: ackThrough,
         inboxMsgs: batch.map(function (m) {
-          return { id: m.id, from: m.from, kind: m.kind, text: m.text };
+          return { id: m.id, from: m.from, kind: m.kind, text: m.text, ref: m.ref };
         }),
+        inboxRefs: ordered.map(function (m) { return m.ref || ""; }),
       });
     }).catch(function (err) {
       onLog("inbox", "poll failed: " + err);
@@ -901,6 +972,10 @@ function createInboxNotifier(deps) {
   function noticeSpoken(meta) {
     if (!meta || !meta.inboxIds) return Promise.resolve();
     meta.inboxIds.forEach(function (id) { seen[id] = true; });
+    // Commit the IDENTITIES too (#1048): a later re-raise of the same prompt
+    // arrives as a new id, and this is what dedups it. Collapsed messages
+    // count — the owner was told they exist, which is this notice's claim.
+    (meta.inboxRefs || []).forEach(function (r) { if (r) seenRefs[r] = true; });
     // Nothing contiguous to ack — this tick spoke past an unread message and
     // the cursor cannot express that. Marking `seen` is the whole receipt; the
     // ack rides the later tick that says the skipped one.
@@ -1268,6 +1343,10 @@ const INBOX_POLL_MS = 5000;
 // Page-lifetime: ids the owner has actually HEARD. Never reset by stop() — a
 // reconnect must not replay every notice.
 const heardReplies = {};
+// Page-lifetime like heardReplies, keyed by stable notice IDENTITY (`ref`)
+// rather than message id (#1048): a re-raised prompt arrives as a new id, and
+// this is the map that keeps it to one mention per state.
+const heardNoticeRefs = {};
 let inboxNotifier = null;
 let ownerSpeaking = false;
 
@@ -1406,15 +1485,47 @@ function forward(path, body) {
 // anything that changes what they should do next. `fallbackText`, when given,
 // is what the browser-voice fallback utters instead of `text` — the
 // un-echo-cancelled channel gets the echo-safe variant.
+//
+// A PROPOSAL ANCHORS HERE, AT RENDER (#1048). The log() call above puts the
+// proposal text — nonce and all — on the owner's screen the moment it exists,
+// so this channel is not screenless while the transcript panel is open, and
+// screen visibility satisfies the announcement precondition. Anchoring only
+// at onSpoken was the livelock: a notice interrupt cut the announcement, the
+// item settled not-spoken, and the proposal was never anchored — so every
+// correct "confirm <nonce>" got "hang on — I haven't finished telling you",
+// forever, AND the volunteering gate (which closes at anchored()) stayed open
+// for the next notice to interrupt with. Anchoring at render closes both at
+// once: the confirm token is acceptable from the moment the text is
+// displayed, and confirmGate.outstanding() holds the hard hold on
+// volunteering from the same moment. The price — an owner who confirms
+// without looking approves a proposal they never heard finish — is bounded by
+// the nonce itself: it is on the screen, never in any refusal, and guessing
+// it is the same odds it always was.
 function announce(text, meta, fallbackText) {
   log("buddy", text, "buddy");
+  if (meta && meta.anchor) {
+    confirmGate.anchored();
+    log("speak", "anchored proposal " + meta.anchor + " (rendered)", "tool");
+    forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
+  }
   if (announcer) announcer.announce(text, meta, fallbackText);
   else {
-    try {
-      window.speechSynthesis.speak(
-        new SpeechSynthesisUtterance(fallbackText || text));
-    } catch (e) {}
+    try { window.speechSynthesis.speak(fallbackUtterance(fallbackText || text)); }
+    catch (e) {}
   }
+}
+
+// The browser voice, volume/rate-matched to the realtime one (#1048). The
+// platform default is FULL volume — jarringly louder than marin — and every
+// fallback utterance ships through here, so the constants are pinned by test
+// rather than left to whatever the browser defaults to this year.
+const FALLBACK_VOICE_VOLUME = 0.4;
+const FALLBACK_VOICE_RATE = 1.0;
+function fallbackUtterance(text) {
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.volume = FALLBACK_VOICE_VOLUME;
+  utterance.rate = FALLBACK_VOICE_RATE;
+  return utterance;
 }
 
 // One spoken error notice at a time. An error event while a previous notice
@@ -1469,11 +1580,10 @@ function onSpoken(meta, how) {
     return;
   }
   if (!meta || !meta.anchor) return;
-  // The proposal is now HEARD and the confirm window is open — the same
-  // evidence that starts the server-side TTL closes the volunteering gate.
-  confirmGate.anchored();
-  log("speak", "anchored proposal " + meta.anchor + " (" + how + ")", "tool");
-  forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });
+  // The anchor already happened, at RENDER (#1048) — announce() closed the
+  // gate and forwarded /anchor before this text was ever queued to be spoken.
+  // This is the on-screen record that the audio landed too, and of HOW.
+  log("speak", "proposal " + meta.anchor + " spoken (" + how + ")", "tool");
 }
 
 // The not-spoken counterpart to onSpoken (#978 item 5, #996). TWO callers, and
@@ -1507,11 +1617,11 @@ function onNotSpoken(meta) {
     return;
   }
   if (meta.anchor) {
-    // Nothing to retry: a proposal is announced once, and the spine's TTL is
-    // what ends it. What is left is to say so on screen rather than let the
-    // owner hear nothing and then be told `not_announced` for 120s.
+    // Nothing to retry: a proposal is announced once. Since #1048 it anchored
+    // at RENDER, so an unspoken proposal is still confirmable from the screen
+    // — say which channel failed rather than claiming it cannot be approved.
     log("error",
-      "proposal " + meta.anchor + " was never spoken — it cannot be approved",
+      "proposal " + meta.anchor + " was never spoken — it's on screen and can still be confirmed",
       "err");
   }
 }
@@ -1680,7 +1790,7 @@ async function start() {
       // evidence actually available, and for the mechanism whose entire job is
       // that silence is unacceptable, taking it is cheap.
       speak: (text, onSpokenAloud, onSpeakFailed) => {
-        const utterance = new SpeechSynthesisUtterance(text);
+        const utterance = fallbackUtterance(text);
         utterance.onend = () => {
           log("speak", "browser voice finished", "tool");
           if (onSpokenAloud) onSpokenAloud();
@@ -1743,6 +1853,7 @@ async function start() {
       onLog: (kind, detail) => log("speak", kind + ": " + detail, "tool"),
       pollMs: INBOX_POLL_MS,
       seen: heardReplies,
+      seenRefs: heardNoticeRefs,
     });
     dc.addEventListener("open", () => { setStatus("listening"); $stop.disabled = false; });
     dc.addEventListener("close", () => setStatus("closed"));

--- a/agentwire/voice_layer/confirm.py
+++ b/agentwire/voice_layer/confirm.py
@@ -218,6 +218,21 @@ APPROVAL_WAIT_S = 2.5
 #: a model that keeps guessing.
 MAX_CONFIRM_ATTEMPTS = 5
 
+#: How many times a confirm may be refused ``not_announced`` before the spine
+#: accepts the token anyway (#1048). The proposal text is RENDERED on the page
+#: the moment it is proposed — the client anchors at render now, so this path
+#: fires only when that forward was lost — and the announcement-gating livelock
+#: is the never-approve-unannounced rule composing with notice interruptions:
+#: the announcement never completes, so every correct "confirm <nonce>" is
+#: answered "hang on — I haven't finished telling you", forever. Same class as
+#: the digit-nonce livelock above: a gate that refuses a CORRECT approval
+#: deterministically is worse than the false-accept the strictness was buying.
+#: One "hang on" is a correction; a second is the livelock, so after one the
+#: judge runs — the nonce, minted at propose and never spoken by any refusal
+#: (#953), remains the evidence the owner knows what they are approving. The
+#: deny-side grammar is untouched.
+MAX_NOT_ANNOUNCED_REFUSALS = 1
+
 #: The nonce alphabet: short, phonetically distinct WORDS with one spelling each.
 #:
 #: **Digits were tried and they livelock.** "four seven" comes back from the
@@ -972,6 +987,9 @@ class Proposal:
     #: msg-shaped "queued" phrasing — see :meth:`Verdict.to_dict` for why the
     #: two claims must differ (§3.6: never claim more than the write did).
     success_say: str = ""
+    #: How many confirms this proposal has refused ``not_announced``. Bounded
+    #: by :data:`MAX_NOT_ANNOUNCED_REFUSALS` — see the livelock note there.
+    not_announced_refusals: int = 0
 
     @property
     def announced(self) -> bool:
@@ -2463,7 +2481,15 @@ class ConfirmSpine:
             if proposal is None:
                 return None, Verdict(approved=False, reason="no_proposal")
             if require_announced and not proposal.announced:
-                return None, Verdict(approved=False, reason="not_announced")
+                # Capped at one "hang on" per proposal (#1048). The client
+                # anchors at RENDER now, so reaching here at all means the
+                # /anchor forward was lost — and a second refusal on the same
+                # proposal is the announcement-gating livelock, not a
+                # correction. Past the cap the claim proceeds: the judge still
+                # requires the spoken nonce, which no refusal ever utters.
+                if proposal.not_announced_refusals < MAX_NOT_ANNOUNCED_REFUSALS:
+                    proposal.not_announced_refusals += 1
+                    return None, Verdict(approved=False, reason="not_announced")
             self._in_flight.add(token)
             return proposal, None
 
@@ -2491,6 +2517,7 @@ __all__ = [
     "APPROVAL_WAIT_S",
     "MAX_BODY_CHARS",
     "MAX_CONFIRM_ATTEMPTS",
+    "MAX_NOT_ANNOUNCED_REFUSALS",
     "PROPOSAL_TTL_S",
     "SPOKEN",
     "WAIT_OUTCOMES",

--- a/agentwire/voice_layer/tools.py
+++ b/agentwire/voice_layer/tools.py
@@ -397,6 +397,113 @@ def _fleet_voice_health(args: dict) -> dict:
     }
 
 
+#: How old spooled mail may be and still be VOLUNTEERED (#1048). Speech has no
+#: scrollback: an hours-stale "is idle and done working" about workers torn
+#: down the previous night was spoken as fresh news. Past this, the notice is
+#: dropped with a reason rather than read out — the spool keeps the body, and
+#: the ack of a later spoken notice retires it.
+STALE_NOTICE_S = 900
+
+#: Grace before "sender session gone" makes a message stale. A worker that
+#: reports and is reaped seconds later still deserves its report spoken; one
+#: whose sender has been gone for minutes is history, not news.
+SENDER_GONE_GRACE_S = 300
+
+
+def _staleness_reason(m: dict, now_ms: int, live: "set | None") -> "str | None":
+    """Why *m* must not be volunteered, or None while it is still news.
+
+    Verified against CURRENT state at read time, never replayed from what was
+    true at enqueue (#1048): a prompt alert whose marker is gone or answered,
+    an activity notice whose subject session no longer exists, mail from a
+    long-gone sender, and anything past :data:`STALE_NOTICE_S`. *live* is the
+    tmux session set, or None when tmux itself was unreachable — an outage is
+    not a verdict, so gone-checks abstain then (only the age gate still runs).
+    """
+    from .. import fleet_alerts
+
+    age_s = max(0, now_ms - int(m.get("ts") or 0)) / 1000.0
+    ref = str(m.get("ref") or "")
+    if ref.startswith("prompt:"):
+        # prompt:{session}:{pane}:{hash} — session names never contain `:`
+        # (tmux rewrites it to `_`, #878), so a plain rsplit is exact.
+        parts = ref[len("prompt:"):].rsplit(":", 2)
+        if len(parts) == 3:
+            from .. import prompt_router
+
+            session, pane_s, phash = parts
+            try:
+                marker = prompt_router.read_marker(session, int(pane_s))
+            except Exception:
+                marker = None
+            if not marker or str(marker.get("hash") or "") != phash:
+                return "prompt no longer live"
+    if ref.startswith("activity:session_idle:") and live is not None:
+        subject = ref[len("activity:session_idle:"):]
+        if subject and subject not in live:
+            return "subject session gone"
+    if age_s > STALE_NOTICE_S:
+        return f"older than {STALE_NOTICE_S // 60} minutes"
+    sender = str(m.get("from") or "")
+    if (
+        sender
+        and sender not in fleet_alerts.MACHINE_SENDERS
+        and live is not None
+        and sender not in live
+        and age_s > SENDER_GONE_GRACE_S
+    ):
+        return "sender session gone"
+    return None
+
+
+def _gate_notices(messages: list[dict]) -> "tuple[list[dict], list[dict]]":
+    """The volunteering gate (#1048): (still news, dropped-with-reason).
+
+    Two passes. Staleness first — each message verified against current state.
+    Then identity dedup: messages sharing a non-empty ``ref`` are re-raises of
+    one condition (the no-parent detector re-fires per TTL with a fresh id),
+    and only the NEWEST speaks; the rest are superseded. Dropped entries carry
+    ``{id, from, ref, reason}`` so the client can put the reason on screen —
+    dropped, never silently missing.
+    """
+    import time
+
+    from .. import inbox
+
+    now_ms = int(time.time() * 1000)
+    live = inbox.live_sessions()
+    live_set = set(live) if live is not None else None
+
+    dropped: list[dict] = []
+    fresh: list[dict] = []
+    for m in messages:
+        reason = _staleness_reason(m, now_ms, live_set)
+        if reason:
+            dropped.append(
+                {"id": m.get("id"), "from": m.get("from"),
+                 "ref": m.get("ref"), "reason": reason}
+            )
+        else:
+            fresh.append(m)
+
+    newest_by_ref: dict[str, str] = {}
+    for m in fresh:
+        ref = str(m.get("ref") or "")
+        if ref:
+            newest_by_ref[ref] = m.get("id")
+    kept: list[dict] = []
+    for m in fresh:
+        ref = str(m.get("ref") or "")
+        if ref and newest_by_ref.get(ref) != m.get("id"):
+            dropped.append(
+                {"id": m.get("id"), "from": m.get("from"),
+                 "ref": ref, "reason": "superseded by a newer re-raise"}
+            )
+        else:
+            kept.append(m)
+    return kept, dropped
+
+
 def _buddy_inbox(args: dict) -> dict:
     """The buddy's OWN mail — what other sessions have reported to it.
 
@@ -439,6 +546,19 @@ def _buddy_inbox(args: dict) -> dict:
         if asked_through
         else bool(ack and messages)
     )
+    # The staleness gate runs on the UNREAD view only (#1048) — that is the
+    # volunteering path, and a stale notice must be dropped at speak time with
+    # a reason, never replayed as fresh news. A deliberate full-history read
+    # (unread_only=false) is the owner asking for the record and gets it
+    # unfiltered. Dropped messages stay in the spool; the contiguous ack of a
+    # later spoken notice retires them from the unread view for good.
+    dropped: list[dict] = []
+    if unread_only:
+        from .. import fleet_alerts
+
+        messages, dropped = _gate_notices(messages)
+        for d in dropped:
+            fleet_alerts.log_event("stale_notice_dropped", buddy=name, **d)
     return {
         "success": True,
         "acked": acked,
@@ -448,6 +568,7 @@ def _buddy_inbox(args: dict) -> dict:
             {k: m.get(k) for k in ("id", "from", "kind", "text", "ts", "ref")}
             for m in messages
         ],
+        "dropped": dropped,
     }
 
 

--- a/tests/unit/test_voice_announcer.py
+++ b/tests/unit/test_voice_announcer.py
@@ -728,11 +728,11 @@ class TestTheBuddyClock:
     speaking path."""
 
     def test_a_fan_out_is_capped_into_utterances_not_a_monologue(self):
-        """#1016. Speech cannot be skimmed and the owner cannot predict when it
-        stops, so an unbounded coalesce is a monologue waiting for a fan-out —
-        ten workers landing in one 5s poll window was one ~2500-char utterance.
-        The overflow is HELD, not dropped: it stays unread and the next quiet
-        tick says it."""
+        """#1016 + #1048. Speech cannot be skimmed, so one utterance reads at
+        most MAX_NOTICE_BODIES bodies — and the overflow now COLLAPSES into a
+        spoken summary (count + senders) rather than being held for serial
+        replay at later gaps, which was the spam. The whole backlog is claimed
+        by this one notice."""
         report = run_notifier("""
             spool = [];
             for (var i = 1; i <= 5; i++) {
@@ -742,33 +742,33 @@ class TestTheBuddyClock:
         """)
         first = report["announced"][0]
         assert "body 1" in first["text"] and "body 3" in first["text"]
-        assert "body 4" not in first["text"]
-        assert first["text"].endswith("And 2 more waiting.")
-        assert first["meta"]["inboxIds"] == ["m1", "m2", "m3"]
-        # And the ack stops at the spoken run — the held mail is not buried.
-        assert first["meta"]["ackThrough"] == "m3"
+        assert "body 4" not in first["text"] and "body 5" not in first["text"]
+        assert "Plus 2 more from w4, w5" in first["text"]
+        assert "collapsed" in first["text"]
+        # The summary CLAIMS the overflow: all five ids, acked to the tail.
+        assert first["meta"]["inboxIds"] == ["m1", "m2", "m3", "m4", "m5"]
+        assert first["meta"]["ackThrough"] == "m5"
 
-    def test_the_held_overflow_is_spoken_on_the_next_gap(self):
+    def test_the_collapsed_overflow_is_never_replayed(self):
+        """#1048. "And N more waiting" used to mean the next quiet tick read
+        the next three bodies — a firehose replayed serially, gap after gap.
+        Collapsed mail is acked with the batch and gets no later airtime."""
         report = run_notifier("""
             spool = [];
             for (var i = 1; i <= 5; i++) {
               spool.push({ id: "m" + i, from: "w" + i, kind: "done", text: "body " + i });
             }
             await notifier.pollOnce();
+            await notifier.noticeSpoken(announcedCalls[0].meta);
             await notifier.pollOnce();
         """)
-        assert len(report["announced"]) == 2
-        second = report["announced"][1]["text"]
-        assert "body 4" in second and "body 5" in second
-        assert "more waiting" not in second
+        assert len(report["announced"]) == 1
+        assert report["cursor"] == 5
 
-    def test_an_escalation_behind_the_cap_waits_one_tick_no_longer(self):
-        """The cap's one real cost, bounded and pinned. An escalation sitting at
-        position 4+ of a full-gate batch is pushed to the next tick — and that
-        tick says it whether or not the gate is still full, because the
-        interrupt path filters to urgent messages only. Delay is one 5s poll;
-        the failure this rules out is the escalation waiting behind an ordinary
-        report indefinitely."""
+    def test_an_escalation_never_waits_behind_ordinary_reports(self):
+        """#1048. The read-in-full slots go to escalations first (stable within
+        each tier), so an alarm arriving fourth in a full batch is READ, not
+        collapsed into the summary behind three routine reports."""
         report = run_notifier("""
             spool = [
               { id: "m1", from: "w1", kind: "done", text: "one" },
@@ -778,15 +778,13 @@ class TestTheBuddyClock:
                 text: "login expired" },
             ];
             await notifier.pollOnce();
-            logs.push("first: " + announcedCalls[0].text);
-            speakable = false;          // the buddy is now mid-chatter
-            interruptable = true;       // …but the interrupt tier is open
-            await notifier.pollOnce();
         """)
-        assert "login expired" not in report["announced"][0]["text"]
-        assert report["announced"][0]["text"].endswith("And 1 more waiting.")
-        assert len(report["announced"]) == 2
-        assert "login expired" in report["announced"][1]["text"]
+        first = report["announced"][0]["text"]
+        assert "login expired" in first
+        assert first.startswith("Heads up")
+        # One ordinary report gave up its slot to the alarm and is summarized.
+        assert "Plus 1 more from w3" in first
+        assert report["announced"][0]["meta"]["inboxIds"] == ["m4", "m1", "m2", "m3"]
 
     def test_machine_mail_is_not_narrated_as_a_reply(self):
         """#1016. The fleet's own senders are not colleagues, and the announcer
@@ -1160,8 +1158,10 @@ class TestTheConfirmGate:
         assert report["outstanding"] is True
 
     def test_the_page_wires_the_gate_to_the_anchor_and_the_outcome(self):
-        """The gate's edges on the page: closed when the proposal is SPOKEN
-        (the onSpoken anchor branch), reopened by the outcome router — which
+        """The gate's edges on the page: closed the moment the proposal is
+        RENDERED (#1048 — announce()'s anchor branch, before the announcer is
+        even asked to speak it, so the volunteering hold cannot be defeated by
+        an interrupted announcement), reopened by the outcome router — which
         keys on the payload's confirm_terminal, never on tool names, so a
         second declared write (#966) reopens it too. The behavioral half runs
         under node in TestTheOutcomeRouter."""
@@ -1170,8 +1170,14 @@ class TestTheConfirmGate:
         assert client.outcome_router_source().strip() in page
         # ttl mirrors confirm.PROPOSAL_TTL_S — the false-reject bound.
         assert "ttlMs: 120000" in page
-        anchor_branch = page.split("if (!meta || !meta.anchor) return;", 1)[1]
-        assert "confirmGate.anchored();" in anchor_branch.split("}", 1)[0]
+        announce_body = page.split("function announce(text, meta, fallbackText) {", 1)[1]
+        announce_body = announce_body.split("\n}", 1)[0]
+        # The RENDER (log) comes first, then the anchor, then the speech path —
+        # anchored-at-render means anchored before the announcer can fail.
+        assert announce_body.index('log("buddy", text, "buddy");') \
+            < announce_body.index("confirmGate.anchored();") \
+            < announce_body.index("announcer.announce(")
+        assert 'forward("/anchor"' in announce_body
         wiring = page.split("createOutcomeRouter({", 1)[1].split("});", 1)[0]
         assert "gate: confirmGate," in wiring
         assert "ledger: reRaiseLedger," in wiring
@@ -1264,11 +1270,15 @@ class TestThePageEmbedsTheRealThing:
         done_at = page.index('case "response.done": {')
         assert cancelled_at < done_at
         assert "announcer.onResponseCancelled()" in page
-        # The only anchor forward is inside onSpoken.
+        # The only anchor forward is inside announce() — the RENDER (#1048).
+        # response.done, cancels, and the announcer's spoken/not-spoken
+        # verdicts touch it not at all, so nothing a response does can steal
+        # it OR starve it.
         assert page.count('forward("/anchor"') == 1
+        announce_at = page.index("function announce(text, meta, fallbackText)")
         onspoken_at = page.index("function onSpoken(meta, how)")
         anchor_at = page.index('forward("/anchor"')
-        assert onspoken_at < anchor_at
+        assert announce_at < anchor_at < onspoken_at
 
     def test_every_client_side_spoken_literal_is_asserted(self):
         """The category no test was exercising.

--- a/tests/unit/test_voice_ux_1048.py
+++ b/tests/unit/test_voice_ux_1048.py
@@ -357,7 +357,7 @@ class TestTheMissLogNamesItsCause:
             fireTimers();                       // the 6s miss
             """,
         )
-        miss = [l for l in report["logs"] if "no spoken confirmation" in l]
+        miss = [line for line in report["logs"] if "no spoken confirmation" in line]
         assert len(miss) == 1
         assert "1 response(s) cancelled while this was pending" in miss[0]
         assert "interrupt-correlated" in miss[0]
@@ -370,7 +370,7 @@ class TestTheMissLogNamesItsCause:
             fireTimers();
             """,
         )
-        miss = [l for l in report["logs"] if "no spoken confirmation" in l]
+        miss = [line for line in report["logs"] if "no spoken confirmation" in line]
         assert len(miss) == 1
         assert "interrupt-correlated" not in miss[0]
 
@@ -561,7 +561,7 @@ class TestTheAcceptanceComposition:
         assert "root-sess is blocked" in texts[0]
         assert "something new" in texts[1]
         # The deduped re-raise is on the record, not silently missing.
-        assert any("re-raised notice deduped" in l for l in report["logs"])
+        assert any("re-raised notice deduped" in line for line in report["logs"])
         # And it is ACKABLE: the changed-prompt notice's ack walks past it.
         assert report["cursor"] == 3
 
@@ -585,7 +585,7 @@ class TestTheAcceptanceComposition:
             await n2.pollOnce();
             await n2.pollOnce();
         """)
-        drop_lines = [l for l in report["logs"] if "stale notice dropped" in l]
+        drop_lines = [line for line in report["logs"] if "stale notice dropped" in line]
         assert len(drop_lines) == 1
         assert "subject session gone" in drop_lines[0]
         assert report["noticeTexts"] == []

--- a/tests/unit/test_voice_ux_1048.py
+++ b/tests/unit/test_voice_ux_1048.py
@@ -1,0 +1,591 @@
+"""#1048 — three composing voice-UX regressions, tested AS the composition.
+
+The live failure was never one defect: the no-parent detector re-raised dead
+alerts as fresh mail (spam), the notices interrupted the proposal announcement
+so it never anchored (livelock — every correct "confirm <nonce>" refused
+``not_announced``), and every interrupted announcement fell back to the
+full-volume browser voice (the 6s-miss firehose). Each piece reviewed fine
+alone; the defect lived between them, so the acceptance test here drives the
+REAL client factories together — gate + announcer + notifier + the page's own
+``announce()`` — through the issue's scenario: a pending proposal plus a
+firehose of inbox notices.
+
+The individual mechanisms get their own pins too:
+
+- the spine caps ``not_announced`` at ONE refusal per proposal, then judges;
+- the page anchors a proposal at RENDER (screen visibility satisfies the
+  announcement precondition — this channel is not screenless while the
+  transcript panel is open);
+- the bridge's staleness gate drops dead notices at read time WITH a reason;
+- the browser fallback voice is volume/rate-pinned, and the 6s-miss log names
+  its interrupt correlation.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+import time
+
+import pytest
+
+from agentwire import core, inbox
+from agentwire.voice_layer import client, confirm, delivery, tools, transcript
+
+_NODE = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is needed to run the client's own JS"
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0):
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class RecordingRunner:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv):
+        self.calls.append(list(argv))
+        return {"success": True}
+
+
+def _spine_and_ring():
+    clock = FakeClock()
+    ring = transcript.TranscriptRing(clock=clock)
+    runner = RecordingRunner()
+    spine = confirm.ConfirmSpine(ring, wait_s=0.0, runner=runner, clock=clock)
+    return spine, ring, runner, clock
+
+
+def _propose(spine):
+    return spine.propose(
+        tool="send_session_message",
+        session="orchestrator",
+        instruction="restart the portal",
+        argv_prefix=["msg", "send", "--to", "orchestrator", "--from", "buddy",
+                     "--kind", "voice"],
+        params={},
+    )
+
+
+def _owner_confirms(ring, proposal, seq_start=100):
+    item = f"item_{seq_start}"
+    ring.speech_started(item, seq_start)
+    ring.commit(item, seq_start + 1)
+    ring.transcribe(item, f"confirm {confirm.spoken_nonce(proposal.nonce)}")
+
+
+# =============================================================================
+# 2. The announcement-gating livelock — server half
+# =============================================================================
+
+
+class TestNotAnnouncedIsCappedAtOneRefusal:
+    def test_the_second_confirm_on_an_unannounced_proposal_is_judged(self):
+        """One "hang on" is a correction; a second is the livelock. After the
+        cap the judge runs — and the nonce, which no refusal ever utters, is
+        still what approves."""
+        spine, ring, runner, _ = _spine_and_ring()
+        proposal = _propose(spine)
+        _owner_confirms(ring, proposal)
+
+        first = spine.confirm(proposal.token)
+        assert first.approved is False
+        assert first.reason == "not_announced"
+        assert runner.calls == []
+
+        second = spine.confirm(proposal.token)
+        assert second.approved is True
+        assert len(runner.calls) == 1
+
+    def test_the_cap_does_not_weaken_the_nonce(self):
+        """Past the cap the claim proceeds to the JUDGE, not to approval: a
+        wrong nonce is still refused, and nothing writes."""
+        spine, ring, runner, _ = _spine_and_ring()
+        proposal = _propose(spine)
+        item = "item_1"
+        ring.speech_started(item, 100)
+        ring.commit(item, 101)
+        ring.transcribe(item, "confirm zebra")  # not in the alphabet
+
+        assert spine.confirm(proposal.token).reason == "not_announced"
+        second = spine.confirm(proposal.token)
+        assert second.approved is False
+        assert second.reason != "not_announced"
+        assert runner.calls == []
+
+    def test_the_cap_is_per_proposal(self):
+        """A second proposal gets its own single "hang on" — the cap is state
+        on the proposal, not on the spine."""
+        spine, ring, runner, _ = _spine_and_ring()
+        first = _propose(spine)
+        _owner_confirms(ring, first, seq_start=100)
+        assert spine.confirm(first.token).reason == "not_announced"
+        assert spine.confirm(first.token).approved is True
+
+        second = _propose(spine)
+        _owner_confirms(ring, second, seq_start=200)
+        assert spine.confirm(second.token).reason == "not_announced"
+        assert spine.confirm(second.token).approved is True
+
+    def test_the_deny_side_grammar_is_untouched(self):
+        """#976's contract: a denial on an ANNOUNCED proposal still refuses,
+        cap or no cap."""
+        spine, ring, runner, _ = _spine_and_ring()
+        proposal = _propose(spine)
+        spine.announce(proposal.id, 50)
+        item = "item_1"
+        ring.speech_started(item, 100)
+        ring.commit(item, 101)
+        ring.transcribe(
+            item, f"no wait don't confirm {confirm.spoken_nonce(proposal.nonce)}"
+        )
+        verdict = spine.confirm(proposal.token)
+        assert verdict.approved is False
+        assert runner.calls == []
+
+
+# =============================================================================
+# 2. The page anchors at RENDER — client half
+# =============================================================================
+
+
+class TestTheProposalAnchorsAtRender:
+    def test_announce_anchors_before_the_announcer_can_fail(self):
+        page = client.page("buddy", "tok")
+        body = page.split("function announce(text, meta, fallbackText) {", 1)[1]
+        body = body.split("\n}", 1)[0]
+        assert body.index('log("buddy", text, "buddy");') \
+            < body.index("confirmGate.anchored();") \
+            < body.index("announcer.announce(")
+        assert 'forward("/anchor", { proposal_id: meta.anchor, seq: nextSeq() });' in body
+
+    def test_the_anchor_forward_no_longer_waits_on_speech(self):
+        """Exactly one /anchor forward on the page, and it lives in announce()
+        — the spoken/not-spoken verdicts can no longer starve it."""
+        page = client.page("buddy", "tok")
+        assert page.count('forward("/anchor"') == 1
+        onspoken = page.split("function onSpoken(meta, how)", 1)[1]
+        onspoken = onspoken.split("function onNotSpoken", 1)[0]
+        assert 'forward("/anchor"' not in onspoken
+        assert "confirmGate.anchored" not in onspoken
+
+
+# =============================================================================
+# 1. The staleness gate at the bridge — verify, never replay
+# =============================================================================
+
+
+@pytest.fixture
+def isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(core, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(inbox, "INBOX_ROOT", tmp_path / "inbox")
+    monkeypatch.setattr(inbox, "EVENTS_FILE", tmp_path / "inbox-events.jsonl")
+    return tmp_path
+
+
+def _seed_spool(entries):
+    path = delivery.spool_path("buddy")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(e) + "\n" for e in entries))
+
+
+def _msg(mid, *, sender="worker-1", kind="done", text="report", age_s=10, ref=""):
+    return {
+        "id": mid, "from": sender, "kind": kind, "text": text,
+        "ts": int((time.time() - age_s) * 1000), "ref": ref,
+    }
+
+
+class TestTheStalenessGate:
+    def test_hours_stale_mail_is_dropped_with_a_reason(self, isolate, monkeypatch):
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"worker-1"})
+        _seed_spool([
+            _msg("m1", age_s=4 * 3600, text="is idle and done working"),
+            _msg("m2", age_s=10, text="fresh report"),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m2"]
+        assert res["dropped"] == [
+            {"id": "m1", "from": "worker-1", "ref": "",
+             "reason": "older than 15 minutes"},
+        ]
+
+    def test_a_dead_prompt_alert_is_verified_against_the_marker(
+        self, isolate, monkeypatch
+    ):
+        """The re-raised no-parent alert carries its prompt identity; at speak
+        time the MARKER decides — answered or changed means dropped, live and
+        unchanged means spoken."""
+        from agentwire import prompt_router
+
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"root-sess"})
+        markers = {("root-sess", 0): {"hash": "abc123"}}
+        monkeypatch.setattr(
+            prompt_router, "read_marker", lambda s, p: markers.get((s, p))
+        )
+        _seed_spool([
+            _msg("m1", sender="fleet-alerts", kind="escalation",
+                 ref="prompt:root-sess:0:abc123", text="blocked prompt"),
+            _msg("m2", sender="fleet-alerts", kind="escalation",
+                 ref="prompt:root-sess:1:def456", text="already answered"),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m1"]
+        assert res["dropped"][0]["id"] == "m2"
+        assert res["dropped"][0]["reason"] == "prompt no longer live"
+
+    def test_idle_news_about_a_torn_down_session_is_not_news(
+        self, isolate, monkeypatch
+    ):
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"alive-sess"})
+        _seed_spool([
+            _msg("m1", sender="fleet-activity",
+                 ref="activity:session_idle:dead-sess",
+                 text="dead-sess is idle and done working"),
+            _msg("m2", sender="fleet-activity",
+                 ref="activity:session_idle:alive-sess",
+                 text="alive-sess is idle and done working"),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m2"]
+        assert res["dropped"][0]["reason"] == "subject session gone"
+
+    def test_a_long_gone_sender_is_dropped_but_a_just_reaped_one_speaks(
+        self, isolate, monkeypatch
+    ):
+        """Both halves priced: a worker reaped seconds after reporting still
+        deserves its report spoken; one gone for minutes is history."""
+        monkeypatch.setattr(inbox, "live_sessions", lambda: set())
+        _seed_spool([
+            _msg("m1", sender="old-worker", age_s=600),
+            _msg("m2", sender="new-worker", age_s=30),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m2"]
+        assert res["dropped"][0]["reason"] == "sender session gone"
+
+    def test_re_raises_in_one_batch_collapse_to_the_newest(self, isolate, monkeypatch):
+        from agentwire import prompt_router
+
+        monkeypatch.setattr(inbox, "live_sessions", lambda: {"root-sess"})
+        monkeypatch.setattr(
+            prompt_router, "read_marker", lambda s, p: {"hash": "abc123"}
+        )
+        _seed_spool([
+            _msg("m1", sender="fleet-alerts", ref="prompt:root-sess:0:abc123"),
+            _msg("m2", sender="fleet-alerts", ref="prompt:root-sess:0:abc123"),
+            _msg("m3", sender="fleet-alerts", ref="prompt:root-sess:0:abc123"),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m3"]
+        assert sorted(d["id"] for d in res["dropped"]) == ["m1", "m2"]
+        assert all(d["reason"] == "superseded by a newer re-raise"
+                   for d in res["dropped"])
+
+    def test_a_tmux_outage_is_not_a_verdict(self, isolate, monkeypatch):
+        """live_sessions() None means tmux was unreachable — gone-checks
+        abstain rather than declaring every sender dead."""
+        monkeypatch.setattr(inbox, "live_sessions", lambda: None)
+        _seed_spool([
+            _msg("m1", sender="worker-1", age_s=600),
+            _msg("m2", sender="fleet-activity",
+                 ref="activity:session_idle:whoever", age_s=30),
+        ])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False})
+        assert [m["id"] for m in res["messages"]] == ["m1", "m2"]
+        assert res["dropped"] == []
+
+    def test_the_full_history_read_is_unfiltered(self, isolate, monkeypatch):
+        """unread_only=false is the owner asking for the record, not the
+        volunteering path — it gets everything."""
+        monkeypatch.setattr(inbox, "live_sessions", lambda: set())
+        _seed_spool([_msg("m1", age_s=4 * 3600)])
+        res = tools._buddy_inbox({"_buddy": "buddy", "ack": False,
+                                  "unread_only": False})
+        assert [m["id"] for m in res["messages"]] == ["m1"]
+        assert res["dropped"] == []
+
+    def test_producers_stamp_the_stable_identity(self):
+        """The refs the gate keys on are the ones the producers actually write
+        — pinned at the source so neither side can drift alone."""
+        import inspect
+
+        from agentwire import fleet_activity, prompt_router
+
+        alert = inspect.getsource(prompt_router._alert_no_parent)
+        assert 'ref=f"prompt:{session}:{pane_index}:{info.content_hash()}"' in alert
+        note = inspect.getsource(fleet_activity.note)
+        assert 'ref=f"activity:{event}:{subject}"' in note
+
+
+# =============================================================================
+# 3. The fallback voice — volume-matched, and the 6s-miss names its cause
+# =============================================================================
+
+
+class TestTheFallbackVoiceIsNormalized:
+    def test_the_constants_are_pinned_and_wired(self):
+        page = client.page("buddy", "tok")
+        assert "const FALLBACK_VOICE_VOLUME = 0.4;" in page
+        assert "const FALLBACK_VOICE_RATE = 1.0;" in page
+        assert "utterance.volume = FALLBACK_VOICE_VOLUME;" in page
+        assert "utterance.rate = FALLBACK_VOICE_RATE;" in page
+        # BOTH speechSynthesis paths route through the normalized constructor:
+        # the announcer's speak dep and announce()'s no-announcer fallback.
+        assert page.count("fallbackUtterance(") >= 3  # def + 2 call sites
+        assert page.count("new SpeechSynthesisUtterance(") == 1  # inside it
+
+
+@_NODE
+class TestTheMissLogNamesItsCause:
+    def test_a_cancelled_announcement_miss_reads_interrupt_correlated(self):
+        report = _run_js(
+            client.announcer_source() + _MINI_ANNOUNCER_HARNESS,
+            """
+            announcer.announce("say confirm tango to approve");
+            announcer.onResponseCreated();
+            announcer.onResponseCancelled();   // a notice interrupt killed it
+            fireTimers();                       // the 6s miss
+            """,
+        )
+        miss = [l for l in report["logs"] if "no spoken confirmation" in l]
+        assert len(miss) == 1
+        assert "1 response(s) cancelled while this was pending" in miss[0]
+        assert "interrupt-correlated" in miss[0]
+
+    def test_an_uninterrupted_miss_carries_no_false_correlation(self):
+        report = _run_js(
+            client.announcer_source() + _MINI_ANNOUNCER_HARNESS,
+            """
+            announcer.announce("say confirm tango to approve");
+            fireTimers();
+            """,
+        )
+        miss = [l for l in report["logs"] if "no spoken confirmation" in l]
+        assert len(miss) == 1
+        assert "interrupt-correlated" not in miss[0]
+
+
+_MINI_ANNOUNCER_HARNESS = """
+const logs = [];
+let timers = [];
+let nextHandle = 1;
+const announcer = createAnnouncer({
+  send: () => true,
+  speak: (t, onDone) => { if (onDone) onDone(); },
+  onLog: (kind, detail) => logs.push(kind + ": " + detail),
+  setTimer: (fn, ms) => { const h = nextHandle++; timers.push({ h, fn }); return h; },
+  clearTimer: (h) => { timers = timers.filter((t) => t.h !== h); },
+});
+function fireTimers() {
+  const due = timers.slice(); timers = [];
+  due.forEach((t) => t.fn());
+}
+function report() { return JSON.stringify({ logs }); }
+"""
+
+
+def _run_js(sources: str, script: str) -> dict:
+    program = "\n".join([sources, textwrap.dedent(script), "console.log(report());"])
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", program],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+# =============================================================================
+# THE COMPOSITION — the issue's acceptance scenario, on the real factories
+# =============================================================================
+
+_COMPOSED_HARNESS = """
+const logs = [];
+const forwards = [];
+const noticeAnnounces = [];
+let timers = [];
+let nextHandle = 1;
+let seq = 0;
+let ownerSpeaking = false;
+let spool = [];
+let cursor = 0;
+const seen = {};
+const seenRefs = {};
+
+function setTimer(fn, ms) { const h = nextHandle++; timers.push({ h, fn }); return h; }
+function clearTimer(h) { timers = timers.filter((t) => t.h !== h); }
+function fireTimers() { const due = timers.slice(); timers = []; due.forEach((t) => t.fn()); }
+function nextSeq() { return ++seq; }
+function log() {}
+function forward(path, body) { forwards.push({ path, body }); return Promise.resolve(); }
+function fallbackUtterance(t) { return t; }
+const window = { speechSynthesis: { speak: function () {} } };
+
+const confirmGate = createConfirmGate({ now: () => Date.now(), ttlMs: 120000 });
+const announcer = createAnnouncer({
+  send: () => true,
+  speak: (t, onDone) => { if (onDone) onDone(); },
+  stopSpeak: () => {},
+  onSpoken: (meta, how) => onSpoken(meta, how),
+  onNotSpoken: () => {},
+  ownerSpeaking: () => ownerSpeaking,
+  setTimer, clearTimer,
+  onLog: (kind, detail) => logs.push(kind + ": " + detail),
+});
+function onSpoken(meta, how) {
+  if (meta && meta.inboxIds) { notifier.noticeSpoken(meta); return; }
+}
+
+__ANNOUNCE__
+
+function fetchInbox() {
+  return Promise.resolve({ success: true, messages: spool.slice(cursor) });
+}
+function ackInbox(through) {
+  const idx = spool.findIndex((m) => m.id === through);
+  if (idx >= 0 && idx + 1 > cursor) cursor = idx + 1;
+  return Promise.resolve({ success: true, acked: idx >= 0 });
+}
+const notifier = createInboxNotifier({
+  fetchInbox, ackInbox,
+  announce: (text, meta) => { noticeAnnounces.push({ text, meta }); announce(text, meta); },
+  // The page's own gate predicates, verbatim in shape.
+  canSpeak: () => !ownerSpeaking && !!announcer && announcer.pending() === 0 && !confirmGate.outstanding(),
+  canInterrupt: () => !ownerSpeaking && !confirmGate.outstanding() && !!announcer && !announcer.anchorPending(),
+  setTimer, clearTimer,
+  onLog: (kind, detail) => logs.push(kind + ": " + detail),
+  pollMs: 5000,
+  seen, seenRefs,
+});
+function report() {
+  return JSON.stringify({
+    logs, forwards, cursor,
+    noticeTexts: noticeAnnounces.map((a) => a.text),
+    outstanding: confirmGate.outstanding(),
+  });
+}
+"""
+
+
+def _composed_program() -> str:
+    """The real factories plus the page's REAL announce(), extracted."""
+    page = client.page("buddy", "tok")
+    body = page.split("function announce(text, meta, fallbackText) {", 1)[1]
+    announce_fn = (
+        "function announce(text, meta, fallbackText) {" + body.split("\n}", 1)[0] + "\n}"
+    )
+    return "\n".join([
+        client.confirm_gate_source(),
+        client.announcer_source(),
+        client.notifier_source(),
+        _COMPOSED_HARNESS.replace("__ANNOUNCE__", announce_fn),
+    ])
+
+
+@_NODE
+class TestTheAcceptanceComposition:
+    """The issue's scenario: a pending proposal plus a firehose of notices."""
+
+    def test_the_firehose_is_held_until_the_proposal_resolves(self):
+        report = _run_js(_composed_program(), """
+            // The write tool proposed; the page renders + anchors immediately.
+            announce("I'd send that to orchestrator. Say confirm tango.",
+                     { anchor: "p1" }, "check the screen for the word");
+            // The announcement is TRUNCATED — the owner talks over the
+            // fallback voice mid-proposal. The anchor must not care.
+            fireTimers();            // fallback fires (model never spoke it)
+            announcer.bargeIn();
+
+            // A firehose lands: 8 notices including an escalation.
+            for (var i = 1; i <= 7; i++) {
+              spool.push({ id: "m" + i, from: "w" + i, kind: "done", text: "report " + i });
+            }
+            spool.push({ id: "m8", from: "fleet-alerts", kind: "escalation",
+                         text: "root-sess is blocked", ref: "prompt:root-sess:0:abc" });
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+            logs.push("held: " + noticeAnnounces.length);
+
+            // The proposal resolves (the outcome router's confirm_terminal).
+            confirmGate.resolved();
+            await notifier.pollOnce();
+        """)
+        # Anchored at render, before and regardless of the truncated speech.
+        assert report["forwards"][0]["path"] == "/anchor"
+        assert report["forwards"][0]["body"]["proposal_id"] == "p1"
+        # ZERO notice utterances while the proposal was outstanding —
+        # escalation included: the hard hold held.
+        assert "held: 0" in report["logs"]
+        # After resolution: exactly ONE utterance, escalation read first, the
+        # backlog collapsed to a summary — never replayed serially.
+        assert len(report["noticeTexts"]) == 1
+        text = report["noticeTexts"][0]
+        assert "root-sess is blocked" in text
+        assert "Plus 5 more from" in text and "collapsed" in text
+
+    def test_a_re_raise_of_a_heard_identity_never_speaks_again(self):
+        report = _run_js(_composed_program(), """
+            spool.push({ id: "m1", from: "fleet-alerts", kind: "escalation",
+                         text: "root-sess is blocked", ref: "prompt:root-sess:0:abc" });
+            await notifier.pollOnce();
+            fireTimers();                  // the fallback voice says it
+            await Promise.resolve();       // let the ack settle
+
+            // The detector re-raises the SAME prompt an hour later: new id,
+            // same identity.
+            spool.push({ id: "m2", from: "fleet-alerts", kind: "escalation",
+                         text: "root-sess is blocked", ref: "prompt:root-sess:0:abc" });
+            await notifier.pollOnce();
+            await notifier.pollOnce();
+
+            // A genuinely CHANGED prompt is a new identity and speaks.
+            spool.push({ id: "m3", from: "fleet-alerts", kind: "escalation",
+                         text: "root-sess asks something new", ref: "prompt:root-sess:0:def" });
+            await notifier.pollOnce();
+            fireTimers();
+            await Promise.resolve();
+        """)
+        texts = report["noticeTexts"]
+        assert len(texts) == 2
+        assert "root-sess is blocked" in texts[0]
+        assert "something new" in texts[1]
+        # The deduped re-raise is on the record, not silently missing.
+        assert any("re-raised notice deduped" in l for l in report["logs"])
+        # And it is ACKABLE: the changed-prompt notice's ack walks past it.
+        assert report["cursor"] == 3
+
+    def test_stale_drops_are_logged_once_not_per_tick(self):
+        report = _run_js(_composed_program(), """
+            const dropped = [{ id: "m9", from: "fleet-activity",
+                               reason: "subject session gone" }];
+            let fetchInboxOverride = () => Promise.resolve(
+              { success: true, messages: [], dropped: dropped });
+            // Re-wire fetch through the override for this scenario.
+            const n2 = createInboxNotifier({
+              fetchInbox: () => fetchInboxOverride(),
+              ackInbox,
+              announce: (text, meta) => noticeAnnounces.push({ text, meta }),
+              canSpeak: () => true, canInterrupt: () => false,
+              setTimer, clearTimer,
+              onLog: (kind, detail) => logs.push(kind + ": " + detail),
+              pollMs: 5000, seen: {}, seenRefs: {},
+            });
+            await n2.pollOnce();
+            await n2.pollOnce();
+            await n2.pollOnce();
+        """)
+        drop_lines = [l for l in report["logs"] if "stale notice dropped" in l]
+        assert len(drop_lines) == 1
+        assert "subject session gone" in drop_lines[0]
+        assert report["noticeTexts"] == []


### PR DESCRIPTION
P0 hotfix for the three composing voice-UX regressions the owner hit live on 2026-08-14.

## 1. Volunteered notice spam
- **Stable identity on alerts**: `_alert_no_parent` stamps `ref=prompt:<session>:<pane>:<hash>`; `fleet_activity.note` stamps `ref=activity:<event>:<subject>`. A re-raise is now recognizably the same condition.
- **Staleness gate at speak time** (`tools._buddy_inbox`, unread view only): verified against *current* state, never replayed — prompt-marker check by hash ("prompt no longer live"), `activity:session_idle` subject liveness ("subject session gone"), sender-gone with a 5-min grace so a just-reaped worker still gets its report spoken, and a 15-min freshness TTL. Drops carry `{id, from, ref, reason}`; the client logs each once and `fleet-alerts-events.jsonl` records them. tmux outage abstains (an outage is not a verdict). Deliberate full-history reads are unfiltered.
- **Dedup across re-raises**: same-ref messages in one batch collapse to the newest ("superseded"); across time, a page-lifetime `seenRefs` map keeps a heard identity to one mention — a *changed* prompt is a new hash, hence a new identity, and speaks again.
- **Backlog collapses to a summary**: past the 3-body cap, the overflow is named by count and sender, claimed and acked with the batch — never replayed serially at later gaps. Escalations take the read-in-full slots first (previously an alarm could wait behind routine reports).

## 2. Announcement-gating livelock ("it argues with me")
- **Anchor at render**: the page displays the proposal text the moment it's proposed, so screen visibility satisfies the announcement precondition. `announce()` now closes the volunteering gate and forwards `/anchor` *before* the announcer is asked to speak — an interrupted/truncated announcement can no longer leave the proposal unanchored (the livelock) or the volunteering gate open (the "hold did not hold" bug). One mechanism closes both.
- **Server backstop**: `not_announced` is capped at ONE refusal per proposal (`MAX_NOT_ANNOUNCED_REFUSALS`); after the single "hang on" the judge runs — the nonce, never uttered by any refusal (#953), remains the evidence. Deny-side grammar untouched; the #976 deny suite and #953 pins stay green.

## 3. Fallback voice
- **Volume/rate normalized**: `FALLBACK_VOICE_VOLUME = 0.4`, `FALLBACK_VOICE_RATE = 1.0`, wired through one `fallbackUtterance()` constructor on both speechSynthesis paths, pinned by test.
- **6s-miss diagnosis**: the announcer now counts responses cancelled while an item was pending and appends "(N response(s) cancelled … interrupt-correlated)" to the miss log. Root cause of the constant misses was the notice firehose itself — each queued announcement's `response.create` cancels the in-flight turn, so under spam every announcement's own model turn was killed before its transcript could disarm the timer. Parts 1+2 remove the firehose; the counter makes the before/after miss rate measurable from the live log (needs a live session, so the measurement itself is post-merge).

## Tests
- New `tests/unit/test_voice_ux_1048.py` (20 tests) including the issue's acceptance scenario driven through the REAL factories plus the page's extracted `announce()`: pending proposal + notice firehose → zero notice utterances until resolution (escalation included), anchor forwarded at render despite a truncated announcement, one collapsed summary after resolution, re-raise deduped-but-ackable, stale drops logged once.
- Mutation control run by hand: neutering `confirmGate.anchored()` in `announce()` leaks a notice through the hold — the composition test is load-bearing.
- Full suite: 6950 passed, 36 skipped.

Closes #1048

Built by [dotdev.dev](https://dotdev.dev)